### PR TITLE
Signature aggregation in block processing

### DIFF
--- a/beacon_chain/datatypes.nim
+++ b/beacon_chain/datatypes.nim
@@ -21,6 +21,7 @@ import milagro_crypto
 type
   # Alias
   BLSPublicKey* = VerKey
+  BLSsig*       = Signature
   BLSaggregateSig* = AggregatedSignature
   Blake2_256_Digest* = Hash256           # TODO change to Blake2b-512[0 ..< 32] see https://github.com/status-im/nim-beacon-chain/issues/3
   Uint24* = range[0'u32 .. 0xFFFFFF'u32] # TODO: wrap-around
@@ -58,7 +59,7 @@ type
     committee*: seq[Uint24]                       # Validator indices
 
   ValidatorRecord* = object
-    pubkey*: VerKey                               # The validator's public key
+    pubkey*: BLSPublicKey                         # The validator's public key
     withdrawal_shard*: int16                      # What shard the validator's balance will be sent to after withdrawal
     withdrawal_address*: EthAddress               # And what address
     randao_commitment*: Blake2_256_Digest         # The validator's current RANDAO beacon commitment
@@ -81,7 +82,7 @@ type
     attester_bitfield*: IntSet                    # Who is participating
     justified_slot*: int64
     justified_block_hash: Blake2_256_Digest
-    aggregateSig*: BLSaggregateSig                # The actual signature
+    aggregate_sig*: BLSaggregateSig               # The actual signature
 
     # Note:
     # We use IntSet from Nim Standard library which are efficient sparse bitsets.


### PR DESCRIPTION
This complete the following steps in [per-block-processing](https://notes.ethereum.org/SCIg8AH5SA-O4C1G1LYZHQ?view#Per-block-processing):

* Derive a group public key by adding the public keys of all of the attesters in attestation_indices for whom the corresponding bit in attester_bitfield (the ith bit is (attester_bitfield[i // 8] >> (7 - (i %8))) % 2) equals 1
* Verify that aggregate_sig verifies using the group pubkey generated and hash(slot.to_bytes(8, 'big') + parent_hashes + shard_id + shard_block_hash + justified_slot.to_bytes(8, 'big')) as the message.

## BLS keys and signatures

This should close #4, we might have a key length issue though, as in [Milagro we have the following](https://github.com/status-im/nim-milagro-crypto/blob/a6581e833d364b8372b15b500410edb27c4c7a36/src/scheme1.nim#L47-L50):

```Nim
const
  RawSignatureKeySize* = MODBYTES_384_29          # private key: 48 bytes
  RawVerificationKeySize* = MODBYTES_384_29 * 4   # public key: 192 bytes
  RawSignatureSize* = MODBYTES_384_29 * 2 + 1     # signature: 97 bytes (1 recovery byte?)
```

i.e. a BLS test suite is needed

## Message construction

The spec doesn't mention if the shard_id, an int16, should be interpreted as big or little endian before hashing. I assumed big endian.

A hash test suite would probably be helpful as well.

cc @djrtwo