### PR TITLE
data type updates from spec

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -131,7 +131,7 @@ proc scheduleCycleActions(node: BeaconNode) =
   ## attestations from our attached validators.
   let cycleStart = node.beaconState.last_state_recalculation_slot.int
 
-  for i in 0 ..< CYCLE_LENGTH:
+  for i in 0 ..< EPOCH_LENGTH:
     # Schedule block proposals
     let
       slot = cycleStart + i
@@ -170,7 +170,7 @@ proc processBlocks*(node: BeaconNode) {.async.} =
     # 3. Peform block processing / state recalculation / etc
     #
 
-    if b.slot mod CYCLE_LENGTH == 0:
+    if b.slot mod EPOCH_LENGTH == 0:
       node.scheduleCycleActions()
       node.attestations.discardHistoryToSlot(b.slot)
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -26,11 +26,11 @@ func on_startup*(initial_validator_entries: openArray[InitialValidator],
   ## must be calculated before creating the genesis block.
   #
   # Induct validators
-  # Not in spec: the system doesn't work unless there are at least CYCLE_LENGTH
+  # Not in spec: the system doesn't work unless there are at least EPOCH_LENGTH
   # validators - there needs to be at least one member in each committee -
   # good to know for testing, though arguably the system is not that useful at
   # at that point :)
-  assert initial_validator_entries.len >= CYCLE_LENGTH
+  assert initial_validator_entries.len >= EPOCH_LENGTH
 
   var validators: seq[ValidatorRecord]
 
@@ -55,10 +55,10 @@ func on_startup*(initial_validator_entries: openArray[InitialValidator],
     x = get_new_shuffling(Eth2Digest(), validators, 0)
 
   # x + x in spec, but more ugly
-  var tmp: array[2 * CYCLE_LENGTH, seq[ShardAndCommittee]]
+  var tmp: array[2 * EPOCH_LENGTH, seq[ShardAndCommittee]]
   for i, n in x:
     tmp[i] = n
-    tmp[CYCLE_LENGTH + i] = n
+    tmp[EPOCH_LENGTH + i] = n
 
   # The spec says to use validators, but it's actually indices..
   let validator_indices = get_active_validator_indices(validators)
@@ -77,13 +77,13 @@ func on_startup*(initial_validator_entries: openArray[InitialValidator],
 func get_shards_and_committees_index*(state: BeaconState, slot: uint64): uint64 =
   # TODO spec unsigned-unsafe here
   let earliest_slot_in_array =
-    if state.last_state_recalculation_slot > CYCLE_LENGTH.uint64:
-      state.last_state_recalculation_slot - CYCLE_LENGTH
+    if state.last_state_recalculation_slot > EPOCH_LENGTH.uint64:
+      state.last_state_recalculation_slot - EPOCH_LENGTH
     else:
       0
 
   doAssert earliest_slot_in_array <= slot and
-           slot < earliest_slot_in_array + CYCLE_LENGTH * 2
+           slot < earliest_slot_in_array + EPOCH_LENGTH * 2
   slot - earliest_slot_in_array
 
 proc get_shards_and_committees_for_slot*(

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -26,14 +26,14 @@ func checkAttestations(state: BeaconState,
                        blck: BeaconBlock,
                        parent_slot: uint64): Option[seq[ProcessedAttestation]] =
   # TODO perf improvement potential..
-  if blck.attestations.len > MAX_ATTESTATION_COUNT:
+  if blck.attestations.len > MAX_ATTESTATIONS_PER_BLOCK:
     return
 
   var res: seq[ProcessedAttestation]
   for attestation in blck.attestations:
     if attestation.data.slot <= blck.slot - MIN_ATTESTATION_INCLUSION_DELAY:
       return
-    if attestation.data.slot >= max(parent_slot - CYCLE_LENGTH + 1, 0):
+    if attestation.data.slot >= max(parent_slot - EPOCH_LENGTH + 1, 0):
       return
     #doAssert attestation.data.justified_slot == justification_source if attestation.data.slot >= state.last_state_recalculation_slot else prev_cycle_justification_source
     # doAssert attestation.data.justified_block_hash == get_block_hash(state, block, attestation.data.justified_slot).

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -6,7 +6,7 @@ import
 type
   ValidatorChangeLogEntry* = object
     case kind*: ValidatorSetDeltaFlags
-    of Entry:
+    of Activation:
       pubkey: ValidatorPubKey
     else:
       index: uint32

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -55,7 +55,7 @@ iterator changes*(log: ChangeLog): ChangeLogEntry =
 
   for i in 0 ..< bits:
     yield if log.order.getBit(i):
-      ChangeLogEntry(kind: Entry, pubkey: nextItem(added))
+      ChangeLogEntry(kind: Activation, pubkey: nextItem(added))
     else:
       ChangeLogEntry(kind: Exit, index: nextItem(removed))
 
@@ -86,7 +86,7 @@ proc applyValidatorChangeLog*(log: ChangeLog,
   #
 
   outBeaconState.last_finalized_slot =
-    log.signedBlock.slot div CYCLE_LENGTH
+    log.signedBlock.slot div EPOCH_LENGTH
 
   outBeaconState.validator_set_delta_hash_chain =
     log.beaconState.validator_set_delta_hash_chain

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -15,5 +15,5 @@ suite "Beacon state":
   # Smoke test
 
   test "Smoke on_startup":
-    let state = on_startup(makeInitialValidators(CYCLE_LENGTH), 0, Eth2Digest())
-    check: state.validators.len == CYCLE_LENGTH
+    let state = on_startup(makeInitialValidators(EPOCH_LENGTH), 0, Eth2Digest())
+    check: state.validators.len == EPOCH_LENGTH

--- a/tests/test_validator.nim
+++ b/tests/test_validator.nim
@@ -27,9 +27,9 @@ suite "Validators":
     # TODO the shuffling looks really odd, probably buggy
     let s = get_new_shuffling(Eth2Digest(), validators, 0)
     check:
-      s.len == CYCLE_LENGTH
+      s.len == EPOCH_LENGTH
        # 32k validators means 2 shards validated per slot - the aim is to get
        # TARGET_COMMITTEE_SIZE validators in each shard and there are
-       # CYCLE_LENGTH slots which each will crosslink a different shard
-      s[0].len == 32 * 1024 div (TARGET_COMMITTEE_SIZE * CYCLE_LENGTH)
+       # EPOCH_LENGTH slots which each will crosslink a different shard
+      s[0].len == 32 * 1024 div (TARGET_COMMITTEE_SIZE * EPOCH_LENGTH)
       sumCommittees(s) == validators.len() # all validators accounted for

--- a/tests/testhelpers.nim
+++ b/tests/testhelpers.nim
@@ -12,7 +12,7 @@ import
 func makeValidatorPubKey(n: int): ValidatorPubKey =
   result.point.x.a.g[0] = n
 
-func makeInitialValidators*(n = CYCLE_LENGTH): seq[InitialValidator] =
+func makeInitialValidators*(n = EPOCH_LENGTH): seq[InitialValidator] =
   for i in 0..<n:
     result.add InitialValidator(
       pubkey: makeValidatorPubKey(i)


### PR DESCRIPTION
A lot of noise from `CYCLE_LENGTH` to `EPOCH_LENGTH`.

The `ValidatorStatusCodes` changed anyway so per consensus, went with spec capitalizations/formatting rather than something NEP-1-like until spec stabilizes some more.

Lots of reorganization and some helper function logic tweaks (didn't get all of those).