### PR TITLE
update some helper functions to current spec, along with a couple of data types that needed tweaking/fixing

### DIFF
--- a/beacon_chain/datatypes.nim
+++ b/beacon_chain/datatypes.nim
@@ -65,7 +65,7 @@ type
     randao_commitment*: Blake2_256_Digest         # RANDAO commitment
     randao_last_change*: uint64                   # Slot the RANDAO commitment was last changed
     balance*: uint64                              # Balance in Gwei
-    status*: uint8                                # Status code [used to be more enum-like]
+    status*: ValidatorStatusCodes                 # Status code
     exit_slot*: uint64                            # Slot when validator exited (or 0)
 
   CrosslinkRecord* = object
@@ -112,7 +112,7 @@ type
     fork_slot_number*: uint64
     pending_attestations*: seq[AttestationRecord]          # Attestations not yet processed
     pending_specials*: seq[SpecialRecord]                  # Specials not yet been processed
-    recent_block_hashes*: Blake2_256_Digest                # recent beacon block hashes needed to process attestations, older to newer
+    recent_block_hashes*: seq[Blake2_256_Digest]           # recent beacon block hashes needed to process attestations, older to newer
     randao_mix*: Blake2_256_Digest                         # RANDAO state
 
   ValidatorStatusCodes* {.pure.} = enum

--- a/beacon_chain/private/helpers.nim
+++ b/beacon_chain/private/helpers.nim
@@ -8,37 +8,52 @@
 # Helper functions
 import ../datatypes, sequtils, nimcrypto, math
 
-func get_active_validator_indices(validators: seq[ValidatorRecord], dynasty: int64): seq[Uint24] =
+func get_active_validator_indices(validators: seq[ValidatorRecord]): seq[Uint24] =
   ## Select the active validators
   result = @[]
   for idx, val in validators:
-    if  val.start_dynasty <= dynasty and
-        dynasty < val.end_dynasty:
+    if val.status == ACTIVE:
       result.add idx.Uint24
 
-func shuffle(validators: seq[Uint24], seed: Blake2_256_Digest): seq[Uint24] {.noInit.}=
-  ## Pseudorandomly shuffles the validator set based on some seed
+func shuffle(values: seq[Uint24], seed: Blake2_256_Digest): seq[Uint24] {.noInit.}=
+  ## Returns the shuffled ``values`` with seed as entropy.
+  ## TODO: this calls out for tests, but I odn't particularly trust spec
+  ## right now.
 
-  const UpperBound = 2^24 # 16777216
-  assert validators.len <= UpperBound
+  let values_count = values.len
 
-  deepCopy(result, validators)
+  # Entropy is consumed from the seed in 3-byte (24 bit) chunks
+  const rand_bytes = 3
+  let rand_max = 2^(rand_bytes * 8) - 1
+
+  # The range of the RNG places an upper-bound on the size of the list that
+  # may be shuffled. It is a logic error to supply an oversized list.
+  assert values_count < rand_max
+
+  deepCopy(result, values)
   var source = seed
 
   var i = 0
-  while i < validators.len:
+  while i < values.len - 1:
+    # Re-hash the `source` to obtain a new pattern of bytes
     source = blake2_256.digest source.data
+    # Iterate through the `source` bytes in 3-byte chunks
     for pos in countup(0, 29, 3):
-      let remaining = validators.len - i
-      if remaining == 0:
+      let remaining = values_count - i
+      if remaining == 1:
         break
 
-      let m = source.data[pos].Uint24 shl 16 or source.data[pos+1].Uint24 shl 8 or source.data[pos+2].Uint24
-      let rand_max = Uint24 UpperBound - UpperBound mod remaining
+      # Read 3-bytes of `source` as a 24-bit big-endian integer.
+      let sample_from_source = source.data[pos].Uint24 shl 16 or source.data[pos+1].Uint24 shl 8 or source.data[pos+2].Uint24
 
-      if m < randMax:
-        let replacementPos = m mod remaining + i
-        swap result[i], result[replacementPos]
+      # Sample values greater than or equal to `sample_max` will cause
+      # modulo bias when mapped into the `remaining` range.
+      let sample_max = rand_max - rand_max mod remaining
+
+      # Perform a swap if the consumed entropy will not cause modulo bias.
+      if sample_from_source < sample_max:
+        let replacement_position = sample_from_source mod remaining + i
+        swap result[i], result[replacement_position]
         inc i
 
 func split[T](lst: seq[T], N: Positive): seq[seq[T]] =
