### PR TITLE
Shuffling test vectors generator

### DIFF
--- a/test_vectors_generator/tgen_shuffling.py
+++ b/test_vectors_generator/tgen_shuffling.py
@@ -1,0 +1,238 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# This file implements a test vectors generator for the shuffling algorithm described in the Ethereum
+# specs as of https://github.com/ethereum/eth2.0-specs/blob/2983e68f0305551083fac7fcf9330c1fc9da3411/specs/core/0_beacon-chain.md#get_new_shuffling
+
+# Reference picture: http://vitalik.ca/files/ShuffleAndAssign.png
+# and description from Py-EVM: https://github.com/ethereum/py-evm/blob/f2d0d5d187400ba46a6b8f5b1f1c9997dc7fbb5a/eth/beacon/helpers.py#L272-L344
+#
+# validators:
+#     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+# After shuffling:
+#     [6, 0, 2, 12, 14, 8, 10, 4, 9, 1, 5, 13, 15, 7, 3, 11]
+# Split by slot:
+#     [
+#         [6, 0, 2, 12, 14], [8, 10, 4, 9, 1], [5, 13, 15, 7, 3, 11]
+#     ]
+# Split by shard:
+#     [
+#         [6, 0], [2, 12, 14], [8, 10], [4, 9, 1], [5, 13, 15] ,[7, 3, 11]
+#     ]
+# Fill to output:
+#     [
+#         # slot 0
+#         [
+#             ShardAndCommittee(shard_id=0, committee=[6, 0]),
+#             ShardAndCommittee(shard_id=1, committee=[2, 12, 14]),
+#         ],
+#         # slot 1
+#         [
+#             ShardAndCommittee(shard_id=2, committee=[8, 10]),
+#             ShardAndCommittee(shard_id=3, committee=[4, 9, 1]),
+#         ],
+#         # slot 2
+#         [
+#             ShardAndCommittee(shard_id=4, committee=[5, 13, 15]),
+#             ShardAndCommittee(shard_id=5, committee=[7, 3, 11]),
+#         ],
+#     ]
+
+# Note that as of 2018-12-03, several implementations are outdated
+# as they are still using dynasty or min_committee_size that are not in the specs
+
+# ################################################################
+#
+#                  Imports and simplified types
+#
+# ################################################################
+
+from typing import(
+    List, Any, Dict, NewType
+)
+
+from enum import IntEnum
+
+Hash32 = NewType('Hash32', bytes)
+
+class ValidatorStatus(IntEnum):
+    PENDING_ACTIVATION = 0
+    ACTIVE = 1
+    EXITED_WITHOUT_PENALTY = 2
+    EXITED_WITH_PENALTY = 3
+    # Not in specs anymore - https://github.com/ethereum/eth2.0-specs/issues/216
+    PENDING_EXIT = 255
+
+class ValidatorRecord:
+    fields = {
+        # Status code
+        'status': 'ValidatorStatus'
+    }
+
+    def __init__(self, **kwargs):
+        for k in self.fields.keys():
+            assert k in kwargs or k in self.defaults
+            setattr(self, k, kwargs.get(k, self.defaults.get(k)))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+
+    def __getattribute__(self, name: str) -> Any:
+        return super().__getattribute__(name)
+
+class ShardAndCommittee:
+    fields = {
+        # Shard number
+        'shard': 'uint64',
+        # Validator indices
+        'committee': ['uint24'],
+        # Total validator count (for proofs of custody)
+        'total_validator_count': 'uint64',
+    }
+
+    def __init__(self, **kwargs):
+        for k in self.fields.keys():
+            assert k in kwargs or k in self.defaults
+            setattr(self, k, kwargs.get(k, self.defaults.get(k)))
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+
+    def __getattribute__(self, name: str) -> Any:
+        return super().__getattribute__(name)
+
+# ################################################################
+#
+#                    Environment variables
+#
+# ################################################################
+
+SHARD_COUNT           = 2**10 # 1024
+EPOCH_LENGTH          = 2**6  # 64 slots, 6.4 minutes
+TARGET_COMMITTEE_SIZE = 2**8  # 256 validators
+
+
+# ################################################################
+#
+#              Procedures (copy-pasted from specs)
+#
+# ################################################################
+
+def get_active_validator_indices(validators: [ValidatorRecord]) -> List[int]:
+    """
+    Gets indices of active validators from ``validators``.
+    """
+    return [i for i, v in enumerate(validators) if v.status in [ACTIVE, PENDING_EXIT]]
+
+def shuffle(values: List[Any], seed: Hash32) -> List[Any]:
+    """
+    Returns the shuffled ``values`` with ``seed`` as entropy.
+    """
+    values_count = len(values)
+
+    # Entropy is consumed from the seed in 3-byte (24 bit) chunks.
+    rand_bytes = 3
+    # The highest possible result of the RNG.
+    rand_max = 2 ** (rand_bytes * 8) - 1
+
+    # The range of the RNG places an upper-bound on the size of the list that
+    # may be shuffled. It is a logic error to supply an oversized list.
+    assert values_count < rand_max
+
+    output = [x for x in values]
+    source = seed
+    index = 0
+    while index < values_count - 1:
+        # Re-hash the `source` to obtain a new pattern of bytes.
+        source = hash(source)
+        # Iterate through the `source` bytes in 3-byte chunks.
+        for position in range(0, 32 - (32 % rand_bytes), rand_bytes):
+            # Determine the number of indices remaining in `values` and exit
+            # once the last index is reached.
+            remaining = values_count - index
+            if remaining == 1:
+                break
+
+            # Read 3-bytes of `source` as a 24-bit big-endian integer.
+            sample_from_source = int.from_bytes(source[position:position + rand_bytes], 'big')
+
+            # Sample values greater than or equal to `sample_max` will cause
+            # modulo bias when mapped into the `remaining` range.
+            sample_max = rand_max - rand_max % remaining
+
+            # Perform a swap if the consumed entropy will not cause modulo bias.
+            if sample_from_source < sample_max:
+                # Select a replacement index for the current index.
+                replacement_position = (sample_from_source % remaining) + index
+                # Swap the current index with the replacement index.
+                output[index], output[replacement_position] = output[replacement_position], output[index]
+                index += 1
+            else:
+                # The sample causes modulo bias. A new sample should be read.
+                pass
+
+    return output
+
+def split(values: List[Any], split_count: int) -> List[Any]:
+    """
+    Splits ``values`` into ``split_count`` pieces.
+    """
+    list_length = len(values)
+    return [
+        values[(list_length * i // split_count): (list_length * (i + 1) // split_count)]
+        for i in range(split_count)
+    ]
+
+def clamp(minval: int, maxval: int, x: int) -> int:
+    """
+    Clamps ``x`` between ``minval`` and ``maxval``.
+    """
+    if x <= minval:
+        return minval
+    elif x >= maxval:
+        return maxval
+    else:
+        return x
+
+def get_new_shuffling(seed: Hash32,
+                      validators: List[ValidatorRecord],
+                      crosslinking_start_shard: int) -> List[List[ShardAndCommittee]]:
+    """
+    Shuffles ``validators`` into shard committees using ``seed`` as entropy.
+    """
+    active_validator_indices = get_active_validator_indices(validators)
+
+    committees_per_slot = clamp(
+        1,
+        SHARD_COUNT // EPOCH_LENGTH,
+        len(active_validator_indices) // EPOCH_LENGTH // TARGET_COMMITTEE_SIZE,
+    )
+
+    # Shuffle with seed
+    shuffled_active_validator_indices = shuffle(active_validator_indices, seed)
+
+    # Split the shuffled list into epoch_length pieces
+    validators_per_slot = split(shuffled_active_validator_indices, EPOCH_LENGTH)
+
+    output = []
+    for slot, slot_indices in enumerate(validators_per_slot):
+        # Split the shuffled list into committees_per_slot pieces
+        shard_indices = split(slot_indices, committees_per_slot)
+
+        shard_id_start = crosslinking_start_shard + slot * committees_per_slot
+
+        shards_and_committees_for_slot = [
+            ShardAndCommittee(
+                shard=(shard_id_start + shard_position) % SHARD_COUNT,
+                committee=indices,
+                total_validator_count=len(active_validator_indices),
+            )
+            for shard_position, indices in enumerate(shard_indices)
+        ]
+        output.append(shards_and_committees_for_slot)
+
+    return output


### PR DESCRIPTION
As mentioned on Gitter and in https://github.com/status-im/nim-beacon-chain/issues/1#issuecomment-443688968, there is currently no reliable test vectors in the specs or in any other implementations.

So I'm building standalone spec fragments in Python and to generate test vectors. Ideally this will include a YAML test file generator and be upstreamed to https://github.com/ethereum/eth2.0-tests.

cc @djrtwo, @paulhauner

## Example output

With 14 validators:

```
$ python test_vectors_generator/tgen_shuffling.py
Hash: 0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d
validators: Val(idx: 0, status: 4), Val(idx: 1, status: 2), Val(idx: 2, status: 4), Val(idx: 3, status: 0), Val(idx: 4, status: 0), Val(idx: 5, status: 2), Val(idx: 6, status: 2), Val(idx: 7, status: 4), Val(idx: 8, status: 2), Val(idx: 9, status: 3), Val(idx: 10, status: 1), Val(idx: 11, status: 0), Val(idx: 12, status: 3), Val(idx: 13, status: 3), Val(idx: 14, status: 4)
crosslinking_start_shard: 395
shuffling: [Slot 12: SaC(shard: 407, comm: [2])
        [Slot 25: SaC(shard: 420, comm: [7])
        [Slot 38: SaC(shard: 433, comm: [10])
        [Slot 51: SaC(shard: 446, comm: [0])
        [Slot 63: SaC(shard: 458, comm: [14])
```

With 256 validators

```
Hash: 0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d
validators: Val(idx: 0, status: 4), Val(idx: 1, status: 2), Val(idx: 2, status: 4), Val(idx: 3, status: 0), Val(idx: 4, status: 0), Val(idx: 5, status: 2), Val(idx: 6, status: 2), Val(idx: 7, status: 4), Val(idx: 8, status: 2), Val(idx: 9, status: 3), Val(idx: 10, status: 1), Val(idx: 11, status: 0), Val(idx: 12, status: 3), Val(idx: 13, status: 3), Val(idx: 14, status: 4), Val(idx: 15, status: 4), Val(idx: 16, status: 4), Val(idx: 17, status: 1), Val(idx: 18, status: 1), Val(idx: 19, status: 1), Val(idx: 20, status: 1), Val(idx: 21, status: 3), Val(idx: 22, status: 2), Val(idx: 23, status: 3), Val(idx: 24, status: 0), Val(idx: 25, status: 2), Val(idx: 26, status: 4), Val(idx: 27, status: 0), Val(idx: 28, status: 2), Val(idx: 29, status: 4), Val(idx: 30, status: 0), Val(idx: 31, status: 0), Val(idx: 32, status: 4), Val(idx: 33, status: 2), Val(idx: 34, status: 1), Val(idx: 35, status: 4), Val(idx: 36, status: 1), Val(idx: 37, status: 4), Val(idx: 38, status: 2), Val(idx: 39, status: 2), Val(idx: 40, status: 1), Val(idx: 41, status: 2), Val(idx: 42, status: 4), Val(idx: 43, status: 0), Val(idx: 44, status: 4), Val(idx: 45, status: 0), Val(idx: 46, status: 3), Val(idx: 47, status: 0), Val(idx: 48, status: 4), Val(idx: 49, status: 4), Val(idx: 50, status: 0), Val(idx: 51, status: 0), Val(idx: 52, status: 1), Val(idx: 53, status: 3), Val(idx: 54, status: 3), Val(idx: 55, status: 0), Val(idx: 56, status: 4), Val(idx: 57, status: 3), Val(idx: 58, status: 1), Val(idx: 59, status: 1), Val(idx: 60, status: 3), Val(idx: 61, status: 1), Val(idx: 62, status: 0), Val(idx: 63, status: 0), Val(idx: 64, status: 1), Val(idx: 65, status: 0), Val(idx: 66, status: 0), Val(idx: 67, status: 4), Val(idx: 68, status: 1), Val(idx: 69, status: 2), Val(idx: 70, status: 0), Val(idx: 71, status: 1), Val(idx: 72, status: 4), Val(idx: 73, status: 2), Val(idx: 74, status: 1), Val(idx: 75, status: 1), Val(idx: 76, status: 4), Val(idx: 77, status: 1), Val(idx: 78, status: 1), Val(idx: 79, status: 1), Val(idx: 80, status: 1), Val(idx: 81, status: 0), Val(idx: 82, status: 4), Val(idx: 83, status: 4), Val(idx: 84, status: 0), Val(idx: 85, status: 1), Val(idx: 86, status: 3), Val(idx: 87, status: 4), Val(idx: 88, status: 2), Val(idx: 89, status: 0), Val(idx: 90, status: 1), Val(idx: 91, status: 4), Val(idx: 92, status: 3), Val(idx: 93, status: 1), Val(idx: 94, status: 2), Val(idx: 95, status: 4), Val(idx: 96, status: 2), Val(idx: 97, status: 2), Val(idx: 98, status: 2), Val(idx: 99, status: 3), Val(idx: 100, status: 3), Val(idx: 101, status: 3), Val(idx: 102, status: 0), Val(idx: 103, status: 2), Val(idx: 104, status: 0), Val(idx: 105, status: 4), Val(idx: 106, status: 1), Val(idx: 107, status: 1), Val(idx: 108, status: 3), Val(idx: 109,status: 0), Val(idx: 110, status: 3), Val(idx: 111, status: 1), Val(idx: 112, status: 3), Val(idx: 113, status: 4), Val(idx: 114, status: 3), Val(idx: 115, status: 3), Val(idx: 116, status: 4), Val(idx: 117, status: 0), Val(idx: 118, status: 1), Val(idx: 119, status: 0), Val(idx: 120, status: 3), Val(idx: 121, status: 3), Val(idx: 122, status: 1), Val(idx: 123, status: 4), Val(idx: 124, status: 2), Val(idx: 125, status: 0), Val(idx: 126, status: 3), Val(idx: 127, status: 2), Val(idx: 128, status: 3), Val(idx: 129, status: 0), Val(idx: 130, status: 4), Val(idx: 131, status: 3), Val(idx: 132, status: 1), Val(idx: 133, status: 3), Val(idx: 134, status: 3), Val(idx: 135, status: 4), Val(idx: 136, status: 3), Val(idx: 137, status: 0), Val(idx: 138, status: 0), Val(idx: 139, status: 1), Val(idx: 140, status: 0), Val(idx: 141, status: 2), Val(idx: 142, status: 4), Val(idx: 143, status: 1), Val(idx: 144, status: 3), Val(idx: 145, status: 1), Val(idx: 146, status: 3), Val(idx: 147, status: 2),Val(idx: 148, status: 4), Val(idx: 149, status: 2), Val(idx: 150, status: 2), Val(idx: 151, status: 0), Val(idx: 152, status: 3), Val(idx: 153, status: 2), Val(idx: 154, status: 3), Val(idx: 155, status: 1), Val(idx: 156, status: 3), Val(idx: 157, status: 0), Val(idx: 158, status: 2), Val(idx: 159, status: 1), Val(idx: 160, status: 3), Val(idx: 161, status: 2), Val(idx: 162, status: 2), Val(idx: 163, status: 1), Val(idx: 164, status: 3), Val(idx: 165, status: 0), Val(idx: 166, status: 2), Val(idx: 167, status: 1), Val(idx: 168, status: 3), Val(idx: 169, status: 2), Val(idx: 170, status: 2), Val(idx: 171, status: 2), Val(idx: 172, status: 0), Val(idx: 173, status: 0), Val(idx: 174, status: 0), Val(idx: 175, status: 3), Val(idx: 176, status:4), Val(idx: 177, status: 1), Val(idx: 178, status: 4), Val(idx: 179, status: 4), Val(idx: 180, status: 3), Val(idx: 181, status: 3), Val(idx: 182, status: 0), Val(idx: 183, status: 1), Val(idx: 184, status: 2), Val(idx: 185, status: 4), Val(idx: 186, status: 1), Val(idx: 187, status: 4), Val(idx: 188, status: 0), Val(idx: 189, status: 0), Val(idx: 190, status: 4), Val(idx: 191, status: 3), Val(idx: 192, status: 2), Val(idx: 193, status: 4), Val(idx: 194, status: 3), Val(idx: 195, status: 1), Val(idx: 196, status: 2), Val(idx: 197, status: 0), Val(idx: 198, status: 4), Val(idx: 199, status: 4), Val(idx: 200, status: 2), Val(idx: 201, status: 0), Val(idx: 202, status: 4), Val(idx: 203, status: 4), Val(idx: 204, status: 4), Val(idx: 205, status: 4), Val(idx: 206, status: 0), Val(idx: 207, status: 1), Val(idx: 208, status: 4), Val(idx: 209, status: 4), Val(idx: 210, status: 3), Val(idx: 211, status: 0), Val(idx: 212, status: 3), Val(idx: 213, status: 2), Val(idx: 214, status: 1), Val(idx: 215, status: 4), Val(idx: 216, status: 3), Val(idx: 217, status: 0), Val(idx: 218, status: 3), Val(idx: 219, status: 0), Val(idx: 220, status: 3), Val(idx: 221, status: 1), Val(idx: 222, status: 3), Val(idx: 223, status: 3), Val(idx: 224, status: 2), Val(idx: 225, status: 3), Val(idx: 226, status: 2), Val(idx: 227, status: 2), Val(idx: 228, status: 2), Val(idx: 229, status: 1), Val(idx: 230, status: 0), Val(idx: 231, status: 4), Val(idx: 232, status: 2), Val(idx: 233, status: 0), Val(idx: 234,status: 4), Val(idx: 235, status: 2), Val(idx: 236, status: 2), Val(idx: 237, status: 0), Val(idx: 238, status: 1), Val(idx: 239, status: 0), Val(idx: 240, status: 0), Val(idx: 241, status: 2), Val(idx: 242, status: 0), Val(idx: 243, status: 3), Val(idx: 244, status: 3), Val(idx: 245, status: 2), Val(idx: 246, status: 4), Val(idx: 247, status: 0), Val(idx: 248, status: 3), Val(idx: 249, status: 1), Val(idx: 250, status: 0), Val(idx: 251, status: 3), Val(idx: 252, status: 4), Val(idx: 253, status: 2), Val(idx: 254, status: 4), Val(idx: 255, status: 0)
crosslinking_start_shard: 361
shuffling: [Slot 0: SaC(shard: 361, comm: [71])
        [Slot 1: SaC(shard: 362, comm: [130, 17])
        [Slot 2: SaC(shard: 363, comm: [183])
        [Slot 3: SaC(shard: 364, comm: [10, 64])
        [Slot 4: SaC(shard: 365, comm: [202])
        [Slot 5: SaC(shard: 366, comm: [67, 143])
        [Slot 6: SaC(shard: 367, comm: [145])
        [Slot 7: SaC(shard: 368, comm: [111, 19])
        [Slot 8: SaC(shard: 369, comm: [56, 34])
        [Slot 9: SaC(shard: 370, comm: [234])
        [Slot 10: SaC(shard: 371, comm: [132, 26])
        [Slot 11: SaC(shard: 372, comm: [61])
        [Slot 12: SaC(shard: 373, comm: [122, 35])
        [Slot 13: SaC(shard: 374, comm: [91])
        [Slot 14: SaC(shard: 375, comm: [221, 207])
        [Slot 15: SaC(shard: 376, comm: [249, 85])
        [Slot 16: SaC(shard: 377, comm: [20])
        [Slot 17: SaC(shard: 378, comm: [78, 204])
        [Slot 18: SaC(shard: 379, comm: [187])
        [Slot 19: SaC(shard: 380, comm: [252, 193])
        [Slot 20: SaC(shard: 381, comm: [90])
        [Slot 21: SaC(shard: 382, comm: [178, 82])
        [Slot 22: SaC(shard: 383, comm: [203])
        [Slot 23: SaC(shard: 384, comm: [49, 208])
        [Slot 24: SaC(shard: 385, comm: [159, 238])
        [Slot 25: SaC(shard: 386, comm: [163])
        [Slot 26: SaC(shard: 387, comm: [118, 185])
        [Slot 27: SaC(shard: 388, comm: [75])
        [Slot 28: SaC(shard: 389, comm: [176, 16])
        [Slot 29: SaC(shard: 390, comm: [113])
        [Slot 30: SaC(shard: 391, comm: [123, 215])
        [Slot 31: SaC(shard: 392, comm: [29, 83])
        [Slot 32: SaC(shard: 393, comm: [199])
        [Slot 33: SaC(shard: 394, comm: [167, 36])
        [Slot 34: SaC(shard: 395, comm: [105])
        [Slot 35: SaC(shard: 396, comm: [42, 2])
        [Slot 36: SaC(shard: 397, comm: [14])
        [Slot 37: SaC(shard: 398, comm: [195, 231])
        [Slot 38: SaC(shard: 399, comm: [135])
        [Slot 39: SaC(shard: 400, comm: [80, 52])
        [Slot 40: SaC(shard: 401, comm: [44, 142])
        [Slot 41: SaC(shard: 402, comm: [76])
        [Slot 42: SaC(shard: 403, comm: [93, 148])
        [Slot 43: SaC(shard: 404, comm: [198])
        [Slot 44: SaC(shard: 405, comm: [186, 205])
        [Slot 45: SaC(shard: 406, comm: [139])
        [Slot 46: SaC(shard: 407, comm: [254, 177])
        [Slot 47: SaC(shard: 408, comm: [229, 77])
        [Slot 48: SaC(shard: 409, comm: [190])
        [Slot 49: SaC(shard: 410, comm: [48, 87])
        [Slot 50: SaC(shard: 411, comm: [95])
        [Slot 51: SaC(shard: 412, comm: [116, 74])
        [Slot 52: SaC(shard: 413, comm: [155])
        [Slot 53: SaC(shard: 414, comm: [68, 37])
        [Slot 54: SaC(shard: 415, comm: [214])
        [Slot 55: SaC(shard: 416, comm: [79, 58])
        [Slot 56: SaC(shard: 417, comm: [0, 179])
        [Slot 57: SaC(shard: 418, comm: [18])
        [Slot 58: SaC(shard: 419, comm: [209, 246])
        [Slot 59: SaC(shard: 420, comm: [32])
        [Slot 60: SaC(shard: 421, comm: [106, 72])
        [Slot 61: SaC(shard: 422, comm: [107])
        [Slot 62: SaC(shard: 423, comm: [7, 15])
        [Slot 63: SaC(shard: 424, comm: [40, 59])
```