### PR TITLE
first part of spec updating; some constants, structure changes, data type changes from int to uint

### DIFF
--- a/beacon_chain/datatypes.nim
+++ b/beacon_chain/datatypes.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # In process of being updated as of spec from 2018-11-05
-# Commit id 59f32978d489020770ae50e6d45450103445c6ad
+# https://github.com/ethereum/eth2.0-specs/tree/59f32978d489020770ae50e6d45450103445c6ad
 
 import
   intsets, eth_common, math, stint

--- a/beacon_chain/private/helpers.nim
+++ b/beacon_chain/private/helpers.nim
@@ -80,7 +80,7 @@ func get_new_shuffling*(seed: Blake2_256_Digest, validators: seq[ValidatorRecord
     result.add committees
 
 func get_shards_and_committees_for_slot*(crystallized_state: CrystallizedState,
-        slot: int64): seq[ShardAndCommittee] =
+        slot: uint64): seq[ShardAndCommittee] =
   # TODO: Spec why is active_state an argument?
 
   let start = crystallized_state.last_state_recalc - CYCLE_LENGTH
@@ -88,13 +88,13 @@ func get_shards_and_committees_for_slot*(crystallized_state: CrystallizedState,
   assert slot < start + CYCLE_LENGTH * 2
 
   result = crystallized_state.shard_and_committee_for_slots[int slot - start]
-  # TODO, slot is an int64 will be an issue on int32 arch.
+  # TODO, slot is a uint64; will be an issue on int32 arch.
   #       Clarify with EF if light clients will need the beacon chain
 
 func get_block_hash*(active_state: ActiveState,
-        beacon_block: BeaconBlock, slot: int64): Blake2_256_Digest =
+        beacon_block: BeaconBlock, slot: uint64): Blake2_256_Digest =
 
-  let sback = beacon_block.slot_number - CYCLE_LENGTH * 2
+  let sback = beacon_block.slot - CYCLE_LENGTH * 2
   assert sback <= slot
   assert slot < sback + CYCLE_LENGTH * 2
 

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -26,21 +26,21 @@ import
   milagro_crypto # nimble install https://github.com/status-im/nim-milagro-crypto@#master
 
 
-func process_block*(active_state: ActiveState, crystallized_state: CrystallizedState, blck: BeaconBlock, slot: int64) =
+func process_block*(active_state: ActiveState, crystallized_state: CrystallizedState, blck: BeaconBlock, slot: uint64) =
   # TODO: unfinished spec
 
   for attestation in blck.attestations:
     ## Spec changes: Verify that slot <= parent.slot_number and slot >= max(parent.slot_number - CYCLE_LENGTH + 1, 0)
     ## (Outdated) Verify that slot < block.slot_number and slot >= max(block.slot_number - CYCLE_LENGTH, 0)
-    doAssert slot < blck.slot_number
-    doAssert slot >= max(blck.slot_number - CYCLE_LENGTH, 0)
+    doAssert slot < blck.slot
+    doAssert slot >= max(blck.slot - CYCLE_LENGTH, 0)
 
     # Compute parent_hashes = [get_block_hash(active_state, block, slot - CYCLE_LENGTH + i)
     #  for i in range(1, CYCLE_LENGTH - len(oblique_parent_hashes) + 1)] + oblique_parent_hashes
     # TODO - don't allocate in tight loop
     var parent_hashes = newSeq[Blake2_256_Digest](CYCLE_LENGTH - attestation.oblique_parent_hashes.len)
     for idx, val in parent_hashes.mpairs:
-      val = get_block_hash(active_state, blck, slot - CYCLE_LENGTH + idx + 1)
+      val = get_block_hash(active_state, blck, slot - CYCLE_LENGTH + cast[uint64](idx) + 1)
     parent_hashes.add attestation.oblique_parent_hashes
 
     # Let attestation_indices be get_shards_and_committees_for_slot(crystallized_state, slot)[x], choosing x so that attestation_indices.shard_id equals the shard_id value provided to find the set of validators that is creating this attestation record.

--- a/tests/test_block_processing.nim
+++ b/tests/test_block_processing.nim
@@ -16,6 +16,6 @@ suite "Block processing":
     let actState = ActiveState()
     let crystState = CrystallizedState()
     let blck = BeaconBlock()
-    let slot = 10
+    let slot = 10'u
 
     actState.process_block(crystState, blck, slot)


### PR DESCRIPTION
I'm leaning towards using uint where the spec does, rather than int for its overflow semantics, but I'm not terribly opinionated. It seems better to follow the spec by default, even if it won't matter as much until interop tests some months from now.

My guess is that other clients have/will use uint with its implications.

The uint64 cast isn't great, but it's the best of some not-great options I played with. Open to better.