@@ -53,52 +68,51 @@ func get_new_shuffling*(seed: Blake2_256_Digest, validators: seq[ValidatorRecord
   ## determining at what height they can make attestations and what shard they are making crosslinks for
   ## Implementation should do the following: http://vitalik.ca/files/ShuffleAndAssign.png
 
-  let avs = get_active_validator_indices(validators, dynasty)
-  var committees_per_slot, slots_per_committee: int16
+  let avs = get_active_validator_indices(validators)
+  var committees_per_slot, slots_per_committee: uint16
 
   if avs.len >= CYCLE_LENGTH * MIN_COMMITTEE_SIZE:
-    committees_per_slot = int16 avs.len div CYCLE_LENGTH div (MIN_COMMITTEE_SIZE * 2) + 1
+    committees_per_slot = uint16 avs.len div CYCLE_LENGTH div (MIN_COMMITTEE_SIZE * 2) + 1
     slots_per_committee = 1
   else:
     committees_per_slot = 1
     slots_per_committee = 1
-    while avs.len * slots_per_committee < CYCLE_LENGTH * MIN_COMMITTEE_SIZE and
+    while avs.len.uint16 * slots_per_committee < CYCLE_LENGTH * MIN_COMMITTEE_SIZE and
         slots_per_committee < CYCLE_LENGTH:
       slots_per_committee *= 2
 
   result = @[]
   for slot, slot_indices in shuffle(avs, seed).split(CYCLE_LENGTH):
     let shard_indices = slot_indices.split(committees_per_slot)
-    let shard_id_start = crosslinking_start_shard +
-                            slot.int16 * committees_per_slot div slots_per_committee
+    let shard_id_start = crosslinking_start_shard.uint16 +
+                            slot.uint16 * committees_per_slot div slots_per_committee
 
     var committees = newSeq[ShardAndCommittee](shard_indices.len)
     for j, indices in shard_indices:
-      committees[j].shard_id = (shard_id_start + j.int16) mod SHARD_COUNT
+      committees[j].shard_id = (shard_id_start + j.uint16) mod SHARD_COUNT
       committees[j].committee = indices
 
     result.add committees
 
-func get_shards_and_committees_for_slot*(crystallized_state: CrystallizedState,
-        slot: uint64): seq[ShardAndCommittee] =
+func get_shards_and_committees_for_slot*(state: BeaconState,
+        slot: uint64): ShardAndCommittee =
   # TODO: Spec why is active_state an argument?
+  # TODO: this returns a scalar, not vector, but its return type in spec is a seq/list?
 
-  let start = crystallized_state.last_state_recalc - CYCLE_LENGTH
-  assert start <= slot
-  assert slot < start + CYCLE_LENGTH * 2
+  let earliest_slot_in_array = state.last_state_recalculation_slot - CYCLE_LENGTH
+  assert earliest_slot_in_array <= slot
+  assert slot < earliest_slot_in_array + CYCLE_LENGTH * 2
 
-  result = crystallized_state.shard_and_committee_for_slots[int slot - start]
+  return state.shard_and_committee_for_slots[int slot - earliest_slot_in_array]
   # TODO, slot is a uint64; will be an issue on int32 arch.
   #       Clarify with EF if light clients will need the beacon chain
 
-func get_block_hash*(active_state: ActiveState,
-        beacon_block: BeaconBlock, slot: uint64): Blake2_256_Digest =
+func get_block_hash*(state: BeaconState, current_block: BeaconBlock, slot: int): Blake2_256_Digest =
+  let earliest_slot_in_array = current_block.slot.int - state.recent_block_hashes.len
+  assert earliest_slot_in_array <= slot
+  assert slot < current_block.slot.int
 
-  let sback = beacon_block.slot - CYCLE_LENGTH * 2
-  assert sback <= slot
-  assert slot < sback + CYCLE_LENGTH * 2
-
-  result = active_state.recent_block_hashes[int slot - sback]
+  return state.recent_block_hashes[slot - earliest_slot_in_array]
 
 func get_new_recent_block_hashes*(
   old_block_hashes: seq[Blake2_256_Digest],


### PR DESCRIPTION
Nothing fundamental here.

I went with EF variable naming conventions to make it easier to refer/map back to the spec.

`CrystallizedState` is gone, subsumed into to `BeaconState`. Likewise `ActiveState`.

I found https://github.com/ethereum/eth2.0-specs/issues/135 which they fixed, but even then, `# TODO: this returns a scalar, not vector, but its return type in spec is a seq/list?` points to what still confuses me.

https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md has `return state.shard_and_committee_for_slots[slot - earliest_slot_in_array]` for `get_shards_and_committees_for_slot` which looks, with typical Python pseudocode setup (I know, NumPy, etc can do other things here; it's in principle arbitrary operator overloading), to return a scalar.

Still, that's what the spec says right now, so I figure get that in, then iterate on the spec upstream.