### PR TITLE
Yaml shuffling test vectors generator

### DIFF
--- a/test_vectors_generator/test_vector_shuffling.yml
+++ b/test_vectors_generator/test_vector_shuffling.yml
@@ -8,1012 +8,1172 @@ test_cases:
     crosslinking_start_shard: 210
     validators:
     - original_index: 0
-      status: [2]
+      status: 2
     - original_index: 1
-      status: [4]
+      status: 4
     - original_index: 2
-      status: [0]
+      status: 0
     - original_index: 3
-      status: [0]
+      status: 0
     - original_index: 4
-      status: [2]
+      status: 2
     - original_index: 5
-      status: [2]
+      status: 2
     - original_index: 6
-      status: [4]
+      status: 4
     - original_index: 7
-      status: [2]
+      status: 2
     - original_index: 8
-      status: [3]
+      status: 3
     - original_index: 9
-      status: [1]
+      status: 1
     - original_index: 10
-      status: [0]
+      status: 0
     - original_index: 11
-      status: [3]
+      status: 3
     - original_index: 12
-      status: [3]
+      status: 3
     - original_index: 13
-      status: [4]
+      status: 4
     - original_index: 14
-      status: [4]
+      status: 4
     - original_index: 15
-      status: [4]
+      status: 4
     - original_index: 16
-      status: [1]
+      status: 1
     - original_index: 17
-      status: [1]
+      status: 1
     - original_index: 18
-      status: [1]
+      status: 1
     - original_index: 19
-      status: [1]
+      status: 1
     - original_index: 20
-      status: [3]
+      status: 3
     - original_index: 21
-      status: [2]
+      status: 2
     - original_index: 22
-      status: [3]
+      status: 3
     - original_index: 23
-      status: [0]
+      status: 0
     - original_index: 24
-      status: [2]
+      status: 2
     - original_index: 25
-      status: [4]
+      status: 4
     - original_index: 26
-      status: [0]
+      status: 0
     - original_index: 27
-      status: [2]
+      status: 2
     - original_index: 28
-      status: [4]
+      status: 4
     - original_index: 29
-      status: [0]
+      status: 0
     - original_index: 30
-      status: [0]
+      status: 0
     - original_index: 31
-      status: [4]
+      status: 4
     - original_index: 32
-      status: [2]
+      status: 2
     - original_index: 33
-      status: [1]
+      status: 1
     - original_index: 34
-      status: [4]
+      status: 4
     - original_index: 35
-      status: [1]
+      status: 1
     - original_index: 36
-      status: [4]
+      status: 4
     - original_index: 37
-      status: [2]
+      status: 2
     - original_index: 38
-      status: [2]
+      status: 2
     - original_index: 39
-      status: [1]
+      status: 1
     - original_index: 40
-      status: [2]
+      status: 2
     - original_index: 41
-      status: [4]
+      status: 4
     - original_index: 42
-      status: [0]
+      status: 0
     - original_index: 43
-      status: [4]
+      status: 4
     - original_index: 44
-      status: [0]
+      status: 0
     - original_index: 45
-      status: [3]
+      status: 3
     - original_index: 46
-      status: [0]
+      status: 0
     - original_index: 47
-      status: [4]
+      status: 4
     - original_index: 48
-      status: [4]
+      status: 4
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [0]
+      status: 0
     - original_index: 51
-      status: [1]
+      status: 1
     - original_index: 52
-      status: [3]
+      status: 3
     - original_index: 53
-      status: [3]
+      status: 3
     - original_index: 54
-      status: [0]
+      status: 0
     - original_index: 55
-      status: [4]
+      status: 4
     - original_index: 56
-      status: [3]
+      status: 3
     - original_index: 57
-      status: [1]
+      status: 1
     - original_index: 58
-      status: [1]
+      status: 1
     - original_index: 59
-      status: [3]
+      status: 3
     - original_index: 60
-      status: [1]
+      status: 1
     - original_index: 61
-      status: [0]
+      status: 0
     - original_index: 62
-      status: [0]
+      status: 0
     - original_index: 63
-      status: [1]
+      status: 1
     - original_index: 64
-      status: [0]
+      status: 0
     - original_index: 65
-      status: [0]
+      status: 0
     - original_index: 66
-      status: [4]
+      status: 4
     - original_index: 67
-      status: [1]
+      status: 1
     - original_index: 68
-      status: [2]
+      status: 2
     - original_index: 69
-      status: [0]
+      status: 0
     - original_index: 70
-      status: [1]
+      status: 1
     - original_index: 71
-      status: [4]
+      status: 4
     - original_index: 72
-      status: [2]
+      status: 2
     - original_index: 73
-      status: [1]
+      status: 1
     - original_index: 74
-      status: [1]
+      status: 1
     - original_index: 75
-      status: [4]
+      status: 4
     - original_index: 76
-      status: [1]
+      status: 1
     - original_index: 77
-      status: [1]
+      status: 1
     - original_index: 78
-      status: [1]
+      status: 1
     - original_index: 79
-      status: [1]
+      status: 1
     - original_index: 80
-      status: [0]
+      status: 0
     - original_index: 81
-      status: [4]
+      status: 4
     - original_index: 82
-      status: [4]
+      status: 4
     - original_index: 83
-      status: [0]
+      status: 0
     - original_index: 84
-      status: [1]
+      status: 1
     - original_index: 85
-      status: [3]
+      status: 3
     - original_index: 86
-      status: [4]
+      status: 4
     - original_index: 87
-      status: [2]
+      status: 2
     - original_index: 88
-      status: [0]
+      status: 0
     - original_index: 89
-      status: [1]
+      status: 1
     - original_index: 90
-      status: [4]
+      status: 4
     - original_index: 91
-      status: [3]
+      status: 3
     - original_index: 92
-      status: [1]
+      status: 1
     - original_index: 93
-      status: [2]
+      status: 2
     - original_index: 94
-      status: [4]
+      status: 4
     - original_index: 95
-      status: [2]
+      status: 2
     - original_index: 96
-      status: [2]
+      status: 2
     - original_index: 97
-      status: [2]
+      status: 2
     - original_index: 98
-      status: [3]
+      status: 3
     - original_index: 99
-      status: [3]
+      status: 3
     - original_index: 100
-      status: [3]
+      status: 3
     - original_index: 101
-      status: [0]
+      status: 0
     - original_index: 102
-      status: [2]
+      status: 2
     - original_index: 103
-      status: [0]
+      status: 0
     - original_index: 104
-      status: [4]
+      status: 4
     - original_index: 105
-      status: [1]
+      status: 1
     - original_index: 106
-      status: [1]
+      status: 1
     - original_index: 107
-      status: [3]
+      status: 3
     - original_index: 108
-      status: [0]
+      status: 0
     - original_index: 109
-      status: [3]
+      status: 3
     - original_index: 110
-      status: [1]
+      status: 1
     - original_index: 111
-      status: [3]
+      status: 3
     - original_index: 112
-      status: [4]
+      status: 4
     - original_index: 113
-      status: [3]
+      status: 3
     - original_index: 114
-      status: [3]
+      status: 3
     - original_index: 115
-      status: [4]
+      status: 4
     - original_index: 116
-      status: [0]
+      status: 0
     - original_index: 117
-      status: [1]
+      status: 1
     - original_index: 118
-      status: [0]
+      status: 0
     - original_index: 119
-      status: [3]
+      status: 3
     - original_index: 120
-      status: [3]
+      status: 3
     - original_index: 121
-      status: [1]
+      status: 1
     - original_index: 122
-      status: [4]
+      status: 4
     - original_index: 123
-      status: [2]
+      status: 2
     - original_index: 124
-      status: [0]
+      status: 0
     - original_index: 125
-      status: [3]
+      status: 3
     - original_index: 126
-      status: [2]
+      status: 2
     - original_index: 127
-      status: [3]
+      status: 3
     - original_index: 128
-      status: [0]
+      status: 0
     - original_index: 129
-      status: [4]
+      status: 4
     - original_index: 130
-      status: [3]
+      status: 3
     - original_index: 131
-      status: [1]
+      status: 1
     - original_index: 132
-      status: [3]
+      status: 3
     - original_index: 133
-      status: [3]
+      status: 3
     - original_index: 134
-      status: [4]
+      status: 4
     - original_index: 135
-      status: [3]
+      status: 3
     - original_index: 136
-      status: [0]
+      status: 0
     - original_index: 137
-      status: [0]
+      status: 0
     - original_index: 138
-      status: [1]
+      status: 1
     - original_index: 139
-      status: [0]
+      status: 0
     - original_index: 140
-      status: [2]
+      status: 2
     - original_index: 141
-      status: [4]
+      status: 4
     - original_index: 142
-      status: [1]
+      status: 1
     - original_index: 143
-      status: [3]
+      status: 3
     - original_index: 144
-      status: [1]
+      status: 1
     - original_index: 145
-      status: [3]
+      status: 3
     - original_index: 146
-      status: [2]
+      status: 2
     - original_index: 147
-      status: [4]
+      status: 4
     - original_index: 148
-      status: [2]
+      status: 2
     - original_index: 149
-      status: [2]
+      status: 2
     - original_index: 150
-      status: [0]
+      status: 0
     - original_index: 151
-      status: [3]
+      status: 3
     - original_index: 152
-      status: [2]
+      status: 2
     - original_index: 153
-      status: [3]
+      status: 3
     - original_index: 154
-      status: [1]
+      status: 1
     - original_index: 155
-      status: [3]
+      status: 3
     - original_index: 156
-      status: [0]
+      status: 0
     - original_index: 157
-      status: [2]
+      status: 2
     - original_index: 158
-      status: [1]
+      status: 1
     - original_index: 159
-      status: [3]
+      status: 3
     - original_index: 160
-      status: [2]
+      status: 2
     - original_index: 161
-      status: [2]
+      status: 2
     - original_index: 162
-      status: [1]
+      status: 1
     - original_index: 163
-      status: [3]
+      status: 3
     - original_index: 164
-      status: [0]
+      status: 0
     - original_index: 165
-      status: [2]
+      status: 2
     - original_index: 166
-      status: [1]
+      status: 1
     - original_index: 167
-      status: [3]
+      status: 3
     - original_index: 168
-      status: [2]
+      status: 2
     - original_index: 169
-      status: [2]
+      status: 2
     - original_index: 170
-      status: [2]
+      status: 2
     - original_index: 171
-      status: [0]
+      status: 0
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [0]
+      status: 0
     - original_index: 174
-      status: [3]
+      status: 3
     - original_index: 175
-      status: [4]
+      status: 4
     - original_index: 176
-      status: [1]
+      status: 1
     - original_index: 177
-      status: [4]
+      status: 4
     - original_index: 178
-      status: [4]
+      status: 4
     - original_index: 179
-      status: [3]
+      status: 3
     - original_index: 180
-      status: [3]
+      status: 3
     - original_index: 181
-      status: [0]
+      status: 0
     - original_index: 182
-      status: [1]
+      status: 1
     - original_index: 183
-      status: [2]
+      status: 2
     - original_index: 184
-      status: [4]
+      status: 4
     - original_index: 185
-      status: [1]
+      status: 1
     - original_index: 186
-      status: [4]
+      status: 4
     - original_index: 187
-      status: [0]
+      status: 0
     - original_index: 188
-      status: [0]
+      status: 0
     - original_index: 189
-      status: [4]
+      status: 4
     - original_index: 190
-      status: [3]
+      status: 3
     - original_index: 191
-      status: [2]
+      status: 2
     - original_index: 192
-      status: [4]
+      status: 4
     - original_index: 193
-      status: [3]
+      status: 3
     - original_index: 194
-      status: [1]
+      status: 1
     - original_index: 195
-      status: [2]
+      status: 2
     - original_index: 196
-      status: [0]
+      status: 0
     - original_index: 197
-      status: [4]
+      status: 4
     - original_index: 198
-      status: [4]
+      status: 4
     - original_index: 199
-      status: [2]
+      status: 2
     - original_index: 200
-      status: [0]
+      status: 0
     - original_index: 201
-      status: [4]
+      status: 4
     - original_index: 202
-      status: [4]
+      status: 4
     - original_index: 203
-      status: [4]
+      status: 4
     - original_index: 204
-      status: [4]
+      status: 4
     - original_index: 205
-      status: [0]
+      status: 0
     - original_index: 206
-      status: [1]
+      status: 1
     - original_index: 207
-      status: [4]
+      status: 4
     - original_index: 208
-      status: [4]
+      status: 4
     - original_index: 209
-      status: [3]
+      status: 3
     - original_index: 210
-      status: [0]
+      status: 0
     - original_index: 211
-      status: [3]
+      status: 3
     - original_index: 212
-      status: [2]
+      status: 2
     - original_index: 213
-      status: [1]
+      status: 1
     - original_index: 214
-      status: [4]
+      status: 4
     - original_index: 215
-      status: [3]
+      status: 3
     - original_index: 216
-      status: [0]
+      status: 0
     - original_index: 217
-      status: [3]
+      status: 3
     - original_index: 218
-      status: [0]
+      status: 0
     - original_index: 219
-      status: [3]
+      status: 3
     - original_index: 220
-      status: [1]
+      status: 1
     - original_index: 221
-      status: [3]
+      status: 3
     - original_index: 222
-      status: [3]
+      status: 3
     - original_index: 223
-      status: [2]
+      status: 2
     - original_index: 224
-      status: [3]
+      status: 3
     - original_index: 225
-      status: [2]
+      status: 2
     - original_index: 226
-      status: [2]
+      status: 2
     - original_index: 227
-      status: [2]
+      status: 2
     - original_index: 228
-      status: [1]
+      status: 1
     - original_index: 229
-      status: [0]
+      status: 0
     - original_index: 230
-      status: [4]
+      status: 4
     - original_index: 231
-      status: [2]
+      status: 2
     - original_index: 232
-      status: [0]
+      status: 0
     - original_index: 233
-      status: [4]
+      status: 4
     - original_index: 234
-      status: [2]
+      status: 2
     - original_index: 235
-      status: [2]
+      status: 2
     - original_index: 236
-      status: [0]
+      status: 0
     - original_index: 237
-      status: [1]
+      status: 1
     - original_index: 238
-      status: [0]
+      status: 0
     - original_index: 239
-      status: [0]
+      status: 0
     - original_index: 240
-      status: [2]
+      status: 2
     - original_index: 241
-      status: [0]
+      status: 0
     - original_index: 242
-      status: [3]
+      status: 3
     - original_index: 243
-      status: [3]
+      status: 3
     - original_index: 244
-      status: [2]
+      status: 2
     - original_index: 245
-      status: [4]
+      status: 4
     - original_index: 246
-      status: [0]
+      status: 0
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [1]
+      status: 1
     - original_index: 249
-      status: [0]
+      status: 0
     - original_index: 250
-      status: [3]
+      status: 3
     - original_index: 251
-      status: [4]
+      status: 4
     - original_index: 252
-      status: [2]
+      status: 2
     - original_index: 253
-      status: [4]
+      status: 4
     - original_index: 254
-      status: [0]
+      status: 0
     - original_index: 255
-      status: [1]
+      status: 1
     - original_index: 256
-      status: [4]
+      status: 4
     - original_index: 257
-      status: [1]
+      status: 1
     - original_index: 258
-      status: [0]
+      status: 0
     - original_index: 259
-      status: [0]
+      status: 0
     - original_index: 260
-      status: [4]
+      status: 4
     - original_index: 261
-      status: [3]
+      status: 3
     - original_index: 262
-      status: [3]
+      status: 3
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [1]
+      status: 1
     - original_index: 265
-      status: [4]
+      status: 4
     - original_index: 266
-      status: [1]
+      status: 1
     - original_index: 267
-      status: [3]
+      status: 3
     - original_index: 268
-      status: [1]
+      status: 1
     - original_index: 269
-      status: [0]
+      status: 0
     - original_index: 270
-      status: [4]
+      status: 4
     - original_index: 271
-      status: [3]
+      status: 3
     - original_index: 272
-      status: [3]
+      status: 3
     - original_index: 273
-      status: [0]
+      status: 0
     - original_index: 274
-      status: [2]
+      status: 2
     - original_index: 275
-      status: [1]
+      status: 1
     - original_index: 276
-      status: [3]
+      status: 3
     - original_index: 277
-      status: [4]
+      status: 4
     - original_index: 278
-      status: [1]
+      status: 1
     - original_index: 279
-      status: [3]
+      status: 3
     - original_index: 280
-      status: [3]
+      status: 3
     - original_index: 281
-      status: [3]
+      status: 3
     - original_index: 282
-      status: [0]
+      status: 0
     - original_index: 283
-      status: [4]
+      status: 4
     - original_index: 284
-      status: [2]
+      status: 2
     - original_index: 285
-      status: [3]
+      status: 3
     - original_index: 286
-      status: [0]
+      status: 0
     - original_index: 287
-      status: [0]
+      status: 0
     - original_index: 288
-      status: [0]
+      status: 0
     - original_index: 289
-      status: [1]
+      status: 1
     - original_index: 290
-      status: [4]
+      status: 4
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [1]
+      status: 1
     - original_index: 293
-      status: [4]
+      status: 4
     - original_index: 294
-      status: [2]
+      status: 2
     - original_index: 295
-      status: [0]
+      status: 0
     - original_index: 296
-      status: [4]
+      status: 4
     - original_index: 297
-      status: [2]
+      status: 2
     - original_index: 298
-      status: [3]
+      status: 3
     - original_index: 299
-      status: [0]
+      status: 0
     - original_index: 300
-      status: [1]
+      status: 1
     - original_index: 301
-      status: [2]
+      status: 2
     - original_index: 302
-      status: [0]
+      status: 0
     - original_index: 303
-      status: [4]
+      status: 4
     - original_index: 304
-      status: [0]
+      status: 0
     - original_index: 305
-      status: [4]
+      status: 4
     - original_index: 306
-      status: [4]
+      status: 4
     - original_index: 307
-      status: [2]
+      status: 2
     - original_index: 308
-      status: [1]
+      status: 1
     - original_index: 309
-      status: [3]
+      status: 3
     - original_index: 310
-      status: [4]
+      status: 4
     - original_index: 311
-      status: [3]
+      status: 3
     - original_index: 312
-      status: [2]
+      status: 2
     - original_index: 313
-      status: [3]
+      status: 3
     - original_index: 314
-      status: [3]
+      status: 3
     - original_index: 315
-      status: [4]
+      status: 4
     - original_index: 316
-      status: [3]
+      status: 3
     - original_index: 317
-      status: [2]
+      status: 2
     - original_index: 318
-      status: [2]
+      status: 2
     - original_index: 319
-      status: [1]
+      status: 1
     - original_index: 320
-      status: [3]
+      status: 3
     - original_index: 321
-      status: [0]
+      status: 0
     - original_index: 322
-      status: [3]
+      status: 3
     - original_index: 323
-      status: [2]
+      status: 2
     - original_index: 324
-      status: [1]
+      status: 1
     - original_index: 325
-      status: [0]
+      status: 0
     - original_index: 326
-      status: [1]
+      status: 1
     - original_index: 327
-      status: [3]
+      status: 3
     - original_index: 328
-      status: [2]
+      status: 2
     - original_index: 329
-      status: [0]
+      status: 0
     - original_index: 330
-      status: [0]
+      status: 0
     - original_index: 331
-      status: [0]
+      status: 0
     - original_index: 332
-      status: [1]
+      status: 1
     - original_index: 333
-      status: [1]
+      status: 1
     - original_index: 334
-      status: [2]
+      status: 2
     - original_index: 335
-      status: [2]
+      status: 2
     - original_index: 336
-      status: [0]
+      status: 0
     - original_index: 337
-      status: [3]
+      status: 3
     - original_index: 338
-      status: [1]
+      status: 1
     - original_index: 339
-      status: [0]
+      status: 0
     - original_index: 340
-      status: [3]
+      status: 3
     - original_index: 341
-      status: [2]
+      status: 2
     - original_index: 342
-      status: [0]
+      status: 0
     - original_index: 343
-      status: [0]
+      status: 0
     - original_index: 344
-      status: [2]
+      status: 2
     - original_index: 345
-      status: [3]
+      status: 3
     - original_index: 346
-      status: [0]
+      status: 0
     - original_index: 347
-      status: [0]
+      status: 0
     - original_index: 348
-      status: [4]
+      status: 4
     - original_index: 349
-      status: [4]
+      status: 4
     - original_index: 350
-      status: [2]
+      status: 2
     - original_index: 351
-      status: [0]
+      status: 0
     - original_index: 352
-      status: [1]
+      status: 1
     - original_index: 353
-      status: [1]
+      status: 1
     - original_index: 354
-      status: [3]
+      status: 3
     - original_index: 355
-      status: [0]
+      status: 0
     - original_index: 356
-      status: [1]
+      status: 1
     - original_index: 357
-      status: [0]
+      status: 0
     - original_index: 358
-      status: [1]
+      status: 1
     - original_index: 359
-      status: [1]
+      status: 1
     - original_index: 360
-      status: [3]
+      status: 3
     - original_index: 361
-      status: [4]
+      status: 4
     - original_index: 362
-      status: [0]
+      status: 0
     - original_index: 363
-      status: [0]
+      status: 0
     - original_index: 364
-      status: [3]
+      status: 3
     - original_index: 365
-      status: [4]
+      status: 4
     - original_index: 366
-      status: [4]
+      status: 4
     - original_index: 367
-      status: [4]
+      status: 4
     - original_index: 368
-      status: [0]
+      status: 0
     - original_index: 369
-      status: [2]
+      status: 2
     - original_index: 370
-      status: [4]
+      status: 4
     - original_index: 371
-      status: [4]
+      status: 4
     - original_index: 372
-      status: [1]
+      status: 1
     - original_index: 373
-      status: [0]
+      status: 0
     - original_index: 374
-      status: [2]
+      status: 2
     - original_index: 375
-      status: [2]
+      status: 2
     - original_index: 376
-      status: [3]
+      status: 3
     - original_index: 377
-      status: [4]
+      status: 4
     - original_index: 378
-      status: [4]
+      status: 4
     - original_index: 379
-      status: [0]
+      status: 0
     - original_index: 380
-      status: [1]
+      status: 1
     - original_index: 381
-      status: [3]
+      status: 3
     - original_index: 382
-      status: [2]
+      status: 2
     - original_index: 383
-      status: [4]
+      status: 4
     - original_index: 384
-      status: [0]
+      status: 0
     - original_index: 385
-      status: [1]
+      status: 1
     - original_index: 386
-      status: [2]
+      status: 2
     - original_index: 387
-      status: [1]
+      status: 1
     - original_index: 388
-      status: [3]
+      status: 3
     - original_index: 389
-      status: [3]
+      status: 3
     - original_index: 390
-      status: [0]
+      status: 0
     - original_index: 391
-      status: [3]
+      status: 3
     - original_index: 392
-      status: [4]
+      status: 4
     - original_index: 393
-      status: [1]
+      status: 1
     - original_index: 394
-      status: [3]
+      status: 3
     - original_index: 395
-      status: [1]
+      status: 1
     - original_index: 396
-      status: [0]
+      status: 0
     - original_index: 397
-      status: [1]
+      status: 1
     - original_index: 398
-      status: [0]
+      status: 0
     - original_index: 399
-      status: [4]
+      status: 4
     - original_index: 400
-      status: [4]
+      status: 4
     - original_index: 401
-      status: [3]
+      status: 3
     - original_index: 402
-      status: [4]
+      status: 4
     - original_index: 403
-      status: [1]
+      status: 1
     - original_index: 404
-      status: [0]
+      status: 0
     - original_index: 405
-      status: [3]
+      status: 3
     - original_index: 406
-      status: [1]
+      status: 1
     - original_index: 407
-      status: [3]
+      status: 3
   output:
-  - - committee: [131, 104]
+  - - committee:
+      - 131
+      - 104
       shard: 210
       total_validator_count: 160
-  - - committee: [1, 256, 16]
+  - - committee:
+      - 1
+      - 256
+      - 16
       shard: 211
       total_validator_count: 160
-  - - committee: [175, 255]
+  - - committee:
+      - 175
+      - 255
       shard: 212
       total_validator_count: 160
-  - - committee: [51, 333, 9]
+  - - committee:
+      - 51
+      - 333
+      - 9
       shard: 213
       total_validator_count: 160
-  - - committee: [182, 117]
+  - - committee:
+      - 182
+      - 117
       shard: 214
       total_validator_count: 160
-  - - committee: [400, 366, 399]
+  - - committee:
+      - 400
+      - 366
+      - 399
       shard: 215
       total_validator_count: 160
-  - - committee: [278, 214]
+  - - committee:
+      - 278
+      - 214
       shard: 216
       total_validator_count: 160
-  - - committee: [177, 352, 387]
+  - - committee:
+      - 177
+      - 352
+      - 387
       shard: 217
       total_validator_count: 160
-  - - committee: [106, 35]
+  - - committee:
+      - 106
+      - 35
       shard: 218
       total_validator_count: 160
-  - - committee: [293, 14, 33]
+  - - committee:
+      - 293
+      - 14
+      - 33
       shard: 219
       total_validator_count: 160
-  - - committee: [34, 122]
+  - - committee:
+      - 34
+      - 122
       shard: 220
       total_validator_count: 160
-  - - committee: [178, 305, 372]
+  - - committee:
+      - 178
+      - 305
+      - 372
       shard: 221
       total_validator_count: 160
-  - - committee: [358, 296]
+  - - committee:
+      - 358
+      - 296
       shard: 222
       total_validator_count: 160
-  - - committee: [115, 74, 393]
+  - - committee:
+      - 115
+      - 74
+      - 393
       shard: 223
       total_validator_count: 160
-  - - committee: [94, 192]
+  - - committee:
+      - 94
+      - 192
       shard: 224
       total_validator_count: 160
-  - - committee: [397, 202, 186]
+  - - committee:
+      - 397
+      - 202
+      - 186
       shard: 225
       total_validator_count: 160
-  - - committee: [81, 76]
+  - - committee:
+      - 81
+      - 76
       shard: 226
       total_validator_count: 160
-  - - committee: [90, 266, 58]
+  - - committee:
+      - 90
+      - 266
+      - 58
       shard: 227
       total_validator_count: 160
-  - - committee: [283, 47]
+  - - committee:
+      - 283
+      - 47
       shard: 228
       total_validator_count: 160
-  - - committee: [110, 89, 265]
+  - - committee:
+      - 110
+      - 89
+      - 265
       shard: 229
       total_validator_count: 160
-  - - committee: [201, 237]
+  - - committee:
+      - 201
+      - 237
       shard: 230
       total_validator_count: 160
-  - - committee: [75, 25, 263]
+  - - committee:
+      - 75
+      - 25
+      - 263
       shard: 231
       total_validator_count: 160
-  - - committee: [303, 86]
+  - - committee:
+      - 303
+      - 86
       shard: 232
       total_validator_count: 160
-  - - committee: [17, 82, 138]
+  - - committee:
+      - 17
+      - 82
+      - 138
       shard: 233
       total_validator_count: 160
-  - - committee: [338, 365]
+  - - committee:
+      - 338
+      - 365
       shard: 234
       total_validator_count: 160
-  - - committee: [308, 55, 332]
+  - - committee:
+      - 308
+      - 55
+      - 332
       shard: 235
       total_validator_count: 160
-  - - committee: [370, 275]
+  - - committee:
+      - 370
+      - 275
       shard: 236
       total_validator_count: 160
-  - - committee: [377, 57, 147]
+  - - committee:
+      - 377
+      - 57
+      - 147
       shard: 237
       total_validator_count: 160
-  - - committee: [112, 141]
+  - - committee:
+      - 112
+      - 141
       shard: 238
       total_validator_count: 160
-  - - committee: [204, 233, 207]
+  - - committee:
+      - 204
+      - 233
+      - 207
       shard: 239
       total_validator_count: 160
-  - - committee: [206, 78]
+  - - committee:
+      - 206
+      - 78
       shard: 240
       total_validator_count: 160
-  - - committee: [253, 367, 73]
+  - - committee:
+      - 253
+      - 367
+      - 73
       shard: 241
       total_validator_count: 160
-  - - committee: [402, 158]
+  - - committee:
+      - 402
+      - 158
       shard: 242
       total_validator_count: 160
-  - - committee: [248, 105, 70]
+  - - committee:
+      - 248
+      - 105
+      - 70
       shard: 243
       total_validator_count: 160
-  - - committee: [292, 289]
+  - - committee:
+      - 292
+      - 289
       shard: 244
       total_validator_count: 160
-  - - committee: [315, 395, 380]
+  - - committee:
+      - 315
+      - 395
+      - 380
       shard: 245
       total_validator_count: 160
-  - - committee: [60, 220]
+  - - committee:
+      - 60
+      - 220
       shard: 246
       total_validator_count: 160
-  - - committee: [213, 13, 121]
+  - - committee:
+      - 213
+      - 13
+      - 121
       shard: 247
       total_validator_count: 160
-  - - committee: [142, 31]
+  - - committee:
+      - 142
+      - 31
       shard: 248
       total_validator_count: 160
-  - - committee: [230, 129, 353]
+  - - committee:
+      - 230
+      - 129
+      - 353
       shard: 249
       total_validator_count: 160
-  - - committee: [378, 77]
+  - - committee:
+      - 378
+      - 77
       shard: 250
       total_validator_count: 160
-  - - committee: [15, 92, 166]
+  - - committee:
+      - 15
+      - 92
+      - 166
       shard: 251
       total_validator_count: 160
-  - - committee: [277, 260]
+  - - committee:
+      - 277
+      - 260
       shard: 252
       total_validator_count: 160
-  - - committee: [349, 403, 406]
+  - - committee:
+      - 349
+      - 403
+      - 406
       shard: 253
       total_validator_count: 160
-  - - committee: [185, 36]
+  - - committee:
+      - 185
+      - 36
       shard: 254
       total_validator_count: 160
-  - - committee: [28, 18, 270]
+  - - committee:
+      - 28
+      - 18
+      - 270
       shard: 255
       total_validator_count: 160
-  - - committee: [39, 197]
+  - - committee:
+      - 39
+      - 197
       shard: 256
       total_validator_count: 160
-  - - committee: [383, 134, 228]
+  - - committee:
+      - 383
+      - 134
+      - 228
       shard: 257
       total_validator_count: 160
-  - - committee: [257, 79]
+  - - committee:
+      - 257
+      - 79
       shard: 258
       total_validator_count: 160
-  - - committee: [319, 245, 144]
+  - - committee:
+      - 319
+      - 245
+      - 144
       shard: 259
       total_validator_count: 160
-  - - committee: [84, 356]
+  - - committee:
+      - 84
+      - 356
       shard: 260
       total_validator_count: 160
-  - - committee: [359, 184, 324]
+  - - committee:
+      - 359
+      - 184
+      - 324
       shard: 261
       total_validator_count: 160
-  - - committee: [67, 41]
+  - - committee:
+      - 67
+      - 41
       shard: 262
       total_validator_count: 160
-  - - committee: [290, 63, 176]
+  - - committee:
+      - 290
+      - 63
+      - 176
       shard: 263
       total_validator_count: 160
-  - - committee: [385, 154]
+  - - committee:
+      - 385
+      - 154
       shard: 264
       total_validator_count: 160
-  - - committee: [66, 43, 162]
+  - - committee:
+      - 66
+      - 43
+      - 162
       shard: 265
       total_validator_count: 160
-  - - committee: [306, 251]
+  - - committee:
+      - 306
+      - 251
       shard: 266
       total_validator_count: 160
-  - - committee: [310, 189, 208]
+  - - committee:
+      - 310
+      - 189
+      - 208
       shard: 267
       total_validator_count: 160
-  - - committee: [198, 48]
+  - - committee:
+      - 198
+      - 48
       shard: 268
       total_validator_count: 160
-  - - committee: [348, 19, 392]
+  - - committee:
+      - 348
+      - 19
+      - 392
       shard: 269
       total_validator_count: 160
-  - - committee: [326, 71]
+  - - committee:
+      - 326
+      - 71
       shard: 270
       total_validator_count: 160
-  - - committee: [268, 203, 264]
+  - - committee:
+      - 268
+      - 203
+      - 264
       shard: 271
       total_validator_count: 160
-  - - committee: [361, 6]
+  - - committee:
+      - 361
+      - 6
       shard: 272
       total_validator_count: 160
-  - - committee: [300, 194, 371]
+  - - committee:
+      - 300
+      - 194
+      - 371
       shard: 273
       total_validator_count: 160
   seed: '0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d'
@@ -1021,1132 +1181,1305 @@ test_cases:
     crosslinking_start_shard: 102
     validators:
     - original_index: 0
-      status: [3]
+      status: 3
     - original_index: 1
-      status: [2]
+      status: 2
     - original_index: 2
-      status: [4]
+      status: 4
     - original_index: 3
-      status: [4]
+      status: 4
     - original_index: 4
-      status: [3]
+      status: 3
     - original_index: 5
-      status: [1]
+      status: 1
     - original_index: 6
-      status: [0]
+      status: 0
     - original_index: 7
-      status: [4]
+      status: 4
     - original_index: 8
-      status: [3]
+      status: 3
     - original_index: 9
-      status: [3]
+      status: 3
     - original_index: 10
-      status: [3]
+      status: 3
     - original_index: 11
-      status: [3]
+      status: 3
     - original_index: 12
-      status: [4]
+      status: 4
     - original_index: 13
-      status: [2]
+      status: 2
     - original_index: 14
-      status: [1]
+      status: 1
     - original_index: 15
-      status: [1]
+      status: 1
     - original_index: 16
-      status: [3]
+      status: 3
     - original_index: 17
-      status: [4]
+      status: 4
     - original_index: 18
-      status: [1]
+      status: 1
     - original_index: 19
-      status: [1]
+      status: 1
     - original_index: 20
-      status: [3]
+      status: 3
     - original_index: 21
-      status: [0]
+      status: 0
     - original_index: 22
-      status: [4]
+      status: 4
     - original_index: 23
-      status: [0]
+      status: 0
     - original_index: 24
-      status: [2]
+      status: 2
     - original_index: 25
-      status: [4]
+      status: 4
     - original_index: 26
-      status: [1]
+      status: 1
     - original_index: 27
-      status: [1]
+      status: 1
     - original_index: 28
-      status: [3]
+      status: 3
     - original_index: 29
-      status: [4]
+      status: 4
     - original_index: 30
-      status: [1]
+      status: 1
     - original_index: 31
-      status: [0]
+      status: 0
     - original_index: 32
-      status: [2]
+      status: 2
     - original_index: 33
-      status: [3]
+      status: 3
     - original_index: 34
-      status: [4]
+      status: 4
     - original_index: 35
-      status: [2]
+      status: 2
     - original_index: 36
-      status: [2]
+      status: 2
     - original_index: 37
-      status: [4]
+      status: 4
     - original_index: 38
-      status: [1]
+      status: 1
     - original_index: 39
-      status: [4]
+      status: 4
     - original_index: 40
-      status: [4]
+      status: 4
     - original_index: 41
-      status: [2]
+      status: 2
     - original_index: 42
-      status: [0]
+      status: 0
     - original_index: 43
-      status: [2]
+      status: 2
     - original_index: 44
-      status: [4]
+      status: 4
     - original_index: 45
-      status: [0]
+      status: 0
     - original_index: 46
-      status: [1]
+      status: 1
     - original_index: 47
-      status: [4]
+      status: 4
     - original_index: 48
-      status: [0]
+      status: 0
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [1]
+      status: 1
     - original_index: 51
-      status: [3]
+      status: 3
     - original_index: 52
-      status: [0]
+      status: 0
     - original_index: 53
-      status: [3]
+      status: 3
     - original_index: 54
-      status: [0]
+      status: 0
     - original_index: 55
-      status: [2]
+      status: 2
     - original_index: 56
-      status: [2]
+      status: 2
     - original_index: 57
-      status: [3]
+      status: 3
     - original_index: 58
-      status: [4]
+      status: 4
     - original_index: 59
-      status: [3]
+      status: 3
     - original_index: 60
-      status: [0]
+      status: 0
     - original_index: 61
-      status: [1]
+      status: 1
     - original_index: 62
-      status: [0]
+      status: 0
     - original_index: 63
-      status: [0]
+      status: 0
     - original_index: 64
-      status: [3]
+      status: 3
     - original_index: 65
-      status: [4]
+      status: 4
     - original_index: 66
-      status: [1]
+      status: 1
     - original_index: 67
-      status: [0]
+      status: 0
     - original_index: 68
-      status: [3]
+      status: 3
     - original_index: 69
-      status: [2]
+      status: 2
     - original_index: 70
-      status: [3]
+      status: 3
     - original_index: 71
-      status: [4]
+      status: 4
     - original_index: 72
-      status: [3]
+      status: 3
     - original_index: 73
-      status: [1]
+      status: 1
     - original_index: 74
-      status: [0]
+      status: 0
     - original_index: 75
-      status: [4]
+      status: 4
     - original_index: 76
-      status: [0]
+      status: 0
     - original_index: 77
-      status: [3]
+      status: 3
     - original_index: 78
-      status: [4]
+      status: 4
     - original_index: 79
-      status: [3]
+      status: 3
     - original_index: 80
-      status: [3]
+      status: 3
     - original_index: 81
-      status: [0]
+      status: 0
     - original_index: 82
-      status: [3]
+      status: 3
     - original_index: 83
-      status: [1]
+      status: 1
     - original_index: 84
-      status: [4]
+      status: 4
     - original_index: 85
-      status: [0]
+      status: 0
     - original_index: 86
-      status: [2]
+      status: 2
     - original_index: 87
-      status: [1]
+      status: 1
     - original_index: 88
-      status: [4]
+      status: 4
     - original_index: 89
-      status: [4]
+      status: 4
     - original_index: 90
-      status: [4]
+      status: 4
     - original_index: 91
-      status: [3]
+      status: 3
     - original_index: 92
-      status: [3]
+      status: 3
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [4]
+      status: 4
     - original_index: 95
-      status: [3]
+      status: 3
     - original_index: 96
-      status: [2]
+      status: 2
     - original_index: 97
-      status: [2]
+      status: 2
     - original_index: 98
-      status: [2]
+      status: 2
     - original_index: 99
-      status: [3]
+      status: 3
     - original_index: 100
-      status: [2]
+      status: 2
     - original_index: 101
-      status: [2]
+      status: 2
     - original_index: 102
-      status: [1]
+      status: 1
     - original_index: 103
-      status: [2]
+      status: 2
     - original_index: 104
-      status: [3]
+      status: 3
     - original_index: 105
-      status: [3]
+      status: 3
     - original_index: 106
-      status: [3]
+      status: 3
     - original_index: 107
-      status: [0]
+      status: 0
     - original_index: 108
-      status: [3]
+      status: 3
     - original_index: 109
-      status: [2]
+      status: 2
     - original_index: 110
-      status: [1]
+      status: 1
     - original_index: 111
-      status: [4]
+      status: 4
     - original_index: 112
-      status: [3]
+      status: 3
     - original_index: 113
-      status: [4]
+      status: 4
     - original_index: 114
-      status: [2]
+      status: 2
     - original_index: 115
-      status: [4]
+      status: 4
     - original_index: 116
-      status: [0]
+      status: 0
     - original_index: 117
-      status: [1]
+      status: 1
     - original_index: 118
-      status: [2]
+      status: 2
     - original_index: 119
-      status: [1]
+      status: 1
     - original_index: 120
-      status: [0]
+      status: 0
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [3]
+      status: 3
     - original_index: 124
-      status: [3]
+      status: 3
     - original_index: 125
-      status: [3]
+      status: 3
     - original_index: 126
-      status: [1]
+      status: 1
     - original_index: 127
-      status: [4]
+      status: 4
     - original_index: 128
-      status: [2]
+      status: 2
     - original_index: 129
-      status: [1]
+      status: 1
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [1]
+      status: 1
     - original_index: 132
-      status: [0]
+      status: 0
     - original_index: 133
-      status: [3]
+      status: 3
     - original_index: 134
-      status: [3]
+      status: 3
     - original_index: 135
-      status: [4]
+      status: 4
     - original_index: 136
-      status: [3]
+      status: 3
     - original_index: 137
-      status: [1]
+      status: 1
     - original_index: 138
-      status: [1]
+      status: 1
     - original_index: 139
-      status: [1]
+      status: 1
     - original_index: 140
-      status: [3]
+      status: 3
     - original_index: 141
-      status: [1]
+      status: 1
     - original_index: 142
-      status: [3]
+      status: 3
     - original_index: 143
-      status: [2]
+      status: 2
     - original_index: 144
-      status: [4]
+      status: 4
     - original_index: 145
-      status: [2]
+      status: 2
     - original_index: 146
-      status: [2]
+      status: 2
     - original_index: 147
-      status: [0]
+      status: 0
     - original_index: 148
-      status: [3]
+      status: 3
     - original_index: 149
-      status: [3]
+      status: 3
     - original_index: 150
-      status: [1]
+      status: 1
     - original_index: 151
-      status: [0]
+      status: 0
     - original_index: 152
-      status: [2]
+      status: 2
     - original_index: 153
-      status: [0]
+      status: 0
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [1]
+      status: 1
     - original_index: 156
-      status: [2]
+      status: 2
     - original_index: 157
-      status: [0]
+      status: 0
     - original_index: 158
-      status: [3]
+      status: 3
     - original_index: 159
-      status: [2]
+      status: 2
     - original_index: 160
-      status: [2]
+      status: 2
     - original_index: 161
-      status: [3]
+      status: 3
     - original_index: 162
-      status: [1]
+      status: 1
     - original_index: 163
-      status: [0]
+      status: 0
     - original_index: 164
-      status: [3]
+      status: 3
     - original_index: 165
-      status: [3]
+      status: 3
     - original_index: 166
-      status: [0]
+      status: 0
     - original_index: 167
-      status: [1]
+      status: 1
     - original_index: 168
-      status: [0]
+      status: 0
     - original_index: 169
-      status: [1]
+      status: 1
     - original_index: 170
-      status: [0]
+      status: 0
     - original_index: 171
-      status: [0]
+      status: 0
     - original_index: 172
-      status: [2]
+      status: 2
     - original_index: 173
-      status: [2]
+      status: 2
     - original_index: 174
-      status: [3]
+      status: 3
     - original_index: 175
-      status: [0]
+      status: 0
     - original_index: 176
-      status: [4]
+      status: 4
     - original_index: 177
-      status: [1]
+      status: 1
     - original_index: 178
-      status: [4]
+      status: 4
     - original_index: 179
-      status: [1]
+      status: 1
     - original_index: 180
-      status: [1]
+      status: 1
     - original_index: 181
-      status: [3]
+      status: 3
     - original_index: 182
-      status: [2]
+      status: 2
     - original_index: 183
-      status: [2]
+      status: 2
     - original_index: 184
-      status: [1]
+      status: 1
     - original_index: 185
-      status: [0]
+      status: 0
     - original_index: 186
-      status: [3]
+      status: 3
     - original_index: 187
-      status: [2]
+      status: 2
     - original_index: 188
-      status: [0]
+      status: 0
     - original_index: 189
-      status: [1]
+      status: 1
     - original_index: 190
-      status: [0]
+      status: 0
     - original_index: 191
-      status: [2]
+      status: 2
     - original_index: 192
-      status: [2]
+      status: 2
     - original_index: 193
-      status: [0]
+      status: 0
     - original_index: 194
-      status: [2]
+      status: 2
     - original_index: 195
-      status: [1]
+      status: 1
     - original_index: 196
-      status: [0]
+      status: 0
     - original_index: 197
-      status: [1]
+      status: 1
     - original_index: 198
-      status: [0]
+      status: 0
     - original_index: 199
-      status: [0]
+      status: 0
     - original_index: 200
-      status: [3]
+      status: 3
     - original_index: 201
-      status: [1]
+      status: 1
     - original_index: 202
-      status: [1]
+      status: 1
     - original_index: 203
-      status: [2]
+      status: 2
     - original_index: 204
-      status: [3]
+      status: 3
     - original_index: 205
-      status: [0]
+      status: 0
     - original_index: 206
-      status: [0]
+      status: 0
     - original_index: 207
-      status: [3]
+      status: 3
     - original_index: 208
-      status: [1]
+      status: 1
     - original_index: 209
-      status: [2]
+      status: 2
     - original_index: 210
-      status: [3]
+      status: 3
     - original_index: 211
-      status: [1]
+      status: 1
     - original_index: 212
-      status: [3]
+      status: 3
     - original_index: 213
-      status: [3]
+      status: 3
     - original_index: 214
-      status: [3]
+      status: 3
     - original_index: 215
-      status: [4]
+      status: 4
     - original_index: 216
-      status: [4]
+      status: 4
     - original_index: 217
-      status: [2]
+      status: 2
     - original_index: 218
-      status: [4]
+      status: 4
     - original_index: 219
-      status: [3]
+      status: 3
     - original_index: 220
-      status: [1]
+      status: 1
     - original_index: 221
-      status: [2]
+      status: 2
     - original_index: 222
-      status: [1]
+      status: 1
     - original_index: 223
-      status: [4]
+      status: 4
     - original_index: 224
-      status: [3]
+      status: 3
     - original_index: 225
-      status: [4]
+      status: 4
     - original_index: 226
-      status: [4]
+      status: 4
     - original_index: 227
-      status: [3]
+      status: 3
     - original_index: 228
-      status: [0]
+      status: 0
     - original_index: 229
-      status: [3]
+      status: 3
     - original_index: 230
-      status: [4]
+      status: 4
     - original_index: 231
-      status: [2]
+      status: 2
     - original_index: 232
-      status: [3]
+      status: 3
     - original_index: 233
-      status: [3]
+      status: 3
     - original_index: 234
-      status: [2]
+      status: 2
     - original_index: 235
-      status: [4]
+      status: 4
     - original_index: 236
-      status: [3]
+      status: 3
     - original_index: 237
-      status: [2]
+      status: 2
     - original_index: 238
-      status: [4]
+      status: 4
     - original_index: 239
-      status: [1]
+      status: 1
     - original_index: 240
-      status: [4]
+      status: 4
     - original_index: 241
-      status: [2]
+      status: 2
     - original_index: 242
-      status: [1]
+      status: 1
     - original_index: 243
-      status: [3]
+      status: 3
     - original_index: 244
-      status: [4]
+      status: 4
     - original_index: 245
-      status: [0]
+      status: 0
     - original_index: 246
-      status: [1]
+      status: 1
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [0]
+      status: 0
     - original_index: 249
-      status: [0]
+      status: 0
     - original_index: 250
-      status: [1]
+      status: 1
     - original_index: 251
-      status: [2]
+      status: 2
     - original_index: 252
-      status: [0]
+      status: 0
     - original_index: 253
-      status: [4]
+      status: 4
     - original_index: 254
-      status: [0]
+      status: 0
     - original_index: 255
-      status: [2]
+      status: 2
     - original_index: 256
-      status: [4]
+      status: 4
     - original_index: 257
-      status: [3]
+      status: 3
     - original_index: 258
-      status: [1]
+      status: 1
     - original_index: 259
-      status: [0]
+      status: 0
     - original_index: 260
-      status: [0]
+      status: 0
     - original_index: 261
-      status: [1]
+      status: 1
     - original_index: 262
-      status: [4]
+      status: 4
     - original_index: 263
-      status: [3]
+      status: 3
     - original_index: 264
-      status: [2]
+      status: 2
     - original_index: 265
-      status: [4]
+      status: 4
     - original_index: 266
-      status: [0]
+      status: 0
     - original_index: 267
-      status: [2]
+      status: 2
     - original_index: 268
-      status: [3]
+      status: 3
     - original_index: 269
-      status: [1]
+      status: 1
     - original_index: 270
-      status: [4]
+      status: 4
     - original_index: 271
-      status: [0]
+      status: 0
     - original_index: 272
-      status: [2]
+      status: 2
     - original_index: 273
-      status: [2]
+      status: 2
     - original_index: 274
-      status: [1]
+      status: 1
     - original_index: 275
-      status: [0]
+      status: 0
     - original_index: 276
-      status: [0]
+      status: 0
     - original_index: 277
-      status: [2]
+      status: 2
     - original_index: 278
-      status: [0]
+      status: 0
     - original_index: 279
-      status: [2]
+      status: 2
     - original_index: 280
-      status: [0]
+      status: 0
     - original_index: 281
-      status: [3]
+      status: 3
     - original_index: 282
-      status: [3]
+      status: 3
     - original_index: 283
-      status: [3]
+      status: 3
     - original_index: 284
-      status: [0]
+      status: 0
     - original_index: 285
-      status: [2]
+      status: 2
     - original_index: 286
-      status: [2]
+      status: 2
     - original_index: 287
-      status: [4]
+      status: 4
     - original_index: 288
-      status: [2]
+      status: 2
     - original_index: 289
-      status: [3]
+      status: 3
     - original_index: 290
-      status: [3]
+      status: 3
     - original_index: 291
-      status: [1]
+      status: 1
     - original_index: 292
-      status: [2]
+      status: 2
     - original_index: 293
-      status: [1]
+      status: 1
     - original_index: 294
-      status: [3]
+      status: 3
     - original_index: 295
-      status: [1]
+      status: 1
     - original_index: 296
-      status: [0]
+      status: 0
     - original_index: 297
-      status: [2]
+      status: 2
     - original_index: 298
-      status: [3]
+      status: 3
     - original_index: 299
-      status: [0]
+      status: 0
     - original_index: 300
-      status: [3]
+      status: 3
     - original_index: 301
-      status: [0]
+      status: 0
     - original_index: 302
-      status: [4]
+      status: 4
     - original_index: 303
-      status: [4]
+      status: 4
     - original_index: 304
-      status: [4]
+      status: 4
     - original_index: 305
-      status: [3]
+      status: 3
     - original_index: 306
-      status: [4]
+      status: 4
     - original_index: 307
-      status: [0]
+      status: 0
     - original_index: 308
-      status: [2]
+      status: 2
     - original_index: 309
-      status: [3]
+      status: 3
     - original_index: 310
-      status: [3]
+      status: 3
     - original_index: 311
-      status: [3]
+      status: 3
     - original_index: 312
-      status: [4]
+      status: 4
     - original_index: 313
-      status: [4]
+      status: 4
     - original_index: 314
-      status: [0]
+      status: 0
     - original_index: 315
-      status: [4]
+      status: 4
     - original_index: 316
-      status: [4]
+      status: 4
     - original_index: 317
-      status: [1]
+      status: 1
     - original_index: 318
-      status: [0]
+      status: 0
     - original_index: 319
-      status: [2]
+      status: 2
     - original_index: 320
-      status: [3]
+      status: 3
     - original_index: 321
-      status: [4]
+      status: 4
     - original_index: 322
-      status: [2]
+      status: 2
     - original_index: 323
-      status: [3]
+      status: 3
     - original_index: 324
-      status: [3]
+      status: 3
     - original_index: 325
-      status: [3]
+      status: 3
     - original_index: 326
-      status: [4]
+      status: 4
     - original_index: 327
-      status: [4]
+      status: 4
     - original_index: 328
-      status: [1]
+      status: 1
     - original_index: 329
-      status: [1]
+      status: 1
     - original_index: 330
-      status: [0]
+      status: 0
     - original_index: 331
-      status: [0]
+      status: 0
     - original_index: 332
-      status: [4]
+      status: 4
     - original_index: 333
-      status: [4]
+      status: 4
     - original_index: 334
-      status: [1]
+      status: 1
     - original_index: 335
-      status: [3]
+      status: 3
     - original_index: 336
-      status: [0]
+      status: 0
     - original_index: 337
-      status: [2]
+      status: 2
     - original_index: 338
-      status: [2]
+      status: 2
     - original_index: 339
-      status: [1]
+      status: 1
     - original_index: 340
-      status: [2]
+      status: 2
     - original_index: 341
-      status: [4]
+      status: 4
     - original_index: 342
-      status: [2]
+      status: 2
     - original_index: 343
-      status: [0]
+      status: 0
     - original_index: 344
-      status: [1]
+      status: 1
     - original_index: 345
-      status: [3]
+      status: 3
     - original_index: 346
-      status: [2]
+      status: 2
     - original_index: 347
-      status: [0]
+      status: 0
     - original_index: 348
-      status: [2]
+      status: 2
     - original_index: 349
-      status: [2]
+      status: 2
     - original_index: 350
-      status: [3]
+      status: 3
     - original_index: 351
-      status: [3]
+      status: 3
     - original_index: 352
-      status: [3]
+      status: 3
     - original_index: 353
-      status: [2]
+      status: 2
     - original_index: 354
-      status: [3]
+      status: 3
     - original_index: 355
-      status: [0]
+      status: 0
     - original_index: 356
-      status: [4]
+      status: 4
     - original_index: 357
-      status: [1]
+      status: 1
     - original_index: 358
-      status: [2]
+      status: 2
     - original_index: 359
-      status: [4]
+      status: 4
     - original_index: 360
-      status: [0]
+      status: 0
     - original_index: 361
-      status: [1]
+      status: 1
     - original_index: 362
-      status: [1]
+      status: 1
     - original_index: 363
-      status: [3]
+      status: 3
     - original_index: 364
-      status: [3]
+      status: 3
     - original_index: 365
-      status: [3]
+      status: 3
     - original_index: 366
-      status: [4]
+      status: 4
     - original_index: 367
-      status: [3]
+      status: 3
     - original_index: 368
-      status: [3]
+      status: 3
     - original_index: 369
-      status: [2]
+      status: 2
     - original_index: 370
-      status: [1]
+      status: 1
     - original_index: 371
-      status: [0]
+      status: 0
     - original_index: 372
-      status: [2]
+      status: 2
     - original_index: 373
-      status: [2]
+      status: 2
     - original_index: 374
-      status: [0]
+      status: 0
     - original_index: 375
-      status: [4]
+      status: 4
     - original_index: 376
-      status: [3]
+      status: 3
     - original_index: 377
-      status: [0]
+      status: 0
     - original_index: 378
-      status: [2]
+      status: 2
     - original_index: 379
-      status: [3]
+      status: 3
     - original_index: 380
-      status: [1]
+      status: 1
     - original_index: 381
-      status: [4]
+      status: 4
     - original_index: 382
-      status: [4]
+      status: 4
     - original_index: 383
-      status: [2]
+      status: 2
     - original_index: 384
-      status: [4]
+      status: 4
     - original_index: 385
-      status: [0]
+      status: 0
     - original_index: 386
-      status: [0]
+      status: 0
     - original_index: 387
-      status: [2]
+      status: 2
     - original_index: 388
-      status: [1]
+      status: 1
     - original_index: 389
-      status: [4]
+      status: 4
     - original_index: 390
-      status: [3]
+      status: 3
     - original_index: 391
-      status: [4]
+      status: 4
     - original_index: 392
-      status: [2]
+      status: 2
     - original_index: 393
-      status: [1]
+      status: 1
     - original_index: 394
-      status: [3]
+      status: 3
     - original_index: 395
-      status: [4]
+      status: 4
     - original_index: 396
-      status: [2]
+      status: 2
     - original_index: 397
-      status: [4]
+      status: 4
     - original_index: 398
-      status: [0]
+      status: 0
     - original_index: 399
-      status: [4]
+      status: 4
     - original_index: 400
-      status: [4]
+      status: 4
     - original_index: 401
-      status: [2]
+      status: 2
     - original_index: 402
-      status: [3]
+      status: 3
     - original_index: 403
-      status: [0]
+      status: 0
     - original_index: 404
-      status: [2]
+      status: 2
     - original_index: 405
-      status: [4]
+      status: 4
     - original_index: 406
-      status: [4]
+      status: 4
     - original_index: 407
-      status: [1]
+      status: 1
     - original_index: 408
-      status: [0]
+      status: 0
     - original_index: 409
-      status: [2]
+      status: 2
     - original_index: 410
-      status: [1]
+      status: 1
     - original_index: 411
-      status: [3]
+      status: 3
     - original_index: 412
-      status: [3]
+      status: 3
     - original_index: 413
-      status: [4]
+      status: 4
     - original_index: 414
-      status: [2]
+      status: 2
     - original_index: 415
-      status: [2]
+      status: 2
     - original_index: 416
-      status: [0]
+      status: 0
     - original_index: 417
-      status: [1]
+      status: 1
     - original_index: 418
-      status: [0]
+      status: 0
     - original_index: 419
-      status: [1]
+      status: 1
     - original_index: 420
-      status: [2]
+      status: 2
     - original_index: 421
-      status: [4]
+      status: 4
     - original_index: 422
-      status: [2]
+      status: 2
     - original_index: 423
-      status: [0]
+      status: 0
     - original_index: 424
-      status: [3]
+      status: 3
     - original_index: 425
-      status: [1]
+      status: 1
     - original_index: 426
-      status: [2]
+      status: 2
     - original_index: 427
-      status: [4]
+      status: 4
     - original_index: 428
-      status: [4]
+      status: 4
     - original_index: 429
-      status: [2]
+      status: 2
     - original_index: 430
-      status: [4]
+      status: 4
     - original_index: 431
-      status: [2]
+      status: 2
     - original_index: 432
-      status: [1]
+      status: 1
     - original_index: 433
-      status: [0]
+      status: 0
     - original_index: 434
-      status: [3]
+      status: 3
     - original_index: 435
-      status: [3]
+      status: 3
     - original_index: 436
-      status: [0]
+      status: 0
     - original_index: 437
-      status: [1]
+      status: 1
     - original_index: 438
-      status: [0]
+      status: 0
     - original_index: 439
-      status: [1]
+      status: 1
     - original_index: 440
-      status: [1]
+      status: 1
     - original_index: 441
-      status: [1]
+      status: 1
     - original_index: 442
-      status: [3]
+      status: 3
     - original_index: 443
-      status: [3]
+      status: 3
     - original_index: 444
-      status: [0]
+      status: 0
     - original_index: 445
-      status: [0]
+      status: 0
     - original_index: 446
-      status: [4]
+      status: 4
     - original_index: 447
-      status: [4]
+      status: 4
     - original_index: 448
-      status: [0]
+      status: 0
     - original_index: 449
-      status: [2]
+      status: 2
     - original_index: 450
-      status: [4]
+      status: 4
     - original_index: 451
-      status: [2]
+      status: 2
     - original_index: 452
-      status: [4]
+      status: 4
     - original_index: 453
-      status: [3]
+      status: 3
     - original_index: 454
-      status: [2]
+      status: 2
     - original_index: 455
-      status: [2]
+      status: 2
     - original_index: 456
-      status: [0]
+      status: 0
     - original_index: 457
-      status: [1]
+      status: 1
     - original_index: 458
-      status: [1]
+      status: 1
     - original_index: 459
-      status: [3]
+      status: 3
     - original_index: 460
-      status: [3]
+      status: 3
     - original_index: 461
-      status: [2]
+      status: 2
     - original_index: 462
-      status: [1]
+      status: 1
     - original_index: 463
-      status: [4]
+      status: 4
     - original_index: 464
-      status: [0]
+      status: 0
     - original_index: 465
-      status: [0]
+      status: 0
     - original_index: 466
-      status: [1]
+      status: 1
     - original_index: 467
-      status: [0]
+      status: 0
   output:
-  - - committee: [202, 39]
+  - - committee:
+      - 202
+      - 39
       shard: 102
       total_validator_count: 173
-  - - committee: [384, 417, 46]
+  - - committee:
+      - 384
+      - 417
+      - 46
       shard: 103
       total_validator_count: 173
-  - - committee: [119, 235, 400]
+  - - committee:
+      - 119
+      - 235
+      - 400
       shard: 104
       total_validator_count: 173
-  - - committee: [84, 457]
+  - - committee:
+      - 84
+      - 457
       shard: 105
       total_validator_count: 173
-  - - committee: [381, 184, 61]
+  - - committee:
+      - 381
+      - 184
+      - 61
       shard: 106
       total_validator_count: 173
-  - - committee: [19, 291, 391]
+  - - committee:
+      - 19
+      - 291
+      - 391
       shard: 107
       total_validator_count: 173
-  - - committee: [65, 370]
+  - - committee:
+      - 65
+      - 370
       shard: 108
       total_validator_count: 173
-  - - committee: [102, 246, 362]
+  - - committee:
+      - 102
+      - 246
+      - 362
       shard: 109
       total_validator_count: 173
-  - - committee: [113, 44, 58]
+  - - committee:
+      - 113
+      - 44
+      - 58
       shard: 110
       total_validator_count: 173
-  - - committee: [293, 446, 162]
+  - - committee:
+      - 293
+      - 446
+      - 162
       shard: 111
       total_validator_count: 173
-  - - committee: [427, 262]
+  - - committee:
+      - 427
+      - 262
       shard: 112
       total_validator_count: 173
-  - - committee: [216, 393, 447]
+  - - committee:
+      - 216
+      - 393
+      - 447
       shard: 113
       total_validator_count: 173
-  - - committee: [397, 2, 27]
+  - - committee:
+      - 397
+      - 2
+      - 27
       shard: 114
       total_validator_count: 173
-  - - committee: [425, 265]
+  - - committee:
+      - 425
+      - 265
       shard: 115
       total_validator_count: 173
-  - - committee: [389, 223, 180]
+  - - committee:
+      - 389
+      - 223
+      - 180
       shard: 116
       total_validator_count: 173
-  - - committee: [287, 154, 115]
+  - - committee:
+      - 287
+      - 154
+      - 115
       shard: 117
       total_validator_count: 173
-  - - committee: [304, 90]
+  - - committee:
+      - 304
+      - 90
       shard: 118
       total_validator_count: 173
-  - - committee: [244, 250, 117]
+  - - committee:
+      - 244
+      - 250
+      - 117
       shard: 119
       total_validator_count: 173
-  - - committee: [110, 239, 155]
+  - - committee:
+      - 110
+      - 239
+      - 155
       shard: 120
       total_validator_count: 173
-  - - committee: [17, 178, 189]
+  - - committee:
+      - 17
+      - 178
+      - 189
       shard: 121
       total_validator_count: 173
-  - - committee: [240, 225]
+  - - committee:
+      - 240
+      - 225
       shard: 122
       total_validator_count: 173
-  - - committee: [3, 356, 357]
+  - - committee:
+      - 3
+      - 356
+      - 357
       shard: 123
       total_validator_count: 173
-  - - committee: [261, 407, 208]
+  - - committee:
+      - 261
+      - 407
+      - 208
       shard: 124
       total_validator_count: 173
-  - - committee: [7, 270]
+  - - committee:
+      - 7
+      - 270
       shard: 125
       total_validator_count: 173
-  - - committee: [25, 274, 14]
+  - - committee:
+      - 25
+      - 274
+      - 14
       shard: 126
       total_validator_count: 173
-  - - committee: [321, 312, 333]
+  - - committee:
+      - 321
+      - 312
+      - 333
       shard: 127
       total_validator_count: 173
-  - - committee: [135, 344]
+  - - committee:
+      - 135
+      - 344
       shard: 128
       total_validator_count: 173
-  - - committee: [332, 326, 126]
+  - - committee:
+      - 332
+      - 326
+      - 126
       shard: 129
       total_validator_count: 173
-  - - committee: [195, 226, 71]
+  - - committee:
+      - 195
+      - 226
+      - 71
       shard: 130
       total_validator_count: 173
-  - - committee: [87, 306, 139]
+  - - committee:
+      - 87
+      - 306
+      - 139
       shard: 131
       total_validator_count: 173
-  - - committee: [395, 256]
+  - - committee:
+      - 395
+      - 256
       shard: 132
       total_validator_count: 173
-  - - committee: [258, 405, 359]
+  - - committee:
+      - 258
+      - 405
+      - 359
       shard: 133
       total_validator_count: 173
-  - - committee: [419, 253, 47]
+  - - committee:
+      - 419
+      - 253
+      - 47
       shard: 134
       total_validator_count: 173
-  - - committee: [269, 220]
+  - - committee:
+      - 269
+      - 220
       shard: 135
       total_validator_count: 173
-  - - committee: [421, 138, 66]
+  - - committee:
+      - 421
+      - 138
+      - 66
       shard: 136
       total_validator_count: 173
-  - - committee: [222, 78, 75]
+  - - committee:
+      - 222
+      - 78
+      - 75
       shard: 137
       total_validator_count: 173
-  - - committee: [366, 458, 430]
+  - - committee:
+      - 366
+      - 458
+      - 430
       shard: 138
       total_validator_count: 173
-  - - committee: [334, 26]
+  - - committee:
+      - 334
+      - 26
       shard: 139
       total_validator_count: 173
-  - - committee: [169, 137, 327]
+  - - committee:
+      - 169
+      - 137
+      - 327
       shard: 140
       total_validator_count: 173
-  - - committee: [452, 130, 89]
+  - - committee:
+      - 452
+      - 130
+      - 89
       shard: 141
       total_validator_count: 173
-  - - committee: [450, 131]
+  - - committee:
+      - 450
+      - 131
       shard: 142
       total_validator_count: 173
-  - - committee: [328, 218, 230]
+  - - committee:
+      - 328
+      - 218
+      - 230
       shard: 143
       total_validator_count: 173
-  - - committee: [176, 466, 167]
+  - - committee:
+      - 176
+      - 466
+      - 167
       shard: 144
       total_validator_count: 173
-  - - committee: [179, 30]
+  - - committee:
+      - 179
+      - 30
       shard: 145
       total_validator_count: 173
-  - - committee: [329, 341, 50]
+  - - committee:
+      - 329
+      - 341
+      - 50
       shard: 146
       total_validator_count: 173
-  - - committee: [238, 463, 215]
+  - - committee:
+      - 238
+      - 463
+      - 215
       shard: 147
       total_validator_count: 173
-  - - committee: [440, 141, 111]
+  - - committee:
+      - 440
+      - 141
+      - 111
       shard: 148
       total_validator_count: 173
-  - - committee: [303, 439]
+  - - committee:
+      - 303
+      - 439
       shard: 149
       total_validator_count: 173
-  - - committee: [315, 410, 38]
+  - - committee:
+      - 315
+      - 410
+      - 38
       shard: 150
       total_validator_count: 173
-  - - committee: [382, 94, 29]
+  - - committee:
+      - 382
+      - 94
+      - 29
       shard: 151
       total_validator_count: 173
-  - - committee: [150, 12]
+  - - committee:
+      - 150
+      - 12
       shard: 152
       total_validator_count: 173
-  - - committee: [437, 15, 428]
+  - - committee:
+      - 437
+      - 15
+      - 428
       shard: 153
       total_validator_count: 173
-  - - committee: [83, 40, 302]
+  - - committee:
+      - 83
+      - 40
+      - 302
       shard: 154
       total_validator_count: 173
-  - - committee: [413, 201]
+  - - committee:
+      - 413
+      - 201
       shard: 155
       total_validator_count: 173
-  - - committee: [399, 129, 197]
+  - - committee:
+      - 399
+      - 129
+      - 197
       shard: 156
       total_validator_count: 173
-  - - committee: [5, 388, 295]
+  - - committee:
+      - 5
+      - 388
+      - 295
       shard: 157
       total_validator_count: 173
-  - - committee: [375, 34, 462]
+  - - committee:
+      - 375
+      - 34
+      - 462
       shard: 158
       total_validator_count: 173
-  - - committee: [73, 127]
+  - - committee:
+      - 73
+      - 127
       shard: 159
       total_validator_count: 173
-  - - committee: [177, 406, 313]
+  - - committee:
+      - 177
+      - 406
+      - 313
       shard: 160
       total_validator_count: 173
-  - - committee: [144, 432, 339]
+  - - committee:
+      - 144
+      - 432
+      - 339
       shard: 161
       total_validator_count: 173
-  - - committee: [361, 37]
+  - - committee:
+      - 361
+      - 37
       shard: 162
       total_validator_count: 173
-  - - committee: [316, 88, 22]
+  - - committee:
+      - 316
+      - 88
+      - 22
       shard: 163
       total_validator_count: 173
-  - - committee: [18, 317, 242]
+  - - committee:
+      - 18
+      - 317
+      - 242
       shard: 164
       total_validator_count: 173
-  - - committee: [380, 211, 441]
+  - - committee:
+      - 380
+      - 211
+      - 441
       shard: 165
       total_validator_count: 173
   seed: '0xadb35f3fc2880d220e520120a032bbaa0f4bd7a5fcf1c2269de21075e7a46471'
@@ -2154,900 +2487,1046 @@ test_cases:
     crosslinking_start_shard: 133
     validators:
     - original_index: 0
-      status: [2]
+      status: 2
     - original_index: 1
-      status: [0]
+      status: 0
     - original_index: 2
-      status: [4]
+      status: 4
     - original_index: 3
-      status: [2]
+      status: 2
     - original_index: 4
-      status: [4]
+      status: 4
     - original_index: 5
-      status: [2]
+      status: 2
     - original_index: 6
-      status: [0]
+      status: 0
     - original_index: 7
-      status: [3]
+      status: 3
     - original_index: 8
-      status: [1]
+      status: 1
     - original_index: 9
-      status: [0]
+      status: 0
     - original_index: 10
-      status: [2]
+      status: 2
     - original_index: 11
-      status: [1]
+      status: 1
     - original_index: 12
-      status: [0]
+      status: 0
     - original_index: 13
-      status: [3]
+      status: 3
     - original_index: 14
-      status: [2]
+      status: 2
     - original_index: 15
-      status: [2]
+      status: 2
     - original_index: 16
-      status: [0]
+      status: 0
     - original_index: 17
-      status: [0]
+      status: 0
     - original_index: 18
-      status: [3]
+      status: 3
     - original_index: 19
-      status: [4]
+      status: 4
     - original_index: 20
-      status: [1]
+      status: 1
     - original_index: 21
-      status: [2]
+      status: 2
     - original_index: 22
-      status: [4]
+      status: 4
     - original_index: 23
-      status: [0]
+      status: 0
     - original_index: 24
-      status: [0]
+      status: 0
     - original_index: 25
-      status: [0]
+      status: 0
     - original_index: 26
-      status: [2]
+      status: 2
     - original_index: 27
-      status: [3]
+      status: 3
     - original_index: 28
-      status: [0]
+      status: 0
     - original_index: 29
-      status: [3]
+      status: 3
     - original_index: 30
-      status: [4]
+      status: 4
     - original_index: 31
-      status: [1]
+      status: 1
     - original_index: 32
-      status: [0]
+      status: 0
     - original_index: 33
-      status: [1]
+      status: 1
     - original_index: 34
-      status: [4]
+      status: 4
     - original_index: 35
-      status: [0]
+      status: 0
     - original_index: 36
-      status: [3]
+      status: 3
     - original_index: 37
-      status: [0]
+      status: 0
     - original_index: 38
-      status: [4]
+      status: 4
     - original_index: 39
-      status: [1]
+      status: 1
     - original_index: 40
-      status: [0]
+      status: 0
     - original_index: 41
-      status: [3]
+      status: 3
     - original_index: 42
-      status: [2]
+      status: 2
     - original_index: 43
-      status: [3]
+      status: 3
     - original_index: 44
-      status: [4]
+      status: 4
     - original_index: 45
-      status: [0]
+      status: 0
     - original_index: 46
-      status: [3]
+      status: 3
     - original_index: 47
-      status: [3]
+      status: 3
     - original_index: 48
-      status: [4]
+      status: 4
     - original_index: 49
-      status: [3]
+      status: 3
     - original_index: 50
-      status: [3]
+      status: 3
     - original_index: 51
-      status: [4]
+      status: 4
     - original_index: 52
-      status: [1]
+      status: 1
     - original_index: 53
-      status: [3]
+      status: 3
     - original_index: 54
-      status: [3]
+      status: 3
     - original_index: 55
-      status: [1]
+      status: 1
     - original_index: 56
-      status: [0]
+      status: 0
     - original_index: 57
-      status: [0]
+      status: 0
     - original_index: 58
-      status: [0]
+      status: 0
     - original_index: 59
-      status: [0]
+      status: 0
     - original_index: 60
-      status: [2]
+      status: 2
     - original_index: 61
-      status: [2]
+      status: 2
     - original_index: 62
-      status: [1]
+      status: 1
     - original_index: 63
-      status: [3]
+      status: 3
     - original_index: 64
-      status: [4]
+      status: 4
     - original_index: 65
-      status: [4]
+      status: 4
     - original_index: 66
-      status: [4]
+      status: 4
     - original_index: 67
-      status: [3]
+      status: 3
     - original_index: 68
-      status: [3]
+      status: 3
     - original_index: 69
-      status: [3]
+      status: 3
     - original_index: 70
-      status: [4]
+      status: 4
     - original_index: 71
-      status: [3]
+      status: 3
     - original_index: 72
-      status: [3]
+      status: 3
     - original_index: 73
-      status: [1]
+      status: 1
     - original_index: 74
-      status: [2]
+      status: 2
     - original_index: 75
-      status: [3]
+      status: 3
     - original_index: 76
-      status: [2]
+      status: 2
     - original_index: 77
-      status: [3]
+      status: 3
     - original_index: 78
-      status: [3]
+      status: 3
     - original_index: 79
-      status: [3]
+      status: 3
     - original_index: 80
-      status: [2]
+      status: 2
     - original_index: 81
-      status: [2]
+      status: 2
     - original_index: 82
-      status: [2]
+      status: 2
     - original_index: 83
-      status: [4]
+      status: 4
     - original_index: 84
-      status: [0]
+      status: 0
     - original_index: 85
-      status: [0]
+      status: 0
     - original_index: 86
-      status: [1]
+      status: 1
     - original_index: 87
-      status: [2]
+      status: 2
     - original_index: 88
-      status: [2]
+      status: 2
     - original_index: 89
-      status: [4]
+      status: 4
     - original_index: 90
-      status: [4]
+      status: 4
     - original_index: 91
-      status: [4]
+      status: 4
     - original_index: 92
-      status: [2]
+      status: 2
     - original_index: 93
-      status: [0]
+      status: 0
     - original_index: 94
-      status: [4]
+      status: 4
     - original_index: 95
-      status: [0]
+      status: 0
     - original_index: 96
-      status: [1]
+      status: 1
     - original_index: 97
-      status: [1]
+      status: 1
     - original_index: 98
-      status: [4]
+      status: 4
     - original_index: 99
-      status: [3]
+      status: 3
     - original_index: 100
-      status: [4]
+      status: 4
     - original_index: 101
-      status: [4]
+      status: 4
     - original_index: 102
-      status: [3]
+      status: 3
     - original_index: 103
-      status: [4]
+      status: 4
     - original_index: 104
-      status: [0]
+      status: 0
     - original_index: 105
-      status: [1]
+      status: 1
     - original_index: 106
-      status: [0]
+      status: 0
     - original_index: 107
-      status: [1]
+      status: 1
     - original_index: 108
-      status: [1]
+      status: 1
     - original_index: 109
-      status: [3]
+      status: 3
     - original_index: 110
-      status: [3]
+      status: 3
     - original_index: 111
-      status: [0]
+      status: 0
     - original_index: 112
-      status: [0]
+      status: 0
     - original_index: 113
-      status: [0]
+      status: 0
     - original_index: 114
-      status: [1]
+      status: 1
     - original_index: 115
-      status: [3]
+      status: 3
     - original_index: 116
-      status: [2]
+      status: 2
     - original_index: 117
-      status: [0]
+      status: 0
     - original_index: 118
-      status: [0]
+      status: 0
     - original_index: 119
-      status: [4]
+      status: 4
     - original_index: 120
-      status: [2]
+      status: 2
     - original_index: 121
-      status: [1]
+      status: 1
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [4]
+      status: 4
     - original_index: 124
-      status: [3]
+      status: 3
     - original_index: 125
-      status: [0]
+      status: 0
     - original_index: 126
-      status: [4]
+      status: 4
     - original_index: 127
-      status: [0]
+      status: 0
     - original_index: 128
-      status: [0]
+      status: 0
     - original_index: 129
-      status: [0]
+      status: 0
     - original_index: 130
-      status: [3]
+      status: 3
     - original_index: 131
-      status: [0]
+      status: 0
     - original_index: 132
-      status: [4]
+      status: 4
     - original_index: 133
-      status: [1]
+      status: 1
     - original_index: 134
-      status: [1]
+      status: 1
     - original_index: 135
-      status: [1]
+      status: 1
     - original_index: 136
-      status: [4]
+      status: 4
     - original_index: 137
-      status: [1]
+      status: 1
     - original_index: 138
-      status: [0]
+      status: 0
     - original_index: 139
-      status: [3]
+      status: 3
     - original_index: 140
-      status: [2]
+      status: 2
     - original_index: 141
-      status: [4]
+      status: 4
     - original_index: 142
-      status: [2]
+      status: 2
     - original_index: 143
-      status: [0]
+      status: 0
     - original_index: 144
-      status: [4]
+      status: 4
     - original_index: 145
-      status: [2]
+      status: 2
     - original_index: 146
-      status: [3]
+      status: 3
     - original_index: 147
-      status: [4]
+      status: 4
     - original_index: 148
-      status: [1]
+      status: 1
     - original_index: 149
-      status: [1]
+      status: 1
     - original_index: 150
-      status: [0]
+      status: 0
     - original_index: 151
-      status: [1]
+      status: 1
     - original_index: 152
-      status: [3]
+      status: 3
     - original_index: 153
-      status: [2]
+      status: 2
     - original_index: 154
-      status: [2]
+      status: 2
     - original_index: 155
-      status: [2]
+      status: 2
     - original_index: 156
-      status: [3]
+      status: 3
     - original_index: 157
-      status: [0]
+      status: 0
     - original_index: 158
-      status: [3]
+      status: 3
     - original_index: 159
-      status: [0]
+      status: 0
     - original_index: 160
-      status: [1]
+      status: 1
     - original_index: 161
-      status: [0]
+      status: 0
     - original_index: 162
-      status: [2]
+      status: 2
     - original_index: 163
-      status: [0]
+      status: 0
     - original_index: 164
-      status: [2]
+      status: 2
     - original_index: 165
-      status: [1]
+      status: 1
     - original_index: 166
-      status: [1]
+      status: 1
     - original_index: 167
-      status: [4]
+      status: 4
     - original_index: 168
-      status: [1]
+      status: 1
     - original_index: 169
-      status: [2]
+      status: 2
     - original_index: 170
-      status: [4]
+      status: 4
     - original_index: 171
-      status: [1]
+      status: 1
     - original_index: 172
-      status: [1]
+      status: 1
     - original_index: 173
-      status: [4]
+      status: 4
     - original_index: 174
-      status: [0]
+      status: 0
     - original_index: 175
-      status: [3]
+      status: 3
     - original_index: 176
-      status: [2]
+      status: 2
     - original_index: 177
-      status: [3]
+      status: 3
     - original_index: 178
-      status: [0]
+      status: 0
     - original_index: 179
-      status: [4]
+      status: 4
     - original_index: 180
-      status: [1]
+      status: 1
     - original_index: 181
-      status: [0]
+      status: 0
     - original_index: 182
-      status: [0]
+      status: 0
     - original_index: 183
-      status: [0]
+      status: 0
     - original_index: 184
-      status: [4]
+      status: 4
     - original_index: 185
-      status: [1]
+      status: 1
     - original_index: 186
-      status: [3]
+      status: 3
     - original_index: 187
-      status: [0]
+      status: 0
     - original_index: 188
-      status: [3]
+      status: 3
     - original_index: 189
-      status: [1]
+      status: 1
     - original_index: 190
-      status: [4]
+      status: 4
     - original_index: 191
-      status: [3]
+      status: 3
     - original_index: 192
-      status: [2]
+      status: 2
     - original_index: 193
-      status: [0]
+      status: 0
     - original_index: 194
-      status: [2]
+      status: 2
     - original_index: 195
-      status: [4]
+      status: 4
     - original_index: 196
-      status: [1]
+      status: 1
     - original_index: 197
-      status: [3]
+      status: 3
     - original_index: 198
-      status: [1]
+      status: 1
     - original_index: 199
-      status: [4]
+      status: 4
     - original_index: 200
-      status: [1]
+      status: 1
     - original_index: 201
-      status: [3]
+      status: 3
     - original_index: 202
-      status: [2]
+      status: 2
     - original_index: 203
-      status: [1]
+      status: 1
     - original_index: 204
-      status: [2]
+      status: 2
     - original_index: 205
-      status: [4]
+      status: 4
     - original_index: 206
-      status: [0]
+      status: 0
     - original_index: 207
-      status: [3]
+      status: 3
     - original_index: 208
-      status: [1]
+      status: 1
     - original_index: 209
-      status: [1]
+      status: 1
     - original_index: 210
-      status: [0]
+      status: 0
     - original_index: 211
-      status: [3]
+      status: 3
     - original_index: 212
-      status: [1]
+      status: 1
     - original_index: 213
-      status: [1]
+      status: 1
     - original_index: 214
-      status: [2]
+      status: 2
     - original_index: 215
-      status: [1]
+      status: 1
     - original_index: 216
-      status: [4]
+      status: 4
     - original_index: 217
-      status: [2]
+      status: 2
     - original_index: 218
-      status: [1]
+      status: 1
     - original_index: 219
-      status: [4]
+      status: 4
     - original_index: 220
-      status: [0]
+      status: 0
     - original_index: 221
-      status: [3]
+      status: 3
     - original_index: 222
-      status: [2]
+      status: 2
     - original_index: 223
-      status: [0]
+      status: 0
     - original_index: 224
-      status: [0]
+      status: 0
     - original_index: 225
-      status: [4]
+      status: 4
     - original_index: 226
-      status: [3]
+      status: 3
     - original_index: 227
-      status: [2]
+      status: 2
     - original_index: 228
-      status: [1]
+      status: 1
     - original_index: 229
-      status: [2]
+      status: 2
     - original_index: 230
-      status: [3]
+      status: 3
     - original_index: 231
-      status: [1]
+      status: 1
     - original_index: 232
-      status: [1]
+      status: 1
     - original_index: 233
-      status: [1]
+      status: 1
     - original_index: 234
-      status: [4]
+      status: 4
     - original_index: 235
-      status: [2]
+      status: 2
     - original_index: 236
-      status: [2]
+      status: 2
     - original_index: 237
-      status: [0]
+      status: 0
     - original_index: 238
-      status: [1]
+      status: 1
     - original_index: 239
-      status: [1]
+      status: 1
     - original_index: 240
-      status: [0]
+      status: 0
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [4]
+      status: 4
     - original_index: 243
-      status: [2]
+      status: 2
     - original_index: 244
-      status: [0]
+      status: 0
     - original_index: 245
-      status: [4]
+      status: 4
     - original_index: 246
-      status: [1]
+      status: 1
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [0]
+      status: 0
     - original_index: 249
-      status: [0]
+      status: 0
     - original_index: 250
-      status: [0]
+      status: 0
     - original_index: 251
-      status: [1]
+      status: 1
     - original_index: 252
-      status: [3]
+      status: 3
     - original_index: 253
-      status: [1]
+      status: 1
     - original_index: 254
-      status: [4]
+      status: 4
     - original_index: 255
-      status: [3]
+      status: 3
     - original_index: 256
-      status: [0]
+      status: 0
     - original_index: 257
-      status: [1]
+      status: 1
     - original_index: 258
-      status: [0]
+      status: 0
     - original_index: 259
-      status: [2]
+      status: 2
     - original_index: 260
-      status: [4]
+      status: 4
     - original_index: 261
-      status: [1]
+      status: 1
     - original_index: 262
-      status: [0]
+      status: 0
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [1]
+      status: 1
     - original_index: 265
-      status: [0]
+      status: 0
     - original_index: 266
-      status: [4]
+      status: 4
     - original_index: 267
-      status: [3]
+      status: 3
     - original_index: 268
-      status: [1]
+      status: 1
     - original_index: 269
-      status: [1]
+      status: 1
     - original_index: 270
-      status: [1]
+      status: 1
     - original_index: 271
-      status: [2]
+      status: 2
     - original_index: 272
-      status: [0]
+      status: 0
     - original_index: 273
-      status: [0]
+      status: 0
     - original_index: 274
-      status: [0]
+      status: 0
     - original_index: 275
-      status: [4]
+      status: 4
     - original_index: 276
-      status: [0]
+      status: 0
     - original_index: 277
-      status: [2]
+      status: 2
     - original_index: 278
-      status: [2]
+      status: 2
     - original_index: 279
-      status: [0]
+      status: 0
     - original_index: 280
-      status: [4]
+      status: 4
     - original_index: 281
-      status: [2]
+      status: 2
     - original_index: 282
-      status: [3]
+      status: 3
     - original_index: 283
-      status: [2]
+      status: 2
     - original_index: 284
-      status: [4]
+      status: 4
     - original_index: 285
-      status: [4]
+      status: 4
     - original_index: 286
-      status: [3]
+      status: 3
     - original_index: 287
-      status: [4]
+      status: 4
     - original_index: 288
-      status: [3]
+      status: 3
     - original_index: 289
-      status: [3]
+      status: 3
     - original_index: 290
-      status: [0]
+      status: 0
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [0]
+      status: 0
     - original_index: 293
-      status: [2]
+      status: 2
     - original_index: 294
-      status: [2]
+      status: 2
     - original_index: 295
-      status: [4]
+      status: 4
     - original_index: 296
-      status: [1]
+      status: 1
     - original_index: 297
-      status: [4]
+      status: 4
     - original_index: 298
-      status: [4]
+      status: 4
     - original_index: 299
-      status: [4]
+      status: 4
     - original_index: 300
-      status: [3]
+      status: 3
     - original_index: 301
-      status: [2]
+      status: 2
     - original_index: 302
-      status: [3]
+      status: 3
     - original_index: 303
-      status: [2]
+      status: 2
     - original_index: 304
-      status: [0]
+      status: 0
     - original_index: 305
-      status: [2]
+      status: 2
     - original_index: 306
-      status: [2]
+      status: 2
     - original_index: 307
-      status: [2]
+      status: 2
     - original_index: 308
-      status: [4]
+      status: 4
     - original_index: 309
-      status: [2]
+      status: 2
     - original_index: 310
-      status: [4]
+      status: 4
     - original_index: 311
-      status: [1]
+      status: 1
     - original_index: 312
-      status: [0]
+      status: 0
     - original_index: 313
-      status: [1]
+      status: 1
     - original_index: 314
-      status: [0]
+      status: 0
     - original_index: 315
-      status: [4]
+      status: 4
     - original_index: 316
-      status: [0]
+      status: 0
     - original_index: 317
-      status: [4]
+      status: 4
     - original_index: 318
-      status: [1]
+      status: 1
     - original_index: 319
-      status: [1]
+      status: 1
     - original_index: 320
-      status: [2]
+      status: 2
     - original_index: 321
-      status: [2]
+      status: 2
     - original_index: 322
-      status: [4]
+      status: 4
     - original_index: 323
-      status: [3]
+      status: 3
     - original_index: 324
-      status: [4]
+      status: 4
     - original_index: 325
-      status: [4]
+      status: 4
     - original_index: 326
-      status: [3]
+      status: 3
     - original_index: 327
-      status: [3]
+      status: 3
     - original_index: 328
-      status: [4]
+      status: 4
     - original_index: 329
-      status: [2]
+      status: 2
     - original_index: 330
-      status: [3]
+      status: 3
     - original_index: 331
-      status: [0]
+      status: 0
     - original_index: 332
-      status: [2]
+      status: 2
     - original_index: 333
-      status: [1]
+      status: 1
     - original_index: 334
-      status: [4]
+      status: 4
     - original_index: 335
-      status: [0]
+      status: 0
     - original_index: 336
-      status: [0]
+      status: 0
     - original_index: 337
-      status: [4]
+      status: 4
     - original_index: 338
-      status: [1]
+      status: 1
     - original_index: 339
-      status: [2]
+      status: 2
     - original_index: 340
-      status: [1]
+      status: 1
     - original_index: 341
-      status: [4]
+      status: 4
     - original_index: 342
-      status: [1]
+      status: 1
     - original_index: 343
-      status: [2]
+      status: 2
     - original_index: 344
-      status: [0]
+      status: 0
     - original_index: 345
-      status: [4]
+      status: 4
     - original_index: 346
-      status: [4]
+      status: 4
     - original_index: 347
-      status: [1]
+      status: 1
     - original_index: 348
-      status: [4]
+      status: 4
     - original_index: 349
-      status: [1]
+      status: 1
     - original_index: 350
-      status: [1]
+      status: 1
     - original_index: 351
-      status: [4]
+      status: 4
   output:
-  - - committee: [126, 346]
+  - - committee:
+      - 126
+      - 346
       shard: 133
       total_validator_count: 146
-  - - committee: [171, 328]
+  - - committee:
+      - 171
+      - 328
       shard: 134
       total_validator_count: 146
-  - - committee: [105, 121]
+  - - committee:
+      - 105
+      - 121
       shard: 135
       total_validator_count: 146
-  - - committee: [209, 173, 66]
+  - - committee:
+      - 209
+      - 173
+      - 66
       shard: 136
       total_validator_count: 146
-  - - committee: [52, 242]
+  - - committee:
+      - 52
+      - 242
       shard: 137
       total_validator_count: 146
-  - - committee: [347, 199]
+  - - committee:
+      - 347
+      - 199
       shard: 138
       total_validator_count: 146
-  - - committee: [198, 232]
+  - - committee:
+      - 198
+      - 232
       shard: 139
       total_validator_count: 146
-  - - committee: [263, 55, 269]
+  - - committee:
+      - 263
+      - 55
+      - 269
       shard: 140
       total_validator_count: 146
-  - - committee: [20, 233]
+  - - committee:
+      - 20
+      - 233
       shard: 141
       total_validator_count: 146
-  - - committee: [225, 94]
+  - - committee:
+      - 225
+      - 94
       shard: 142
       total_validator_count: 146
-  - - committee: [338, 196, 239]
+  - - committee:
+      - 338
+      - 196
+      - 239
       shard: 143
       total_validator_count: 146
-  - - committee: [185, 144]
+  - - committee:
+      - 185
+      - 144
       shard: 144
       total_validator_count: 146
-  - - committee: [219, 180]
+  - - committee:
+      - 219
+      - 180
       shard: 145
       total_validator_count: 146
-  - - committee: [324, 297]
+  - - committee:
+      - 324
+      - 297
       shard: 146
       total_validator_count: 146
-  - - committee: [22, 96, 342]
+  - - committee:
+      - 22
+      - 96
+      - 342
       shard: 147
       total_validator_count: 146
-  - - committee: [160, 285]
+  - - committee:
+      - 160
+      - 285
       shard: 148
       total_validator_count: 146
-  - - committee: [103, 200]
+  - - committee:
+      - 103
+      - 200
       shard: 149
       total_validator_count: 146
-  - - committee: [266, 208, 351]
+  - - committee:
+      - 266
+      - 208
+      - 351
       shard: 150
       total_validator_count: 146
-  - - committee: [257, 350]
+  - - committee:
+      - 257
+      - 350
       shard: 151
       total_validator_count: 146
-  - - committee: [245, 345]
+  - - committee:
+      - 245
+      - 345
       shard: 152
       total_validator_count: 146
-  - - committee: [134, 48]
+  - - committee:
+      - 134
+      - 48
       shard: 153
       total_validator_count: 146
-  - - committee: [349, 62, 275]
+  - - committee:
+      - 349
+      - 62
+      - 275
       shard: 154
       total_validator_count: 146
-  - - committee: [34, 114]
+  - - committee:
+      - 34
+      - 114
       shard: 155
       total_validator_count: 146
-  - - committee: [284, 167]
+  - - committee:
+      - 284
+      - 167
       shard: 156
       total_validator_count: 146
-  - - committee: [319, 31, 147]
+  - - committee:
+      - 319
+      - 31
+      - 147
       shard: 157
       total_validator_count: 146
-  - - committee: [340, 348]
+  - - committee:
+      - 340
+      - 348
       shard: 158
       total_validator_count: 146
-  - - committee: [98, 246]
+  - - committee:
+      - 98
+      - 246
       shard: 159
       total_validator_count: 146
-  - - committee: [51, 315]
+  - - committee:
+      - 51
+      - 315
       shard: 160
       total_validator_count: 146
-  - - committee: [30, 241, 119]
+  - - committee:
+      - 30
+      - 241
+      - 119
       shard: 161
       total_validator_count: 146
-  - - committee: [189, 251]
+  - - committee:
+      - 189
+      - 251
       shard: 162
       total_validator_count: 146
-  - - committee: [205, 70]
+  - - committee:
+      - 205
+      - 70
       shard: 163
       total_validator_count: 146
-  - - committee: [44, 317, 90]
+  - - committee:
+      - 44
+      - 317
+      - 90
       shard: 164
       total_validator_count: 146
-  - - committee: [19, 295]
+  - - committee:
+      - 19
+      - 295
       shard: 165
       total_validator_count: 146
-  - - committee: [296, 231]
+  - - committee:
+      - 296
+      - 231
       shard: 166
       total_validator_count: 146
-  - - committee: [64, 4]
+  - - committee:
+      - 64
+      - 4
       shard: 167
       total_validator_count: 146
-  - - committee: [165, 38, 8]
+  - - committee:
+      - 165
+      - 38
+      - 8
       shard: 168
       total_validator_count: 146
-  - - committee: [135, 195]
+  - - committee:
+      - 135
+      - 195
       shard: 169
       total_validator_count: 146
-  - - committee: [89, 151]
+  - - committee:
+      - 89
+      - 151
       shard: 170
       total_validator_count: 146
-  - - committee: [168, 253]
+  - - committee:
+      - 168
+      - 253
       shard: 171
       total_validator_count: 146
-  - - committee: [310, 280, 333]
+  - - committee:
+      - 310
+      - 280
+      - 333
       shard: 172
       total_validator_count: 146
-  - - committee: [11, 337]
+  - - committee:
+      - 11
+      - 337
       shard: 173
       total_validator_count: 146
-  - - committee: [261, 268]
+  - - committee:
+      - 261
+      - 268
       shard: 174
       total_validator_count: 146
-  - - committee: [318, 184, 170]
+  - - committee:
+      - 318
+      - 184
+      - 170
       shard: 175
       total_validator_count: 146
-  - - committee: [228, 149]
+  - - committee:
+      - 228
+      - 149
       shard: 176
       total_validator_count: 146
-  - - committee: [190, 132]
+  - - committee:
+      - 190
+      - 132
       shard: 177
       total_validator_count: 146
-  - - committee: [107, 238]
+  - - committee:
+      - 107
+      - 238
       shard: 178
       total_validator_count: 146
-  - - committee: [123, 334, 179]
+  - - committee:
+      - 123
+      - 334
+      - 179
       shard: 179
       total_validator_count: 146
-  - - committee: [108, 148]
+  - - committee:
+      - 108
+      - 148
       shard: 180
       total_validator_count: 146
-  - - committee: [91, 166]
+  - - committee:
+      - 91
+      - 166
       shard: 181
       total_validator_count: 146
-  - - committee: [172, 325, 73]
+  - - committee:
+      - 172
+      - 325
+      - 73
       shard: 182
       total_validator_count: 146
-  - - committee: [213, 322]
+  - - committee:
+      - 213
+      - 322
       shard: 183
       total_validator_count: 146
-  - - committee: [254, 203]
+  - - committee:
+      - 254
+      - 203
       shard: 184
       total_validator_count: 146
-  - - committee: [270, 308]
+  - - committee:
+      - 270
+      - 308
       shard: 185
       total_validator_count: 146
-  - - committee: [260, 100, 65]
+  - - committee:
+      - 260
+      - 100
+      - 65
       shard: 186
       total_validator_count: 146
-  - - committee: [311, 298]
+  - - committee:
+      - 311
+      - 298
       shard: 187
       total_validator_count: 146
-  - - committee: [133, 97]
+  - - committee:
+      - 133
+      - 97
       shard: 188
       total_validator_count: 146
-  - - committee: [2, 136, 33]
+  - - committee:
+      - 2
+      - 136
+      - 33
       shard: 189
       total_validator_count: 146
-  - - committee: [218, 86]
+  - - committee:
+      - 218
+      - 86
       shard: 190
       total_validator_count: 146
-  - - committee: [141, 264]
+  - - committee:
+      - 141
+      - 264
       shard: 191
       total_validator_count: 146
-  - - committee: [137, 215]
+  - - committee:
+      - 137
+      - 215
       shard: 192
       total_validator_count: 146
-  - - committee: [234, 101, 212]
+  - - committee:
+      - 234
+      - 101
+      - 212
       shard: 193
       total_validator_count: 146
-  - - committee: [216, 39]
+  - - committee:
+      - 216
+      - 39
       shard: 194
       total_validator_count: 146
-  - - committee: [299, 313]
+  - - committee:
+      - 299
+      - 313
       shard: 195
       total_validator_count: 146
-  - - committee: [83, 287, 341]
+  - - committee:
+      - 83
+      - 287
+      - 341
       shard: 196
       total_validator_count: 146
   seed: '0x1e91ab35b1106e8984dfc0dfa36018004f880b431c2a14f66354bf0192292ffa'
@@ -3055,1058 +3534,1216 @@ test_cases:
     crosslinking_start_shard: 323
     validators:
     - original_index: 0
-      status: [0]
+      status: 0
     - original_index: 1
-      status: [3]
+      status: 3
     - original_index: 2
-      status: [2]
+      status: 2
     - original_index: 3
-      status: [3]
+      status: 3
     - original_index: 4
-      status: [2]
+      status: 2
     - original_index: 5
-      status: [2]
+      status: 2
     - original_index: 6
-      status: [2]
+      status: 2
     - original_index: 7
-      status: [2]
+      status: 2
     - original_index: 8
-      status: [4]
+      status: 4
     - original_index: 9
-      status: [3]
+      status: 3
     - original_index: 10
-      status: [1]
+      status: 1
     - original_index: 11
-      status: [1]
+      status: 1
     - original_index: 12
-      status: [2]
+      status: 2
     - original_index: 13
-      status: [3]
+      status: 3
     - original_index: 14
-      status: [1]
+      status: 1
     - original_index: 15
-      status: [1]
+      status: 1
     - original_index: 16
-      status: [2]
+      status: 2
     - original_index: 17
-      status: [0]
+      status: 0
     - original_index: 18
-      status: [2]
+      status: 2
     - original_index: 19
-      status: [2]
+      status: 2
     - original_index: 20
-      status: [2]
+      status: 2
     - original_index: 21
-      status: [0]
+      status: 0
     - original_index: 22
-      status: [2]
+      status: 2
     - original_index: 23
-      status: [2]
+      status: 2
     - original_index: 24
-      status: [2]
+      status: 2
     - original_index: 25
-      status: [1]
+      status: 1
     - original_index: 26
-      status: [3]
+      status: 3
     - original_index: 27
-      status: [1]
+      status: 1
     - original_index: 28
-      status: [3]
+      status: 3
     - original_index: 29
-      status: [0]
+      status: 0
     - original_index: 30
-      status: [4]
+      status: 4
     - original_index: 31
-      status: [4]
+      status: 4
     - original_index: 32
-      status: [2]
+      status: 2
     - original_index: 33
-      status: [3]
+      status: 3
     - original_index: 34
-      status: [0]
+      status: 0
     - original_index: 35
-      status: [0]
+      status: 0
     - original_index: 36
-      status: [0]
+      status: 0
     - original_index: 37
-      status: [0]
+      status: 0
     - original_index: 38
-      status: [3]
+      status: 3
     - original_index: 39
-      status: [4]
+      status: 4
     - original_index: 40
-      status: [1]
+      status: 1
     - original_index: 41
-      status: [2]
+      status: 2
     - original_index: 42
-      status: [1]
+      status: 1
     - original_index: 43
-      status: [4]
+      status: 4
     - original_index: 44
-      status: [3]
+      status: 3
     - original_index: 45
-      status: [3]
+      status: 3
     - original_index: 46
-      status: [4]
+      status: 4
     - original_index: 47
-      status: [0]
+      status: 0
     - original_index: 48
-      status: [4]
+      status: 4
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [4]
+      status: 4
     - original_index: 51
-      status: [0]
+      status: 0
     - original_index: 52
-      status: [0]
+      status: 0
     - original_index: 53
-      status: [1]
+      status: 1
     - original_index: 54
-      status: [1]
+      status: 1
     - original_index: 55
-      status: [3]
+      status: 3
     - original_index: 56
-      status: [0]
+      status: 0
     - original_index: 57
-      status: [1]
+      status: 1
     - original_index: 58
-      status: [4]
+      status: 4
     - original_index: 59
-      status: [1]
+      status: 1
     - original_index: 60
-      status: [4]
+      status: 4
     - original_index: 61
-      status: [0]
+      status: 0
     - original_index: 62
-      status: [3]
+      status: 3
     - original_index: 63
-      status: [0]
+      status: 0
     - original_index: 64
-      status: [2]
+      status: 2
     - original_index: 65
-      status: [1]
+      status: 1
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [0]
+      status: 0
     - original_index: 68
-      status: [4]
+      status: 4
     - original_index: 69
-      status: [2]
+      status: 2
     - original_index: 70
-      status: [0]
+      status: 0
     - original_index: 71
-      status: [3]
+      status: 3
     - original_index: 72
-      status: [0]
+      status: 0
     - original_index: 73
-      status: [3]
+      status: 3
     - original_index: 74
-      status: [4]
+      status: 4
     - original_index: 75
-      status: [4]
+      status: 4
     - original_index: 76
-      status: [2]
+      status: 2
     - original_index: 77
-      status: [0]
+      status: 0
     - original_index: 78
-      status: [4]
+      status: 4
     - original_index: 79
-      status: [4]
+      status: 4
     - original_index: 80
-      status: [1]
+      status: 1
     - original_index: 81
-      status: [2]
+      status: 2
     - original_index: 82
-      status: [0]
+      status: 0
     - original_index: 83
-      status: [4]
+      status: 4
     - original_index: 84
-      status: [3]
+      status: 3
     - original_index: 85
-      status: [2]
+      status: 2
     - original_index: 86
-      status: [0]
+      status: 0
     - original_index: 87
-      status: [1]
+      status: 1
     - original_index: 88
-      status: [1]
+      status: 1
     - original_index: 89
-      status: [4]
+      status: 4
     - original_index: 90
-      status: [2]
+      status: 2
     - original_index: 91
-      status: [3]
+      status: 3
     - original_index: 92
-      status: [3]
+      status: 3
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [3]
+      status: 3
     - original_index: 95
-      status: [2]
+      status: 2
     - original_index: 96
-      status: [2]
+      status: 2
     - original_index: 97
-      status: [3]
+      status: 3
     - original_index: 98
-      status: [4]
+      status: 4
     - original_index: 99
-      status: [0]
+      status: 0
     - original_index: 100
-      status: [3]
+      status: 3
     - original_index: 101
-      status: [2]
+      status: 2
     - original_index: 102
-      status: [4]
+      status: 4
     - original_index: 103
-      status: [2]
+      status: 2
     - original_index: 104
-      status: [2]
+      status: 2
     - original_index: 105
-      status: [4]
+      status: 4
     - original_index: 106
-      status: [3]
+      status: 3
     - original_index: 107
-      status: [1]
+      status: 1
     - original_index: 108
-      status: [1]
+      status: 1
     - original_index: 109
-      status: [4]
+      status: 4
     - original_index: 110
-      status: [0]
+      status: 0
     - original_index: 111
-      status: [3]
+      status: 3
     - original_index: 112
-      status: [4]
+      status: 4
     - original_index: 113
-      status: [1]
+      status: 1
     - original_index: 114
-      status: [1]
+      status: 1
     - original_index: 115
-      status: [4]
+      status: 4
     - original_index: 116
-      status: [1]
+      status: 1
     - original_index: 117
-      status: [3]
+      status: 3
     - original_index: 118
-      status: [3]
+      status: 3
     - original_index: 119
-      status: [4]
+      status: 4
     - original_index: 120
-      status: [0]
+      status: 0
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [2]
+      status: 2
     - original_index: 123
-      status: [4]
+      status: 4
     - original_index: 124
-      status: [2]
+      status: 2
     - original_index: 125
-      status: [2]
+      status: 2
     - original_index: 126
-      status: [1]
+      status: 1
     - original_index: 127
-      status: [4]
+      status: 4
     - original_index: 128
-      status: [3]
+      status: 3
     - original_index: 129
-      status: [4]
+      status: 4
     - original_index: 130
-      status: [2]
+      status: 2
     - original_index: 131
-      status: [4]
+      status: 4
     - original_index: 132
-      status: [0]
+      status: 0
     - original_index: 133
-      status: [4]
+      status: 4
     - original_index: 134
-      status: [0]
+      status: 0
     - original_index: 135
-      status: [3]
+      status: 3
     - original_index: 136
-      status: [0]
+      status: 0
     - original_index: 137
-      status: [4]
+      status: 4
     - original_index: 138
-      status: [4]
+      status: 4
     - original_index: 139
-      status: [3]
+      status: 3
     - original_index: 140
-      status: [2]
+      status: 2
     - original_index: 141
-      status: [4]
+      status: 4
     - original_index: 142
-      status: [3]
+      status: 3
     - original_index: 143
-      status: [2]
+      status: 2
     - original_index: 144
-      status: [1]
+      status: 1
     - original_index: 145
-      status: [0]
+      status: 0
     - original_index: 146
-      status: [4]
+      status: 4
     - original_index: 147
-      status: [2]
+      status: 2
     - original_index: 148
-      status: [4]
+      status: 4
     - original_index: 149
-      status: [2]
+      status: 2
     - original_index: 150
-      status: [2]
+      status: 2
     - original_index: 151
-      status: [4]
+      status: 4
     - original_index: 152
-      status: [3]
+      status: 3
     - original_index: 153
-      status: [0]
+      status: 0
     - original_index: 154
-      status: [0]
+      status: 0
     - original_index: 155
-      status: [2]
+      status: 2
     - original_index: 156
-      status: [0]
+      status: 0
     - original_index: 157
-      status: [3]
+      status: 3
     - original_index: 158
-      status: [3]
+      status: 3
     - original_index: 159
-      status: [4]
+      status: 4
     - original_index: 160
-      status: [2]
+      status: 2
     - original_index: 161
-      status: [3]
+      status: 3
     - original_index: 162
-      status: [2]
+      status: 2
     - original_index: 163
-      status: [4]
+      status: 4
     - original_index: 164
-      status: [2]
+      status: 2
     - original_index: 165
-      status: [4]
+      status: 4
     - original_index: 166
-      status: [4]
+      status: 4
     - original_index: 167
-      status: [1]
+      status: 1
     - original_index: 168
-      status: [4]
+      status: 4
     - original_index: 169
-      status: [3]
+      status: 3
     - original_index: 170
-      status: [4]
+      status: 4
     - original_index: 171
-      status: [3]
+      status: 3
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [1]
+      status: 1
     - original_index: 174
-      status: [4]
+      status: 4
     - original_index: 175
-      status: [4]
+      status: 4
     - original_index: 176
-      status: [4]
+      status: 4
     - original_index: 177
-      status: [2]
+      status: 2
     - original_index: 178
-      status: [3]
+      status: 3
     - original_index: 179
-      status: [3]
+      status: 3
     - original_index: 180
-      status: [0]
+      status: 0
     - original_index: 181
-      status: [0]
+      status: 0
     - original_index: 182
-      status: [0]
+      status: 0
     - original_index: 183
-      status: [2]
+      status: 2
     - original_index: 184
-      status: [3]
+      status: 3
     - original_index: 185
-      status: [2]
+      status: 2
     - original_index: 186
-      status: [3]
+      status: 3
     - original_index: 187
-      status: [1]
+      status: 1
     - original_index: 188
-      status: [0]
+      status: 0
     - original_index: 189
-      status: [3]
+      status: 3
     - original_index: 190
-      status: [3]
+      status: 3
     - original_index: 191
-      status: [1]
+      status: 1
     - original_index: 192
-      status: [2]
+      status: 2
     - original_index: 193
-      status: [3]
+      status: 3
     - original_index: 194
-      status: [3]
+      status: 3
     - original_index: 195
-      status: [2]
+      status: 2
     - original_index: 196
-      status: [2]
+      status: 2
     - original_index: 197
-      status: [3]
+      status: 3
     - original_index: 198
-      status: [0]
+      status: 0
     - original_index: 199
-      status: [4]
+      status: 4
     - original_index: 200
-      status: [3]
+      status: 3
     - original_index: 201
-      status: [3]
+      status: 3
     - original_index: 202
-      status: [1]
+      status: 1
     - original_index: 203
-      status: [4]
+      status: 4
     - original_index: 204
-      status: [2]
+      status: 2
     - original_index: 205
-      status: [4]
+      status: 4
     - original_index: 206
-      status: [2]
+      status: 2
     - original_index: 207
-      status: [0]
+      status: 0
     - original_index: 208
-      status: [2]
+      status: 2
     - original_index: 209
-      status: [1]
+      status: 1
     - original_index: 210
-      status: [0]
+      status: 0
     - original_index: 211
-      status: [2]
+      status: 2
     - original_index: 212
-      status: [2]
+      status: 2
     - original_index: 213
-      status: [2]
+      status: 2
     - original_index: 214
-      status: [0]
+      status: 0
     - original_index: 215
-      status: [2]
+      status: 2
     - original_index: 216
-      status: [1]
+      status: 1
     - original_index: 217
-      status: [0]
+      status: 0
     - original_index: 218
-      status: [0]
+      status: 0
     - original_index: 219
-      status: [1]
+      status: 1
     - original_index: 220
-      status: [3]
+      status: 3
     - original_index: 221
-      status: [2]
+      status: 2
     - original_index: 222
-      status: [3]
+      status: 3
     - original_index: 223
-      status: [3]
+      status: 3
     - original_index: 224
-      status: [1]
+      status: 1
     - original_index: 225
-      status: [4]
+      status: 4
     - original_index: 226
-      status: [4]
+      status: 4
     - original_index: 227
-      status: [0]
+      status: 0
     - original_index: 228
-      status: [1]
+      status: 1
     - original_index: 229
-      status: [3]
+      status: 3
     - original_index: 230
-      status: [2]
+      status: 2
     - original_index: 231
-      status: [3]
+      status: 3
     - original_index: 232
-      status: [0]
+      status: 0
     - original_index: 233
-      status: [2]
+      status: 2
     - original_index: 234
-      status: [0]
+      status: 0
     - original_index: 235
-      status: [4]
+      status: 4
     - original_index: 236
-      status: [4]
+      status: 4
     - original_index: 237
-      status: [3]
+      status: 3
     - original_index: 238
-      status: [1]
+      status: 1
     - original_index: 239
-      status: [3]
+      status: 3
     - original_index: 240
-      status: [3]
+      status: 3
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [0]
+      status: 0
     - original_index: 243
-      status: [0]
+      status: 0
     - original_index: 244
-      status: [0]
+      status: 0
     - original_index: 245
-      status: [1]
+      status: 1
     - original_index: 246
-      status: [0]
+      status: 0
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [0]
+      status: 0
     - original_index: 249
-      status: [3]
+      status: 3
     - original_index: 250
-      status: [1]
+      status: 1
     - original_index: 251
-      status: [0]
+      status: 0
     - original_index: 252
-      status: [0]
+      status: 0
     - original_index: 253
-      status: [2]
+      status: 2
     - original_index: 254
-      status: [1]
+      status: 1
     - original_index: 255
-      status: [2]
+      status: 2
     - original_index: 256
-      status: [0]
+      status: 0
     - original_index: 257
-      status: [1]
+      status: 1
     - original_index: 258
-      status: [4]
+      status: 4
     - original_index: 259
-      status: [2]
+      status: 2
     - original_index: 260
-      status: [0]
+      status: 0
     - original_index: 261
-      status: [4]
+      status: 4
     - original_index: 262
-      status: [0]
+      status: 0
     - original_index: 263
-      status: [3]
+      status: 3
     - original_index: 264
-      status: [3]
+      status: 3
     - original_index: 265
-      status: [3]
+      status: 3
     - original_index: 266
-      status: [3]
+      status: 3
     - original_index: 267
-      status: [2]
+      status: 2
     - original_index: 268
-      status: [0]
+      status: 0
     - original_index: 269
-      status: [2]
+      status: 2
     - original_index: 270
-      status: [4]
+      status: 4
     - original_index: 271
-      status: [1]
+      status: 1
     - original_index: 272
-      status: [3]
+      status: 3
     - original_index: 273
-      status: [3]
+      status: 3
     - original_index: 274
-      status: [3]
+      status: 3
     - original_index: 275
-      status: [4]
+      status: 4
     - original_index: 276
-      status: [1]
+      status: 1
     - original_index: 277
-      status: [2]
+      status: 2
     - original_index: 278
-      status: [3]
+      status: 3
     - original_index: 279
-      status: [0]
+      status: 0
     - original_index: 280
-      status: [4]
+      status: 4
     - original_index: 281
-      status: [2]
+      status: 2
     - original_index: 282
-      status: [0]
+      status: 0
     - original_index: 283
-      status: [0]
+      status: 0
     - original_index: 284
-      status: [0]
+      status: 0
     - original_index: 285
-      status: [1]
+      status: 1
     - original_index: 286
-      status: [0]
+      status: 0
     - original_index: 287
-      status: [3]
+      status: 3
     - original_index: 288
-      status: [1]
+      status: 1
     - original_index: 289
-      status: [2]
+      status: 2
     - original_index: 290
-      status: [0]
+      status: 0
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [2]
+      status: 2
     - original_index: 293
-      status: [2]
+      status: 2
     - original_index: 294
-      status: [1]
+      status: 1
     - original_index: 295
-      status: [4]
+      status: 4
     - original_index: 296
-      status: [4]
+      status: 4
     - original_index: 297
-      status: [3]
+      status: 3
     - original_index: 298
-      status: [1]
+      status: 1
     - original_index: 299
-      status: [2]
+      status: 2
     - original_index: 300
-      status: [1]
+      status: 1
     - original_index: 301
-      status: [0]
+      status: 0
     - original_index: 302
-      status: [1]
+      status: 1
     - original_index: 303
-      status: [2]
+      status: 2
     - original_index: 304
-      status: [0]
+      status: 0
     - original_index: 305
-      status: [2]
+      status: 2
     - original_index: 306
-      status: [0]
+      status: 0
     - original_index: 307
-      status: [4]
+      status: 4
     - original_index: 308
-      status: [0]
+      status: 0
     - original_index: 309
-      status: [0]
+      status: 0
     - original_index: 310
-      status: [1]
+      status: 1
     - original_index: 311
-      status: [0]
+      status: 0
     - original_index: 312
-      status: [1]
+      status: 1
     - original_index: 313
-      status: [4]
+      status: 4
     - original_index: 314
-      status: [2]
+      status: 2
     - original_index: 315
-      status: [4]
+      status: 4
     - original_index: 316
-      status: [3]
+      status: 3
     - original_index: 317
-      status: [2]
+      status: 2
     - original_index: 318
-      status: [0]
+      status: 0
     - original_index: 319
-      status: [3]
+      status: 3
     - original_index: 320
-      status: [2]
+      status: 2
     - original_index: 321
-      status: [3]
+      status: 3
     - original_index: 322
-      status: [2]
+      status: 2
     - original_index: 323
-      status: [4]
+      status: 4
     - original_index: 324
-      status: [1]
+      status: 1
     - original_index: 325
-      status: [4]
+      status: 4
     - original_index: 326
-      status: [2]
+      status: 2
     - original_index: 327
-      status: [1]
+      status: 1
     - original_index: 328
-      status: [0]
+      status: 0
     - original_index: 329
-      status: [0]
+      status: 0
     - original_index: 330
-      status: [1]
+      status: 1
     - original_index: 331
-      status: [4]
+      status: 4
     - original_index: 332
-      status: [4]
+      status: 4
     - original_index: 333
-      status: [0]
+      status: 0
     - original_index: 334
-      status: [4]
+      status: 4
     - original_index: 335
-      status: [2]
+      status: 2
     - original_index: 336
-      status: [1]
+      status: 1
     - original_index: 337
-      status: [1]
+      status: 1
     - original_index: 338
-      status: [1]
+      status: 1
     - original_index: 339
-      status: [0]
+      status: 0
     - original_index: 340
-      status: [1]
+      status: 1
     - original_index: 341
-      status: [0]
+      status: 0
     - original_index: 342
-      status: [3]
+      status: 3
     - original_index: 343
-      status: [0]
+      status: 0
     - original_index: 344
-      status: [3]
+      status: 3
     - original_index: 345
-      status: [1]
+      status: 1
     - original_index: 346
-      status: [4]
+      status: 4
     - original_index: 347
-      status: [3]
+      status: 3
     - original_index: 348
-      status: [1]
+      status: 1
     - original_index: 349
-      status: [2]
+      status: 2
     - original_index: 350
-      status: [0]
+      status: 0
     - original_index: 351
-      status: [3]
+      status: 3
     - original_index: 352
-      status: [3]
+      status: 3
     - original_index: 353
-      status: [2]
+      status: 2
     - original_index: 354
-      status: [0]
+      status: 0
     - original_index: 355
-      status: [0]
+      status: 0
     - original_index: 356
-      status: [3]
+      status: 3
     - original_index: 357
-      status: [4]
+      status: 4
     - original_index: 358
-      status: [1]
+      status: 1
     - original_index: 359
-      status: [1]
+      status: 1
     - original_index: 360
-      status: [4]
+      status: 4
     - original_index: 361
-      status: [4]
+      status: 4
     - original_index: 362
-      status: [2]
+      status: 2
     - original_index: 363
-      status: [0]
+      status: 0
     - original_index: 364
-      status: [4]
+      status: 4
     - original_index: 365
-      status: [1]
+      status: 1
     - original_index: 366
-      status: [1]
+      status: 1
     - original_index: 367
-      status: [0]
+      status: 0
     - original_index: 368
-      status: [4]
+      status: 4
     - original_index: 369
-      status: [4]
+      status: 4
     - original_index: 370
-      status: [4]
+      status: 4
     - original_index: 371
-      status: [1]
+      status: 1
     - original_index: 372
-      status: [2]
+      status: 2
     - original_index: 373
-      status: [0]
+      status: 0
     - original_index: 374
-      status: [3]
+      status: 3
     - original_index: 375
-      status: [1]
+      status: 1
     - original_index: 376
-      status: [2]
+      status: 2
     - original_index: 377
-      status: [2]
+      status: 2
     - original_index: 378
-      status: [1]
+      status: 1
     - original_index: 379
-      status: [2]
+      status: 2
     - original_index: 380
-      status: [1]
+      status: 1
     - original_index: 381
-      status: [1]
+      status: 1
     - original_index: 382
-      status: [2]
+      status: 2
     - original_index: 383
-      status: [0]
+      status: 0
     - original_index: 384
-      status: [3]
+      status: 3
     - original_index: 385
-      status: [0]
+      status: 0
     - original_index: 386
-      status: [2]
+      status: 2
     - original_index: 387
-      status: [0]
+      status: 0
     - original_index: 388
-      status: [4]
+      status: 4
     - original_index: 389
-      status: [3]
+      status: 3
     - original_index: 390
-      status: [4]
+      status: 4
     - original_index: 391
-      status: [1]
+      status: 1
     - original_index: 392
-      status: [0]
+      status: 0
     - original_index: 393
-      status: [2]
+      status: 2
     - original_index: 394
-      status: [4]
+      status: 4
     - original_index: 395
-      status: [4]
+      status: 4
     - original_index: 396
-      status: [3]
+      status: 3
     - original_index: 397
-      status: [3]
+      status: 3
     - original_index: 398
-      status: [0]
+      status: 0
     - original_index: 399
-      status: [2]
+      status: 2
     - original_index: 400
-      status: [3]
+      status: 3
     - original_index: 401
-      status: [2]
+      status: 2
     - original_index: 402
-      status: [2]
+      status: 2
     - original_index: 403
-      status: [3]
+      status: 3
     - original_index: 404
-      status: [4]
+      status: 4
     - original_index: 405
-      status: [2]
+      status: 2
     - original_index: 406
-      status: [2]
+      status: 2
     - original_index: 407
-      status: [3]
+      status: 3
     - original_index: 408
-      status: [3]
+      status: 3
     - original_index: 409
-      status: [4]
+      status: 4
     - original_index: 410
-      status: [1]
+      status: 1
     - original_index: 411
-      status: [4]
+      status: 4
     - original_index: 412
-      status: [4]
+      status: 4
     - original_index: 413
-      status: [0]
+      status: 0
     - original_index: 414
-      status: [2]
+      status: 2
     - original_index: 415
-      status: [3]
+      status: 3
     - original_index: 416
-      status: [1]
+      status: 1
     - original_index: 417
-      status: [2]
+      status: 2
     - original_index: 418
-      status: [1]
+      status: 1
     - original_index: 419
-      status: [4]
+      status: 4
     - original_index: 420
-      status: [1]
+      status: 1
     - original_index: 421
-      status: [2]
+      status: 2
     - original_index: 422
-      status: [4]
+      status: 4
     - original_index: 423
-      status: [0]
+      status: 0
     - original_index: 424
-      status: [4]
+      status: 4
     - original_index: 425
-      status: [0]
+      status: 0
     - original_index: 426
-      status: [3]
+      status: 3
     - original_index: 427
-      status: [3]
+      status: 3
     - original_index: 428
-      status: [2]
+      status: 2
     - original_index: 429
-      status: [0]
+      status: 0
     - original_index: 430
-      status: [4]
+      status: 4
   output:
-  - - committee: [151, 209]
+  - - committee:
+      - 151
+      - 209
       shard: 323
       total_validator_count: 158
-  - - committee: [176, 340]
+  - - committee:
+      - 176
+      - 340
       shard: 324
       total_validator_count: 158
-  - - committee: [191, 53, 271]
+  - - committee:
+      - 191
+      - 53
+      - 271
       shard: 325
       total_validator_count: 158
-  - - committee: [412, 325]
+  - - committee:
+      - 412
+      - 325
       shard: 326
       total_validator_count: 158
-  - - committee: [163, 375, 409]
+  - - committee:
+      - 163
+      - 375
+      - 409
       shard: 327
       total_validator_count: 158
-  - - committee: [357, 337]
+  - - committee:
+      - 357
+      - 337
       shard: 328
       total_validator_count: 158
-  - - committee: [170, 202, 187]
+  - - committee:
+      - 170
+      - 202
+      - 187
       shard: 329
       total_validator_count: 158
-  - - committee: [148, 424]
+  - - committee:
+      - 148
+      - 424
       shard: 330
       total_validator_count: 158
-  - - committee: [107, 368, 330]
+  - - committee:
+      - 107
+      - 368
+      - 330
       shard: 331
       total_validator_count: 158
-  - - committee: [225, 168]
+  - - committee:
+      - 225
+      - 168
       shard: 332
       total_validator_count: 158
-  - - committee: [416, 381, 87]
+  - - committee:
+      - 416
+      - 381
+      - 87
       shard: 333
       total_validator_count: 158
-  - - committee: [366, 395]
+  - - committee:
+      - 366
+      - 395
       shard: 334
       total_validator_count: 158
-  - - committee: [105, 313, 116]
+  - - committee:
+      - 105
+      - 313
+      - 116
       shard: 335
       total_validator_count: 158
-  - - committee: [10, 380]
+  - - committee:
+      - 10
+      - 380
       shard: 336
       total_validator_count: 158
-  - - committee: [114, 365, 276]
+  - - committee:
+      - 114
+      - 365
+      - 276
       shard: 337
       total_validator_count: 158
-  - - committee: [80, 361]
+  - - committee:
+      - 80
+      - 361
       shard: 338
       total_validator_count: 158
-  - - committee: [98, 25]
+  - - committee:
+      - 98
+      - 25
       shard: 339
       total_validator_count: 158
-  - - committee: [257, 378, 167]
+  - - committee:
+      - 257
+      - 378
+      - 167
       shard: 340
       total_validator_count: 158
-  - - committee: [133, 165]
+  - - committee:
+      - 133
+      - 165
       shard: 341
       total_validator_count: 158
-  - - committee: [119, 166, 298]
+  - - committee:
+      - 119
+      - 166
+      - 298
       shard: 342
       total_validator_count: 158
-  - - committee: [338, 203]
+  - - committee:
+      - 338
+      - 203
       shard: 343
       total_validator_count: 158
-  - - committee: [57, 241, 307]
+  - - committee:
+      - 57
+      - 241
+      - 307
       shard: 344
       total_validator_count: 158
-  - - committee: [30, 235]
+  - - committee:
+      - 30
+      - 235
       shard: 345
       total_validator_count: 158
-  - - committee: [173, 144, 108]
+  - - committee:
+      - 173
+      - 144
+      - 108
       shard: 346
       total_validator_count: 158
-  - - committee: [159, 324]
+  - - committee:
+      - 159
+      - 324
       shard: 347
       total_validator_count: 158
-  - - committee: [68, 288, 254]
+  - - committee:
+      - 68
+      - 288
+      - 254
       shard: 348
       total_validator_count: 158
-  - - committee: [39, 50]
+  - - committee:
+      - 39
+      - 50
       shard: 349
       total_validator_count: 158
-  - - committee: [300, 358, 123]
+  - - committee:
+      - 300
+      - 358
+      - 123
       shard: 350
       total_validator_count: 158
-  - - committee: [79, 46]
+  - - committee:
+      - 79
+      - 46
       shard: 351
       total_validator_count: 158
-  - - committee: [302, 371, 430]
+  - - committee:
+      - 302
+      - 371
+      - 430
       shard: 352
       total_validator_count: 158
-  - - committee: [54, 228]
+  - - committee:
+      - 54
+      - 228
       shard: 353
       total_validator_count: 158
-  - - committee: [88, 258, 113]
+  - - committee:
+      - 88
+      - 258
+      - 113
       shard: 354
       total_validator_count: 158
-  - - committee: [336, 89]
+  - - committee:
+      - 336
+      - 89
       shard: 355
       total_validator_count: 158
-  - - committee: [236, 418]
+  - - committee:
+      - 236
+      - 418
       shard: 356
       total_validator_count: 158
-  - - committee: [102, 369, 40]
+  - - committee:
+      - 102
+      - 369
+      - 40
       shard: 357
       total_validator_count: 158
-  - - committee: [146, 419]
+  - - committee:
+      - 146
+      - 419
       shard: 358
       total_validator_count: 158
-  - - committee: [216, 75, 109]
+  - - committee:
+      - 216
+      - 75
+      - 109
       shard: 359
       total_validator_count: 158
-  - - committee: [205, 199]
+  - - committee:
+      - 205
+      - 199
       shard: 360
       total_validator_count: 158
-  - - committee: [15, 238, 270]
+  - - committee:
+      - 15
+      - 238
+      - 270
       shard: 361
       total_validator_count: 158
-  - - committee: [280, 65]
+  - - committee:
+      - 280
+      - 65
       shard: 362
       total_validator_count: 158
-  - - committee: [275, 346, 327]
+  - - committee:
+      - 275
+      - 346
+      - 327
       shard: 363
       total_validator_count: 158
-  - - committee: [312, 410]
+  - - committee:
+      - 312
+      - 410
       shard: 364
       total_validator_count: 158
-  - - committee: [391, 332, 411]
+  - - committee:
+      - 391
+      - 332
+      - 411
       shard: 365
       total_validator_count: 158
-  - - committee: [59, 323]
+  - - committee:
+      - 59
+      - 323
       shard: 366
       total_validator_count: 158
-  - - committee: [245, 60, 388]
+  - - committee:
+      - 245
+      - 60
+      - 388
       shard: 367
       total_validator_count: 158
-  - - committee: [141, 74]
+  - - committee:
+      - 141
+      - 74
       shard: 368
       total_validator_count: 158
-  - - committee: [48, 394, 226]
+  - - committee:
+      - 48
+      - 394
+      - 226
       shard: 369
       total_validator_count: 158
-  - - committee: [250, 126]
+  - - committee:
+      - 250
+      - 126
       shard: 370
       total_validator_count: 158
-  - - committee: [8, 78]
+  - - committee:
+      - 8
+      - 78
       shard: 371
       total_validator_count: 158
-  - - committee: [175, 31, 261]
+  - - committee:
+      - 175
+      - 31
+      - 261
       shard: 372
       total_validator_count: 158
-  - - committee: [131, 420]
+  - - committee:
+      - 131
+      - 420
       shard: 373
       total_validator_count: 158
-  - - committee: [296, 370, 404]
+  - - committee:
+      - 296
+      - 370
+      - 404
       shard: 374
       total_validator_count: 158
-  - - committee: [129, 422]
+  - - committee:
+      - 129
+      - 422
       shard: 375
       total_validator_count: 158
-  - - committee: [138, 115, 127]
+  - - committee:
+      - 138
+      - 115
+      - 127
       shard: 376
       total_validator_count: 158
-  - - committee: [390, 359]
+  - - committee:
+      - 390
+      - 359
       shard: 377
       total_validator_count: 158
-  - - committee: [83, 224, 345]
+  - - committee:
+      - 83
+      - 224
+      - 345
       shard: 378
       total_validator_count: 158
-  - - committee: [174, 295]
+  - - committee:
+      - 174
+      - 295
       shard: 379
       total_validator_count: 158
-  - - committee: [219, 331, 42]
+  - - committee:
+      - 219
+      - 331
+      - 42
       shard: 380
       total_validator_count: 158
-  - - committee: [294, 14]
+  - - committee:
+      - 294
+      - 14
       shard: 381
       total_validator_count: 158
-  - - committee: [27, 364, 334]
+  - - committee:
+      - 27
+      - 364
+      - 334
       shard: 382
       total_validator_count: 158
-  - - committee: [58, 11]
+  - - committee:
+      - 58
+      - 11
       shard: 383
       total_validator_count: 158
-  - - committee: [112, 348, 360]
+  - - committee:
+      - 112
+      - 348
+      - 360
       shard: 384
       total_validator_count: 158
-  - - committee: [310, 285]
+  - - committee:
+      - 310
+      - 285
       shard: 385
       total_validator_count: 158
-  - - committee: [43, 137, 315]
+  - - committee:
+      - 43
+      - 137
+      - 315
       shard: 386
       total_validator_count: 158
   seed: '0x3e0145d6c946e5121aa6a8f761d1647d093fb976f2497361897012dfa6dc0190'
@@ -4114,1164 +4751,1362 @@ test_cases:
     crosslinking_start_shard: 233
     validators:
     - original_index: 0
-      status: [3]
+      status: 3
     - original_index: 1
-      status: [0]
+      status: 0
     - original_index: 2
-      status: [1]
+      status: 1
     - original_index: 3
-      status: [3]
+      status: 3
     - original_index: 4
-      status: [3]
+      status: 3
     - original_index: 5
-      status: [2]
+      status: 2
     - original_index: 6
-      status: [4]
+      status: 4
     - original_index: 7
-      status: [2]
+      status: 2
     - original_index: 8
-      status: [4]
+      status: 4
     - original_index: 9
-      status: [4]
+      status: 4
     - original_index: 10
-      status: [2]
+      status: 2
     - original_index: 11
-      status: [4]
+      status: 4
     - original_index: 12
-      status: [2]
+      status: 2
     - original_index: 13
-      status: [1]
+      status: 1
     - original_index: 14
-      status: [1]
+      status: 1
     - original_index: 15
-      status: [2]
+      status: 2
     - original_index: 16
-      status: [2]
+      status: 2
     - original_index: 17
-      status: [1]
+      status: 1
     - original_index: 18
-      status: [4]
+      status: 4
     - original_index: 19
-      status: [2]
+      status: 2
     - original_index: 20
-      status: [1]
+      status: 1
     - original_index: 21
-      status: [2]
+      status: 2
     - original_index: 22
-      status: [3]
+      status: 3
     - original_index: 23
-      status: [4]
+      status: 4
     - original_index: 24
-      status: [3]
+      status: 3
     - original_index: 25
-      status: [1]
+      status: 1
     - original_index: 26
-      status: [0]
+      status: 0
     - original_index: 27
-      status: [1]
+      status: 1
     - original_index: 28
-      status: [0]
+      status: 0
     - original_index: 29
-      status: [4]
+      status: 4
     - original_index: 30
-      status: [4]
+      status: 4
     - original_index: 31
-      status: [0]
+      status: 0
     - original_index: 32
-      status: [3]
+      status: 3
     - original_index: 33
-      status: [3]
+      status: 3
     - original_index: 34
-      status: [1]
+      status: 1
     - original_index: 35
-      status: [2]
+      status: 2
     - original_index: 36
-      status: [4]
+      status: 4
     - original_index: 37
-      status: [4]
+      status: 4
     - original_index: 38
-      status: [1]
+      status: 1
     - original_index: 39
-      status: [3]
+      status: 3
     - original_index: 40
-      status: [4]
+      status: 4
     - original_index: 41
-      status: [2]
+      status: 2
     - original_index: 42
-      status: [2]
+      status: 2
     - original_index: 43
-      status: [3]
+      status: 3
     - original_index: 44
-      status: [4]
+      status: 4
     - original_index: 45
-      status: [4]
+      status: 4
     - original_index: 46
-      status: [3]
+      status: 3
     - original_index: 47
-      status: [1]
+      status: 1
     - original_index: 48
-      status: [3]
+      status: 3
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [3]
+      status: 3
     - original_index: 51
-      status: [0]
+      status: 0
     - original_index: 52
-      status: [2]
+      status: 2
     - original_index: 53
-      status: [4]
+      status: 4
     - original_index: 54
-      status: [1]
+      status: 1
     - original_index: 55
-      status: [2]
+      status: 2
     - original_index: 56
-      status: [4]
+      status: 4
     - original_index: 57
-      status: [1]
+      status: 1
     - original_index: 58
-      status: [2]
+      status: 2
     - original_index: 59
-      status: [2]
+      status: 2
     - original_index: 60
-      status: [1]
+      status: 1
     - original_index: 61
-      status: [3]
+      status: 3
     - original_index: 62
-      status: [3]
+      status: 3
     - original_index: 63
-      status: [3]
+      status: 3
     - original_index: 64
-      status: [1]
+      status: 1
     - original_index: 65
-      status: [1]
+      status: 1
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [3]
+      status: 3
     - original_index: 68
-      status: [2]
+      status: 2
     - original_index: 69
-      status: [2]
+      status: 2
     - original_index: 70
-      status: [0]
+      status: 0
     - original_index: 71
-      status: [4]
+      status: 4
     - original_index: 72
-      status: [4]
+      status: 4
     - original_index: 73
-      status: [1]
+      status: 1
     - original_index: 74
-      status: [4]
+      status: 4
     - original_index: 75
-      status: [1]
+      status: 1
     - original_index: 76
-      status: [4]
+      status: 4
     - original_index: 77
-      status: [0]
+      status: 0
     - original_index: 78
-      status: [4]
+      status: 4
     - original_index: 79
-      status: [2]
+      status: 2
     - original_index: 80
-      status: [2]
+      status: 2
     - original_index: 81
-      status: [4]
+      status: 4
     - original_index: 82
-      status: [4]
+      status: 4
     - original_index: 83
-      status: [0]
+      status: 0
     - original_index: 84
-      status: [1]
+      status: 1
     - original_index: 85
-      status: [1]
+      status: 1
     - original_index: 86
-      status: [1]
+      status: 1
     - original_index: 87
-      status: [2]
+      status: 2
     - original_index: 88
-      status: [1]
+      status: 1
     - original_index: 89
-      status: [2]
+      status: 2
     - original_index: 90
-      status: [1]
+      status: 1
     - original_index: 91
-      status: [2]
+      status: 2
     - original_index: 92
-      status: [2]
+      status: 2
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [1]
+      status: 1
     - original_index: 95
-      status: [0]
+      status: 0
     - original_index: 96
-      status: [0]
+      status: 0
     - original_index: 97
-      status: [0]
+      status: 0
     - original_index: 98
-      status: [0]
+      status: 0
     - original_index: 99
-      status: [4]
+      status: 4
     - original_index: 100
-      status: [2]
+      status: 2
     - original_index: 101
-      status: [4]
+      status: 4
     - original_index: 102
-      status: [0]
+      status: 0
     - original_index: 103
-      status: [3]
+      status: 3
     - original_index: 104
-      status: [2]
+      status: 2
     - original_index: 105
-      status: [2]
+      status: 2
     - original_index: 106
-      status: [4]
+      status: 4
     - original_index: 107
-      status: [3]
+      status: 3
     - original_index: 108
-      status: [3]
+      status: 3
     - original_index: 109
-      status: [3]
+      status: 3
     - original_index: 110
-      status: [1]
+      status: 1
     - original_index: 111
-      status: [0]
+      status: 0
     - original_index: 112
-      status: [2]
+      status: 2
     - original_index: 113
-      status: [4]
+      status: 4
     - original_index: 114
-      status: [2]
+      status: 2
     - original_index: 115
-      status: [2]
+      status: 2
     - original_index: 116
-      status: [4]
+      status: 4
     - original_index: 117
-      status: [2]
+      status: 2
     - original_index: 118
-      status: [4]
+      status: 4
     - original_index: 119
-      status: [3]
+      status: 3
     - original_index: 120
-      status: [1]
+      status: 1
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [3]
+      status: 3
     - original_index: 124
-      status: [2]
+      status: 2
     - original_index: 125
-      status: [0]
+      status: 0
     - original_index: 126
-      status: [1]
+      status: 1
     - original_index: 127
-      status: [4]
+      status: 4
     - original_index: 128
-      status: [3]
+      status: 3
     - original_index: 129
-      status: [2]
+      status: 2
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [1]
+      status: 1
     - original_index: 132
-      status: [0]
+      status: 0
     - original_index: 133
-      status: [4]
+      status: 4
     - original_index: 134
-      status: [3]
+      status: 3
     - original_index: 135
-      status: [2]
+      status: 2
     - original_index: 136
-      status: [1]
+      status: 1
     - original_index: 137
-      status: [0]
+      status: 0
     - original_index: 138
-      status: [1]
+      status: 1
     - original_index: 139
-      status: [4]
+      status: 4
     - original_index: 140
-      status: [2]
+      status: 2
     - original_index: 141
-      status: [3]
+      status: 3
     - original_index: 142
-      status: [0]
+      status: 0
     - original_index: 143
-      status: [3]
+      status: 3
     - original_index: 144
-      status: [0]
+      status: 0
     - original_index: 145
-      status: [0]
+      status: 0
     - original_index: 146
-      status: [4]
+      status: 4
     - original_index: 147
-      status: [0]
+      status: 0
     - original_index: 148
-      status: [4]
+      status: 4
     - original_index: 149
-      status: [1]
+      status: 1
     - original_index: 150
-      status: [0]
+      status: 0
     - original_index: 151
-      status: [2]
+      status: 2
     - original_index: 152
-      status: [3]
+      status: 3
     - original_index: 153
-      status: [2]
+      status: 2
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [2]
+      status: 2
     - original_index: 156
-      status: [1]
+      status: 1
     - original_index: 157
-      status: [1]
+      status: 1
     - original_index: 158
-      status: [3]
+      status: 3
     - original_index: 159
-      status: [2]
+      status: 2
     - original_index: 160
-      status: [4]
+      status: 4
     - original_index: 161
-      status: [4]
+      status: 4
     - original_index: 162
-      status: [2]
+      status: 2
     - original_index: 163
-      status: [1]
+      status: 1
     - original_index: 164
-      status: [1]
+      status: 1
     - original_index: 165
-      status: [0]
+      status: 0
     - original_index: 166
-      status: [0]
+      status: 0
     - original_index: 167
-      status: [4]
+      status: 4
     - original_index: 168
-      status: [4]
+      status: 4
     - original_index: 169
-      status: [1]
+      status: 1
     - original_index: 170
-      status: [0]
+      status: 0
     - original_index: 171
-      status: [1]
+      status: 1
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [3]
+      status: 3
     - original_index: 174
-      status: [4]
+      status: 4
     - original_index: 175
-      status: [3]
+      status: 3
     - original_index: 176
-      status: [0]
+      status: 0
     - original_index: 177
-      status: [0]
+      status: 0
     - original_index: 178
-      status: [2]
+      status: 2
     - original_index: 179
-      status: [4]
+      status: 4
     - original_index: 180
-      status: [1]
+      status: 1
     - original_index: 181
-      status: [1]
+      status: 1
     - original_index: 182
-      status: [3]
+      status: 3
     - original_index: 183
-      status: [0]
+      status: 0
     - original_index: 184
-      status: [4]
+      status: 4
     - original_index: 185
-      status: [0]
+      status: 0
     - original_index: 186
-      status: [4]
+      status: 4
     - original_index: 187
-      status: [0]
+      status: 0
     - original_index: 188
-      status: [3]
+      status: 3
     - original_index: 189
-      status: [0]
+      status: 0
     - original_index: 190
-      status: [2]
+      status: 2
     - original_index: 191
-      status: [2]
+      status: 2
     - original_index: 192
-      status: [4]
+      status: 4
     - original_index: 193
-      status: [1]
+      status: 1
     - original_index: 194
-      status: [1]
+      status: 1
     - original_index: 195
-      status: [2]
+      status: 2
     - original_index: 196
-      status: [4]
+      status: 4
     - original_index: 197
-      status: [0]
+      status: 0
     - original_index: 198
-      status: [3]
+      status: 3
     - original_index: 199
-      status: [4]
+      status: 4
     - original_index: 200
-      status: [1]
+      status: 1
     - original_index: 201
-      status: [4]
+      status: 4
     - original_index: 202
-      status: [2]
+      status: 2
     - original_index: 203
-      status: [3]
+      status: 3
     - original_index: 204
-      status: [2]
+      status: 2
     - original_index: 205
-      status: [1]
+      status: 1
     - original_index: 206
-      status: [3]
+      status: 3
     - original_index: 207
-      status: [0]
+      status: 0
     - original_index: 208
-      status: [1]
+      status: 1
     - original_index: 209
-      status: [0]
+      status: 0
     - original_index: 210
-      status: [3]
+      status: 3
     - original_index: 211
-      status: [1]
+      status: 1
     - original_index: 212
-      status: [2]
+      status: 2
     - original_index: 213
-      status: [1]
+      status: 1
     - original_index: 214
-      status: [4]
+      status: 4
     - original_index: 215
-      status: [2]
+      status: 2
     - original_index: 216
-      status: [1]
+      status: 1
     - original_index: 217
-      status: [3]
+      status: 3
     - original_index: 218
-      status: [0]
+      status: 0
     - original_index: 219
-      status: [4]
+      status: 4
     - original_index: 220
-      status: [2]
+      status: 2
     - original_index: 221
-      status: [2]
+      status: 2
     - original_index: 222
-      status: [0]
+      status: 0
     - original_index: 223
-      status: [1]
+      status: 1
     - original_index: 224
-      status: [2]
+      status: 2
     - original_index: 225
-      status: [3]
+      status: 3
     - original_index: 226
-      status: [4]
+      status: 4
     - original_index: 227
-      status: [2]
+      status: 2
     - original_index: 228
-      status: [2]
+      status: 2
     - original_index: 229
-      status: [2]
+      status: 2
     - original_index: 230
-      status: [2]
+      status: 2
     - original_index: 231
-      status: [4]
+      status: 4
     - original_index: 232
-      status: [0]
+      status: 0
     - original_index: 233
-      status: [1]
+      status: 1
     - original_index: 234
-      status: [1]
+      status: 1
     - original_index: 235
-      status: [2]
+      status: 2
     - original_index: 236
-      status: [1]
+      status: 1
     - original_index: 237
-      status: [4]
+      status: 4
     - original_index: 238
-      status: [1]
+      status: 1
     - original_index: 239
-      status: [0]
+      status: 0
     - original_index: 240
-      status: [1]
+      status: 1
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [3]
+      status: 3
     - original_index: 243
-      status: [1]
+      status: 1
     - original_index: 244
-      status: [2]
+      status: 2
     - original_index: 245
-      status: [3]
+      status: 3
     - original_index: 246
-      status: [0]
+      status: 0
     - original_index: 247
-      status: [2]
+      status: 2
     - original_index: 248
-      status: [3]
+      status: 3
     - original_index: 249
-      status: [3]
+      status: 3
     - original_index: 250
-      status: [4]
+      status: 4
     - original_index: 251
-      status: [2]
+      status: 2
     - original_index: 252
-      status: [4]
+      status: 4
     - original_index: 253
-      status: [4]
+      status: 4
     - original_index: 254
-      status: [0]
+      status: 0
     - original_index: 255
-      status: [0]
+      status: 0
     - original_index: 256
-      status: [2]
+      status: 2
     - original_index: 257
-      status: [3]
+      status: 3
     - original_index: 258
-      status: [4]
+      status: 4
     - original_index: 259
-      status: [1]
+      status: 1
     - original_index: 260
-      status: [2]
+      status: 2
     - original_index: 261
-      status: [2]
+      status: 2
     - original_index: 262
-      status: [2]
+      status: 2
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [4]
+      status: 4
     - original_index: 265
-      status: [4]
+      status: 4
     - original_index: 266
-      status: [0]
+      status: 0
     - original_index: 267
-      status: [3]
+      status: 3
     - original_index: 268
-      status: [2]
+      status: 2
     - original_index: 269
-      status: [0]
+      status: 0
     - original_index: 270
-      status: [0]
+      status: 0
     - original_index: 271
-      status: [1]
+      status: 1
     - original_index: 272
-      status: [3]
+      status: 3
     - original_index: 273
-      status: [4]
+      status: 4
     - original_index: 274
-      status: [2]
+      status: 2
     - original_index: 275
-      status: [4]
+      status: 4
     - original_index: 276
-      status: [4]
+      status: 4
     - original_index: 277
-      status: [2]
+      status: 2
     - original_index: 278
-      status: [0]
+      status: 0
     - original_index: 279
-      status: [0]
+      status: 0
     - original_index: 280
-      status: [3]
+      status: 3
     - original_index: 281
-      status: [4]
+      status: 4
     - original_index: 282
-      status: [1]
+      status: 1
     - original_index: 283
-      status: [4]
+      status: 4
     - original_index: 284
-      status: [0]
+      status: 0
     - original_index: 285
-      status: [0]
+      status: 0
     - original_index: 286
-      status: [1]
+      status: 1
     - original_index: 287
-      status: [0]
+      status: 0
     - original_index: 288
-      status: [3]
+      status: 3
     - original_index: 289
-      status: [2]
+      status: 2
     - original_index: 290
-      status: [1]
+      status: 1
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [1]
+      status: 1
     - original_index: 293
-      status: [1]
+      status: 1
     - original_index: 294
-      status: [1]
+      status: 1
     - original_index: 295
-      status: [2]
+      status: 2
     - original_index: 296
-      status: [0]
+      status: 0
     - original_index: 297
-      status: [4]
+      status: 4
     - original_index: 298
-      status: [3]
+      status: 3
     - original_index: 299
-      status: [1]
+      status: 1
     - original_index: 300
-      status: [3]
+      status: 3
     - original_index: 301
-      status: [1]
+      status: 1
     - original_index: 302
-      status: [0]
+      status: 0
     - original_index: 303
-      status: [4]
+      status: 4
     - original_index: 304
-      status: [1]
+      status: 1
     - original_index: 305
-      status: [4]
+      status: 4
     - original_index: 306
-      status: [1]
+      status: 1
     - original_index: 307
-      status: [3]
+      status: 3
     - original_index: 308
-      status: [2]
+      status: 2
     - original_index: 309
-      status: [3]
+      status: 3
     - original_index: 310
-      status: [2]
+      status: 2
     - original_index: 311
-      status: [1]
+      status: 1
     - original_index: 312
-      status: [2]
+      status: 2
     - original_index: 313
-      status: [0]
+      status: 0
     - original_index: 314
-      status: [3]
+      status: 3
     - original_index: 315
-      status: [2]
+      status: 2
     - original_index: 316
-      status: [1]
+      status: 1
     - original_index: 317
-      status: [1]
+      status: 1
     - original_index: 318
-      status: [1]
+      status: 1
     - original_index: 319
-      status: [0]
+      status: 0
     - original_index: 320
-      status: [2]
+      status: 2
     - original_index: 321
-      status: [2]
+      status: 2
     - original_index: 322
-      status: [2]
+      status: 2
     - original_index: 323
-      status: [0]
+      status: 0
     - original_index: 324
-      status: [2]
+      status: 2
     - original_index: 325
-      status: [0]
+      status: 0
     - original_index: 326
-      status: [2]
+      status: 2
     - original_index: 327
-      status: [3]
+      status: 3
     - original_index: 328
-      status: [1]
+      status: 1
     - original_index: 329
-      status: [3]
+      status: 3
     - original_index: 330
-      status: [3]
+      status: 3
     - original_index: 331
-      status: [3]
+      status: 3
     - original_index: 332
-      status: [1]
+      status: 1
     - original_index: 333
-      status: [2]
+      status: 2
     - original_index: 334
-      status: [3]
+      status: 3
     - original_index: 335
-      status: [0]
+      status: 0
     - original_index: 336
-      status: [0]
+      status: 0
     - original_index: 337
-      status: [2]
+      status: 2
     - original_index: 338
-      status: [1]
+      status: 1
     - original_index: 339
-      status: [2]
+      status: 2
     - original_index: 340
-      status: [1]
+      status: 1
     - original_index: 341
-      status: [4]
+      status: 4
     - original_index: 342
-      status: [2]
+      status: 2
     - original_index: 343
-      status: [1]
+      status: 1
     - original_index: 344
-      status: [1]
+      status: 1
     - original_index: 345
-      status: [3]
+      status: 3
     - original_index: 346
-      status: [4]
+      status: 4
     - original_index: 347
-      status: [1]
+      status: 1
     - original_index: 348
-      status: [0]
+      status: 0
     - original_index: 349
-      status: [3]
+      status: 3
     - original_index: 350
-      status: [0]
+      status: 0
     - original_index: 351
-      status: [3]
+      status: 3
     - original_index: 352
-      status: [2]
+      status: 2
     - original_index: 353
-      status: [2]
+      status: 2
     - original_index: 354
-      status: [1]
+      status: 1
     - original_index: 355
-      status: [3]
+      status: 3
     - original_index: 356
-      status: [3]
+      status: 3
     - original_index: 357
-      status: [4]
+      status: 4
     - original_index: 358
-      status: [0]
+      status: 0
     - original_index: 359
-      status: [2]
+      status: 2
     - original_index: 360
-      status: [4]
+      status: 4
     - original_index: 361
-      status: [1]
+      status: 1
     - original_index: 362
-      status: [2]
+      status: 2
     - original_index: 363
-      status: [1]
+      status: 1
     - original_index: 364
-      status: [4]
+      status: 4
     - original_index: 365
-      status: [3]
+      status: 3
     - original_index: 366
-      status: [0]
+      status: 0
     - original_index: 367
-      status: [2]
+      status: 2
     - original_index: 368
-      status: [3]
+      status: 3
     - original_index: 369
-      status: [0]
+      status: 0
     - original_index: 370
-      status: [2]
+      status: 2
     - original_index: 371
-      status: [0]
+      status: 0
     - original_index: 372
-      status: [3]
+      status: 3
     - original_index: 373
-      status: [0]
+      status: 0
     - original_index: 374
-      status: [0]
+      status: 0
     - original_index: 375
-      status: [0]
+      status: 0
     - original_index: 376
-      status: [2]
+      status: 2
     - original_index: 377
-      status: [4]
+      status: 4
     - original_index: 378
-      status: [4]
+      status: 4
     - original_index: 379
-      status: [3]
+      status: 3
     - original_index: 380
-      status: [4]
+      status: 4
     - original_index: 381
-      status: [3]
+      status: 3
     - original_index: 382
-      status: [2]
+      status: 2
     - original_index: 383
-      status: [0]
+      status: 0
     - original_index: 384
-      status: [0]
+      status: 0
     - original_index: 385
-      status: [1]
+      status: 1
     - original_index: 386
-      status: [2]
+      status: 2
     - original_index: 387
-      status: [2]
+      status: 2
     - original_index: 388
-      status: [4]
+      status: 4
     - original_index: 389
-      status: [0]
+      status: 0
     - original_index: 390
-      status: [0]
+      status: 0
     - original_index: 391
-      status: [1]
+      status: 1
     - original_index: 392
-      status: [3]
+      status: 3
     - original_index: 393
-      status: [3]
+      status: 3
     - original_index: 394
-      status: [3]
+      status: 3
     - original_index: 395
-      status: [4]
+      status: 4
     - original_index: 396
-      status: [4]
+      status: 4
     - original_index: 397
-      status: [3]
+      status: 3
     - original_index: 398
-      status: [4]
+      status: 4
     - original_index: 399
-      status: [0]
+      status: 0
     - original_index: 400
-      status: [4]
+      status: 4
     - original_index: 401
-      status: [3]
+      status: 3
     - original_index: 402
-      status: [1]
+      status: 1
     - original_index: 403
-      status: [4]
+      status: 4
     - original_index: 404
-      status: [0]
+      status: 0
     - original_index: 405
-      status: [1]
+      status: 1
     - original_index: 406
-      status: [3]
+      status: 3
     - original_index: 407
-      status: [0]
+      status: 0
     - original_index: 408
-      status: [4]
+      status: 4
     - original_index: 409
-      status: [0]
+      status: 0
     - original_index: 410
-      status: [0]
+      status: 0
     - original_index: 411
-      status: [3]
+      status: 3
     - original_index: 412
-      status: [0]
+      status: 0
     - original_index: 413
-      status: [2]
+      status: 2
     - original_index: 414
-      status: [0]
+      status: 0
     - original_index: 415
-      status: [4]
+      status: 4
     - original_index: 416
-      status: [3]
+      status: 3
     - original_index: 417
-      status: [0]
+      status: 0
     - original_index: 418
-      status: [0]
+      status: 0
     - original_index: 419
-      status: [1]
+      status: 1
     - original_index: 420
-      status: [3]
+      status: 3
     - original_index: 421
-      status: [4]
+      status: 4
     - original_index: 422
-      status: [3]
+      status: 3
     - original_index: 423
-      status: [1]
+      status: 1
     - original_index: 424
-      status: [2]
+      status: 2
     - original_index: 425
-      status: [4]
+      status: 4
     - original_index: 426
-      status: [0]
+      status: 0
     - original_index: 427
-      status: [4]
+      status: 4
     - original_index: 428
-      status: [0]
+      status: 0
     - original_index: 429
-      status: [0]
+      status: 0
     - original_index: 430
-      status: [0]
+      status: 0
     - original_index: 431
-      status: [4]
+      status: 4
     - original_index: 432
-      status: [3]
+      status: 3
     - original_index: 433
-      status: [4]
+      status: 4
     - original_index: 434
-      status: [2]
+      status: 2
     - original_index: 435
-      status: [3]
+      status: 3
     - original_index: 436
-      status: [2]
+      status: 2
     - original_index: 437
-      status: [3]
+      status: 3
     - original_index: 438
-      status: [4]
+      status: 4
     - original_index: 439
-      status: [4]
+      status: 4
     - original_index: 440
-      status: [1]
+      status: 1
     - original_index: 441
-      status: [4]
+      status: 4
     - original_index: 442
-      status: [1]
+      status: 1
     - original_index: 443
-      status: [1]
+      status: 1
     - original_index: 444
-      status: [3]
+      status: 3
     - original_index: 445
-      status: [2]
+      status: 2
     - original_index: 446
-      status: [3]
+      status: 3
     - original_index: 447
-      status: [0]
+      status: 0
     - original_index: 448
-      status: [4]
+      status: 4
     - original_index: 449
-      status: [1]
+      status: 1
     - original_index: 450
-      status: [4]
+      status: 4
     - original_index: 451
-      status: [4]
+      status: 4
     - original_index: 452
-      status: [4]
+      status: 4
     - original_index: 453
-      status: [3]
+      status: 3
     - original_index: 454
-      status: [1]
+      status: 1
     - original_index: 455
-      status: [4]
+      status: 4
     - original_index: 456
-      status: [4]
+      status: 4
     - original_index: 457
-      status: [2]
+      status: 2
     - original_index: 458
-      status: [0]
+      status: 0
     - original_index: 459
-      status: [1]
+      status: 1
     - original_index: 460
-      status: [3]
+      status: 3
     - original_index: 461
-      status: [3]
+      status: 3
     - original_index: 462
-      status: [2]
+      status: 2
     - original_index: 463
-      status: [4]
+      status: 4
     - original_index: 464
-      status: [1]
+      status: 1
     - original_index: 465
-      status: [0]
+      status: 0
     - original_index: 466
-      status: [2]
+      status: 2
     - original_index: 467
-      status: [4]
+      status: 4
     - original_index: 468
-      status: [4]
+      status: 4
     - original_index: 469
-      status: [1]
+      status: 1
     - original_index: 470
-      status: [2]
+      status: 2
     - original_index: 471
-      status: [1]
+      status: 1
     - original_index: 472
-      status: [4]
+      status: 4
     - original_index: 473
-      status: [2]
+      status: 2
     - original_index: 474
-      status: [0]
+      status: 0
     - original_index: 475
-      status: [2]
+      status: 2
     - original_index: 476
-      status: [1]
+      status: 1
     - original_index: 477
-      status: [0]
+      status: 0
     - original_index: 478
-      status: [3]
+      status: 3
     - original_index: 479
-      status: [1]
+      status: 1
     - original_index: 480
-      status: [0]
+      status: 0
     - original_index: 481
-      status: [3]
+      status: 3
     - original_index: 482
-      status: [0]
+      status: 0
     - original_index: 483
-      status: [0]
+      status: 0
   output:
-  - - committee: [304, 340, 201]
+  - - committee:
+      - 304
+      - 340
+      - 201
       shard: 233
       total_validator_count: 198
-  - - committee: [113, 451, 456]
+  - - committee:
+      - 113
+      - 451
+      - 456
       shard: 234
       total_validator_count: 198
-  - - committee: [459, 450, 361]
+  - - committee:
+      - 459
+      - 450
+      - 361
       shard: 235
       total_validator_count: 198
-  - - committee: [29, 281, 74]
+  - - committee:
+      - 29
+      - 281
+      - 74
       shard: 236
       total_validator_count: 198
-  - - committee: [347, 237, 193]
+  - - committee:
+      - 347
+      - 237
+      - 193
       shard: 237
       total_validator_count: 198
-  - - committee: [297, 354, 292]
+  - - committee:
+      - 297
+      - 354
+      - 292
       shard: 238
       total_validator_count: 198
-  - - committee: [211, 258, 293]
+  - - committee:
+      - 211
+      - 258
+      - 293
       shard: 239
       total_validator_count: 198
-  - - committee: [276, 400, 8]
+  - - committee:
+      - 276
+      - 400
+      - 8
       shard: 240
       total_validator_count: 198
-  - - committee: [316, 243, 64]
+  - - committee:
+      - 316
+      - 243
+      - 64
       shard: 241
       total_validator_count: 198
-  - - committee: [17, 303, 205]
+  - - committee:
+      - 17
+      - 303
+      - 205
       shard: 242
       total_validator_count: 198
-  - - committee: [378, 90, 171, 226]
+  - - committee:
+      - 378
+      - 90
+      - 171
+      - 226
       shard: 243
       total_validator_count: 198
-  - - committee: [126, 20, 431]
+  - - committee:
+      - 126
+      - 20
+      - 431
       shard: 244
       total_validator_count: 198
-  - - committee: [391, 455, 427]
+  - - committee:
+      - 391
+      - 455
+      - 427
       shard: 245
       total_validator_count: 198
-  - - committee: [13, 174, 363]
+  - - committee:
+      - 13
+      - 174
+      - 363
       shard: 246
       total_validator_count: 198
-  - - committee: [259, 240, 433]
+  - - committee:
+      - 259
+      - 240
+      - 433
       shard: 247
       total_validator_count: 198
-  - - committee: [9, 380, 441]
+  - - committee:
+      - 9
+      - 380
+      - 441
       shard: 248
       total_validator_count: 198
-  - - committee: [396, 65, 425]
+  - - committee:
+      - 396
+      - 65
+      - 425
       shard: 249
       total_validator_count: 198
-  - - committee: [449, 357, 164]
+  - - committee:
+      - 449
+      - 357
+      - 164
       shard: 250
       total_validator_count: 198
-  - - committee: [421, 306, 328]
+  - - committee:
+      - 421
+      - 306
+      - 328
       shard: 251
       total_validator_count: 198
-  - - committee: [139, 344, 94]
+  - - committee:
+      - 139
+      - 344
+      - 94
       shard: 252
       total_validator_count: 198
-  - - committee: [464, 157, 264]
+  - - committee:
+      - 464
+      - 157
+      - 264
       shard: 253
       total_validator_count: 198
-  - - committee: [317, 283, 440, 439]
+  - - committee:
+      - 317
+      - 283
+      - 440
+      - 439
       shard: 254
       total_validator_count: 198
-  - - committee: [341, 265, 60]
+  - - committee:
+      - 341
+      - 265
+      - 60
       shard: 255
       total_validator_count: 198
-  - - committee: [208, 305, 443]
+  - - committee:
+      - 208
+      - 305
+      - 443
       shard: 256
       total_validator_count: 198
-  - - committee: [442, 88, 311]
+  - - committee:
+      - 442
+      - 88
+      - 311
       shard: 257
       total_validator_count: 198
-  - - committee: [360, 181, 405]
+  - - committee:
+      - 360
+      - 181
+      - 405
       shard: 258
       total_validator_count: 198
-  - - committee: [120, 241, 110]
+  - - committee:
+      - 120
+      - 241
+      - 110
       shard: 259
       total_validator_count: 198
-  - - committee: [472, 36, 25]
+  - - committee:
+      - 472
+      - 36
+      - 25
       shard: 260
       total_validator_count: 198
-  - - committee: [467, 146, 346]
+  - - committee:
+      - 467
+      - 146
+      - 346
       shard: 261
       total_validator_count: 198
-  - - committee: [53, 192, 438]
+  - - committee:
+      - 53
+      - 192
+      - 438
       shard: 262
       total_validator_count: 198
-  - - committee: [34, 184, 273]
+  - - committee:
+      - 34
+      - 184
+      - 273
       shard: 263
       total_validator_count: 198
-  - - committee: [82, 136, 364, 44]
+  - - committee:
+      - 82
+      - 136
+      - 364
+      - 44
       shard: 264
       total_validator_count: 198
-  - - committee: [30, 194, 199]
+  - - committee:
+      - 30
+      - 194
+      - 199
       shard: 265
       total_validator_count: 198
-  - - committee: [263, 131, 196]
+  - - committee:
+      - 263
+      - 131
+      - 196
       shard: 266
       total_validator_count: 198
-  - - committee: [290, 6, 388]
+  - - committee:
+      - 290
+      - 6
+      - 388
       shard: 267
       total_validator_count: 198
-  - - committee: [299, 454, 479]
+  - - committee:
+      - 299
+      - 454
+      - 479
       shard: 268
       total_validator_count: 198
-  - - committee: [37, 471, 332]
+  - - committee:
+      - 37
+      - 471
+      - 332
       shard: 269
       total_validator_count: 198
-  - - committee: [385, 161, 415]
+  - - committee:
+      - 385
+      - 161
+      - 415
       shard: 270
       total_validator_count: 198
-  - - committee: [179, 294, 54]
+  - - committee:
+      - 179
+      - 294
+      - 54
       shard: 271
       total_validator_count: 198
-  - - committee: [403, 186, 73]
+  - - committee:
+      - 403
+      - 186
+      - 73
       shard: 272
       total_validator_count: 198
-  - - committee: [377, 2, 85]
+  - - committee:
+      - 377
+      - 2
+      - 85
       shard: 273
       total_validator_count: 198
-  - - committee: [84, 133, 71]
+  - - committee:
+      - 84
+      - 133
+      - 71
       shard: 274
       total_validator_count: 198
-  - - committee: [81, 219, 27, 338]
+  - - committee:
+      - 81
+      - 219
+      - 27
+      - 338
       shard: 275
       total_validator_count: 198
-  - - committee: [233, 180, 130]
+  - - committee:
+      - 233
+      - 180
+      - 130
       shard: 276
       total_validator_count: 198
-  - - committee: [167, 236, 250]
+  - - committee:
+      - 167
+      - 236
+      - 250
       shard: 277
       total_validator_count: 198
-  - - committee: [18, 286, 148]
+  - - committee:
+      - 18
+      - 286
+      - 148
       shard: 278
       total_validator_count: 198
-  - - committee: [200, 402, 149]
+  - - committee:
+      - 200
+      - 402
+      - 149
       shard: 279
       total_validator_count: 198
-  - - committee: [223, 271, 75]
+  - - committee:
+      - 223
+      - 271
+      - 75
       shard: 280
       total_validator_count: 198
-  - - committee: [138, 213, 469]
+  - - committee:
+      - 138
+      - 213
+      - 469
       shard: 281
       total_validator_count: 198
-  - - committee: [238, 101, 253]
+  - - committee:
+      - 238
+      - 101
+      - 253
       shard: 282
       total_validator_count: 198
-  - - committee: [57, 14, 116]
+  - - committee:
+      - 57
+      - 14
+      - 116
       shard: 283
       total_validator_count: 198
-  - - committee: [154, 398, 118]
+  - - committee:
+      - 154
+      - 398
+      - 118
       shard: 284
       total_validator_count: 198
-  - - committee: [156, 47, 127]
+  - - committee:
+      - 156
+      - 47
+      - 127
       shard: 285
       total_validator_count: 198
-  - - committee: [423, 56, 160, 395]
+  - - committee:
+      - 423
+      - 56
+      - 160
+      - 395
       shard: 286
       total_validator_count: 198
-  - - committee: [252, 169, 463]
+  - - committee:
+      - 252
+      - 169
+      - 463
       shard: 287
       total_validator_count: 198
-  - - committee: [106, 72, 234]
+  - - committee:
+      - 106
+      - 72
+      - 234
       shard: 288
       total_validator_count: 198
-  - - committee: [214, 275, 76]
+  - - committee:
+      - 214
+      - 275
+      - 76
       shard: 289
       total_validator_count: 198
-  - - committee: [282, 23, 408]
+  - - committee:
+      - 282
+      - 23
+      - 408
       shard: 290
       total_validator_count: 198
-  - - committee: [45, 452, 38]
+  - - committee:
+      - 45
+      - 452
+      - 38
       shard: 291
       total_validator_count: 198
-  - - committee: [168, 301, 343]
+  - - committee:
+      - 168
+      - 301
+      - 343
       shard: 292
       total_validator_count: 198
-  - - committee: [78, 476, 419]
+  - - committee:
+      - 78
+      - 476
+      - 419
       shard: 293
       total_validator_count: 198
-  - - committee: [40, 11, 99]
+  - - committee:
+      - 40
+      - 11
+      - 99
       shard: 294
       total_validator_count: 198
-  - - committee: [86, 468, 163]
+  - - committee:
+      - 86
+      - 468
+      - 163
       shard: 295
       total_validator_count: 198
-  - - committee: [448, 216, 318, 231]
+  - - committee:
+      - 448
+      - 216
+      - 318
+      - 231
       shard: 296
       total_validator_count: 198
   seed: '0xeefb66740fd23df786731edb105354862abc8bc52ee4d0bffe8b7bc2d61f22d7'
@@ -5279,1016 +6114,1173 @@ test_cases:
     crosslinking_start_shard: 400
     validators:
     - original_index: 0
-      status: [0]
+      status: 0
     - original_index: 1
-      status: [4]
+      status: 4
     - original_index: 2
-      status: [0]
+      status: 0
     - original_index: 3
-      status: [3]
+      status: 3
     - original_index: 4
-      status: [1]
+      status: 1
     - original_index: 5
-      status: [2]
+      status: 2
     - original_index: 6
-      status: [1]
+      status: 1
     - original_index: 7
-      status: [2]
+      status: 2
     - original_index: 8
-      status: [2]
+      status: 2
     - original_index: 9
-      status: [2]
+      status: 2
     - original_index: 10
-      status: [1]
+      status: 1
     - original_index: 11
-      status: [0]
+      status: 0
     - original_index: 12
-      status: [3]
+      status: 3
     - original_index: 13
-      status: [0]
+      status: 0
     - original_index: 14
-      status: [2]
+      status: 2
     - original_index: 15
-      status: [4]
+      status: 4
     - original_index: 16
-      status: [4]
+      status: 4
     - original_index: 17
-      status: [4]
+      status: 4
     - original_index: 18
-      status: [2]
+      status: 2
     - original_index: 19
-      status: [2]
+      status: 2
     - original_index: 20
-      status: [2]
+      status: 2
     - original_index: 21
-      status: [1]
+      status: 1
     - original_index: 22
-      status: [1]
+      status: 1
     - original_index: 23
-      status: [4]
+      status: 4
     - original_index: 24
-      status: [1]
+      status: 1
     - original_index: 25
-      status: [2]
+      status: 2
     - original_index: 26
-      status: [1]
+      status: 1
     - original_index: 27
-      status: [3]
+      status: 3
     - original_index: 28
-      status: [0]
+      status: 0
     - original_index: 29
-      status: [0]
+      status: 0
     - original_index: 30
-      status: [3]
+      status: 3
     - original_index: 31
-      status: [4]
+      status: 4
     - original_index: 32
-      status: [1]
+      status: 1
     - original_index: 33
-      status: [1]
+      status: 1
     - original_index: 34
-      status: [0]
+      status: 0
     - original_index: 35
-      status: [4]
+      status: 4
     - original_index: 36
-      status: [3]
+      status: 3
     - original_index: 37
-      status: [0]
+      status: 0
     - original_index: 38
-      status: [4]
+      status: 4
     - original_index: 39
-      status: [4]
+      status: 4
     - original_index: 40
-      status: [3]
+      status: 3
     - original_index: 41
-      status: [2]
+      status: 2
     - original_index: 42
-      status: [3]
+      status: 3
     - original_index: 43
-      status: [1]
+      status: 1
     - original_index: 44
-      status: [3]
+      status: 3
     - original_index: 45
-      status: [1]
+      status: 1
     - original_index: 46
-      status: [1]
+      status: 1
     - original_index: 47
-      status: [3]
+      status: 3
     - original_index: 48
-      status: [0]
+      status: 0
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [0]
+      status: 0
     - original_index: 51
-      status: [4]
+      status: 4
     - original_index: 52
-      status: [1]
+      status: 1
     - original_index: 53
-      status: [1]
+      status: 1
     - original_index: 54
-      status: [1]
+      status: 1
     - original_index: 55
-      status: [1]
+      status: 1
     - original_index: 56
-      status: [2]
+      status: 2
     - original_index: 57
-      status: [3]
+      status: 3
     - original_index: 58
-      status: [3]
+      status: 3
     - original_index: 59
-      status: [4]
+      status: 4
     - original_index: 60
-      status: [2]
+      status: 2
     - original_index: 61
-      status: [0]
+      status: 0
     - original_index: 62
-      status: [2]
+      status: 2
     - original_index: 63
-      status: [3]
+      status: 3
     - original_index: 64
-      status: [3]
+      status: 3
     - original_index: 65
-      status: [0]
+      status: 0
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [0]
+      status: 0
     - original_index: 68
-      status: [2]
+      status: 2
     - original_index: 69
-      status: [4]
+      status: 4
     - original_index: 70
-      status: [3]
+      status: 3
     - original_index: 71
-      status: [3]
+      status: 3
     - original_index: 72
-      status: [3]
+      status: 3
     - original_index: 73
-      status: [2]
+      status: 2
     - original_index: 74
-      status: [1]
+      status: 1
     - original_index: 75
-      status: [3]
+      status: 3
     - original_index: 76
-      status: [4]
+      status: 4
     - original_index: 77
-      status: [2]
+      status: 2
     - original_index: 78
-      status: [3]
+      status: 3
     - original_index: 79
-      status: [0]
+      status: 0
     - original_index: 80
-      status: [2]
+      status: 2
     - original_index: 81
-      status: [0]
+      status: 0
     - original_index: 82
-      status: [1]
+      status: 1
     - original_index: 83
-      status: [3]
+      status: 3
     - original_index: 84
-      status: [1]
+      status: 1
     - original_index: 85
-      status: [4]
+      status: 4
     - original_index: 86
-      status: [4]
+      status: 4
     - original_index: 87
-      status: [1]
+      status: 1
     - original_index: 88
-      status: [4]
+      status: 4
     - original_index: 89
-      status: [4]
+      status: 4
     - original_index: 90
-      status: [2]
+      status: 2
     - original_index: 91
-      status: [1]
+      status: 1
     - original_index: 92
-      status: [3]
+      status: 3
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [2]
+      status: 2
     - original_index: 95
-      status: [3]
+      status: 3
     - original_index: 96
-      status: [3]
+      status: 3
     - original_index: 97
-      status: [4]
+      status: 4
     - original_index: 98
-      status: [4]
+      status: 4
     - original_index: 99
-      status: [4]
+      status: 4
     - original_index: 100
-      status: [2]
+      status: 2
     - original_index: 101
-      status: [3]
+      status: 3
     - original_index: 102
-      status: [0]
+      status: 0
     - original_index: 103
-      status: [0]
+      status: 0
     - original_index: 104
-      status: [2]
+      status: 2
     - original_index: 105
-      status: [3]
+      status: 3
     - original_index: 106
-      status: [1]
+      status: 1
     - original_index: 107
-      status: [4]
+      status: 4
     - original_index: 108
-      status: [2]
+      status: 2
     - original_index: 109
-      status: [3]
+      status: 3
     - original_index: 110
-      status: [2]
+      status: 2
     - original_index: 111
-      status: [2]
+      status: 2
     - original_index: 112
-      status: [4]
+      status: 4
     - original_index: 113
-      status: [0]
+      status: 0
     - original_index: 114
-      status: [0]
+      status: 0
     - original_index: 115
-      status: [4]
+      status: 4
     - original_index: 116
-      status: [0]
+      status: 0
     - original_index: 117
-      status: [1]
+      status: 1
     - original_index: 118
-      status: [0]
+      status: 0
     - original_index: 119
-      status: [3]
+      status: 3
     - original_index: 120
-      status: [0]
+      status: 0
     - original_index: 121
-      status: [2]
+      status: 2
     - original_index: 122
-      status: [2]
+      status: 2
     - original_index: 123
-      status: [1]
+      status: 1
     - original_index: 124
-      status: [3]
+      status: 3
     - original_index: 125
-      status: [3]
+      status: 3
     - original_index: 126
-      status: [2]
+      status: 2
     - original_index: 127
-      status: [3]
+      status: 3
     - original_index: 128
-      status: [4]
+      status: 4
     - original_index: 129
-      status: [3]
+      status: 3
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [2]
+      status: 2
     - original_index: 132
-      status: [0]
+      status: 0
     - original_index: 133
-      status: [0]
+      status: 0
     - original_index: 134
-      status: [1]
+      status: 1
     - original_index: 135
-      status: [4]
+      status: 4
     - original_index: 136
-      status: [3]
+      status: 3
     - original_index: 137
-      status: [1]
+      status: 1
     - original_index: 138
-      status: [2]
+      status: 2
     - original_index: 139
-      status: [0]
+      status: 0
     - original_index: 140
-      status: [4]
+      status: 4
     - original_index: 141
-      status: [1]
+      status: 1
     - original_index: 142
-      status: [1]
+      status: 1
     - original_index: 143
-      status: [0]
+      status: 0
     - original_index: 144
-      status: [0]
+      status: 0
     - original_index: 145
-      status: [4]
+      status: 4
     - original_index: 146
-      status: [1]
+      status: 1
     - original_index: 147
-      status: [2]
+      status: 2
     - original_index: 148
-      status: [4]
+      status: 4
     - original_index: 149
-      status: [3]
+      status: 3
     - original_index: 150
-      status: [3]
+      status: 3
     - original_index: 151
-      status: [3]
+      status: 3
     - original_index: 152
-      status: [2]
+      status: 2
     - original_index: 153
-      status: [0]
+      status: 0
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [4]
+      status: 4
     - original_index: 156
-      status: [0]
+      status: 0
     - original_index: 157
-      status: [1]
+      status: 1
     - original_index: 158
-      status: [2]
+      status: 2
     - original_index: 159
-      status: [0]
+      status: 0
     - original_index: 160
-      status: [2]
+      status: 2
     - original_index: 161
-      status: [0]
+      status: 0
     - original_index: 162
-      status: [3]
+      status: 3
     - original_index: 163
-      status: [1]
+      status: 1
     - original_index: 164
-      status: [2]
+      status: 2
     - original_index: 165
-      status: [0]
+      status: 0
     - original_index: 166
-      status: [1]
+      status: 1
     - original_index: 167
-      status: [0]
+      status: 0
     - original_index: 168
-      status: [4]
+      status: 4
     - original_index: 169
-      status: [0]
+      status: 0
     - original_index: 170
-      status: [3]
+      status: 3
     - original_index: 171
-      status: [3]
+      status: 3
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [3]
+      status: 3
     - original_index: 174
-      status: [0]
+      status: 0
     - original_index: 175
-      status: [0]
+      status: 0
     - original_index: 176
-      status: [3]
+      status: 3
     - original_index: 177
-      status: [3]
+      status: 3
     - original_index: 178
-      status: [4]
+      status: 4
     - original_index: 179
-      status: [4]
+      status: 4
     - original_index: 180
-      status: [2]
+      status: 2
     - original_index: 181
-      status: [3]
+      status: 3
     - original_index: 182
-      status: [2]
+      status: 2
     - original_index: 183
-      status: [0]
+      status: 0
     - original_index: 184
-      status: [2]
+      status: 2
     - original_index: 185
-      status: [0]
+      status: 0
     - original_index: 186
-      status: [4]
+      status: 4
     - original_index: 187
-      status: [4]
+      status: 4
     - original_index: 188
-      status: [4]
+      status: 4
     - original_index: 189
-      status: [2]
+      status: 2
     - original_index: 190
-      status: [2]
+      status: 2
     - original_index: 191
-      status: [3]
+      status: 3
     - original_index: 192
-      status: [4]
+      status: 4
     - original_index: 193
-      status: [3]
+      status: 3
     - original_index: 194
-      status: [2]
+      status: 2
     - original_index: 195
-      status: [2]
+      status: 2
     - original_index: 196
-      status: [4]
+      status: 4
     - original_index: 197
-      status: [3]
+      status: 3
     - original_index: 198
-      status: [4]
+      status: 4
     - original_index: 199
-      status: [0]
+      status: 0
     - original_index: 200
-      status: [4]
+      status: 4
     - original_index: 201
-      status: [4]
+      status: 4
     - original_index: 202
-      status: [3]
+      status: 3
     - original_index: 203
-      status: [1]
+      status: 1
     - original_index: 204
-      status: [0]
+      status: 0
     - original_index: 205
-      status: [2]
+      status: 2
     - original_index: 206
-      status: [3]
+      status: 3
     - original_index: 207
-      status: [1]
+      status: 1
     - original_index: 208
-      status: [1]
+      status: 1
     - original_index: 209
-      status: [2]
+      status: 2
     - original_index: 210
-      status: [3]
+      status: 3
     - original_index: 211
-      status: [0]
+      status: 0
     - original_index: 212
-      status: [0]
+      status: 0
     - original_index: 213
-      status: [4]
+      status: 4
     - original_index: 214
-      status: [3]
+      status: 3
     - original_index: 215
-      status: [2]
+      status: 2
     - original_index: 216
-      status: [2]
+      status: 2
     - original_index: 217
-      status: [3]
+      status: 3
     - original_index: 218
-      status: [1]
+      status: 1
     - original_index: 219
-      status: [0]
+      status: 0
     - original_index: 220
-      status: [3]
+      status: 3
     - original_index: 221
-      status: [1]
+      status: 1
     - original_index: 222
-      status: [0]
+      status: 0
     - original_index: 223
-      status: [1]
+      status: 1
     - original_index: 224
-      status: [1]
+      status: 1
     - original_index: 225
-      status: [2]
+      status: 2
     - original_index: 226
-      status: [2]
+      status: 2
     - original_index: 227
-      status: [2]
+      status: 2
     - original_index: 228
-      status: [4]
+      status: 4
     - original_index: 229
-      status: [0]
+      status: 0
     - original_index: 230
-      status: [2]
+      status: 2
     - original_index: 231
-      status: [4]
+      status: 4
     - original_index: 232
-      status: [4]
+      status: 4
     - original_index: 233
-      status: [4]
+      status: 4
     - original_index: 234
-      status: [4]
+      status: 4
     - original_index: 235
-      status: [2]
+      status: 2
     - original_index: 236
-      status: [4]
+      status: 4
     - original_index: 237
-      status: [4]
+      status: 4
     - original_index: 238
-      status: [0]
+      status: 0
     - original_index: 239
-      status: [4]
+      status: 4
     - original_index: 240
-      status: [1]
+      status: 1
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [4]
+      status: 4
     - original_index: 243
-      status: [4]
+      status: 4
     - original_index: 244
-      status: [3]
+      status: 3
     - original_index: 245
-      status: [1]
+      status: 1
     - original_index: 246
-      status: [2]
+      status: 2
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [4]
+      status: 4
     - original_index: 249
-      status: [1]
+      status: 1
     - original_index: 250
-      status: [1]
+      status: 1
     - original_index: 251
-      status: [1]
+      status: 1
     - original_index: 252
-      status: [0]
+      status: 0
     - original_index: 253
-      status: [3]
+      status: 3
     - original_index: 254
-      status: [0]
+      status: 0
     - original_index: 255
-      status: [2]
+      status: 2
     - original_index: 256
-      status: [4]
+      status: 4
     - original_index: 257
-      status: [1]
+      status: 1
     - original_index: 258
-      status: [1]
+      status: 1
     - original_index: 259
-      status: [3]
+      status: 3
     - original_index: 260
-      status: [3]
+      status: 3
     - original_index: 261
-      status: [0]
+      status: 0
     - original_index: 262
-      status: [4]
+      status: 4
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [1]
+      status: 1
     - original_index: 265
-      status: [3]
+      status: 3
     - original_index: 266
-      status: [2]
+      status: 2
     - original_index: 267
-      status: [0]
+      status: 0
     - original_index: 268
-      status: [2]
+      status: 2
     - original_index: 269
-      status: [2]
+      status: 2
     - original_index: 270
-      status: [0]
+      status: 0
     - original_index: 271
-      status: [0]
+      status: 0
     - original_index: 272
-      status: [4]
+      status: 4
     - original_index: 273
-      status: [2]
+      status: 2
     - original_index: 274
-      status: [4]
+      status: 4
     - original_index: 275
-      status: [1]
+      status: 1
     - original_index: 276
-      status: [1]
+      status: 1
     - original_index: 277
-      status: [0]
+      status: 0
     - original_index: 278
-      status: [4]
+      status: 4
     - original_index: 279
-      status: [2]
+      status: 2
     - original_index: 280
-      status: [3]
+      status: 3
     - original_index: 281
-      status: [1]
+      status: 1
     - original_index: 282
-      status: [0]
+      status: 0
     - original_index: 283
-      status: [3]
+      status: 3
     - original_index: 284
-      status: [2]
+      status: 2
     - original_index: 285
-      status: [2]
+      status: 2
     - original_index: 286
-      status: [1]
+      status: 1
     - original_index: 287
-      status: [0]
+      status: 0
     - original_index: 288
-      status: [3]
+      status: 3
     - original_index: 289
-      status: [2]
+      status: 2
     - original_index: 290
-      status: [4]
+      status: 4
     - original_index: 291
-      status: [0]
+      status: 0
     - original_index: 292
-      status: [3]
+      status: 3
     - original_index: 293
-      status: [2]
+      status: 2
     - original_index: 294
-      status: [3]
+      status: 3
     - original_index: 295
-      status: [1]
+      status: 1
     - original_index: 296
-      status: [1]
+      status: 1
     - original_index: 297
-      status: [1]
+      status: 1
     - original_index: 298
-      status: [2]
+      status: 2
     - original_index: 299
-      status: [2]
+      status: 2
     - original_index: 300
-      status: [0]
+      status: 0
     - original_index: 301
-      status: [3]
+      status: 3
     - original_index: 302
-      status: [2]
+      status: 2
     - original_index: 303
-      status: [3]
+      status: 3
     - original_index: 304
-      status: [3]
+      status: 3
     - original_index: 305
-      status: [0]
+      status: 0
     - original_index: 306
-      status: [2]
+      status: 2
     - original_index: 307
-      status: [1]
+      status: 1
     - original_index: 308
-      status: [4]
+      status: 4
     - original_index: 309
-      status: [4]
+      status: 4
     - original_index: 310
-      status: [2]
+      status: 2
     - original_index: 311
-      status: [1]
+      status: 1
     - original_index: 312
-      status: [3]
+      status: 3
     - original_index: 313
-      status: [0]
+      status: 0
     - original_index: 314
-      status: [2]
+      status: 2
     - original_index: 315
-      status: [1]
+      status: 1
     - original_index: 316
-      status: [0]
+      status: 0
     - original_index: 317
-      status: [2]
+      status: 2
     - original_index: 318
-      status: [3]
+      status: 3
     - original_index: 319
-      status: [2]
+      status: 2
     - original_index: 320
-      status: [2]
+      status: 2
     - original_index: 321
-      status: [3]
+      status: 3
     - original_index: 322
-      status: [0]
+      status: 0
     - original_index: 323
-      status: [4]
+      status: 4
     - original_index: 324
-      status: [0]
+      status: 0
     - original_index: 325
-      status: [3]
+      status: 3
     - original_index: 326
-      status: [2]
+      status: 2
     - original_index: 327
-      status: [3]
+      status: 3
     - original_index: 328
-      status: [1]
+      status: 1
     - original_index: 329
-      status: [4]
+      status: 4
     - original_index: 330
-      status: [2]
+      status: 2
     - original_index: 331
-      status: [1]
+      status: 1
     - original_index: 332
-      status: [0]
+      status: 0
     - original_index: 333
-      status: [4]
+      status: 4
     - original_index: 334
-      status: [2]
+      status: 2
     - original_index: 335
-      status: [1]
+      status: 1
     - original_index: 336
-      status: [1]
+      status: 1
     - original_index: 337
-      status: [0]
+      status: 0
     - original_index: 338
-      status: [0]
+      status: 0
     - original_index: 339
-      status: [0]
+      status: 0
     - original_index: 340
-      status: [4]
+      status: 4
     - original_index: 341
-      status: [4]
+      status: 4
     - original_index: 342
-      status: [0]
+      status: 0
     - original_index: 343
-      status: [1]
+      status: 1
     - original_index: 344
-      status: [1]
+      status: 1
     - original_index: 345
-      status: [0]
+      status: 0
     - original_index: 346
-      status: [1]
+      status: 1
     - original_index: 347
-      status: [1]
+      status: 1
     - original_index: 348
-      status: [4]
+      status: 4
     - original_index: 349
-      status: [0]
+      status: 0
     - original_index: 350
-      status: [4]
+      status: 4
     - original_index: 351
-      status: [1]
+      status: 1
     - original_index: 352
-      status: [0]
+      status: 0
     - original_index: 353
-      status: [0]
+      status: 0
     - original_index: 354
-      status: [0]
+      status: 0
     - original_index: 355
-      status: [3]
+      status: 3
     - original_index: 356
-      status: [2]
+      status: 2
     - original_index: 357
-      status: [0]
+      status: 0
     - original_index: 358
-      status: [3]
+      status: 3
     - original_index: 359
-      status: [3]
+      status: 3
     - original_index: 360
-      status: [2]
+      status: 2
     - original_index: 361
-      status: [3]
+      status: 3
     - original_index: 362
-      status: [0]
+      status: 0
     - original_index: 363
-      status: [3]
+      status: 3
     - original_index: 364
-      status: [1]
+      status: 1
     - original_index: 365
-      status: [1]
+      status: 1
     - original_index: 366
-      status: [3]
+      status: 3
     - original_index: 367
-      status: [0]
+      status: 0
     - original_index: 368
-      status: [4]
+      status: 4
     - original_index: 369
-      status: [4]
+      status: 4
     - original_index: 370
-      status: [3]
+      status: 3
     - original_index: 371
-      status: [4]
+      status: 4
     - original_index: 372
-      status: [2]
+      status: 2
     - original_index: 373
-      status: [2]
+      status: 2
     - original_index: 374
-      status: [3]
+      status: 3
     - original_index: 375
-      status: [3]
+      status: 3
     - original_index: 376
-      status: [0]
+      status: 0
     - original_index: 377
-      status: [0]
+      status: 0
     - original_index: 378
-      status: [3]
+      status: 3
     - original_index: 379
-      status: [1]
+      status: 1
     - original_index: 380
-      status: [2]
+      status: 2
     - original_index: 381
-      status: [0]
+      status: 0
     - original_index: 382
-      status: [2]
+      status: 2
     - original_index: 383
-      status: [2]
+      status: 2
     - original_index: 384
-      status: [1]
+      status: 1
     - original_index: 385
-      status: [1]
+      status: 1
     - original_index: 386
-      status: [1]
+      status: 1
     - original_index: 387
-      status: [4]
+      status: 4
     - original_index: 388
-      status: [4]
+      status: 4
     - original_index: 389
-      status: [3]
+      status: 3
     - original_index: 390
-      status: [0]
+      status: 0
     - original_index: 391
-      status: [3]
+      status: 3
     - original_index: 392
-      status: [3]
+      status: 3
     - original_index: 393
-      status: [3]
+      status: 3
     - original_index: 394
-      status: [2]
+      status: 2
     - original_index: 395
-      status: [1]
+      status: 1
     - original_index: 396
-      status: [1]
+      status: 1
     - original_index: 397
-      status: [2]
+      status: 2
     - original_index: 398
-      status: [1]
+      status: 1
     - original_index: 399
-      status: [1]
+      status: 1
     - original_index: 400
-      status: [3]
+      status: 3
     - original_index: 401
-      status: [4]
+      status: 4
     - original_index: 402
-      status: [1]
+      status: 1
     - original_index: 403
-      status: [0]
+      status: 0
     - original_index: 404
-      status: [4]
+      status: 4
     - original_index: 405
-      status: [0]
+      status: 0
     - original_index: 406
-      status: [4]
+      status: 4
     - original_index: 407
-      status: [4]
+      status: 4
     - original_index: 408
-      status: [0]
+      status: 0
     - original_index: 409
-      status: [3]
+      status: 3
   output:
-  - - committee: [82, 200]
+  - - committee:
+      - 82
+      - 200
       shard: 400
       total_validator_count: 157
-  - - committee: [365, 286]
+  - - committee:
+      - 365
+      - 286
       shard: 401
       total_validator_count: 157
-  - - committee: [350, 248, 106]
+  - - committee:
+      - 350
+      - 248
+      - 106
       shard: 402
       total_validator_count: 157
-  - - committee: [208, 234]
+  - - committee:
+      - 208
+      - 234
       shard: 403
       total_validator_count: 157
-  - - committee: [74, 84, 278]
+  - - committee:
+      - 74
+      - 84
+      - 278
       shard: 404
       total_validator_count: 157
-  - - committee: [148, 351]
+  - - committee:
+      - 148
+      - 351
       shard: 405
       total_validator_count: 157
-  - - committee: [53, 140, 31]
+  - - committee:
+      - 53
+      - 140
+      - 31
       shard: 406
       total_validator_count: 157
-  - - committee: [272, 154]
+  - - committee:
+      - 272
+      - 154
       shard: 407
       total_validator_count: 157
-  - - committee: [107, 6, 388]
+  - - committee:
+      - 107
+      - 6
+      - 388
       shard: 408
       total_validator_count: 157
-  - - committee: [128, 251]
+  - - committee:
+      - 128
+      - 251
       shard: 409
       total_validator_count: 157
-  - - committee: [335, 346]
+  - - committee:
+      - 335
+      - 346
       shard: 410
       total_validator_count: 157
-  - - committee: [54, 85, 371]
+  - - committee:
+      - 54
+      - 85
+      - 371
       shard: 411
       total_validator_count: 157
-  - - committee: [347, 10]
+  - - committee:
+      - 347
+      - 10
       shard: 412
       total_validator_count: 157
-  - - committee: [55, 341, 245]
+  - - committee:
+      - 55
+      - 341
+      - 245
       shard: 413
       total_validator_count: 157
-  - - committee: [308, 281]
+  - - committee:
+      - 308
+      - 281
       shard: 414
       total_validator_count: 157
-  - - committee: [198, 157, 134]
+  - - committee:
+      - 198
+      - 157
+      - 134
       shard: 415
       total_validator_count: 157
-  - - committee: [256, 86]
+  - - committee:
+      - 256
+      - 86
       shard: 416
       total_validator_count: 157
-  - - committee: [51, 16, 99]
+  - - committee:
+      - 51
+      - 16
+      - 99
       shard: 417
       total_validator_count: 157
-  - - committee: [228, 142]
+  - - committee:
+      - 228
+      - 142
       shard: 418
       total_validator_count: 157
-  - - committee: [186, 223, 23]
+  - - committee:
+      - 186
+      - 223
+      - 23
       shard: 419
       total_validator_count: 157
-  - - committee: [123, 32]
+  - - committee:
+      - 123
+      - 32
       shard: 420
       total_validator_count: 157
-  - - committee: [276, 343]
+  - - committee:
+      - 276
+      - 343
       shard: 421
       total_validator_count: 157
-  - - committee: [258, 52, 166]
+  - - committee:
+      - 258
+      - 52
+      - 166
       shard: 422
       total_validator_count: 157
-  - - committee: [33, 386]
+  - - committee:
+      - 33
+      - 386
       shard: 423
       total_validator_count: 157
-  - - committee: [344, 274, 35]
+  - - committee:
+      - 344
+      - 274
+      - 35
       shard: 424
       total_validator_count: 157
-  - - committee: [311, 241]
+  - - committee:
+      - 311
+      - 241
       shard: 425
       total_validator_count: 157
-  - - committee: [348, 91, 130]
+  - - committee:
+      - 348
+      - 91
+      - 130
       shard: 426
       total_validator_count: 157
-  - - committee: [231, 196]
+  - - committee:
+      - 231
+      - 196
       shard: 427
       total_validator_count: 157
-  - - committee: [340, 329, 97]
+  - - committee:
+      - 340
+      - 329
+      - 97
       shard: 428
       total_validator_count: 157
-  - - committee: [384, 213]
+  - - committee:
+      - 384
+      - 213
       shard: 429
       total_validator_count: 157
-  - - committee: [26, 168, 239]
+  - - committee:
+      - 26
+      - 168
+      - 239
       shard: 430
       total_validator_count: 157
-  - - committee: [224, 398]
+  - - committee:
+      - 224
+      - 398
       shard: 431
       total_validator_count: 157
-  - - committee: [207, 406]
+  - - committee:
+      - 207
+      - 406
       shard: 432
       total_validator_count: 157
-  - - committee: [137, 404, 22]
+  - - committee:
+      - 137
+      - 404
+      - 22
       shard: 433
       total_validator_count: 157
-  - - committee: [145, 368]
+  - - committee:
+      - 145
+      - 368
       shard: 434
       total_validator_count: 157
-  - - committee: [141, 263, 328]
+  - - committee:
+      - 141
+      - 263
+      - 328
       shard: 435
       total_validator_count: 157
-  - - committee: [43, 115]
+  - - committee:
+      - 43
+      - 115
       shard: 436
       total_validator_count: 157
-  - - committee: [87, 69, 187]
+  - - committee:
+      - 87
+      - 69
+      - 187
       shard: 437
       total_validator_count: 157
-  - - committee: [385, 203]
+  - - committee:
+      - 385
+      - 203
       shard: 438
       total_validator_count: 157
-  - - committee: [1, 323, 188]
+  - - committee:
+      - 1
+      - 323
+      - 188
       shard: 439
       total_validator_count: 157
-  - - committee: [402, 290]
+  - - committee:
+      - 402
+      - 290
       shard: 440
       total_validator_count: 157
-  - - committee: [46, 257, 243]
+  - - committee:
+      - 46
+      - 257
+      - 243
       shard: 441
       total_validator_count: 157
-  - - committee: [15, 236]
+  - - committee:
+      - 15
+      - 236
       shard: 442
       total_validator_count: 157
-  - - committee: [218, 250]
+  - - committee:
+      - 218
+      - 250
       shard: 443
       total_validator_count: 157
-  - - committee: [38, 98, 17]
+  - - committee:
+      - 38
+      - 98
+      - 17
       shard: 444
       total_validator_count: 157
-  - - committee: [146, 233]
+  - - committee:
+      - 146
+      - 233
       shard: 445
       total_validator_count: 157
-  - - committee: [240, 163, 315]
+  - - committee:
+      - 240
+      - 163
+      - 315
       shard: 446
       total_validator_count: 157
-  - - committee: [331, 45]
+  - - committee:
+      - 331
+      - 45
       shard: 447
       total_validator_count: 157
-  - - committee: [275, 76, 135]
+  - - committee:
+      - 275
+      - 76
+      - 135
       shard: 448
       total_validator_count: 157
-  - - committee: [178, 192]
+  - - committee:
+      - 178
+      - 192
       shard: 449
       total_validator_count: 157
-  - - committee: [401, 379, 112]
+  - - committee:
+      - 401
+      - 379
+      - 112
       shard: 450
       total_validator_count: 157
-  - - committee: [333, 39]
+  - - committee:
+      - 333
+      - 39
       shard: 451
       total_validator_count: 157
-  - - committee: [364, 24, 296]
+  - - committee:
+      - 364
+      - 24
+      - 296
       shard: 452
       total_validator_count: 157
-  - - committee: [155, 249]
+  - - committee:
+      - 155
+      - 249
       shard: 453
       total_validator_count: 157
-  - - committee: [232, 59]
+  - - committee:
+      - 232
+      - 59
       shard: 454
       total_validator_count: 157
-  - - committee: [264, 336, 88]
+  - - committee:
+      - 264
+      - 336
+      - 88
       shard: 455
       total_validator_count: 157
-  - - committee: [307, 89]
+  - - committee:
+      - 307
+      - 89
       shard: 456
       total_validator_count: 157
-  - - committee: [242, 407, 399]
+  - - committee:
+      - 242
+      - 407
+      - 399
       shard: 457
       total_validator_count: 157
-  - - committee: [179, 262]
+  - - committee:
+      - 179
+      - 262
       shard: 458
       total_validator_count: 157
-  - - committee: [387, 117, 396]
+  - - committee:
+      - 387
+      - 117
+      - 396
       shard: 459
       total_validator_count: 157
-  - - committee: [201, 309]
+  - - committee:
+      - 201
+      - 309
       shard: 460
       total_validator_count: 157
-  - - committee: [297, 369, 221]
+  - - committee:
+      - 297
+      - 369
+      - 221
       shard: 461
       total_validator_count: 157
-  - - committee: [237, 295]
+  - - committee:
+      - 237
+      - 295
       shard: 462
       total_validator_count: 157
-  - - committee: [4, 395, 21]
+  - - committee:
+      - 4
+      - 395
+      - 21
       shard: 463
       total_validator_count: 157
   seed: '0xebeb8f9a88f523bc0d4ce17deee159c9791c919c3d8884187a66935c7af5665e'
@@ -6296,964 +7288,1137 @@ test_cases:
     crosslinking_start_shard: 669
     validators:
     - original_index: 0
-      status: [1]
+      status: 1
     - original_index: 1
-      status: [1]
+      status: 1
     - original_index: 2
-      status: [0]
+      status: 0
     - original_index: 3
-      status: [1]
+      status: 1
     - original_index: 4
-      status: [4]
+      status: 4
     - original_index: 5
-      status: [3]
+      status: 3
     - original_index: 6
-      status: [1]
+      status: 1
     - original_index: 7
-      status: [4]
+      status: 4
     - original_index: 8
-      status: [4]
+      status: 4
     - original_index: 9
-      status: [1]
+      status: 1
     - original_index: 10
-      status: [2]
+      status: 2
     - original_index: 11
-      status: [2]
+      status: 2
     - original_index: 12
-      status: [0]
+      status: 0
     - original_index: 13
-      status: [2]
+      status: 2
     - original_index: 14
-      status: [3]
+      status: 3
     - original_index: 15
-      status: [4]
+      status: 4
     - original_index: 16
-      status: [0]
+      status: 0
     - original_index: 17
-      status: [4]
+      status: 4
     - original_index: 18
-      status: [4]
+      status: 4
     - original_index: 19
-      status: [0]
+      status: 0
     - original_index: 20
-      status: [4]
+      status: 4
     - original_index: 21
-      status: [3]
+      status: 3
     - original_index: 22
-      status: [3]
+      status: 3
     - original_index: 23
-      status: [2]
+      status: 2
     - original_index: 24
-      status: [4]
+      status: 4
     - original_index: 25
-      status: [2]
+      status: 2
     - original_index: 26
-      status: [3]
+      status: 3
     - original_index: 27
-      status: [2]
+      status: 2
     - original_index: 28
-      status: [1]
+      status: 1
     - original_index: 29
-      status: [4]
+      status: 4
     - original_index: 30
-      status: [1]
+      status: 1
     - original_index: 31
-      status: [1]
+      status: 1
     - original_index: 32
-      status: [4]
+      status: 4
     - original_index: 33
-      status: [1]
+      status: 1
     - original_index: 34
-      status: [2]
+      status: 2
     - original_index: 35
-      status: [0]
+      status: 0
     - original_index: 36
-      status: [0]
+      status: 0
     - original_index: 37
-      status: [4]
+      status: 4
     - original_index: 38
-      status: [4]
+      status: 4
     - original_index: 39
-      status: [4]
+      status: 4
     - original_index: 40
-      status: [3]
+      status: 3
     - original_index: 41
-      status: [4]
+      status: 4
     - original_index: 42
-      status: [0]
+      status: 0
     - original_index: 43
-      status: [0]
+      status: 0
     - original_index: 44
-      status: [3]
+      status: 3
     - original_index: 45
-      status: [1]
+      status: 1
     - original_index: 46
-      status: [3]
+      status: 3
     - original_index: 47
-      status: [4]
+      status: 4
     - original_index: 48
-      status: [2]
+      status: 2
     - original_index: 49
-      status: [0]
+      status: 0
     - original_index: 50
-      status: [2]
+      status: 2
     - original_index: 51
-      status: [2]
+      status: 2
     - original_index: 52
-      status: [0]
+      status: 0
     - original_index: 53
-      status: [1]
+      status: 1
     - original_index: 54
-      status: [1]
+      status: 1
     - original_index: 55
-      status: [4]
+      status: 4
     - original_index: 56
-      status: [2]
+      status: 2
     - original_index: 57
-      status: [2]
+      status: 2
     - original_index: 58
-      status: [1]
+      status: 1
     - original_index: 59
-      status: [4]
+      status: 4
     - original_index: 60
-      status: [2]
+      status: 2
     - original_index: 61
-      status: [4]
+      status: 4
     - original_index: 62
-      status: [0]
+      status: 0
     - original_index: 63
-      status: [4]
+      status: 4
     - original_index: 64
-      status: [2]
+      status: 2
     - original_index: 65
-      status: [0]
+      status: 0
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [1]
+      status: 1
     - original_index: 68
-      status: [4]
+      status: 4
     - original_index: 69
-      status: [1]
+      status: 1
     - original_index: 70
-      status: [4]
+      status: 4
     - original_index: 71
-      status: [2]
+      status: 2
     - original_index: 72
-      status: [3]
+      status: 3
     - original_index: 73
-      status: [4]
+      status: 4
     - original_index: 74
-      status: [4]
+      status: 4
     - original_index: 75
-      status: [1]
+      status: 1
     - original_index: 76
-      status: [2]
+      status: 2
     - original_index: 77
-      status: [4]
+      status: 4
     - original_index: 78
-      status: [4]
+      status: 4
     - original_index: 79
-      status: [4]
+      status: 4
     - original_index: 80
-      status: [1]
+      status: 1
     - original_index: 81
-      status: [0]
+      status: 0
     - original_index: 82
-      status: [4]
+      status: 4
     - original_index: 83
-      status: [3]
+      status: 3
     - original_index: 84
-      status: [2]
+      status: 2
     - original_index: 85
-      status: [2]
+      status: 2
     - original_index: 86
-      status: [4]
+      status: 4
     - original_index: 87
-      status: [2]
+      status: 2
     - original_index: 88
-      status: [1]
+      status: 1
     - original_index: 89
-      status: [3]
+      status: 3
     - original_index: 90
-      status: [3]
+      status: 3
     - original_index: 91
-      status: [1]
+      status: 1
     - original_index: 92
-      status: [3]
+      status: 3
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [3]
+      status: 3
     - original_index: 95
-      status: [2]
+      status: 2
     - original_index: 96
-      status: [4]
+      status: 4
     - original_index: 97
-      status: [3]
+      status: 3
     - original_index: 98
-      status: [4]
+      status: 4
     - original_index: 99
-      status: [4]
+      status: 4
     - original_index: 100
-      status: [0]
+      status: 0
     - original_index: 101
-      status: [0]
+      status: 0
     - original_index: 102
-      status: [3]
+      status: 3
     - original_index: 103
-      status: [4]
+      status: 4
     - original_index: 104
-      status: [4]
+      status: 4
     - original_index: 105
-      status: [2]
+      status: 2
     - original_index: 106
-      status: [3]
+      status: 3
     - original_index: 107
-      status: [3]
+      status: 3
     - original_index: 108
-      status: [1]
+      status: 1
     - original_index: 109
-      status: [2]
+      status: 2
     - original_index: 110
-      status: [3]
+      status: 3
     - original_index: 111
-      status: [4]
+      status: 4
     - original_index: 112
-      status: [1]
+      status: 1
     - original_index: 113
-      status: [1]
+      status: 1
     - original_index: 114
-      status: [4]
+      status: 4
     - original_index: 115
-      status: [4]
+      status: 4
     - original_index: 116
-      status: [1]
+      status: 1
     - original_index: 117
-      status: [2]
+      status: 2
     - original_index: 118
-      status: [3]
+      status: 3
     - original_index: 119
-      status: [4]
+      status: 4
     - original_index: 120
-      status: [1]
+      status: 1
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [0]
+      status: 0
     - original_index: 124
-      status: [0]
+      status: 0
     - original_index: 125
-      status: [0]
+      status: 0
     - original_index: 126
-      status: [2]
+      status: 2
     - original_index: 127
-      status: [3]
+      status: 3
     - original_index: 128
-      status: [4]
+      status: 4
     - original_index: 129
-      status: [2]
+      status: 2
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [1]
+      status: 1
     - original_index: 132
-      status: [2]
+      status: 2
     - original_index: 133
-      status: [4]
+      status: 4
     - original_index: 134
-      status: [4]
+      status: 4
     - original_index: 135
-      status: [2]
+      status: 2
     - original_index: 136
-      status: [4]
+      status: 4
     - original_index: 137
-      status: [2]
+      status: 2
     - original_index: 138
-      status: [3]
+      status: 3
     - original_index: 139
-      status: [3]
+      status: 3
     - original_index: 140
-      status: [4]
+      status: 4
     - original_index: 141
-      status: [4]
+      status: 4
     - original_index: 142
-      status: [0]
+      status: 0
     - original_index: 143
-      status: [0]
+      status: 0
     - original_index: 144
-      status: [2]
+      status: 2
     - original_index: 145
-      status: [3]
+      status: 3
     - original_index: 146
-      status: [4]
+      status: 4
     - original_index: 147
-      status: [2]
+      status: 2
     - original_index: 148
-      status: [2]
+      status: 2
     - original_index: 149
-      status: [3]
+      status: 3
     - original_index: 150
-      status: [3]
+      status: 3
     - original_index: 151
-      status: [1]
+      status: 1
     - original_index: 152
-      status: [1]
+      status: 1
     - original_index: 153
-      status: [2]
+      status: 2
     - original_index: 154
-      status: [3]
+      status: 3
     - original_index: 155
-      status: [4]
+      status: 4
     - original_index: 156
-      status: [4]
+      status: 4
     - original_index: 157
-      status: [0]
+      status: 0
     - original_index: 158
-      status: [4]
+      status: 4
     - original_index: 159
-      status: [2]
+      status: 2
     - original_index: 160
-      status: [0]
+      status: 0
     - original_index: 161
-      status: [3]
+      status: 3
     - original_index: 162
-      status: [3]
+      status: 3
     - original_index: 163
-      status: [1]
+      status: 1
     - original_index: 164
-      status: [3]
+      status: 3
     - original_index: 165
-      status: [4]
+      status: 4
     - original_index: 166
-      status: [1]
+      status: 1
     - original_index: 167
-      status: [1]
+      status: 1
     - original_index: 168
-      status: [1]
+      status: 1
     - original_index: 169
-      status: [3]
+      status: 3
     - original_index: 170
-      status: [1]
+      status: 1
     - original_index: 171
-      status: [2]
+      status: 2
     - original_index: 172
-      status: [3]
+      status: 3
     - original_index: 173
-      status: [3]
+      status: 3
     - original_index: 174
-      status: [4]
+      status: 4
     - original_index: 175
-      status: [4]
+      status: 4
     - original_index: 176
-      status: [1]
+      status: 1
     - original_index: 177
-      status: [4]
+      status: 4
     - original_index: 178
-      status: [4]
+      status: 4
     - original_index: 179
-      status: [1]
+      status: 1
     - original_index: 180
-      status: [4]
+      status: 4
     - original_index: 181
-      status: [0]
+      status: 0
     - original_index: 182
-      status: [4]
+      status: 4
     - original_index: 183
-      status: [1]
+      status: 1
     - original_index: 184
-      status: [0]
+      status: 0
     - original_index: 185
-      status: [4]
+      status: 4
     - original_index: 186
-      status: [0]
+      status: 0
     - original_index: 187
-      status: [3]
+      status: 3
     - original_index: 188
-      status: [3]
+      status: 3
     - original_index: 189
-      status: [1]
+      status: 1
     - original_index: 190
-      status: [0]
+      status: 0
     - original_index: 191
-      status: [0]
+      status: 0
     - original_index: 192
-      status: [2]
+      status: 2
     - original_index: 193
-      status: [1]
+      status: 1
     - original_index: 194
-      status: [2]
+      status: 2
     - original_index: 195
-      status: [4]
+      status: 4
     - original_index: 196
-      status: [4]
+      status: 4
     - original_index: 197
-      status: [1]
+      status: 1
     - original_index: 198
-      status: [2]
+      status: 2
     - original_index: 199
-      status: [4]
+      status: 4
     - original_index: 200
-      status: [2]
+      status: 2
     - original_index: 201
-      status: [1]
+      status: 1
     - original_index: 202
-      status: [0]
+      status: 0
     - original_index: 203
-      status: [2]
+      status: 2
     - original_index: 204
-      status: [2]
+      status: 2
     - original_index: 205
-      status: [1]
+      status: 1
     - original_index: 206
-      status: [3]
+      status: 3
     - original_index: 207
-      status: [4]
+      status: 4
     - original_index: 208
-      status: [1]
+      status: 1
     - original_index: 209
-      status: [1]
+      status: 1
     - original_index: 210
-      status: [0]
+      status: 0
     - original_index: 211
-      status: [3]
+      status: 3
     - original_index: 212
-      status: [2]
+      status: 2
     - original_index: 213
-      status: [2]
+      status: 2
     - original_index: 214
-      status: [2]
+      status: 2
     - original_index: 215
-      status: [1]
+      status: 1
     - original_index: 216
-      status: [2]
+      status: 2
     - original_index: 217
-      status: [1]
+      status: 1
     - original_index: 218
-      status: [1]
+      status: 1
     - original_index: 219
-      status: [3]
+      status: 3
     - original_index: 220
-      status: [4]
+      status: 4
     - original_index: 221
-      status: [0]
+      status: 0
     - original_index: 222
-      status: [2]
+      status: 2
     - original_index: 223
-      status: [3]
+      status: 3
     - original_index: 224
-      status: [4]
+      status: 4
     - original_index: 225
-      status: [2]
+      status: 2
     - original_index: 226
-      status: [0]
+      status: 0
     - original_index: 227
-      status: [3]
+      status: 3
     - original_index: 228
-      status: [1]
+      status: 1
     - original_index: 229
-      status: [2]
+      status: 2
     - original_index: 230
-      status: [1]
+      status: 1
     - original_index: 231
-      status: [0]
+      status: 0
     - original_index: 232
-      status: [4]
+      status: 4
     - original_index: 233
-      status: [4]
+      status: 4
     - original_index: 234
-      status: [1]
+      status: 1
     - original_index: 235
-      status: [4]
+      status: 4
     - original_index: 236
-      status: [4]
+      status: 4
     - original_index: 237
-      status: [4]
+      status: 4
     - original_index: 238
-      status: [0]
+      status: 0
     - original_index: 239
-      status: [2]
+      status: 2
     - original_index: 240
-      status: [0]
+      status: 0
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [3]
+      status: 3
     - original_index: 243
-      status: [4]
+      status: 4
     - original_index: 244
-      status: [3]
+      status: 3
     - original_index: 245
-      status: [3]
+      status: 3
     - original_index: 246
-      status: [3]
+      status: 3
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [0]
+      status: 0
     - original_index: 249
-      status: [2]
+      status: 2
     - original_index: 250
-      status: [4]
+      status: 4
     - original_index: 251
-      status: [1]
+      status: 1
     - original_index: 252
-      status: [1]
+      status: 1
     - original_index: 253
-      status: [1]
+      status: 1
     - original_index: 254
-      status: [3]
+      status: 3
     - original_index: 255
-      status: [3]
+      status: 3
     - original_index: 256
-      status: [0]
+      status: 0
     - original_index: 257
-      status: [3]
+      status: 3
     - original_index: 258
-      status: [3]
+      status: 3
     - original_index: 259
-      status: [3]
+      status: 3
     - original_index: 260
-      status: [3]
+      status: 3
     - original_index: 261
-      status: [3]
+      status: 3
     - original_index: 262
-      status: [4]
+      status: 4
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [1]
+      status: 1
     - original_index: 265
-      status: [1]
+      status: 1
     - original_index: 266
-      status: [3]
+      status: 3
     - original_index: 267
-      status: [3]
+      status: 3
     - original_index: 268
-      status: [3]
+      status: 3
     - original_index: 269
-      status: [1]
+      status: 1
     - original_index: 270
-      status: [1]
+      status: 1
     - original_index: 271
-      status: [1]
+      status: 1
     - original_index: 272
-      status: [1]
+      status: 1
     - original_index: 273
-      status: [3]
+      status: 3
     - original_index: 274
-      status: [0]
+      status: 0
     - original_index: 275
-      status: [3]
+      status: 3
     - original_index: 276
-      status: [4]
+      status: 4
     - original_index: 277
-      status: [0]
+      status: 0
     - original_index: 278
-      status: [4]
+      status: 4
     - original_index: 279
-      status: [4]
+      status: 4
     - original_index: 280
-      status: [0]
+      status: 0
     - original_index: 281
-      status: [4]
+      status: 4
     - original_index: 282
-      status: [1]
+      status: 1
     - original_index: 283
-      status: [0]
+      status: 0
     - original_index: 284
-      status: [1]
+      status: 1
     - original_index: 285
-      status: [1]
+      status: 1
     - original_index: 286
-      status: [1]
+      status: 1
     - original_index: 287
-      status: [2]
+      status: 2
     - original_index: 288
-      status: [4]
+      status: 4
     - original_index: 289
-      status: [0]
+      status: 0
     - original_index: 290
-      status: [0]
+      status: 0
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [0]
+      status: 0
     - original_index: 293
-      status: [3]
+      status: 3
     - original_index: 294
-      status: [1]
+      status: 1
     - original_index: 295
-      status: [0]
+      status: 0
     - original_index: 296
-      status: [3]
+      status: 3
     - original_index: 297
-      status: [4]
+      status: 4
     - original_index: 298
-      status: [3]
+      status: 3
     - original_index: 299
-      status: [3]
+      status: 3
     - original_index: 300
-      status: [2]
+      status: 2
     - original_index: 301
-      status: [3]
+      status: 3
     - original_index: 302
-      status: [1]
+      status: 1
     - original_index: 303
-      status: [0]
+      status: 0
     - original_index: 304
-      status: [4]
+      status: 4
     - original_index: 305
-      status: [0]
+      status: 0
     - original_index: 306
-      status: [1]
+      status: 1
     - original_index: 307
-      status: [4]
+      status: 4
     - original_index: 308
-      status: [4]
+      status: 4
     - original_index: 309
-      status: [4]
+      status: 4
     - original_index: 310
-      status: [4]
+      status: 4
     - original_index: 311
-      status: [2]
+      status: 2
     - original_index: 312
-      status: [1]
+      status: 1
     - original_index: 313
-      status: [2]
+      status: 2
     - original_index: 314
-      status: [4]
+      status: 4
     - original_index: 315
-      status: [2]
+      status: 2
     - original_index: 316
-      status: [0]
+      status: 0
     - original_index: 317
-      status: [1]
+      status: 1
     - original_index: 318
-      status: [2]
+      status: 2
     - original_index: 319
-      status: [2]
+      status: 2
     - original_index: 320
-      status: [4]
+      status: 4
     - original_index: 321
-      status: [3]
+      status: 3
     - original_index: 322
-      status: [1]
+      status: 1
     - original_index: 323
-      status: [0]
+      status: 0
     - original_index: 324
-      status: [1]
+      status: 1
     - original_index: 325
-      status: [0]
+      status: 0
     - original_index: 326
-      status: [4]
+      status: 4
     - original_index: 327
-      status: [0]
+      status: 0
     - original_index: 328
-      status: [3]
+      status: 3
     - original_index: 329
-      status: [1]
+      status: 1
     - original_index: 330
-      status: [2]
+      status: 2
     - original_index: 331
-      status: [1]
+      status: 1
     - original_index: 332
-      status: [0]
+      status: 0
     - original_index: 333
-      status: [3]
+      status: 3
     - original_index: 334
-      status: [3]
+      status: 3
     - original_index: 335
-      status: [4]
+      status: 4
     - original_index: 336
-      status: [4]
+      status: 4
     - original_index: 337
-      status: [1]
+      status: 1
     - original_index: 338
-      status: [0]
+      status: 0
     - original_index: 339
-      status: [0]
+      status: 0
     - original_index: 340
-      status: [1]
+      status: 1
     - original_index: 341
-      status: [0]
+      status: 0
     - original_index: 342
-      status: [4]
+      status: 4
     - original_index: 343
-      status: [3]
+      status: 3
     - original_index: 344
-      status: [3]
+      status: 3
     - original_index: 345
-      status: [2]
+      status: 2
     - original_index: 346
-      status: [2]
+      status: 2
     - original_index: 347
-      status: [3]
+      status: 3
     - original_index: 348
-      status: [3]
+      status: 3
     - original_index: 349
-      status: [0]
+      status: 0
     - original_index: 350
-      status: [0]
+      status: 0
     - original_index: 351
-      status: [4]
+      status: 4
     - original_index: 352
-      status: [2]
+      status: 2
     - original_index: 353
-      status: [3]
+      status: 3
     - original_index: 354
-      status: [3]
+      status: 3
     - original_index: 355
-      status: [4]
+      status: 4
     - original_index: 356
-      status: [1]
+      status: 1
     - original_index: 357
-      status: [0]
+      status: 0
     - original_index: 358
-      status: [4]
+      status: 4
     - original_index: 359
-      status: [2]
+      status: 2
     - original_index: 360
-      status: [0]
+      status: 0
     - original_index: 361
-      status: [3]
+      status: 3
     - original_index: 362
-      status: [0]
+      status: 0
     - original_index: 363
-      status: [0]
+      status: 0
     - original_index: 364
-      status: [4]
+      status: 4
     - original_index: 365
-      status: [2]
+      status: 2
     - original_index: 366
-      status: [3]
+      status: 3
     - original_index: 367
-      status: [3]
+      status: 3
     - original_index: 368
-      status: [4]
+      status: 4
     - original_index: 369
-      status: [0]
+      status: 0
     - original_index: 370
-      status: [4]
+      status: 4
     - original_index: 371
-      status: [2]
+      status: 2
     - original_index: 372
-      status: [3]
+      status: 3
     - original_index: 373
-      status: [3]
+      status: 3
     - original_index: 374
-      status: [3]
+      status: 3
     - original_index: 375
-      status: [2]
+      status: 2
     - original_index: 376
-      status: [4]
+      status: 4
     - original_index: 377
-      status: [0]
+      status: 0
     - original_index: 378
-      status: [0]
+      status: 0
     - original_index: 379
-      status: [1]
+      status: 1
     - original_index: 380
-      status: [0]
+      status: 0
     - original_index: 381
-      status: [4]
+      status: 4
     - original_index: 382
-      status: [4]
+      status: 4
     - original_index: 383
-      status: [4]
+      status: 4
   output:
-  - - committee: [130, 151]
+  - - committee:
+      - 130
+      - 151
       shard: 669
       total_validator_count: 173
-  - - committee: [302, 336, 163]
+  - - committee:
+      - 302
+      - 336
+      - 163
       shard: 670
       total_validator_count: 173
-  - - committee: [234, 262, 179]
+  - - committee:
+      - 234
+      - 262
+      - 179
       shard: 671
       total_validator_count: 173
-  - - committee: [54, 77]
+  - - committee:
+      - 54
+      - 77
       shard: 672
       total_validator_count: 173
-  - - committee: [59, 232, 205]
+  - - committee:
+      - 59
+      - 232
+      - 205
       shard: 673
       total_validator_count: 173
-  - - committee: [0, 356, 337]
+  - - committee:
+      - 0
+      - 356
+      - 337
       shard: 674
       total_validator_count: 173
-  - - committee: [141, 133]
+  - - committee:
+      - 141
+      - 133
       shard: 675
       total_validator_count: 173
-  - - committee: [17, 114, 30]
+  - - committee:
+      - 17
+      - 114
+      - 30
       shard: 676
       total_validator_count: 173
-  - - committee: [312, 368, 177]
+  - - committee:
+      - 312
+      - 368
+      - 177
       shard: 677
       total_validator_count: 173
-  - - committee: [250, 252, 284]
+  - - committee:
+      - 250
+      - 252
+      - 284
       shard: 678
       total_validator_count: 173
-  - - committee: [111, 331]
+  - - committee:
+      - 111
+      - 331
       shard: 679
       total_validator_count: 173
-  - - committee: [174, 272, 68]
+  - - committee:
+      - 174
+      - 272
+      - 68
       shard: 680
       total_validator_count: 173
-  - - committee: [209, 310, 45]
+  - - committee:
+      - 209
+      - 310
+      - 45
       shard: 681
       total_validator_count: 173
-  - - committee: [306, 108]
+  - - committee:
+      - 306
+      - 108
       shard: 682
       total_validator_count: 173
-  - - committee: [74, 379, 75]
+  - - committee:
+      - 74
+      - 379
+      - 75
       shard: 683
       total_validator_count: 173
-  - - committee: [317, 335, 370]
+  - - committee:
+      - 317
+      - 335
+      - 370
       shard: 684
       total_validator_count: 173
-  - - committee: [182, 47]
+  - - committee:
+      - 182
+      - 47
       shard: 685
       total_validator_count: 173
-  - - committee: [88, 383, 241]
+  - - committee:
+      - 88
+      - 383
+      - 241
       shard: 686
       total_validator_count: 173
-  - - committee: [119, 170, 189]
+  - - committee:
+      - 119
+      - 170
+      - 189
       shard: 687
       total_validator_count: 173
-  - - committee: [146, 63, 128]
+  - - committee:
+      - 146
+      - 63
+      - 128
       shard: 688
       total_validator_count: 173
-  - - committee: [308, 9]
+  - - committee:
+      - 308
+      - 9
       shard: 689
       total_validator_count: 173
-  - - committee: [236, 199, 178]
+  - - committee:
+      - 236
+      - 199
+      - 178
       shard: 690
       total_validator_count: 173
-  - - committee: [185, 230, 80]
+  - - committee:
+      - 185
+      - 230
+      - 80
       shard: 691
       total_validator_count: 173
-  - - committee: [53, 37]
+  - - committee:
+      - 53
+      - 37
       shard: 692
       total_validator_count: 173
-  - - committee: [140, 7, 98]
+  - - committee:
+      - 140
+      - 7
+      - 98
       shard: 693
       total_validator_count: 173
-  - - committee: [131, 314, 233]
+  - - committee:
+      - 131
+      - 314
+      - 233
       shard: 694
       total_validator_count: 173
-  - - committee: [31, 324]
+  - - committee:
+      - 31
+      - 324
       shard: 695
       total_validator_count: 173
-  - - committee: [265, 69, 8]
+  - - committee:
+      - 265
+      - 69
+      - 8
       shard: 696
       total_validator_count: 173
-  - - committee: [208, 269, 286]
+  - - committee:
+      - 208
+      - 269
+      - 286
       shard: 697
       total_validator_count: 173
-  - - committee: [329, 3, 196]
+  - - committee:
+      - 329
+      - 3
+      - 196
       shard: 698
       total_validator_count: 173
-  - - committee: [281, 220]
+  - - committee:
+      - 281
+      - 220
       shard: 699
       total_validator_count: 173
-  - - committee: [297, 307, 309]
+  - - committee:
+      - 297
+      - 307
+      - 309
       shard: 700
       total_validator_count: 173
-  - - committee: [82, 67, 116]
+  - - committee:
+      - 82
+      - 67
+      - 116
       shard: 701
       total_validator_count: 173
-  - - committee: [224, 285]
+  - - committee:
+      - 224
+      - 285
       shard: 702
       total_validator_count: 173
-  - - committee: [33, 55, 39]
+  - - committee:
+      - 33
+      - 55
+      - 39
       shard: 703
       total_validator_count: 173
-  - - committee: [381, 197, 243]
+  - - committee:
+      - 381
+      - 197
+      - 243
       shard: 704
       total_validator_count: 173
-  - - committee: [207, 120, 134]
+  - - committee:
+      - 207
+      - 120
+      - 134
       shard: 705
       total_validator_count: 173
-  - - committee: [41, 253]
+  - - committee:
+      - 41
+      - 253
       shard: 706
       total_validator_count: 173
-  - - committee: [18, 166, 193]
+  - - committee:
+      - 18
+      - 166
+      - 193
       shard: 707
       total_validator_count: 173
-  - - committee: [322, 24, 168]
+  - - committee:
+      - 322
+      - 24
+      - 168
       shard: 708
       total_validator_count: 173
-  - - committee: [304, 112]
+  - - committee:
+      - 304
+      - 112
       shard: 709
       total_validator_count: 173
-  - - committee: [155, 271, 136]
+  - - committee:
+      - 155
+      - 271
+      - 136
       shard: 710
       total_validator_count: 173
-  - - committee: [73, 91, 6]
+  - - committee:
+      - 73
+      - 91
+      - 6
       shard: 711
       total_validator_count: 173
-  - - committee: [276, 28]
+  - - committee:
+      - 276
+      - 28
       shard: 712
       total_validator_count: 173
-  - - committee: [103, 320, 235]
+  - - committee:
+      - 103
+      - 320
+      - 235
       shard: 713
       total_validator_count: 173
-  - - committee: [264, 70, 78]
+  - - committee:
+      - 264
+      - 70
+      - 78
       shard: 714
       total_validator_count: 173
-  - - committee: [282, 4, 263]
+  - - committee:
+      - 282
+      - 4
+      - 263
       shard: 715
       total_validator_count: 173
-  - - committee: [158, 237]
+  - - committee:
+      - 158
+      - 237
       shard: 716
       total_validator_count: 173
-  - - committee: [176, 201, 215]
+  - - committee:
+      - 176
+      - 201
+      - 215
       shard: 717
       total_validator_count: 173
-  - - committee: [278, 326, 79]
+  - - committee:
+      - 278
+      - 326
+      - 79
       shard: 718
       total_validator_count: 173
-  - - committee: [113, 355]
+  - - committee:
+      - 113
+      - 355
       shard: 719
       total_validator_count: 173
-  - - committee: [218, 376, 364]
+  - - committee:
+      - 218
+      - 376
+      - 364
       shard: 720
       total_validator_count: 173
-  - - committee: [183, 104, 61]
+  - - committee:
+      - 183
+      - 104
+      - 61
       shard: 721
       total_validator_count: 173
-  - - committee: [288, 279]
+  - - committee:
+      - 288
+      - 279
       shard: 722
       total_validator_count: 173
-  - - committee: [156, 152, 58]
+  - - committee:
+      - 156
+      - 152
+      - 58
       shard: 723
       total_validator_count: 173
-  - - committee: [358, 175, 180]
+  - - committee:
+      - 358
+      - 175
+      - 180
       shard: 724
       total_validator_count: 173
-  - - committee: [340, 115, 32]
+  - - committee:
+      - 340
+      - 115
+      - 32
       shard: 725
       total_validator_count: 173
-  - - committee: [270, 195]
+  - - committee:
+      - 270
+      - 195
       shard: 726
       total_validator_count: 173
-  - - committee: [15, 38, 294]
+  - - committee:
+      - 15
+      - 38
+      - 294
       shard: 727
       total_validator_count: 173
-  - - committee: [251, 29, 86]
+  - - committee:
+      - 251
+      - 29
+      - 86
       shard: 728
       total_validator_count: 173
-  - - committee: [20, 165]
+  - - committee:
+      - 20
+      - 165
       shard: 729
       total_validator_count: 173
-  - - committee: [351, 96, 99]
+  - - committee:
+      - 351
+      - 96
+      - 99
       shard: 730
       total_validator_count: 173
-  - - committee: [342, 217, 1]
+  - - committee:
+      - 342
+      - 217
+      - 1
       shard: 731
       total_validator_count: 173
-  - - committee: [167, 382, 228]
+  - - committee:
+      - 167
+      - 382
+      - 228
       shard: 732
       total_validator_count: 173
   seed: '0x6ff9fde4cd621a9359ee5f08929d2188ed5f72b59aa71c3d10453ccde114d1b6'
@@ -7261,1116 +8426,1299 @@ test_cases:
     crosslinking_start_shard: 946
     validators:
     - original_index: 0
-      status: [2]
+      status: 2
     - original_index: 1
-      status: [2]
+      status: 2
     - original_index: 2
-      status: [1]
+      status: 1
     - original_index: 3
-      status: [4]
+      status: 4
     - original_index: 4
-      status: [1]
+      status: 1
     - original_index: 5
-      status: [1]
+      status: 1
     - original_index: 6
-      status: [0]
+      status: 0
     - original_index: 7
-      status: [4]
+      status: 4
     - original_index: 8
-      status: [4]
+      status: 4
     - original_index: 9
-      status: [1]
+      status: 1
     - original_index: 10
-      status: [0]
+      status: 0
     - original_index: 11
-      status: [1]
+      status: 1
     - original_index: 12
-      status: [4]
+      status: 4
     - original_index: 13
-      status: [0]
+      status: 0
     - original_index: 14
-      status: [2]
+      status: 2
     - original_index: 15
-      status: [0]
+      status: 0
     - original_index: 16
-      status: [2]
+      status: 2
     - original_index: 17
-      status: [0]
+      status: 0
     - original_index: 18
-      status: [3]
+      status: 3
     - original_index: 19
-      status: [1]
+      status: 1
     - original_index: 20
-      status: [2]
+      status: 2
     - original_index: 21
-      status: [4]
+      status: 4
     - original_index: 22
-      status: [4]
+      status: 4
     - original_index: 23
-      status: [1]
+      status: 1
     - original_index: 24
-      status: [4]
+      status: 4
     - original_index: 25
-      status: [2]
+      status: 2
     - original_index: 26
-      status: [3]
+      status: 3
     - original_index: 27
-      status: [4]
+      status: 4
     - original_index: 28
-      status: [4]
+      status: 4
     - original_index: 29
-      status: [3]
+      status: 3
     - original_index: 30
-      status: [2]
+      status: 2
     - original_index: 31
-      status: [3]
+      status: 3
     - original_index: 32
-      status: [0]
+      status: 0
     - original_index: 33
-      status: [0]
+      status: 0
     - original_index: 34
-      status: [1]
+      status: 1
     - original_index: 35
-      status: [0]
+      status: 0
     - original_index: 36
-      status: [0]
+      status: 0
     - original_index: 37
-      status: [2]
+      status: 2
     - original_index: 38
-      status: [0]
+      status: 0
     - original_index: 39
-      status: [1]
+      status: 1
     - original_index: 40
-      status: [4]
+      status: 4
     - original_index: 41
-      status: [1]
+      status: 1
     - original_index: 42
-      status: [3]
+      status: 3
     - original_index: 43
-      status: [0]
+      status: 0
     - original_index: 44
-      status: [0]
+      status: 0
     - original_index: 45
-      status: [4]
+      status: 4
     - original_index: 46
-      status: [0]
+      status: 0
     - original_index: 47
-      status: [0]
+      status: 0
     - original_index: 48
-      status: [1]
+      status: 1
     - original_index: 49
-      status: [1]
+      status: 1
     - original_index: 50
-      status: [1]
+      status: 1
     - original_index: 51
-      status: [4]
+      status: 4
     - original_index: 52
-      status: [3]
+      status: 3
     - original_index: 53
-      status: [1]
+      status: 1
     - original_index: 54
-      status: [2]
+      status: 2
     - original_index: 55
-      status: [0]
+      status: 0
     - original_index: 56
-      status: [1]
+      status: 1
     - original_index: 57
-      status: [1]
+      status: 1
     - original_index: 58
-      status: [1]
+      status: 1
     - original_index: 59
-      status: [4]
+      status: 4
     - original_index: 60
-      status: [1]
+      status: 1
     - original_index: 61
-      status: [3]
+      status: 3
     - original_index: 62
-      status: [1]
+      status: 1
     - original_index: 63
-      status: [1]
+      status: 1
     - original_index: 64
-      status: [3]
+      status: 3
     - original_index: 65
-      status: [4]
+      status: 4
     - original_index: 66
-      status: [4]
+      status: 4
     - original_index: 67
-      status: [3]
+      status: 3
     - original_index: 68
-      status: [4]
+      status: 4
     - original_index: 69
-      status: [1]
+      status: 1
     - original_index: 70
-      status: [1]
+      status: 1
     - original_index: 71
-      status: [0]
+      status: 0
     - original_index: 72
-      status: [3]
+      status: 3
     - original_index: 73
-      status: [4]
+      status: 4
     - original_index: 74
-      status: [0]
+      status: 0
     - original_index: 75
-      status: [1]
+      status: 1
     - original_index: 76
-      status: [0]
+      status: 0
     - original_index: 77
-      status: [2]
+      status: 2
     - original_index: 78
-      status: [2]
+      status: 2
     - original_index: 79
-      status: [3]
+      status: 3
     - original_index: 80
-      status: [0]
+      status: 0
     - original_index: 81
-      status: [4]
+      status: 4
     - original_index: 82
-      status: [4]
+      status: 4
     - original_index: 83
-      status: [0]
+      status: 0
     - original_index: 84
-      status: [2]
+      status: 2
     - original_index: 85
-      status: [0]
+      status: 0
     - original_index: 86
-      status: [2]
+      status: 2
     - original_index: 87
-      status: [0]
+      status: 0
     - original_index: 88
-      status: [0]
+      status: 0
     - original_index: 89
-      status: [0]
+      status: 0
     - original_index: 90
-      status: [2]
+      status: 2
     - original_index: 91
-      status: [3]
+      status: 3
     - original_index: 92
-      status: [2]
+      status: 2
     - original_index: 93
-      status: [3]
+      status: 3
     - original_index: 94
-      status: [3]
+      status: 3
     - original_index: 95
-      status: [0]
+      status: 0
     - original_index: 96
-      status: [2]
+      status: 2
     - original_index: 97
-      status: [1]
+      status: 1
     - original_index: 98
-      status: [0]
+      status: 0
     - original_index: 99
-      status: [0]
+      status: 0
     - original_index: 100
-      status: [4]
+      status: 4
     - original_index: 101
-      status: [4]
+      status: 4
     - original_index: 102
-      status: [4]
+      status: 4
     - original_index: 103
-      status: [1]
+      status: 1
     - original_index: 104
-      status: [2]
+      status: 2
     - original_index: 105
-      status: [3]
+      status: 3
     - original_index: 106
-      status: [3]
+      status: 3
     - original_index: 107
-      status: [0]
+      status: 0
     - original_index: 108
-      status: [1]
+      status: 1
     - original_index: 109
-      status: [0]
+      status: 0
     - original_index: 110
-      status: [1]
+      status: 1
     - original_index: 111
-      status: [1]
+      status: 1
     - original_index: 112
-      status: [2]
+      status: 2
     - original_index: 113
-      status: [3]
+      status: 3
     - original_index: 114
-      status: [1]
+      status: 1
     - original_index: 115
-      status: [2]
+      status: 2
     - original_index: 116
-      status: [4]
+      status: 4
     - original_index: 117
-      status: [3]
+      status: 3
     - original_index: 118
-      status: [0]
+      status: 0
     - original_index: 119
-      status: [0]
+      status: 0
     - original_index: 120
-      status: [3]
+      status: 3
     - original_index: 121
-      status: [2]
+      status: 2
     - original_index: 122
-      status: [1]
+      status: 1
     - original_index: 123
-      status: [1]
+      status: 1
     - original_index: 124
-      status: [0]
+      status: 0
     - original_index: 125
-      status: [2]
+      status: 2
     - original_index: 126
-      status: [0]
+      status: 0
     - original_index: 127
-      status: [3]
+      status: 3
     - original_index: 128
-      status: [0]
+      status: 0
     - original_index: 129
-      status: [2]
+      status: 2
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [3]
+      status: 3
     - original_index: 132
-      status: [4]
+      status: 4
     - original_index: 133
-      status: [0]
+      status: 0
     - original_index: 134
-      status: [3]
+      status: 3
     - original_index: 135
-      status: [4]
+      status: 4
     - original_index: 136
-      status: [2]
+      status: 2
     - original_index: 137
-      status: [4]
+      status: 4
     - original_index: 138
-      status: [3]
+      status: 3
     - original_index: 139
-      status: [0]
+      status: 0
     - original_index: 140
-      status: [1]
+      status: 1
     - original_index: 141
-      status: [1]
+      status: 1
     - original_index: 142
-      status: [2]
+      status: 2
     - original_index: 143
-      status: [2]
+      status: 2
     - original_index: 144
-      status: [3]
+      status: 3
     - original_index: 145
-      status: [0]
+      status: 0
     - original_index: 146
-      status: [0]
+      status: 0
     - original_index: 147
-      status: [2]
+      status: 2
     - original_index: 148
-      status: [3]
+      status: 3
     - original_index: 149
-      status: [1]
+      status: 1
     - original_index: 150
-      status: [3]
+      status: 3
     - original_index: 151
-      status: [4]
+      status: 4
     - original_index: 152
-      status: [3]
+      status: 3
     - original_index: 153
-      status: [1]
+      status: 1
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [2]
+      status: 2
     - original_index: 156
-      status: [0]
+      status: 0
     - original_index: 157
-      status: [4]
+      status: 4
     - original_index: 158
-      status: [4]
+      status: 4
     - original_index: 159
-      status: [2]
+      status: 2
     - original_index: 160
-      status: [0]
+      status: 0
     - original_index: 161
-      status: [0]
+      status: 0
     - original_index: 162
-      status: [1]
+      status: 1
     - original_index: 163
-      status: [2]
+      status: 2
     - original_index: 164
-      status: [4]
+      status: 4
     - original_index: 165
-      status: [2]
+      status: 2
     - original_index: 166
-      status: [1]
+      status: 1
     - original_index: 167
-      status: [0]
+      status: 0
     - original_index: 168
-      status: [3]
+      status: 3
     - original_index: 169
-      status: [2]
+      status: 2
     - original_index: 170
-      status: [0]
+      status: 0
     - original_index: 171
-      status: [3]
+      status: 3
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [3]
+      status: 3
     - original_index: 174
-      status: [0]
+      status: 0
     - original_index: 175
-      status: [3]
+      status: 3
     - original_index: 176
-      status: [0]
+      status: 0
     - original_index: 177
-      status: [1]
+      status: 1
     - original_index: 178
-      status: [0]
+      status: 0
     - original_index: 179
-      status: [4]
+      status: 4
     - original_index: 180
-      status: [4]
+      status: 4
     - original_index: 181
-      status: [0]
+      status: 0
     - original_index: 182
-      status: [4]
+      status: 4
     - original_index: 183
-      status: [0]
+      status: 0
     - original_index: 184
-      status: [2]
+      status: 2
     - original_index: 185
-      status: [2]
+      status: 2
     - original_index: 186
-      status: [2]
+      status: 2
     - original_index: 187
-      status: [4]
+      status: 4
     - original_index: 188
-      status: [1]
+      status: 1
     - original_index: 189
-      status: [2]
+      status: 2
     - original_index: 190
-      status: [4]
+      status: 4
     - original_index: 191
-      status: [2]
+      status: 2
     - original_index: 192
-      status: [4]
+      status: 4
     - original_index: 193
-      status: [1]
+      status: 1
     - original_index: 194
-      status: [0]
+      status: 0
     - original_index: 195
-      status: [0]
+      status: 0
     - original_index: 196
-      status: [2]
+      status: 2
     - original_index: 197
-      status: [3]
+      status: 3
     - original_index: 198
-      status: [3]
+      status: 3
     - original_index: 199
-      status: [3]
+      status: 3
     - original_index: 200
-      status: [1]
+      status: 1
     - original_index: 201
-      status: [1]
+      status: 1
     - original_index: 202
-      status: [2]
+      status: 2
     - original_index: 203
-      status: [4]
+      status: 4
     - original_index: 204
-      status: [1]
+      status: 1
     - original_index: 205
-      status: [4]
+      status: 4
     - original_index: 206
-      status: [0]
+      status: 0
     - original_index: 207
-      status: [2]
+      status: 2
     - original_index: 208
-      status: [2]
+      status: 2
     - original_index: 209
-      status: [0]
+      status: 0
     - original_index: 210
-      status: [0]
+      status: 0
     - original_index: 211
-      status: [2]
+      status: 2
     - original_index: 212
-      status: [4]
+      status: 4
     - original_index: 213
-      status: [2]
+      status: 2
     - original_index: 214
-      status: [1]
+      status: 1
     - original_index: 215
-      status: [4]
+      status: 4
     - original_index: 216
-      status: [2]
+      status: 2
     - original_index: 217
-      status: [0]
+      status: 0
     - original_index: 218
-      status: [1]
+      status: 1
     - original_index: 219
-      status: [0]
+      status: 0
     - original_index: 220
-      status: [3]
+      status: 3
     - original_index: 221
-      status: [1]
+      status: 1
     - original_index: 222
-      status: [1]
+      status: 1
     - original_index: 223
-      status: [1]
+      status: 1
     - original_index: 224
-      status: [3]
+      status: 3
     - original_index: 225
-      status: [4]
+      status: 4
     - original_index: 226
-      status: [3]
+      status: 3
     - original_index: 227
-      status: [0]
+      status: 0
     - original_index: 228
-      status: [1]
+      status: 1
     - original_index: 229
-      status: [0]
+      status: 0
     - original_index: 230
-      status: [2]
+      status: 2
     - original_index: 231
-      status: [3]
+      status: 3
     - original_index: 232
-      status: [3]
+      status: 3
     - original_index: 233
-      status: [1]
+      status: 1
     - original_index: 234
-      status: [4]
+      status: 4
     - original_index: 235
-      status: [1]
+      status: 1
     - original_index: 236
-      status: [3]
+      status: 3
     - original_index: 237
-      status: [0]
+      status: 0
     - original_index: 238
-      status: [3]
+      status: 3
     - original_index: 239
-      status: [1]
+      status: 1
     - original_index: 240
-      status: [2]
+      status: 2
     - original_index: 241
-      status: [2]
+      status: 2
     - original_index: 242
-      status: [4]
+      status: 4
     - original_index: 243
-      status: [2]
+      status: 2
     - original_index: 244
-      status: [2]
+      status: 2
     - original_index: 245
-      status: [1]
+      status: 1
     - original_index: 246
-      status: [1]
+      status: 1
     - original_index: 247
-      status: [4]
+      status: 4
     - original_index: 248
-      status: [1]
+      status: 1
     - original_index: 249
-      status: [4]
+      status: 4
     - original_index: 250
-      status: [3]
+      status: 3
     - original_index: 251
-      status: [4]
+      status: 4
     - original_index: 252
-      status: [3]
+      status: 3
     - original_index: 253
-      status: [1]
+      status: 1
     - original_index: 254
-      status: [4]
+      status: 4
     - original_index: 255
-      status: [2]
+      status: 2
     - original_index: 256
-      status: [4]
+      status: 4
     - original_index: 257
-      status: [0]
+      status: 0
     - original_index: 258
-      status: [0]
+      status: 0
     - original_index: 259
-      status: [2]
+      status: 2
     - original_index: 260
-      status: [0]
+      status: 0
     - original_index: 261
-      status: [4]
+      status: 4
     - original_index: 262
-      status: [0]
+      status: 0
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [3]
+      status: 3
     - original_index: 265
-      status: [4]
+      status: 4
     - original_index: 266
-      status: [1]
+      status: 1
     - original_index: 267
-      status: [4]
+      status: 4
     - original_index: 268
-      status: [1]
+      status: 1
     - original_index: 269
-      status: [4]
+      status: 4
     - original_index: 270
-      status: [2]
+      status: 2
     - original_index: 271
-      status: [2]
+      status: 2
     - original_index: 272
-      status: [3]
+      status: 3
     - original_index: 273
-      status: [1]
+      status: 1
     - original_index: 274
-      status: [2]
+      status: 2
     - original_index: 275
-      status: [2]
+      status: 2
     - original_index: 276
-      status: [1]
+      status: 1
     - original_index: 277
-      status: [4]
+      status: 4
     - original_index: 278
-      status: [2]
+      status: 2
     - original_index: 279
-      status: [4]
+      status: 4
     - original_index: 280
-      status: [2]
+      status: 2
     - original_index: 281
-      status: [4]
+      status: 4
     - original_index: 282
-      status: [1]
+      status: 1
     - original_index: 283
-      status: [2]
+      status: 2
     - original_index: 284
-      status: [4]
+      status: 4
     - original_index: 285
-      status: [3]
+      status: 3
     - original_index: 286
-      status: [1]
+      status: 1
     - original_index: 287
-      status: [0]
+      status: 0
     - original_index: 288
-      status: [2]
+      status: 2
     - original_index: 289
-      status: [0]
+      status: 0
     - original_index: 290
-      status: [2]
+      status: 2
     - original_index: 291
-      status: [2]
+      status: 2
     - original_index: 292
-      status: [4]
+      status: 4
     - original_index: 293
-      status: [0]
+      status: 0
     - original_index: 294
-      status: [1]
+      status: 1
     - original_index: 295
-      status: [1]
+      status: 1
     - original_index: 296
-      status: [2]
+      status: 2
     - original_index: 297
-      status: [0]
+      status: 0
     - original_index: 298
-      status: [4]
+      status: 4
     - original_index: 299
-      status: [1]
+      status: 1
     - original_index: 300
-      status: [1]
+      status: 1
     - original_index: 301
-      status: [2]
+      status: 2
     - original_index: 302
-      status: [1]
+      status: 1
     - original_index: 303
-      status: [3]
+      status: 3
     - original_index: 304
-      status: [3]
+      status: 3
     - original_index: 305
-      status: [1]
+      status: 1
     - original_index: 306
-      status: [3]
+      status: 3
     - original_index: 307
-      status: [1]
+      status: 1
     - original_index: 308
-      status: [4]
+      status: 4
     - original_index: 309
-      status: [2]
+      status: 2
     - original_index: 310
-      status: [0]
+      status: 0
     - original_index: 311
-      status: [3]
+      status: 3
     - original_index: 312
-      status: [3]
+      status: 3
     - original_index: 313
-      status: [2]
+      status: 2
     - original_index: 314
-      status: [2]
+      status: 2
     - original_index: 315
-      status: [0]
+      status: 0
     - original_index: 316
-      status: [3]
+      status: 3
     - original_index: 317
-      status: [2]
+      status: 2
     - original_index: 318
-      status: [2]
+      status: 2
     - original_index: 319
-      status: [1]
+      status: 1
     - original_index: 320
-      status: [4]
+      status: 4
     - original_index: 321
-      status: [3]
+      status: 3
     - original_index: 322
-      status: [3]
+      status: 3
     - original_index: 323
-      status: [0]
+      status: 0
     - original_index: 324
-      status: [2]
+      status: 2
     - original_index: 325
-      status: [4]
+      status: 4
     - original_index: 326
-      status: [2]
+      status: 2
     - original_index: 327
-      status: [4]
+      status: 4
     - original_index: 328
-      status: [1]
+      status: 1
     - original_index: 329
-      status: [3]
+      status: 3
     - original_index: 330
-      status: [2]
+      status: 2
     - original_index: 331
-      status: [0]
+      status: 0
     - original_index: 332
-      status: [0]
+      status: 0
     - original_index: 333
-      status: [4]
+      status: 4
     - original_index: 334
-      status: [0]
+      status: 0
     - original_index: 335
-      status: [0]
+      status: 0
     - original_index: 336
-      status: [2]
+      status: 2
     - original_index: 337
-      status: [1]
+      status: 1
     - original_index: 338
-      status: [4]
+      status: 4
     - original_index: 339
-      status: [4]
+      status: 4
     - original_index: 340
-      status: [4]
+      status: 4
     - original_index: 341
-      status: [2]
+      status: 2
     - original_index: 342
-      status: [4]
+      status: 4
     - original_index: 343
-      status: [3]
+      status: 3
     - original_index: 344
-      status: [4]
+      status: 4
     - original_index: 345
-      status: [4]
+      status: 4
     - original_index: 346
-      status: [4]
+      status: 4
     - original_index: 347
-      status: [3]
+      status: 3
     - original_index: 348
-      status: [2]
+      status: 2
     - original_index: 349
-      status: [0]
+      status: 0
     - original_index: 350
-      status: [1]
+      status: 1
     - original_index: 351
-      status: [4]
+      status: 4
     - original_index: 352
-      status: [3]
+      status: 3
     - original_index: 353
-      status: [2]
+      status: 2
     - original_index: 354
-      status: [3]
+      status: 3
     - original_index: 355
-      status: [2]
+      status: 2
     - original_index: 356
-      status: [0]
+      status: 0
     - original_index: 357
-      status: [3]
+      status: 3
     - original_index: 358
-      status: [3]
+      status: 3
     - original_index: 359
-      status: [1]
+      status: 1
     - original_index: 360
-      status: [3]
+      status: 3
     - original_index: 361
-      status: [1]
+      status: 1
     - original_index: 362
-      status: [2]
+      status: 2
     - original_index: 363
-      status: [0]
+      status: 0
     - original_index: 364
-      status: [0]
+      status: 0
     - original_index: 365
-      status: [2]
+      status: 2
     - original_index: 366
-      status: [4]
+      status: 4
     - original_index: 367
-      status: [0]
+      status: 0
     - original_index: 368
-      status: [1]
+      status: 1
     - original_index: 369
-      status: [2]
+      status: 2
     - original_index: 370
-      status: [1]
+      status: 1
     - original_index: 371
-      status: [4]
+      status: 4
     - original_index: 372
-      status: [1]
+      status: 1
     - original_index: 373
-      status: [2]
+      status: 2
     - original_index: 374
-      status: [2]
+      status: 2
     - original_index: 375
-      status: [2]
+      status: 2
     - original_index: 376
-      status: [1]
+      status: 1
     - original_index: 377
-      status: [2]
+      status: 2
     - original_index: 378
-      status: [2]
+      status: 2
     - original_index: 379
-      status: [0]
+      status: 0
     - original_index: 380
-      status: [1]
+      status: 1
     - original_index: 381
-      status: [0]
+      status: 0
     - original_index: 382
-      status: [1]
+      status: 1
     - original_index: 383
-      status: [0]
+      status: 0
     - original_index: 384
-      status: [1]
+      status: 1
     - original_index: 385
-      status: [2]
+      status: 2
     - original_index: 386
-      status: [1]
+      status: 1
     - original_index: 387
-      status: [2]
+      status: 2
     - original_index: 388
-      status: [1]
+      status: 1
     - original_index: 389
-      status: [4]
+      status: 4
     - original_index: 390
-      status: [2]
+      status: 2
     - original_index: 391
-      status: [2]
+      status: 2
     - original_index: 392
-      status: [1]
+      status: 1
     - original_index: 393
-      status: [4]
+      status: 4
     - original_index: 394
-      status: [2]
+      status: 2
     - original_index: 395
-      status: [4]
+      status: 4
     - original_index: 396
-      status: [1]
+      status: 1
     - original_index: 397
-      status: [2]
+      status: 2
     - original_index: 398
-      status: [1]
+      status: 1
     - original_index: 399
-      status: [4]
+      status: 4
     - original_index: 400
-      status: [0]
+      status: 0
     - original_index: 401
-      status: [1]
+      status: 1
     - original_index: 402
-      status: [2]
+      status: 2
     - original_index: 403
-      status: [0]
+      status: 0
     - original_index: 404
-      status: [3]
+      status: 3
     - original_index: 405
-      status: [1]
+      status: 1
     - original_index: 406
-      status: [2]
+      status: 2
     - original_index: 407
-      status: [1]
+      status: 1
     - original_index: 408
-      status: [2]
+      status: 2
     - original_index: 409
-      status: [3]
+      status: 3
     - original_index: 410
-      status: [0]
+      status: 0
     - original_index: 411
-      status: [0]
+      status: 0
     - original_index: 412
-      status: [2]
+      status: 2
     - original_index: 413
-      status: [0]
+      status: 0
     - original_index: 414
-      status: [2]
+      status: 2
     - original_index: 415
-      status: [0]
+      status: 0
     - original_index: 416
-      status: [4]
+      status: 4
     - original_index: 417
-      status: [0]
+      status: 0
     - original_index: 418
-      status: [2]
+      status: 2
     - original_index: 419
-      status: [3]
+      status: 3
     - original_index: 420
-      status: [1]
+      status: 1
     - original_index: 421
-      status: [4]
+      status: 4
     - original_index: 422
-      status: [2]
+      status: 2
     - original_index: 423
-      status: [3]
+      status: 3
     - original_index: 424
-      status: [0]
+      status: 0
     - original_index: 425
-      status: [2]
+      status: 2
     - original_index: 426
-      status: [0]
+      status: 0
     - original_index: 427
-      status: [3]
+      status: 3
     - original_index: 428
-      status: [4]
+      status: 4
     - original_index: 429
-      status: [4]
+      status: 4
     - original_index: 430
-      status: [2]
+      status: 2
     - original_index: 431
-      status: [3]
+      status: 3
     - original_index: 432
-      status: [1]
+      status: 1
     - original_index: 433
-      status: [2]
+      status: 2
     - original_index: 434
-      status: [2]
+      status: 2
     - original_index: 435
-      status: [2]
+      status: 2
     - original_index: 436
-      status: [4]
+      status: 4
     - original_index: 437
-      status: [4]
+      status: 4
     - original_index: 438
-      status: [2]
+      status: 2
     - original_index: 439
-      status: [3]
+      status: 3
     - original_index: 440
-      status: [0]
+      status: 0
     - original_index: 441
-      status: [0]
+      status: 0
     - original_index: 442
-      status: [3]
+      status: 3
     - original_index: 443
-      status: [0]
+      status: 0
     - original_index: 444
-      status: [3]
+      status: 3
     - original_index: 445
-      status: [3]
+      status: 3
     - original_index: 446
-      status: [3]
+      status: 3
     - original_index: 447
-      status: [3]
+      status: 3
     - original_index: 448
-      status: [3]
+      status: 3
     - original_index: 449
-      status: [0]
+      status: 0
     - original_index: 450
-      status: [2]
+      status: 2
     - original_index: 451
-      status: [2]
+      status: 2
     - original_index: 452
-      status: [1]
+      status: 1
     - original_index: 453
-      status: [0]
+      status: 0
     - original_index: 454
-      status: [0]
+      status: 0
     - original_index: 455
-      status: [1]
+      status: 1
     - original_index: 456
-      status: [1]
+      status: 1
     - original_index: 457
-      status: [1]
+      status: 1
     - original_index: 458
-      status: [4]
+      status: 4
     - original_index: 459
-      status: [3]
+      status: 3
   output:
-  - - committee: [100, 368]
+  - - committee:
+      - 100
+      - 368
       shard: 946
       total_validator_count: 183
-  - - committee: [253, 395, 249]
+  - - committee:
+      - 253
+      - 395
+      - 249
       shard: 947
       total_validator_count: 183
-  - - committee: [2, 401, 286]
+  - - committee:
+      - 2
+      - 401
+      - 286
       shard: 948
       total_validator_count: 183
-  - - committee: [215, 366, 225]
+  - - committee:
+      - 215
+      - 366
+      - 225
       shard: 949
       total_validator_count: 183
-  - - committee: [399, 359, 350]
+  - - committee:
+      - 399
+      - 359
+      - 350
       shard: 950
       total_validator_count: 183
-  - - committee: [24, 223, 3]
+  - - committee:
+      - 24
+      - 223
+      - 3
       shard: 951
       total_validator_count: 183
-  - - committee: [407, 200, 75]
+  - - committee:
+      - 407
+      - 200
+      - 75
       shard: 952
       total_validator_count: 183
-  - - committee: [328, 437]
+  - - committee:
+      - 328
+      - 437
       shard: 953
       total_validator_count: 183
-  - - committee: [135, 300, 59]
+  - - committee:
+      - 135
+      - 300
+      - 59
       shard: 954
       total_validator_count: 183
-  - - committee: [102, 456, 239]
+  - - committee:
+      - 102
+      - 456
+      - 239
       shard: 955
       total_validator_count: 183
-  - - committee: [222, 295, 4]
+  - - committee:
+      - 222
+      - 295
+      - 4
       shard: 956
       total_validator_count: 183
-  - - committee: [396, 51, 110]
+  - - committee:
+      - 396
+      - 51
+      - 110
       shard: 957
       total_validator_count: 183
-  - - committee: [421, 57, 345]
+  - - committee:
+      - 421
+      - 57
+      - 345
       shard: 958
       total_validator_count: 183
-  - - committee: [66, 247, 65]
+  - - committee:
+      - 66
+      - 247
+      - 65
       shard: 959
       total_validator_count: 183
-  - - committee: [254, 388]
+  - - committee:
+      - 254
+      - 388
       shard: 960
       total_validator_count: 183
-  - - committee: [265, 190, 339]
+  - - committee:
+      - 265
+      - 190
+      - 339
       shard: 961
       total_validator_count: 183
-  - - committee: [12, 34, 149]
+  - - committee:
+      - 12
+      - 34
+      - 149
       shard: 962
       total_validator_count: 183
-  - - committee: [279, 298, 193]
+  - - committee:
+      - 279
+      - 298
+      - 193
       shard: 963
       total_validator_count: 183
-  - - committee: [246, 266, 337]
+  - - committee:
+      - 246
+      - 266
+      - 337
       shard: 964
       total_validator_count: 183
-  - - committee: [277, 325, 452]
+  - - committee:
+      - 277
+      - 325
+      - 452
       shard: 965
       total_validator_count: 183
-  - - committee: [69, 340, 269]
+  - - committee:
+      - 69
+      - 340
+      - 269
       shard: 966
       total_validator_count: 183
-  - - committee: [284, 263]
+  - - committee:
+      - 284
+      - 263
       shard: 967
       total_validator_count: 183
-  - - committee: [162, 27, 7]
+  - - committee:
+      - 162
+      - 27
+      - 7
       shard: 968
       total_validator_count: 183
-  - - committee: [49, 23, 180]
+  - - committee:
+      - 49
+      - 23
+      - 180
       shard: 969
       total_validator_count: 183
-  - - committee: [429, 212, 221]
+  - - committee:
+      - 429
+      - 212
+      - 221
       shard: 970
       total_validator_count: 183
-  - - committee: [22, 245, 130]
+  - - committee:
+      - 22
+      - 245
+      - 130
       shard: 971
       total_validator_count: 183
-  - - committee: [384, 19, 97]
+  - - committee:
+      - 384
+      - 19
+      - 97
       shard: 972
       total_validator_count: 183
-  - - committee: [111, 458, 41]
+  - - committee:
+      - 111
+      - 458
+      - 41
       shard: 973
       total_validator_count: 183
-  - - committee: [386, 157]
+  - - committee:
+      - 386
+      - 157
       shard: 974
       total_validator_count: 183
-  - - committee: [248, 140, 405]
+  - - committee:
+      - 248
+      - 140
+      - 405
       shard: 975
       total_validator_count: 183
-  - - committee: [73, 251, 398]
+  - - committee:
+      - 73
+      - 251
+      - 398
       shard: 976
       total_validator_count: 183
-  - - committee: [371, 116, 428]
+  - - committee:
+      - 371
+      - 116
+      - 428
       shard: 977
       total_validator_count: 183
-  - - committee: [108, 39, 235]
+  - - committee:
+      - 108
+      - 39
+      - 235
       shard: 978
       total_validator_count: 183
-  - - committee: [416, 48, 308]
+  - - committee:
+      - 416
+      - 48
+      - 308
       shard: 979
       total_validator_count: 183
-  - - committee: [56, 103, 299]
+  - - committee:
+      - 56
+      - 103
+      - 299
       shard: 980
       total_validator_count: 183
-  - - committee: [158, 201]
+  - - committee:
+      - 158
+      - 201
       shard: 981
       total_validator_count: 183
-  - - committee: [351, 455, 282]
+  - - committee:
+      - 351
+      - 455
+      - 282
       shard: 982
       total_validator_count: 183
-  - - committee: [177, 81, 179]
+  - - committee:
+      - 177
+      - 81
+      - 179
       shard: 983
       total_validator_count: 183
-  - - committee: [9, 53, 218]
+  - - committee:
+      - 9
+      - 53
+      - 218
       shard: 984
       total_validator_count: 183
-  - - committee: [5, 182, 261]
+  - - committee:
+      - 5
+      - 182
+      - 261
       shard: 985
       total_validator_count: 183
-  - - committee: [58, 457, 233]
+  - - committee:
+      - 58
+      - 457
+      - 233
       shard: 986
       total_validator_count: 183
-  - - committee: [294, 242, 342]
+  - - committee:
+      - 294
+      - 242
+      - 342
       shard: 987
       total_validator_count: 183
-  - - committee: [346, 50]
+  - - committee:
+      - 346
+      - 50
       shard: 988
       total_validator_count: 183
-  - - committee: [151, 68, 11]
+  - - committee:
+      - 151
+      - 68
+      - 11
       shard: 989
       total_validator_count: 183
-  - - committee: [389, 204, 302]
+  - - committee:
+      - 389
+      - 204
+      - 302
       shard: 990
       total_validator_count: 183
-  - - committee: [273, 361, 228]
+  - - committee:
+      - 273
+      - 361
+      - 228
       shard: 991
       total_validator_count: 183
-  - - committee: [45, 205, 372]
+  - - committee:
+      - 45
+      - 205
+      - 372
       shard: 992
       total_validator_count: 183
-  - - committee: [305, 268, 141]
+  - - committee:
+      - 305
+      - 268
+      - 141
       shard: 993
       total_validator_count: 183
-  - - committee: [256, 267, 276]
+  - - committee:
+      - 256
+      - 267
+      - 276
       shard: 994
       total_validator_count: 183
-  - - committee: [338, 234]
+  - - committee:
+      - 338
+      - 234
       shard: 995
       total_validator_count: 183
-  - - committee: [154, 203, 187]
+  - - committee:
+      - 154
+      - 203
+      - 187
       shard: 996
       total_validator_count: 183
-  - - committee: [8, 307, 370]
+  - - committee:
+      - 8
+      - 307
+      - 370
       shard: 997
       total_validator_count: 183
-  - - committee: [70, 166, 192]
+  - - committee:
+      - 70
+      - 166
+      - 192
       shard: 998
       total_validator_count: 183
-  - - committee: [380, 132, 344]
+  - - committee:
+      - 380
+      - 132
+      - 344
       shard: 999
       total_validator_count: 183
-  - - committee: [281, 376, 327]
+  - - committee:
+      - 281
+      - 376
+      - 327
       shard: 1000
       total_validator_count: 183
-  - - committee: [137, 114, 214]
+  - - committee:
+      - 137
+      - 114
+      - 214
       shard: 1001
       total_validator_count: 183
-  - - committee: [101, 21]
+  - - committee:
+      - 101
+      - 21
       shard: 1002
       total_validator_count: 183
-  - - committee: [60, 393, 63]
+  - - committee:
+      - 60
+      - 393
+      - 63
       shard: 1003
       total_validator_count: 183
-  - - committee: [188, 392, 432]
+  - - committee:
+      - 188
+      - 392
+      - 432
       shard: 1004
       total_validator_count: 183
-  - - committee: [123, 420, 40]
+  - - committee:
+      - 123
+      - 420
+      - 40
       shard: 1005
       total_validator_count: 183
-  - - committee: [62, 320, 292]
+  - - committee:
+      - 62
+      - 320
+      - 292
       shard: 1006
       total_validator_count: 183
-  - - committee: [436, 319, 333]
+  - - committee:
+      - 436
+      - 319
+      - 333
       shard: 1007
       total_validator_count: 183
-  - - committee: [153, 28, 122]
+  - - committee:
+      - 153
+      - 28
+      - 122
       shard: 1008
       total_validator_count: 183
-  - - committee: [82, 164, 382]
+  - - committee:
+      - 82
+      - 164
+      - 382
       shard: 1009
       total_validator_count: 183
   seed: '0x9d162fc672c9aba987488027bea4cbc77375dc5ab7c620ce42b3bb35f1445aa8'
@@ -8378,564 +9726,638 @@ test_cases:
     crosslinking_start_shard: 378
     validators:
     - original_index: 0
-      status: [0]
+      status: 0
     - original_index: 1
-      status: [0]
+      status: 0
     - original_index: 2
-      status: [1]
+      status: 1
     - original_index: 3
-      status: [2]
+      status: 2
     - original_index: 4
-      status: [0]
+      status: 0
     - original_index: 5
-      status: [1]
+      status: 1
     - original_index: 6
-      status: [4]
+      status: 4
     - original_index: 7
-      status: [0]
+      status: 0
     - original_index: 8
-      status: [0]
+      status: 0
     - original_index: 9
-      status: [2]
+      status: 2
     - original_index: 10
-      status: [1]
+      status: 1
     - original_index: 11
-      status: [4]
+      status: 4
     - original_index: 12
-      status: [3]
+      status: 3
     - original_index: 13
-      status: [4]
+      status: 4
     - original_index: 14
-      status: [1]
+      status: 1
     - original_index: 15
-      status: [4]
+      status: 4
     - original_index: 16
-      status: [2]
+      status: 2
     - original_index: 17
-      status: [2]
+      status: 2
     - original_index: 18
-      status: [3]
+      status: 3
     - original_index: 19
-      status: [3]
+      status: 3
     - original_index: 20
-      status: [4]
+      status: 4
     - original_index: 21
-      status: [0]
+      status: 0
     - original_index: 22
-      status: [0]
+      status: 0
     - original_index: 23
-      status: [3]
+      status: 3
     - original_index: 24
-      status: [3]
+      status: 3
     - original_index: 25
-      status: [3]
+      status: 3
     - original_index: 26
-      status: [1]
+      status: 1
     - original_index: 27
-      status: [0]
+      status: 0
     - original_index: 28
-      status: [1]
+      status: 1
     - original_index: 29
-      status: [2]
+      status: 2
     - original_index: 30
-      status: [2]
+      status: 2
     - original_index: 31
-      status: [4]
+      status: 4
     - original_index: 32
-      status: [1]
+      status: 1
     - original_index: 33
-      status: [3]
+      status: 3
     - original_index: 34
-      status: [4]
+      status: 4
     - original_index: 35
-      status: [2]
+      status: 2
     - original_index: 36
-      status: [3]
+      status: 3
     - original_index: 37
-      status: [3]
+      status: 3
     - original_index: 38
-      status: [4]
+      status: 4
     - original_index: 39
-      status: [1]
+      status: 1
     - original_index: 40
-      status: [1]
+      status: 1
     - original_index: 41
-      status: [2]
+      status: 2
     - original_index: 42
-      status: [1]
+      status: 1
     - original_index: 43
-      status: [2]
+      status: 2
     - original_index: 44
-      status: [3]
+      status: 3
     - original_index: 45
-      status: [3]
+      status: 3
     - original_index: 46
-      status: [0]
+      status: 0
     - original_index: 47
-      status: [0]
+      status: 0
     - original_index: 48
-      status: [3]
+      status: 3
     - original_index: 49
-      status: [4]
+      status: 4
     - original_index: 50
-      status: [3]
+      status: 3
     - original_index: 51
-      status: [3]
+      status: 3
     - original_index: 52
-      status: [4]
+      status: 4
     - original_index: 53
-      status: [0]
+      status: 0
     - original_index: 54
-      status: [1]
+      status: 1
     - original_index: 55
-      status: [2]
+      status: 2
     - original_index: 56
-      status: [3]
+      status: 3
     - original_index: 57
-      status: [0]
+      status: 0
     - original_index: 58
-      status: [2]
+      status: 2
     - original_index: 59
-      status: [3]
+      status: 3
     - original_index: 60
-      status: [2]
+      status: 2
     - original_index: 61
-      status: [4]
+      status: 4
     - original_index: 62
-      status: [0]
+      status: 0
     - original_index: 63
-      status: [3]
+      status: 3
     - original_index: 64
-      status: [2]
+      status: 2
     - original_index: 65
-      status: [4]
+      status: 4
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [4]
+      status: 4
     - original_index: 68
-      status: [4]
+      status: 4
     - original_index: 69
-      status: [3]
+      status: 3
     - original_index: 70
-      status: [0]
+      status: 0
     - original_index: 71
-      status: [2]
+      status: 2
     - original_index: 72
-      status: [1]
+      status: 1
     - original_index: 73
-      status: [2]
+      status: 2
     - original_index: 74
-      status: [4]
+      status: 4
     - original_index: 75
-      status: [3]
+      status: 3
     - original_index: 76
-      status: [2]
+      status: 2
     - original_index: 77
-      status: [2]
+      status: 2
     - original_index: 78
-      status: [1]
+      status: 1
     - original_index: 79
-      status: [3]
+      status: 3
     - original_index: 80
-      status: [2]
+      status: 2
     - original_index: 81
-      status: [4]
+      status: 4
     - original_index: 82
-      status: [1]
+      status: 1
     - original_index: 83
-      status: [1]
+      status: 1
     - original_index: 84
-      status: [0]
+      status: 0
     - original_index: 85
-      status: [1]
+      status: 1
     - original_index: 86
-      status: [4]
+      status: 4
     - original_index: 87
-      status: [2]
+      status: 2
     - original_index: 88
-      status: [3]
+      status: 3
     - original_index: 89
-      status: [4]
+      status: 4
     - original_index: 90
-      status: [1]
+      status: 1
     - original_index: 91
-      status: [1]
+      status: 1
     - original_index: 92
-      status: [0]
+      status: 0
     - original_index: 93
-      status: [4]
+      status: 4
     - original_index: 94
-      status: [4]
+      status: 4
     - original_index: 95
-      status: [3]
+      status: 3
     - original_index: 96
-      status: [4]
+      status: 4
     - original_index: 97
-      status: [4]
+      status: 4
     - original_index: 98
-      status: [3]
+      status: 3
     - original_index: 99
-      status: [3]
+      status: 3
     - original_index: 100
-      status: [3]
+      status: 3
     - original_index: 101
-      status: [3]
+      status: 3
     - original_index: 102
-      status: [3]
+      status: 3
     - original_index: 103
-      status: [3]
+      status: 3
     - original_index: 104
-      status: [0]
+      status: 0
     - original_index: 105
-      status: [1]
+      status: 1
     - original_index: 106
-      status: [4]
+      status: 4
     - original_index: 107
-      status: [4]
+      status: 4
     - original_index: 108
-      status: [0]
+      status: 0
     - original_index: 109
-      status: [2]
+      status: 2
     - original_index: 110
-      status: [4]
+      status: 4
     - original_index: 111
-      status: [3]
+      status: 3
     - original_index: 112
-      status: [2]
+      status: 2
     - original_index: 113
-      status: [0]
+      status: 0
     - original_index: 114
-      status: [1]
+      status: 1
     - original_index: 115
-      status: [3]
+      status: 3
     - original_index: 116
-      status: [2]
+      status: 2
     - original_index: 117
-      status: [0]
+      status: 0
     - original_index: 118
-      status: [1]
+      status: 1
     - original_index: 119
-      status: [4]
+      status: 4
     - original_index: 120
-      status: [2]
+      status: 2
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [4]
+      status: 4
     - original_index: 124
-      status: [2]
+      status: 2
     - original_index: 125
-      status: [2]
+      status: 2
     - original_index: 126
-      status: [1]
+      status: 1
     - original_index: 127
-      status: [0]
+      status: 0
     - original_index: 128
-      status: [2]
+      status: 2
     - original_index: 129
-      status: [4]
+      status: 4
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [3]
+      status: 3
     - original_index: 132
-      status: [1]
+      status: 1
     - original_index: 133
-      status: [4]
+      status: 4
     - original_index: 134
-      status: [3]
+      status: 3
     - original_index: 135
-      status: [4]
+      status: 4
     - original_index: 136
-      status: [4]
+      status: 4
     - original_index: 137
-      status: [4]
+      status: 4
     - original_index: 138
-      status: [1]
+      status: 1
     - original_index: 139
-      status: [0]
+      status: 0
     - original_index: 140
-      status: [4]
+      status: 4
     - original_index: 141
-      status: [1]
+      status: 1
     - original_index: 142
-      status: [0]
+      status: 0
     - original_index: 143
-      status: [4]
+      status: 4
     - original_index: 144
-      status: [1]
+      status: 1
     - original_index: 145
-      status: [2]
+      status: 2
     - original_index: 146
-      status: [2]
+      status: 2
     - original_index: 147
-      status: [4]
+      status: 4
     - original_index: 148
-      status: [4]
+      status: 4
     - original_index: 149
-      status: [2]
+      status: 2
     - original_index: 150
-      status: [0]
+      status: 0
     - original_index: 151
-      status: [2]
+      status: 2
     - original_index: 152
-      status: [3]
+      status: 3
     - original_index: 153
-      status: [3]
+      status: 3
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [1]
+      status: 1
     - original_index: 156
-      status: [4]
+      status: 4
     - original_index: 157
-      status: [0]
+      status: 0
     - original_index: 158
-      status: [3]
+      status: 3
     - original_index: 159
-      status: [1]
+      status: 1
     - original_index: 160
-      status: [0]
+      status: 0
     - original_index: 161
-      status: [0]
+      status: 0
     - original_index: 162
-      status: [2]
+      status: 2
     - original_index: 163
-      status: [0]
+      status: 0
     - original_index: 164
-      status: [1]
+      status: 1
     - original_index: 165
-      status: [3]
+      status: 3
     - original_index: 166
-      status: [3]
+      status: 3
     - original_index: 167
-      status: [3]
+      status: 3
     - original_index: 168
-      status: [3]
+      status: 3
     - original_index: 169
-      status: [1]
+      status: 1
     - original_index: 170
-      status: [2]
+      status: 2
     - original_index: 171
-      status: [3]
+      status: 3
     - original_index: 172
-      status: [0]
+      status: 0
     - original_index: 173
-      status: [2]
+      status: 2
     - original_index: 174
-      status: [4]
+      status: 4
     - original_index: 175
-      status: [1]
+      status: 1
     - original_index: 176
-      status: [1]
+      status: 1
     - original_index: 177
-      status: [1]
+      status: 1
     - original_index: 178
-      status: [3]
+      status: 3
     - original_index: 179
-      status: [2]
+      status: 2
     - original_index: 180
-      status: [0]
+      status: 0
     - original_index: 181
-      status: [3]
+      status: 3
     - original_index: 182
-      status: [3]
+      status: 3
     - original_index: 183
-      status: [1]
+      status: 1
   output:
-  - - committee: [123]
+  - - committee:
+      - 123
       shard: 378
       total_validator_count: 74
-  - - committee: [20]
+  - - committee:
+      - 20
       shard: 379
       total_validator_count: 74
-  - - committee: [81]
+  - - committee:
+      - 81
       shard: 380
       total_validator_count: 74
-  - - committee: [106]
+  - - committee:
+      - 106
       shard: 381
       total_validator_count: 74
-  - - committee: [10]
+  - - committee:
+      - 10
       shard: 382
       total_validator_count: 74
-  - - committee: [72]
+  - - committee:
+      - 72
       shard: 383
       total_validator_count: 74
-  - - committee: [138, 135]
+  - - committee:
+      - 138
+      - 135
       shard: 384
       total_validator_count: 74
-  - - committee: [13]
+  - - committee:
+      - 13
       shard: 385
       total_validator_count: 74
-  - - committee: [31]
+  - - committee:
+      - 31
       shard: 386
       total_validator_count: 74
-  - - committee: [107]
+  - - committee:
+      - 107
       shard: 387
       total_validator_count: 74
-  - - committee: [14]
+  - - committee:
+      - 14
       shard: 388
       total_validator_count: 74
-  - - committee: [126]
+  - - committee:
+      - 126
       shard: 389
       total_validator_count: 74
-  - - committee: [144, 90]
+  - - committee:
+      - 144
+      - 90
       shard: 390
       total_validator_count: 74
-  - - committee: [6]
+  - - committee:
+      - 6
       shard: 391
       total_validator_count: 74
-  - - committee: [26]
+  - - committee:
+      - 26
       shard: 392
       total_validator_count: 74
-  - - committee: [183]
+  - - committee:
+      - 183
       shard: 393
       total_validator_count: 74
-  - - committee: [34]
+  - - committee:
+      - 34
       shard: 394
       total_validator_count: 74
-  - - committee: [38]
+  - - committee:
+      - 38
       shard: 395
       total_validator_count: 74
-  - - committee: [86]
+  - - committee:
+      - 86
       shard: 396
       total_validator_count: 74
-  - - committee: [175, 82]
+  - - committee:
+      - 175
+      - 82
       shard: 397
       total_validator_count: 74
-  - - committee: [143]
+  - - committee:
+      - 143
       shard: 398
       total_validator_count: 74
-  - - committee: [147]
+  - - committee:
+      - 147
       shard: 399
       total_validator_count: 74
-  - - committee: [74]
+  - - committee:
+      - 74
       shard: 400
       total_validator_count: 74
-  - - committee: [140]
+  - - committee:
+      - 140
       shard: 401
       total_validator_count: 74
-  - - committee: [136]
+  - - committee:
+      - 136
       shard: 402
       total_validator_count: 74
-  - - committee: [11, 155]
+  - - committee:
+      - 11
+      - 155
       shard: 403
       total_validator_count: 74
-  - - committee: [174]
+  - - committee:
+      - 174
       shard: 404
       total_validator_count: 74
-  - - committee: [156]
+  - - committee:
+      - 156
       shard: 405
       total_validator_count: 74
-  - - committee: [68]
+  - - committee:
+      - 68
       shard: 406
       total_validator_count: 74
-  - - committee: [130]
+  - - committee:
+      - 130
       shard: 407
       total_validator_count: 74
-  - - committee: [42]
+  - - committee:
+      - 42
       shard: 408
       total_validator_count: 74
-  - - committee: [110, 159]
+  - - committee:
+      - 110
+      - 159
       shard: 409
       total_validator_count: 74
-  - - committee: [54]
+  - - committee:
+      - 54
       shard: 410
       total_validator_count: 74
-  - - committee: [148]
+  - - committee:
+      - 148
       shard: 411
       total_validator_count: 74
-  - - committee: [154]
+  - - committee:
+      - 154
       shard: 412
       total_validator_count: 74
-  - - committee: [96]
+  - - committee:
+      - 96
       shard: 413
       total_validator_count: 74
-  - - committee: [177]
+  - - committee:
+      - 177
       shard: 414
       total_validator_count: 74
-  - - committee: [28]
+  - - committee:
+      - 28
       shard: 415
       total_validator_count: 74
-  - - committee: [133, 137]
+  - - committee:
+      - 133
+      - 137
       shard: 416
       total_validator_count: 74
-  - - committee: [32]
+  - - committee:
+      - 32
       shard: 417
       total_validator_count: 74
-  - - committee: [78]
+  - - committee:
+      - 78
       shard: 418
       total_validator_count: 74
-  - - committee: [83]
+  - - committee:
+      - 83
       shard: 419
       total_validator_count: 74
-  - - committee: [85]
+  - - committee:
+      - 85
       shard: 420
       total_validator_count: 74
-  - - committee: [93]
+  - - committee:
+      - 93
       shard: 421
       total_validator_count: 74
-  - - committee: [2, 169]
+  - - committee:
+      - 2
+      - 169
       shard: 422
       total_validator_count: 74
-  - - committee: [61]
+  - - committee:
+      - 61
       shard: 423
       total_validator_count: 74
-  - - committee: [5]
+  - - committee:
+      - 5
       shard: 424
       total_validator_count: 74
-  - - committee: [40]
+  - - committee:
+      - 40
       shard: 425
       total_validator_count: 74
-  - - committee: [52]
+  - - committee:
+      - 52
       shard: 426
       total_validator_count: 74
-  - - committee: [67]
+  - - committee:
+      - 67
       shard: 427
       total_validator_count: 74
-  - - committee: [15]
+  - - committee:
+      - 15
       shard: 428
       total_validator_count: 74
-  - - committee: [94, 132]
+  - - committee:
+      - 94
+      - 132
       shard: 429
       total_validator_count: 74
-  - - committee: [91]
+  - - committee:
+      - 91
       shard: 430
       total_validator_count: 74
-  - - committee: [97]
+  - - committee:
+      - 97
       shard: 431
       total_validator_count: 74
-  - - committee: [49]
+  - - committee:
+      - 49
       shard: 432
       total_validator_count: 74
-  - - committee: [89]
+  - - committee:
+      - 89
       shard: 433
       total_validator_count: 74
-  - - committee: [164]
+  - - committee:
+      - 164
       shard: 434
       total_validator_count: 74
-  - - committee: [129, 118]
+  - - committee:
+      - 129
+      - 118
       shard: 435
       total_validator_count: 74
-  - - committee: [119]
+  - - committee:
+      - 119
       shard: 436
       total_validator_count: 74
-  - - committee: [176]
+  - - committee:
+      - 176
       shard: 437
       total_validator_count: 74
-  - - committee: [105]
+  - - committee:
+      - 105
       shard: 438
       total_validator_count: 74
-  - - committee: [65]
+  - - committee:
+      - 65
       shard: 439
       total_validator_count: 74
-  - - committee: [141]
+  - - committee:
+      - 141
       shard: 440
       total_validator_count: 74
-  - - committee: [39, 114]
+  - - committee:
+      - 39
+      - 114
       shard: 441
       total_validator_count: 74
   seed: '0xa2cb43c505d74fc9e1af073c677665072308dd06142430203c242aba27ca1da5'
@@ -8943,952 +10365,1100 @@ test_cases:
     crosslinking_start_shard: 986
     validators:
     - original_index: 0
-      status: [0]
+      status: 0
     - original_index: 1
-      status: [4]
+      status: 4
     - original_index: 2
-      status: [2]
+      status: 2
     - original_index: 3
-      status: [2]
+      status: 2
     - original_index: 4
-      status: [0]
+      status: 0
     - original_index: 5
-      status: [3]
+      status: 3
     - original_index: 6
-      status: [3]
+      status: 3
     - original_index: 7
-      status: [0]
+      status: 0
     - original_index: 8
-      status: [4]
+      status: 4
     - original_index: 9
-      status: [0]
+      status: 0
     - original_index: 10
-      status: [1]
+      status: 1
     - original_index: 11
-      status: [3]
+      status: 3
     - original_index: 12
-      status: [3]
+      status: 3
     - original_index: 13
-      status: [2]
+      status: 2
     - original_index: 14
-      status: [3]
+      status: 3
     - original_index: 15
-      status: [3]
+      status: 3
     - original_index: 16
-      status: [2]
+      status: 2
     - original_index: 17
-      status: [1]
+      status: 1
     - original_index: 18
-      status: [4]
+      status: 4
     - original_index: 19
-      status: [4]
+      status: 4
     - original_index: 20
-      status: [1]
+      status: 1
     - original_index: 21
-      status: [1]
+      status: 1
     - original_index: 22
-      status: [0]
+      status: 0
     - original_index: 23
-      status: [1]
+      status: 1
     - original_index: 24
-      status: [3]
+      status: 3
     - original_index: 25
-      status: [3]
+      status: 3
     - original_index: 26
-      status: [4]
+      status: 4
     - original_index: 27
-      status: [2]
+      status: 2
     - original_index: 28
-      status: [2]
+      status: 2
     - original_index: 29
-      status: [3]
+      status: 3
     - original_index: 30
-      status: [2]
+      status: 2
     - original_index: 31
-      status: [1]
+      status: 1
     - original_index: 32
-      status: [0]
+      status: 0
     - original_index: 33
-      status: [0]
+      status: 0
     - original_index: 34
-      status: [2]
+      status: 2
     - original_index: 35
-      status: [3]
+      status: 3
     - original_index: 36
-      status: [0]
+      status: 0
     - original_index: 37
-      status: [0]
+      status: 0
     - original_index: 38
-      status: [3]
+      status: 3
     - original_index: 39
-      status: [3]
+      status: 3
     - original_index: 40
-      status: [2]
+      status: 2
     - original_index: 41
-      status: [4]
+      status: 4
     - original_index: 42
-      status: [2]
+      status: 2
     - original_index: 43
-      status: [3]
+      status: 3
     - original_index: 44
-      status: [0]
+      status: 0
     - original_index: 45
-      status: [0]
+      status: 0
     - original_index: 46
-      status: [4]
+      status: 4
     - original_index: 47
-      status: [1]
+      status: 1
     - original_index: 48
-      status: [3]
+      status: 3
     - original_index: 49
-      status: [4]
+      status: 4
     - original_index: 50
-      status: [2]
+      status: 2
     - original_index: 51
-      status: [3]
+      status: 3
     - original_index: 52
-      status: [4]
+      status: 4
     - original_index: 53
-      status: [1]
+      status: 1
     - original_index: 54
-      status: [0]
+      status: 0
     - original_index: 55
-      status: [4]
+      status: 4
     - original_index: 56
-      status: [2]
+      status: 2
     - original_index: 57
-      status: [2]
+      status: 2
     - original_index: 58
-      status: [3]
+      status: 3
     - original_index: 59
-      status: [4]
+      status: 4
     - original_index: 60
-      status: [0]
+      status: 0
     - original_index: 61
-      status: [3]
+      status: 3
     - original_index: 62
-      status: [3]
+      status: 3
     - original_index: 63
-      status: [0]
+      status: 0
     - original_index: 64
-      status: [0]
+      status: 0
     - original_index: 65
-      status: [3]
+      status: 3
     - original_index: 66
-      status: [3]
+      status: 3
     - original_index: 67
-      status: [3]
+      status: 3
     - original_index: 68
-      status: [2]
+      status: 2
     - original_index: 69
-      status: [4]
+      status: 4
     - original_index: 70
-      status: [2]
+      status: 2
     - original_index: 71
-      status: [3]
+      status: 3
     - original_index: 72
-      status: [2]
+      status: 2
     - original_index: 73
-      status: [4]
+      status: 4
     - original_index: 74
-      status: [4]
+      status: 4
     - original_index: 75
-      status: [2]
+      status: 2
     - original_index: 76
-      status: [4]
+      status: 4
     - original_index: 77
-      status: [2]
+      status: 2
     - original_index: 78
-      status: [3]
+      status: 3
     - original_index: 79
-      status: [4]
+      status: 4
     - original_index: 80
-      status: [1]
+      status: 1
     - original_index: 81
-      status: [2]
+      status: 2
     - original_index: 82
-      status: [3]
+      status: 3
     - original_index: 83
-      status: [3]
+      status: 3
     - original_index: 84
-      status: [1]
+      status: 1
     - original_index: 85
-      status: [3]
+      status: 3
     - original_index: 86
-      status: [3]
+      status: 3
     - original_index: 87
-      status: [4]
+      status: 4
     - original_index: 88
-      status: [3]
+      status: 3
     - original_index: 89
-      status: [1]
+      status: 1
     - original_index: 90
-      status: [3]
+      status: 3
     - original_index: 91
-      status: [2]
+      status: 2
     - original_index: 92
-      status: [4]
+      status: 4
     - original_index: 93
-      status: [0]
+      status: 0
     - original_index: 94
-      status: [0]
+      status: 0
     - original_index: 95
-      status: [3]
+      status: 3
     - original_index: 96
-      status: [3]
+      status: 3
     - original_index: 97
-      status: [0]
+      status: 0
     - original_index: 98
-      status: [1]
+      status: 1
     - original_index: 99
-      status: [0]
+      status: 0
     - original_index: 100
-      status: [4]
+      status: 4
     - original_index: 101
-      status: [0]
+      status: 0
     - original_index: 102
-      status: [0]
+      status: 0
     - original_index: 103
-      status: [1]
+      status: 1
     - original_index: 104
-      status: [4]
+      status: 4
     - original_index: 105
-      status: [1]
+      status: 1
     - original_index: 106
-      status: [3]
+      status: 3
     - original_index: 107
-      status: [3]
+      status: 3
     - original_index: 108
-      status: [1]
+      status: 1
     - original_index: 109
-      status: [2]
+      status: 2
     - original_index: 110
-      status: [1]
+      status: 1
     - original_index: 111
-      status: [2]
+      status: 2
     - original_index: 112
-      status: [2]
+      status: 2
     - original_index: 113
-      status: [4]
+      status: 4
     - original_index: 114
-      status: [1]
+      status: 1
     - original_index: 115
-      status: [3]
+      status: 3
     - original_index: 116
-      status: [3]
+      status: 3
     - original_index: 117
-      status: [2]
+      status: 2
     - original_index: 118
-      status: [0]
+      status: 0
     - original_index: 119
-      status: [3]
+      status: 3
     - original_index: 120
-      status: [4]
+      status: 4
     - original_index: 121
-      status: [0]
+      status: 0
     - original_index: 122
-      status: [0]
+      status: 0
     - original_index: 123
-      status: [1]
+      status: 1
     - original_index: 124
-      status: [1]
+      status: 1
     - original_index: 125
-      status: [4]
+      status: 4
     - original_index: 126
-      status: [2]
+      status: 2
     - original_index: 127
-      status: [0]
+      status: 0
     - original_index: 128
-      status: [4]
+      status: 4
     - original_index: 129
-      status: [1]
+      status: 1
     - original_index: 130
-      status: [1]
+      status: 1
     - original_index: 131
-      status: [1]
+      status: 1
     - original_index: 132
-      status: [0]
+      status: 0
     - original_index: 133
-      status: [0]
+      status: 0
     - original_index: 134
-      status: [4]
+      status: 4
     - original_index: 135
-      status: [3]
+      status: 3
     - original_index: 136
-      status: [3]
+      status: 3
     - original_index: 137
-      status: [4]
+      status: 4
     - original_index: 138
-      status: [0]
+      status: 0
     - original_index: 139
-      status: [2]
+      status: 2
     - original_index: 140
-      status: [4]
+      status: 4
     - original_index: 141
-      status: [3]
+      status: 3
     - original_index: 142
-      status: [1]
+      status: 1
     - original_index: 143
-      status: [4]
+      status: 4
     - original_index: 144
-      status: [2]
+      status: 2
     - original_index: 145
-      status: [1]
+      status: 1
     - original_index: 146
-      status: [3]
+      status: 3
     - original_index: 147
-      status: [1]
+      status: 1
     - original_index: 148
-      status: [1]
+      status: 1
     - original_index: 149
-      status: [4]
+      status: 4
     - original_index: 150
-      status: [3]
+      status: 3
     - original_index: 151
-      status: [2]
+      status: 2
     - original_index: 152
-      status: [1]
+      status: 1
     - original_index: 153
-      status: [4]
+      status: 4
     - original_index: 154
-      status: [4]
+      status: 4
     - original_index: 155
-      status: [0]
+      status: 0
     - original_index: 156
-      status: [0]
+      status: 0
     - original_index: 157
-      status: [1]
+      status: 1
     - original_index: 158
-      status: [0]
+      status: 0
     - original_index: 159
-      status: [2]
+      status: 2
     - original_index: 160
-      status: [3]
+      status: 3
     - original_index: 161
-      status: [2]
+      status: 2
     - original_index: 162
-      status: [1]
+      status: 1
     - original_index: 163
-      status: [4]
+      status: 4
     - original_index: 164
-      status: [3]
+      status: 3
     - original_index: 165
-      status: [0]
+      status: 0
     - original_index: 166
-      status: [2]
+      status: 2
     - original_index: 167
-      status: [3]
+      status: 3
     - original_index: 168
-      status: [3]
+      status: 3
     - original_index: 169
-      status: [3]
+      status: 3
     - original_index: 170
-      status: [2]
+      status: 2
     - original_index: 171
-      status: [0]
+      status: 0
     - original_index: 172
-      status: [3]
+      status: 3
     - original_index: 173
-      status: [2]
+      status: 2
     - original_index: 174
-      status: [1]
+      status: 1
     - original_index: 175
-      status: [0]
+      status: 0
     - original_index: 176
-      status: [0]
+      status: 0
     - original_index: 177
-      status: [3]
+      status: 3
     - original_index: 178
-      status: [1]
+      status: 1
     - original_index: 179
-      status: [3]
+      status: 3
     - original_index: 180
-      status: [1]
+      status: 1
     - original_index: 181
-      status: [3]
+      status: 3
     - original_index: 182
-      status: [2]
+      status: 2
     - original_index: 183
-      status: [4]
+      status: 4
     - original_index: 184
-      status: [1]
+      status: 1
     - original_index: 185
-      status: [3]
+      status: 3
     - original_index: 186
-      status: [3]
+      status: 3
     - original_index: 187
-      status: [2]
+      status: 2
     - original_index: 188
-      status: [3]
+      status: 3
     - original_index: 189
-      status: [2]
+      status: 2
     - original_index: 190
-      status: [2]
+      status: 2
     - original_index: 191
-      status: [4]
+      status: 4
     - original_index: 192
-      status: [1]
+      status: 1
     - original_index: 193
-      status: [3]
+      status: 3
     - original_index: 194
-      status: [3]
+      status: 3
     - original_index: 195
-      status: [0]
+      status: 0
     - original_index: 196
-      status: [4]
+      status: 4
     - original_index: 197
-      status: [2]
+      status: 2
     - original_index: 198
-      status: [2]
+      status: 2
     - original_index: 199
-      status: [3]
+      status: 3
     - original_index: 200
-      status: [4]
+      status: 4
     - original_index: 201
-      status: [2]
+      status: 2
     - original_index: 202
-      status: [3]
+      status: 3
     - original_index: 203
-      status: [4]
+      status: 4
     - original_index: 204
-      status: [3]
+      status: 3
     - original_index: 205
-      status: [1]
+      status: 1
     - original_index: 206
-      status: [2]
+      status: 2
     - original_index: 207
-      status: [4]
+      status: 4
     - original_index: 208
-      status: [0]
+      status: 0
     - original_index: 209
-      status: [3]
+      status: 3
     - original_index: 210
-      status: [3]
+      status: 3
     - original_index: 211
-      status: [3]
+      status: 3
     - original_index: 212
-      status: [0]
+      status: 0
     - original_index: 213
-      status: [3]
+      status: 3
     - original_index: 214
-      status: [3]
+      status: 3
     - original_index: 215
-      status: [4]
+      status: 4
     - original_index: 216
-      status: [3]
+      status: 3
     - original_index: 217
-      status: [1]
+      status: 1
     - original_index: 218
-      status: [4]
+      status: 4
     - original_index: 219
-      status: [0]
+      status: 0
     - original_index: 220
-      status: [1]
+      status: 1
     - original_index: 221
-      status: [1]
+      status: 1
     - original_index: 222
-      status: [0]
+      status: 0
     - original_index: 223
-      status: [2]
+      status: 2
     - original_index: 224
-      status: [1]
+      status: 1
     - original_index: 225
-      status: [0]
+      status: 0
     - original_index: 226
-      status: [4]
+      status: 4
     - original_index: 227
-      status: [4]
+      status: 4
     - original_index: 228
-      status: [4]
+      status: 4
     - original_index: 229
-      status: [4]
+      status: 4
     - original_index: 230
-      status: [1]
+      status: 1
     - original_index: 231
-      status: [3]
+      status: 3
     - original_index: 232
-      status: [0]
+      status: 0
     - original_index: 233
-      status: [4]
+      status: 4
     - original_index: 234
-      status: [4]
+      status: 4
     - original_index: 235
-      status: [0]
+      status: 0
     - original_index: 236
-      status: [2]
+      status: 2
     - original_index: 237
-      status: [2]
+      status: 2
     - original_index: 238
-      status: [4]
+      status: 4
     - original_index: 239
-      status: [2]
+      status: 2
     - original_index: 240
-      status: [1]
+      status: 1
     - original_index: 241
-      status: [4]
+      status: 4
     - original_index: 242
-      status: [3]
+      status: 3
     - original_index: 243
-      status: [3]
+      status: 3
     - original_index: 244
-      status: [1]
+      status: 1
     - original_index: 245
-      status: [3]
+      status: 3
     - original_index: 246
-      status: [0]
+      status: 0
     - original_index: 247
-      status: [3]
+      status: 3
     - original_index: 248
-      status: [4]
+      status: 4
     - original_index: 249
-      status: [2]
+      status: 2
     - original_index: 250
-      status: [0]
+      status: 0
     - original_index: 251
-      status: [0]
+      status: 0
     - original_index: 252
-      status: [0]
+      status: 0
     - original_index: 253
-      status: [1]
+      status: 1
     - original_index: 254
-      status: [3]
+      status: 3
     - original_index: 255
-      status: [2]
+      status: 2
     - original_index: 256
-      status: [1]
+      status: 1
     - original_index: 257
-      status: [3]
+      status: 3
     - original_index: 258
-      status: [3]
+      status: 3
     - original_index: 259
-      status: [1]
+      status: 1
     - original_index: 260
-      status: [3]
+      status: 3
     - original_index: 261
-      status: [3]
+      status: 3
     - original_index: 262
-      status: [2]
+      status: 2
     - original_index: 263
-      status: [1]
+      status: 1
     - original_index: 264
-      status: [2]
+      status: 2
     - original_index: 265
-      status: [4]
+      status: 4
     - original_index: 266
-      status: [4]
+      status: 4
     - original_index: 267
-      status: [2]
+      status: 2
     - original_index: 268
-      status: [0]
+      status: 0
     - original_index: 269
-      status: [4]
+      status: 4
     - original_index: 270
-      status: [2]
+      status: 2
     - original_index: 271
-      status: [3]
+      status: 3
     - original_index: 272
-      status: [3]
+      status: 3
     - original_index: 273
-      status: [1]
+      status: 1
     - original_index: 274
-      status: [3]
+      status: 3
     - original_index: 275
-      status: [1]
+      status: 1
     - original_index: 276
-      status: [4]
+      status: 4
     - original_index: 277
-      status: [2]
+      status: 2
     - original_index: 278
-      status: [0]
+      status: 0
     - original_index: 279
-      status: [1]
+      status: 1
     - original_index: 280
-      status: [2]
+      status: 2
     - original_index: 281
-      status: [0]
+      status: 0
     - original_index: 282
-      status: [4]
+      status: 4
     - original_index: 283
-      status: [1]
+      status: 1
     - original_index: 284
-      status: [0]
+      status: 0
     - original_index: 285
-      status: [0]
+      status: 0
     - original_index: 286
-      status: [4]
+      status: 4
     - original_index: 287
-      status: [3]
+      status: 3
     - original_index: 288
-      status: [4]
+      status: 4
     - original_index: 289
-      status: [0]
+      status: 0
     - original_index: 290
-      status: [4]
+      status: 4
     - original_index: 291
-      status: [3]
+      status: 3
     - original_index: 292
-      status: [4]
+      status: 4
     - original_index: 293
-      status: [4]
+      status: 4
     - original_index: 294
-      status: [4]
+      status: 4
     - original_index: 295
-      status: [0]
+      status: 0
     - original_index: 296
-      status: [0]
+      status: 0
     - original_index: 297
-      status: [0]
+      status: 0
     - original_index: 298
-      status: [3]
+      status: 3
     - original_index: 299
-      status: [0]
+      status: 0
     - original_index: 300
-      status: [0]
+      status: 0
     - original_index: 301
-      status: [1]
+      status: 1
     - original_index: 302
-      status: [2]
+      status: 2
     - original_index: 303
-      status: [2]
+      status: 2
     - original_index: 304
-      status: [4]
+      status: 4
     - original_index: 305
-      status: [2]
+      status: 2
     - original_index: 306
-      status: [4]
+      status: 4
     - original_index: 307
-      status: [2]
+      status: 2
     - original_index: 308
-      status: [0]
+      status: 0
     - original_index: 309
-      status: [3]
+      status: 3
     - original_index: 310
-      status: [1]
+      status: 1
     - original_index: 311
-      status: [2]
+      status: 2
     - original_index: 312
-      status: [3]
+      status: 3
     - original_index: 313
-      status: [0]
+      status: 0
     - original_index: 314
-      status: [1]
+      status: 1
     - original_index: 315
-      status: [1]
+      status: 1
     - original_index: 316
-      status: [3]
+      status: 3
     - original_index: 317
-      status: [0]
+      status: 0
     - original_index: 318
-      status: [0]
+      status: 0
     - original_index: 319
-      status: [2]
+      status: 2
     - original_index: 320
-      status: [4]
+      status: 4
     - original_index: 321
-      status: [1]
+      status: 1
     - original_index: 322
-      status: [4]
+      status: 4
     - original_index: 323
-      status: [2]
+      status: 2
     - original_index: 324
-      status: [1]
+      status: 1
     - original_index: 325
-      status: [4]
+      status: 4
     - original_index: 326
-      status: [0]
+      status: 0
     - original_index: 327
-      status: [1]
+      status: 1
     - original_index: 328
-      status: [3]
+      status: 3
     - original_index: 329
-      status: [4]
+      status: 4
     - original_index: 330
-      status: [0]
+      status: 0
     - original_index: 331
-      status: [1]
+      status: 1
     - original_index: 332
-      status: [1]
+      status: 1
     - original_index: 333
-      status: [1]
+      status: 1
     - original_index: 334
-      status: [1]
+      status: 1
     - original_index: 335
-      status: [4]
+      status: 4
     - original_index: 336
-      status: [2]
+      status: 2
     - original_index: 337
-      status: [3]
+      status: 3
     - original_index: 338
-      status: [4]
+      status: 4
     - original_index: 339
-      status: [0]
+      status: 0
     - original_index: 340
-      status: [1]
+      status: 1
     - original_index: 341
-      status: [2]
+      status: 2
     - original_index: 342
-      status: [1]
+      status: 1
     - original_index: 343
-      status: [4]
+      status: 4
     - original_index: 344
-      status: [2]
+      status: 2
     - original_index: 345
-      status: [2]
+      status: 2
     - original_index: 346
-      status: [1]
+      status: 1
     - original_index: 347
-      status: [3]
+      status: 3
     - original_index: 348
-      status: [4]
+      status: 4
     - original_index: 349
-      status: [0]
+      status: 0
     - original_index: 350
-      status: [2]
+      status: 2
     - original_index: 351
-      status: [3]
+      status: 3
     - original_index: 352
-      status: [1]
+      status: 1
     - original_index: 353
-      status: [1]
+      status: 1
     - original_index: 354
-      status: [1]
+      status: 1
     - original_index: 355
-      status: [4]
+      status: 4
     - original_index: 356
-      status: [1]
+      status: 1
     - original_index: 357
-      status: [0]
+      status: 0
     - original_index: 358
-      status: [2]
+      status: 2
     - original_index: 359
-      status: [1]
+      status: 1
     - original_index: 360
-      status: [4]
+      status: 4
     - original_index: 361
-      status: [3]
+      status: 3
     - original_index: 362
-      status: [0]
+      status: 0
     - original_index: 363
-      status: [4]
+      status: 4
     - original_index: 364
-      status: [0]
+      status: 0
     - original_index: 365
-      status: [2]
+      status: 2
     - original_index: 366
-      status: [1]
+      status: 1
     - original_index: 367
-      status: [1]
+      status: 1
     - original_index: 368
-      status: [4]
+      status: 4
     - original_index: 369
-      status: [1]
+      status: 1
     - original_index: 370
-      status: [0]
+      status: 0
     - original_index: 371
-      status: [2]
+      status: 2
     - original_index: 372
-      status: [2]
+      status: 2
     - original_index: 373
-      status: [2]
+      status: 2
     - original_index: 374
-      status: [2]
+      status: 2
     - original_index: 375
-      status: [1]
+      status: 1
     - original_index: 376
-      status: [4]
+      status: 4
     - original_index: 377
-      status: [2]
+      status: 2
   output:
-  - - committee: [162, 74]
+  - - committee:
+      - 162
+      - 74
       shard: 986
       total_validator_count: 148
-  - - committee: [205, 76]
+  - - committee:
+      - 205
+      - 76
       shard: 987
       total_validator_count: 148
-  - - committee: [352, 100]
+  - - committee:
+      - 352
+      - 100
       shard: 988
       total_validator_count: 148
-  - - committee: [324, 47, 73]
+  - - committee:
+      - 324
+      - 47
+      - 73
       shard: 989
       total_validator_count: 148
-  - - committee: [110, 31]
+  - - committee:
+      - 110
+      - 31
       shard: 990
       total_validator_count: 148
-  - - committee: [343, 203]
+  - - committee:
+      - 343
+      - 203
       shard: 991
       total_validator_count: 148
-  - - committee: [259, 230, 293]
+  - - committee:
+      - 259
+      - 230
+      - 293
       shard: 992
       total_validator_count: 148
-  - - committee: [233, 353]
+  - - committee:
+      - 233
+      - 353
       shard: 993
       total_validator_count: 148
-  - - committee: [356, 108]
+  - - committee:
+      - 356
+      - 108
       shard: 994
       total_validator_count: 148
-  - - committee: [273, 315, 152]
+  - - committee:
+      - 273
+      - 315
+      - 152
       shard: 995
       total_validator_count: 148
-  - - committee: [275, 147]
+  - - committee:
+      - 275
+      - 147
       shard: 996
       total_validator_count: 148
-  - - committee: [49, 143]
+  - - committee:
+      - 49
+      - 143
       shard: 997
       total_validator_count: 148
-  - - committee: [369, 332, 333]
+  - - committee:
+      - 369
+      - 332
+      - 333
       shard: 998
       total_validator_count: 148
-  - - committee: [105, 192]
+  - - committee:
+      - 105
+      - 192
       shard: 999
       total_validator_count: 148
-  - - committee: [148, 363]
+  - - committee:
+      - 148
+      - 363
       shard: 1000
       total_validator_count: 148
-  - - committee: [220, 80, 142]
+  - - committee:
+      - 220
+      - 80
+      - 142
       shard: 1001
       total_validator_count: 148
-  - - committee: [331, 184]
+  - - committee:
+      - 331
+      - 184
       shard: 1002
       total_validator_count: 148
-  - - committee: [338, 17]
+  - - committee:
+      - 338
+      - 17
       shard: 1003
       total_validator_count: 148
-  - - committee: [217, 367]
+  - - committee:
+      - 217
+      - 367
       shard: 1004
       total_validator_count: 148
-  - - committee: [266, 196, 321]
+  - - committee:
+      - 266
+      - 196
+      - 321
       shard: 1005
       total_validator_count: 148
-  - - committee: [46, 228]
+  - - committee:
+      - 46
+      - 228
       shard: 1006
       total_validator_count: 148
-  - - committee: [329, 301]
+  - - committee:
+      - 329
+      - 301
       shard: 1007
       total_validator_count: 148
-  - - committee: [200, 98, 137]
+  - - committee:
+      - 200
+      - 98
+      - 137
       shard: 1008
       total_validator_count: 148
-  - - committee: [123, 227]
+  - - committee:
+      - 123
+      - 227
       shard: 1009
       total_validator_count: 148
-  - - committee: [340, 248]
+  - - committee:
+      - 340
+      - 248
       shard: 1010
       total_validator_count: 148
-  - - committee: [140, 191, 18]
+  - - committee:
+      - 140
+      - 191
+      - 18
       shard: 1011
       total_validator_count: 148
-  - - committee: [129, 240]
+  - - committee:
+      - 129
+      - 240
       shard: 1012
       total_validator_count: 148
-  - - committee: [276, 92]
+  - - committee:
+      - 276
+      - 92
       shard: 1013
       total_validator_count: 148
-  - - committee: [157, 114, 325]
+  - - committee:
+      - 157
+      - 114
+      - 325
       shard: 1014
       total_validator_count: 148
-  - - committee: [265, 241]
+  - - committee:
+      - 265
+      - 241
       shard: 1015
       total_validator_count: 148
-  - - committee: [229, 178]
+  - - committee:
+      - 229
+      - 178
       shard: 1016
       total_validator_count: 148
-  - - committee: [124, 131, 180]
+  - - committee:
+      - 124
+      - 131
+      - 180
       shard: 1017
       total_validator_count: 148
-  - - committee: [103, 79]
+  - - committee:
+      - 103
+      - 79
       shard: 1018
       total_validator_count: 148
-  - - committee: [238, 130]
+  - - committee:
+      - 238
+      - 130
       shard: 1019
       total_validator_count: 148
-  - - committee: [55, 290]
+  - - committee:
+      - 55
+      - 290
       shard: 1020
       total_validator_count: 148
-  - - committee: [69, 218, 366]
+  - - committee:
+      - 69
+      - 218
+      - 366
       shard: 1021
       total_validator_count: 148
-  - - committee: [335, 149]
+  - - committee:
+      - 335
+      - 149
       shard: 1022
       total_validator_count: 148
-  - - committee: [368, 327]
+  - - committee:
+      - 368
+      - 327
       shard: 1023
       total_validator_count: 148
-  - - committee: [322, 256, 376]
+  - - committee:
+      - 322
+      - 256
+      - 376
       shard: 0
       total_validator_count: 148
-  - - committee: [282, 226]
+  - - committee:
+      - 282
+      - 226
       shard: 1
       total_validator_count: 148
-  - - committee: [224, 306]
+  - - committee:
+      - 224
+      - 306
       shard: 2
       total_validator_count: 148
-  - - committee: [314, 8, 134]
+  - - committee:
+      - 314
+      - 8
+      - 134
       shard: 3
       total_validator_count: 148
-  - - committee: [263, 279]
+  - - committee:
+      - 263
+      - 279
       shard: 4
       total_validator_count: 148
-  - - committee: [163, 183]
+  - - committee:
+      - 163
+      - 183
       shard: 5
       total_validator_count: 148
-  - - committee: [304, 125, 19]
+  - - committee:
+      - 304
+      - 125
+      - 19
       shard: 6
       total_validator_count: 148
-  - - committee: [234, 23]
+  - - committee:
+      - 234
+      - 23
       shard: 7
       total_validator_count: 148
-  - - committee: [113, 360]
+  - - committee:
+      - 113
+      - 360
       shard: 8
       total_validator_count: 148
-  - - committee: [286, 342, 253]
+  - - committee:
+      - 286
+      - 342
+      - 253
       shard: 9
       total_validator_count: 148
-  - - committee: [375, 145]
+  - - committee:
+      - 375
+      - 145
       shard: 10
       total_validator_count: 148
-  - - committee: [41, 84]
+  - - committee:
+      - 41
+      - 84
       shard: 11
       total_validator_count: 148
-  - - committee: [215, 120]
+  - - committee:
+      - 215
+      - 120
       shard: 12
       total_validator_count: 148
-  - - committee: [20, 89, 334]
+  - - committee:
+      - 20
+      - 89
+      - 334
       shard: 13
       total_validator_count: 148
-  - - committee: [320, 354]
+  - - committee:
+      - 320
+      - 354
       shard: 14
       total_validator_count: 148
-  - - committee: [359, 269]
+  - - committee:
+      - 359
+      - 269
       shard: 15
       total_validator_count: 148
-  - - committee: [153, 310, 87]
+  - - committee:
+      - 153
+      - 310
+      - 87
       shard: 16
       total_validator_count: 148
-  - - committee: [221, 26]
+  - - committee:
+      - 221
+      - 26
       shard: 17
       total_validator_count: 148
-  - - committee: [355, 283]
+  - - committee:
+      - 355
+      - 283
       shard: 18
       total_validator_count: 148
-  - - committee: [288, 59, 346]
+  - - committee:
+      - 288
+      - 59
+      - 346
       shard: 19
       total_validator_count: 148
-  - - committee: [154, 128]
+  - - committee:
+      - 154
+      - 128
       shard: 20
       total_validator_count: 148
-  - - committee: [292, 104]
+  - - committee:
+      - 292
+      - 104
       shard: 21
       total_validator_count: 148
-  - - committee: [10, 348, 52]
+  - - committee:
+      - 10
+      - 348
+      - 52
       shard: 22
       total_validator_count: 148
-  - - committee: [174, 53]
+  - - committee:
+      - 174
+      - 53
       shard: 23
       total_validator_count: 148
-  - - committee: [207, 21]
+  - - committee:
+      - 207
+      - 21
       shard: 24
       total_validator_count: 148
-  - - committee: [244, 294, 1]
+  - - committee:
+      - 244
+      - 294
+      - 1
       shard: 25
       total_validator_count: 148
   seed: '0xfe331725ea135ef16c8289d503c6c653938ba23e88ca435dbba2e8733402898c'

--- a/test_vectors_generator/test_vector_shuffling.yml
+++ b/test_vectors_generator/test_vector_shuffling.yml
@@ -7,11458 +7,5929 @@ test_cases:
 - input:
     crosslinking_start_shard: 210
     validators:
-    - original_index: 0
-      status: 2
-    - original_index: 1
-      status: 4
-    - original_index: 2
-      status: 0
-    - original_index: 3
-      status: 0
-    - original_index: 4
-      status: 2
-    - original_index: 5
-      status: 2
-    - original_index: 6
-      status: 4
-    - original_index: 7
-      status: 2
-    - original_index: 8
-      status: 3
-    - original_index: 9
-      status: 1
-    - original_index: 10
-      status: 0
-    - original_index: 11
-      status: 3
-    - original_index: 12
-      status: 3
-    - original_index: 13
-      status: 4
-    - original_index: 14
-      status: 4
-    - original_index: 15
-      status: 4
-    - original_index: 16
-      status: 1
-    - original_index: 17
-      status: 1
-    - original_index: 18
-      status: 1
-    - original_index: 19
-      status: 1
-    - original_index: 20
-      status: 3
-    - original_index: 21
-      status: 2
-    - original_index: 22
-      status: 3
-    - original_index: 23
-      status: 0
-    - original_index: 24
-      status: 2
-    - original_index: 25
-      status: 4
-    - original_index: 26
-      status: 0
-    - original_index: 27
-      status: 2
-    - original_index: 28
-      status: 4
-    - original_index: 29
-      status: 0
-    - original_index: 30
-      status: 0
-    - original_index: 31
-      status: 4
-    - original_index: 32
-      status: 2
-    - original_index: 33
-      status: 1
-    - original_index: 34
-      status: 4
-    - original_index: 35
-      status: 1
-    - original_index: 36
-      status: 4
-    - original_index: 37
-      status: 2
-    - original_index: 38
-      status: 2
-    - original_index: 39
-      status: 1
-    - original_index: 40
-      status: 2
-    - original_index: 41
-      status: 4
-    - original_index: 42
-      status: 0
-    - original_index: 43
-      status: 4
-    - original_index: 44
-      status: 0
-    - original_index: 45
-      status: 3
-    - original_index: 46
-      status: 0
-    - original_index: 47
-      status: 4
-    - original_index: 48
-      status: 4
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 0
-    - original_index: 51
-      status: 1
-    - original_index: 52
-      status: 3
-    - original_index: 53
-      status: 3
-    - original_index: 54
-      status: 0
-    - original_index: 55
-      status: 4
-    - original_index: 56
-      status: 3
-    - original_index: 57
-      status: 1
-    - original_index: 58
-      status: 1
-    - original_index: 59
-      status: 3
-    - original_index: 60
-      status: 1
-    - original_index: 61
-      status: 0
-    - original_index: 62
-      status: 0
-    - original_index: 63
-      status: 1
-    - original_index: 64
-      status: 0
-    - original_index: 65
-      status: 0
-    - original_index: 66
-      status: 4
-    - original_index: 67
-      status: 1
-    - original_index: 68
-      status: 2
-    - original_index: 69
-      status: 0
-    - original_index: 70
-      status: 1
-    - original_index: 71
-      status: 4
-    - original_index: 72
-      status: 2
-    - original_index: 73
-      status: 1
-    - original_index: 74
-      status: 1
-    - original_index: 75
-      status: 4
-    - original_index: 76
-      status: 1
-    - original_index: 77
-      status: 1
-    - original_index: 78
-      status: 1
-    - original_index: 79
-      status: 1
-    - original_index: 80
-      status: 0
-    - original_index: 81
-      status: 4
-    - original_index: 82
-      status: 4
-    - original_index: 83
-      status: 0
-    - original_index: 84
-      status: 1
-    - original_index: 85
-      status: 3
-    - original_index: 86
-      status: 4
-    - original_index: 87
-      status: 2
-    - original_index: 88
-      status: 0
-    - original_index: 89
-      status: 1
-    - original_index: 90
-      status: 4
-    - original_index: 91
-      status: 3
-    - original_index: 92
-      status: 1
-    - original_index: 93
-      status: 2
-    - original_index: 94
-      status: 4
-    - original_index: 95
-      status: 2
-    - original_index: 96
-      status: 2
-    - original_index: 97
-      status: 2
-    - original_index: 98
-      status: 3
-    - original_index: 99
-      status: 3
-    - original_index: 100
-      status: 3
-    - original_index: 101
-      status: 0
-    - original_index: 102
-      status: 2
-    - original_index: 103
-      status: 0
-    - original_index: 104
-      status: 4
-    - original_index: 105
-      status: 1
-    - original_index: 106
-      status: 1
-    - original_index: 107
-      status: 3
-    - original_index: 108
-      status: 0
-    - original_index: 109
-      status: 3
-    - original_index: 110
-      status: 1
-    - original_index: 111
-      status: 3
-    - original_index: 112
-      status: 4
-    - original_index: 113
-      status: 3
-    - original_index: 114
-      status: 3
-    - original_index: 115
-      status: 4
-    - original_index: 116
-      status: 0
-    - original_index: 117
-      status: 1
-    - original_index: 118
-      status: 0
-    - original_index: 119
-      status: 3
-    - original_index: 120
-      status: 3
-    - original_index: 121
-      status: 1
-    - original_index: 122
-      status: 4
-    - original_index: 123
-      status: 2
-    - original_index: 124
-      status: 0
-    - original_index: 125
-      status: 3
-    - original_index: 126
-      status: 2
-    - original_index: 127
-      status: 3
-    - original_index: 128
-      status: 0
-    - original_index: 129
-      status: 4
-    - original_index: 130
-      status: 3
-    - original_index: 131
-      status: 1
-    - original_index: 132
-      status: 3
-    - original_index: 133
-      status: 3
-    - original_index: 134
-      status: 4
-    - original_index: 135
-      status: 3
-    - original_index: 136
-      status: 0
-    - original_index: 137
-      status: 0
-    - original_index: 138
-      status: 1
-    - original_index: 139
-      status: 0
-    - original_index: 140
-      status: 2
-    - original_index: 141
-      status: 4
-    - original_index: 142
-      status: 1
-    - original_index: 143
-      status: 3
-    - original_index: 144
-      status: 1
-    - original_index: 145
-      status: 3
-    - original_index: 146
-      status: 2
-    - original_index: 147
-      status: 4
-    - original_index: 148
-      status: 2
-    - original_index: 149
-      status: 2
-    - original_index: 150
-      status: 0
-    - original_index: 151
-      status: 3
-    - original_index: 152
-      status: 2
-    - original_index: 153
-      status: 3
-    - original_index: 154
-      status: 1
-    - original_index: 155
-      status: 3
-    - original_index: 156
-      status: 0
-    - original_index: 157
-      status: 2
-    - original_index: 158
-      status: 1
-    - original_index: 159
-      status: 3
-    - original_index: 160
-      status: 2
-    - original_index: 161
-      status: 2
-    - original_index: 162
-      status: 1
-    - original_index: 163
-      status: 3
-    - original_index: 164
-      status: 0
-    - original_index: 165
-      status: 2
-    - original_index: 166
-      status: 1
-    - original_index: 167
-      status: 3
-    - original_index: 168
-      status: 2
-    - original_index: 169
-      status: 2
-    - original_index: 170
-      status: 2
-    - original_index: 171
-      status: 0
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 0
-    - original_index: 174
-      status: 3
-    - original_index: 175
-      status: 4
-    - original_index: 176
-      status: 1
-    - original_index: 177
-      status: 4
-    - original_index: 178
-      status: 4
-    - original_index: 179
-      status: 3
-    - original_index: 180
-      status: 3
-    - original_index: 181
-      status: 0
-    - original_index: 182
-      status: 1
-    - original_index: 183
-      status: 2
-    - original_index: 184
-      status: 4
-    - original_index: 185
-      status: 1
-    - original_index: 186
-      status: 4
-    - original_index: 187
-      status: 0
-    - original_index: 188
-      status: 0
-    - original_index: 189
-      status: 4
-    - original_index: 190
-      status: 3
-    - original_index: 191
-      status: 2
-    - original_index: 192
-      status: 4
-    - original_index: 193
-      status: 3
-    - original_index: 194
-      status: 1
-    - original_index: 195
-      status: 2
-    - original_index: 196
-      status: 0
-    - original_index: 197
-      status: 4
-    - original_index: 198
-      status: 4
-    - original_index: 199
-      status: 2
-    - original_index: 200
-      status: 0
-    - original_index: 201
-      status: 4
-    - original_index: 202
-      status: 4
-    - original_index: 203
-      status: 4
-    - original_index: 204
-      status: 4
-    - original_index: 205
-      status: 0
-    - original_index: 206
-      status: 1
-    - original_index: 207
-      status: 4
-    - original_index: 208
-      status: 4
-    - original_index: 209
-      status: 3
-    - original_index: 210
-      status: 0
-    - original_index: 211
-      status: 3
-    - original_index: 212
-      status: 2
-    - original_index: 213
-      status: 1
-    - original_index: 214
-      status: 4
-    - original_index: 215
-      status: 3
-    - original_index: 216
-      status: 0
-    - original_index: 217
-      status: 3
-    - original_index: 218
-      status: 0
-    - original_index: 219
-      status: 3
-    - original_index: 220
-      status: 1
-    - original_index: 221
-      status: 3
-    - original_index: 222
-      status: 3
-    - original_index: 223
-      status: 2
-    - original_index: 224
-      status: 3
-    - original_index: 225
-      status: 2
-    - original_index: 226
-      status: 2
-    - original_index: 227
-      status: 2
-    - original_index: 228
-      status: 1
-    - original_index: 229
-      status: 0
-    - original_index: 230
-      status: 4
-    - original_index: 231
-      status: 2
-    - original_index: 232
-      status: 0
-    - original_index: 233
-      status: 4
-    - original_index: 234
-      status: 2
-    - original_index: 235
-      status: 2
-    - original_index: 236
-      status: 0
-    - original_index: 237
-      status: 1
-    - original_index: 238
-      status: 0
-    - original_index: 239
-      status: 0
-    - original_index: 240
-      status: 2
-    - original_index: 241
-      status: 0
-    - original_index: 242
-      status: 3
-    - original_index: 243
-      status: 3
-    - original_index: 244
-      status: 2
-    - original_index: 245
-      status: 4
-    - original_index: 246
-      status: 0
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 1
-    - original_index: 249
-      status: 0
-    - original_index: 250
-      status: 3
-    - original_index: 251
-      status: 4
-    - original_index: 252
-      status: 2
-    - original_index: 253
-      status: 4
-    - original_index: 254
-      status: 0
-    - original_index: 255
-      status: 1
-    - original_index: 256
-      status: 4
-    - original_index: 257
-      status: 1
-    - original_index: 258
-      status: 0
-    - original_index: 259
-      status: 0
-    - original_index: 260
-      status: 4
-    - original_index: 261
-      status: 3
-    - original_index: 262
-      status: 3
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 1
-    - original_index: 265
-      status: 4
-    - original_index: 266
-      status: 1
-    - original_index: 267
-      status: 3
-    - original_index: 268
-      status: 1
-    - original_index: 269
-      status: 0
-    - original_index: 270
-      status: 4
-    - original_index: 271
-      status: 3
-    - original_index: 272
-      status: 3
-    - original_index: 273
-      status: 0
-    - original_index: 274
-      status: 2
-    - original_index: 275
-      status: 1
-    - original_index: 276
-      status: 3
-    - original_index: 277
-      status: 4
-    - original_index: 278
-      status: 1
-    - original_index: 279
-      status: 3
-    - original_index: 280
-      status: 3
-    - original_index: 281
-      status: 3
-    - original_index: 282
-      status: 0
-    - original_index: 283
-      status: 4
-    - original_index: 284
-      status: 2
-    - original_index: 285
-      status: 3
-    - original_index: 286
-      status: 0
-    - original_index: 287
-      status: 0
-    - original_index: 288
-      status: 0
-    - original_index: 289
-      status: 1
-    - original_index: 290
-      status: 4
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 1
-    - original_index: 293
-      status: 4
-    - original_index: 294
-      status: 2
-    - original_index: 295
-      status: 0
-    - original_index: 296
-      status: 4
-    - original_index: 297
-      status: 2
-    - original_index: 298
-      status: 3
-    - original_index: 299
-      status: 0
-    - original_index: 300
-      status: 1
-    - original_index: 301
-      status: 2
-    - original_index: 302
-      status: 0
-    - original_index: 303
-      status: 4
-    - original_index: 304
-      status: 0
-    - original_index: 305
-      status: 4
-    - original_index: 306
-      status: 4
-    - original_index: 307
-      status: 2
-    - original_index: 308
-      status: 1
-    - original_index: 309
-      status: 3
-    - original_index: 310
-      status: 4
-    - original_index: 311
-      status: 3
-    - original_index: 312
-      status: 2
-    - original_index: 313
-      status: 3
-    - original_index: 314
-      status: 3
-    - original_index: 315
-      status: 4
-    - original_index: 316
-      status: 3
-    - original_index: 317
-      status: 2
-    - original_index: 318
-      status: 2
-    - original_index: 319
-      status: 1
-    - original_index: 320
-      status: 3
-    - original_index: 321
-      status: 0
-    - original_index: 322
-      status: 3
-    - original_index: 323
-      status: 2
-    - original_index: 324
-      status: 1
-    - original_index: 325
-      status: 0
-    - original_index: 326
-      status: 1
-    - original_index: 327
-      status: 3
-    - original_index: 328
-      status: 2
-    - original_index: 329
-      status: 0
-    - original_index: 330
-      status: 0
-    - original_index: 331
-      status: 0
-    - original_index: 332
-      status: 1
-    - original_index: 333
-      status: 1
-    - original_index: 334
-      status: 2
-    - original_index: 335
-      status: 2
-    - original_index: 336
-      status: 0
-    - original_index: 337
-      status: 3
-    - original_index: 338
-      status: 1
-    - original_index: 339
-      status: 0
-    - original_index: 340
-      status: 3
-    - original_index: 341
-      status: 2
-    - original_index: 342
-      status: 0
-    - original_index: 343
-      status: 0
-    - original_index: 344
-      status: 2
-    - original_index: 345
-      status: 3
-    - original_index: 346
-      status: 0
-    - original_index: 347
-      status: 0
-    - original_index: 348
-      status: 4
-    - original_index: 349
-      status: 4
-    - original_index: 350
-      status: 2
-    - original_index: 351
-      status: 0
-    - original_index: 352
-      status: 1
-    - original_index: 353
-      status: 1
-    - original_index: 354
-      status: 3
-    - original_index: 355
-      status: 0
-    - original_index: 356
-      status: 1
-    - original_index: 357
-      status: 0
-    - original_index: 358
-      status: 1
-    - original_index: 359
-      status: 1
-    - original_index: 360
-      status: 3
-    - original_index: 361
-      status: 4
-    - original_index: 362
-      status: 0
-    - original_index: 363
-      status: 0
-    - original_index: 364
-      status: 3
-    - original_index: 365
-      status: 4
-    - original_index: 366
-      status: 4
-    - original_index: 367
-      status: 4
-    - original_index: 368
-      status: 0
-    - original_index: 369
-      status: 2
-    - original_index: 370
-      status: 4
-    - original_index: 371
-      status: 4
-    - original_index: 372
-      status: 1
-    - original_index: 373
-      status: 0
-    - original_index: 374
-      status: 2
-    - original_index: 375
-      status: 2
-    - original_index: 376
-      status: 3
-    - original_index: 377
-      status: 4
-    - original_index: 378
-      status: 4
-    - original_index: 379
-      status: 0
-    - original_index: 380
-      status: 1
-    - original_index: 381
-      status: 3
-    - original_index: 382
-      status: 2
-    - original_index: 383
-      status: 4
-    - original_index: 384
-      status: 0
-    - original_index: 385
-      status: 1
-    - original_index: 386
-      status: 2
-    - original_index: 387
-      status: 1
-    - original_index: 388
-      status: 3
-    - original_index: 389
-      status: 3
-    - original_index: 390
-      status: 0
-    - original_index: 391
-      status: 3
-    - original_index: 392
-      status: 4
-    - original_index: 393
-      status: 1
-    - original_index: 394
-      status: 3
-    - original_index: 395
-      status: 1
-    - original_index: 396
-      status: 0
-    - original_index: 397
-      status: 1
-    - original_index: 398
-      status: 0
-    - original_index: 399
-      status: 4
-    - original_index: 400
-      status: 4
-    - original_index: 401
-      status: 3
-    - original_index: 402
-      status: 4
-    - original_index: 403
-      status: 1
-    - original_index: 404
-      status: 0
-    - original_index: 405
-      status: 3
-    - original_index: 406
-      status: 1
-    - original_index: 407
-      status: 3
+    - {original_index: 0, status: 2}
+    - {original_index: 1, status: 4}
+    - {original_index: 2, status: 0}
+    - {original_index: 3, status: 0}
+    - {original_index: 4, status: 2}
+    - {original_index: 5, status: 2}
+    - {original_index: 6, status: 4}
+    - {original_index: 7, status: 2}
+    - {original_index: 8, status: 3}
+    - {original_index: 9, status: 1}
+    - {original_index: 10, status: 0}
+    - {original_index: 11, status: 3}
+    - {original_index: 12, status: 3}
+    - {original_index: 13, status: 4}
+    - {original_index: 14, status: 4}
+    - {original_index: 15, status: 4}
+    - {original_index: 16, status: 1}
+    - {original_index: 17, status: 1}
+    - {original_index: 18, status: 1}
+    - {original_index: 19, status: 1}
+    - {original_index: 20, status: 3}
+    - {original_index: 21, status: 2}
+    - {original_index: 22, status: 3}
+    - {original_index: 23, status: 0}
+    - {original_index: 24, status: 2}
+    - {original_index: 25, status: 4}
+    - {original_index: 26, status: 0}
+    - {original_index: 27, status: 2}
+    - {original_index: 28, status: 4}
+    - {original_index: 29, status: 0}
+    - {original_index: 30, status: 0}
+    - {original_index: 31, status: 4}
+    - {original_index: 32, status: 2}
+    - {original_index: 33, status: 1}
+    - {original_index: 34, status: 4}
+    - {original_index: 35, status: 1}
+    - {original_index: 36, status: 4}
+    - {original_index: 37, status: 2}
+    - {original_index: 38, status: 2}
+    - {original_index: 39, status: 1}
+    - {original_index: 40, status: 2}
+    - {original_index: 41, status: 4}
+    - {original_index: 42, status: 0}
+    - {original_index: 43, status: 4}
+    - {original_index: 44, status: 0}
+    - {original_index: 45, status: 3}
+    - {original_index: 46, status: 0}
+    - {original_index: 47, status: 4}
+    - {original_index: 48, status: 4}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 0}
+    - {original_index: 51, status: 1}
+    - {original_index: 52, status: 3}
+    - {original_index: 53, status: 3}
+    - {original_index: 54, status: 0}
+    - {original_index: 55, status: 4}
+    - {original_index: 56, status: 3}
+    - {original_index: 57, status: 1}
+    - {original_index: 58, status: 1}
+    - {original_index: 59, status: 3}
+    - {original_index: 60, status: 1}
+    - {original_index: 61, status: 0}
+    - {original_index: 62, status: 0}
+    - {original_index: 63, status: 1}
+    - {original_index: 64, status: 0}
+    - {original_index: 65, status: 0}
+    - {original_index: 66, status: 4}
+    - {original_index: 67, status: 1}
+    - {original_index: 68, status: 2}
+    - {original_index: 69, status: 0}
+    - {original_index: 70, status: 1}
+    - {original_index: 71, status: 4}
+    - {original_index: 72, status: 2}
+    - {original_index: 73, status: 1}
+    - {original_index: 74, status: 1}
+    - {original_index: 75, status: 4}
+    - {original_index: 76, status: 1}
+    - {original_index: 77, status: 1}
+    - {original_index: 78, status: 1}
+    - {original_index: 79, status: 1}
+    - {original_index: 80, status: 0}
+    - {original_index: 81, status: 4}
+    - {original_index: 82, status: 4}
+    - {original_index: 83, status: 0}
+    - {original_index: 84, status: 1}
+    - {original_index: 85, status: 3}
+    - {original_index: 86, status: 4}
+    - {original_index: 87, status: 2}
+    - {original_index: 88, status: 0}
+    - {original_index: 89, status: 1}
+    - {original_index: 90, status: 4}
+    - {original_index: 91, status: 3}
+    - {original_index: 92, status: 1}
+    - {original_index: 93, status: 2}
+    - {original_index: 94, status: 4}
+    - {original_index: 95, status: 2}
+    - {original_index: 96, status: 2}
+    - {original_index: 97, status: 2}
+    - {original_index: 98, status: 3}
+    - {original_index: 99, status: 3}
+    - {original_index: 100, status: 3}
+    - {original_index: 101, status: 0}
+    - {original_index: 102, status: 2}
+    - {original_index: 103, status: 0}
+    - {original_index: 104, status: 4}
+    - {original_index: 105, status: 1}
+    - {original_index: 106, status: 1}
+    - {original_index: 107, status: 3}
+    - {original_index: 108, status: 0}
+    - {original_index: 109, status: 3}
+    - {original_index: 110, status: 1}
+    - {original_index: 111, status: 3}
+    - {original_index: 112, status: 4}
+    - {original_index: 113, status: 3}
+    - {original_index: 114, status: 3}
+    - {original_index: 115, status: 4}
+    - {original_index: 116, status: 0}
+    - {original_index: 117, status: 1}
+    - {original_index: 118, status: 0}
+    - {original_index: 119, status: 3}
+    - {original_index: 120, status: 3}
+    - {original_index: 121, status: 1}
+    - {original_index: 122, status: 4}
+    - {original_index: 123, status: 2}
+    - {original_index: 124, status: 0}
+    - {original_index: 125, status: 3}
+    - {original_index: 126, status: 2}
+    - {original_index: 127, status: 3}
+    - {original_index: 128, status: 0}
+    - {original_index: 129, status: 4}
+    - {original_index: 130, status: 3}
+    - {original_index: 131, status: 1}
+    - {original_index: 132, status: 3}
+    - {original_index: 133, status: 3}
+    - {original_index: 134, status: 4}
+    - {original_index: 135, status: 3}
+    - {original_index: 136, status: 0}
+    - {original_index: 137, status: 0}
+    - {original_index: 138, status: 1}
+    - {original_index: 139, status: 0}
+    - {original_index: 140, status: 2}
+    - {original_index: 141, status: 4}
+    - {original_index: 142, status: 1}
+    - {original_index: 143, status: 3}
+    - {original_index: 144, status: 1}
+    - {original_index: 145, status: 3}
+    - {original_index: 146, status: 2}
+    - {original_index: 147, status: 4}
+    - {original_index: 148, status: 2}
+    - {original_index: 149, status: 2}
+    - {original_index: 150, status: 0}
+    - {original_index: 151, status: 3}
+    - {original_index: 152, status: 2}
+    - {original_index: 153, status: 3}
+    - {original_index: 154, status: 1}
+    - {original_index: 155, status: 3}
+    - {original_index: 156, status: 0}
+    - {original_index: 157, status: 2}
+    - {original_index: 158, status: 1}
+    - {original_index: 159, status: 3}
+    - {original_index: 160, status: 2}
+    - {original_index: 161, status: 2}
+    - {original_index: 162, status: 1}
+    - {original_index: 163, status: 3}
+    - {original_index: 164, status: 0}
+    - {original_index: 165, status: 2}
+    - {original_index: 166, status: 1}
+    - {original_index: 167, status: 3}
+    - {original_index: 168, status: 2}
+    - {original_index: 169, status: 2}
+    - {original_index: 170, status: 2}
+    - {original_index: 171, status: 0}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 0}
+    - {original_index: 174, status: 3}
+    - {original_index: 175, status: 4}
+    - {original_index: 176, status: 1}
+    - {original_index: 177, status: 4}
+    - {original_index: 178, status: 4}
+    - {original_index: 179, status: 3}
+    - {original_index: 180, status: 3}
+    - {original_index: 181, status: 0}
+    - {original_index: 182, status: 1}
+    - {original_index: 183, status: 2}
+    - {original_index: 184, status: 4}
+    - {original_index: 185, status: 1}
+    - {original_index: 186, status: 4}
+    - {original_index: 187, status: 0}
+    - {original_index: 188, status: 0}
+    - {original_index: 189, status: 4}
+    - {original_index: 190, status: 3}
+    - {original_index: 191, status: 2}
+    - {original_index: 192, status: 4}
+    - {original_index: 193, status: 3}
+    - {original_index: 194, status: 1}
+    - {original_index: 195, status: 2}
+    - {original_index: 196, status: 0}
+    - {original_index: 197, status: 4}
+    - {original_index: 198, status: 4}
+    - {original_index: 199, status: 2}
+    - {original_index: 200, status: 0}
+    - {original_index: 201, status: 4}
+    - {original_index: 202, status: 4}
+    - {original_index: 203, status: 4}
+    - {original_index: 204, status: 4}
+    - {original_index: 205, status: 0}
+    - {original_index: 206, status: 1}
+    - {original_index: 207, status: 4}
+    - {original_index: 208, status: 4}
+    - {original_index: 209, status: 3}
+    - {original_index: 210, status: 0}
+    - {original_index: 211, status: 3}
+    - {original_index: 212, status: 2}
+    - {original_index: 213, status: 1}
+    - {original_index: 214, status: 4}
+    - {original_index: 215, status: 3}
+    - {original_index: 216, status: 0}
+    - {original_index: 217, status: 3}
+    - {original_index: 218, status: 0}
+    - {original_index: 219, status: 3}
+    - {original_index: 220, status: 1}
+    - {original_index: 221, status: 3}
+    - {original_index: 222, status: 3}
+    - {original_index: 223, status: 2}
+    - {original_index: 224, status: 3}
+    - {original_index: 225, status: 2}
+    - {original_index: 226, status: 2}
+    - {original_index: 227, status: 2}
+    - {original_index: 228, status: 1}
+    - {original_index: 229, status: 0}
+    - {original_index: 230, status: 4}
+    - {original_index: 231, status: 2}
+    - {original_index: 232, status: 0}
+    - {original_index: 233, status: 4}
+    - {original_index: 234, status: 2}
+    - {original_index: 235, status: 2}
+    - {original_index: 236, status: 0}
+    - {original_index: 237, status: 1}
+    - {original_index: 238, status: 0}
+    - {original_index: 239, status: 0}
+    - {original_index: 240, status: 2}
+    - {original_index: 241, status: 0}
+    - {original_index: 242, status: 3}
+    - {original_index: 243, status: 3}
+    - {original_index: 244, status: 2}
+    - {original_index: 245, status: 4}
+    - {original_index: 246, status: 0}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 1}
+    - {original_index: 249, status: 0}
+    - {original_index: 250, status: 3}
+    - {original_index: 251, status: 4}
+    - {original_index: 252, status: 2}
+    - {original_index: 253, status: 4}
+    - {original_index: 254, status: 0}
+    - {original_index: 255, status: 1}
+    - {original_index: 256, status: 4}
+    - {original_index: 257, status: 1}
+    - {original_index: 258, status: 0}
+    - {original_index: 259, status: 0}
+    - {original_index: 260, status: 4}
+    - {original_index: 261, status: 3}
+    - {original_index: 262, status: 3}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 1}
+    - {original_index: 265, status: 4}
+    - {original_index: 266, status: 1}
+    - {original_index: 267, status: 3}
+    - {original_index: 268, status: 1}
+    - {original_index: 269, status: 0}
+    - {original_index: 270, status: 4}
+    - {original_index: 271, status: 3}
+    - {original_index: 272, status: 3}
+    - {original_index: 273, status: 0}
+    - {original_index: 274, status: 2}
+    - {original_index: 275, status: 1}
+    - {original_index: 276, status: 3}
+    - {original_index: 277, status: 4}
+    - {original_index: 278, status: 1}
+    - {original_index: 279, status: 3}
+    - {original_index: 280, status: 3}
+    - {original_index: 281, status: 3}
+    - {original_index: 282, status: 0}
+    - {original_index: 283, status: 4}
+    - {original_index: 284, status: 2}
+    - {original_index: 285, status: 3}
+    - {original_index: 286, status: 0}
+    - {original_index: 287, status: 0}
+    - {original_index: 288, status: 0}
+    - {original_index: 289, status: 1}
+    - {original_index: 290, status: 4}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 1}
+    - {original_index: 293, status: 4}
+    - {original_index: 294, status: 2}
+    - {original_index: 295, status: 0}
+    - {original_index: 296, status: 4}
+    - {original_index: 297, status: 2}
+    - {original_index: 298, status: 3}
+    - {original_index: 299, status: 0}
+    - {original_index: 300, status: 1}
+    - {original_index: 301, status: 2}
+    - {original_index: 302, status: 0}
+    - {original_index: 303, status: 4}
+    - {original_index: 304, status: 0}
+    - {original_index: 305, status: 4}
+    - {original_index: 306, status: 4}
+    - {original_index: 307, status: 2}
+    - {original_index: 308, status: 1}
+    - {original_index: 309, status: 3}
+    - {original_index: 310, status: 4}
+    - {original_index: 311, status: 3}
+    - {original_index: 312, status: 2}
+    - {original_index: 313, status: 3}
+    - {original_index: 314, status: 3}
+    - {original_index: 315, status: 4}
+    - {original_index: 316, status: 3}
+    - {original_index: 317, status: 2}
+    - {original_index: 318, status: 2}
+    - {original_index: 319, status: 1}
+    - {original_index: 320, status: 3}
+    - {original_index: 321, status: 0}
+    - {original_index: 322, status: 3}
+    - {original_index: 323, status: 2}
+    - {original_index: 324, status: 1}
+    - {original_index: 325, status: 0}
+    - {original_index: 326, status: 1}
+    - {original_index: 327, status: 3}
+    - {original_index: 328, status: 2}
+    - {original_index: 329, status: 0}
+    - {original_index: 330, status: 0}
+    - {original_index: 331, status: 0}
+    - {original_index: 332, status: 1}
+    - {original_index: 333, status: 1}
+    - {original_index: 334, status: 2}
+    - {original_index: 335, status: 2}
+    - {original_index: 336, status: 0}
+    - {original_index: 337, status: 3}
+    - {original_index: 338, status: 1}
+    - {original_index: 339, status: 0}
+    - {original_index: 340, status: 3}
+    - {original_index: 341, status: 2}
+    - {original_index: 342, status: 0}
+    - {original_index: 343, status: 0}
+    - {original_index: 344, status: 2}
+    - {original_index: 345, status: 3}
+    - {original_index: 346, status: 0}
+    - {original_index: 347, status: 0}
+    - {original_index: 348, status: 4}
+    - {original_index: 349, status: 4}
+    - {original_index: 350, status: 2}
+    - {original_index: 351, status: 0}
+    - {original_index: 352, status: 1}
+    - {original_index: 353, status: 1}
+    - {original_index: 354, status: 3}
+    - {original_index: 355, status: 0}
+    - {original_index: 356, status: 1}
+    - {original_index: 357, status: 0}
+    - {original_index: 358, status: 1}
+    - {original_index: 359, status: 1}
+    - {original_index: 360, status: 3}
+    - {original_index: 361, status: 4}
+    - {original_index: 362, status: 0}
+    - {original_index: 363, status: 0}
+    - {original_index: 364, status: 3}
+    - {original_index: 365, status: 4}
+    - {original_index: 366, status: 4}
+    - {original_index: 367, status: 4}
+    - {original_index: 368, status: 0}
+    - {original_index: 369, status: 2}
+    - {original_index: 370, status: 4}
+    - {original_index: 371, status: 4}
+    - {original_index: 372, status: 1}
+    - {original_index: 373, status: 0}
+    - {original_index: 374, status: 2}
+    - {original_index: 375, status: 2}
+    - {original_index: 376, status: 3}
+    - {original_index: 377, status: 4}
+    - {original_index: 378, status: 4}
+    - {original_index: 379, status: 0}
+    - {original_index: 380, status: 1}
+    - {original_index: 381, status: 3}
+    - {original_index: 382, status: 2}
+    - {original_index: 383, status: 4}
+    - {original_index: 384, status: 0}
+    - {original_index: 385, status: 1}
+    - {original_index: 386, status: 2}
+    - {original_index: 387, status: 1}
+    - {original_index: 388, status: 3}
+    - {original_index: 389, status: 3}
+    - {original_index: 390, status: 0}
+    - {original_index: 391, status: 3}
+    - {original_index: 392, status: 4}
+    - {original_index: 393, status: 1}
+    - {original_index: 394, status: 3}
+    - {original_index: 395, status: 1}
+    - {original_index: 396, status: 0}
+    - {original_index: 397, status: 1}
+    - {original_index: 398, status: 0}
+    - {original_index: 399, status: 4}
+    - {original_index: 400, status: 4}
+    - {original_index: 401, status: 3}
+    - {original_index: 402, status: 4}
+    - {original_index: 403, status: 1}
+    - {original_index: 404, status: 0}
+    - {original_index: 405, status: 3}
+    - {original_index: 406, status: 1}
+    - {original_index: 407, status: 3}
   output:
-  - - committee:
-      - 131
-      - 104
+  - - committee: [131, 104]
       shard: 210
       total_validator_count: 160
-  - - committee:
-      - 1
-      - 256
-      - 16
+  - - committee: [1, 256, 16]
       shard: 211
       total_validator_count: 160
-  - - committee:
-      - 175
-      - 255
+  - - committee: [175, 255]
       shard: 212
       total_validator_count: 160
-  - - committee:
-      - 51
-      - 333
-      - 9
+  - - committee: [51, 333, 9]
       shard: 213
       total_validator_count: 160
-  - - committee:
-      - 182
-      - 117
+  - - committee: [182, 117]
       shard: 214
       total_validator_count: 160
-  - - committee:
-      - 400
-      - 366
-      - 399
+  - - committee: [400, 366, 399]
       shard: 215
       total_validator_count: 160
-  - - committee:
-      - 278
-      - 214
+  - - committee: [278, 214]
       shard: 216
       total_validator_count: 160
-  - - committee:
-      - 177
-      - 352
-      - 387
+  - - committee: [177, 352, 387]
       shard: 217
       total_validator_count: 160
-  - - committee:
-      - 106
-      - 35
+  - - committee: [106, 35]
       shard: 218
       total_validator_count: 160
-  - - committee:
-      - 293
-      - 14
-      - 33
+  - - committee: [293, 14, 33]
       shard: 219
       total_validator_count: 160
-  - - committee:
-      - 34
-      - 122
+  - - committee: [34, 122]
       shard: 220
       total_validator_count: 160
-  - - committee:
-      - 178
-      - 305
-      - 372
+  - - committee: [178, 305, 372]
       shard: 221
       total_validator_count: 160
-  - - committee:
-      - 358
-      - 296
+  - - committee: [358, 296]
       shard: 222
       total_validator_count: 160
-  - - committee:
-      - 115
-      - 74
-      - 393
+  - - committee: [115, 74, 393]
       shard: 223
       total_validator_count: 160
-  - - committee:
-      - 94
-      - 192
+  - - committee: [94, 192]
       shard: 224
       total_validator_count: 160
-  - - committee:
-      - 397
-      - 202
-      - 186
+  - - committee: [397, 202, 186]
       shard: 225
       total_validator_count: 160
-  - - committee:
-      - 81
-      - 76
+  - - committee: [81, 76]
       shard: 226
       total_validator_count: 160
-  - - committee:
-      - 90
-      - 266
-      - 58
+  - - committee: [90, 266, 58]
       shard: 227
       total_validator_count: 160
-  - - committee:
-      - 283
-      - 47
+  - - committee: [283, 47]
       shard: 228
       total_validator_count: 160
-  - - committee:
-      - 110
-      - 89
-      - 265
+  - - committee: [110, 89, 265]
       shard: 229
       total_validator_count: 160
-  - - committee:
-      - 201
-      - 237
+  - - committee: [201, 237]
       shard: 230
       total_validator_count: 160
-  - - committee:
-      - 75
-      - 25
-      - 263
+  - - committee: [75, 25, 263]
       shard: 231
       total_validator_count: 160
-  - - committee:
-      - 303
-      - 86
+  - - committee: [303, 86]
       shard: 232
       total_validator_count: 160
-  - - committee:
-      - 17
-      - 82
-      - 138
+  - - committee: [17, 82, 138]
       shard: 233
       total_validator_count: 160
-  - - committee:
-      - 338
-      - 365
+  - - committee: [338, 365]
       shard: 234
       total_validator_count: 160
-  - - committee:
-      - 308
-      - 55
-      - 332
+  - - committee: [308, 55, 332]
       shard: 235
       total_validator_count: 160
-  - - committee:
-      - 370
-      - 275
+  - - committee: [370, 275]
       shard: 236
       total_validator_count: 160
-  - - committee:
-      - 377
-      - 57
-      - 147
+  - - committee: [377, 57, 147]
       shard: 237
       total_validator_count: 160
-  - - committee:
-      - 112
-      - 141
+  - - committee: [112, 141]
       shard: 238
       total_validator_count: 160
-  - - committee:
-      - 204
-      - 233
-      - 207
+  - - committee: [204, 233, 207]
       shard: 239
       total_validator_count: 160
-  - - committee:
-      - 206
-      - 78
+  - - committee: [206, 78]
       shard: 240
       total_validator_count: 160
-  - - committee:
-      - 253
-      - 367
-      - 73
+  - - committee: [253, 367, 73]
       shard: 241
       total_validator_count: 160
-  - - committee:
-      - 402
-      - 158
+  - - committee: [402, 158]
       shard: 242
       total_validator_count: 160
-  - - committee:
-      - 248
-      - 105
-      - 70
+  - - committee: [248, 105, 70]
       shard: 243
       total_validator_count: 160
-  - - committee:
-      - 292
-      - 289
+  - - committee: [292, 289]
       shard: 244
       total_validator_count: 160
-  - - committee:
-      - 315
-      - 395
-      - 380
+  - - committee: [315, 395, 380]
       shard: 245
       total_validator_count: 160
-  - - committee:
-      - 60
-      - 220
+  - - committee: [60, 220]
       shard: 246
       total_validator_count: 160
-  - - committee:
-      - 213
-      - 13
-      - 121
+  - - committee: [213, 13, 121]
       shard: 247
       total_validator_count: 160
-  - - committee:
-      - 142
-      - 31
+  - - committee: [142, 31]
       shard: 248
       total_validator_count: 160
-  - - committee:
-      - 230
-      - 129
-      - 353
+  - - committee: [230, 129, 353]
       shard: 249
       total_validator_count: 160
-  - - committee:
-      - 378
-      - 77
+  - - committee: [378, 77]
       shard: 250
       total_validator_count: 160
-  - - committee:
-      - 15
-      - 92
-      - 166
+  - - committee: [15, 92, 166]
       shard: 251
       total_validator_count: 160
-  - - committee:
-      - 277
-      - 260
+  - - committee: [277, 260]
       shard: 252
       total_validator_count: 160
-  - - committee:
-      - 349
-      - 403
-      - 406
+  - - committee: [349, 403, 406]
       shard: 253
       total_validator_count: 160
-  - - committee:
-      - 185
-      - 36
+  - - committee: [185, 36]
       shard: 254
       total_validator_count: 160
-  - - committee:
-      - 28
-      - 18
-      - 270
+  - - committee: [28, 18, 270]
       shard: 255
       total_validator_count: 160
-  - - committee:
-      - 39
-      - 197
+  - - committee: [39, 197]
       shard: 256
       total_validator_count: 160
-  - - committee:
-      - 383
-      - 134
-      - 228
+  - - committee: [383, 134, 228]
       shard: 257
       total_validator_count: 160
-  - - committee:
-      - 257
-      - 79
+  - - committee: [257, 79]
       shard: 258
       total_validator_count: 160
-  - - committee:
-      - 319
-      - 245
-      - 144
+  - - committee: [319, 245, 144]
       shard: 259
       total_validator_count: 160
-  - - committee:
-      - 84
-      - 356
+  - - committee: [84, 356]
       shard: 260
       total_validator_count: 160
-  - - committee:
-      - 359
-      - 184
-      - 324
+  - - committee: [359, 184, 324]
       shard: 261
       total_validator_count: 160
-  - - committee:
-      - 67
-      - 41
+  - - committee: [67, 41]
       shard: 262
       total_validator_count: 160
-  - - committee:
-      - 290
-      - 63
-      - 176
+  - - committee: [290, 63, 176]
       shard: 263
       total_validator_count: 160
-  - - committee:
-      - 385
-      - 154
+  - - committee: [385, 154]
       shard: 264
       total_validator_count: 160
-  - - committee:
-      - 66
-      - 43
-      - 162
+  - - committee: [66, 43, 162]
       shard: 265
       total_validator_count: 160
-  - - committee:
-      - 306
-      - 251
+  - - committee: [306, 251]
       shard: 266
       total_validator_count: 160
-  - - committee:
-      - 310
-      - 189
-      - 208
+  - - committee: [310, 189, 208]
       shard: 267
       total_validator_count: 160
-  - - committee:
-      - 198
-      - 48
+  - - committee: [198, 48]
       shard: 268
       total_validator_count: 160
-  - - committee:
-      - 348
-      - 19
-      - 392
+  - - committee: [348, 19, 392]
       shard: 269
       total_validator_count: 160
-  - - committee:
-      - 326
-      - 71
+  - - committee: [326, 71]
       shard: 270
       total_validator_count: 160
-  - - committee:
-      - 268
-      - 203
-      - 264
+  - - committee: [268, 203, 264]
       shard: 271
       total_validator_count: 160
-  - - committee:
-      - 361
-      - 6
+  - - committee: [361, 6]
       shard: 272
       total_validator_count: 160
-  - - committee:
-      - 300
-      - 194
-      - 371
+  - - committee: [300, 194, 371]
       shard: 273
       total_validator_count: 160
   seed: '0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d'
 - input:
     crosslinking_start_shard: 102
     validators:
-    - original_index: 0
-      status: 3
-    - original_index: 1
-      status: 2
-    - original_index: 2
-      status: 4
-    - original_index: 3
-      status: 4
-    - original_index: 4
-      status: 3
-    - original_index: 5
-      status: 1
-    - original_index: 6
-      status: 0
-    - original_index: 7
-      status: 4
-    - original_index: 8
-      status: 3
-    - original_index: 9
-      status: 3
-    - original_index: 10
-      status: 3
-    - original_index: 11
-      status: 3
-    - original_index: 12
-      status: 4
-    - original_index: 13
-      status: 2
-    - original_index: 14
-      status: 1
-    - original_index: 15
-      status: 1
-    - original_index: 16
-      status: 3
-    - original_index: 17
-      status: 4
-    - original_index: 18
-      status: 1
-    - original_index: 19
-      status: 1
-    - original_index: 20
-      status: 3
-    - original_index: 21
-      status: 0
-    - original_index: 22
-      status: 4
-    - original_index: 23
-      status: 0
-    - original_index: 24
-      status: 2
-    - original_index: 25
-      status: 4
-    - original_index: 26
-      status: 1
-    - original_index: 27
-      status: 1
-    - original_index: 28
-      status: 3
-    - original_index: 29
-      status: 4
-    - original_index: 30
-      status: 1
-    - original_index: 31
-      status: 0
-    - original_index: 32
-      status: 2
-    - original_index: 33
-      status: 3
-    - original_index: 34
-      status: 4
-    - original_index: 35
-      status: 2
-    - original_index: 36
-      status: 2
-    - original_index: 37
-      status: 4
-    - original_index: 38
-      status: 1
-    - original_index: 39
-      status: 4
-    - original_index: 40
-      status: 4
-    - original_index: 41
-      status: 2
-    - original_index: 42
-      status: 0
-    - original_index: 43
-      status: 2
-    - original_index: 44
-      status: 4
-    - original_index: 45
-      status: 0
-    - original_index: 46
-      status: 1
-    - original_index: 47
-      status: 4
-    - original_index: 48
-      status: 0
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 1
-    - original_index: 51
-      status: 3
-    - original_index: 52
-      status: 0
-    - original_index: 53
-      status: 3
-    - original_index: 54
-      status: 0
-    - original_index: 55
-      status: 2
-    - original_index: 56
-      status: 2
-    - original_index: 57
-      status: 3
-    - original_index: 58
-      status: 4
-    - original_index: 59
-      status: 3
-    - original_index: 60
-      status: 0
-    - original_index: 61
-      status: 1
-    - original_index: 62
-      status: 0
-    - original_index: 63
-      status: 0
-    - original_index: 64
-      status: 3
-    - original_index: 65
-      status: 4
-    - original_index: 66
-      status: 1
-    - original_index: 67
-      status: 0
-    - original_index: 68
-      status: 3
-    - original_index: 69
-      status: 2
-    - original_index: 70
-      status: 3
-    - original_index: 71
-      status: 4
-    - original_index: 72
-      status: 3
-    - original_index: 73
-      status: 1
-    - original_index: 74
-      status: 0
-    - original_index: 75
-      status: 4
-    - original_index: 76
-      status: 0
-    - original_index: 77
-      status: 3
-    - original_index: 78
-      status: 4
-    - original_index: 79
-      status: 3
-    - original_index: 80
-      status: 3
-    - original_index: 81
-      status: 0
-    - original_index: 82
-      status: 3
-    - original_index: 83
-      status: 1
-    - original_index: 84
-      status: 4
-    - original_index: 85
-      status: 0
-    - original_index: 86
-      status: 2
-    - original_index: 87
-      status: 1
-    - original_index: 88
-      status: 4
-    - original_index: 89
-      status: 4
-    - original_index: 90
-      status: 4
-    - original_index: 91
-      status: 3
-    - original_index: 92
-      status: 3
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 4
-    - original_index: 95
-      status: 3
-    - original_index: 96
-      status: 2
-    - original_index: 97
-      status: 2
-    - original_index: 98
-      status: 2
-    - original_index: 99
-      status: 3
-    - original_index: 100
-      status: 2
-    - original_index: 101
-      status: 2
-    - original_index: 102
-      status: 1
-    - original_index: 103
-      status: 2
-    - original_index: 104
-      status: 3
-    - original_index: 105
-      status: 3
-    - original_index: 106
-      status: 3
-    - original_index: 107
-      status: 0
-    - original_index: 108
-      status: 3
-    - original_index: 109
-      status: 2
-    - original_index: 110
-      status: 1
-    - original_index: 111
-      status: 4
-    - original_index: 112
-      status: 3
-    - original_index: 113
-      status: 4
-    - original_index: 114
-      status: 2
-    - original_index: 115
-      status: 4
-    - original_index: 116
-      status: 0
-    - original_index: 117
-      status: 1
-    - original_index: 118
-      status: 2
-    - original_index: 119
-      status: 1
-    - original_index: 120
-      status: 0
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 3
-    - original_index: 124
-      status: 3
-    - original_index: 125
-      status: 3
-    - original_index: 126
-      status: 1
-    - original_index: 127
-      status: 4
-    - original_index: 128
-      status: 2
-    - original_index: 129
-      status: 1
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 1
-    - original_index: 132
-      status: 0
-    - original_index: 133
-      status: 3
-    - original_index: 134
-      status: 3
-    - original_index: 135
-      status: 4
-    - original_index: 136
-      status: 3
-    - original_index: 137
-      status: 1
-    - original_index: 138
-      status: 1
-    - original_index: 139
-      status: 1
-    - original_index: 140
-      status: 3
-    - original_index: 141
-      status: 1
-    - original_index: 142
-      status: 3
-    - original_index: 143
-      status: 2
-    - original_index: 144
-      status: 4
-    - original_index: 145
-      status: 2
-    - original_index: 146
-      status: 2
-    - original_index: 147
-      status: 0
-    - original_index: 148
-      status: 3
-    - original_index: 149
-      status: 3
-    - original_index: 150
-      status: 1
-    - original_index: 151
-      status: 0
-    - original_index: 152
-      status: 2
-    - original_index: 153
-      status: 0
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 1
-    - original_index: 156
-      status: 2
-    - original_index: 157
-      status: 0
-    - original_index: 158
-      status: 3
-    - original_index: 159
-      status: 2
-    - original_index: 160
-      status: 2
-    - original_index: 161
-      status: 3
-    - original_index: 162
-      status: 1
-    - original_index: 163
-      status: 0
-    - original_index: 164
-      status: 3
-    - original_index: 165
-      status: 3
-    - original_index: 166
-      status: 0
-    - original_index: 167
-      status: 1
-    - original_index: 168
-      status: 0
-    - original_index: 169
-      status: 1
-    - original_index: 170
-      status: 0
-    - original_index: 171
-      status: 0
-    - original_index: 172
-      status: 2
-    - original_index: 173
-      status: 2
-    - original_index: 174
-      status: 3
-    - original_index: 175
-      status: 0
-    - original_index: 176
-      status: 4
-    - original_index: 177
-      status: 1
-    - original_index: 178
-      status: 4
-    - original_index: 179
-      status: 1
-    - original_index: 180
-      status: 1
-    - original_index: 181
-      status: 3
-    - original_index: 182
-      status: 2
-    - original_index: 183
-      status: 2
-    - original_index: 184
-      status: 1
-    - original_index: 185
-      status: 0
-    - original_index: 186
-      status: 3
-    - original_index: 187
-      status: 2
-    - original_index: 188
-      status: 0
-    - original_index: 189
-      status: 1
-    - original_index: 190
-      status: 0
-    - original_index: 191
-      status: 2
-    - original_index: 192
-      status: 2
-    - original_index: 193
-      status: 0
-    - original_index: 194
-      status: 2
-    - original_index: 195
-      status: 1
-    - original_index: 196
-      status: 0
-    - original_index: 197
-      status: 1
-    - original_index: 198
-      status: 0
-    - original_index: 199
-      status: 0
-    - original_index: 200
-      status: 3
-    - original_index: 201
-      status: 1
-    - original_index: 202
-      status: 1
-    - original_index: 203
-      status: 2
-    - original_index: 204
-      status: 3
-    - original_index: 205
-      status: 0
-    - original_index: 206
-      status: 0
-    - original_index: 207
-      status: 3
-    - original_index: 208
-      status: 1
-    - original_index: 209
-      status: 2
-    - original_index: 210
-      status: 3
-    - original_index: 211
-      status: 1
-    - original_index: 212
-      status: 3
-    - original_index: 213
-      status: 3
-    - original_index: 214
-      status: 3
-    - original_index: 215
-      status: 4
-    - original_index: 216
-      status: 4
-    - original_index: 217
-      status: 2
-    - original_index: 218
-      status: 4
-    - original_index: 219
-      status: 3
-    - original_index: 220
-      status: 1
-    - original_index: 221
-      status: 2
-    - original_index: 222
-      status: 1
-    - original_index: 223
-      status: 4
-    - original_index: 224
-      status: 3
-    - original_index: 225
-      status: 4
-    - original_index: 226
-      status: 4
-    - original_index: 227
-      status: 3
-    - original_index: 228
-      status: 0
-    - original_index: 229
-      status: 3
-    - original_index: 230
-      status: 4
-    - original_index: 231
-      status: 2
-    - original_index: 232
-      status: 3
-    - original_index: 233
-      status: 3
-    - original_index: 234
-      status: 2
-    - original_index: 235
-      status: 4
-    - original_index: 236
-      status: 3
-    - original_index: 237
-      status: 2
-    - original_index: 238
-      status: 4
-    - original_index: 239
-      status: 1
-    - original_index: 240
-      status: 4
-    - original_index: 241
-      status: 2
-    - original_index: 242
-      status: 1
-    - original_index: 243
-      status: 3
-    - original_index: 244
-      status: 4
-    - original_index: 245
-      status: 0
-    - original_index: 246
-      status: 1
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 0
-    - original_index: 249
-      status: 0
-    - original_index: 250
-      status: 1
-    - original_index: 251
-      status: 2
-    - original_index: 252
-      status: 0
-    - original_index: 253
-      status: 4
-    - original_index: 254
-      status: 0
-    - original_index: 255
-      status: 2
-    - original_index: 256
-      status: 4
-    - original_index: 257
-      status: 3
-    - original_index: 258
-      status: 1
-    - original_index: 259
-      status: 0
-    - original_index: 260
-      status: 0
-    - original_index: 261
-      status: 1
-    - original_index: 262
-      status: 4
-    - original_index: 263
-      status: 3
-    - original_index: 264
-      status: 2
-    - original_index: 265
-      status: 4
-    - original_index: 266
-      status: 0
-    - original_index: 267
-      status: 2
-    - original_index: 268
-      status: 3
-    - original_index: 269
-      status: 1
-    - original_index: 270
-      status: 4
-    - original_index: 271
-      status: 0
-    - original_index: 272
-      status: 2
-    - original_index: 273
-      status: 2
-    - original_index: 274
-      status: 1
-    - original_index: 275
-      status: 0
-    - original_index: 276
-      status: 0
-    - original_index: 277
-      status: 2
-    - original_index: 278
-      status: 0
-    - original_index: 279
-      status: 2
-    - original_index: 280
-      status: 0
-    - original_index: 281
-      status: 3
-    - original_index: 282
-      status: 3
-    - original_index: 283
-      status: 3
-    - original_index: 284
-      status: 0
-    - original_index: 285
-      status: 2
-    - original_index: 286
-      status: 2
-    - original_index: 287
-      status: 4
-    - original_index: 288
-      status: 2
-    - original_index: 289
-      status: 3
-    - original_index: 290
-      status: 3
-    - original_index: 291
-      status: 1
-    - original_index: 292
-      status: 2
-    - original_index: 293
-      status: 1
-    - original_index: 294
-      status: 3
-    - original_index: 295
-      status: 1
-    - original_index: 296
-      status: 0
-    - original_index: 297
-      status: 2
-    - original_index: 298
-      status: 3
-    - original_index: 299
-      status: 0
-    - original_index: 300
-      status: 3
-    - original_index: 301
-      status: 0
-    - original_index: 302
-      status: 4
-    - original_index: 303
-      status: 4
-    - original_index: 304
-      status: 4
-    - original_index: 305
-      status: 3
-    - original_index: 306
-      status: 4
-    - original_index: 307
-      status: 0
-    - original_index: 308
-      status: 2
-    - original_index: 309
-      status: 3
-    - original_index: 310
-      status: 3
-    - original_index: 311
-      status: 3
-    - original_index: 312
-      status: 4
-    - original_index: 313
-      status: 4
-    - original_index: 314
-      status: 0
-    - original_index: 315
-      status: 4
-    - original_index: 316
-      status: 4
-    - original_index: 317
-      status: 1
-    - original_index: 318
-      status: 0
-    - original_index: 319
-      status: 2
-    - original_index: 320
-      status: 3
-    - original_index: 321
-      status: 4
-    - original_index: 322
-      status: 2
-    - original_index: 323
-      status: 3
-    - original_index: 324
-      status: 3
-    - original_index: 325
-      status: 3
-    - original_index: 326
-      status: 4
-    - original_index: 327
-      status: 4
-    - original_index: 328
-      status: 1
-    - original_index: 329
-      status: 1
-    - original_index: 330
-      status: 0
-    - original_index: 331
-      status: 0
-    - original_index: 332
-      status: 4
-    - original_index: 333
-      status: 4
-    - original_index: 334
-      status: 1
-    - original_index: 335
-      status: 3
-    - original_index: 336
-      status: 0
-    - original_index: 337
-      status: 2
-    - original_index: 338
-      status: 2
-    - original_index: 339
-      status: 1
-    - original_index: 340
-      status: 2
-    - original_index: 341
-      status: 4
-    - original_index: 342
-      status: 2
-    - original_index: 343
-      status: 0
-    - original_index: 344
-      status: 1
-    - original_index: 345
-      status: 3
-    - original_index: 346
-      status: 2
-    - original_index: 347
-      status: 0
-    - original_index: 348
-      status: 2
-    - original_index: 349
-      status: 2
-    - original_index: 350
-      status: 3
-    - original_index: 351
-      status: 3
-    - original_index: 352
-      status: 3
-    - original_index: 353
-      status: 2
-    - original_index: 354
-      status: 3
-    - original_index: 355
-      status: 0
-    - original_index: 356
-      status: 4
-    - original_index: 357
-      status: 1
-    - original_index: 358
-      status: 2
-    - original_index: 359
-      status: 4
-    - original_index: 360
-      status: 0
-    - original_index: 361
-      status: 1
-    - original_index: 362
-      status: 1
-    - original_index: 363
-      status: 3
-    - original_index: 364
-      status: 3
-    - original_index: 365
-      status: 3
-    - original_index: 366
-      status: 4
-    - original_index: 367
-      status: 3
-    - original_index: 368
-      status: 3
-    - original_index: 369
-      status: 2
-    - original_index: 370
-      status: 1
-    - original_index: 371
-      status: 0
-    - original_index: 372
-      status: 2
-    - original_index: 373
-      status: 2
-    - original_index: 374
-      status: 0
-    - original_index: 375
-      status: 4
-    - original_index: 376
-      status: 3
-    - original_index: 377
-      status: 0
-    - original_index: 378
-      status: 2
-    - original_index: 379
-      status: 3
-    - original_index: 380
-      status: 1
-    - original_index: 381
-      status: 4
-    - original_index: 382
-      status: 4
-    - original_index: 383
-      status: 2
-    - original_index: 384
-      status: 4
-    - original_index: 385
-      status: 0
-    - original_index: 386
-      status: 0
-    - original_index: 387
-      status: 2
-    - original_index: 388
-      status: 1
-    - original_index: 389
-      status: 4
-    - original_index: 390
-      status: 3
-    - original_index: 391
-      status: 4
-    - original_index: 392
-      status: 2
-    - original_index: 393
-      status: 1
-    - original_index: 394
-      status: 3
-    - original_index: 395
-      status: 4
-    - original_index: 396
-      status: 2
-    - original_index: 397
-      status: 4
-    - original_index: 398
-      status: 0
-    - original_index: 399
-      status: 4
-    - original_index: 400
-      status: 4
-    - original_index: 401
-      status: 2
-    - original_index: 402
-      status: 3
-    - original_index: 403
-      status: 0
-    - original_index: 404
-      status: 2
-    - original_index: 405
-      status: 4
-    - original_index: 406
-      status: 4
-    - original_index: 407
-      status: 1
-    - original_index: 408
-      status: 0
-    - original_index: 409
-      status: 2
-    - original_index: 410
-      status: 1
-    - original_index: 411
-      status: 3
-    - original_index: 412
-      status: 3
-    - original_index: 413
-      status: 4
-    - original_index: 414
-      status: 2
-    - original_index: 415
-      status: 2
-    - original_index: 416
-      status: 0
-    - original_index: 417
-      status: 1
-    - original_index: 418
-      status: 0
-    - original_index: 419
-      status: 1
-    - original_index: 420
-      status: 2
-    - original_index: 421
-      status: 4
-    - original_index: 422
-      status: 2
-    - original_index: 423
-      status: 0
-    - original_index: 424
-      status: 3
-    - original_index: 425
-      status: 1
-    - original_index: 426
-      status: 2
-    - original_index: 427
-      status: 4
-    - original_index: 428
-      status: 4
-    - original_index: 429
-      status: 2
-    - original_index: 430
-      status: 4
-    - original_index: 431
-      status: 2
-    - original_index: 432
-      status: 1
-    - original_index: 433
-      status: 0
-    - original_index: 434
-      status: 3
-    - original_index: 435
-      status: 3
-    - original_index: 436
-      status: 0
-    - original_index: 437
-      status: 1
-    - original_index: 438
-      status: 0
-    - original_index: 439
-      status: 1
-    - original_index: 440
-      status: 1
-    - original_index: 441
-      status: 1
-    - original_index: 442
-      status: 3
-    - original_index: 443
-      status: 3
-    - original_index: 444
-      status: 0
-    - original_index: 445
-      status: 0
-    - original_index: 446
-      status: 4
-    - original_index: 447
-      status: 4
-    - original_index: 448
-      status: 0
-    - original_index: 449
-      status: 2
-    - original_index: 450
-      status: 4
-    - original_index: 451
-      status: 2
-    - original_index: 452
-      status: 4
-    - original_index: 453
-      status: 3
-    - original_index: 454
-      status: 2
-    - original_index: 455
-      status: 2
-    - original_index: 456
-      status: 0
-    - original_index: 457
-      status: 1
-    - original_index: 458
-      status: 1
-    - original_index: 459
-      status: 3
-    - original_index: 460
-      status: 3
-    - original_index: 461
-      status: 2
-    - original_index: 462
-      status: 1
-    - original_index: 463
-      status: 4
-    - original_index: 464
-      status: 0
-    - original_index: 465
-      status: 0
-    - original_index: 466
-      status: 1
-    - original_index: 467
-      status: 0
+    - {original_index: 0, status: 3}
+    - {original_index: 1, status: 2}
+    - {original_index: 2, status: 4}
+    - {original_index: 3, status: 4}
+    - {original_index: 4, status: 3}
+    - {original_index: 5, status: 1}
+    - {original_index: 6, status: 0}
+    - {original_index: 7, status: 4}
+    - {original_index: 8, status: 3}
+    - {original_index: 9, status: 3}
+    - {original_index: 10, status: 3}
+    - {original_index: 11, status: 3}
+    - {original_index: 12, status: 4}
+    - {original_index: 13, status: 2}
+    - {original_index: 14, status: 1}
+    - {original_index: 15, status: 1}
+    - {original_index: 16, status: 3}
+    - {original_index: 17, status: 4}
+    - {original_index: 18, status: 1}
+    - {original_index: 19, status: 1}
+    - {original_index: 20, status: 3}
+    - {original_index: 21, status: 0}
+    - {original_index: 22, status: 4}
+    - {original_index: 23, status: 0}
+    - {original_index: 24, status: 2}
+    - {original_index: 25, status: 4}
+    - {original_index: 26, status: 1}
+    - {original_index: 27, status: 1}
+    - {original_index: 28, status: 3}
+    - {original_index: 29, status: 4}
+    - {original_index: 30, status: 1}
+    - {original_index: 31, status: 0}
+    - {original_index: 32, status: 2}
+    - {original_index: 33, status: 3}
+    - {original_index: 34, status: 4}
+    - {original_index: 35, status: 2}
+    - {original_index: 36, status: 2}
+    - {original_index: 37, status: 4}
+    - {original_index: 38, status: 1}
+    - {original_index: 39, status: 4}
+    - {original_index: 40, status: 4}
+    - {original_index: 41, status: 2}
+    - {original_index: 42, status: 0}
+    - {original_index: 43, status: 2}
+    - {original_index: 44, status: 4}
+    - {original_index: 45, status: 0}
+    - {original_index: 46, status: 1}
+    - {original_index: 47, status: 4}
+    - {original_index: 48, status: 0}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 1}
+    - {original_index: 51, status: 3}
+    - {original_index: 52, status: 0}
+    - {original_index: 53, status: 3}
+    - {original_index: 54, status: 0}
+    - {original_index: 55, status: 2}
+    - {original_index: 56, status: 2}
+    - {original_index: 57, status: 3}
+    - {original_index: 58, status: 4}
+    - {original_index: 59, status: 3}
+    - {original_index: 60, status: 0}
+    - {original_index: 61, status: 1}
+    - {original_index: 62, status: 0}
+    - {original_index: 63, status: 0}
+    - {original_index: 64, status: 3}
+    - {original_index: 65, status: 4}
+    - {original_index: 66, status: 1}
+    - {original_index: 67, status: 0}
+    - {original_index: 68, status: 3}
+    - {original_index: 69, status: 2}
+    - {original_index: 70, status: 3}
+    - {original_index: 71, status: 4}
+    - {original_index: 72, status: 3}
+    - {original_index: 73, status: 1}
+    - {original_index: 74, status: 0}
+    - {original_index: 75, status: 4}
+    - {original_index: 76, status: 0}
+    - {original_index: 77, status: 3}
+    - {original_index: 78, status: 4}
+    - {original_index: 79, status: 3}
+    - {original_index: 80, status: 3}
+    - {original_index: 81, status: 0}
+    - {original_index: 82, status: 3}
+    - {original_index: 83, status: 1}
+    - {original_index: 84, status: 4}
+    - {original_index: 85, status: 0}
+    - {original_index: 86, status: 2}
+    - {original_index: 87, status: 1}
+    - {original_index: 88, status: 4}
+    - {original_index: 89, status: 4}
+    - {original_index: 90, status: 4}
+    - {original_index: 91, status: 3}
+    - {original_index: 92, status: 3}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 4}
+    - {original_index: 95, status: 3}
+    - {original_index: 96, status: 2}
+    - {original_index: 97, status: 2}
+    - {original_index: 98, status: 2}
+    - {original_index: 99, status: 3}
+    - {original_index: 100, status: 2}
+    - {original_index: 101, status: 2}
+    - {original_index: 102, status: 1}
+    - {original_index: 103, status: 2}
+    - {original_index: 104, status: 3}
+    - {original_index: 105, status: 3}
+    - {original_index: 106, status: 3}
+    - {original_index: 107, status: 0}
+    - {original_index: 108, status: 3}
+    - {original_index: 109, status: 2}
+    - {original_index: 110, status: 1}
+    - {original_index: 111, status: 4}
+    - {original_index: 112, status: 3}
+    - {original_index: 113, status: 4}
+    - {original_index: 114, status: 2}
+    - {original_index: 115, status: 4}
+    - {original_index: 116, status: 0}
+    - {original_index: 117, status: 1}
+    - {original_index: 118, status: 2}
+    - {original_index: 119, status: 1}
+    - {original_index: 120, status: 0}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 3}
+    - {original_index: 124, status: 3}
+    - {original_index: 125, status: 3}
+    - {original_index: 126, status: 1}
+    - {original_index: 127, status: 4}
+    - {original_index: 128, status: 2}
+    - {original_index: 129, status: 1}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 1}
+    - {original_index: 132, status: 0}
+    - {original_index: 133, status: 3}
+    - {original_index: 134, status: 3}
+    - {original_index: 135, status: 4}
+    - {original_index: 136, status: 3}
+    - {original_index: 137, status: 1}
+    - {original_index: 138, status: 1}
+    - {original_index: 139, status: 1}
+    - {original_index: 140, status: 3}
+    - {original_index: 141, status: 1}
+    - {original_index: 142, status: 3}
+    - {original_index: 143, status: 2}
+    - {original_index: 144, status: 4}
+    - {original_index: 145, status: 2}
+    - {original_index: 146, status: 2}
+    - {original_index: 147, status: 0}
+    - {original_index: 148, status: 3}
+    - {original_index: 149, status: 3}
+    - {original_index: 150, status: 1}
+    - {original_index: 151, status: 0}
+    - {original_index: 152, status: 2}
+    - {original_index: 153, status: 0}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 1}
+    - {original_index: 156, status: 2}
+    - {original_index: 157, status: 0}
+    - {original_index: 158, status: 3}
+    - {original_index: 159, status: 2}
+    - {original_index: 160, status: 2}
+    - {original_index: 161, status: 3}
+    - {original_index: 162, status: 1}
+    - {original_index: 163, status: 0}
+    - {original_index: 164, status: 3}
+    - {original_index: 165, status: 3}
+    - {original_index: 166, status: 0}
+    - {original_index: 167, status: 1}
+    - {original_index: 168, status: 0}
+    - {original_index: 169, status: 1}
+    - {original_index: 170, status: 0}
+    - {original_index: 171, status: 0}
+    - {original_index: 172, status: 2}
+    - {original_index: 173, status: 2}
+    - {original_index: 174, status: 3}
+    - {original_index: 175, status: 0}
+    - {original_index: 176, status: 4}
+    - {original_index: 177, status: 1}
+    - {original_index: 178, status: 4}
+    - {original_index: 179, status: 1}
+    - {original_index: 180, status: 1}
+    - {original_index: 181, status: 3}
+    - {original_index: 182, status: 2}
+    - {original_index: 183, status: 2}
+    - {original_index: 184, status: 1}
+    - {original_index: 185, status: 0}
+    - {original_index: 186, status: 3}
+    - {original_index: 187, status: 2}
+    - {original_index: 188, status: 0}
+    - {original_index: 189, status: 1}
+    - {original_index: 190, status: 0}
+    - {original_index: 191, status: 2}
+    - {original_index: 192, status: 2}
+    - {original_index: 193, status: 0}
+    - {original_index: 194, status: 2}
+    - {original_index: 195, status: 1}
+    - {original_index: 196, status: 0}
+    - {original_index: 197, status: 1}
+    - {original_index: 198, status: 0}
+    - {original_index: 199, status: 0}
+    - {original_index: 200, status: 3}
+    - {original_index: 201, status: 1}
+    - {original_index: 202, status: 1}
+    - {original_index: 203, status: 2}
+    - {original_index: 204, status: 3}
+    - {original_index: 205, status: 0}
+    - {original_index: 206, status: 0}
+    - {original_index: 207, status: 3}
+    - {original_index: 208, status: 1}
+    - {original_index: 209, status: 2}
+    - {original_index: 210, status: 3}
+    - {original_index: 211, status: 1}
+    - {original_index: 212, status: 3}
+    - {original_index: 213, status: 3}
+    - {original_index: 214, status: 3}
+    - {original_index: 215, status: 4}
+    - {original_index: 216, status: 4}
+    - {original_index: 217, status: 2}
+    - {original_index: 218, status: 4}
+    - {original_index: 219, status: 3}
+    - {original_index: 220, status: 1}
+    - {original_index: 221, status: 2}
+    - {original_index: 222, status: 1}
+    - {original_index: 223, status: 4}
+    - {original_index: 224, status: 3}
+    - {original_index: 225, status: 4}
+    - {original_index: 226, status: 4}
+    - {original_index: 227, status: 3}
+    - {original_index: 228, status: 0}
+    - {original_index: 229, status: 3}
+    - {original_index: 230, status: 4}
+    - {original_index: 231, status: 2}
+    - {original_index: 232, status: 3}
+    - {original_index: 233, status: 3}
+    - {original_index: 234, status: 2}
+    - {original_index: 235, status: 4}
+    - {original_index: 236, status: 3}
+    - {original_index: 237, status: 2}
+    - {original_index: 238, status: 4}
+    - {original_index: 239, status: 1}
+    - {original_index: 240, status: 4}
+    - {original_index: 241, status: 2}
+    - {original_index: 242, status: 1}
+    - {original_index: 243, status: 3}
+    - {original_index: 244, status: 4}
+    - {original_index: 245, status: 0}
+    - {original_index: 246, status: 1}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 0}
+    - {original_index: 249, status: 0}
+    - {original_index: 250, status: 1}
+    - {original_index: 251, status: 2}
+    - {original_index: 252, status: 0}
+    - {original_index: 253, status: 4}
+    - {original_index: 254, status: 0}
+    - {original_index: 255, status: 2}
+    - {original_index: 256, status: 4}
+    - {original_index: 257, status: 3}
+    - {original_index: 258, status: 1}
+    - {original_index: 259, status: 0}
+    - {original_index: 260, status: 0}
+    - {original_index: 261, status: 1}
+    - {original_index: 262, status: 4}
+    - {original_index: 263, status: 3}
+    - {original_index: 264, status: 2}
+    - {original_index: 265, status: 4}
+    - {original_index: 266, status: 0}
+    - {original_index: 267, status: 2}
+    - {original_index: 268, status: 3}
+    - {original_index: 269, status: 1}
+    - {original_index: 270, status: 4}
+    - {original_index: 271, status: 0}
+    - {original_index: 272, status: 2}
+    - {original_index: 273, status: 2}
+    - {original_index: 274, status: 1}
+    - {original_index: 275, status: 0}
+    - {original_index: 276, status: 0}
+    - {original_index: 277, status: 2}
+    - {original_index: 278, status: 0}
+    - {original_index: 279, status: 2}
+    - {original_index: 280, status: 0}
+    - {original_index: 281, status: 3}
+    - {original_index: 282, status: 3}
+    - {original_index: 283, status: 3}
+    - {original_index: 284, status: 0}
+    - {original_index: 285, status: 2}
+    - {original_index: 286, status: 2}
+    - {original_index: 287, status: 4}
+    - {original_index: 288, status: 2}
+    - {original_index: 289, status: 3}
+    - {original_index: 290, status: 3}
+    - {original_index: 291, status: 1}
+    - {original_index: 292, status: 2}
+    - {original_index: 293, status: 1}
+    - {original_index: 294, status: 3}
+    - {original_index: 295, status: 1}
+    - {original_index: 296, status: 0}
+    - {original_index: 297, status: 2}
+    - {original_index: 298, status: 3}
+    - {original_index: 299, status: 0}
+    - {original_index: 300, status: 3}
+    - {original_index: 301, status: 0}
+    - {original_index: 302, status: 4}
+    - {original_index: 303, status: 4}
+    - {original_index: 304, status: 4}
+    - {original_index: 305, status: 3}
+    - {original_index: 306, status: 4}
+    - {original_index: 307, status: 0}
+    - {original_index: 308, status: 2}
+    - {original_index: 309, status: 3}
+    - {original_index: 310, status: 3}
+    - {original_index: 311, status: 3}
+    - {original_index: 312, status: 4}
+    - {original_index: 313, status: 4}
+    - {original_index: 314, status: 0}
+    - {original_index: 315, status: 4}
+    - {original_index: 316, status: 4}
+    - {original_index: 317, status: 1}
+    - {original_index: 318, status: 0}
+    - {original_index: 319, status: 2}
+    - {original_index: 320, status: 3}
+    - {original_index: 321, status: 4}
+    - {original_index: 322, status: 2}
+    - {original_index: 323, status: 3}
+    - {original_index: 324, status: 3}
+    - {original_index: 325, status: 3}
+    - {original_index: 326, status: 4}
+    - {original_index: 327, status: 4}
+    - {original_index: 328, status: 1}
+    - {original_index: 329, status: 1}
+    - {original_index: 330, status: 0}
+    - {original_index: 331, status: 0}
+    - {original_index: 332, status: 4}
+    - {original_index: 333, status: 4}
+    - {original_index: 334, status: 1}
+    - {original_index: 335, status: 3}
+    - {original_index: 336, status: 0}
+    - {original_index: 337, status: 2}
+    - {original_index: 338, status: 2}
+    - {original_index: 339, status: 1}
+    - {original_index: 340, status: 2}
+    - {original_index: 341, status: 4}
+    - {original_index: 342, status: 2}
+    - {original_index: 343, status: 0}
+    - {original_index: 344, status: 1}
+    - {original_index: 345, status: 3}
+    - {original_index: 346, status: 2}
+    - {original_index: 347, status: 0}
+    - {original_index: 348, status: 2}
+    - {original_index: 349, status: 2}
+    - {original_index: 350, status: 3}
+    - {original_index: 351, status: 3}
+    - {original_index: 352, status: 3}
+    - {original_index: 353, status: 2}
+    - {original_index: 354, status: 3}
+    - {original_index: 355, status: 0}
+    - {original_index: 356, status: 4}
+    - {original_index: 357, status: 1}
+    - {original_index: 358, status: 2}
+    - {original_index: 359, status: 4}
+    - {original_index: 360, status: 0}
+    - {original_index: 361, status: 1}
+    - {original_index: 362, status: 1}
+    - {original_index: 363, status: 3}
+    - {original_index: 364, status: 3}
+    - {original_index: 365, status: 3}
+    - {original_index: 366, status: 4}
+    - {original_index: 367, status: 3}
+    - {original_index: 368, status: 3}
+    - {original_index: 369, status: 2}
+    - {original_index: 370, status: 1}
+    - {original_index: 371, status: 0}
+    - {original_index: 372, status: 2}
+    - {original_index: 373, status: 2}
+    - {original_index: 374, status: 0}
+    - {original_index: 375, status: 4}
+    - {original_index: 376, status: 3}
+    - {original_index: 377, status: 0}
+    - {original_index: 378, status: 2}
+    - {original_index: 379, status: 3}
+    - {original_index: 380, status: 1}
+    - {original_index: 381, status: 4}
+    - {original_index: 382, status: 4}
+    - {original_index: 383, status: 2}
+    - {original_index: 384, status: 4}
+    - {original_index: 385, status: 0}
+    - {original_index: 386, status: 0}
+    - {original_index: 387, status: 2}
+    - {original_index: 388, status: 1}
+    - {original_index: 389, status: 4}
+    - {original_index: 390, status: 3}
+    - {original_index: 391, status: 4}
+    - {original_index: 392, status: 2}
+    - {original_index: 393, status: 1}
+    - {original_index: 394, status: 3}
+    - {original_index: 395, status: 4}
+    - {original_index: 396, status: 2}
+    - {original_index: 397, status: 4}
+    - {original_index: 398, status: 0}
+    - {original_index: 399, status: 4}
+    - {original_index: 400, status: 4}
+    - {original_index: 401, status: 2}
+    - {original_index: 402, status: 3}
+    - {original_index: 403, status: 0}
+    - {original_index: 404, status: 2}
+    - {original_index: 405, status: 4}
+    - {original_index: 406, status: 4}
+    - {original_index: 407, status: 1}
+    - {original_index: 408, status: 0}
+    - {original_index: 409, status: 2}
+    - {original_index: 410, status: 1}
+    - {original_index: 411, status: 3}
+    - {original_index: 412, status: 3}
+    - {original_index: 413, status: 4}
+    - {original_index: 414, status: 2}
+    - {original_index: 415, status: 2}
+    - {original_index: 416, status: 0}
+    - {original_index: 417, status: 1}
+    - {original_index: 418, status: 0}
+    - {original_index: 419, status: 1}
+    - {original_index: 420, status: 2}
+    - {original_index: 421, status: 4}
+    - {original_index: 422, status: 2}
+    - {original_index: 423, status: 0}
+    - {original_index: 424, status: 3}
+    - {original_index: 425, status: 1}
+    - {original_index: 426, status: 2}
+    - {original_index: 427, status: 4}
+    - {original_index: 428, status: 4}
+    - {original_index: 429, status: 2}
+    - {original_index: 430, status: 4}
+    - {original_index: 431, status: 2}
+    - {original_index: 432, status: 1}
+    - {original_index: 433, status: 0}
+    - {original_index: 434, status: 3}
+    - {original_index: 435, status: 3}
+    - {original_index: 436, status: 0}
+    - {original_index: 437, status: 1}
+    - {original_index: 438, status: 0}
+    - {original_index: 439, status: 1}
+    - {original_index: 440, status: 1}
+    - {original_index: 441, status: 1}
+    - {original_index: 442, status: 3}
+    - {original_index: 443, status: 3}
+    - {original_index: 444, status: 0}
+    - {original_index: 445, status: 0}
+    - {original_index: 446, status: 4}
+    - {original_index: 447, status: 4}
+    - {original_index: 448, status: 0}
+    - {original_index: 449, status: 2}
+    - {original_index: 450, status: 4}
+    - {original_index: 451, status: 2}
+    - {original_index: 452, status: 4}
+    - {original_index: 453, status: 3}
+    - {original_index: 454, status: 2}
+    - {original_index: 455, status: 2}
+    - {original_index: 456, status: 0}
+    - {original_index: 457, status: 1}
+    - {original_index: 458, status: 1}
+    - {original_index: 459, status: 3}
+    - {original_index: 460, status: 3}
+    - {original_index: 461, status: 2}
+    - {original_index: 462, status: 1}
+    - {original_index: 463, status: 4}
+    - {original_index: 464, status: 0}
+    - {original_index: 465, status: 0}
+    - {original_index: 466, status: 1}
+    - {original_index: 467, status: 0}
   output:
-  - - committee:
-      - 202
-      - 39
+  - - committee: [202, 39]
       shard: 102
       total_validator_count: 173
-  - - committee:
-      - 384
-      - 417
-      - 46
+  - - committee: [384, 417, 46]
       shard: 103
       total_validator_count: 173
-  - - committee:
-      - 119
-      - 235
-      - 400
+  - - committee: [119, 235, 400]
       shard: 104
       total_validator_count: 173
-  - - committee:
-      - 84
-      - 457
+  - - committee: [84, 457]
       shard: 105
       total_validator_count: 173
-  - - committee:
-      - 381
-      - 184
-      - 61
+  - - committee: [381, 184, 61]
       shard: 106
       total_validator_count: 173
-  - - committee:
-      - 19
-      - 291
-      - 391
+  - - committee: [19, 291, 391]
       shard: 107
       total_validator_count: 173
-  - - committee:
-      - 65
-      - 370
+  - - committee: [65, 370]
       shard: 108
       total_validator_count: 173
-  - - committee:
-      - 102
-      - 246
-      - 362
+  - - committee: [102, 246, 362]
       shard: 109
       total_validator_count: 173
-  - - committee:
-      - 113
-      - 44
-      - 58
+  - - committee: [113, 44, 58]
       shard: 110
       total_validator_count: 173
-  - - committee:
-      - 293
-      - 446
-      - 162
+  - - committee: [293, 446, 162]
       shard: 111
       total_validator_count: 173
-  - - committee:
-      - 427
-      - 262
+  - - committee: [427, 262]
       shard: 112
       total_validator_count: 173
-  - - committee:
-      - 216
-      - 393
-      - 447
+  - - committee: [216, 393, 447]
       shard: 113
       total_validator_count: 173
-  - - committee:
-      - 397
-      - 2
-      - 27
+  - - committee: [397, 2, 27]
       shard: 114
       total_validator_count: 173
-  - - committee:
-      - 425
-      - 265
+  - - committee: [425, 265]
       shard: 115
       total_validator_count: 173
-  - - committee:
-      - 389
-      - 223
-      - 180
+  - - committee: [389, 223, 180]
       shard: 116
       total_validator_count: 173
-  - - committee:
-      - 287
-      - 154
-      - 115
+  - - committee: [287, 154, 115]
       shard: 117
       total_validator_count: 173
-  - - committee:
-      - 304
-      - 90
+  - - committee: [304, 90]
       shard: 118
       total_validator_count: 173
-  - - committee:
-      - 244
-      - 250
-      - 117
+  - - committee: [244, 250, 117]
       shard: 119
       total_validator_count: 173
-  - - committee:
-      - 110
-      - 239
-      - 155
+  - - committee: [110, 239, 155]
       shard: 120
       total_validator_count: 173
-  - - committee:
-      - 17
-      - 178
-      - 189
+  - - committee: [17, 178, 189]
       shard: 121
       total_validator_count: 173
-  - - committee:
-      - 240
-      - 225
+  - - committee: [240, 225]
       shard: 122
       total_validator_count: 173
-  - - committee:
-      - 3
-      - 356
-      - 357
+  - - committee: [3, 356, 357]
       shard: 123
       total_validator_count: 173
-  - - committee:
-      - 261
-      - 407
-      - 208
+  - - committee: [261, 407, 208]
       shard: 124
       total_validator_count: 173
-  - - committee:
-      - 7
-      - 270
+  - - committee: [7, 270]
       shard: 125
       total_validator_count: 173
-  - - committee:
-      - 25
-      - 274
-      - 14
+  - - committee: [25, 274, 14]
       shard: 126
       total_validator_count: 173
-  - - committee:
-      - 321
-      - 312
-      - 333
+  - - committee: [321, 312, 333]
       shard: 127
       total_validator_count: 173
-  - - committee:
-      - 135
-      - 344
+  - - committee: [135, 344]
       shard: 128
       total_validator_count: 173
-  - - committee:
-      - 332
-      - 326
-      - 126
+  - - committee: [332, 326, 126]
       shard: 129
       total_validator_count: 173
-  - - committee:
-      - 195
-      - 226
-      - 71
+  - - committee: [195, 226, 71]
       shard: 130
       total_validator_count: 173
-  - - committee:
-      - 87
-      - 306
-      - 139
+  - - committee: [87, 306, 139]
       shard: 131
       total_validator_count: 173
-  - - committee:
-      - 395
-      - 256
+  - - committee: [395, 256]
       shard: 132
       total_validator_count: 173
-  - - committee:
-      - 258
-      - 405
-      - 359
+  - - committee: [258, 405, 359]
       shard: 133
       total_validator_count: 173
-  - - committee:
-      - 419
-      - 253
-      - 47
+  - - committee: [419, 253, 47]
       shard: 134
       total_validator_count: 173
-  - - committee:
-      - 269
-      - 220
+  - - committee: [269, 220]
       shard: 135
       total_validator_count: 173
-  - - committee:
-      - 421
-      - 138
-      - 66
+  - - committee: [421, 138, 66]
       shard: 136
       total_validator_count: 173
-  - - committee:
-      - 222
-      - 78
-      - 75
+  - - committee: [222, 78, 75]
       shard: 137
       total_validator_count: 173
-  - - committee:
-      - 366
-      - 458
-      - 430
+  - - committee: [366, 458, 430]
       shard: 138
       total_validator_count: 173
-  - - committee:
-      - 334
-      - 26
+  - - committee: [334, 26]
       shard: 139
       total_validator_count: 173
-  - - committee:
-      - 169
-      - 137
-      - 327
+  - - committee: [169, 137, 327]
       shard: 140
       total_validator_count: 173
-  - - committee:
-      - 452
-      - 130
-      - 89
+  - - committee: [452, 130, 89]
       shard: 141
       total_validator_count: 173
-  - - committee:
-      - 450
-      - 131
+  - - committee: [450, 131]
       shard: 142
       total_validator_count: 173
-  - - committee:
-      - 328
-      - 218
-      - 230
+  - - committee: [328, 218, 230]
       shard: 143
       total_validator_count: 173
-  - - committee:
-      - 176
-      - 466
-      - 167
+  - - committee: [176, 466, 167]
       shard: 144
       total_validator_count: 173
-  - - committee:
-      - 179
-      - 30
+  - - committee: [179, 30]
       shard: 145
       total_validator_count: 173
-  - - committee:
-      - 329
-      - 341
-      - 50
+  - - committee: [329, 341, 50]
       shard: 146
       total_validator_count: 173
-  - - committee:
-      - 238
-      - 463
-      - 215
+  - - committee: [238, 463, 215]
       shard: 147
       total_validator_count: 173
-  - - committee:
-      - 440
-      - 141
-      - 111
+  - - committee: [440, 141, 111]
       shard: 148
       total_validator_count: 173
-  - - committee:
-      - 303
-      - 439
+  - - committee: [303, 439]
       shard: 149
       total_validator_count: 173
-  - - committee:
-      - 315
-      - 410
-      - 38
+  - - committee: [315, 410, 38]
       shard: 150
       total_validator_count: 173
-  - - committee:
-      - 382
-      - 94
-      - 29
+  - - committee: [382, 94, 29]
       shard: 151
       total_validator_count: 173
-  - - committee:
-      - 150
-      - 12
+  - - committee: [150, 12]
       shard: 152
       total_validator_count: 173
-  - - committee:
-      - 437
-      - 15
-      - 428
+  - - committee: [437, 15, 428]
       shard: 153
       total_validator_count: 173
-  - - committee:
-      - 83
-      - 40
-      - 302
+  - - committee: [83, 40, 302]
       shard: 154
       total_validator_count: 173
-  - - committee:
-      - 413
-      - 201
+  - - committee: [413, 201]
       shard: 155
       total_validator_count: 173
-  - - committee:
-      - 399
-      - 129
-      - 197
+  - - committee: [399, 129, 197]
       shard: 156
       total_validator_count: 173
-  - - committee:
-      - 5
-      - 388
-      - 295
+  - - committee: [5, 388, 295]
       shard: 157
       total_validator_count: 173
-  - - committee:
-      - 375
-      - 34
-      - 462
+  - - committee: [375, 34, 462]
       shard: 158
       total_validator_count: 173
-  - - committee:
-      - 73
-      - 127
+  - - committee: [73, 127]
       shard: 159
       total_validator_count: 173
-  - - committee:
-      - 177
-      - 406
-      - 313
+  - - committee: [177, 406, 313]
       shard: 160
       total_validator_count: 173
-  - - committee:
-      - 144
-      - 432
-      - 339
+  - - committee: [144, 432, 339]
       shard: 161
       total_validator_count: 173
-  - - committee:
-      - 361
-      - 37
+  - - committee: [361, 37]
       shard: 162
       total_validator_count: 173
-  - - committee:
-      - 316
-      - 88
-      - 22
+  - - committee: [316, 88, 22]
       shard: 163
       total_validator_count: 173
-  - - committee:
-      - 18
-      - 317
-      - 242
+  - - committee: [18, 317, 242]
       shard: 164
       total_validator_count: 173
-  - - committee:
-      - 380
-      - 211
-      - 441
+  - - committee: [380, 211, 441]
       shard: 165
       total_validator_count: 173
   seed: '0xadb35f3fc2880d220e520120a032bbaa0f4bd7a5fcf1c2269de21075e7a46471'
 - input:
     crosslinking_start_shard: 133
     validators:
-    - original_index: 0
-      status: 2
-    - original_index: 1
-      status: 0
-    - original_index: 2
-      status: 4
-    - original_index: 3
-      status: 2
-    - original_index: 4
-      status: 4
-    - original_index: 5
-      status: 2
-    - original_index: 6
-      status: 0
-    - original_index: 7
-      status: 3
-    - original_index: 8
-      status: 1
-    - original_index: 9
-      status: 0
-    - original_index: 10
-      status: 2
-    - original_index: 11
-      status: 1
-    - original_index: 12
-      status: 0
-    - original_index: 13
-      status: 3
-    - original_index: 14
-      status: 2
-    - original_index: 15
-      status: 2
-    - original_index: 16
-      status: 0
-    - original_index: 17
-      status: 0
-    - original_index: 18
-      status: 3
-    - original_index: 19
-      status: 4
-    - original_index: 20
-      status: 1
-    - original_index: 21
-      status: 2
-    - original_index: 22
-      status: 4
-    - original_index: 23
-      status: 0
-    - original_index: 24
-      status: 0
-    - original_index: 25
-      status: 0
-    - original_index: 26
-      status: 2
-    - original_index: 27
-      status: 3
-    - original_index: 28
-      status: 0
-    - original_index: 29
-      status: 3
-    - original_index: 30
-      status: 4
-    - original_index: 31
-      status: 1
-    - original_index: 32
-      status: 0
-    - original_index: 33
-      status: 1
-    - original_index: 34
-      status: 4
-    - original_index: 35
-      status: 0
-    - original_index: 36
-      status: 3
-    - original_index: 37
-      status: 0
-    - original_index: 38
-      status: 4
-    - original_index: 39
-      status: 1
-    - original_index: 40
-      status: 0
-    - original_index: 41
-      status: 3
-    - original_index: 42
-      status: 2
-    - original_index: 43
-      status: 3
-    - original_index: 44
-      status: 4
-    - original_index: 45
-      status: 0
-    - original_index: 46
-      status: 3
-    - original_index: 47
-      status: 3
-    - original_index: 48
-      status: 4
-    - original_index: 49
-      status: 3
-    - original_index: 50
-      status: 3
-    - original_index: 51
-      status: 4
-    - original_index: 52
-      status: 1
-    - original_index: 53
-      status: 3
-    - original_index: 54
-      status: 3
-    - original_index: 55
-      status: 1
-    - original_index: 56
-      status: 0
-    - original_index: 57
-      status: 0
-    - original_index: 58
-      status: 0
-    - original_index: 59
-      status: 0
-    - original_index: 60
-      status: 2
-    - original_index: 61
-      status: 2
-    - original_index: 62
-      status: 1
-    - original_index: 63
-      status: 3
-    - original_index: 64
-      status: 4
-    - original_index: 65
-      status: 4
-    - original_index: 66
-      status: 4
-    - original_index: 67
-      status: 3
-    - original_index: 68
-      status: 3
-    - original_index: 69
-      status: 3
-    - original_index: 70
-      status: 4
-    - original_index: 71
-      status: 3
-    - original_index: 72
-      status: 3
-    - original_index: 73
-      status: 1
-    - original_index: 74
-      status: 2
-    - original_index: 75
-      status: 3
-    - original_index: 76
-      status: 2
-    - original_index: 77
-      status: 3
-    - original_index: 78
-      status: 3
-    - original_index: 79
-      status: 3
-    - original_index: 80
-      status: 2
-    - original_index: 81
-      status: 2
-    - original_index: 82
-      status: 2
-    - original_index: 83
-      status: 4
-    - original_index: 84
-      status: 0
-    - original_index: 85
-      status: 0
-    - original_index: 86
-      status: 1
-    - original_index: 87
-      status: 2
-    - original_index: 88
-      status: 2
-    - original_index: 89
-      status: 4
-    - original_index: 90
-      status: 4
-    - original_index: 91
-      status: 4
-    - original_index: 92
-      status: 2
-    - original_index: 93
-      status: 0
-    - original_index: 94
-      status: 4
-    - original_index: 95
-      status: 0
-    - original_index: 96
-      status: 1
-    - original_index: 97
-      status: 1
-    - original_index: 98
-      status: 4
-    - original_index: 99
-      status: 3
-    - original_index: 100
-      status: 4
-    - original_index: 101
-      status: 4
-    - original_index: 102
-      status: 3
-    - original_index: 103
-      status: 4
-    - original_index: 104
-      status: 0
-    - original_index: 105
-      status: 1
-    - original_index: 106
-      status: 0
-    - original_index: 107
-      status: 1
-    - original_index: 108
-      status: 1
-    - original_index: 109
-      status: 3
-    - original_index: 110
-      status: 3
-    - original_index: 111
-      status: 0
-    - original_index: 112
-      status: 0
-    - original_index: 113
-      status: 0
-    - original_index: 114
-      status: 1
-    - original_index: 115
-      status: 3
-    - original_index: 116
-      status: 2
-    - original_index: 117
-      status: 0
-    - original_index: 118
-      status: 0
-    - original_index: 119
-      status: 4
-    - original_index: 120
-      status: 2
-    - original_index: 121
-      status: 1
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 4
-    - original_index: 124
-      status: 3
-    - original_index: 125
-      status: 0
-    - original_index: 126
-      status: 4
-    - original_index: 127
-      status: 0
-    - original_index: 128
-      status: 0
-    - original_index: 129
-      status: 0
-    - original_index: 130
-      status: 3
-    - original_index: 131
-      status: 0
-    - original_index: 132
-      status: 4
-    - original_index: 133
-      status: 1
-    - original_index: 134
-      status: 1
-    - original_index: 135
-      status: 1
-    - original_index: 136
-      status: 4
-    - original_index: 137
-      status: 1
-    - original_index: 138
-      status: 0
-    - original_index: 139
-      status: 3
-    - original_index: 140
-      status: 2
-    - original_index: 141
-      status: 4
-    - original_index: 142
-      status: 2
-    - original_index: 143
-      status: 0
-    - original_index: 144
-      status: 4
-    - original_index: 145
-      status: 2
-    - original_index: 146
-      status: 3
-    - original_index: 147
-      status: 4
-    - original_index: 148
-      status: 1
-    - original_index: 149
-      status: 1
-    - original_index: 150
-      status: 0
-    - original_index: 151
-      status: 1
-    - original_index: 152
-      status: 3
-    - original_index: 153
-      status: 2
-    - original_index: 154
-      status: 2
-    - original_index: 155
-      status: 2
-    - original_index: 156
-      status: 3
-    - original_index: 157
-      status: 0
-    - original_index: 158
-      status: 3
-    - original_index: 159
-      status: 0
-    - original_index: 160
-      status: 1
-    - original_index: 161
-      status: 0
-    - original_index: 162
-      status: 2
-    - original_index: 163
-      status: 0
-    - original_index: 164
-      status: 2
-    - original_index: 165
-      status: 1
-    - original_index: 166
-      status: 1
-    - original_index: 167
-      status: 4
-    - original_index: 168
-      status: 1
-    - original_index: 169
-      status: 2
-    - original_index: 170
-      status: 4
-    - original_index: 171
-      status: 1
-    - original_index: 172
-      status: 1
-    - original_index: 173
-      status: 4
-    - original_index: 174
-      status: 0
-    - original_index: 175
-      status: 3
-    - original_index: 176
-      status: 2
-    - original_index: 177
-      status: 3
-    - original_index: 178
-      status: 0
-    - original_index: 179
-      status: 4
-    - original_index: 180
-      status: 1
-    - original_index: 181
-      status: 0
-    - original_index: 182
-      status: 0
-    - original_index: 183
-      status: 0
-    - original_index: 184
-      status: 4
-    - original_index: 185
-      status: 1
-    - original_index: 186
-      status: 3
-    - original_index: 187
-      status: 0
-    - original_index: 188
-      status: 3
-    - original_index: 189
-      status: 1
-    - original_index: 190
-      status: 4
-    - original_index: 191
-      status: 3
-    - original_index: 192
-      status: 2
-    - original_index: 193
-      status: 0
-    - original_index: 194
-      status: 2
-    - original_index: 195
-      status: 4
-    - original_index: 196
-      status: 1
-    - original_index: 197
-      status: 3
-    - original_index: 198
-      status: 1
-    - original_index: 199
-      status: 4
-    - original_index: 200
-      status: 1
-    - original_index: 201
-      status: 3
-    - original_index: 202
-      status: 2
-    - original_index: 203
-      status: 1
-    - original_index: 204
-      status: 2
-    - original_index: 205
-      status: 4
-    - original_index: 206
-      status: 0
-    - original_index: 207
-      status: 3
-    - original_index: 208
-      status: 1
-    - original_index: 209
-      status: 1
-    - original_index: 210
-      status: 0
-    - original_index: 211
-      status: 3
-    - original_index: 212
-      status: 1
-    - original_index: 213
-      status: 1
-    - original_index: 214
-      status: 2
-    - original_index: 215
-      status: 1
-    - original_index: 216
-      status: 4
-    - original_index: 217
-      status: 2
-    - original_index: 218
-      status: 1
-    - original_index: 219
-      status: 4
-    - original_index: 220
-      status: 0
-    - original_index: 221
-      status: 3
-    - original_index: 222
-      status: 2
-    - original_index: 223
-      status: 0
-    - original_index: 224
-      status: 0
-    - original_index: 225
-      status: 4
-    - original_index: 226
-      status: 3
-    - original_index: 227
-      status: 2
-    - original_index: 228
-      status: 1
-    - original_index: 229
-      status: 2
-    - original_index: 230
-      status: 3
-    - original_index: 231
-      status: 1
-    - original_index: 232
-      status: 1
-    - original_index: 233
-      status: 1
-    - original_index: 234
-      status: 4
-    - original_index: 235
-      status: 2
-    - original_index: 236
-      status: 2
-    - original_index: 237
-      status: 0
-    - original_index: 238
-      status: 1
-    - original_index: 239
-      status: 1
-    - original_index: 240
-      status: 0
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 4
-    - original_index: 243
-      status: 2
-    - original_index: 244
-      status: 0
-    - original_index: 245
-      status: 4
-    - original_index: 246
-      status: 1
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 0
-    - original_index: 249
-      status: 0
-    - original_index: 250
-      status: 0
-    - original_index: 251
-      status: 1
-    - original_index: 252
-      status: 3
-    - original_index: 253
-      status: 1
-    - original_index: 254
-      status: 4
-    - original_index: 255
-      status: 3
-    - original_index: 256
-      status: 0
-    - original_index: 257
-      status: 1
-    - original_index: 258
-      status: 0
-    - original_index: 259
-      status: 2
-    - original_index: 260
-      status: 4
-    - original_index: 261
-      status: 1
-    - original_index: 262
-      status: 0
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 1
-    - original_index: 265
-      status: 0
-    - original_index: 266
-      status: 4
-    - original_index: 267
-      status: 3
-    - original_index: 268
-      status: 1
-    - original_index: 269
-      status: 1
-    - original_index: 270
-      status: 1
-    - original_index: 271
-      status: 2
-    - original_index: 272
-      status: 0
-    - original_index: 273
-      status: 0
-    - original_index: 274
-      status: 0
-    - original_index: 275
-      status: 4
-    - original_index: 276
-      status: 0
-    - original_index: 277
-      status: 2
-    - original_index: 278
-      status: 2
-    - original_index: 279
-      status: 0
-    - original_index: 280
-      status: 4
-    - original_index: 281
-      status: 2
-    - original_index: 282
-      status: 3
-    - original_index: 283
-      status: 2
-    - original_index: 284
-      status: 4
-    - original_index: 285
-      status: 4
-    - original_index: 286
-      status: 3
-    - original_index: 287
-      status: 4
-    - original_index: 288
-      status: 3
-    - original_index: 289
-      status: 3
-    - original_index: 290
-      status: 0
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 0
-    - original_index: 293
-      status: 2
-    - original_index: 294
-      status: 2
-    - original_index: 295
-      status: 4
-    - original_index: 296
-      status: 1
-    - original_index: 297
-      status: 4
-    - original_index: 298
-      status: 4
-    - original_index: 299
-      status: 4
-    - original_index: 300
-      status: 3
-    - original_index: 301
-      status: 2
-    - original_index: 302
-      status: 3
-    - original_index: 303
-      status: 2
-    - original_index: 304
-      status: 0
-    - original_index: 305
-      status: 2
-    - original_index: 306
-      status: 2
-    - original_index: 307
-      status: 2
-    - original_index: 308
-      status: 4
-    - original_index: 309
-      status: 2
-    - original_index: 310
-      status: 4
-    - original_index: 311
-      status: 1
-    - original_index: 312
-      status: 0
-    - original_index: 313
-      status: 1
-    - original_index: 314
-      status: 0
-    - original_index: 315
-      status: 4
-    - original_index: 316
-      status: 0
-    - original_index: 317
-      status: 4
-    - original_index: 318
-      status: 1
-    - original_index: 319
-      status: 1
-    - original_index: 320
-      status: 2
-    - original_index: 321
-      status: 2
-    - original_index: 322
-      status: 4
-    - original_index: 323
-      status: 3
-    - original_index: 324
-      status: 4
-    - original_index: 325
-      status: 4
-    - original_index: 326
-      status: 3
-    - original_index: 327
-      status: 3
-    - original_index: 328
-      status: 4
-    - original_index: 329
-      status: 2
-    - original_index: 330
-      status: 3
-    - original_index: 331
-      status: 0
-    - original_index: 332
-      status: 2
-    - original_index: 333
-      status: 1
-    - original_index: 334
-      status: 4
-    - original_index: 335
-      status: 0
-    - original_index: 336
-      status: 0
-    - original_index: 337
-      status: 4
-    - original_index: 338
-      status: 1
-    - original_index: 339
-      status: 2
-    - original_index: 340
-      status: 1
-    - original_index: 341
-      status: 4
-    - original_index: 342
-      status: 1
-    - original_index: 343
-      status: 2
-    - original_index: 344
-      status: 0
-    - original_index: 345
-      status: 4
-    - original_index: 346
-      status: 4
-    - original_index: 347
-      status: 1
-    - original_index: 348
-      status: 4
-    - original_index: 349
-      status: 1
-    - original_index: 350
-      status: 1
-    - original_index: 351
-      status: 4
+    - {original_index: 0, status: 2}
+    - {original_index: 1, status: 0}
+    - {original_index: 2, status: 4}
+    - {original_index: 3, status: 2}
+    - {original_index: 4, status: 4}
+    - {original_index: 5, status: 2}
+    - {original_index: 6, status: 0}
+    - {original_index: 7, status: 3}
+    - {original_index: 8, status: 1}
+    - {original_index: 9, status: 0}
+    - {original_index: 10, status: 2}
+    - {original_index: 11, status: 1}
+    - {original_index: 12, status: 0}
+    - {original_index: 13, status: 3}
+    - {original_index: 14, status: 2}
+    - {original_index: 15, status: 2}
+    - {original_index: 16, status: 0}
+    - {original_index: 17, status: 0}
+    - {original_index: 18, status: 3}
+    - {original_index: 19, status: 4}
+    - {original_index: 20, status: 1}
+    - {original_index: 21, status: 2}
+    - {original_index: 22, status: 4}
+    - {original_index: 23, status: 0}
+    - {original_index: 24, status: 0}
+    - {original_index: 25, status: 0}
+    - {original_index: 26, status: 2}
+    - {original_index: 27, status: 3}
+    - {original_index: 28, status: 0}
+    - {original_index: 29, status: 3}
+    - {original_index: 30, status: 4}
+    - {original_index: 31, status: 1}
+    - {original_index: 32, status: 0}
+    - {original_index: 33, status: 1}
+    - {original_index: 34, status: 4}
+    - {original_index: 35, status: 0}
+    - {original_index: 36, status: 3}
+    - {original_index: 37, status: 0}
+    - {original_index: 38, status: 4}
+    - {original_index: 39, status: 1}
+    - {original_index: 40, status: 0}
+    - {original_index: 41, status: 3}
+    - {original_index: 42, status: 2}
+    - {original_index: 43, status: 3}
+    - {original_index: 44, status: 4}
+    - {original_index: 45, status: 0}
+    - {original_index: 46, status: 3}
+    - {original_index: 47, status: 3}
+    - {original_index: 48, status: 4}
+    - {original_index: 49, status: 3}
+    - {original_index: 50, status: 3}
+    - {original_index: 51, status: 4}
+    - {original_index: 52, status: 1}
+    - {original_index: 53, status: 3}
+    - {original_index: 54, status: 3}
+    - {original_index: 55, status: 1}
+    - {original_index: 56, status: 0}
+    - {original_index: 57, status: 0}
+    - {original_index: 58, status: 0}
+    - {original_index: 59, status: 0}
+    - {original_index: 60, status: 2}
+    - {original_index: 61, status: 2}
+    - {original_index: 62, status: 1}
+    - {original_index: 63, status: 3}
+    - {original_index: 64, status: 4}
+    - {original_index: 65, status: 4}
+    - {original_index: 66, status: 4}
+    - {original_index: 67, status: 3}
+    - {original_index: 68, status: 3}
+    - {original_index: 69, status: 3}
+    - {original_index: 70, status: 4}
+    - {original_index: 71, status: 3}
+    - {original_index: 72, status: 3}
+    - {original_index: 73, status: 1}
+    - {original_index: 74, status: 2}
+    - {original_index: 75, status: 3}
+    - {original_index: 76, status: 2}
+    - {original_index: 77, status: 3}
+    - {original_index: 78, status: 3}
+    - {original_index: 79, status: 3}
+    - {original_index: 80, status: 2}
+    - {original_index: 81, status: 2}
+    - {original_index: 82, status: 2}
+    - {original_index: 83, status: 4}
+    - {original_index: 84, status: 0}
+    - {original_index: 85, status: 0}
+    - {original_index: 86, status: 1}
+    - {original_index: 87, status: 2}
+    - {original_index: 88, status: 2}
+    - {original_index: 89, status: 4}
+    - {original_index: 90, status: 4}
+    - {original_index: 91, status: 4}
+    - {original_index: 92, status: 2}
+    - {original_index: 93, status: 0}
+    - {original_index: 94, status: 4}
+    - {original_index: 95, status: 0}
+    - {original_index: 96, status: 1}
+    - {original_index: 97, status: 1}
+    - {original_index: 98, status: 4}
+    - {original_index: 99, status: 3}
+    - {original_index: 100, status: 4}
+    - {original_index: 101, status: 4}
+    - {original_index: 102, status: 3}
+    - {original_index: 103, status: 4}
+    - {original_index: 104, status: 0}
+    - {original_index: 105, status: 1}
+    - {original_index: 106, status: 0}
+    - {original_index: 107, status: 1}
+    - {original_index: 108, status: 1}
+    - {original_index: 109, status: 3}
+    - {original_index: 110, status: 3}
+    - {original_index: 111, status: 0}
+    - {original_index: 112, status: 0}
+    - {original_index: 113, status: 0}
+    - {original_index: 114, status: 1}
+    - {original_index: 115, status: 3}
+    - {original_index: 116, status: 2}
+    - {original_index: 117, status: 0}
+    - {original_index: 118, status: 0}
+    - {original_index: 119, status: 4}
+    - {original_index: 120, status: 2}
+    - {original_index: 121, status: 1}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 4}
+    - {original_index: 124, status: 3}
+    - {original_index: 125, status: 0}
+    - {original_index: 126, status: 4}
+    - {original_index: 127, status: 0}
+    - {original_index: 128, status: 0}
+    - {original_index: 129, status: 0}
+    - {original_index: 130, status: 3}
+    - {original_index: 131, status: 0}
+    - {original_index: 132, status: 4}
+    - {original_index: 133, status: 1}
+    - {original_index: 134, status: 1}
+    - {original_index: 135, status: 1}
+    - {original_index: 136, status: 4}
+    - {original_index: 137, status: 1}
+    - {original_index: 138, status: 0}
+    - {original_index: 139, status: 3}
+    - {original_index: 140, status: 2}
+    - {original_index: 141, status: 4}
+    - {original_index: 142, status: 2}
+    - {original_index: 143, status: 0}
+    - {original_index: 144, status: 4}
+    - {original_index: 145, status: 2}
+    - {original_index: 146, status: 3}
+    - {original_index: 147, status: 4}
+    - {original_index: 148, status: 1}
+    - {original_index: 149, status: 1}
+    - {original_index: 150, status: 0}
+    - {original_index: 151, status: 1}
+    - {original_index: 152, status: 3}
+    - {original_index: 153, status: 2}
+    - {original_index: 154, status: 2}
+    - {original_index: 155, status: 2}
+    - {original_index: 156, status: 3}
+    - {original_index: 157, status: 0}
+    - {original_index: 158, status: 3}
+    - {original_index: 159, status: 0}
+    - {original_index: 160, status: 1}
+    - {original_index: 161, status: 0}
+    - {original_index: 162, status: 2}
+    - {original_index: 163, status: 0}
+    - {original_index: 164, status: 2}
+    - {original_index: 165, status: 1}
+    - {original_index: 166, status: 1}
+    - {original_index: 167, status: 4}
+    - {original_index: 168, status: 1}
+    - {original_index: 169, status: 2}
+    - {original_index: 170, status: 4}
+    - {original_index: 171, status: 1}
+    - {original_index: 172, status: 1}
+    - {original_index: 173, status: 4}
+    - {original_index: 174, status: 0}
+    - {original_index: 175, status: 3}
+    - {original_index: 176, status: 2}
+    - {original_index: 177, status: 3}
+    - {original_index: 178, status: 0}
+    - {original_index: 179, status: 4}
+    - {original_index: 180, status: 1}
+    - {original_index: 181, status: 0}
+    - {original_index: 182, status: 0}
+    - {original_index: 183, status: 0}
+    - {original_index: 184, status: 4}
+    - {original_index: 185, status: 1}
+    - {original_index: 186, status: 3}
+    - {original_index: 187, status: 0}
+    - {original_index: 188, status: 3}
+    - {original_index: 189, status: 1}
+    - {original_index: 190, status: 4}
+    - {original_index: 191, status: 3}
+    - {original_index: 192, status: 2}
+    - {original_index: 193, status: 0}
+    - {original_index: 194, status: 2}
+    - {original_index: 195, status: 4}
+    - {original_index: 196, status: 1}
+    - {original_index: 197, status: 3}
+    - {original_index: 198, status: 1}
+    - {original_index: 199, status: 4}
+    - {original_index: 200, status: 1}
+    - {original_index: 201, status: 3}
+    - {original_index: 202, status: 2}
+    - {original_index: 203, status: 1}
+    - {original_index: 204, status: 2}
+    - {original_index: 205, status: 4}
+    - {original_index: 206, status: 0}
+    - {original_index: 207, status: 3}
+    - {original_index: 208, status: 1}
+    - {original_index: 209, status: 1}
+    - {original_index: 210, status: 0}
+    - {original_index: 211, status: 3}
+    - {original_index: 212, status: 1}
+    - {original_index: 213, status: 1}
+    - {original_index: 214, status: 2}
+    - {original_index: 215, status: 1}
+    - {original_index: 216, status: 4}
+    - {original_index: 217, status: 2}
+    - {original_index: 218, status: 1}
+    - {original_index: 219, status: 4}
+    - {original_index: 220, status: 0}
+    - {original_index: 221, status: 3}
+    - {original_index: 222, status: 2}
+    - {original_index: 223, status: 0}
+    - {original_index: 224, status: 0}
+    - {original_index: 225, status: 4}
+    - {original_index: 226, status: 3}
+    - {original_index: 227, status: 2}
+    - {original_index: 228, status: 1}
+    - {original_index: 229, status: 2}
+    - {original_index: 230, status: 3}
+    - {original_index: 231, status: 1}
+    - {original_index: 232, status: 1}
+    - {original_index: 233, status: 1}
+    - {original_index: 234, status: 4}
+    - {original_index: 235, status: 2}
+    - {original_index: 236, status: 2}
+    - {original_index: 237, status: 0}
+    - {original_index: 238, status: 1}
+    - {original_index: 239, status: 1}
+    - {original_index: 240, status: 0}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 4}
+    - {original_index: 243, status: 2}
+    - {original_index: 244, status: 0}
+    - {original_index: 245, status: 4}
+    - {original_index: 246, status: 1}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 0}
+    - {original_index: 249, status: 0}
+    - {original_index: 250, status: 0}
+    - {original_index: 251, status: 1}
+    - {original_index: 252, status: 3}
+    - {original_index: 253, status: 1}
+    - {original_index: 254, status: 4}
+    - {original_index: 255, status: 3}
+    - {original_index: 256, status: 0}
+    - {original_index: 257, status: 1}
+    - {original_index: 258, status: 0}
+    - {original_index: 259, status: 2}
+    - {original_index: 260, status: 4}
+    - {original_index: 261, status: 1}
+    - {original_index: 262, status: 0}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 1}
+    - {original_index: 265, status: 0}
+    - {original_index: 266, status: 4}
+    - {original_index: 267, status: 3}
+    - {original_index: 268, status: 1}
+    - {original_index: 269, status: 1}
+    - {original_index: 270, status: 1}
+    - {original_index: 271, status: 2}
+    - {original_index: 272, status: 0}
+    - {original_index: 273, status: 0}
+    - {original_index: 274, status: 0}
+    - {original_index: 275, status: 4}
+    - {original_index: 276, status: 0}
+    - {original_index: 277, status: 2}
+    - {original_index: 278, status: 2}
+    - {original_index: 279, status: 0}
+    - {original_index: 280, status: 4}
+    - {original_index: 281, status: 2}
+    - {original_index: 282, status: 3}
+    - {original_index: 283, status: 2}
+    - {original_index: 284, status: 4}
+    - {original_index: 285, status: 4}
+    - {original_index: 286, status: 3}
+    - {original_index: 287, status: 4}
+    - {original_index: 288, status: 3}
+    - {original_index: 289, status: 3}
+    - {original_index: 290, status: 0}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 0}
+    - {original_index: 293, status: 2}
+    - {original_index: 294, status: 2}
+    - {original_index: 295, status: 4}
+    - {original_index: 296, status: 1}
+    - {original_index: 297, status: 4}
+    - {original_index: 298, status: 4}
+    - {original_index: 299, status: 4}
+    - {original_index: 300, status: 3}
+    - {original_index: 301, status: 2}
+    - {original_index: 302, status: 3}
+    - {original_index: 303, status: 2}
+    - {original_index: 304, status: 0}
+    - {original_index: 305, status: 2}
+    - {original_index: 306, status: 2}
+    - {original_index: 307, status: 2}
+    - {original_index: 308, status: 4}
+    - {original_index: 309, status: 2}
+    - {original_index: 310, status: 4}
+    - {original_index: 311, status: 1}
+    - {original_index: 312, status: 0}
+    - {original_index: 313, status: 1}
+    - {original_index: 314, status: 0}
+    - {original_index: 315, status: 4}
+    - {original_index: 316, status: 0}
+    - {original_index: 317, status: 4}
+    - {original_index: 318, status: 1}
+    - {original_index: 319, status: 1}
+    - {original_index: 320, status: 2}
+    - {original_index: 321, status: 2}
+    - {original_index: 322, status: 4}
+    - {original_index: 323, status: 3}
+    - {original_index: 324, status: 4}
+    - {original_index: 325, status: 4}
+    - {original_index: 326, status: 3}
+    - {original_index: 327, status: 3}
+    - {original_index: 328, status: 4}
+    - {original_index: 329, status: 2}
+    - {original_index: 330, status: 3}
+    - {original_index: 331, status: 0}
+    - {original_index: 332, status: 2}
+    - {original_index: 333, status: 1}
+    - {original_index: 334, status: 4}
+    - {original_index: 335, status: 0}
+    - {original_index: 336, status: 0}
+    - {original_index: 337, status: 4}
+    - {original_index: 338, status: 1}
+    - {original_index: 339, status: 2}
+    - {original_index: 340, status: 1}
+    - {original_index: 341, status: 4}
+    - {original_index: 342, status: 1}
+    - {original_index: 343, status: 2}
+    - {original_index: 344, status: 0}
+    - {original_index: 345, status: 4}
+    - {original_index: 346, status: 4}
+    - {original_index: 347, status: 1}
+    - {original_index: 348, status: 4}
+    - {original_index: 349, status: 1}
+    - {original_index: 350, status: 1}
+    - {original_index: 351, status: 4}
   output:
-  - - committee:
-      - 126
-      - 346
+  - - committee: [126, 346]
       shard: 133
       total_validator_count: 146
-  - - committee:
-      - 171
-      - 328
+  - - committee: [171, 328]
       shard: 134
       total_validator_count: 146
-  - - committee:
-      - 105
-      - 121
+  - - committee: [105, 121]
       shard: 135
       total_validator_count: 146
-  - - committee:
-      - 209
-      - 173
-      - 66
+  - - committee: [209, 173, 66]
       shard: 136
       total_validator_count: 146
-  - - committee:
-      - 52
-      - 242
+  - - committee: [52, 242]
       shard: 137
       total_validator_count: 146
-  - - committee:
-      - 347
-      - 199
+  - - committee: [347, 199]
       shard: 138
       total_validator_count: 146
-  - - committee:
-      - 198
-      - 232
+  - - committee: [198, 232]
       shard: 139
       total_validator_count: 146
-  - - committee:
-      - 263
-      - 55
-      - 269
+  - - committee: [263, 55, 269]
       shard: 140
       total_validator_count: 146
-  - - committee:
-      - 20
-      - 233
+  - - committee: [20, 233]
       shard: 141
       total_validator_count: 146
-  - - committee:
-      - 225
-      - 94
+  - - committee: [225, 94]
       shard: 142
       total_validator_count: 146
-  - - committee:
-      - 338
-      - 196
-      - 239
+  - - committee: [338, 196, 239]
       shard: 143
       total_validator_count: 146
-  - - committee:
-      - 185
-      - 144
+  - - committee: [185, 144]
       shard: 144
       total_validator_count: 146
-  - - committee:
-      - 219
-      - 180
+  - - committee: [219, 180]
       shard: 145
       total_validator_count: 146
-  - - committee:
-      - 324
-      - 297
+  - - committee: [324, 297]
       shard: 146
       total_validator_count: 146
-  - - committee:
-      - 22
-      - 96
-      - 342
+  - - committee: [22, 96, 342]
       shard: 147
       total_validator_count: 146
-  - - committee:
-      - 160
-      - 285
+  - - committee: [160, 285]
       shard: 148
       total_validator_count: 146
-  - - committee:
-      - 103
-      - 200
+  - - committee: [103, 200]
       shard: 149
       total_validator_count: 146
-  - - committee:
-      - 266
-      - 208
-      - 351
+  - - committee: [266, 208, 351]
       shard: 150
       total_validator_count: 146
-  - - committee:
-      - 257
-      - 350
+  - - committee: [257, 350]
       shard: 151
       total_validator_count: 146
-  - - committee:
-      - 245
-      - 345
+  - - committee: [245, 345]
       shard: 152
       total_validator_count: 146
-  - - committee:
-      - 134
-      - 48
+  - - committee: [134, 48]
       shard: 153
       total_validator_count: 146
-  - - committee:
-      - 349
-      - 62
-      - 275
+  - - committee: [349, 62, 275]
       shard: 154
       total_validator_count: 146
-  - - committee:
-      - 34
-      - 114
+  - - committee: [34, 114]
       shard: 155
       total_validator_count: 146
-  - - committee:
-      - 284
-      - 167
+  - - committee: [284, 167]
       shard: 156
       total_validator_count: 146
-  - - committee:
-      - 319
-      - 31
-      - 147
+  - - committee: [319, 31, 147]
       shard: 157
       total_validator_count: 146
-  - - committee:
-      - 340
-      - 348
+  - - committee: [340, 348]
       shard: 158
       total_validator_count: 146
-  - - committee:
-      - 98
-      - 246
+  - - committee: [98, 246]
       shard: 159
       total_validator_count: 146
-  - - committee:
-      - 51
-      - 315
+  - - committee: [51, 315]
       shard: 160
       total_validator_count: 146
-  - - committee:
-      - 30
-      - 241
-      - 119
+  - - committee: [30, 241, 119]
       shard: 161
       total_validator_count: 146
-  - - committee:
-      - 189
-      - 251
+  - - committee: [189, 251]
       shard: 162
       total_validator_count: 146
-  - - committee:
-      - 205
-      - 70
+  - - committee: [205, 70]
       shard: 163
       total_validator_count: 146
-  - - committee:
-      - 44
-      - 317
-      - 90
+  - - committee: [44, 317, 90]
       shard: 164
       total_validator_count: 146
-  - - committee:
-      - 19
-      - 295
+  - - committee: [19, 295]
       shard: 165
       total_validator_count: 146
-  - - committee:
-      - 296
-      - 231
+  - - committee: [296, 231]
       shard: 166
       total_validator_count: 146
-  - - committee:
-      - 64
-      - 4
+  - - committee: [64, 4]
       shard: 167
       total_validator_count: 146
-  - - committee:
-      - 165
-      - 38
-      - 8
+  - - committee: [165, 38, 8]
       shard: 168
       total_validator_count: 146
-  - - committee:
-      - 135
-      - 195
+  - - committee: [135, 195]
       shard: 169
       total_validator_count: 146
-  - - committee:
-      - 89
-      - 151
+  - - committee: [89, 151]
       shard: 170
       total_validator_count: 146
-  - - committee:
-      - 168
-      - 253
+  - - committee: [168, 253]
       shard: 171
       total_validator_count: 146
-  - - committee:
-      - 310
-      - 280
-      - 333
+  - - committee: [310, 280, 333]
       shard: 172
       total_validator_count: 146
-  - - committee:
-      - 11
-      - 337
+  - - committee: [11, 337]
       shard: 173
       total_validator_count: 146
-  - - committee:
-      - 261
-      - 268
+  - - committee: [261, 268]
       shard: 174
       total_validator_count: 146
-  - - committee:
-      - 318
-      - 184
-      - 170
+  - - committee: [318, 184, 170]
       shard: 175
       total_validator_count: 146
-  - - committee:
-      - 228
-      - 149
+  - - committee: [228, 149]
       shard: 176
       total_validator_count: 146
-  - - committee:
-      - 190
-      - 132
+  - - committee: [190, 132]
       shard: 177
       total_validator_count: 146
-  - - committee:
-      - 107
-      - 238
+  - - committee: [107, 238]
       shard: 178
       total_validator_count: 146
-  - - committee:
-      - 123
-      - 334
-      - 179
+  - - committee: [123, 334, 179]
       shard: 179
       total_validator_count: 146
-  - - committee:
-      - 108
-      - 148
+  - - committee: [108, 148]
       shard: 180
       total_validator_count: 146
-  - - committee:
-      - 91
-      - 166
+  - - committee: [91, 166]
       shard: 181
       total_validator_count: 146
-  - - committee:
-      - 172
-      - 325
-      - 73
+  - - committee: [172, 325, 73]
       shard: 182
       total_validator_count: 146
-  - - committee:
-      - 213
-      - 322
+  - - committee: [213, 322]
       shard: 183
       total_validator_count: 146
-  - - committee:
-      - 254
-      - 203
+  - - committee: [254, 203]
       shard: 184
       total_validator_count: 146
-  - - committee:
-      - 270
-      - 308
+  - - committee: [270, 308]
       shard: 185
       total_validator_count: 146
-  - - committee:
-      - 260
-      - 100
-      - 65
+  - - committee: [260, 100, 65]
       shard: 186
       total_validator_count: 146
-  - - committee:
-      - 311
-      - 298
+  - - committee: [311, 298]
       shard: 187
       total_validator_count: 146
-  - - committee:
-      - 133
-      - 97
+  - - committee: [133, 97]
       shard: 188
       total_validator_count: 146
-  - - committee:
-      - 2
-      - 136
-      - 33
+  - - committee: [2, 136, 33]
       shard: 189
       total_validator_count: 146
-  - - committee:
-      - 218
-      - 86
+  - - committee: [218, 86]
       shard: 190
       total_validator_count: 146
-  - - committee:
-      - 141
-      - 264
+  - - committee: [141, 264]
       shard: 191
       total_validator_count: 146
-  - - committee:
-      - 137
-      - 215
+  - - committee: [137, 215]
       shard: 192
       total_validator_count: 146
-  - - committee:
-      - 234
-      - 101
-      - 212
+  - - committee: [234, 101, 212]
       shard: 193
       total_validator_count: 146
-  - - committee:
-      - 216
-      - 39
+  - - committee: [216, 39]
       shard: 194
       total_validator_count: 146
-  - - committee:
-      - 299
-      - 313
+  - - committee: [299, 313]
       shard: 195
       total_validator_count: 146
-  - - committee:
-      - 83
-      - 287
-      - 341
+  - - committee: [83, 287, 341]
       shard: 196
       total_validator_count: 146
   seed: '0x1e91ab35b1106e8984dfc0dfa36018004f880b431c2a14f66354bf0192292ffa'
 - input:
     crosslinking_start_shard: 323
     validators:
-    - original_index: 0
-      status: 0
-    - original_index: 1
-      status: 3
-    - original_index: 2
-      status: 2
-    - original_index: 3
-      status: 3
-    - original_index: 4
-      status: 2
-    - original_index: 5
-      status: 2
-    - original_index: 6
-      status: 2
-    - original_index: 7
-      status: 2
-    - original_index: 8
-      status: 4
-    - original_index: 9
-      status: 3
-    - original_index: 10
-      status: 1
-    - original_index: 11
-      status: 1
-    - original_index: 12
-      status: 2
-    - original_index: 13
-      status: 3
-    - original_index: 14
-      status: 1
-    - original_index: 15
-      status: 1
-    - original_index: 16
-      status: 2
-    - original_index: 17
-      status: 0
-    - original_index: 18
-      status: 2
-    - original_index: 19
-      status: 2
-    - original_index: 20
-      status: 2
-    - original_index: 21
-      status: 0
-    - original_index: 22
-      status: 2
-    - original_index: 23
-      status: 2
-    - original_index: 24
-      status: 2
-    - original_index: 25
-      status: 1
-    - original_index: 26
-      status: 3
-    - original_index: 27
-      status: 1
-    - original_index: 28
-      status: 3
-    - original_index: 29
-      status: 0
-    - original_index: 30
-      status: 4
-    - original_index: 31
-      status: 4
-    - original_index: 32
-      status: 2
-    - original_index: 33
-      status: 3
-    - original_index: 34
-      status: 0
-    - original_index: 35
-      status: 0
-    - original_index: 36
-      status: 0
-    - original_index: 37
-      status: 0
-    - original_index: 38
-      status: 3
-    - original_index: 39
-      status: 4
-    - original_index: 40
-      status: 1
-    - original_index: 41
-      status: 2
-    - original_index: 42
-      status: 1
-    - original_index: 43
-      status: 4
-    - original_index: 44
-      status: 3
-    - original_index: 45
-      status: 3
-    - original_index: 46
-      status: 4
-    - original_index: 47
-      status: 0
-    - original_index: 48
-      status: 4
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 4
-    - original_index: 51
-      status: 0
-    - original_index: 52
-      status: 0
-    - original_index: 53
-      status: 1
-    - original_index: 54
-      status: 1
-    - original_index: 55
-      status: 3
-    - original_index: 56
-      status: 0
-    - original_index: 57
-      status: 1
-    - original_index: 58
-      status: 4
-    - original_index: 59
-      status: 1
-    - original_index: 60
-      status: 4
-    - original_index: 61
-      status: 0
-    - original_index: 62
-      status: 3
-    - original_index: 63
-      status: 0
-    - original_index: 64
-      status: 2
-    - original_index: 65
-      status: 1
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 0
-    - original_index: 68
-      status: 4
-    - original_index: 69
-      status: 2
-    - original_index: 70
-      status: 0
-    - original_index: 71
-      status: 3
-    - original_index: 72
-      status: 0
-    - original_index: 73
-      status: 3
-    - original_index: 74
-      status: 4
-    - original_index: 75
-      status: 4
-    - original_index: 76
-      status: 2
-    - original_index: 77
-      status: 0
-    - original_index: 78
-      status: 4
-    - original_index: 79
-      status: 4
-    - original_index: 80
-      status: 1
-    - original_index: 81
-      status: 2
-    - original_index: 82
-      status: 0
-    - original_index: 83
-      status: 4
-    - original_index: 84
-      status: 3
-    - original_index: 85
-      status: 2
-    - original_index: 86
-      status: 0
-    - original_index: 87
-      status: 1
-    - original_index: 88
-      status: 1
-    - original_index: 89
-      status: 4
-    - original_index: 90
-      status: 2
-    - original_index: 91
-      status: 3
-    - original_index: 92
-      status: 3
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 3
-    - original_index: 95
-      status: 2
-    - original_index: 96
-      status: 2
-    - original_index: 97
-      status: 3
-    - original_index: 98
-      status: 4
-    - original_index: 99
-      status: 0
-    - original_index: 100
-      status: 3
-    - original_index: 101
-      status: 2
-    - original_index: 102
-      status: 4
-    - original_index: 103
-      status: 2
-    - original_index: 104
-      status: 2
-    - original_index: 105
-      status: 4
-    - original_index: 106
-      status: 3
-    - original_index: 107
-      status: 1
-    - original_index: 108
-      status: 1
-    - original_index: 109
-      status: 4
-    - original_index: 110
-      status: 0
-    - original_index: 111
-      status: 3
-    - original_index: 112
-      status: 4
-    - original_index: 113
-      status: 1
-    - original_index: 114
-      status: 1
-    - original_index: 115
-      status: 4
-    - original_index: 116
-      status: 1
-    - original_index: 117
-      status: 3
-    - original_index: 118
-      status: 3
-    - original_index: 119
-      status: 4
-    - original_index: 120
-      status: 0
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 2
-    - original_index: 123
-      status: 4
-    - original_index: 124
-      status: 2
-    - original_index: 125
-      status: 2
-    - original_index: 126
-      status: 1
-    - original_index: 127
-      status: 4
-    - original_index: 128
-      status: 3
-    - original_index: 129
-      status: 4
-    - original_index: 130
-      status: 2
-    - original_index: 131
-      status: 4
-    - original_index: 132
-      status: 0
-    - original_index: 133
-      status: 4
-    - original_index: 134
-      status: 0
-    - original_index: 135
-      status: 3
-    - original_index: 136
-      status: 0
-    - original_index: 137
-      status: 4
-    - original_index: 138
-      status: 4
-    - original_index: 139
-      status: 3
-    - original_index: 140
-      status: 2
-    - original_index: 141
-      status: 4
-    - original_index: 142
-      status: 3
-    - original_index: 143
-      status: 2
-    - original_index: 144
-      status: 1
-    - original_index: 145
-      status: 0
-    - original_index: 146
-      status: 4
-    - original_index: 147
-      status: 2
-    - original_index: 148
-      status: 4
-    - original_index: 149
-      status: 2
-    - original_index: 150
-      status: 2
-    - original_index: 151
-      status: 4
-    - original_index: 152
-      status: 3
-    - original_index: 153
-      status: 0
-    - original_index: 154
-      status: 0
-    - original_index: 155
-      status: 2
-    - original_index: 156
-      status: 0
-    - original_index: 157
-      status: 3
-    - original_index: 158
-      status: 3
-    - original_index: 159
-      status: 4
-    - original_index: 160
-      status: 2
-    - original_index: 161
-      status: 3
-    - original_index: 162
-      status: 2
-    - original_index: 163
-      status: 4
-    - original_index: 164
-      status: 2
-    - original_index: 165
-      status: 4
-    - original_index: 166
-      status: 4
-    - original_index: 167
-      status: 1
-    - original_index: 168
-      status: 4
-    - original_index: 169
-      status: 3
-    - original_index: 170
-      status: 4
-    - original_index: 171
-      status: 3
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 1
-    - original_index: 174
-      status: 4
-    - original_index: 175
-      status: 4
-    - original_index: 176
-      status: 4
-    - original_index: 177
-      status: 2
-    - original_index: 178
-      status: 3
-    - original_index: 179
-      status: 3
-    - original_index: 180
-      status: 0
-    - original_index: 181
-      status: 0
-    - original_index: 182
-      status: 0
-    - original_index: 183
-      status: 2
-    - original_index: 184
-      status: 3
-    - original_index: 185
-      status: 2
-    - original_index: 186
-      status: 3
-    - original_index: 187
-      status: 1
-    - original_index: 188
-      status: 0
-    - original_index: 189
-      status: 3
-    - original_index: 190
-      status: 3
-    - original_index: 191
-      status: 1
-    - original_index: 192
-      status: 2
-    - original_index: 193
-      status: 3
-    - original_index: 194
-      status: 3
-    - original_index: 195
-      status: 2
-    - original_index: 196
-      status: 2
-    - original_index: 197
-      status: 3
-    - original_index: 198
-      status: 0
-    - original_index: 199
-      status: 4
-    - original_index: 200
-      status: 3
-    - original_index: 201
-      status: 3
-    - original_index: 202
-      status: 1
-    - original_index: 203
-      status: 4
-    - original_index: 204
-      status: 2
-    - original_index: 205
-      status: 4
-    - original_index: 206
-      status: 2
-    - original_index: 207
-      status: 0
-    - original_index: 208
-      status: 2
-    - original_index: 209
-      status: 1
-    - original_index: 210
-      status: 0
-    - original_index: 211
-      status: 2
-    - original_index: 212
-      status: 2
-    - original_index: 213
-      status: 2
-    - original_index: 214
-      status: 0
-    - original_index: 215
-      status: 2
-    - original_index: 216
-      status: 1
-    - original_index: 217
-      status: 0
-    - original_index: 218
-      status: 0
-    - original_index: 219
-      status: 1
-    - original_index: 220
-      status: 3
-    - original_index: 221
-      status: 2
-    - original_index: 222
-      status: 3
-    - original_index: 223
-      status: 3
-    - original_index: 224
-      status: 1
-    - original_index: 225
-      status: 4
-    - original_index: 226
-      status: 4
-    - original_index: 227
-      status: 0
-    - original_index: 228
-      status: 1
-    - original_index: 229
-      status: 3
-    - original_index: 230
-      status: 2
-    - original_index: 231
-      status: 3
-    - original_index: 232
-      status: 0
-    - original_index: 233
-      status: 2
-    - original_index: 234
-      status: 0
-    - original_index: 235
-      status: 4
-    - original_index: 236
-      status: 4
-    - original_index: 237
-      status: 3
-    - original_index: 238
-      status: 1
-    - original_index: 239
-      status: 3
-    - original_index: 240
-      status: 3
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 0
-    - original_index: 243
-      status: 0
-    - original_index: 244
-      status: 0
-    - original_index: 245
-      status: 1
-    - original_index: 246
-      status: 0
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 0
-    - original_index: 249
-      status: 3
-    - original_index: 250
-      status: 1
-    - original_index: 251
-      status: 0
-    - original_index: 252
-      status: 0
-    - original_index: 253
-      status: 2
-    - original_index: 254
-      status: 1
-    - original_index: 255
-      status: 2
-    - original_index: 256
-      status: 0
-    - original_index: 257
-      status: 1
-    - original_index: 258
-      status: 4
-    - original_index: 259
-      status: 2
-    - original_index: 260
-      status: 0
-    - original_index: 261
-      status: 4
-    - original_index: 262
-      status: 0
-    - original_index: 263
-      status: 3
-    - original_index: 264
-      status: 3
-    - original_index: 265
-      status: 3
-    - original_index: 266
-      status: 3
-    - original_index: 267
-      status: 2
-    - original_index: 268
-      status: 0
-    - original_index: 269
-      status: 2
-    - original_index: 270
-      status: 4
-    - original_index: 271
-      status: 1
-    - original_index: 272
-      status: 3
-    - original_index: 273
-      status: 3
-    - original_index: 274
-      status: 3
-    - original_index: 275
-      status: 4
-    - original_index: 276
-      status: 1
-    - original_index: 277
-      status: 2
-    - original_index: 278
-      status: 3
-    - original_index: 279
-      status: 0
-    - original_index: 280
-      status: 4
-    - original_index: 281
-      status: 2
-    - original_index: 282
-      status: 0
-    - original_index: 283
-      status: 0
-    - original_index: 284
-      status: 0
-    - original_index: 285
-      status: 1
-    - original_index: 286
-      status: 0
-    - original_index: 287
-      status: 3
-    - original_index: 288
-      status: 1
-    - original_index: 289
-      status: 2
-    - original_index: 290
-      status: 0
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 2
-    - original_index: 293
-      status: 2
-    - original_index: 294
-      status: 1
-    - original_index: 295
-      status: 4
-    - original_index: 296
-      status: 4
-    - original_index: 297
-      status: 3
-    - original_index: 298
-      status: 1
-    - original_index: 299
-      status: 2
-    - original_index: 300
-      status: 1
-    - original_index: 301
-      status: 0
-    - original_index: 302
-      status: 1
-    - original_index: 303
-      status: 2
-    - original_index: 304
-      status: 0
-    - original_index: 305
-      status: 2
-    - original_index: 306
-      status: 0
-    - original_index: 307
-      status: 4
-    - original_index: 308
-      status: 0
-    - original_index: 309
-      status: 0
-    - original_index: 310
-      status: 1
-    - original_index: 311
-      status: 0
-    - original_index: 312
-      status: 1
-    - original_index: 313
-      status: 4
-    - original_index: 314
-      status: 2
-    - original_index: 315
-      status: 4
-    - original_index: 316
-      status: 3
-    - original_index: 317
-      status: 2
-    - original_index: 318
-      status: 0
-    - original_index: 319
-      status: 3
-    - original_index: 320
-      status: 2
-    - original_index: 321
-      status: 3
-    - original_index: 322
-      status: 2
-    - original_index: 323
-      status: 4
-    - original_index: 324
-      status: 1
-    - original_index: 325
-      status: 4
-    - original_index: 326
-      status: 2
-    - original_index: 327
-      status: 1
-    - original_index: 328
-      status: 0
-    - original_index: 329
-      status: 0
-    - original_index: 330
-      status: 1
-    - original_index: 331
-      status: 4
-    - original_index: 332
-      status: 4
-    - original_index: 333
-      status: 0
-    - original_index: 334
-      status: 4
-    - original_index: 335
-      status: 2
-    - original_index: 336
-      status: 1
-    - original_index: 337
-      status: 1
-    - original_index: 338
-      status: 1
-    - original_index: 339
-      status: 0
-    - original_index: 340
-      status: 1
-    - original_index: 341
-      status: 0
-    - original_index: 342
-      status: 3
-    - original_index: 343
-      status: 0
-    - original_index: 344
-      status: 3
-    - original_index: 345
-      status: 1
-    - original_index: 346
-      status: 4
-    - original_index: 347
-      status: 3
-    - original_index: 348
-      status: 1
-    - original_index: 349
-      status: 2
-    - original_index: 350
-      status: 0
-    - original_index: 351
-      status: 3
-    - original_index: 352
-      status: 3
-    - original_index: 353
-      status: 2
-    - original_index: 354
-      status: 0
-    - original_index: 355
-      status: 0
-    - original_index: 356
-      status: 3
-    - original_index: 357
-      status: 4
-    - original_index: 358
-      status: 1
-    - original_index: 359
-      status: 1
-    - original_index: 360
-      status: 4
-    - original_index: 361
-      status: 4
-    - original_index: 362
-      status: 2
-    - original_index: 363
-      status: 0
-    - original_index: 364
-      status: 4
-    - original_index: 365
-      status: 1
-    - original_index: 366
-      status: 1
-    - original_index: 367
-      status: 0
-    - original_index: 368
-      status: 4
-    - original_index: 369
-      status: 4
-    - original_index: 370
-      status: 4
-    - original_index: 371
-      status: 1
-    - original_index: 372
-      status: 2
-    - original_index: 373
-      status: 0
-    - original_index: 374
-      status: 3
-    - original_index: 375
-      status: 1
-    - original_index: 376
-      status: 2
-    - original_index: 377
-      status: 2
-    - original_index: 378
-      status: 1
-    - original_index: 379
-      status: 2
-    - original_index: 380
-      status: 1
-    - original_index: 381
-      status: 1
-    - original_index: 382
-      status: 2
-    - original_index: 383
-      status: 0
-    - original_index: 384
-      status: 3
-    - original_index: 385
-      status: 0
-    - original_index: 386
-      status: 2
-    - original_index: 387
-      status: 0
-    - original_index: 388
-      status: 4
-    - original_index: 389
-      status: 3
-    - original_index: 390
-      status: 4
-    - original_index: 391
-      status: 1
-    - original_index: 392
-      status: 0
-    - original_index: 393
-      status: 2
-    - original_index: 394
-      status: 4
-    - original_index: 395
-      status: 4
-    - original_index: 396
-      status: 3
-    - original_index: 397
-      status: 3
-    - original_index: 398
-      status: 0
-    - original_index: 399
-      status: 2
-    - original_index: 400
-      status: 3
-    - original_index: 401
-      status: 2
-    - original_index: 402
-      status: 2
-    - original_index: 403
-      status: 3
-    - original_index: 404
-      status: 4
-    - original_index: 405
-      status: 2
-    - original_index: 406
-      status: 2
-    - original_index: 407
-      status: 3
-    - original_index: 408
-      status: 3
-    - original_index: 409
-      status: 4
-    - original_index: 410
-      status: 1
-    - original_index: 411
-      status: 4
-    - original_index: 412
-      status: 4
-    - original_index: 413
-      status: 0
-    - original_index: 414
-      status: 2
-    - original_index: 415
-      status: 3
-    - original_index: 416
-      status: 1
-    - original_index: 417
-      status: 2
-    - original_index: 418
-      status: 1
-    - original_index: 419
-      status: 4
-    - original_index: 420
-      status: 1
-    - original_index: 421
-      status: 2
-    - original_index: 422
-      status: 4
-    - original_index: 423
-      status: 0
-    - original_index: 424
-      status: 4
-    - original_index: 425
-      status: 0
-    - original_index: 426
-      status: 3
-    - original_index: 427
-      status: 3
-    - original_index: 428
-      status: 2
-    - original_index: 429
-      status: 0
-    - original_index: 430
-      status: 4
+    - {original_index: 0, status: 0}
+    - {original_index: 1, status: 3}
+    - {original_index: 2, status: 2}
+    - {original_index: 3, status: 3}
+    - {original_index: 4, status: 2}
+    - {original_index: 5, status: 2}
+    - {original_index: 6, status: 2}
+    - {original_index: 7, status: 2}
+    - {original_index: 8, status: 4}
+    - {original_index: 9, status: 3}
+    - {original_index: 10, status: 1}
+    - {original_index: 11, status: 1}
+    - {original_index: 12, status: 2}
+    - {original_index: 13, status: 3}
+    - {original_index: 14, status: 1}
+    - {original_index: 15, status: 1}
+    - {original_index: 16, status: 2}
+    - {original_index: 17, status: 0}
+    - {original_index: 18, status: 2}
+    - {original_index: 19, status: 2}
+    - {original_index: 20, status: 2}
+    - {original_index: 21, status: 0}
+    - {original_index: 22, status: 2}
+    - {original_index: 23, status: 2}
+    - {original_index: 24, status: 2}
+    - {original_index: 25, status: 1}
+    - {original_index: 26, status: 3}
+    - {original_index: 27, status: 1}
+    - {original_index: 28, status: 3}
+    - {original_index: 29, status: 0}
+    - {original_index: 30, status: 4}
+    - {original_index: 31, status: 4}
+    - {original_index: 32, status: 2}
+    - {original_index: 33, status: 3}
+    - {original_index: 34, status: 0}
+    - {original_index: 35, status: 0}
+    - {original_index: 36, status: 0}
+    - {original_index: 37, status: 0}
+    - {original_index: 38, status: 3}
+    - {original_index: 39, status: 4}
+    - {original_index: 40, status: 1}
+    - {original_index: 41, status: 2}
+    - {original_index: 42, status: 1}
+    - {original_index: 43, status: 4}
+    - {original_index: 44, status: 3}
+    - {original_index: 45, status: 3}
+    - {original_index: 46, status: 4}
+    - {original_index: 47, status: 0}
+    - {original_index: 48, status: 4}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 4}
+    - {original_index: 51, status: 0}
+    - {original_index: 52, status: 0}
+    - {original_index: 53, status: 1}
+    - {original_index: 54, status: 1}
+    - {original_index: 55, status: 3}
+    - {original_index: 56, status: 0}
+    - {original_index: 57, status: 1}
+    - {original_index: 58, status: 4}
+    - {original_index: 59, status: 1}
+    - {original_index: 60, status: 4}
+    - {original_index: 61, status: 0}
+    - {original_index: 62, status: 3}
+    - {original_index: 63, status: 0}
+    - {original_index: 64, status: 2}
+    - {original_index: 65, status: 1}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 0}
+    - {original_index: 68, status: 4}
+    - {original_index: 69, status: 2}
+    - {original_index: 70, status: 0}
+    - {original_index: 71, status: 3}
+    - {original_index: 72, status: 0}
+    - {original_index: 73, status: 3}
+    - {original_index: 74, status: 4}
+    - {original_index: 75, status: 4}
+    - {original_index: 76, status: 2}
+    - {original_index: 77, status: 0}
+    - {original_index: 78, status: 4}
+    - {original_index: 79, status: 4}
+    - {original_index: 80, status: 1}
+    - {original_index: 81, status: 2}
+    - {original_index: 82, status: 0}
+    - {original_index: 83, status: 4}
+    - {original_index: 84, status: 3}
+    - {original_index: 85, status: 2}
+    - {original_index: 86, status: 0}
+    - {original_index: 87, status: 1}
+    - {original_index: 88, status: 1}
+    - {original_index: 89, status: 4}
+    - {original_index: 90, status: 2}
+    - {original_index: 91, status: 3}
+    - {original_index: 92, status: 3}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 3}
+    - {original_index: 95, status: 2}
+    - {original_index: 96, status: 2}
+    - {original_index: 97, status: 3}
+    - {original_index: 98, status: 4}
+    - {original_index: 99, status: 0}
+    - {original_index: 100, status: 3}
+    - {original_index: 101, status: 2}
+    - {original_index: 102, status: 4}
+    - {original_index: 103, status: 2}
+    - {original_index: 104, status: 2}
+    - {original_index: 105, status: 4}
+    - {original_index: 106, status: 3}
+    - {original_index: 107, status: 1}
+    - {original_index: 108, status: 1}
+    - {original_index: 109, status: 4}
+    - {original_index: 110, status: 0}
+    - {original_index: 111, status: 3}
+    - {original_index: 112, status: 4}
+    - {original_index: 113, status: 1}
+    - {original_index: 114, status: 1}
+    - {original_index: 115, status: 4}
+    - {original_index: 116, status: 1}
+    - {original_index: 117, status: 3}
+    - {original_index: 118, status: 3}
+    - {original_index: 119, status: 4}
+    - {original_index: 120, status: 0}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 2}
+    - {original_index: 123, status: 4}
+    - {original_index: 124, status: 2}
+    - {original_index: 125, status: 2}
+    - {original_index: 126, status: 1}
+    - {original_index: 127, status: 4}
+    - {original_index: 128, status: 3}
+    - {original_index: 129, status: 4}
+    - {original_index: 130, status: 2}
+    - {original_index: 131, status: 4}
+    - {original_index: 132, status: 0}
+    - {original_index: 133, status: 4}
+    - {original_index: 134, status: 0}
+    - {original_index: 135, status: 3}
+    - {original_index: 136, status: 0}
+    - {original_index: 137, status: 4}
+    - {original_index: 138, status: 4}
+    - {original_index: 139, status: 3}
+    - {original_index: 140, status: 2}
+    - {original_index: 141, status: 4}
+    - {original_index: 142, status: 3}
+    - {original_index: 143, status: 2}
+    - {original_index: 144, status: 1}
+    - {original_index: 145, status: 0}
+    - {original_index: 146, status: 4}
+    - {original_index: 147, status: 2}
+    - {original_index: 148, status: 4}
+    - {original_index: 149, status: 2}
+    - {original_index: 150, status: 2}
+    - {original_index: 151, status: 4}
+    - {original_index: 152, status: 3}
+    - {original_index: 153, status: 0}
+    - {original_index: 154, status: 0}
+    - {original_index: 155, status: 2}
+    - {original_index: 156, status: 0}
+    - {original_index: 157, status: 3}
+    - {original_index: 158, status: 3}
+    - {original_index: 159, status: 4}
+    - {original_index: 160, status: 2}
+    - {original_index: 161, status: 3}
+    - {original_index: 162, status: 2}
+    - {original_index: 163, status: 4}
+    - {original_index: 164, status: 2}
+    - {original_index: 165, status: 4}
+    - {original_index: 166, status: 4}
+    - {original_index: 167, status: 1}
+    - {original_index: 168, status: 4}
+    - {original_index: 169, status: 3}
+    - {original_index: 170, status: 4}
+    - {original_index: 171, status: 3}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 1}
+    - {original_index: 174, status: 4}
+    - {original_index: 175, status: 4}
+    - {original_index: 176, status: 4}
+    - {original_index: 177, status: 2}
+    - {original_index: 178, status: 3}
+    - {original_index: 179, status: 3}
+    - {original_index: 180, status: 0}
+    - {original_index: 181, status: 0}
+    - {original_index: 182, status: 0}
+    - {original_index: 183, status: 2}
+    - {original_index: 184, status: 3}
+    - {original_index: 185, status: 2}
+    - {original_index: 186, status: 3}
+    - {original_index: 187, status: 1}
+    - {original_index: 188, status: 0}
+    - {original_index: 189, status: 3}
+    - {original_index: 190, status: 3}
+    - {original_index: 191, status: 1}
+    - {original_index: 192, status: 2}
+    - {original_index: 193, status: 3}
+    - {original_index: 194, status: 3}
+    - {original_index: 195, status: 2}
+    - {original_index: 196, status: 2}
+    - {original_index: 197, status: 3}
+    - {original_index: 198, status: 0}
+    - {original_index: 199, status: 4}
+    - {original_index: 200, status: 3}
+    - {original_index: 201, status: 3}
+    - {original_index: 202, status: 1}
+    - {original_index: 203, status: 4}
+    - {original_index: 204, status: 2}
+    - {original_index: 205, status: 4}
+    - {original_index: 206, status: 2}
+    - {original_index: 207, status: 0}
+    - {original_index: 208, status: 2}
+    - {original_index: 209, status: 1}
+    - {original_index: 210, status: 0}
+    - {original_index: 211, status: 2}
+    - {original_index: 212, status: 2}
+    - {original_index: 213, status: 2}
+    - {original_index: 214, status: 0}
+    - {original_index: 215, status: 2}
+    - {original_index: 216, status: 1}
+    - {original_index: 217, status: 0}
+    - {original_index: 218, status: 0}
+    - {original_index: 219, status: 1}
+    - {original_index: 220, status: 3}
+    - {original_index: 221, status: 2}
+    - {original_index: 222, status: 3}
+    - {original_index: 223, status: 3}
+    - {original_index: 224, status: 1}
+    - {original_index: 225, status: 4}
+    - {original_index: 226, status: 4}
+    - {original_index: 227, status: 0}
+    - {original_index: 228, status: 1}
+    - {original_index: 229, status: 3}
+    - {original_index: 230, status: 2}
+    - {original_index: 231, status: 3}
+    - {original_index: 232, status: 0}
+    - {original_index: 233, status: 2}
+    - {original_index: 234, status: 0}
+    - {original_index: 235, status: 4}
+    - {original_index: 236, status: 4}
+    - {original_index: 237, status: 3}
+    - {original_index: 238, status: 1}
+    - {original_index: 239, status: 3}
+    - {original_index: 240, status: 3}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 0}
+    - {original_index: 243, status: 0}
+    - {original_index: 244, status: 0}
+    - {original_index: 245, status: 1}
+    - {original_index: 246, status: 0}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 0}
+    - {original_index: 249, status: 3}
+    - {original_index: 250, status: 1}
+    - {original_index: 251, status: 0}
+    - {original_index: 252, status: 0}
+    - {original_index: 253, status: 2}
+    - {original_index: 254, status: 1}
+    - {original_index: 255, status: 2}
+    - {original_index: 256, status: 0}
+    - {original_index: 257, status: 1}
+    - {original_index: 258, status: 4}
+    - {original_index: 259, status: 2}
+    - {original_index: 260, status: 0}
+    - {original_index: 261, status: 4}
+    - {original_index: 262, status: 0}
+    - {original_index: 263, status: 3}
+    - {original_index: 264, status: 3}
+    - {original_index: 265, status: 3}
+    - {original_index: 266, status: 3}
+    - {original_index: 267, status: 2}
+    - {original_index: 268, status: 0}
+    - {original_index: 269, status: 2}
+    - {original_index: 270, status: 4}
+    - {original_index: 271, status: 1}
+    - {original_index: 272, status: 3}
+    - {original_index: 273, status: 3}
+    - {original_index: 274, status: 3}
+    - {original_index: 275, status: 4}
+    - {original_index: 276, status: 1}
+    - {original_index: 277, status: 2}
+    - {original_index: 278, status: 3}
+    - {original_index: 279, status: 0}
+    - {original_index: 280, status: 4}
+    - {original_index: 281, status: 2}
+    - {original_index: 282, status: 0}
+    - {original_index: 283, status: 0}
+    - {original_index: 284, status: 0}
+    - {original_index: 285, status: 1}
+    - {original_index: 286, status: 0}
+    - {original_index: 287, status: 3}
+    - {original_index: 288, status: 1}
+    - {original_index: 289, status: 2}
+    - {original_index: 290, status: 0}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 2}
+    - {original_index: 293, status: 2}
+    - {original_index: 294, status: 1}
+    - {original_index: 295, status: 4}
+    - {original_index: 296, status: 4}
+    - {original_index: 297, status: 3}
+    - {original_index: 298, status: 1}
+    - {original_index: 299, status: 2}
+    - {original_index: 300, status: 1}
+    - {original_index: 301, status: 0}
+    - {original_index: 302, status: 1}
+    - {original_index: 303, status: 2}
+    - {original_index: 304, status: 0}
+    - {original_index: 305, status: 2}
+    - {original_index: 306, status: 0}
+    - {original_index: 307, status: 4}
+    - {original_index: 308, status: 0}
+    - {original_index: 309, status: 0}
+    - {original_index: 310, status: 1}
+    - {original_index: 311, status: 0}
+    - {original_index: 312, status: 1}
+    - {original_index: 313, status: 4}
+    - {original_index: 314, status: 2}
+    - {original_index: 315, status: 4}
+    - {original_index: 316, status: 3}
+    - {original_index: 317, status: 2}
+    - {original_index: 318, status: 0}
+    - {original_index: 319, status: 3}
+    - {original_index: 320, status: 2}
+    - {original_index: 321, status: 3}
+    - {original_index: 322, status: 2}
+    - {original_index: 323, status: 4}
+    - {original_index: 324, status: 1}
+    - {original_index: 325, status: 4}
+    - {original_index: 326, status: 2}
+    - {original_index: 327, status: 1}
+    - {original_index: 328, status: 0}
+    - {original_index: 329, status: 0}
+    - {original_index: 330, status: 1}
+    - {original_index: 331, status: 4}
+    - {original_index: 332, status: 4}
+    - {original_index: 333, status: 0}
+    - {original_index: 334, status: 4}
+    - {original_index: 335, status: 2}
+    - {original_index: 336, status: 1}
+    - {original_index: 337, status: 1}
+    - {original_index: 338, status: 1}
+    - {original_index: 339, status: 0}
+    - {original_index: 340, status: 1}
+    - {original_index: 341, status: 0}
+    - {original_index: 342, status: 3}
+    - {original_index: 343, status: 0}
+    - {original_index: 344, status: 3}
+    - {original_index: 345, status: 1}
+    - {original_index: 346, status: 4}
+    - {original_index: 347, status: 3}
+    - {original_index: 348, status: 1}
+    - {original_index: 349, status: 2}
+    - {original_index: 350, status: 0}
+    - {original_index: 351, status: 3}
+    - {original_index: 352, status: 3}
+    - {original_index: 353, status: 2}
+    - {original_index: 354, status: 0}
+    - {original_index: 355, status: 0}
+    - {original_index: 356, status: 3}
+    - {original_index: 357, status: 4}
+    - {original_index: 358, status: 1}
+    - {original_index: 359, status: 1}
+    - {original_index: 360, status: 4}
+    - {original_index: 361, status: 4}
+    - {original_index: 362, status: 2}
+    - {original_index: 363, status: 0}
+    - {original_index: 364, status: 4}
+    - {original_index: 365, status: 1}
+    - {original_index: 366, status: 1}
+    - {original_index: 367, status: 0}
+    - {original_index: 368, status: 4}
+    - {original_index: 369, status: 4}
+    - {original_index: 370, status: 4}
+    - {original_index: 371, status: 1}
+    - {original_index: 372, status: 2}
+    - {original_index: 373, status: 0}
+    - {original_index: 374, status: 3}
+    - {original_index: 375, status: 1}
+    - {original_index: 376, status: 2}
+    - {original_index: 377, status: 2}
+    - {original_index: 378, status: 1}
+    - {original_index: 379, status: 2}
+    - {original_index: 380, status: 1}
+    - {original_index: 381, status: 1}
+    - {original_index: 382, status: 2}
+    - {original_index: 383, status: 0}
+    - {original_index: 384, status: 3}
+    - {original_index: 385, status: 0}
+    - {original_index: 386, status: 2}
+    - {original_index: 387, status: 0}
+    - {original_index: 388, status: 4}
+    - {original_index: 389, status: 3}
+    - {original_index: 390, status: 4}
+    - {original_index: 391, status: 1}
+    - {original_index: 392, status: 0}
+    - {original_index: 393, status: 2}
+    - {original_index: 394, status: 4}
+    - {original_index: 395, status: 4}
+    - {original_index: 396, status: 3}
+    - {original_index: 397, status: 3}
+    - {original_index: 398, status: 0}
+    - {original_index: 399, status: 2}
+    - {original_index: 400, status: 3}
+    - {original_index: 401, status: 2}
+    - {original_index: 402, status: 2}
+    - {original_index: 403, status: 3}
+    - {original_index: 404, status: 4}
+    - {original_index: 405, status: 2}
+    - {original_index: 406, status: 2}
+    - {original_index: 407, status: 3}
+    - {original_index: 408, status: 3}
+    - {original_index: 409, status: 4}
+    - {original_index: 410, status: 1}
+    - {original_index: 411, status: 4}
+    - {original_index: 412, status: 4}
+    - {original_index: 413, status: 0}
+    - {original_index: 414, status: 2}
+    - {original_index: 415, status: 3}
+    - {original_index: 416, status: 1}
+    - {original_index: 417, status: 2}
+    - {original_index: 418, status: 1}
+    - {original_index: 419, status: 4}
+    - {original_index: 420, status: 1}
+    - {original_index: 421, status: 2}
+    - {original_index: 422, status: 4}
+    - {original_index: 423, status: 0}
+    - {original_index: 424, status: 4}
+    - {original_index: 425, status: 0}
+    - {original_index: 426, status: 3}
+    - {original_index: 427, status: 3}
+    - {original_index: 428, status: 2}
+    - {original_index: 429, status: 0}
+    - {original_index: 430, status: 4}
   output:
-  - - committee:
-      - 151
-      - 209
+  - - committee: [151, 209]
       shard: 323
       total_validator_count: 158
-  - - committee:
-      - 176
-      - 340
+  - - committee: [176, 340]
       shard: 324
       total_validator_count: 158
-  - - committee:
-      - 191
-      - 53
-      - 271
+  - - committee: [191, 53, 271]
       shard: 325
       total_validator_count: 158
-  - - committee:
-      - 412
-      - 325
+  - - committee: [412, 325]
       shard: 326
       total_validator_count: 158
-  - - committee:
-      - 163
-      - 375
-      - 409
+  - - committee: [163, 375, 409]
       shard: 327
       total_validator_count: 158
-  - - committee:
-      - 357
-      - 337
+  - - committee: [357, 337]
       shard: 328
       total_validator_count: 158
-  - - committee:
-      - 170
-      - 202
-      - 187
+  - - committee: [170, 202, 187]
       shard: 329
       total_validator_count: 158
-  - - committee:
-      - 148
-      - 424
+  - - committee: [148, 424]
       shard: 330
       total_validator_count: 158
-  - - committee:
-      - 107
-      - 368
-      - 330
+  - - committee: [107, 368, 330]
       shard: 331
       total_validator_count: 158
-  - - committee:
-      - 225
-      - 168
+  - - committee: [225, 168]
       shard: 332
       total_validator_count: 158
-  - - committee:
-      - 416
-      - 381
-      - 87
+  - - committee: [416, 381, 87]
       shard: 333
       total_validator_count: 158
-  - - committee:
-      - 366
-      - 395
+  - - committee: [366, 395]
       shard: 334
       total_validator_count: 158
-  - - committee:
-      - 105
-      - 313
-      - 116
+  - - committee: [105, 313, 116]
       shard: 335
       total_validator_count: 158
-  - - committee:
-      - 10
-      - 380
+  - - committee: [10, 380]
       shard: 336
       total_validator_count: 158
-  - - committee:
-      - 114
-      - 365
-      - 276
+  - - committee: [114, 365, 276]
       shard: 337
       total_validator_count: 158
-  - - committee:
-      - 80
-      - 361
+  - - committee: [80, 361]
       shard: 338
       total_validator_count: 158
-  - - committee:
-      - 98
-      - 25
+  - - committee: [98, 25]
       shard: 339
       total_validator_count: 158
-  - - committee:
-      - 257
-      - 378
-      - 167
+  - - committee: [257, 378, 167]
       shard: 340
       total_validator_count: 158
-  - - committee:
-      - 133
-      - 165
+  - - committee: [133, 165]
       shard: 341
       total_validator_count: 158
-  - - committee:
-      - 119
-      - 166
-      - 298
+  - - committee: [119, 166, 298]
       shard: 342
       total_validator_count: 158
-  - - committee:
-      - 338
-      - 203
+  - - committee: [338, 203]
       shard: 343
       total_validator_count: 158
-  - - committee:
-      - 57
-      - 241
-      - 307
+  - - committee: [57, 241, 307]
       shard: 344
       total_validator_count: 158
-  - - committee:
-      - 30
-      - 235
+  - - committee: [30, 235]
       shard: 345
       total_validator_count: 158
-  - - committee:
-      - 173
-      - 144
-      - 108
+  - - committee: [173, 144, 108]
       shard: 346
       total_validator_count: 158
-  - - committee:
-      - 159
-      - 324
+  - - committee: [159, 324]
       shard: 347
       total_validator_count: 158
-  - - committee:
-      - 68
-      - 288
-      - 254
+  - - committee: [68, 288, 254]
       shard: 348
       total_validator_count: 158
-  - - committee:
-      - 39
-      - 50
+  - - committee: [39, 50]
       shard: 349
       total_validator_count: 158
-  - - committee:
-      - 300
-      - 358
-      - 123
+  - - committee: [300, 358, 123]
       shard: 350
       total_validator_count: 158
-  - - committee:
-      - 79
-      - 46
+  - - committee: [79, 46]
       shard: 351
       total_validator_count: 158
-  - - committee:
-      - 302
-      - 371
-      - 430
+  - - committee: [302, 371, 430]
       shard: 352
       total_validator_count: 158
-  - - committee:
-      - 54
-      - 228
+  - - committee: [54, 228]
       shard: 353
       total_validator_count: 158
-  - - committee:
-      - 88
-      - 258
-      - 113
+  - - committee: [88, 258, 113]
       shard: 354
       total_validator_count: 158
-  - - committee:
-      - 336
-      - 89
+  - - committee: [336, 89]
       shard: 355
       total_validator_count: 158
-  - - committee:
-      - 236
-      - 418
+  - - committee: [236, 418]
       shard: 356
       total_validator_count: 158
-  - - committee:
-      - 102
-      - 369
-      - 40
+  - - committee: [102, 369, 40]
       shard: 357
       total_validator_count: 158
-  - - committee:
-      - 146
-      - 419
+  - - committee: [146, 419]
       shard: 358
       total_validator_count: 158
-  - - committee:
-      - 216
-      - 75
-      - 109
+  - - committee: [216, 75, 109]
       shard: 359
       total_validator_count: 158
-  - - committee:
-      - 205
-      - 199
+  - - committee: [205, 199]
       shard: 360
       total_validator_count: 158
-  - - committee:
-      - 15
-      - 238
-      - 270
+  - - committee: [15, 238, 270]
       shard: 361
       total_validator_count: 158
-  - - committee:
-      - 280
-      - 65
+  - - committee: [280, 65]
       shard: 362
       total_validator_count: 158
-  - - committee:
-      - 275
-      - 346
-      - 327
+  - - committee: [275, 346, 327]
       shard: 363
       total_validator_count: 158
-  - - committee:
-      - 312
-      - 410
+  - - committee: [312, 410]
       shard: 364
       total_validator_count: 158
-  - - committee:
-      - 391
-      - 332
-      - 411
+  - - committee: [391, 332, 411]
       shard: 365
       total_validator_count: 158
-  - - committee:
-      - 59
-      - 323
+  - - committee: [59, 323]
       shard: 366
       total_validator_count: 158
-  - - committee:
-      - 245
-      - 60
-      - 388
+  - - committee: [245, 60, 388]
       shard: 367
       total_validator_count: 158
-  - - committee:
-      - 141
-      - 74
+  - - committee: [141, 74]
       shard: 368
       total_validator_count: 158
-  - - committee:
-      - 48
-      - 394
-      - 226
+  - - committee: [48, 394, 226]
       shard: 369
       total_validator_count: 158
-  - - committee:
-      - 250
-      - 126
+  - - committee: [250, 126]
       shard: 370
       total_validator_count: 158
-  - - committee:
-      - 8
-      - 78
+  - - committee: [8, 78]
       shard: 371
       total_validator_count: 158
-  - - committee:
-      - 175
-      - 31
-      - 261
+  - - committee: [175, 31, 261]
       shard: 372
       total_validator_count: 158
-  - - committee:
-      - 131
-      - 420
+  - - committee: [131, 420]
       shard: 373
       total_validator_count: 158
-  - - committee:
-      - 296
-      - 370
-      - 404
+  - - committee: [296, 370, 404]
       shard: 374
       total_validator_count: 158
-  - - committee:
-      - 129
-      - 422
+  - - committee: [129, 422]
       shard: 375
       total_validator_count: 158
-  - - committee:
-      - 138
-      - 115
-      - 127
+  - - committee: [138, 115, 127]
       shard: 376
       total_validator_count: 158
-  - - committee:
-      - 390
-      - 359
+  - - committee: [390, 359]
       shard: 377
       total_validator_count: 158
-  - - committee:
-      - 83
-      - 224
-      - 345
+  - - committee: [83, 224, 345]
       shard: 378
       total_validator_count: 158
-  - - committee:
-      - 174
-      - 295
+  - - committee: [174, 295]
       shard: 379
       total_validator_count: 158
-  - - committee:
-      - 219
-      - 331
-      - 42
+  - - committee: [219, 331, 42]
       shard: 380
       total_validator_count: 158
-  - - committee:
-      - 294
-      - 14
+  - - committee: [294, 14]
       shard: 381
       total_validator_count: 158
-  - - committee:
-      - 27
-      - 364
-      - 334
+  - - committee: [27, 364, 334]
       shard: 382
       total_validator_count: 158
-  - - committee:
-      - 58
-      - 11
+  - - committee: [58, 11]
       shard: 383
       total_validator_count: 158
-  - - committee:
-      - 112
-      - 348
-      - 360
+  - - committee: [112, 348, 360]
       shard: 384
       total_validator_count: 158
-  - - committee:
-      - 310
-      - 285
+  - - committee: [310, 285]
       shard: 385
       total_validator_count: 158
-  - - committee:
-      - 43
-      - 137
-      - 315
+  - - committee: [43, 137, 315]
       shard: 386
       total_validator_count: 158
   seed: '0x3e0145d6c946e5121aa6a8f761d1647d093fb976f2497361897012dfa6dc0190'
 - input:
     crosslinking_start_shard: 233
     validators:
-    - original_index: 0
-      status: 3
-    - original_index: 1
-      status: 0
-    - original_index: 2
-      status: 1
-    - original_index: 3
-      status: 3
-    - original_index: 4
-      status: 3
-    - original_index: 5
-      status: 2
-    - original_index: 6
-      status: 4
-    - original_index: 7
-      status: 2
-    - original_index: 8
-      status: 4
-    - original_index: 9
-      status: 4
-    - original_index: 10
-      status: 2
-    - original_index: 11
-      status: 4
-    - original_index: 12
-      status: 2
-    - original_index: 13
-      status: 1
-    - original_index: 14
-      status: 1
-    - original_index: 15
-      status: 2
-    - original_index: 16
-      status: 2
-    - original_index: 17
-      status: 1
-    - original_index: 18
-      status: 4
-    - original_index: 19
-      status: 2
-    - original_index: 20
-      status: 1
-    - original_index: 21
-      status: 2
-    - original_index: 22
-      status: 3
-    - original_index: 23
-      status: 4
-    - original_index: 24
-      status: 3
-    - original_index: 25
-      status: 1
-    - original_index: 26
-      status: 0
-    - original_index: 27
-      status: 1
-    - original_index: 28
-      status: 0
-    - original_index: 29
-      status: 4
-    - original_index: 30
-      status: 4
-    - original_index: 31
-      status: 0
-    - original_index: 32
-      status: 3
-    - original_index: 33
-      status: 3
-    - original_index: 34
-      status: 1
-    - original_index: 35
-      status: 2
-    - original_index: 36
-      status: 4
-    - original_index: 37
-      status: 4
-    - original_index: 38
-      status: 1
-    - original_index: 39
-      status: 3
-    - original_index: 40
-      status: 4
-    - original_index: 41
-      status: 2
-    - original_index: 42
-      status: 2
-    - original_index: 43
-      status: 3
-    - original_index: 44
-      status: 4
-    - original_index: 45
-      status: 4
-    - original_index: 46
-      status: 3
-    - original_index: 47
-      status: 1
-    - original_index: 48
-      status: 3
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 3
-    - original_index: 51
-      status: 0
-    - original_index: 52
-      status: 2
-    - original_index: 53
-      status: 4
-    - original_index: 54
-      status: 1
-    - original_index: 55
-      status: 2
-    - original_index: 56
-      status: 4
-    - original_index: 57
-      status: 1
-    - original_index: 58
-      status: 2
-    - original_index: 59
-      status: 2
-    - original_index: 60
-      status: 1
-    - original_index: 61
-      status: 3
-    - original_index: 62
-      status: 3
-    - original_index: 63
-      status: 3
-    - original_index: 64
-      status: 1
-    - original_index: 65
-      status: 1
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 3
-    - original_index: 68
-      status: 2
-    - original_index: 69
-      status: 2
-    - original_index: 70
-      status: 0
-    - original_index: 71
-      status: 4
-    - original_index: 72
-      status: 4
-    - original_index: 73
-      status: 1
-    - original_index: 74
-      status: 4
-    - original_index: 75
-      status: 1
-    - original_index: 76
-      status: 4
-    - original_index: 77
-      status: 0
-    - original_index: 78
-      status: 4
-    - original_index: 79
-      status: 2
-    - original_index: 80
-      status: 2
-    - original_index: 81
-      status: 4
-    - original_index: 82
-      status: 4
-    - original_index: 83
-      status: 0
-    - original_index: 84
-      status: 1
-    - original_index: 85
-      status: 1
-    - original_index: 86
-      status: 1
-    - original_index: 87
-      status: 2
-    - original_index: 88
-      status: 1
-    - original_index: 89
-      status: 2
-    - original_index: 90
-      status: 1
-    - original_index: 91
-      status: 2
-    - original_index: 92
-      status: 2
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 1
-    - original_index: 95
-      status: 0
-    - original_index: 96
-      status: 0
-    - original_index: 97
-      status: 0
-    - original_index: 98
-      status: 0
-    - original_index: 99
-      status: 4
-    - original_index: 100
-      status: 2
-    - original_index: 101
-      status: 4
-    - original_index: 102
-      status: 0
-    - original_index: 103
-      status: 3
-    - original_index: 104
-      status: 2
-    - original_index: 105
-      status: 2
-    - original_index: 106
-      status: 4
-    - original_index: 107
-      status: 3
-    - original_index: 108
-      status: 3
-    - original_index: 109
-      status: 3
-    - original_index: 110
-      status: 1
-    - original_index: 111
-      status: 0
-    - original_index: 112
-      status: 2
-    - original_index: 113
-      status: 4
-    - original_index: 114
-      status: 2
-    - original_index: 115
-      status: 2
-    - original_index: 116
-      status: 4
-    - original_index: 117
-      status: 2
-    - original_index: 118
-      status: 4
-    - original_index: 119
-      status: 3
-    - original_index: 120
-      status: 1
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 3
-    - original_index: 124
-      status: 2
-    - original_index: 125
-      status: 0
-    - original_index: 126
-      status: 1
-    - original_index: 127
-      status: 4
-    - original_index: 128
-      status: 3
-    - original_index: 129
-      status: 2
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 1
-    - original_index: 132
-      status: 0
-    - original_index: 133
-      status: 4
-    - original_index: 134
-      status: 3
-    - original_index: 135
-      status: 2
-    - original_index: 136
-      status: 1
-    - original_index: 137
-      status: 0
-    - original_index: 138
-      status: 1
-    - original_index: 139
-      status: 4
-    - original_index: 140
-      status: 2
-    - original_index: 141
-      status: 3
-    - original_index: 142
-      status: 0
-    - original_index: 143
-      status: 3
-    - original_index: 144
-      status: 0
-    - original_index: 145
-      status: 0
-    - original_index: 146
-      status: 4
-    - original_index: 147
-      status: 0
-    - original_index: 148
-      status: 4
-    - original_index: 149
-      status: 1
-    - original_index: 150
-      status: 0
-    - original_index: 151
-      status: 2
-    - original_index: 152
-      status: 3
-    - original_index: 153
-      status: 2
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 2
-    - original_index: 156
-      status: 1
-    - original_index: 157
-      status: 1
-    - original_index: 158
-      status: 3
-    - original_index: 159
-      status: 2
-    - original_index: 160
-      status: 4
-    - original_index: 161
-      status: 4
-    - original_index: 162
-      status: 2
-    - original_index: 163
-      status: 1
-    - original_index: 164
-      status: 1
-    - original_index: 165
-      status: 0
-    - original_index: 166
-      status: 0
-    - original_index: 167
-      status: 4
-    - original_index: 168
-      status: 4
-    - original_index: 169
-      status: 1
-    - original_index: 170
-      status: 0
-    - original_index: 171
-      status: 1
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 3
-    - original_index: 174
-      status: 4
-    - original_index: 175
-      status: 3
-    - original_index: 176
-      status: 0
-    - original_index: 177
-      status: 0
-    - original_index: 178
-      status: 2
-    - original_index: 179
-      status: 4
-    - original_index: 180
-      status: 1
-    - original_index: 181
-      status: 1
-    - original_index: 182
-      status: 3
-    - original_index: 183
-      status: 0
-    - original_index: 184
-      status: 4
-    - original_index: 185
-      status: 0
-    - original_index: 186
-      status: 4
-    - original_index: 187
-      status: 0
-    - original_index: 188
-      status: 3
-    - original_index: 189
-      status: 0
-    - original_index: 190
-      status: 2
-    - original_index: 191
-      status: 2
-    - original_index: 192
-      status: 4
-    - original_index: 193
-      status: 1
-    - original_index: 194
-      status: 1
-    - original_index: 195
-      status: 2
-    - original_index: 196
-      status: 4
-    - original_index: 197
-      status: 0
-    - original_index: 198
-      status: 3
-    - original_index: 199
-      status: 4
-    - original_index: 200
-      status: 1
-    - original_index: 201
-      status: 4
-    - original_index: 202
-      status: 2
-    - original_index: 203
-      status: 3
-    - original_index: 204
-      status: 2
-    - original_index: 205
-      status: 1
-    - original_index: 206
-      status: 3
-    - original_index: 207
-      status: 0
-    - original_index: 208
-      status: 1
-    - original_index: 209
-      status: 0
-    - original_index: 210
-      status: 3
-    - original_index: 211
-      status: 1
-    - original_index: 212
-      status: 2
-    - original_index: 213
-      status: 1
-    - original_index: 214
-      status: 4
-    - original_index: 215
-      status: 2
-    - original_index: 216
-      status: 1
-    - original_index: 217
-      status: 3
-    - original_index: 218
-      status: 0
-    - original_index: 219
-      status: 4
-    - original_index: 220
-      status: 2
-    - original_index: 221
-      status: 2
-    - original_index: 222
-      status: 0
-    - original_index: 223
-      status: 1
-    - original_index: 224
-      status: 2
-    - original_index: 225
-      status: 3
-    - original_index: 226
-      status: 4
-    - original_index: 227
-      status: 2
-    - original_index: 228
-      status: 2
-    - original_index: 229
-      status: 2
-    - original_index: 230
-      status: 2
-    - original_index: 231
-      status: 4
-    - original_index: 232
-      status: 0
-    - original_index: 233
-      status: 1
-    - original_index: 234
-      status: 1
-    - original_index: 235
-      status: 2
-    - original_index: 236
-      status: 1
-    - original_index: 237
-      status: 4
-    - original_index: 238
-      status: 1
-    - original_index: 239
-      status: 0
-    - original_index: 240
-      status: 1
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 3
-    - original_index: 243
-      status: 1
-    - original_index: 244
-      status: 2
-    - original_index: 245
-      status: 3
-    - original_index: 246
-      status: 0
-    - original_index: 247
-      status: 2
-    - original_index: 248
-      status: 3
-    - original_index: 249
-      status: 3
-    - original_index: 250
-      status: 4
-    - original_index: 251
-      status: 2
-    - original_index: 252
-      status: 4
-    - original_index: 253
-      status: 4
-    - original_index: 254
-      status: 0
-    - original_index: 255
-      status: 0
-    - original_index: 256
-      status: 2
-    - original_index: 257
-      status: 3
-    - original_index: 258
-      status: 4
-    - original_index: 259
-      status: 1
-    - original_index: 260
-      status: 2
-    - original_index: 261
-      status: 2
-    - original_index: 262
-      status: 2
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 4
-    - original_index: 265
-      status: 4
-    - original_index: 266
-      status: 0
-    - original_index: 267
-      status: 3
-    - original_index: 268
-      status: 2
-    - original_index: 269
-      status: 0
-    - original_index: 270
-      status: 0
-    - original_index: 271
-      status: 1
-    - original_index: 272
-      status: 3
-    - original_index: 273
-      status: 4
-    - original_index: 274
-      status: 2
-    - original_index: 275
-      status: 4
-    - original_index: 276
-      status: 4
-    - original_index: 277
-      status: 2
-    - original_index: 278
-      status: 0
-    - original_index: 279
-      status: 0
-    - original_index: 280
-      status: 3
-    - original_index: 281
-      status: 4
-    - original_index: 282
-      status: 1
-    - original_index: 283
-      status: 4
-    - original_index: 284
-      status: 0
-    - original_index: 285
-      status: 0
-    - original_index: 286
-      status: 1
-    - original_index: 287
-      status: 0
-    - original_index: 288
-      status: 3
-    - original_index: 289
-      status: 2
-    - original_index: 290
-      status: 1
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 1
-    - original_index: 293
-      status: 1
-    - original_index: 294
-      status: 1
-    - original_index: 295
-      status: 2
-    - original_index: 296
-      status: 0
-    - original_index: 297
-      status: 4
-    - original_index: 298
-      status: 3
-    - original_index: 299
-      status: 1
-    - original_index: 300
-      status: 3
-    - original_index: 301
-      status: 1
-    - original_index: 302
-      status: 0
-    - original_index: 303
-      status: 4
-    - original_index: 304
-      status: 1
-    - original_index: 305
-      status: 4
-    - original_index: 306
-      status: 1
-    - original_index: 307
-      status: 3
-    - original_index: 308
-      status: 2
-    - original_index: 309
-      status: 3
-    - original_index: 310
-      status: 2
-    - original_index: 311
-      status: 1
-    - original_index: 312
-      status: 2
-    - original_index: 313
-      status: 0
-    - original_index: 314
-      status: 3
-    - original_index: 315
-      status: 2
-    - original_index: 316
-      status: 1
-    - original_index: 317
-      status: 1
-    - original_index: 318
-      status: 1
-    - original_index: 319
-      status: 0
-    - original_index: 320
-      status: 2
-    - original_index: 321
-      status: 2
-    - original_index: 322
-      status: 2
-    - original_index: 323
-      status: 0
-    - original_index: 324
-      status: 2
-    - original_index: 325
-      status: 0
-    - original_index: 326
-      status: 2
-    - original_index: 327
-      status: 3
-    - original_index: 328
-      status: 1
-    - original_index: 329
-      status: 3
-    - original_index: 330
-      status: 3
-    - original_index: 331
-      status: 3
-    - original_index: 332
-      status: 1
-    - original_index: 333
-      status: 2
-    - original_index: 334
-      status: 3
-    - original_index: 335
-      status: 0
-    - original_index: 336
-      status: 0
-    - original_index: 337
-      status: 2
-    - original_index: 338
-      status: 1
-    - original_index: 339
-      status: 2
-    - original_index: 340
-      status: 1
-    - original_index: 341
-      status: 4
-    - original_index: 342
-      status: 2
-    - original_index: 343
-      status: 1
-    - original_index: 344
-      status: 1
-    - original_index: 345
-      status: 3
-    - original_index: 346
-      status: 4
-    - original_index: 347
-      status: 1
-    - original_index: 348
-      status: 0
-    - original_index: 349
-      status: 3
-    - original_index: 350
-      status: 0
-    - original_index: 351
-      status: 3
-    - original_index: 352
-      status: 2
-    - original_index: 353
-      status: 2
-    - original_index: 354
-      status: 1
-    - original_index: 355
-      status: 3
-    - original_index: 356
-      status: 3
-    - original_index: 357
-      status: 4
-    - original_index: 358
-      status: 0
-    - original_index: 359
-      status: 2
-    - original_index: 360
-      status: 4
-    - original_index: 361
-      status: 1
-    - original_index: 362
-      status: 2
-    - original_index: 363
-      status: 1
-    - original_index: 364
-      status: 4
-    - original_index: 365
-      status: 3
-    - original_index: 366
-      status: 0
-    - original_index: 367
-      status: 2
-    - original_index: 368
-      status: 3
-    - original_index: 369
-      status: 0
-    - original_index: 370
-      status: 2
-    - original_index: 371
-      status: 0
-    - original_index: 372
-      status: 3
-    - original_index: 373
-      status: 0
-    - original_index: 374
-      status: 0
-    - original_index: 375
-      status: 0
-    - original_index: 376
-      status: 2
-    - original_index: 377
-      status: 4
-    - original_index: 378
-      status: 4
-    - original_index: 379
-      status: 3
-    - original_index: 380
-      status: 4
-    - original_index: 381
-      status: 3
-    - original_index: 382
-      status: 2
-    - original_index: 383
-      status: 0
-    - original_index: 384
-      status: 0
-    - original_index: 385
-      status: 1
-    - original_index: 386
-      status: 2
-    - original_index: 387
-      status: 2
-    - original_index: 388
-      status: 4
-    - original_index: 389
-      status: 0
-    - original_index: 390
-      status: 0
-    - original_index: 391
-      status: 1
-    - original_index: 392
-      status: 3
-    - original_index: 393
-      status: 3
-    - original_index: 394
-      status: 3
-    - original_index: 395
-      status: 4
-    - original_index: 396
-      status: 4
-    - original_index: 397
-      status: 3
-    - original_index: 398
-      status: 4
-    - original_index: 399
-      status: 0
-    - original_index: 400
-      status: 4
-    - original_index: 401
-      status: 3
-    - original_index: 402
-      status: 1
-    - original_index: 403
-      status: 4
-    - original_index: 404
-      status: 0
-    - original_index: 405
-      status: 1
-    - original_index: 406
-      status: 3
-    - original_index: 407
-      status: 0
-    - original_index: 408
-      status: 4
-    - original_index: 409
-      status: 0
-    - original_index: 410
-      status: 0
-    - original_index: 411
-      status: 3
-    - original_index: 412
-      status: 0
-    - original_index: 413
-      status: 2
-    - original_index: 414
-      status: 0
-    - original_index: 415
-      status: 4
-    - original_index: 416
-      status: 3
-    - original_index: 417
-      status: 0
-    - original_index: 418
-      status: 0
-    - original_index: 419
-      status: 1
-    - original_index: 420
-      status: 3
-    - original_index: 421
-      status: 4
-    - original_index: 422
-      status: 3
-    - original_index: 423
-      status: 1
-    - original_index: 424
-      status: 2
-    - original_index: 425
-      status: 4
-    - original_index: 426
-      status: 0
-    - original_index: 427
-      status: 4
-    - original_index: 428
-      status: 0
-    - original_index: 429
-      status: 0
-    - original_index: 430
-      status: 0
-    - original_index: 431
-      status: 4
-    - original_index: 432
-      status: 3
-    - original_index: 433
-      status: 4
-    - original_index: 434
-      status: 2
-    - original_index: 435
-      status: 3
-    - original_index: 436
-      status: 2
-    - original_index: 437
-      status: 3
-    - original_index: 438
-      status: 4
-    - original_index: 439
-      status: 4
-    - original_index: 440
-      status: 1
-    - original_index: 441
-      status: 4
-    - original_index: 442
-      status: 1
-    - original_index: 443
-      status: 1
-    - original_index: 444
-      status: 3
-    - original_index: 445
-      status: 2
-    - original_index: 446
-      status: 3
-    - original_index: 447
-      status: 0
-    - original_index: 448
-      status: 4
-    - original_index: 449
-      status: 1
-    - original_index: 450
-      status: 4
-    - original_index: 451
-      status: 4
-    - original_index: 452
-      status: 4
-    - original_index: 453
-      status: 3
-    - original_index: 454
-      status: 1
-    - original_index: 455
-      status: 4
-    - original_index: 456
-      status: 4
-    - original_index: 457
-      status: 2
-    - original_index: 458
-      status: 0
-    - original_index: 459
-      status: 1
-    - original_index: 460
-      status: 3
-    - original_index: 461
-      status: 3
-    - original_index: 462
-      status: 2
-    - original_index: 463
-      status: 4
-    - original_index: 464
-      status: 1
-    - original_index: 465
-      status: 0
-    - original_index: 466
-      status: 2
-    - original_index: 467
-      status: 4
-    - original_index: 468
-      status: 4
-    - original_index: 469
-      status: 1
-    - original_index: 470
-      status: 2
-    - original_index: 471
-      status: 1
-    - original_index: 472
-      status: 4
-    - original_index: 473
-      status: 2
-    - original_index: 474
-      status: 0
-    - original_index: 475
-      status: 2
-    - original_index: 476
-      status: 1
-    - original_index: 477
-      status: 0
-    - original_index: 478
-      status: 3
-    - original_index: 479
-      status: 1
-    - original_index: 480
-      status: 0
-    - original_index: 481
-      status: 3
-    - original_index: 482
-      status: 0
-    - original_index: 483
-      status: 0
+    - {original_index: 0, status: 3}
+    - {original_index: 1, status: 0}
+    - {original_index: 2, status: 1}
+    - {original_index: 3, status: 3}
+    - {original_index: 4, status: 3}
+    - {original_index: 5, status: 2}
+    - {original_index: 6, status: 4}
+    - {original_index: 7, status: 2}
+    - {original_index: 8, status: 4}
+    - {original_index: 9, status: 4}
+    - {original_index: 10, status: 2}
+    - {original_index: 11, status: 4}
+    - {original_index: 12, status: 2}
+    - {original_index: 13, status: 1}
+    - {original_index: 14, status: 1}
+    - {original_index: 15, status: 2}
+    - {original_index: 16, status: 2}
+    - {original_index: 17, status: 1}
+    - {original_index: 18, status: 4}
+    - {original_index: 19, status: 2}
+    - {original_index: 20, status: 1}
+    - {original_index: 21, status: 2}
+    - {original_index: 22, status: 3}
+    - {original_index: 23, status: 4}
+    - {original_index: 24, status: 3}
+    - {original_index: 25, status: 1}
+    - {original_index: 26, status: 0}
+    - {original_index: 27, status: 1}
+    - {original_index: 28, status: 0}
+    - {original_index: 29, status: 4}
+    - {original_index: 30, status: 4}
+    - {original_index: 31, status: 0}
+    - {original_index: 32, status: 3}
+    - {original_index: 33, status: 3}
+    - {original_index: 34, status: 1}
+    - {original_index: 35, status: 2}
+    - {original_index: 36, status: 4}
+    - {original_index: 37, status: 4}
+    - {original_index: 38, status: 1}
+    - {original_index: 39, status: 3}
+    - {original_index: 40, status: 4}
+    - {original_index: 41, status: 2}
+    - {original_index: 42, status: 2}
+    - {original_index: 43, status: 3}
+    - {original_index: 44, status: 4}
+    - {original_index: 45, status: 4}
+    - {original_index: 46, status: 3}
+    - {original_index: 47, status: 1}
+    - {original_index: 48, status: 3}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 3}
+    - {original_index: 51, status: 0}
+    - {original_index: 52, status: 2}
+    - {original_index: 53, status: 4}
+    - {original_index: 54, status: 1}
+    - {original_index: 55, status: 2}
+    - {original_index: 56, status: 4}
+    - {original_index: 57, status: 1}
+    - {original_index: 58, status: 2}
+    - {original_index: 59, status: 2}
+    - {original_index: 60, status: 1}
+    - {original_index: 61, status: 3}
+    - {original_index: 62, status: 3}
+    - {original_index: 63, status: 3}
+    - {original_index: 64, status: 1}
+    - {original_index: 65, status: 1}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 3}
+    - {original_index: 68, status: 2}
+    - {original_index: 69, status: 2}
+    - {original_index: 70, status: 0}
+    - {original_index: 71, status: 4}
+    - {original_index: 72, status: 4}
+    - {original_index: 73, status: 1}
+    - {original_index: 74, status: 4}
+    - {original_index: 75, status: 1}
+    - {original_index: 76, status: 4}
+    - {original_index: 77, status: 0}
+    - {original_index: 78, status: 4}
+    - {original_index: 79, status: 2}
+    - {original_index: 80, status: 2}
+    - {original_index: 81, status: 4}
+    - {original_index: 82, status: 4}
+    - {original_index: 83, status: 0}
+    - {original_index: 84, status: 1}
+    - {original_index: 85, status: 1}
+    - {original_index: 86, status: 1}
+    - {original_index: 87, status: 2}
+    - {original_index: 88, status: 1}
+    - {original_index: 89, status: 2}
+    - {original_index: 90, status: 1}
+    - {original_index: 91, status: 2}
+    - {original_index: 92, status: 2}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 1}
+    - {original_index: 95, status: 0}
+    - {original_index: 96, status: 0}
+    - {original_index: 97, status: 0}
+    - {original_index: 98, status: 0}
+    - {original_index: 99, status: 4}
+    - {original_index: 100, status: 2}
+    - {original_index: 101, status: 4}
+    - {original_index: 102, status: 0}
+    - {original_index: 103, status: 3}
+    - {original_index: 104, status: 2}
+    - {original_index: 105, status: 2}
+    - {original_index: 106, status: 4}
+    - {original_index: 107, status: 3}
+    - {original_index: 108, status: 3}
+    - {original_index: 109, status: 3}
+    - {original_index: 110, status: 1}
+    - {original_index: 111, status: 0}
+    - {original_index: 112, status: 2}
+    - {original_index: 113, status: 4}
+    - {original_index: 114, status: 2}
+    - {original_index: 115, status: 2}
+    - {original_index: 116, status: 4}
+    - {original_index: 117, status: 2}
+    - {original_index: 118, status: 4}
+    - {original_index: 119, status: 3}
+    - {original_index: 120, status: 1}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 3}
+    - {original_index: 124, status: 2}
+    - {original_index: 125, status: 0}
+    - {original_index: 126, status: 1}
+    - {original_index: 127, status: 4}
+    - {original_index: 128, status: 3}
+    - {original_index: 129, status: 2}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 1}
+    - {original_index: 132, status: 0}
+    - {original_index: 133, status: 4}
+    - {original_index: 134, status: 3}
+    - {original_index: 135, status: 2}
+    - {original_index: 136, status: 1}
+    - {original_index: 137, status: 0}
+    - {original_index: 138, status: 1}
+    - {original_index: 139, status: 4}
+    - {original_index: 140, status: 2}
+    - {original_index: 141, status: 3}
+    - {original_index: 142, status: 0}
+    - {original_index: 143, status: 3}
+    - {original_index: 144, status: 0}
+    - {original_index: 145, status: 0}
+    - {original_index: 146, status: 4}
+    - {original_index: 147, status: 0}
+    - {original_index: 148, status: 4}
+    - {original_index: 149, status: 1}
+    - {original_index: 150, status: 0}
+    - {original_index: 151, status: 2}
+    - {original_index: 152, status: 3}
+    - {original_index: 153, status: 2}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 2}
+    - {original_index: 156, status: 1}
+    - {original_index: 157, status: 1}
+    - {original_index: 158, status: 3}
+    - {original_index: 159, status: 2}
+    - {original_index: 160, status: 4}
+    - {original_index: 161, status: 4}
+    - {original_index: 162, status: 2}
+    - {original_index: 163, status: 1}
+    - {original_index: 164, status: 1}
+    - {original_index: 165, status: 0}
+    - {original_index: 166, status: 0}
+    - {original_index: 167, status: 4}
+    - {original_index: 168, status: 4}
+    - {original_index: 169, status: 1}
+    - {original_index: 170, status: 0}
+    - {original_index: 171, status: 1}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 3}
+    - {original_index: 174, status: 4}
+    - {original_index: 175, status: 3}
+    - {original_index: 176, status: 0}
+    - {original_index: 177, status: 0}
+    - {original_index: 178, status: 2}
+    - {original_index: 179, status: 4}
+    - {original_index: 180, status: 1}
+    - {original_index: 181, status: 1}
+    - {original_index: 182, status: 3}
+    - {original_index: 183, status: 0}
+    - {original_index: 184, status: 4}
+    - {original_index: 185, status: 0}
+    - {original_index: 186, status: 4}
+    - {original_index: 187, status: 0}
+    - {original_index: 188, status: 3}
+    - {original_index: 189, status: 0}
+    - {original_index: 190, status: 2}
+    - {original_index: 191, status: 2}
+    - {original_index: 192, status: 4}
+    - {original_index: 193, status: 1}
+    - {original_index: 194, status: 1}
+    - {original_index: 195, status: 2}
+    - {original_index: 196, status: 4}
+    - {original_index: 197, status: 0}
+    - {original_index: 198, status: 3}
+    - {original_index: 199, status: 4}
+    - {original_index: 200, status: 1}
+    - {original_index: 201, status: 4}
+    - {original_index: 202, status: 2}
+    - {original_index: 203, status: 3}
+    - {original_index: 204, status: 2}
+    - {original_index: 205, status: 1}
+    - {original_index: 206, status: 3}
+    - {original_index: 207, status: 0}
+    - {original_index: 208, status: 1}
+    - {original_index: 209, status: 0}
+    - {original_index: 210, status: 3}
+    - {original_index: 211, status: 1}
+    - {original_index: 212, status: 2}
+    - {original_index: 213, status: 1}
+    - {original_index: 214, status: 4}
+    - {original_index: 215, status: 2}
+    - {original_index: 216, status: 1}
+    - {original_index: 217, status: 3}
+    - {original_index: 218, status: 0}
+    - {original_index: 219, status: 4}
+    - {original_index: 220, status: 2}
+    - {original_index: 221, status: 2}
+    - {original_index: 222, status: 0}
+    - {original_index: 223, status: 1}
+    - {original_index: 224, status: 2}
+    - {original_index: 225, status: 3}
+    - {original_index: 226, status: 4}
+    - {original_index: 227, status: 2}
+    - {original_index: 228, status: 2}
+    - {original_index: 229, status: 2}
+    - {original_index: 230, status: 2}
+    - {original_index: 231, status: 4}
+    - {original_index: 232, status: 0}
+    - {original_index: 233, status: 1}
+    - {original_index: 234, status: 1}
+    - {original_index: 235, status: 2}
+    - {original_index: 236, status: 1}
+    - {original_index: 237, status: 4}
+    - {original_index: 238, status: 1}
+    - {original_index: 239, status: 0}
+    - {original_index: 240, status: 1}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 3}
+    - {original_index: 243, status: 1}
+    - {original_index: 244, status: 2}
+    - {original_index: 245, status: 3}
+    - {original_index: 246, status: 0}
+    - {original_index: 247, status: 2}
+    - {original_index: 248, status: 3}
+    - {original_index: 249, status: 3}
+    - {original_index: 250, status: 4}
+    - {original_index: 251, status: 2}
+    - {original_index: 252, status: 4}
+    - {original_index: 253, status: 4}
+    - {original_index: 254, status: 0}
+    - {original_index: 255, status: 0}
+    - {original_index: 256, status: 2}
+    - {original_index: 257, status: 3}
+    - {original_index: 258, status: 4}
+    - {original_index: 259, status: 1}
+    - {original_index: 260, status: 2}
+    - {original_index: 261, status: 2}
+    - {original_index: 262, status: 2}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 4}
+    - {original_index: 265, status: 4}
+    - {original_index: 266, status: 0}
+    - {original_index: 267, status: 3}
+    - {original_index: 268, status: 2}
+    - {original_index: 269, status: 0}
+    - {original_index: 270, status: 0}
+    - {original_index: 271, status: 1}
+    - {original_index: 272, status: 3}
+    - {original_index: 273, status: 4}
+    - {original_index: 274, status: 2}
+    - {original_index: 275, status: 4}
+    - {original_index: 276, status: 4}
+    - {original_index: 277, status: 2}
+    - {original_index: 278, status: 0}
+    - {original_index: 279, status: 0}
+    - {original_index: 280, status: 3}
+    - {original_index: 281, status: 4}
+    - {original_index: 282, status: 1}
+    - {original_index: 283, status: 4}
+    - {original_index: 284, status: 0}
+    - {original_index: 285, status: 0}
+    - {original_index: 286, status: 1}
+    - {original_index: 287, status: 0}
+    - {original_index: 288, status: 3}
+    - {original_index: 289, status: 2}
+    - {original_index: 290, status: 1}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 1}
+    - {original_index: 293, status: 1}
+    - {original_index: 294, status: 1}
+    - {original_index: 295, status: 2}
+    - {original_index: 296, status: 0}
+    - {original_index: 297, status: 4}
+    - {original_index: 298, status: 3}
+    - {original_index: 299, status: 1}
+    - {original_index: 300, status: 3}
+    - {original_index: 301, status: 1}
+    - {original_index: 302, status: 0}
+    - {original_index: 303, status: 4}
+    - {original_index: 304, status: 1}
+    - {original_index: 305, status: 4}
+    - {original_index: 306, status: 1}
+    - {original_index: 307, status: 3}
+    - {original_index: 308, status: 2}
+    - {original_index: 309, status: 3}
+    - {original_index: 310, status: 2}
+    - {original_index: 311, status: 1}
+    - {original_index: 312, status: 2}
+    - {original_index: 313, status: 0}
+    - {original_index: 314, status: 3}
+    - {original_index: 315, status: 2}
+    - {original_index: 316, status: 1}
+    - {original_index: 317, status: 1}
+    - {original_index: 318, status: 1}
+    - {original_index: 319, status: 0}
+    - {original_index: 320, status: 2}
+    - {original_index: 321, status: 2}
+    - {original_index: 322, status: 2}
+    - {original_index: 323, status: 0}
+    - {original_index: 324, status: 2}
+    - {original_index: 325, status: 0}
+    - {original_index: 326, status: 2}
+    - {original_index: 327, status: 3}
+    - {original_index: 328, status: 1}
+    - {original_index: 329, status: 3}
+    - {original_index: 330, status: 3}
+    - {original_index: 331, status: 3}
+    - {original_index: 332, status: 1}
+    - {original_index: 333, status: 2}
+    - {original_index: 334, status: 3}
+    - {original_index: 335, status: 0}
+    - {original_index: 336, status: 0}
+    - {original_index: 337, status: 2}
+    - {original_index: 338, status: 1}
+    - {original_index: 339, status: 2}
+    - {original_index: 340, status: 1}
+    - {original_index: 341, status: 4}
+    - {original_index: 342, status: 2}
+    - {original_index: 343, status: 1}
+    - {original_index: 344, status: 1}
+    - {original_index: 345, status: 3}
+    - {original_index: 346, status: 4}
+    - {original_index: 347, status: 1}
+    - {original_index: 348, status: 0}
+    - {original_index: 349, status: 3}
+    - {original_index: 350, status: 0}
+    - {original_index: 351, status: 3}
+    - {original_index: 352, status: 2}
+    - {original_index: 353, status: 2}
+    - {original_index: 354, status: 1}
+    - {original_index: 355, status: 3}
+    - {original_index: 356, status: 3}
+    - {original_index: 357, status: 4}
+    - {original_index: 358, status: 0}
+    - {original_index: 359, status: 2}
+    - {original_index: 360, status: 4}
+    - {original_index: 361, status: 1}
+    - {original_index: 362, status: 2}
+    - {original_index: 363, status: 1}
+    - {original_index: 364, status: 4}
+    - {original_index: 365, status: 3}
+    - {original_index: 366, status: 0}
+    - {original_index: 367, status: 2}
+    - {original_index: 368, status: 3}
+    - {original_index: 369, status: 0}
+    - {original_index: 370, status: 2}
+    - {original_index: 371, status: 0}
+    - {original_index: 372, status: 3}
+    - {original_index: 373, status: 0}
+    - {original_index: 374, status: 0}
+    - {original_index: 375, status: 0}
+    - {original_index: 376, status: 2}
+    - {original_index: 377, status: 4}
+    - {original_index: 378, status: 4}
+    - {original_index: 379, status: 3}
+    - {original_index: 380, status: 4}
+    - {original_index: 381, status: 3}
+    - {original_index: 382, status: 2}
+    - {original_index: 383, status: 0}
+    - {original_index: 384, status: 0}
+    - {original_index: 385, status: 1}
+    - {original_index: 386, status: 2}
+    - {original_index: 387, status: 2}
+    - {original_index: 388, status: 4}
+    - {original_index: 389, status: 0}
+    - {original_index: 390, status: 0}
+    - {original_index: 391, status: 1}
+    - {original_index: 392, status: 3}
+    - {original_index: 393, status: 3}
+    - {original_index: 394, status: 3}
+    - {original_index: 395, status: 4}
+    - {original_index: 396, status: 4}
+    - {original_index: 397, status: 3}
+    - {original_index: 398, status: 4}
+    - {original_index: 399, status: 0}
+    - {original_index: 400, status: 4}
+    - {original_index: 401, status: 3}
+    - {original_index: 402, status: 1}
+    - {original_index: 403, status: 4}
+    - {original_index: 404, status: 0}
+    - {original_index: 405, status: 1}
+    - {original_index: 406, status: 3}
+    - {original_index: 407, status: 0}
+    - {original_index: 408, status: 4}
+    - {original_index: 409, status: 0}
+    - {original_index: 410, status: 0}
+    - {original_index: 411, status: 3}
+    - {original_index: 412, status: 0}
+    - {original_index: 413, status: 2}
+    - {original_index: 414, status: 0}
+    - {original_index: 415, status: 4}
+    - {original_index: 416, status: 3}
+    - {original_index: 417, status: 0}
+    - {original_index: 418, status: 0}
+    - {original_index: 419, status: 1}
+    - {original_index: 420, status: 3}
+    - {original_index: 421, status: 4}
+    - {original_index: 422, status: 3}
+    - {original_index: 423, status: 1}
+    - {original_index: 424, status: 2}
+    - {original_index: 425, status: 4}
+    - {original_index: 426, status: 0}
+    - {original_index: 427, status: 4}
+    - {original_index: 428, status: 0}
+    - {original_index: 429, status: 0}
+    - {original_index: 430, status: 0}
+    - {original_index: 431, status: 4}
+    - {original_index: 432, status: 3}
+    - {original_index: 433, status: 4}
+    - {original_index: 434, status: 2}
+    - {original_index: 435, status: 3}
+    - {original_index: 436, status: 2}
+    - {original_index: 437, status: 3}
+    - {original_index: 438, status: 4}
+    - {original_index: 439, status: 4}
+    - {original_index: 440, status: 1}
+    - {original_index: 441, status: 4}
+    - {original_index: 442, status: 1}
+    - {original_index: 443, status: 1}
+    - {original_index: 444, status: 3}
+    - {original_index: 445, status: 2}
+    - {original_index: 446, status: 3}
+    - {original_index: 447, status: 0}
+    - {original_index: 448, status: 4}
+    - {original_index: 449, status: 1}
+    - {original_index: 450, status: 4}
+    - {original_index: 451, status: 4}
+    - {original_index: 452, status: 4}
+    - {original_index: 453, status: 3}
+    - {original_index: 454, status: 1}
+    - {original_index: 455, status: 4}
+    - {original_index: 456, status: 4}
+    - {original_index: 457, status: 2}
+    - {original_index: 458, status: 0}
+    - {original_index: 459, status: 1}
+    - {original_index: 460, status: 3}
+    - {original_index: 461, status: 3}
+    - {original_index: 462, status: 2}
+    - {original_index: 463, status: 4}
+    - {original_index: 464, status: 1}
+    - {original_index: 465, status: 0}
+    - {original_index: 466, status: 2}
+    - {original_index: 467, status: 4}
+    - {original_index: 468, status: 4}
+    - {original_index: 469, status: 1}
+    - {original_index: 470, status: 2}
+    - {original_index: 471, status: 1}
+    - {original_index: 472, status: 4}
+    - {original_index: 473, status: 2}
+    - {original_index: 474, status: 0}
+    - {original_index: 475, status: 2}
+    - {original_index: 476, status: 1}
+    - {original_index: 477, status: 0}
+    - {original_index: 478, status: 3}
+    - {original_index: 479, status: 1}
+    - {original_index: 480, status: 0}
+    - {original_index: 481, status: 3}
+    - {original_index: 482, status: 0}
+    - {original_index: 483, status: 0}
   output:
-  - - committee:
-      - 304
-      - 340
-      - 201
+  - - committee: [304, 340, 201]
       shard: 233
       total_validator_count: 198
-  - - committee:
-      - 113
-      - 451
-      - 456
+  - - committee: [113, 451, 456]
       shard: 234
       total_validator_count: 198
-  - - committee:
-      - 459
-      - 450
-      - 361
+  - - committee: [459, 450, 361]
       shard: 235
       total_validator_count: 198
-  - - committee:
-      - 29
-      - 281
-      - 74
+  - - committee: [29, 281, 74]
       shard: 236
       total_validator_count: 198
-  - - committee:
-      - 347
-      - 237
-      - 193
+  - - committee: [347, 237, 193]
       shard: 237
       total_validator_count: 198
-  - - committee:
-      - 297
-      - 354
-      - 292
+  - - committee: [297, 354, 292]
       shard: 238
       total_validator_count: 198
-  - - committee:
-      - 211
-      - 258
-      - 293
+  - - committee: [211, 258, 293]
       shard: 239
       total_validator_count: 198
-  - - committee:
-      - 276
-      - 400
-      - 8
+  - - committee: [276, 400, 8]
       shard: 240
       total_validator_count: 198
-  - - committee:
-      - 316
-      - 243
-      - 64
+  - - committee: [316, 243, 64]
       shard: 241
       total_validator_count: 198
-  - - committee:
-      - 17
-      - 303
-      - 205
+  - - committee: [17, 303, 205]
       shard: 242
       total_validator_count: 198
-  - - committee:
-      - 378
-      - 90
-      - 171
-      - 226
+  - - committee: [378, 90, 171, 226]
       shard: 243
       total_validator_count: 198
-  - - committee:
-      - 126
-      - 20
-      - 431
+  - - committee: [126, 20, 431]
       shard: 244
       total_validator_count: 198
-  - - committee:
-      - 391
-      - 455
-      - 427
+  - - committee: [391, 455, 427]
       shard: 245
       total_validator_count: 198
-  - - committee:
-      - 13
-      - 174
-      - 363
+  - - committee: [13, 174, 363]
       shard: 246
       total_validator_count: 198
-  - - committee:
-      - 259
-      - 240
-      - 433
+  - - committee: [259, 240, 433]
       shard: 247
       total_validator_count: 198
-  - - committee:
-      - 9
-      - 380
-      - 441
+  - - committee: [9, 380, 441]
       shard: 248
       total_validator_count: 198
-  - - committee:
-      - 396
-      - 65
-      - 425
+  - - committee: [396, 65, 425]
       shard: 249
       total_validator_count: 198
-  - - committee:
-      - 449
-      - 357
-      - 164
+  - - committee: [449, 357, 164]
       shard: 250
       total_validator_count: 198
-  - - committee:
-      - 421
-      - 306
-      - 328
+  - - committee: [421, 306, 328]
       shard: 251
       total_validator_count: 198
-  - - committee:
-      - 139
-      - 344
-      - 94
+  - - committee: [139, 344, 94]
       shard: 252
       total_validator_count: 198
-  - - committee:
-      - 464
-      - 157
-      - 264
+  - - committee: [464, 157, 264]
       shard: 253
       total_validator_count: 198
-  - - committee:
-      - 317
-      - 283
-      - 440
-      - 439
+  - - committee: [317, 283, 440, 439]
       shard: 254
       total_validator_count: 198
-  - - committee:
-      - 341
-      - 265
-      - 60
+  - - committee: [341, 265, 60]
       shard: 255
       total_validator_count: 198
-  - - committee:
-      - 208
-      - 305
-      - 443
+  - - committee: [208, 305, 443]
       shard: 256
       total_validator_count: 198
-  - - committee:
-      - 442
-      - 88
-      - 311
+  - - committee: [442, 88, 311]
       shard: 257
       total_validator_count: 198
-  - - committee:
-      - 360
-      - 181
-      - 405
+  - - committee: [360, 181, 405]
       shard: 258
       total_validator_count: 198
-  - - committee:
-      - 120
-      - 241
-      - 110
+  - - committee: [120, 241, 110]
       shard: 259
       total_validator_count: 198
-  - - committee:
-      - 472
-      - 36
-      - 25
+  - - committee: [472, 36, 25]
       shard: 260
       total_validator_count: 198
-  - - committee:
-      - 467
-      - 146
-      - 346
+  - - committee: [467, 146, 346]
       shard: 261
       total_validator_count: 198
-  - - committee:
-      - 53
-      - 192
-      - 438
+  - - committee: [53, 192, 438]
       shard: 262
       total_validator_count: 198
-  - - committee:
-      - 34
-      - 184
-      - 273
+  - - committee: [34, 184, 273]
       shard: 263
       total_validator_count: 198
-  - - committee:
-      - 82
-      - 136
-      - 364
-      - 44
+  - - committee: [82, 136, 364, 44]
       shard: 264
       total_validator_count: 198
-  - - committee:
-      - 30
-      - 194
-      - 199
+  - - committee: [30, 194, 199]
       shard: 265
       total_validator_count: 198
-  - - committee:
-      - 263
-      - 131
-      - 196
+  - - committee: [263, 131, 196]
       shard: 266
       total_validator_count: 198
-  - - committee:
-      - 290
-      - 6
-      - 388
+  - - committee: [290, 6, 388]
       shard: 267
       total_validator_count: 198
-  - - committee:
-      - 299
-      - 454
-      - 479
+  - - committee: [299, 454, 479]
       shard: 268
       total_validator_count: 198
-  - - committee:
-      - 37
-      - 471
-      - 332
+  - - committee: [37, 471, 332]
       shard: 269
       total_validator_count: 198
-  - - committee:
-      - 385
-      - 161
-      - 415
+  - - committee: [385, 161, 415]
       shard: 270
       total_validator_count: 198
-  - - committee:
-      - 179
-      - 294
-      - 54
+  - - committee: [179, 294, 54]
       shard: 271
       total_validator_count: 198
-  - - committee:
-      - 403
-      - 186
-      - 73
+  - - committee: [403, 186, 73]
       shard: 272
       total_validator_count: 198
-  - - committee:
-      - 377
-      - 2
-      - 85
+  - - committee: [377, 2, 85]
       shard: 273
       total_validator_count: 198
-  - - committee:
-      - 84
-      - 133
-      - 71
+  - - committee: [84, 133, 71]
       shard: 274
       total_validator_count: 198
-  - - committee:
-      - 81
-      - 219
-      - 27
-      - 338
+  - - committee: [81, 219, 27, 338]
       shard: 275
       total_validator_count: 198
-  - - committee:
-      - 233
-      - 180
-      - 130
+  - - committee: [233, 180, 130]
       shard: 276
       total_validator_count: 198
-  - - committee:
-      - 167
-      - 236
-      - 250
+  - - committee: [167, 236, 250]
       shard: 277
       total_validator_count: 198
-  - - committee:
-      - 18
-      - 286
-      - 148
+  - - committee: [18, 286, 148]
       shard: 278
       total_validator_count: 198
-  - - committee:
-      - 200
-      - 402
-      - 149
+  - - committee: [200, 402, 149]
       shard: 279
       total_validator_count: 198
-  - - committee:
-      - 223
-      - 271
-      - 75
+  - - committee: [223, 271, 75]
       shard: 280
       total_validator_count: 198
-  - - committee:
-      - 138
-      - 213
-      - 469
+  - - committee: [138, 213, 469]
       shard: 281
       total_validator_count: 198
-  - - committee:
-      - 238
-      - 101
-      - 253
+  - - committee: [238, 101, 253]
       shard: 282
       total_validator_count: 198
-  - - committee:
-      - 57
-      - 14
-      - 116
+  - - committee: [57, 14, 116]
       shard: 283
       total_validator_count: 198
-  - - committee:
-      - 154
-      - 398
-      - 118
+  - - committee: [154, 398, 118]
       shard: 284
       total_validator_count: 198
-  - - committee:
-      - 156
-      - 47
-      - 127
+  - - committee: [156, 47, 127]
       shard: 285
       total_validator_count: 198
-  - - committee:
-      - 423
-      - 56
-      - 160
-      - 395
+  - - committee: [423, 56, 160, 395]
       shard: 286
       total_validator_count: 198
-  - - committee:
-      - 252
-      - 169
-      - 463
+  - - committee: [252, 169, 463]
       shard: 287
       total_validator_count: 198
-  - - committee:
-      - 106
-      - 72
-      - 234
+  - - committee: [106, 72, 234]
       shard: 288
       total_validator_count: 198
-  - - committee:
-      - 214
-      - 275
-      - 76
+  - - committee: [214, 275, 76]
       shard: 289
       total_validator_count: 198
-  - - committee:
-      - 282
-      - 23
-      - 408
+  - - committee: [282, 23, 408]
       shard: 290
       total_validator_count: 198
-  - - committee:
-      - 45
-      - 452
-      - 38
+  - - committee: [45, 452, 38]
       shard: 291
       total_validator_count: 198
-  - - committee:
-      - 168
-      - 301
-      - 343
+  - - committee: [168, 301, 343]
       shard: 292
       total_validator_count: 198
-  - - committee:
-      - 78
-      - 476
-      - 419
+  - - committee: [78, 476, 419]
       shard: 293
       total_validator_count: 198
-  - - committee:
-      - 40
-      - 11
-      - 99
+  - - committee: [40, 11, 99]
       shard: 294
       total_validator_count: 198
-  - - committee:
-      - 86
-      - 468
-      - 163
+  - - committee: [86, 468, 163]
       shard: 295
       total_validator_count: 198
-  - - committee:
-      - 448
-      - 216
-      - 318
-      - 231
+  - - committee: [448, 216, 318, 231]
       shard: 296
       total_validator_count: 198
   seed: '0xeefb66740fd23df786731edb105354862abc8bc52ee4d0bffe8b7bc2d61f22d7'
 - input:
     crosslinking_start_shard: 400
     validators:
-    - original_index: 0
-      status: 0
-    - original_index: 1
-      status: 4
-    - original_index: 2
-      status: 0
-    - original_index: 3
-      status: 3
-    - original_index: 4
-      status: 1
-    - original_index: 5
-      status: 2
-    - original_index: 6
-      status: 1
-    - original_index: 7
-      status: 2
-    - original_index: 8
-      status: 2
-    - original_index: 9
-      status: 2
-    - original_index: 10
-      status: 1
-    - original_index: 11
-      status: 0
-    - original_index: 12
-      status: 3
-    - original_index: 13
-      status: 0
-    - original_index: 14
-      status: 2
-    - original_index: 15
-      status: 4
-    - original_index: 16
-      status: 4
-    - original_index: 17
-      status: 4
-    - original_index: 18
-      status: 2
-    - original_index: 19
-      status: 2
-    - original_index: 20
-      status: 2
-    - original_index: 21
-      status: 1
-    - original_index: 22
-      status: 1
-    - original_index: 23
-      status: 4
-    - original_index: 24
-      status: 1
-    - original_index: 25
-      status: 2
-    - original_index: 26
-      status: 1
-    - original_index: 27
-      status: 3
-    - original_index: 28
-      status: 0
-    - original_index: 29
-      status: 0
-    - original_index: 30
-      status: 3
-    - original_index: 31
-      status: 4
-    - original_index: 32
-      status: 1
-    - original_index: 33
-      status: 1
-    - original_index: 34
-      status: 0
-    - original_index: 35
-      status: 4
-    - original_index: 36
-      status: 3
-    - original_index: 37
-      status: 0
-    - original_index: 38
-      status: 4
-    - original_index: 39
-      status: 4
-    - original_index: 40
-      status: 3
-    - original_index: 41
-      status: 2
-    - original_index: 42
-      status: 3
-    - original_index: 43
-      status: 1
-    - original_index: 44
-      status: 3
-    - original_index: 45
-      status: 1
-    - original_index: 46
-      status: 1
-    - original_index: 47
-      status: 3
-    - original_index: 48
-      status: 0
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 0
-    - original_index: 51
-      status: 4
-    - original_index: 52
-      status: 1
-    - original_index: 53
-      status: 1
-    - original_index: 54
-      status: 1
-    - original_index: 55
-      status: 1
-    - original_index: 56
-      status: 2
-    - original_index: 57
-      status: 3
-    - original_index: 58
-      status: 3
-    - original_index: 59
-      status: 4
-    - original_index: 60
-      status: 2
-    - original_index: 61
-      status: 0
-    - original_index: 62
-      status: 2
-    - original_index: 63
-      status: 3
-    - original_index: 64
-      status: 3
-    - original_index: 65
-      status: 0
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 0
-    - original_index: 68
-      status: 2
-    - original_index: 69
-      status: 4
-    - original_index: 70
-      status: 3
-    - original_index: 71
-      status: 3
-    - original_index: 72
-      status: 3
-    - original_index: 73
-      status: 2
-    - original_index: 74
-      status: 1
-    - original_index: 75
-      status: 3
-    - original_index: 76
-      status: 4
-    - original_index: 77
-      status: 2
-    - original_index: 78
-      status: 3
-    - original_index: 79
-      status: 0
-    - original_index: 80
-      status: 2
-    - original_index: 81
-      status: 0
-    - original_index: 82
-      status: 1
-    - original_index: 83
-      status: 3
-    - original_index: 84
-      status: 1
-    - original_index: 85
-      status: 4
-    - original_index: 86
-      status: 4
-    - original_index: 87
-      status: 1
-    - original_index: 88
-      status: 4
-    - original_index: 89
-      status: 4
-    - original_index: 90
-      status: 2
-    - original_index: 91
-      status: 1
-    - original_index: 92
-      status: 3
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 2
-    - original_index: 95
-      status: 3
-    - original_index: 96
-      status: 3
-    - original_index: 97
-      status: 4
-    - original_index: 98
-      status: 4
-    - original_index: 99
-      status: 4
-    - original_index: 100
-      status: 2
-    - original_index: 101
-      status: 3
-    - original_index: 102
-      status: 0
-    - original_index: 103
-      status: 0
-    - original_index: 104
-      status: 2
-    - original_index: 105
-      status: 3
-    - original_index: 106
-      status: 1
-    - original_index: 107
-      status: 4
-    - original_index: 108
-      status: 2
-    - original_index: 109
-      status: 3
-    - original_index: 110
-      status: 2
-    - original_index: 111
-      status: 2
-    - original_index: 112
-      status: 4
-    - original_index: 113
-      status: 0
-    - original_index: 114
-      status: 0
-    - original_index: 115
-      status: 4
-    - original_index: 116
-      status: 0
-    - original_index: 117
-      status: 1
-    - original_index: 118
-      status: 0
-    - original_index: 119
-      status: 3
-    - original_index: 120
-      status: 0
-    - original_index: 121
-      status: 2
-    - original_index: 122
-      status: 2
-    - original_index: 123
-      status: 1
-    - original_index: 124
-      status: 3
-    - original_index: 125
-      status: 3
-    - original_index: 126
-      status: 2
-    - original_index: 127
-      status: 3
-    - original_index: 128
-      status: 4
-    - original_index: 129
-      status: 3
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 2
-    - original_index: 132
-      status: 0
-    - original_index: 133
-      status: 0
-    - original_index: 134
-      status: 1
-    - original_index: 135
-      status: 4
-    - original_index: 136
-      status: 3
-    - original_index: 137
-      status: 1
-    - original_index: 138
-      status: 2
-    - original_index: 139
-      status: 0
-    - original_index: 140
-      status: 4
-    - original_index: 141
-      status: 1
-    - original_index: 142
-      status: 1
-    - original_index: 143
-      status: 0
-    - original_index: 144
-      status: 0
-    - original_index: 145
-      status: 4
-    - original_index: 146
-      status: 1
-    - original_index: 147
-      status: 2
-    - original_index: 148
-      status: 4
-    - original_index: 149
-      status: 3
-    - original_index: 150
-      status: 3
-    - original_index: 151
-      status: 3
-    - original_index: 152
-      status: 2
-    - original_index: 153
-      status: 0
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 4
-    - original_index: 156
-      status: 0
-    - original_index: 157
-      status: 1
-    - original_index: 158
-      status: 2
-    - original_index: 159
-      status: 0
-    - original_index: 160
-      status: 2
-    - original_index: 161
-      status: 0
-    - original_index: 162
-      status: 3
-    - original_index: 163
-      status: 1
-    - original_index: 164
-      status: 2
-    - original_index: 165
-      status: 0
-    - original_index: 166
-      status: 1
-    - original_index: 167
-      status: 0
-    - original_index: 168
-      status: 4
-    - original_index: 169
-      status: 0
-    - original_index: 170
-      status: 3
-    - original_index: 171
-      status: 3
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 3
-    - original_index: 174
-      status: 0
-    - original_index: 175
-      status: 0
-    - original_index: 176
-      status: 3
-    - original_index: 177
-      status: 3
-    - original_index: 178
-      status: 4
-    - original_index: 179
-      status: 4
-    - original_index: 180
-      status: 2
-    - original_index: 181
-      status: 3
-    - original_index: 182
-      status: 2
-    - original_index: 183
-      status: 0
-    - original_index: 184
-      status: 2
-    - original_index: 185
-      status: 0
-    - original_index: 186
-      status: 4
-    - original_index: 187
-      status: 4
-    - original_index: 188
-      status: 4
-    - original_index: 189
-      status: 2
-    - original_index: 190
-      status: 2
-    - original_index: 191
-      status: 3
-    - original_index: 192
-      status: 4
-    - original_index: 193
-      status: 3
-    - original_index: 194
-      status: 2
-    - original_index: 195
-      status: 2
-    - original_index: 196
-      status: 4
-    - original_index: 197
-      status: 3
-    - original_index: 198
-      status: 4
-    - original_index: 199
-      status: 0
-    - original_index: 200
-      status: 4
-    - original_index: 201
-      status: 4
-    - original_index: 202
-      status: 3
-    - original_index: 203
-      status: 1
-    - original_index: 204
-      status: 0
-    - original_index: 205
-      status: 2
-    - original_index: 206
-      status: 3
-    - original_index: 207
-      status: 1
-    - original_index: 208
-      status: 1
-    - original_index: 209
-      status: 2
-    - original_index: 210
-      status: 3
-    - original_index: 211
-      status: 0
-    - original_index: 212
-      status: 0
-    - original_index: 213
-      status: 4
-    - original_index: 214
-      status: 3
-    - original_index: 215
-      status: 2
-    - original_index: 216
-      status: 2
-    - original_index: 217
-      status: 3
-    - original_index: 218
-      status: 1
-    - original_index: 219
-      status: 0
-    - original_index: 220
-      status: 3
-    - original_index: 221
-      status: 1
-    - original_index: 222
-      status: 0
-    - original_index: 223
-      status: 1
-    - original_index: 224
-      status: 1
-    - original_index: 225
-      status: 2
-    - original_index: 226
-      status: 2
-    - original_index: 227
-      status: 2
-    - original_index: 228
-      status: 4
-    - original_index: 229
-      status: 0
-    - original_index: 230
-      status: 2
-    - original_index: 231
-      status: 4
-    - original_index: 232
-      status: 4
-    - original_index: 233
-      status: 4
-    - original_index: 234
-      status: 4
-    - original_index: 235
-      status: 2
-    - original_index: 236
-      status: 4
-    - original_index: 237
-      status: 4
-    - original_index: 238
-      status: 0
-    - original_index: 239
-      status: 4
-    - original_index: 240
-      status: 1
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 4
-    - original_index: 243
-      status: 4
-    - original_index: 244
-      status: 3
-    - original_index: 245
-      status: 1
-    - original_index: 246
-      status: 2
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 4
-    - original_index: 249
-      status: 1
-    - original_index: 250
-      status: 1
-    - original_index: 251
-      status: 1
-    - original_index: 252
-      status: 0
-    - original_index: 253
-      status: 3
-    - original_index: 254
-      status: 0
-    - original_index: 255
-      status: 2
-    - original_index: 256
-      status: 4
-    - original_index: 257
-      status: 1
-    - original_index: 258
-      status: 1
-    - original_index: 259
-      status: 3
-    - original_index: 260
-      status: 3
-    - original_index: 261
-      status: 0
-    - original_index: 262
-      status: 4
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 1
-    - original_index: 265
-      status: 3
-    - original_index: 266
-      status: 2
-    - original_index: 267
-      status: 0
-    - original_index: 268
-      status: 2
-    - original_index: 269
-      status: 2
-    - original_index: 270
-      status: 0
-    - original_index: 271
-      status: 0
-    - original_index: 272
-      status: 4
-    - original_index: 273
-      status: 2
-    - original_index: 274
-      status: 4
-    - original_index: 275
-      status: 1
-    - original_index: 276
-      status: 1
-    - original_index: 277
-      status: 0
-    - original_index: 278
-      status: 4
-    - original_index: 279
-      status: 2
-    - original_index: 280
-      status: 3
-    - original_index: 281
-      status: 1
-    - original_index: 282
-      status: 0
-    - original_index: 283
-      status: 3
-    - original_index: 284
-      status: 2
-    - original_index: 285
-      status: 2
-    - original_index: 286
-      status: 1
-    - original_index: 287
-      status: 0
-    - original_index: 288
-      status: 3
-    - original_index: 289
-      status: 2
-    - original_index: 290
-      status: 4
-    - original_index: 291
-      status: 0
-    - original_index: 292
-      status: 3
-    - original_index: 293
-      status: 2
-    - original_index: 294
-      status: 3
-    - original_index: 295
-      status: 1
-    - original_index: 296
-      status: 1
-    - original_index: 297
-      status: 1
-    - original_index: 298
-      status: 2
-    - original_index: 299
-      status: 2
-    - original_index: 300
-      status: 0
-    - original_index: 301
-      status: 3
-    - original_index: 302
-      status: 2
-    - original_index: 303
-      status: 3
-    - original_index: 304
-      status: 3
-    - original_index: 305
-      status: 0
-    - original_index: 306
-      status: 2
-    - original_index: 307
-      status: 1
-    - original_index: 308
-      status: 4
-    - original_index: 309
-      status: 4
-    - original_index: 310
-      status: 2
-    - original_index: 311
-      status: 1
-    - original_index: 312
-      status: 3
-    - original_index: 313
-      status: 0
-    - original_index: 314
-      status: 2
-    - original_index: 315
-      status: 1
-    - original_index: 316
-      status: 0
-    - original_index: 317
-      status: 2
-    - original_index: 318
-      status: 3
-    - original_index: 319
-      status: 2
-    - original_index: 320
-      status: 2
-    - original_index: 321
-      status: 3
-    - original_index: 322
-      status: 0
-    - original_index: 323
-      status: 4
-    - original_index: 324
-      status: 0
-    - original_index: 325
-      status: 3
-    - original_index: 326
-      status: 2
-    - original_index: 327
-      status: 3
-    - original_index: 328
-      status: 1
-    - original_index: 329
-      status: 4
-    - original_index: 330
-      status: 2
-    - original_index: 331
-      status: 1
-    - original_index: 332
-      status: 0
-    - original_index: 333
-      status: 4
-    - original_index: 334
-      status: 2
-    - original_index: 335
-      status: 1
-    - original_index: 336
-      status: 1
-    - original_index: 337
-      status: 0
-    - original_index: 338
-      status: 0
-    - original_index: 339
-      status: 0
-    - original_index: 340
-      status: 4
-    - original_index: 341
-      status: 4
-    - original_index: 342
-      status: 0
-    - original_index: 343
-      status: 1
-    - original_index: 344
-      status: 1
-    - original_index: 345
-      status: 0
-    - original_index: 346
-      status: 1
-    - original_index: 347
-      status: 1
-    - original_index: 348
-      status: 4
-    - original_index: 349
-      status: 0
-    - original_index: 350
-      status: 4
-    - original_index: 351
-      status: 1
-    - original_index: 352
-      status: 0
-    - original_index: 353
-      status: 0
-    - original_index: 354
-      status: 0
-    - original_index: 355
-      status: 3
-    - original_index: 356
-      status: 2
-    - original_index: 357
-      status: 0
-    - original_index: 358
-      status: 3
-    - original_index: 359
-      status: 3
-    - original_index: 360
-      status: 2
-    - original_index: 361
-      status: 3
-    - original_index: 362
-      status: 0
-    - original_index: 363
-      status: 3
-    - original_index: 364
-      status: 1
-    - original_index: 365
-      status: 1
-    - original_index: 366
-      status: 3
-    - original_index: 367
-      status: 0
-    - original_index: 368
-      status: 4
-    - original_index: 369
-      status: 4
-    - original_index: 370
-      status: 3
-    - original_index: 371
-      status: 4
-    - original_index: 372
-      status: 2
-    - original_index: 373
-      status: 2
-    - original_index: 374
-      status: 3
-    - original_index: 375
-      status: 3
-    - original_index: 376
-      status: 0
-    - original_index: 377
-      status: 0
-    - original_index: 378
-      status: 3
-    - original_index: 379
-      status: 1
-    - original_index: 380
-      status: 2
-    - original_index: 381
-      status: 0
-    - original_index: 382
-      status: 2
-    - original_index: 383
-      status: 2
-    - original_index: 384
-      status: 1
-    - original_index: 385
-      status: 1
-    - original_index: 386
-      status: 1
-    - original_index: 387
-      status: 4
-    - original_index: 388
-      status: 4
-    - original_index: 389
-      status: 3
-    - original_index: 390
-      status: 0
-    - original_index: 391
-      status: 3
-    - original_index: 392
-      status: 3
-    - original_index: 393
-      status: 3
-    - original_index: 394
-      status: 2
-    - original_index: 395
-      status: 1
-    - original_index: 396
-      status: 1
-    - original_index: 397
-      status: 2
-    - original_index: 398
-      status: 1
-    - original_index: 399
-      status: 1
-    - original_index: 400
-      status: 3
-    - original_index: 401
-      status: 4
-    - original_index: 402
-      status: 1
-    - original_index: 403
-      status: 0
-    - original_index: 404
-      status: 4
-    - original_index: 405
-      status: 0
-    - original_index: 406
-      status: 4
-    - original_index: 407
-      status: 4
-    - original_index: 408
-      status: 0
-    - original_index: 409
-      status: 3
+    - {original_index: 0, status: 0}
+    - {original_index: 1, status: 4}
+    - {original_index: 2, status: 0}
+    - {original_index: 3, status: 3}
+    - {original_index: 4, status: 1}
+    - {original_index: 5, status: 2}
+    - {original_index: 6, status: 1}
+    - {original_index: 7, status: 2}
+    - {original_index: 8, status: 2}
+    - {original_index: 9, status: 2}
+    - {original_index: 10, status: 1}
+    - {original_index: 11, status: 0}
+    - {original_index: 12, status: 3}
+    - {original_index: 13, status: 0}
+    - {original_index: 14, status: 2}
+    - {original_index: 15, status: 4}
+    - {original_index: 16, status: 4}
+    - {original_index: 17, status: 4}
+    - {original_index: 18, status: 2}
+    - {original_index: 19, status: 2}
+    - {original_index: 20, status: 2}
+    - {original_index: 21, status: 1}
+    - {original_index: 22, status: 1}
+    - {original_index: 23, status: 4}
+    - {original_index: 24, status: 1}
+    - {original_index: 25, status: 2}
+    - {original_index: 26, status: 1}
+    - {original_index: 27, status: 3}
+    - {original_index: 28, status: 0}
+    - {original_index: 29, status: 0}
+    - {original_index: 30, status: 3}
+    - {original_index: 31, status: 4}
+    - {original_index: 32, status: 1}
+    - {original_index: 33, status: 1}
+    - {original_index: 34, status: 0}
+    - {original_index: 35, status: 4}
+    - {original_index: 36, status: 3}
+    - {original_index: 37, status: 0}
+    - {original_index: 38, status: 4}
+    - {original_index: 39, status: 4}
+    - {original_index: 40, status: 3}
+    - {original_index: 41, status: 2}
+    - {original_index: 42, status: 3}
+    - {original_index: 43, status: 1}
+    - {original_index: 44, status: 3}
+    - {original_index: 45, status: 1}
+    - {original_index: 46, status: 1}
+    - {original_index: 47, status: 3}
+    - {original_index: 48, status: 0}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 0}
+    - {original_index: 51, status: 4}
+    - {original_index: 52, status: 1}
+    - {original_index: 53, status: 1}
+    - {original_index: 54, status: 1}
+    - {original_index: 55, status: 1}
+    - {original_index: 56, status: 2}
+    - {original_index: 57, status: 3}
+    - {original_index: 58, status: 3}
+    - {original_index: 59, status: 4}
+    - {original_index: 60, status: 2}
+    - {original_index: 61, status: 0}
+    - {original_index: 62, status: 2}
+    - {original_index: 63, status: 3}
+    - {original_index: 64, status: 3}
+    - {original_index: 65, status: 0}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 0}
+    - {original_index: 68, status: 2}
+    - {original_index: 69, status: 4}
+    - {original_index: 70, status: 3}
+    - {original_index: 71, status: 3}
+    - {original_index: 72, status: 3}
+    - {original_index: 73, status: 2}
+    - {original_index: 74, status: 1}
+    - {original_index: 75, status: 3}
+    - {original_index: 76, status: 4}
+    - {original_index: 77, status: 2}
+    - {original_index: 78, status: 3}
+    - {original_index: 79, status: 0}
+    - {original_index: 80, status: 2}
+    - {original_index: 81, status: 0}
+    - {original_index: 82, status: 1}
+    - {original_index: 83, status: 3}
+    - {original_index: 84, status: 1}
+    - {original_index: 85, status: 4}
+    - {original_index: 86, status: 4}
+    - {original_index: 87, status: 1}
+    - {original_index: 88, status: 4}
+    - {original_index: 89, status: 4}
+    - {original_index: 90, status: 2}
+    - {original_index: 91, status: 1}
+    - {original_index: 92, status: 3}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 2}
+    - {original_index: 95, status: 3}
+    - {original_index: 96, status: 3}
+    - {original_index: 97, status: 4}
+    - {original_index: 98, status: 4}
+    - {original_index: 99, status: 4}
+    - {original_index: 100, status: 2}
+    - {original_index: 101, status: 3}
+    - {original_index: 102, status: 0}
+    - {original_index: 103, status: 0}
+    - {original_index: 104, status: 2}
+    - {original_index: 105, status: 3}
+    - {original_index: 106, status: 1}
+    - {original_index: 107, status: 4}
+    - {original_index: 108, status: 2}
+    - {original_index: 109, status: 3}
+    - {original_index: 110, status: 2}
+    - {original_index: 111, status: 2}
+    - {original_index: 112, status: 4}
+    - {original_index: 113, status: 0}
+    - {original_index: 114, status: 0}
+    - {original_index: 115, status: 4}
+    - {original_index: 116, status: 0}
+    - {original_index: 117, status: 1}
+    - {original_index: 118, status: 0}
+    - {original_index: 119, status: 3}
+    - {original_index: 120, status: 0}
+    - {original_index: 121, status: 2}
+    - {original_index: 122, status: 2}
+    - {original_index: 123, status: 1}
+    - {original_index: 124, status: 3}
+    - {original_index: 125, status: 3}
+    - {original_index: 126, status: 2}
+    - {original_index: 127, status: 3}
+    - {original_index: 128, status: 4}
+    - {original_index: 129, status: 3}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 2}
+    - {original_index: 132, status: 0}
+    - {original_index: 133, status: 0}
+    - {original_index: 134, status: 1}
+    - {original_index: 135, status: 4}
+    - {original_index: 136, status: 3}
+    - {original_index: 137, status: 1}
+    - {original_index: 138, status: 2}
+    - {original_index: 139, status: 0}
+    - {original_index: 140, status: 4}
+    - {original_index: 141, status: 1}
+    - {original_index: 142, status: 1}
+    - {original_index: 143, status: 0}
+    - {original_index: 144, status: 0}
+    - {original_index: 145, status: 4}
+    - {original_index: 146, status: 1}
+    - {original_index: 147, status: 2}
+    - {original_index: 148, status: 4}
+    - {original_index: 149, status: 3}
+    - {original_index: 150, status: 3}
+    - {original_index: 151, status: 3}
+    - {original_index: 152, status: 2}
+    - {original_index: 153, status: 0}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 4}
+    - {original_index: 156, status: 0}
+    - {original_index: 157, status: 1}
+    - {original_index: 158, status: 2}
+    - {original_index: 159, status: 0}
+    - {original_index: 160, status: 2}
+    - {original_index: 161, status: 0}
+    - {original_index: 162, status: 3}
+    - {original_index: 163, status: 1}
+    - {original_index: 164, status: 2}
+    - {original_index: 165, status: 0}
+    - {original_index: 166, status: 1}
+    - {original_index: 167, status: 0}
+    - {original_index: 168, status: 4}
+    - {original_index: 169, status: 0}
+    - {original_index: 170, status: 3}
+    - {original_index: 171, status: 3}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 3}
+    - {original_index: 174, status: 0}
+    - {original_index: 175, status: 0}
+    - {original_index: 176, status: 3}
+    - {original_index: 177, status: 3}
+    - {original_index: 178, status: 4}
+    - {original_index: 179, status: 4}
+    - {original_index: 180, status: 2}
+    - {original_index: 181, status: 3}
+    - {original_index: 182, status: 2}
+    - {original_index: 183, status: 0}
+    - {original_index: 184, status: 2}
+    - {original_index: 185, status: 0}
+    - {original_index: 186, status: 4}
+    - {original_index: 187, status: 4}
+    - {original_index: 188, status: 4}
+    - {original_index: 189, status: 2}
+    - {original_index: 190, status: 2}
+    - {original_index: 191, status: 3}
+    - {original_index: 192, status: 4}
+    - {original_index: 193, status: 3}
+    - {original_index: 194, status: 2}
+    - {original_index: 195, status: 2}
+    - {original_index: 196, status: 4}
+    - {original_index: 197, status: 3}
+    - {original_index: 198, status: 4}
+    - {original_index: 199, status: 0}
+    - {original_index: 200, status: 4}
+    - {original_index: 201, status: 4}
+    - {original_index: 202, status: 3}
+    - {original_index: 203, status: 1}
+    - {original_index: 204, status: 0}
+    - {original_index: 205, status: 2}
+    - {original_index: 206, status: 3}
+    - {original_index: 207, status: 1}
+    - {original_index: 208, status: 1}
+    - {original_index: 209, status: 2}
+    - {original_index: 210, status: 3}
+    - {original_index: 211, status: 0}
+    - {original_index: 212, status: 0}
+    - {original_index: 213, status: 4}
+    - {original_index: 214, status: 3}
+    - {original_index: 215, status: 2}
+    - {original_index: 216, status: 2}
+    - {original_index: 217, status: 3}
+    - {original_index: 218, status: 1}
+    - {original_index: 219, status: 0}
+    - {original_index: 220, status: 3}
+    - {original_index: 221, status: 1}
+    - {original_index: 222, status: 0}
+    - {original_index: 223, status: 1}
+    - {original_index: 224, status: 1}
+    - {original_index: 225, status: 2}
+    - {original_index: 226, status: 2}
+    - {original_index: 227, status: 2}
+    - {original_index: 228, status: 4}
+    - {original_index: 229, status: 0}
+    - {original_index: 230, status: 2}
+    - {original_index: 231, status: 4}
+    - {original_index: 232, status: 4}
+    - {original_index: 233, status: 4}
+    - {original_index: 234, status: 4}
+    - {original_index: 235, status: 2}
+    - {original_index: 236, status: 4}
+    - {original_index: 237, status: 4}
+    - {original_index: 238, status: 0}
+    - {original_index: 239, status: 4}
+    - {original_index: 240, status: 1}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 4}
+    - {original_index: 243, status: 4}
+    - {original_index: 244, status: 3}
+    - {original_index: 245, status: 1}
+    - {original_index: 246, status: 2}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 4}
+    - {original_index: 249, status: 1}
+    - {original_index: 250, status: 1}
+    - {original_index: 251, status: 1}
+    - {original_index: 252, status: 0}
+    - {original_index: 253, status: 3}
+    - {original_index: 254, status: 0}
+    - {original_index: 255, status: 2}
+    - {original_index: 256, status: 4}
+    - {original_index: 257, status: 1}
+    - {original_index: 258, status: 1}
+    - {original_index: 259, status: 3}
+    - {original_index: 260, status: 3}
+    - {original_index: 261, status: 0}
+    - {original_index: 262, status: 4}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 1}
+    - {original_index: 265, status: 3}
+    - {original_index: 266, status: 2}
+    - {original_index: 267, status: 0}
+    - {original_index: 268, status: 2}
+    - {original_index: 269, status: 2}
+    - {original_index: 270, status: 0}
+    - {original_index: 271, status: 0}
+    - {original_index: 272, status: 4}
+    - {original_index: 273, status: 2}
+    - {original_index: 274, status: 4}
+    - {original_index: 275, status: 1}
+    - {original_index: 276, status: 1}
+    - {original_index: 277, status: 0}
+    - {original_index: 278, status: 4}
+    - {original_index: 279, status: 2}
+    - {original_index: 280, status: 3}
+    - {original_index: 281, status: 1}
+    - {original_index: 282, status: 0}
+    - {original_index: 283, status: 3}
+    - {original_index: 284, status: 2}
+    - {original_index: 285, status: 2}
+    - {original_index: 286, status: 1}
+    - {original_index: 287, status: 0}
+    - {original_index: 288, status: 3}
+    - {original_index: 289, status: 2}
+    - {original_index: 290, status: 4}
+    - {original_index: 291, status: 0}
+    - {original_index: 292, status: 3}
+    - {original_index: 293, status: 2}
+    - {original_index: 294, status: 3}
+    - {original_index: 295, status: 1}
+    - {original_index: 296, status: 1}
+    - {original_index: 297, status: 1}
+    - {original_index: 298, status: 2}
+    - {original_index: 299, status: 2}
+    - {original_index: 300, status: 0}
+    - {original_index: 301, status: 3}
+    - {original_index: 302, status: 2}
+    - {original_index: 303, status: 3}
+    - {original_index: 304, status: 3}
+    - {original_index: 305, status: 0}
+    - {original_index: 306, status: 2}
+    - {original_index: 307, status: 1}
+    - {original_index: 308, status: 4}
+    - {original_index: 309, status: 4}
+    - {original_index: 310, status: 2}
+    - {original_index: 311, status: 1}
+    - {original_index: 312, status: 3}
+    - {original_index: 313, status: 0}
+    - {original_index: 314, status: 2}
+    - {original_index: 315, status: 1}
+    - {original_index: 316, status: 0}
+    - {original_index: 317, status: 2}
+    - {original_index: 318, status: 3}
+    - {original_index: 319, status: 2}
+    - {original_index: 320, status: 2}
+    - {original_index: 321, status: 3}
+    - {original_index: 322, status: 0}
+    - {original_index: 323, status: 4}
+    - {original_index: 324, status: 0}
+    - {original_index: 325, status: 3}
+    - {original_index: 326, status: 2}
+    - {original_index: 327, status: 3}
+    - {original_index: 328, status: 1}
+    - {original_index: 329, status: 4}
+    - {original_index: 330, status: 2}
+    - {original_index: 331, status: 1}
+    - {original_index: 332, status: 0}
+    - {original_index: 333, status: 4}
+    - {original_index: 334, status: 2}
+    - {original_index: 335, status: 1}
+    - {original_index: 336, status: 1}
+    - {original_index: 337, status: 0}
+    - {original_index: 338, status: 0}
+    - {original_index: 339, status: 0}
+    - {original_index: 340, status: 4}
+    - {original_index: 341, status: 4}
+    - {original_index: 342, status: 0}
+    - {original_index: 343, status: 1}
+    - {original_index: 344, status: 1}
+    - {original_index: 345, status: 0}
+    - {original_index: 346, status: 1}
+    - {original_index: 347, status: 1}
+    - {original_index: 348, status: 4}
+    - {original_index: 349, status: 0}
+    - {original_index: 350, status: 4}
+    - {original_index: 351, status: 1}
+    - {original_index: 352, status: 0}
+    - {original_index: 353, status: 0}
+    - {original_index: 354, status: 0}
+    - {original_index: 355, status: 3}
+    - {original_index: 356, status: 2}
+    - {original_index: 357, status: 0}
+    - {original_index: 358, status: 3}
+    - {original_index: 359, status: 3}
+    - {original_index: 360, status: 2}
+    - {original_index: 361, status: 3}
+    - {original_index: 362, status: 0}
+    - {original_index: 363, status: 3}
+    - {original_index: 364, status: 1}
+    - {original_index: 365, status: 1}
+    - {original_index: 366, status: 3}
+    - {original_index: 367, status: 0}
+    - {original_index: 368, status: 4}
+    - {original_index: 369, status: 4}
+    - {original_index: 370, status: 3}
+    - {original_index: 371, status: 4}
+    - {original_index: 372, status: 2}
+    - {original_index: 373, status: 2}
+    - {original_index: 374, status: 3}
+    - {original_index: 375, status: 3}
+    - {original_index: 376, status: 0}
+    - {original_index: 377, status: 0}
+    - {original_index: 378, status: 3}
+    - {original_index: 379, status: 1}
+    - {original_index: 380, status: 2}
+    - {original_index: 381, status: 0}
+    - {original_index: 382, status: 2}
+    - {original_index: 383, status: 2}
+    - {original_index: 384, status: 1}
+    - {original_index: 385, status: 1}
+    - {original_index: 386, status: 1}
+    - {original_index: 387, status: 4}
+    - {original_index: 388, status: 4}
+    - {original_index: 389, status: 3}
+    - {original_index: 390, status: 0}
+    - {original_index: 391, status: 3}
+    - {original_index: 392, status: 3}
+    - {original_index: 393, status: 3}
+    - {original_index: 394, status: 2}
+    - {original_index: 395, status: 1}
+    - {original_index: 396, status: 1}
+    - {original_index: 397, status: 2}
+    - {original_index: 398, status: 1}
+    - {original_index: 399, status: 1}
+    - {original_index: 400, status: 3}
+    - {original_index: 401, status: 4}
+    - {original_index: 402, status: 1}
+    - {original_index: 403, status: 0}
+    - {original_index: 404, status: 4}
+    - {original_index: 405, status: 0}
+    - {original_index: 406, status: 4}
+    - {original_index: 407, status: 4}
+    - {original_index: 408, status: 0}
+    - {original_index: 409, status: 3}
   output:
-  - - committee:
-      - 82
-      - 200
+  - - committee: [82, 200]
       shard: 400
       total_validator_count: 157
-  - - committee:
-      - 365
-      - 286
+  - - committee: [365, 286]
       shard: 401
       total_validator_count: 157
-  - - committee:
-      - 350
-      - 248
-      - 106
+  - - committee: [350, 248, 106]
       shard: 402
       total_validator_count: 157
-  - - committee:
-      - 208
-      - 234
+  - - committee: [208, 234]
       shard: 403
       total_validator_count: 157
-  - - committee:
-      - 74
-      - 84
-      - 278
+  - - committee: [74, 84, 278]
       shard: 404
       total_validator_count: 157
-  - - committee:
-      - 148
-      - 351
+  - - committee: [148, 351]
       shard: 405
       total_validator_count: 157
-  - - committee:
-      - 53
-      - 140
-      - 31
+  - - committee: [53, 140, 31]
       shard: 406
       total_validator_count: 157
-  - - committee:
-      - 272
-      - 154
+  - - committee: [272, 154]
       shard: 407
       total_validator_count: 157
-  - - committee:
-      - 107
-      - 6
-      - 388
+  - - committee: [107, 6, 388]
       shard: 408
       total_validator_count: 157
-  - - committee:
-      - 128
-      - 251
+  - - committee: [128, 251]
       shard: 409
       total_validator_count: 157
-  - - committee:
-      - 335
-      - 346
+  - - committee: [335, 346]
       shard: 410
       total_validator_count: 157
-  - - committee:
-      - 54
-      - 85
-      - 371
+  - - committee: [54, 85, 371]
       shard: 411
       total_validator_count: 157
-  - - committee:
-      - 347
-      - 10
+  - - committee: [347, 10]
       shard: 412
       total_validator_count: 157
-  - - committee:
-      - 55
-      - 341
-      - 245
+  - - committee: [55, 341, 245]
       shard: 413
       total_validator_count: 157
-  - - committee:
-      - 308
-      - 281
+  - - committee: [308, 281]
       shard: 414
       total_validator_count: 157
-  - - committee:
-      - 198
-      - 157
-      - 134
+  - - committee: [198, 157, 134]
       shard: 415
       total_validator_count: 157
-  - - committee:
-      - 256
-      - 86
+  - - committee: [256, 86]
       shard: 416
       total_validator_count: 157
-  - - committee:
-      - 51
-      - 16
-      - 99
+  - - committee: [51, 16, 99]
       shard: 417
       total_validator_count: 157
-  - - committee:
-      - 228
-      - 142
+  - - committee: [228, 142]
       shard: 418
       total_validator_count: 157
-  - - committee:
-      - 186
-      - 223
-      - 23
+  - - committee: [186, 223, 23]
       shard: 419
       total_validator_count: 157
-  - - committee:
-      - 123
-      - 32
+  - - committee: [123, 32]
       shard: 420
       total_validator_count: 157
-  - - committee:
-      - 276
-      - 343
+  - - committee: [276, 343]
       shard: 421
       total_validator_count: 157
-  - - committee:
-      - 258
-      - 52
-      - 166
+  - - committee: [258, 52, 166]
       shard: 422
       total_validator_count: 157
-  - - committee:
-      - 33
-      - 386
+  - - committee: [33, 386]
       shard: 423
       total_validator_count: 157
-  - - committee:
-      - 344
-      - 274
-      - 35
+  - - committee: [344, 274, 35]
       shard: 424
       total_validator_count: 157
-  - - committee:
-      - 311
-      - 241
+  - - committee: [311, 241]
       shard: 425
       total_validator_count: 157
-  - - committee:
-      - 348
-      - 91
-      - 130
+  - - committee: [348, 91, 130]
       shard: 426
       total_validator_count: 157
-  - - committee:
-      - 231
-      - 196
+  - - committee: [231, 196]
       shard: 427
       total_validator_count: 157
-  - - committee:
-      - 340
-      - 329
-      - 97
+  - - committee: [340, 329, 97]
       shard: 428
       total_validator_count: 157
-  - - committee:
-      - 384
-      - 213
+  - - committee: [384, 213]
       shard: 429
       total_validator_count: 157
-  - - committee:
-      - 26
-      - 168
-      - 239
+  - - committee: [26, 168, 239]
       shard: 430
       total_validator_count: 157
-  - - committee:
-      - 224
-      - 398
+  - - committee: [224, 398]
       shard: 431
       total_validator_count: 157
-  - - committee:
-      - 207
-      - 406
+  - - committee: [207, 406]
       shard: 432
       total_validator_count: 157
-  - - committee:
-      - 137
-      - 404
-      - 22
+  - - committee: [137, 404, 22]
       shard: 433
       total_validator_count: 157
-  - - committee:
-      - 145
-      - 368
+  - - committee: [145, 368]
       shard: 434
       total_validator_count: 157
-  - - committee:
-      - 141
-      - 263
-      - 328
+  - - committee: [141, 263, 328]
       shard: 435
       total_validator_count: 157
-  - - committee:
-      - 43
-      - 115
+  - - committee: [43, 115]
       shard: 436
       total_validator_count: 157
-  - - committee:
-      - 87
-      - 69
-      - 187
+  - - committee: [87, 69, 187]
       shard: 437
       total_validator_count: 157
-  - - committee:
-      - 385
-      - 203
+  - - committee: [385, 203]
       shard: 438
       total_validator_count: 157
-  - - committee:
-      - 1
-      - 323
-      - 188
+  - - committee: [1, 323, 188]
       shard: 439
       total_validator_count: 157
-  - - committee:
-      - 402
-      - 290
+  - - committee: [402, 290]
       shard: 440
       total_validator_count: 157
-  - - committee:
-      - 46
-      - 257
-      - 243
+  - - committee: [46, 257, 243]
       shard: 441
       total_validator_count: 157
-  - - committee:
-      - 15
-      - 236
+  - - committee: [15, 236]
       shard: 442
       total_validator_count: 157
-  - - committee:
-      - 218
-      - 250
+  - - committee: [218, 250]
       shard: 443
       total_validator_count: 157
-  - - committee:
-      - 38
-      - 98
-      - 17
+  - - committee: [38, 98, 17]
       shard: 444
       total_validator_count: 157
-  - - committee:
-      - 146
-      - 233
+  - - committee: [146, 233]
       shard: 445
       total_validator_count: 157
-  - - committee:
-      - 240
-      - 163
-      - 315
+  - - committee: [240, 163, 315]
       shard: 446
       total_validator_count: 157
-  - - committee:
-      - 331
-      - 45
+  - - committee: [331, 45]
       shard: 447
       total_validator_count: 157
-  - - committee:
-      - 275
-      - 76
-      - 135
+  - - committee: [275, 76, 135]
       shard: 448
       total_validator_count: 157
-  - - committee:
-      - 178
-      - 192
+  - - committee: [178, 192]
       shard: 449
       total_validator_count: 157
-  - - committee:
-      - 401
-      - 379
-      - 112
+  - - committee: [401, 379, 112]
       shard: 450
       total_validator_count: 157
-  - - committee:
-      - 333
-      - 39
+  - - committee: [333, 39]
       shard: 451
       total_validator_count: 157
-  - - committee:
-      - 364
-      - 24
-      - 296
+  - - committee: [364, 24, 296]
       shard: 452
       total_validator_count: 157
-  - - committee:
-      - 155
-      - 249
+  - - committee: [155, 249]
       shard: 453
       total_validator_count: 157
-  - - committee:
-      - 232
-      - 59
+  - - committee: [232, 59]
       shard: 454
       total_validator_count: 157
-  - - committee:
-      - 264
-      - 336
-      - 88
+  - - committee: [264, 336, 88]
       shard: 455
       total_validator_count: 157
-  - - committee:
-      - 307
-      - 89
+  - - committee: [307, 89]
       shard: 456
       total_validator_count: 157
-  - - committee:
-      - 242
-      - 407
-      - 399
+  - - committee: [242, 407, 399]
       shard: 457
       total_validator_count: 157
-  - - committee:
-      - 179
-      - 262
+  - - committee: [179, 262]
       shard: 458
       total_validator_count: 157
-  - - committee:
-      - 387
-      - 117
-      - 396
+  - - committee: [387, 117, 396]
       shard: 459
       total_validator_count: 157
-  - - committee:
-      - 201
-      - 309
+  - - committee: [201, 309]
       shard: 460
       total_validator_count: 157
-  - - committee:
-      - 297
-      - 369
-      - 221
+  - - committee: [297, 369, 221]
       shard: 461
       total_validator_count: 157
-  - - committee:
-      - 237
-      - 295
+  - - committee: [237, 295]
       shard: 462
       total_validator_count: 157
-  - - committee:
-      - 4
-      - 395
-      - 21
+  - - committee: [4, 395, 21]
       shard: 463
       total_validator_count: 157
   seed: '0xebeb8f9a88f523bc0d4ce17deee159c9791c919c3d8884187a66935c7af5665e'
 - input:
     crosslinking_start_shard: 669
     validators:
-    - original_index: 0
-      status: 1
-    - original_index: 1
-      status: 1
-    - original_index: 2
-      status: 0
-    - original_index: 3
-      status: 1
-    - original_index: 4
-      status: 4
-    - original_index: 5
-      status: 3
-    - original_index: 6
-      status: 1
-    - original_index: 7
-      status: 4
-    - original_index: 8
-      status: 4
-    - original_index: 9
-      status: 1
-    - original_index: 10
-      status: 2
-    - original_index: 11
-      status: 2
-    - original_index: 12
-      status: 0
-    - original_index: 13
-      status: 2
-    - original_index: 14
-      status: 3
-    - original_index: 15
-      status: 4
-    - original_index: 16
-      status: 0
-    - original_index: 17
-      status: 4
-    - original_index: 18
-      status: 4
-    - original_index: 19
-      status: 0
-    - original_index: 20
-      status: 4
-    - original_index: 21
-      status: 3
-    - original_index: 22
-      status: 3
-    - original_index: 23
-      status: 2
-    - original_index: 24
-      status: 4
-    - original_index: 25
-      status: 2
-    - original_index: 26
-      status: 3
-    - original_index: 27
-      status: 2
-    - original_index: 28
-      status: 1
-    - original_index: 29
-      status: 4
-    - original_index: 30
-      status: 1
-    - original_index: 31
-      status: 1
-    - original_index: 32
-      status: 4
-    - original_index: 33
-      status: 1
-    - original_index: 34
-      status: 2
-    - original_index: 35
-      status: 0
-    - original_index: 36
-      status: 0
-    - original_index: 37
-      status: 4
-    - original_index: 38
-      status: 4
-    - original_index: 39
-      status: 4
-    - original_index: 40
-      status: 3
-    - original_index: 41
-      status: 4
-    - original_index: 42
-      status: 0
-    - original_index: 43
-      status: 0
-    - original_index: 44
-      status: 3
-    - original_index: 45
-      status: 1
-    - original_index: 46
-      status: 3
-    - original_index: 47
-      status: 4
-    - original_index: 48
-      status: 2
-    - original_index: 49
-      status: 0
-    - original_index: 50
-      status: 2
-    - original_index: 51
-      status: 2
-    - original_index: 52
-      status: 0
-    - original_index: 53
-      status: 1
-    - original_index: 54
-      status: 1
-    - original_index: 55
-      status: 4
-    - original_index: 56
-      status: 2
-    - original_index: 57
-      status: 2
-    - original_index: 58
-      status: 1
-    - original_index: 59
-      status: 4
-    - original_index: 60
-      status: 2
-    - original_index: 61
-      status: 4
-    - original_index: 62
-      status: 0
-    - original_index: 63
-      status: 4
-    - original_index: 64
-      status: 2
-    - original_index: 65
-      status: 0
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 1
-    - original_index: 68
-      status: 4
-    - original_index: 69
-      status: 1
-    - original_index: 70
-      status: 4
-    - original_index: 71
-      status: 2
-    - original_index: 72
-      status: 3
-    - original_index: 73
-      status: 4
-    - original_index: 74
-      status: 4
-    - original_index: 75
-      status: 1
-    - original_index: 76
-      status: 2
-    - original_index: 77
-      status: 4
-    - original_index: 78
-      status: 4
-    - original_index: 79
-      status: 4
-    - original_index: 80
-      status: 1
-    - original_index: 81
-      status: 0
-    - original_index: 82
-      status: 4
-    - original_index: 83
-      status: 3
-    - original_index: 84
-      status: 2
-    - original_index: 85
-      status: 2
-    - original_index: 86
-      status: 4
-    - original_index: 87
-      status: 2
-    - original_index: 88
-      status: 1
-    - original_index: 89
-      status: 3
-    - original_index: 90
-      status: 3
-    - original_index: 91
-      status: 1
-    - original_index: 92
-      status: 3
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 3
-    - original_index: 95
-      status: 2
-    - original_index: 96
-      status: 4
-    - original_index: 97
-      status: 3
-    - original_index: 98
-      status: 4
-    - original_index: 99
-      status: 4
-    - original_index: 100
-      status: 0
-    - original_index: 101
-      status: 0
-    - original_index: 102
-      status: 3
-    - original_index: 103
-      status: 4
-    - original_index: 104
-      status: 4
-    - original_index: 105
-      status: 2
-    - original_index: 106
-      status: 3
-    - original_index: 107
-      status: 3
-    - original_index: 108
-      status: 1
-    - original_index: 109
-      status: 2
-    - original_index: 110
-      status: 3
-    - original_index: 111
-      status: 4
-    - original_index: 112
-      status: 1
-    - original_index: 113
-      status: 1
-    - original_index: 114
-      status: 4
-    - original_index: 115
-      status: 4
-    - original_index: 116
-      status: 1
-    - original_index: 117
-      status: 2
-    - original_index: 118
-      status: 3
-    - original_index: 119
-      status: 4
-    - original_index: 120
-      status: 1
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 0
-    - original_index: 124
-      status: 0
-    - original_index: 125
-      status: 0
-    - original_index: 126
-      status: 2
-    - original_index: 127
-      status: 3
-    - original_index: 128
-      status: 4
-    - original_index: 129
-      status: 2
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 1
-    - original_index: 132
-      status: 2
-    - original_index: 133
-      status: 4
-    - original_index: 134
-      status: 4
-    - original_index: 135
-      status: 2
-    - original_index: 136
-      status: 4
-    - original_index: 137
-      status: 2
-    - original_index: 138
-      status: 3
-    - original_index: 139
-      status: 3
-    - original_index: 140
-      status: 4
-    - original_index: 141
-      status: 4
-    - original_index: 142
-      status: 0
-    - original_index: 143
-      status: 0
-    - original_index: 144
-      status: 2
-    - original_index: 145
-      status: 3
-    - original_index: 146
-      status: 4
-    - original_index: 147
-      status: 2
-    - original_index: 148
-      status: 2
-    - original_index: 149
-      status: 3
-    - original_index: 150
-      status: 3
-    - original_index: 151
-      status: 1
-    - original_index: 152
-      status: 1
-    - original_index: 153
-      status: 2
-    - original_index: 154
-      status: 3
-    - original_index: 155
-      status: 4
-    - original_index: 156
-      status: 4
-    - original_index: 157
-      status: 0
-    - original_index: 158
-      status: 4
-    - original_index: 159
-      status: 2
-    - original_index: 160
-      status: 0
-    - original_index: 161
-      status: 3
-    - original_index: 162
-      status: 3
-    - original_index: 163
-      status: 1
-    - original_index: 164
-      status: 3
-    - original_index: 165
-      status: 4
-    - original_index: 166
-      status: 1
-    - original_index: 167
-      status: 1
-    - original_index: 168
-      status: 1
-    - original_index: 169
-      status: 3
-    - original_index: 170
-      status: 1
-    - original_index: 171
-      status: 2
-    - original_index: 172
-      status: 3
-    - original_index: 173
-      status: 3
-    - original_index: 174
-      status: 4
-    - original_index: 175
-      status: 4
-    - original_index: 176
-      status: 1
-    - original_index: 177
-      status: 4
-    - original_index: 178
-      status: 4
-    - original_index: 179
-      status: 1
-    - original_index: 180
-      status: 4
-    - original_index: 181
-      status: 0
-    - original_index: 182
-      status: 4
-    - original_index: 183
-      status: 1
-    - original_index: 184
-      status: 0
-    - original_index: 185
-      status: 4
-    - original_index: 186
-      status: 0
-    - original_index: 187
-      status: 3
-    - original_index: 188
-      status: 3
-    - original_index: 189
-      status: 1
-    - original_index: 190
-      status: 0
-    - original_index: 191
-      status: 0
-    - original_index: 192
-      status: 2
-    - original_index: 193
-      status: 1
-    - original_index: 194
-      status: 2
-    - original_index: 195
-      status: 4
-    - original_index: 196
-      status: 4
-    - original_index: 197
-      status: 1
-    - original_index: 198
-      status: 2
-    - original_index: 199
-      status: 4
-    - original_index: 200
-      status: 2
-    - original_index: 201
-      status: 1
-    - original_index: 202
-      status: 0
-    - original_index: 203
-      status: 2
-    - original_index: 204
-      status: 2
-    - original_index: 205
-      status: 1
-    - original_index: 206
-      status: 3
-    - original_index: 207
-      status: 4
-    - original_index: 208
-      status: 1
-    - original_index: 209
-      status: 1
-    - original_index: 210
-      status: 0
-    - original_index: 211
-      status: 3
-    - original_index: 212
-      status: 2
-    - original_index: 213
-      status: 2
-    - original_index: 214
-      status: 2
-    - original_index: 215
-      status: 1
-    - original_index: 216
-      status: 2
-    - original_index: 217
-      status: 1
-    - original_index: 218
-      status: 1
-    - original_index: 219
-      status: 3
-    - original_index: 220
-      status: 4
-    - original_index: 221
-      status: 0
-    - original_index: 222
-      status: 2
-    - original_index: 223
-      status: 3
-    - original_index: 224
-      status: 4
-    - original_index: 225
-      status: 2
-    - original_index: 226
-      status: 0
-    - original_index: 227
-      status: 3
-    - original_index: 228
-      status: 1
-    - original_index: 229
-      status: 2
-    - original_index: 230
-      status: 1
-    - original_index: 231
-      status: 0
-    - original_index: 232
-      status: 4
-    - original_index: 233
-      status: 4
-    - original_index: 234
-      status: 1
-    - original_index: 235
-      status: 4
-    - original_index: 236
-      status: 4
-    - original_index: 237
-      status: 4
-    - original_index: 238
-      status: 0
-    - original_index: 239
-      status: 2
-    - original_index: 240
-      status: 0
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 3
-    - original_index: 243
-      status: 4
-    - original_index: 244
-      status: 3
-    - original_index: 245
-      status: 3
-    - original_index: 246
-      status: 3
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 0
-    - original_index: 249
-      status: 2
-    - original_index: 250
-      status: 4
-    - original_index: 251
-      status: 1
-    - original_index: 252
-      status: 1
-    - original_index: 253
-      status: 1
-    - original_index: 254
-      status: 3
-    - original_index: 255
-      status: 3
-    - original_index: 256
-      status: 0
-    - original_index: 257
-      status: 3
-    - original_index: 258
-      status: 3
-    - original_index: 259
-      status: 3
-    - original_index: 260
-      status: 3
-    - original_index: 261
-      status: 3
-    - original_index: 262
-      status: 4
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 1
-    - original_index: 265
-      status: 1
-    - original_index: 266
-      status: 3
-    - original_index: 267
-      status: 3
-    - original_index: 268
-      status: 3
-    - original_index: 269
-      status: 1
-    - original_index: 270
-      status: 1
-    - original_index: 271
-      status: 1
-    - original_index: 272
-      status: 1
-    - original_index: 273
-      status: 3
-    - original_index: 274
-      status: 0
-    - original_index: 275
-      status: 3
-    - original_index: 276
-      status: 4
-    - original_index: 277
-      status: 0
-    - original_index: 278
-      status: 4
-    - original_index: 279
-      status: 4
-    - original_index: 280
-      status: 0
-    - original_index: 281
-      status: 4
-    - original_index: 282
-      status: 1
-    - original_index: 283
-      status: 0
-    - original_index: 284
-      status: 1
-    - original_index: 285
-      status: 1
-    - original_index: 286
-      status: 1
-    - original_index: 287
-      status: 2
-    - original_index: 288
-      status: 4
-    - original_index: 289
-      status: 0
-    - original_index: 290
-      status: 0
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 0
-    - original_index: 293
-      status: 3
-    - original_index: 294
-      status: 1
-    - original_index: 295
-      status: 0
-    - original_index: 296
-      status: 3
-    - original_index: 297
-      status: 4
-    - original_index: 298
-      status: 3
-    - original_index: 299
-      status: 3
-    - original_index: 300
-      status: 2
-    - original_index: 301
-      status: 3
-    - original_index: 302
-      status: 1
-    - original_index: 303
-      status: 0
-    - original_index: 304
-      status: 4
-    - original_index: 305
-      status: 0
-    - original_index: 306
-      status: 1
-    - original_index: 307
-      status: 4
-    - original_index: 308
-      status: 4
-    - original_index: 309
-      status: 4
-    - original_index: 310
-      status: 4
-    - original_index: 311
-      status: 2
-    - original_index: 312
-      status: 1
-    - original_index: 313
-      status: 2
-    - original_index: 314
-      status: 4
-    - original_index: 315
-      status: 2
-    - original_index: 316
-      status: 0
-    - original_index: 317
-      status: 1
-    - original_index: 318
-      status: 2
-    - original_index: 319
-      status: 2
-    - original_index: 320
-      status: 4
-    - original_index: 321
-      status: 3
-    - original_index: 322
-      status: 1
-    - original_index: 323
-      status: 0
-    - original_index: 324
-      status: 1
-    - original_index: 325
-      status: 0
-    - original_index: 326
-      status: 4
-    - original_index: 327
-      status: 0
-    - original_index: 328
-      status: 3
-    - original_index: 329
-      status: 1
-    - original_index: 330
-      status: 2
-    - original_index: 331
-      status: 1
-    - original_index: 332
-      status: 0
-    - original_index: 333
-      status: 3
-    - original_index: 334
-      status: 3
-    - original_index: 335
-      status: 4
-    - original_index: 336
-      status: 4
-    - original_index: 337
-      status: 1
-    - original_index: 338
-      status: 0
-    - original_index: 339
-      status: 0
-    - original_index: 340
-      status: 1
-    - original_index: 341
-      status: 0
-    - original_index: 342
-      status: 4
-    - original_index: 343
-      status: 3
-    - original_index: 344
-      status: 3
-    - original_index: 345
-      status: 2
-    - original_index: 346
-      status: 2
-    - original_index: 347
-      status: 3
-    - original_index: 348
-      status: 3
-    - original_index: 349
-      status: 0
-    - original_index: 350
-      status: 0
-    - original_index: 351
-      status: 4
-    - original_index: 352
-      status: 2
-    - original_index: 353
-      status: 3
-    - original_index: 354
-      status: 3
-    - original_index: 355
-      status: 4
-    - original_index: 356
-      status: 1
-    - original_index: 357
-      status: 0
-    - original_index: 358
-      status: 4
-    - original_index: 359
-      status: 2
-    - original_index: 360
-      status: 0
-    - original_index: 361
-      status: 3
-    - original_index: 362
-      status: 0
-    - original_index: 363
-      status: 0
-    - original_index: 364
-      status: 4
-    - original_index: 365
-      status: 2
-    - original_index: 366
-      status: 3
-    - original_index: 367
-      status: 3
-    - original_index: 368
-      status: 4
-    - original_index: 369
-      status: 0
-    - original_index: 370
-      status: 4
-    - original_index: 371
-      status: 2
-    - original_index: 372
-      status: 3
-    - original_index: 373
-      status: 3
-    - original_index: 374
-      status: 3
-    - original_index: 375
-      status: 2
-    - original_index: 376
-      status: 4
-    - original_index: 377
-      status: 0
-    - original_index: 378
-      status: 0
-    - original_index: 379
-      status: 1
-    - original_index: 380
-      status: 0
-    - original_index: 381
-      status: 4
-    - original_index: 382
-      status: 4
-    - original_index: 383
-      status: 4
+    - {original_index: 0, status: 1}
+    - {original_index: 1, status: 1}
+    - {original_index: 2, status: 0}
+    - {original_index: 3, status: 1}
+    - {original_index: 4, status: 4}
+    - {original_index: 5, status: 3}
+    - {original_index: 6, status: 1}
+    - {original_index: 7, status: 4}
+    - {original_index: 8, status: 4}
+    - {original_index: 9, status: 1}
+    - {original_index: 10, status: 2}
+    - {original_index: 11, status: 2}
+    - {original_index: 12, status: 0}
+    - {original_index: 13, status: 2}
+    - {original_index: 14, status: 3}
+    - {original_index: 15, status: 4}
+    - {original_index: 16, status: 0}
+    - {original_index: 17, status: 4}
+    - {original_index: 18, status: 4}
+    - {original_index: 19, status: 0}
+    - {original_index: 20, status: 4}
+    - {original_index: 21, status: 3}
+    - {original_index: 22, status: 3}
+    - {original_index: 23, status: 2}
+    - {original_index: 24, status: 4}
+    - {original_index: 25, status: 2}
+    - {original_index: 26, status: 3}
+    - {original_index: 27, status: 2}
+    - {original_index: 28, status: 1}
+    - {original_index: 29, status: 4}
+    - {original_index: 30, status: 1}
+    - {original_index: 31, status: 1}
+    - {original_index: 32, status: 4}
+    - {original_index: 33, status: 1}
+    - {original_index: 34, status: 2}
+    - {original_index: 35, status: 0}
+    - {original_index: 36, status: 0}
+    - {original_index: 37, status: 4}
+    - {original_index: 38, status: 4}
+    - {original_index: 39, status: 4}
+    - {original_index: 40, status: 3}
+    - {original_index: 41, status: 4}
+    - {original_index: 42, status: 0}
+    - {original_index: 43, status: 0}
+    - {original_index: 44, status: 3}
+    - {original_index: 45, status: 1}
+    - {original_index: 46, status: 3}
+    - {original_index: 47, status: 4}
+    - {original_index: 48, status: 2}
+    - {original_index: 49, status: 0}
+    - {original_index: 50, status: 2}
+    - {original_index: 51, status: 2}
+    - {original_index: 52, status: 0}
+    - {original_index: 53, status: 1}
+    - {original_index: 54, status: 1}
+    - {original_index: 55, status: 4}
+    - {original_index: 56, status: 2}
+    - {original_index: 57, status: 2}
+    - {original_index: 58, status: 1}
+    - {original_index: 59, status: 4}
+    - {original_index: 60, status: 2}
+    - {original_index: 61, status: 4}
+    - {original_index: 62, status: 0}
+    - {original_index: 63, status: 4}
+    - {original_index: 64, status: 2}
+    - {original_index: 65, status: 0}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 1}
+    - {original_index: 68, status: 4}
+    - {original_index: 69, status: 1}
+    - {original_index: 70, status: 4}
+    - {original_index: 71, status: 2}
+    - {original_index: 72, status: 3}
+    - {original_index: 73, status: 4}
+    - {original_index: 74, status: 4}
+    - {original_index: 75, status: 1}
+    - {original_index: 76, status: 2}
+    - {original_index: 77, status: 4}
+    - {original_index: 78, status: 4}
+    - {original_index: 79, status: 4}
+    - {original_index: 80, status: 1}
+    - {original_index: 81, status: 0}
+    - {original_index: 82, status: 4}
+    - {original_index: 83, status: 3}
+    - {original_index: 84, status: 2}
+    - {original_index: 85, status: 2}
+    - {original_index: 86, status: 4}
+    - {original_index: 87, status: 2}
+    - {original_index: 88, status: 1}
+    - {original_index: 89, status: 3}
+    - {original_index: 90, status: 3}
+    - {original_index: 91, status: 1}
+    - {original_index: 92, status: 3}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 3}
+    - {original_index: 95, status: 2}
+    - {original_index: 96, status: 4}
+    - {original_index: 97, status: 3}
+    - {original_index: 98, status: 4}
+    - {original_index: 99, status: 4}
+    - {original_index: 100, status: 0}
+    - {original_index: 101, status: 0}
+    - {original_index: 102, status: 3}
+    - {original_index: 103, status: 4}
+    - {original_index: 104, status: 4}
+    - {original_index: 105, status: 2}
+    - {original_index: 106, status: 3}
+    - {original_index: 107, status: 3}
+    - {original_index: 108, status: 1}
+    - {original_index: 109, status: 2}
+    - {original_index: 110, status: 3}
+    - {original_index: 111, status: 4}
+    - {original_index: 112, status: 1}
+    - {original_index: 113, status: 1}
+    - {original_index: 114, status: 4}
+    - {original_index: 115, status: 4}
+    - {original_index: 116, status: 1}
+    - {original_index: 117, status: 2}
+    - {original_index: 118, status: 3}
+    - {original_index: 119, status: 4}
+    - {original_index: 120, status: 1}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 0}
+    - {original_index: 124, status: 0}
+    - {original_index: 125, status: 0}
+    - {original_index: 126, status: 2}
+    - {original_index: 127, status: 3}
+    - {original_index: 128, status: 4}
+    - {original_index: 129, status: 2}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 1}
+    - {original_index: 132, status: 2}
+    - {original_index: 133, status: 4}
+    - {original_index: 134, status: 4}
+    - {original_index: 135, status: 2}
+    - {original_index: 136, status: 4}
+    - {original_index: 137, status: 2}
+    - {original_index: 138, status: 3}
+    - {original_index: 139, status: 3}
+    - {original_index: 140, status: 4}
+    - {original_index: 141, status: 4}
+    - {original_index: 142, status: 0}
+    - {original_index: 143, status: 0}
+    - {original_index: 144, status: 2}
+    - {original_index: 145, status: 3}
+    - {original_index: 146, status: 4}
+    - {original_index: 147, status: 2}
+    - {original_index: 148, status: 2}
+    - {original_index: 149, status: 3}
+    - {original_index: 150, status: 3}
+    - {original_index: 151, status: 1}
+    - {original_index: 152, status: 1}
+    - {original_index: 153, status: 2}
+    - {original_index: 154, status: 3}
+    - {original_index: 155, status: 4}
+    - {original_index: 156, status: 4}
+    - {original_index: 157, status: 0}
+    - {original_index: 158, status: 4}
+    - {original_index: 159, status: 2}
+    - {original_index: 160, status: 0}
+    - {original_index: 161, status: 3}
+    - {original_index: 162, status: 3}
+    - {original_index: 163, status: 1}
+    - {original_index: 164, status: 3}
+    - {original_index: 165, status: 4}
+    - {original_index: 166, status: 1}
+    - {original_index: 167, status: 1}
+    - {original_index: 168, status: 1}
+    - {original_index: 169, status: 3}
+    - {original_index: 170, status: 1}
+    - {original_index: 171, status: 2}
+    - {original_index: 172, status: 3}
+    - {original_index: 173, status: 3}
+    - {original_index: 174, status: 4}
+    - {original_index: 175, status: 4}
+    - {original_index: 176, status: 1}
+    - {original_index: 177, status: 4}
+    - {original_index: 178, status: 4}
+    - {original_index: 179, status: 1}
+    - {original_index: 180, status: 4}
+    - {original_index: 181, status: 0}
+    - {original_index: 182, status: 4}
+    - {original_index: 183, status: 1}
+    - {original_index: 184, status: 0}
+    - {original_index: 185, status: 4}
+    - {original_index: 186, status: 0}
+    - {original_index: 187, status: 3}
+    - {original_index: 188, status: 3}
+    - {original_index: 189, status: 1}
+    - {original_index: 190, status: 0}
+    - {original_index: 191, status: 0}
+    - {original_index: 192, status: 2}
+    - {original_index: 193, status: 1}
+    - {original_index: 194, status: 2}
+    - {original_index: 195, status: 4}
+    - {original_index: 196, status: 4}
+    - {original_index: 197, status: 1}
+    - {original_index: 198, status: 2}
+    - {original_index: 199, status: 4}
+    - {original_index: 200, status: 2}
+    - {original_index: 201, status: 1}
+    - {original_index: 202, status: 0}
+    - {original_index: 203, status: 2}
+    - {original_index: 204, status: 2}
+    - {original_index: 205, status: 1}
+    - {original_index: 206, status: 3}
+    - {original_index: 207, status: 4}
+    - {original_index: 208, status: 1}
+    - {original_index: 209, status: 1}
+    - {original_index: 210, status: 0}
+    - {original_index: 211, status: 3}
+    - {original_index: 212, status: 2}
+    - {original_index: 213, status: 2}
+    - {original_index: 214, status: 2}
+    - {original_index: 215, status: 1}
+    - {original_index: 216, status: 2}
+    - {original_index: 217, status: 1}
+    - {original_index: 218, status: 1}
+    - {original_index: 219, status: 3}
+    - {original_index: 220, status: 4}
+    - {original_index: 221, status: 0}
+    - {original_index: 222, status: 2}
+    - {original_index: 223, status: 3}
+    - {original_index: 224, status: 4}
+    - {original_index: 225, status: 2}
+    - {original_index: 226, status: 0}
+    - {original_index: 227, status: 3}
+    - {original_index: 228, status: 1}
+    - {original_index: 229, status: 2}
+    - {original_index: 230, status: 1}
+    - {original_index: 231, status: 0}
+    - {original_index: 232, status: 4}
+    - {original_index: 233, status: 4}
+    - {original_index: 234, status: 1}
+    - {original_index: 235, status: 4}
+    - {original_index: 236, status: 4}
+    - {original_index: 237, status: 4}
+    - {original_index: 238, status: 0}
+    - {original_index: 239, status: 2}
+    - {original_index: 240, status: 0}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 3}
+    - {original_index: 243, status: 4}
+    - {original_index: 244, status: 3}
+    - {original_index: 245, status: 3}
+    - {original_index: 246, status: 3}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 0}
+    - {original_index: 249, status: 2}
+    - {original_index: 250, status: 4}
+    - {original_index: 251, status: 1}
+    - {original_index: 252, status: 1}
+    - {original_index: 253, status: 1}
+    - {original_index: 254, status: 3}
+    - {original_index: 255, status: 3}
+    - {original_index: 256, status: 0}
+    - {original_index: 257, status: 3}
+    - {original_index: 258, status: 3}
+    - {original_index: 259, status: 3}
+    - {original_index: 260, status: 3}
+    - {original_index: 261, status: 3}
+    - {original_index: 262, status: 4}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 1}
+    - {original_index: 265, status: 1}
+    - {original_index: 266, status: 3}
+    - {original_index: 267, status: 3}
+    - {original_index: 268, status: 3}
+    - {original_index: 269, status: 1}
+    - {original_index: 270, status: 1}
+    - {original_index: 271, status: 1}
+    - {original_index: 272, status: 1}
+    - {original_index: 273, status: 3}
+    - {original_index: 274, status: 0}
+    - {original_index: 275, status: 3}
+    - {original_index: 276, status: 4}
+    - {original_index: 277, status: 0}
+    - {original_index: 278, status: 4}
+    - {original_index: 279, status: 4}
+    - {original_index: 280, status: 0}
+    - {original_index: 281, status: 4}
+    - {original_index: 282, status: 1}
+    - {original_index: 283, status: 0}
+    - {original_index: 284, status: 1}
+    - {original_index: 285, status: 1}
+    - {original_index: 286, status: 1}
+    - {original_index: 287, status: 2}
+    - {original_index: 288, status: 4}
+    - {original_index: 289, status: 0}
+    - {original_index: 290, status: 0}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 0}
+    - {original_index: 293, status: 3}
+    - {original_index: 294, status: 1}
+    - {original_index: 295, status: 0}
+    - {original_index: 296, status: 3}
+    - {original_index: 297, status: 4}
+    - {original_index: 298, status: 3}
+    - {original_index: 299, status: 3}
+    - {original_index: 300, status: 2}
+    - {original_index: 301, status: 3}
+    - {original_index: 302, status: 1}
+    - {original_index: 303, status: 0}
+    - {original_index: 304, status: 4}
+    - {original_index: 305, status: 0}
+    - {original_index: 306, status: 1}
+    - {original_index: 307, status: 4}
+    - {original_index: 308, status: 4}
+    - {original_index: 309, status: 4}
+    - {original_index: 310, status: 4}
+    - {original_index: 311, status: 2}
+    - {original_index: 312, status: 1}
+    - {original_index: 313, status: 2}
+    - {original_index: 314, status: 4}
+    - {original_index: 315, status: 2}
+    - {original_index: 316, status: 0}
+    - {original_index: 317, status: 1}
+    - {original_index: 318, status: 2}
+    - {original_index: 319, status: 2}
+    - {original_index: 320, status: 4}
+    - {original_index: 321, status: 3}
+    - {original_index: 322, status: 1}
+    - {original_index: 323, status: 0}
+    - {original_index: 324, status: 1}
+    - {original_index: 325, status: 0}
+    - {original_index: 326, status: 4}
+    - {original_index: 327, status: 0}
+    - {original_index: 328, status: 3}
+    - {original_index: 329, status: 1}
+    - {original_index: 330, status: 2}
+    - {original_index: 331, status: 1}
+    - {original_index: 332, status: 0}
+    - {original_index: 333, status: 3}
+    - {original_index: 334, status: 3}
+    - {original_index: 335, status: 4}
+    - {original_index: 336, status: 4}
+    - {original_index: 337, status: 1}
+    - {original_index: 338, status: 0}
+    - {original_index: 339, status: 0}
+    - {original_index: 340, status: 1}
+    - {original_index: 341, status: 0}
+    - {original_index: 342, status: 4}
+    - {original_index: 343, status: 3}
+    - {original_index: 344, status: 3}
+    - {original_index: 345, status: 2}
+    - {original_index: 346, status: 2}
+    - {original_index: 347, status: 3}
+    - {original_index: 348, status: 3}
+    - {original_index: 349, status: 0}
+    - {original_index: 350, status: 0}
+    - {original_index: 351, status: 4}
+    - {original_index: 352, status: 2}
+    - {original_index: 353, status: 3}
+    - {original_index: 354, status: 3}
+    - {original_index: 355, status: 4}
+    - {original_index: 356, status: 1}
+    - {original_index: 357, status: 0}
+    - {original_index: 358, status: 4}
+    - {original_index: 359, status: 2}
+    - {original_index: 360, status: 0}
+    - {original_index: 361, status: 3}
+    - {original_index: 362, status: 0}
+    - {original_index: 363, status: 0}
+    - {original_index: 364, status: 4}
+    - {original_index: 365, status: 2}
+    - {original_index: 366, status: 3}
+    - {original_index: 367, status: 3}
+    - {original_index: 368, status: 4}
+    - {original_index: 369, status: 0}
+    - {original_index: 370, status: 4}
+    - {original_index: 371, status: 2}
+    - {original_index: 372, status: 3}
+    - {original_index: 373, status: 3}
+    - {original_index: 374, status: 3}
+    - {original_index: 375, status: 2}
+    - {original_index: 376, status: 4}
+    - {original_index: 377, status: 0}
+    - {original_index: 378, status: 0}
+    - {original_index: 379, status: 1}
+    - {original_index: 380, status: 0}
+    - {original_index: 381, status: 4}
+    - {original_index: 382, status: 4}
+    - {original_index: 383, status: 4}
   output:
-  - - committee:
-      - 130
-      - 151
+  - - committee: [130, 151]
       shard: 669
       total_validator_count: 173
-  - - committee:
-      - 302
-      - 336
-      - 163
+  - - committee: [302, 336, 163]
       shard: 670
       total_validator_count: 173
-  - - committee:
-      - 234
-      - 262
-      - 179
+  - - committee: [234, 262, 179]
       shard: 671
       total_validator_count: 173
-  - - committee:
-      - 54
-      - 77
+  - - committee: [54, 77]
       shard: 672
       total_validator_count: 173
-  - - committee:
-      - 59
-      - 232
-      - 205
+  - - committee: [59, 232, 205]
       shard: 673
       total_validator_count: 173
-  - - committee:
-      - 0
-      - 356
-      - 337
+  - - committee: [0, 356, 337]
       shard: 674
       total_validator_count: 173
-  - - committee:
-      - 141
-      - 133
+  - - committee: [141, 133]
       shard: 675
       total_validator_count: 173
-  - - committee:
-      - 17
-      - 114
-      - 30
+  - - committee: [17, 114, 30]
       shard: 676
       total_validator_count: 173
-  - - committee:
-      - 312
-      - 368
-      - 177
+  - - committee: [312, 368, 177]
       shard: 677
       total_validator_count: 173
-  - - committee:
-      - 250
-      - 252
-      - 284
+  - - committee: [250, 252, 284]
       shard: 678
       total_validator_count: 173
-  - - committee:
-      - 111
-      - 331
+  - - committee: [111, 331]
       shard: 679
       total_validator_count: 173
-  - - committee:
-      - 174
-      - 272
-      - 68
+  - - committee: [174, 272, 68]
       shard: 680
       total_validator_count: 173
-  - - committee:
-      - 209
-      - 310
-      - 45
+  - - committee: [209, 310, 45]
       shard: 681
       total_validator_count: 173
-  - - committee:
-      - 306
-      - 108
+  - - committee: [306, 108]
       shard: 682
       total_validator_count: 173
-  - - committee:
-      - 74
-      - 379
-      - 75
+  - - committee: [74, 379, 75]
       shard: 683
       total_validator_count: 173
-  - - committee:
-      - 317
-      - 335
-      - 370
+  - - committee: [317, 335, 370]
       shard: 684
       total_validator_count: 173
-  - - committee:
-      - 182
-      - 47
+  - - committee: [182, 47]
       shard: 685
       total_validator_count: 173
-  - - committee:
-      - 88
-      - 383
-      - 241
+  - - committee: [88, 383, 241]
       shard: 686
       total_validator_count: 173
-  - - committee:
-      - 119
-      - 170
-      - 189
+  - - committee: [119, 170, 189]
       shard: 687
       total_validator_count: 173
-  - - committee:
-      - 146
-      - 63
-      - 128
+  - - committee: [146, 63, 128]
       shard: 688
       total_validator_count: 173
-  - - committee:
-      - 308
-      - 9
+  - - committee: [308, 9]
       shard: 689
       total_validator_count: 173
-  - - committee:
-      - 236
-      - 199
-      - 178
+  - - committee: [236, 199, 178]
       shard: 690
       total_validator_count: 173
-  - - committee:
-      - 185
-      - 230
-      - 80
+  - - committee: [185, 230, 80]
       shard: 691
       total_validator_count: 173
-  - - committee:
-      - 53
-      - 37
+  - - committee: [53, 37]
       shard: 692
       total_validator_count: 173
-  - - committee:
-      - 140
-      - 7
-      - 98
+  - - committee: [140, 7, 98]
       shard: 693
       total_validator_count: 173
-  - - committee:
-      - 131
-      - 314
-      - 233
+  - - committee: [131, 314, 233]
       shard: 694
       total_validator_count: 173
-  - - committee:
-      - 31
-      - 324
+  - - committee: [31, 324]
       shard: 695
       total_validator_count: 173
-  - - committee:
-      - 265
-      - 69
-      - 8
+  - - committee: [265, 69, 8]
       shard: 696
       total_validator_count: 173
-  - - committee:
-      - 208
-      - 269
-      - 286
+  - - committee: [208, 269, 286]
       shard: 697
       total_validator_count: 173
-  - - committee:
-      - 329
-      - 3
-      - 196
+  - - committee: [329, 3, 196]
       shard: 698
       total_validator_count: 173
-  - - committee:
-      - 281
-      - 220
+  - - committee: [281, 220]
       shard: 699
       total_validator_count: 173
-  - - committee:
-      - 297
-      - 307
-      - 309
+  - - committee: [297, 307, 309]
       shard: 700
       total_validator_count: 173
-  - - committee:
-      - 82
-      - 67
-      - 116
+  - - committee: [82, 67, 116]
       shard: 701
       total_validator_count: 173
-  - - committee:
-      - 224
-      - 285
+  - - committee: [224, 285]
       shard: 702
       total_validator_count: 173
-  - - committee:
-      - 33
-      - 55
-      - 39
+  - - committee: [33, 55, 39]
       shard: 703
       total_validator_count: 173
-  - - committee:
-      - 381
-      - 197
-      - 243
+  - - committee: [381, 197, 243]
       shard: 704
       total_validator_count: 173
-  - - committee:
-      - 207
-      - 120
-      - 134
+  - - committee: [207, 120, 134]
       shard: 705
       total_validator_count: 173
-  - - committee:
-      - 41
-      - 253
+  - - committee: [41, 253]
       shard: 706
       total_validator_count: 173
-  - - committee:
-      - 18
-      - 166
-      - 193
+  - - committee: [18, 166, 193]
       shard: 707
       total_validator_count: 173
-  - - committee:
-      - 322
-      - 24
-      - 168
+  - - committee: [322, 24, 168]
       shard: 708
       total_validator_count: 173
-  - - committee:
-      - 304
-      - 112
+  - - committee: [304, 112]
       shard: 709
       total_validator_count: 173
-  - - committee:
-      - 155
-      - 271
-      - 136
+  - - committee: [155, 271, 136]
       shard: 710
       total_validator_count: 173
-  - - committee:
-      - 73
-      - 91
-      - 6
+  - - committee: [73, 91, 6]
       shard: 711
       total_validator_count: 173
-  - - committee:
-      - 276
-      - 28
+  - - committee: [276, 28]
       shard: 712
       total_validator_count: 173
-  - - committee:
-      - 103
-      - 320
-      - 235
+  - - committee: [103, 320, 235]
       shard: 713
       total_validator_count: 173
-  - - committee:
-      - 264
-      - 70
-      - 78
+  - - committee: [264, 70, 78]
       shard: 714
       total_validator_count: 173
-  - - committee:
-      - 282
-      - 4
-      - 263
+  - - committee: [282, 4, 263]
       shard: 715
       total_validator_count: 173
-  - - committee:
-      - 158
-      - 237
+  - - committee: [158, 237]
       shard: 716
       total_validator_count: 173
-  - - committee:
-      - 176
-      - 201
-      - 215
+  - - committee: [176, 201, 215]
       shard: 717
       total_validator_count: 173
-  - - committee:
-      - 278
-      - 326
-      - 79
+  - - committee: [278, 326, 79]
       shard: 718
       total_validator_count: 173
-  - - committee:
-      - 113
-      - 355
+  - - committee: [113, 355]
       shard: 719
       total_validator_count: 173
-  - - committee:
-      - 218
-      - 376
-      - 364
+  - - committee: [218, 376, 364]
       shard: 720
       total_validator_count: 173
-  - - committee:
-      - 183
-      - 104
-      - 61
+  - - committee: [183, 104, 61]
       shard: 721
       total_validator_count: 173
-  - - committee:
-      - 288
-      - 279
+  - - committee: [288, 279]
       shard: 722
       total_validator_count: 173
-  - - committee:
-      - 156
-      - 152
-      - 58
+  - - committee: [156, 152, 58]
       shard: 723
       total_validator_count: 173
-  - - committee:
-      - 358
-      - 175
-      - 180
+  - - committee: [358, 175, 180]
       shard: 724
       total_validator_count: 173
-  - - committee:
-      - 340
-      - 115
-      - 32
+  - - committee: [340, 115, 32]
       shard: 725
       total_validator_count: 173
-  - - committee:
-      - 270
-      - 195
+  - - committee: [270, 195]
       shard: 726
       total_validator_count: 173
-  - - committee:
-      - 15
-      - 38
-      - 294
+  - - committee: [15, 38, 294]
       shard: 727
       total_validator_count: 173
-  - - committee:
-      - 251
-      - 29
-      - 86
+  - - committee: [251, 29, 86]
       shard: 728
       total_validator_count: 173
-  - - committee:
-      - 20
-      - 165
+  - - committee: [20, 165]
       shard: 729
       total_validator_count: 173
-  - - committee:
-      - 351
-      - 96
-      - 99
+  - - committee: [351, 96, 99]
       shard: 730
       total_validator_count: 173
-  - - committee:
-      - 342
-      - 217
-      - 1
+  - - committee: [342, 217, 1]
       shard: 731
       total_validator_count: 173
-  - - committee:
-      - 167
-      - 382
-      - 228
+  - - committee: [167, 382, 228]
       shard: 732
       total_validator_count: 173
   seed: '0x6ff9fde4cd621a9359ee5f08929d2188ed5f72b59aa71c3d10453ccde114d1b6'
 - input:
     crosslinking_start_shard: 946
     validators:
-    - original_index: 0
-      status: 2
-    - original_index: 1
-      status: 2
-    - original_index: 2
-      status: 1
-    - original_index: 3
-      status: 4
-    - original_index: 4
-      status: 1
-    - original_index: 5
-      status: 1
-    - original_index: 6
-      status: 0
-    - original_index: 7
-      status: 4
-    - original_index: 8
-      status: 4
-    - original_index: 9
-      status: 1
-    - original_index: 10
-      status: 0
-    - original_index: 11
-      status: 1
-    - original_index: 12
-      status: 4
-    - original_index: 13
-      status: 0
-    - original_index: 14
-      status: 2
-    - original_index: 15
-      status: 0
-    - original_index: 16
-      status: 2
-    - original_index: 17
-      status: 0
-    - original_index: 18
-      status: 3
-    - original_index: 19
-      status: 1
-    - original_index: 20
-      status: 2
-    - original_index: 21
-      status: 4
-    - original_index: 22
-      status: 4
-    - original_index: 23
-      status: 1
-    - original_index: 24
-      status: 4
-    - original_index: 25
-      status: 2
-    - original_index: 26
-      status: 3
-    - original_index: 27
-      status: 4
-    - original_index: 28
-      status: 4
-    - original_index: 29
-      status: 3
-    - original_index: 30
-      status: 2
-    - original_index: 31
-      status: 3
-    - original_index: 32
-      status: 0
-    - original_index: 33
-      status: 0
-    - original_index: 34
-      status: 1
-    - original_index: 35
-      status: 0
-    - original_index: 36
-      status: 0
-    - original_index: 37
-      status: 2
-    - original_index: 38
-      status: 0
-    - original_index: 39
-      status: 1
-    - original_index: 40
-      status: 4
-    - original_index: 41
-      status: 1
-    - original_index: 42
-      status: 3
-    - original_index: 43
-      status: 0
-    - original_index: 44
-      status: 0
-    - original_index: 45
-      status: 4
-    - original_index: 46
-      status: 0
-    - original_index: 47
-      status: 0
-    - original_index: 48
-      status: 1
-    - original_index: 49
-      status: 1
-    - original_index: 50
-      status: 1
-    - original_index: 51
-      status: 4
-    - original_index: 52
-      status: 3
-    - original_index: 53
-      status: 1
-    - original_index: 54
-      status: 2
-    - original_index: 55
-      status: 0
-    - original_index: 56
-      status: 1
-    - original_index: 57
-      status: 1
-    - original_index: 58
-      status: 1
-    - original_index: 59
-      status: 4
-    - original_index: 60
-      status: 1
-    - original_index: 61
-      status: 3
-    - original_index: 62
-      status: 1
-    - original_index: 63
-      status: 1
-    - original_index: 64
-      status: 3
-    - original_index: 65
-      status: 4
-    - original_index: 66
-      status: 4
-    - original_index: 67
-      status: 3
-    - original_index: 68
-      status: 4
-    - original_index: 69
-      status: 1
-    - original_index: 70
-      status: 1
-    - original_index: 71
-      status: 0
-    - original_index: 72
-      status: 3
-    - original_index: 73
-      status: 4
-    - original_index: 74
-      status: 0
-    - original_index: 75
-      status: 1
-    - original_index: 76
-      status: 0
-    - original_index: 77
-      status: 2
-    - original_index: 78
-      status: 2
-    - original_index: 79
-      status: 3
-    - original_index: 80
-      status: 0
-    - original_index: 81
-      status: 4
-    - original_index: 82
-      status: 4
-    - original_index: 83
-      status: 0
-    - original_index: 84
-      status: 2
-    - original_index: 85
-      status: 0
-    - original_index: 86
-      status: 2
-    - original_index: 87
-      status: 0
-    - original_index: 88
-      status: 0
-    - original_index: 89
-      status: 0
-    - original_index: 90
-      status: 2
-    - original_index: 91
-      status: 3
-    - original_index: 92
-      status: 2
-    - original_index: 93
-      status: 3
-    - original_index: 94
-      status: 3
-    - original_index: 95
-      status: 0
-    - original_index: 96
-      status: 2
-    - original_index: 97
-      status: 1
-    - original_index: 98
-      status: 0
-    - original_index: 99
-      status: 0
-    - original_index: 100
-      status: 4
-    - original_index: 101
-      status: 4
-    - original_index: 102
-      status: 4
-    - original_index: 103
-      status: 1
-    - original_index: 104
-      status: 2
-    - original_index: 105
-      status: 3
-    - original_index: 106
-      status: 3
-    - original_index: 107
-      status: 0
-    - original_index: 108
-      status: 1
-    - original_index: 109
-      status: 0
-    - original_index: 110
-      status: 1
-    - original_index: 111
-      status: 1
-    - original_index: 112
-      status: 2
-    - original_index: 113
-      status: 3
-    - original_index: 114
-      status: 1
-    - original_index: 115
-      status: 2
-    - original_index: 116
-      status: 4
-    - original_index: 117
-      status: 3
-    - original_index: 118
-      status: 0
-    - original_index: 119
-      status: 0
-    - original_index: 120
-      status: 3
-    - original_index: 121
-      status: 2
-    - original_index: 122
-      status: 1
-    - original_index: 123
-      status: 1
-    - original_index: 124
-      status: 0
-    - original_index: 125
-      status: 2
-    - original_index: 126
-      status: 0
-    - original_index: 127
-      status: 3
-    - original_index: 128
-      status: 0
-    - original_index: 129
-      status: 2
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 3
-    - original_index: 132
-      status: 4
-    - original_index: 133
-      status: 0
-    - original_index: 134
-      status: 3
-    - original_index: 135
-      status: 4
-    - original_index: 136
-      status: 2
-    - original_index: 137
-      status: 4
-    - original_index: 138
-      status: 3
-    - original_index: 139
-      status: 0
-    - original_index: 140
-      status: 1
-    - original_index: 141
-      status: 1
-    - original_index: 142
-      status: 2
-    - original_index: 143
-      status: 2
-    - original_index: 144
-      status: 3
-    - original_index: 145
-      status: 0
-    - original_index: 146
-      status: 0
-    - original_index: 147
-      status: 2
-    - original_index: 148
-      status: 3
-    - original_index: 149
-      status: 1
-    - original_index: 150
-      status: 3
-    - original_index: 151
-      status: 4
-    - original_index: 152
-      status: 3
-    - original_index: 153
-      status: 1
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 2
-    - original_index: 156
-      status: 0
-    - original_index: 157
-      status: 4
-    - original_index: 158
-      status: 4
-    - original_index: 159
-      status: 2
-    - original_index: 160
-      status: 0
-    - original_index: 161
-      status: 0
-    - original_index: 162
-      status: 1
-    - original_index: 163
-      status: 2
-    - original_index: 164
-      status: 4
-    - original_index: 165
-      status: 2
-    - original_index: 166
-      status: 1
-    - original_index: 167
-      status: 0
-    - original_index: 168
-      status: 3
-    - original_index: 169
-      status: 2
-    - original_index: 170
-      status: 0
-    - original_index: 171
-      status: 3
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 3
-    - original_index: 174
-      status: 0
-    - original_index: 175
-      status: 3
-    - original_index: 176
-      status: 0
-    - original_index: 177
-      status: 1
-    - original_index: 178
-      status: 0
-    - original_index: 179
-      status: 4
-    - original_index: 180
-      status: 4
-    - original_index: 181
-      status: 0
-    - original_index: 182
-      status: 4
-    - original_index: 183
-      status: 0
-    - original_index: 184
-      status: 2
-    - original_index: 185
-      status: 2
-    - original_index: 186
-      status: 2
-    - original_index: 187
-      status: 4
-    - original_index: 188
-      status: 1
-    - original_index: 189
-      status: 2
-    - original_index: 190
-      status: 4
-    - original_index: 191
-      status: 2
-    - original_index: 192
-      status: 4
-    - original_index: 193
-      status: 1
-    - original_index: 194
-      status: 0
-    - original_index: 195
-      status: 0
-    - original_index: 196
-      status: 2
-    - original_index: 197
-      status: 3
-    - original_index: 198
-      status: 3
-    - original_index: 199
-      status: 3
-    - original_index: 200
-      status: 1
-    - original_index: 201
-      status: 1
-    - original_index: 202
-      status: 2
-    - original_index: 203
-      status: 4
-    - original_index: 204
-      status: 1
-    - original_index: 205
-      status: 4
-    - original_index: 206
-      status: 0
-    - original_index: 207
-      status: 2
-    - original_index: 208
-      status: 2
-    - original_index: 209
-      status: 0
-    - original_index: 210
-      status: 0
-    - original_index: 211
-      status: 2
-    - original_index: 212
-      status: 4
-    - original_index: 213
-      status: 2
-    - original_index: 214
-      status: 1
-    - original_index: 215
-      status: 4
-    - original_index: 216
-      status: 2
-    - original_index: 217
-      status: 0
-    - original_index: 218
-      status: 1
-    - original_index: 219
-      status: 0
-    - original_index: 220
-      status: 3
-    - original_index: 221
-      status: 1
-    - original_index: 222
-      status: 1
-    - original_index: 223
-      status: 1
-    - original_index: 224
-      status: 3
-    - original_index: 225
-      status: 4
-    - original_index: 226
-      status: 3
-    - original_index: 227
-      status: 0
-    - original_index: 228
-      status: 1
-    - original_index: 229
-      status: 0
-    - original_index: 230
-      status: 2
-    - original_index: 231
-      status: 3
-    - original_index: 232
-      status: 3
-    - original_index: 233
-      status: 1
-    - original_index: 234
-      status: 4
-    - original_index: 235
-      status: 1
-    - original_index: 236
-      status: 3
-    - original_index: 237
-      status: 0
-    - original_index: 238
-      status: 3
-    - original_index: 239
-      status: 1
-    - original_index: 240
-      status: 2
-    - original_index: 241
-      status: 2
-    - original_index: 242
-      status: 4
-    - original_index: 243
-      status: 2
-    - original_index: 244
-      status: 2
-    - original_index: 245
-      status: 1
-    - original_index: 246
-      status: 1
-    - original_index: 247
-      status: 4
-    - original_index: 248
-      status: 1
-    - original_index: 249
-      status: 4
-    - original_index: 250
-      status: 3
-    - original_index: 251
-      status: 4
-    - original_index: 252
-      status: 3
-    - original_index: 253
-      status: 1
-    - original_index: 254
-      status: 4
-    - original_index: 255
-      status: 2
-    - original_index: 256
-      status: 4
-    - original_index: 257
-      status: 0
-    - original_index: 258
-      status: 0
-    - original_index: 259
-      status: 2
-    - original_index: 260
-      status: 0
-    - original_index: 261
-      status: 4
-    - original_index: 262
-      status: 0
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 3
-    - original_index: 265
-      status: 4
-    - original_index: 266
-      status: 1
-    - original_index: 267
-      status: 4
-    - original_index: 268
-      status: 1
-    - original_index: 269
-      status: 4
-    - original_index: 270
-      status: 2
-    - original_index: 271
-      status: 2
-    - original_index: 272
-      status: 3
-    - original_index: 273
-      status: 1
-    - original_index: 274
-      status: 2
-    - original_index: 275
-      status: 2
-    - original_index: 276
-      status: 1
-    - original_index: 277
-      status: 4
-    - original_index: 278
-      status: 2
-    - original_index: 279
-      status: 4
-    - original_index: 280
-      status: 2
-    - original_index: 281
-      status: 4
-    - original_index: 282
-      status: 1
-    - original_index: 283
-      status: 2
-    - original_index: 284
-      status: 4
-    - original_index: 285
-      status: 3
-    - original_index: 286
-      status: 1
-    - original_index: 287
-      status: 0
-    - original_index: 288
-      status: 2
-    - original_index: 289
-      status: 0
-    - original_index: 290
-      status: 2
-    - original_index: 291
-      status: 2
-    - original_index: 292
-      status: 4
-    - original_index: 293
-      status: 0
-    - original_index: 294
-      status: 1
-    - original_index: 295
-      status: 1
-    - original_index: 296
-      status: 2
-    - original_index: 297
-      status: 0
-    - original_index: 298
-      status: 4
-    - original_index: 299
-      status: 1
-    - original_index: 300
-      status: 1
-    - original_index: 301
-      status: 2
-    - original_index: 302
-      status: 1
-    - original_index: 303
-      status: 3
-    - original_index: 304
-      status: 3
-    - original_index: 305
-      status: 1
-    - original_index: 306
-      status: 3
-    - original_index: 307
-      status: 1
-    - original_index: 308
-      status: 4
-    - original_index: 309
-      status: 2
-    - original_index: 310
-      status: 0
-    - original_index: 311
-      status: 3
-    - original_index: 312
-      status: 3
-    - original_index: 313
-      status: 2
-    - original_index: 314
-      status: 2
-    - original_index: 315
-      status: 0
-    - original_index: 316
-      status: 3
-    - original_index: 317
-      status: 2
-    - original_index: 318
-      status: 2
-    - original_index: 319
-      status: 1
-    - original_index: 320
-      status: 4
-    - original_index: 321
-      status: 3
-    - original_index: 322
-      status: 3
-    - original_index: 323
-      status: 0
-    - original_index: 324
-      status: 2
-    - original_index: 325
-      status: 4
-    - original_index: 326
-      status: 2
-    - original_index: 327
-      status: 4
-    - original_index: 328
-      status: 1
-    - original_index: 329
-      status: 3
-    - original_index: 330
-      status: 2
-    - original_index: 331
-      status: 0
-    - original_index: 332
-      status: 0
-    - original_index: 333
-      status: 4
-    - original_index: 334
-      status: 0
-    - original_index: 335
-      status: 0
-    - original_index: 336
-      status: 2
-    - original_index: 337
-      status: 1
-    - original_index: 338
-      status: 4
-    - original_index: 339
-      status: 4
-    - original_index: 340
-      status: 4
-    - original_index: 341
-      status: 2
-    - original_index: 342
-      status: 4
-    - original_index: 343
-      status: 3
-    - original_index: 344
-      status: 4
-    - original_index: 345
-      status: 4
-    - original_index: 346
-      status: 4
-    - original_index: 347
-      status: 3
-    - original_index: 348
-      status: 2
-    - original_index: 349
-      status: 0
-    - original_index: 350
-      status: 1
-    - original_index: 351
-      status: 4
-    - original_index: 352
-      status: 3
-    - original_index: 353
-      status: 2
-    - original_index: 354
-      status: 3
-    - original_index: 355
-      status: 2
-    - original_index: 356
-      status: 0
-    - original_index: 357
-      status: 3
-    - original_index: 358
-      status: 3
-    - original_index: 359
-      status: 1
-    - original_index: 360
-      status: 3
-    - original_index: 361
-      status: 1
-    - original_index: 362
-      status: 2
-    - original_index: 363
-      status: 0
-    - original_index: 364
-      status: 0
-    - original_index: 365
-      status: 2
-    - original_index: 366
-      status: 4
-    - original_index: 367
-      status: 0
-    - original_index: 368
-      status: 1
-    - original_index: 369
-      status: 2
-    - original_index: 370
-      status: 1
-    - original_index: 371
-      status: 4
-    - original_index: 372
-      status: 1
-    - original_index: 373
-      status: 2
-    - original_index: 374
-      status: 2
-    - original_index: 375
-      status: 2
-    - original_index: 376
-      status: 1
-    - original_index: 377
-      status: 2
-    - original_index: 378
-      status: 2
-    - original_index: 379
-      status: 0
-    - original_index: 380
-      status: 1
-    - original_index: 381
-      status: 0
-    - original_index: 382
-      status: 1
-    - original_index: 383
-      status: 0
-    - original_index: 384
-      status: 1
-    - original_index: 385
-      status: 2
-    - original_index: 386
-      status: 1
-    - original_index: 387
-      status: 2
-    - original_index: 388
-      status: 1
-    - original_index: 389
-      status: 4
-    - original_index: 390
-      status: 2
-    - original_index: 391
-      status: 2
-    - original_index: 392
-      status: 1
-    - original_index: 393
-      status: 4
-    - original_index: 394
-      status: 2
-    - original_index: 395
-      status: 4
-    - original_index: 396
-      status: 1
-    - original_index: 397
-      status: 2
-    - original_index: 398
-      status: 1
-    - original_index: 399
-      status: 4
-    - original_index: 400
-      status: 0
-    - original_index: 401
-      status: 1
-    - original_index: 402
-      status: 2
-    - original_index: 403
-      status: 0
-    - original_index: 404
-      status: 3
-    - original_index: 405
-      status: 1
-    - original_index: 406
-      status: 2
-    - original_index: 407
-      status: 1
-    - original_index: 408
-      status: 2
-    - original_index: 409
-      status: 3
-    - original_index: 410
-      status: 0
-    - original_index: 411
-      status: 0
-    - original_index: 412
-      status: 2
-    - original_index: 413
-      status: 0
-    - original_index: 414
-      status: 2
-    - original_index: 415
-      status: 0
-    - original_index: 416
-      status: 4
-    - original_index: 417
-      status: 0
-    - original_index: 418
-      status: 2
-    - original_index: 419
-      status: 3
-    - original_index: 420
-      status: 1
-    - original_index: 421
-      status: 4
-    - original_index: 422
-      status: 2
-    - original_index: 423
-      status: 3
-    - original_index: 424
-      status: 0
-    - original_index: 425
-      status: 2
-    - original_index: 426
-      status: 0
-    - original_index: 427
-      status: 3
-    - original_index: 428
-      status: 4
-    - original_index: 429
-      status: 4
-    - original_index: 430
-      status: 2
-    - original_index: 431
-      status: 3
-    - original_index: 432
-      status: 1
-    - original_index: 433
-      status: 2
-    - original_index: 434
-      status: 2
-    - original_index: 435
-      status: 2
-    - original_index: 436
-      status: 4
-    - original_index: 437
-      status: 4
-    - original_index: 438
-      status: 2
-    - original_index: 439
-      status: 3
-    - original_index: 440
-      status: 0
-    - original_index: 441
-      status: 0
-    - original_index: 442
-      status: 3
-    - original_index: 443
-      status: 0
-    - original_index: 444
-      status: 3
-    - original_index: 445
-      status: 3
-    - original_index: 446
-      status: 3
-    - original_index: 447
-      status: 3
-    - original_index: 448
-      status: 3
-    - original_index: 449
-      status: 0
-    - original_index: 450
-      status: 2
-    - original_index: 451
-      status: 2
-    - original_index: 452
-      status: 1
-    - original_index: 453
-      status: 0
-    - original_index: 454
-      status: 0
-    - original_index: 455
-      status: 1
-    - original_index: 456
-      status: 1
-    - original_index: 457
-      status: 1
-    - original_index: 458
-      status: 4
-    - original_index: 459
-      status: 3
+    - {original_index: 0, status: 2}
+    - {original_index: 1, status: 2}
+    - {original_index: 2, status: 1}
+    - {original_index: 3, status: 4}
+    - {original_index: 4, status: 1}
+    - {original_index: 5, status: 1}
+    - {original_index: 6, status: 0}
+    - {original_index: 7, status: 4}
+    - {original_index: 8, status: 4}
+    - {original_index: 9, status: 1}
+    - {original_index: 10, status: 0}
+    - {original_index: 11, status: 1}
+    - {original_index: 12, status: 4}
+    - {original_index: 13, status: 0}
+    - {original_index: 14, status: 2}
+    - {original_index: 15, status: 0}
+    - {original_index: 16, status: 2}
+    - {original_index: 17, status: 0}
+    - {original_index: 18, status: 3}
+    - {original_index: 19, status: 1}
+    - {original_index: 20, status: 2}
+    - {original_index: 21, status: 4}
+    - {original_index: 22, status: 4}
+    - {original_index: 23, status: 1}
+    - {original_index: 24, status: 4}
+    - {original_index: 25, status: 2}
+    - {original_index: 26, status: 3}
+    - {original_index: 27, status: 4}
+    - {original_index: 28, status: 4}
+    - {original_index: 29, status: 3}
+    - {original_index: 30, status: 2}
+    - {original_index: 31, status: 3}
+    - {original_index: 32, status: 0}
+    - {original_index: 33, status: 0}
+    - {original_index: 34, status: 1}
+    - {original_index: 35, status: 0}
+    - {original_index: 36, status: 0}
+    - {original_index: 37, status: 2}
+    - {original_index: 38, status: 0}
+    - {original_index: 39, status: 1}
+    - {original_index: 40, status: 4}
+    - {original_index: 41, status: 1}
+    - {original_index: 42, status: 3}
+    - {original_index: 43, status: 0}
+    - {original_index: 44, status: 0}
+    - {original_index: 45, status: 4}
+    - {original_index: 46, status: 0}
+    - {original_index: 47, status: 0}
+    - {original_index: 48, status: 1}
+    - {original_index: 49, status: 1}
+    - {original_index: 50, status: 1}
+    - {original_index: 51, status: 4}
+    - {original_index: 52, status: 3}
+    - {original_index: 53, status: 1}
+    - {original_index: 54, status: 2}
+    - {original_index: 55, status: 0}
+    - {original_index: 56, status: 1}
+    - {original_index: 57, status: 1}
+    - {original_index: 58, status: 1}
+    - {original_index: 59, status: 4}
+    - {original_index: 60, status: 1}
+    - {original_index: 61, status: 3}
+    - {original_index: 62, status: 1}
+    - {original_index: 63, status: 1}
+    - {original_index: 64, status: 3}
+    - {original_index: 65, status: 4}
+    - {original_index: 66, status: 4}
+    - {original_index: 67, status: 3}
+    - {original_index: 68, status: 4}
+    - {original_index: 69, status: 1}
+    - {original_index: 70, status: 1}
+    - {original_index: 71, status: 0}
+    - {original_index: 72, status: 3}
+    - {original_index: 73, status: 4}
+    - {original_index: 74, status: 0}
+    - {original_index: 75, status: 1}
+    - {original_index: 76, status: 0}
+    - {original_index: 77, status: 2}
+    - {original_index: 78, status: 2}
+    - {original_index: 79, status: 3}
+    - {original_index: 80, status: 0}
+    - {original_index: 81, status: 4}
+    - {original_index: 82, status: 4}
+    - {original_index: 83, status: 0}
+    - {original_index: 84, status: 2}
+    - {original_index: 85, status: 0}
+    - {original_index: 86, status: 2}
+    - {original_index: 87, status: 0}
+    - {original_index: 88, status: 0}
+    - {original_index: 89, status: 0}
+    - {original_index: 90, status: 2}
+    - {original_index: 91, status: 3}
+    - {original_index: 92, status: 2}
+    - {original_index: 93, status: 3}
+    - {original_index: 94, status: 3}
+    - {original_index: 95, status: 0}
+    - {original_index: 96, status: 2}
+    - {original_index: 97, status: 1}
+    - {original_index: 98, status: 0}
+    - {original_index: 99, status: 0}
+    - {original_index: 100, status: 4}
+    - {original_index: 101, status: 4}
+    - {original_index: 102, status: 4}
+    - {original_index: 103, status: 1}
+    - {original_index: 104, status: 2}
+    - {original_index: 105, status: 3}
+    - {original_index: 106, status: 3}
+    - {original_index: 107, status: 0}
+    - {original_index: 108, status: 1}
+    - {original_index: 109, status: 0}
+    - {original_index: 110, status: 1}
+    - {original_index: 111, status: 1}
+    - {original_index: 112, status: 2}
+    - {original_index: 113, status: 3}
+    - {original_index: 114, status: 1}
+    - {original_index: 115, status: 2}
+    - {original_index: 116, status: 4}
+    - {original_index: 117, status: 3}
+    - {original_index: 118, status: 0}
+    - {original_index: 119, status: 0}
+    - {original_index: 120, status: 3}
+    - {original_index: 121, status: 2}
+    - {original_index: 122, status: 1}
+    - {original_index: 123, status: 1}
+    - {original_index: 124, status: 0}
+    - {original_index: 125, status: 2}
+    - {original_index: 126, status: 0}
+    - {original_index: 127, status: 3}
+    - {original_index: 128, status: 0}
+    - {original_index: 129, status: 2}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 3}
+    - {original_index: 132, status: 4}
+    - {original_index: 133, status: 0}
+    - {original_index: 134, status: 3}
+    - {original_index: 135, status: 4}
+    - {original_index: 136, status: 2}
+    - {original_index: 137, status: 4}
+    - {original_index: 138, status: 3}
+    - {original_index: 139, status: 0}
+    - {original_index: 140, status: 1}
+    - {original_index: 141, status: 1}
+    - {original_index: 142, status: 2}
+    - {original_index: 143, status: 2}
+    - {original_index: 144, status: 3}
+    - {original_index: 145, status: 0}
+    - {original_index: 146, status: 0}
+    - {original_index: 147, status: 2}
+    - {original_index: 148, status: 3}
+    - {original_index: 149, status: 1}
+    - {original_index: 150, status: 3}
+    - {original_index: 151, status: 4}
+    - {original_index: 152, status: 3}
+    - {original_index: 153, status: 1}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 2}
+    - {original_index: 156, status: 0}
+    - {original_index: 157, status: 4}
+    - {original_index: 158, status: 4}
+    - {original_index: 159, status: 2}
+    - {original_index: 160, status: 0}
+    - {original_index: 161, status: 0}
+    - {original_index: 162, status: 1}
+    - {original_index: 163, status: 2}
+    - {original_index: 164, status: 4}
+    - {original_index: 165, status: 2}
+    - {original_index: 166, status: 1}
+    - {original_index: 167, status: 0}
+    - {original_index: 168, status: 3}
+    - {original_index: 169, status: 2}
+    - {original_index: 170, status: 0}
+    - {original_index: 171, status: 3}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 3}
+    - {original_index: 174, status: 0}
+    - {original_index: 175, status: 3}
+    - {original_index: 176, status: 0}
+    - {original_index: 177, status: 1}
+    - {original_index: 178, status: 0}
+    - {original_index: 179, status: 4}
+    - {original_index: 180, status: 4}
+    - {original_index: 181, status: 0}
+    - {original_index: 182, status: 4}
+    - {original_index: 183, status: 0}
+    - {original_index: 184, status: 2}
+    - {original_index: 185, status: 2}
+    - {original_index: 186, status: 2}
+    - {original_index: 187, status: 4}
+    - {original_index: 188, status: 1}
+    - {original_index: 189, status: 2}
+    - {original_index: 190, status: 4}
+    - {original_index: 191, status: 2}
+    - {original_index: 192, status: 4}
+    - {original_index: 193, status: 1}
+    - {original_index: 194, status: 0}
+    - {original_index: 195, status: 0}
+    - {original_index: 196, status: 2}
+    - {original_index: 197, status: 3}
+    - {original_index: 198, status: 3}
+    - {original_index: 199, status: 3}
+    - {original_index: 200, status: 1}
+    - {original_index: 201, status: 1}
+    - {original_index: 202, status: 2}
+    - {original_index: 203, status: 4}
+    - {original_index: 204, status: 1}
+    - {original_index: 205, status: 4}
+    - {original_index: 206, status: 0}
+    - {original_index: 207, status: 2}
+    - {original_index: 208, status: 2}
+    - {original_index: 209, status: 0}
+    - {original_index: 210, status: 0}
+    - {original_index: 211, status: 2}
+    - {original_index: 212, status: 4}
+    - {original_index: 213, status: 2}
+    - {original_index: 214, status: 1}
+    - {original_index: 215, status: 4}
+    - {original_index: 216, status: 2}
+    - {original_index: 217, status: 0}
+    - {original_index: 218, status: 1}
+    - {original_index: 219, status: 0}
+    - {original_index: 220, status: 3}
+    - {original_index: 221, status: 1}
+    - {original_index: 222, status: 1}
+    - {original_index: 223, status: 1}
+    - {original_index: 224, status: 3}
+    - {original_index: 225, status: 4}
+    - {original_index: 226, status: 3}
+    - {original_index: 227, status: 0}
+    - {original_index: 228, status: 1}
+    - {original_index: 229, status: 0}
+    - {original_index: 230, status: 2}
+    - {original_index: 231, status: 3}
+    - {original_index: 232, status: 3}
+    - {original_index: 233, status: 1}
+    - {original_index: 234, status: 4}
+    - {original_index: 235, status: 1}
+    - {original_index: 236, status: 3}
+    - {original_index: 237, status: 0}
+    - {original_index: 238, status: 3}
+    - {original_index: 239, status: 1}
+    - {original_index: 240, status: 2}
+    - {original_index: 241, status: 2}
+    - {original_index: 242, status: 4}
+    - {original_index: 243, status: 2}
+    - {original_index: 244, status: 2}
+    - {original_index: 245, status: 1}
+    - {original_index: 246, status: 1}
+    - {original_index: 247, status: 4}
+    - {original_index: 248, status: 1}
+    - {original_index: 249, status: 4}
+    - {original_index: 250, status: 3}
+    - {original_index: 251, status: 4}
+    - {original_index: 252, status: 3}
+    - {original_index: 253, status: 1}
+    - {original_index: 254, status: 4}
+    - {original_index: 255, status: 2}
+    - {original_index: 256, status: 4}
+    - {original_index: 257, status: 0}
+    - {original_index: 258, status: 0}
+    - {original_index: 259, status: 2}
+    - {original_index: 260, status: 0}
+    - {original_index: 261, status: 4}
+    - {original_index: 262, status: 0}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 3}
+    - {original_index: 265, status: 4}
+    - {original_index: 266, status: 1}
+    - {original_index: 267, status: 4}
+    - {original_index: 268, status: 1}
+    - {original_index: 269, status: 4}
+    - {original_index: 270, status: 2}
+    - {original_index: 271, status: 2}
+    - {original_index: 272, status: 3}
+    - {original_index: 273, status: 1}
+    - {original_index: 274, status: 2}
+    - {original_index: 275, status: 2}
+    - {original_index: 276, status: 1}
+    - {original_index: 277, status: 4}
+    - {original_index: 278, status: 2}
+    - {original_index: 279, status: 4}
+    - {original_index: 280, status: 2}
+    - {original_index: 281, status: 4}
+    - {original_index: 282, status: 1}
+    - {original_index: 283, status: 2}
+    - {original_index: 284, status: 4}
+    - {original_index: 285, status: 3}
+    - {original_index: 286, status: 1}
+    - {original_index: 287, status: 0}
+    - {original_index: 288, status: 2}
+    - {original_index: 289, status: 0}
+    - {original_index: 290, status: 2}
+    - {original_index: 291, status: 2}
+    - {original_index: 292, status: 4}
+    - {original_index: 293, status: 0}
+    - {original_index: 294, status: 1}
+    - {original_index: 295, status: 1}
+    - {original_index: 296, status: 2}
+    - {original_index: 297, status: 0}
+    - {original_index: 298, status: 4}
+    - {original_index: 299, status: 1}
+    - {original_index: 300, status: 1}
+    - {original_index: 301, status: 2}
+    - {original_index: 302, status: 1}
+    - {original_index: 303, status: 3}
+    - {original_index: 304, status: 3}
+    - {original_index: 305, status: 1}
+    - {original_index: 306, status: 3}
+    - {original_index: 307, status: 1}
+    - {original_index: 308, status: 4}
+    - {original_index: 309, status: 2}
+    - {original_index: 310, status: 0}
+    - {original_index: 311, status: 3}
+    - {original_index: 312, status: 3}
+    - {original_index: 313, status: 2}
+    - {original_index: 314, status: 2}
+    - {original_index: 315, status: 0}
+    - {original_index: 316, status: 3}
+    - {original_index: 317, status: 2}
+    - {original_index: 318, status: 2}
+    - {original_index: 319, status: 1}
+    - {original_index: 320, status: 4}
+    - {original_index: 321, status: 3}
+    - {original_index: 322, status: 3}
+    - {original_index: 323, status: 0}
+    - {original_index: 324, status: 2}
+    - {original_index: 325, status: 4}
+    - {original_index: 326, status: 2}
+    - {original_index: 327, status: 4}
+    - {original_index: 328, status: 1}
+    - {original_index: 329, status: 3}
+    - {original_index: 330, status: 2}
+    - {original_index: 331, status: 0}
+    - {original_index: 332, status: 0}
+    - {original_index: 333, status: 4}
+    - {original_index: 334, status: 0}
+    - {original_index: 335, status: 0}
+    - {original_index: 336, status: 2}
+    - {original_index: 337, status: 1}
+    - {original_index: 338, status: 4}
+    - {original_index: 339, status: 4}
+    - {original_index: 340, status: 4}
+    - {original_index: 341, status: 2}
+    - {original_index: 342, status: 4}
+    - {original_index: 343, status: 3}
+    - {original_index: 344, status: 4}
+    - {original_index: 345, status: 4}
+    - {original_index: 346, status: 4}
+    - {original_index: 347, status: 3}
+    - {original_index: 348, status: 2}
+    - {original_index: 349, status: 0}
+    - {original_index: 350, status: 1}
+    - {original_index: 351, status: 4}
+    - {original_index: 352, status: 3}
+    - {original_index: 353, status: 2}
+    - {original_index: 354, status: 3}
+    - {original_index: 355, status: 2}
+    - {original_index: 356, status: 0}
+    - {original_index: 357, status: 3}
+    - {original_index: 358, status: 3}
+    - {original_index: 359, status: 1}
+    - {original_index: 360, status: 3}
+    - {original_index: 361, status: 1}
+    - {original_index: 362, status: 2}
+    - {original_index: 363, status: 0}
+    - {original_index: 364, status: 0}
+    - {original_index: 365, status: 2}
+    - {original_index: 366, status: 4}
+    - {original_index: 367, status: 0}
+    - {original_index: 368, status: 1}
+    - {original_index: 369, status: 2}
+    - {original_index: 370, status: 1}
+    - {original_index: 371, status: 4}
+    - {original_index: 372, status: 1}
+    - {original_index: 373, status: 2}
+    - {original_index: 374, status: 2}
+    - {original_index: 375, status: 2}
+    - {original_index: 376, status: 1}
+    - {original_index: 377, status: 2}
+    - {original_index: 378, status: 2}
+    - {original_index: 379, status: 0}
+    - {original_index: 380, status: 1}
+    - {original_index: 381, status: 0}
+    - {original_index: 382, status: 1}
+    - {original_index: 383, status: 0}
+    - {original_index: 384, status: 1}
+    - {original_index: 385, status: 2}
+    - {original_index: 386, status: 1}
+    - {original_index: 387, status: 2}
+    - {original_index: 388, status: 1}
+    - {original_index: 389, status: 4}
+    - {original_index: 390, status: 2}
+    - {original_index: 391, status: 2}
+    - {original_index: 392, status: 1}
+    - {original_index: 393, status: 4}
+    - {original_index: 394, status: 2}
+    - {original_index: 395, status: 4}
+    - {original_index: 396, status: 1}
+    - {original_index: 397, status: 2}
+    - {original_index: 398, status: 1}
+    - {original_index: 399, status: 4}
+    - {original_index: 400, status: 0}
+    - {original_index: 401, status: 1}
+    - {original_index: 402, status: 2}
+    - {original_index: 403, status: 0}
+    - {original_index: 404, status: 3}
+    - {original_index: 405, status: 1}
+    - {original_index: 406, status: 2}
+    - {original_index: 407, status: 1}
+    - {original_index: 408, status: 2}
+    - {original_index: 409, status: 3}
+    - {original_index: 410, status: 0}
+    - {original_index: 411, status: 0}
+    - {original_index: 412, status: 2}
+    - {original_index: 413, status: 0}
+    - {original_index: 414, status: 2}
+    - {original_index: 415, status: 0}
+    - {original_index: 416, status: 4}
+    - {original_index: 417, status: 0}
+    - {original_index: 418, status: 2}
+    - {original_index: 419, status: 3}
+    - {original_index: 420, status: 1}
+    - {original_index: 421, status: 4}
+    - {original_index: 422, status: 2}
+    - {original_index: 423, status: 3}
+    - {original_index: 424, status: 0}
+    - {original_index: 425, status: 2}
+    - {original_index: 426, status: 0}
+    - {original_index: 427, status: 3}
+    - {original_index: 428, status: 4}
+    - {original_index: 429, status: 4}
+    - {original_index: 430, status: 2}
+    - {original_index: 431, status: 3}
+    - {original_index: 432, status: 1}
+    - {original_index: 433, status: 2}
+    - {original_index: 434, status: 2}
+    - {original_index: 435, status: 2}
+    - {original_index: 436, status: 4}
+    - {original_index: 437, status: 4}
+    - {original_index: 438, status: 2}
+    - {original_index: 439, status: 3}
+    - {original_index: 440, status: 0}
+    - {original_index: 441, status: 0}
+    - {original_index: 442, status: 3}
+    - {original_index: 443, status: 0}
+    - {original_index: 444, status: 3}
+    - {original_index: 445, status: 3}
+    - {original_index: 446, status: 3}
+    - {original_index: 447, status: 3}
+    - {original_index: 448, status: 3}
+    - {original_index: 449, status: 0}
+    - {original_index: 450, status: 2}
+    - {original_index: 451, status: 2}
+    - {original_index: 452, status: 1}
+    - {original_index: 453, status: 0}
+    - {original_index: 454, status: 0}
+    - {original_index: 455, status: 1}
+    - {original_index: 456, status: 1}
+    - {original_index: 457, status: 1}
+    - {original_index: 458, status: 4}
+    - {original_index: 459, status: 3}
   output:
-  - - committee:
-      - 100
-      - 368
+  - - committee: [100, 368]
       shard: 946
       total_validator_count: 183
-  - - committee:
-      - 253
-      - 395
-      - 249
+  - - committee: [253, 395, 249]
       shard: 947
       total_validator_count: 183
-  - - committee:
-      - 2
-      - 401
-      - 286
+  - - committee: [2, 401, 286]
       shard: 948
       total_validator_count: 183
-  - - committee:
-      - 215
-      - 366
-      - 225
+  - - committee: [215, 366, 225]
       shard: 949
       total_validator_count: 183
-  - - committee:
-      - 399
-      - 359
-      - 350
+  - - committee: [399, 359, 350]
       shard: 950
       total_validator_count: 183
-  - - committee:
-      - 24
-      - 223
-      - 3
+  - - committee: [24, 223, 3]
       shard: 951
       total_validator_count: 183
-  - - committee:
-      - 407
-      - 200
-      - 75
+  - - committee: [407, 200, 75]
       shard: 952
       total_validator_count: 183
-  - - committee:
-      - 328
-      - 437
+  - - committee: [328, 437]
       shard: 953
       total_validator_count: 183
-  - - committee:
-      - 135
-      - 300
-      - 59
+  - - committee: [135, 300, 59]
       shard: 954
       total_validator_count: 183
-  - - committee:
-      - 102
-      - 456
-      - 239
+  - - committee: [102, 456, 239]
       shard: 955
       total_validator_count: 183
-  - - committee:
-      - 222
-      - 295
-      - 4
+  - - committee: [222, 295, 4]
       shard: 956
       total_validator_count: 183
-  - - committee:
-      - 396
-      - 51
-      - 110
+  - - committee: [396, 51, 110]
       shard: 957
       total_validator_count: 183
-  - - committee:
-      - 421
-      - 57
-      - 345
+  - - committee: [421, 57, 345]
       shard: 958
       total_validator_count: 183
-  - - committee:
-      - 66
-      - 247
-      - 65
+  - - committee: [66, 247, 65]
       shard: 959
       total_validator_count: 183
-  - - committee:
-      - 254
-      - 388
+  - - committee: [254, 388]
       shard: 960
       total_validator_count: 183
-  - - committee:
-      - 265
-      - 190
-      - 339
+  - - committee: [265, 190, 339]
       shard: 961
       total_validator_count: 183
-  - - committee:
-      - 12
-      - 34
-      - 149
+  - - committee: [12, 34, 149]
       shard: 962
       total_validator_count: 183
-  - - committee:
-      - 279
-      - 298
-      - 193
+  - - committee: [279, 298, 193]
       shard: 963
       total_validator_count: 183
-  - - committee:
-      - 246
-      - 266
-      - 337
+  - - committee: [246, 266, 337]
       shard: 964
       total_validator_count: 183
-  - - committee:
-      - 277
-      - 325
-      - 452
+  - - committee: [277, 325, 452]
       shard: 965
       total_validator_count: 183
-  - - committee:
-      - 69
-      - 340
-      - 269
+  - - committee: [69, 340, 269]
       shard: 966
       total_validator_count: 183
-  - - committee:
-      - 284
-      - 263
+  - - committee: [284, 263]
       shard: 967
       total_validator_count: 183
-  - - committee:
-      - 162
-      - 27
-      - 7
+  - - committee: [162, 27, 7]
       shard: 968
       total_validator_count: 183
-  - - committee:
-      - 49
-      - 23
-      - 180
+  - - committee: [49, 23, 180]
       shard: 969
       total_validator_count: 183
-  - - committee:
-      - 429
-      - 212
-      - 221
+  - - committee: [429, 212, 221]
       shard: 970
       total_validator_count: 183
-  - - committee:
-      - 22
-      - 245
-      - 130
+  - - committee: [22, 245, 130]
       shard: 971
       total_validator_count: 183
-  - - committee:
-      - 384
-      - 19
-      - 97
+  - - committee: [384, 19, 97]
       shard: 972
       total_validator_count: 183
-  - - committee:
-      - 111
-      - 458
-      - 41
+  - - committee: [111, 458, 41]
       shard: 973
       total_validator_count: 183
-  - - committee:
-      - 386
-      - 157
+  - - committee: [386, 157]
       shard: 974
       total_validator_count: 183
-  - - committee:
-      - 248
-      - 140
-      - 405
+  - - committee: [248, 140, 405]
       shard: 975
       total_validator_count: 183
-  - - committee:
-      - 73
-      - 251
-      - 398
+  - - committee: [73, 251, 398]
       shard: 976
       total_validator_count: 183
-  - - committee:
-      - 371
-      - 116
-      - 428
+  - - committee: [371, 116, 428]
       shard: 977
       total_validator_count: 183
-  - - committee:
-      - 108
-      - 39
-      - 235
+  - - committee: [108, 39, 235]
       shard: 978
       total_validator_count: 183
-  - - committee:
-      - 416
-      - 48
-      - 308
+  - - committee: [416, 48, 308]
       shard: 979
       total_validator_count: 183
-  - - committee:
-      - 56
-      - 103
-      - 299
+  - - committee: [56, 103, 299]
       shard: 980
       total_validator_count: 183
-  - - committee:
-      - 158
-      - 201
+  - - committee: [158, 201]
       shard: 981
       total_validator_count: 183
-  - - committee:
-      - 351
-      - 455
-      - 282
+  - - committee: [351, 455, 282]
       shard: 982
       total_validator_count: 183
-  - - committee:
-      - 177
-      - 81
-      - 179
+  - - committee: [177, 81, 179]
       shard: 983
       total_validator_count: 183
-  - - committee:
-      - 9
-      - 53
-      - 218
+  - - committee: [9, 53, 218]
       shard: 984
       total_validator_count: 183
-  - - committee:
-      - 5
-      - 182
-      - 261
+  - - committee: [5, 182, 261]
       shard: 985
       total_validator_count: 183
-  - - committee:
-      - 58
-      - 457
-      - 233
+  - - committee: [58, 457, 233]
       shard: 986
       total_validator_count: 183
-  - - committee:
-      - 294
-      - 242
-      - 342
+  - - committee: [294, 242, 342]
       shard: 987
       total_validator_count: 183
-  - - committee:
-      - 346
-      - 50
+  - - committee: [346, 50]
       shard: 988
       total_validator_count: 183
-  - - committee:
-      - 151
-      - 68
-      - 11
+  - - committee: [151, 68, 11]
       shard: 989
       total_validator_count: 183
-  - - committee:
-      - 389
-      - 204
-      - 302
+  - - committee: [389, 204, 302]
       shard: 990
       total_validator_count: 183
-  - - committee:
-      - 273
-      - 361
-      - 228
+  - - committee: [273, 361, 228]
       shard: 991
       total_validator_count: 183
-  - - committee:
-      - 45
-      - 205
-      - 372
+  - - committee: [45, 205, 372]
       shard: 992
       total_validator_count: 183
-  - - committee:
-      - 305
-      - 268
-      - 141
+  - - committee: [305, 268, 141]
       shard: 993
       total_validator_count: 183
-  - - committee:
-      - 256
-      - 267
-      - 276
+  - - committee: [256, 267, 276]
       shard: 994
       total_validator_count: 183
-  - - committee:
-      - 338
-      - 234
+  - - committee: [338, 234]
       shard: 995
       total_validator_count: 183
-  - - committee:
-      - 154
-      - 203
-      - 187
+  - - committee: [154, 203, 187]
       shard: 996
       total_validator_count: 183
-  - - committee:
-      - 8
-      - 307
-      - 370
+  - - committee: [8, 307, 370]
       shard: 997
       total_validator_count: 183
-  - - committee:
-      - 70
-      - 166
-      - 192
+  - - committee: [70, 166, 192]
       shard: 998
       total_validator_count: 183
-  - - committee:
-      - 380
-      - 132
-      - 344
+  - - committee: [380, 132, 344]
       shard: 999
       total_validator_count: 183
-  - - committee:
-      - 281
-      - 376
-      - 327
+  - - committee: [281, 376, 327]
       shard: 1000
       total_validator_count: 183
-  - - committee:
-      - 137
-      - 114
-      - 214
+  - - committee: [137, 114, 214]
       shard: 1001
       total_validator_count: 183
-  - - committee:
-      - 101
-      - 21
+  - - committee: [101, 21]
       shard: 1002
       total_validator_count: 183
-  - - committee:
-      - 60
-      - 393
-      - 63
+  - - committee: [60, 393, 63]
       shard: 1003
       total_validator_count: 183
-  - - committee:
-      - 188
-      - 392
-      - 432
+  - - committee: [188, 392, 432]
       shard: 1004
       total_validator_count: 183
-  - - committee:
-      - 123
-      - 420
-      - 40
+  - - committee: [123, 420, 40]
       shard: 1005
       total_validator_count: 183
-  - - committee:
-      - 62
-      - 320
-      - 292
+  - - committee: [62, 320, 292]
       shard: 1006
       total_validator_count: 183
-  - - committee:
-      - 436
-      - 319
-      - 333
+  - - committee: [436, 319, 333]
       shard: 1007
       total_validator_count: 183
-  - - committee:
-      - 153
-      - 28
-      - 122
+  - - committee: [153, 28, 122]
       shard: 1008
       total_validator_count: 183
-  - - committee:
-      - 82
-      - 164
-      - 382
+  - - committee: [82, 164, 382]
       shard: 1009
       total_validator_count: 183
   seed: '0x9d162fc672c9aba987488027bea4cbc77375dc5ab7c620ce42b3bb35f1445aa8'
 - input:
     crosslinking_start_shard: 378
     validators:
-    - original_index: 0
-      status: 0
-    - original_index: 1
-      status: 0
-    - original_index: 2
-      status: 1
-    - original_index: 3
-      status: 2
-    - original_index: 4
-      status: 0
-    - original_index: 5
-      status: 1
-    - original_index: 6
-      status: 4
-    - original_index: 7
-      status: 0
-    - original_index: 8
-      status: 0
-    - original_index: 9
-      status: 2
-    - original_index: 10
-      status: 1
-    - original_index: 11
-      status: 4
-    - original_index: 12
-      status: 3
-    - original_index: 13
-      status: 4
-    - original_index: 14
-      status: 1
-    - original_index: 15
-      status: 4
-    - original_index: 16
-      status: 2
-    - original_index: 17
-      status: 2
-    - original_index: 18
-      status: 3
-    - original_index: 19
-      status: 3
-    - original_index: 20
-      status: 4
-    - original_index: 21
-      status: 0
-    - original_index: 22
-      status: 0
-    - original_index: 23
-      status: 3
-    - original_index: 24
-      status: 3
-    - original_index: 25
-      status: 3
-    - original_index: 26
-      status: 1
-    - original_index: 27
-      status: 0
-    - original_index: 28
-      status: 1
-    - original_index: 29
-      status: 2
-    - original_index: 30
-      status: 2
-    - original_index: 31
-      status: 4
-    - original_index: 32
-      status: 1
-    - original_index: 33
-      status: 3
-    - original_index: 34
-      status: 4
-    - original_index: 35
-      status: 2
-    - original_index: 36
-      status: 3
-    - original_index: 37
-      status: 3
-    - original_index: 38
-      status: 4
-    - original_index: 39
-      status: 1
-    - original_index: 40
-      status: 1
-    - original_index: 41
-      status: 2
-    - original_index: 42
-      status: 1
-    - original_index: 43
-      status: 2
-    - original_index: 44
-      status: 3
-    - original_index: 45
-      status: 3
-    - original_index: 46
-      status: 0
-    - original_index: 47
-      status: 0
-    - original_index: 48
-      status: 3
-    - original_index: 49
-      status: 4
-    - original_index: 50
-      status: 3
-    - original_index: 51
-      status: 3
-    - original_index: 52
-      status: 4
-    - original_index: 53
-      status: 0
-    - original_index: 54
-      status: 1
-    - original_index: 55
-      status: 2
-    - original_index: 56
-      status: 3
-    - original_index: 57
-      status: 0
-    - original_index: 58
-      status: 2
-    - original_index: 59
-      status: 3
-    - original_index: 60
-      status: 2
-    - original_index: 61
-      status: 4
-    - original_index: 62
-      status: 0
-    - original_index: 63
-      status: 3
-    - original_index: 64
-      status: 2
-    - original_index: 65
-      status: 4
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 4
-    - original_index: 68
-      status: 4
-    - original_index: 69
-      status: 3
-    - original_index: 70
-      status: 0
-    - original_index: 71
-      status: 2
-    - original_index: 72
-      status: 1
-    - original_index: 73
-      status: 2
-    - original_index: 74
-      status: 4
-    - original_index: 75
-      status: 3
-    - original_index: 76
-      status: 2
-    - original_index: 77
-      status: 2
-    - original_index: 78
-      status: 1
-    - original_index: 79
-      status: 3
-    - original_index: 80
-      status: 2
-    - original_index: 81
-      status: 4
-    - original_index: 82
-      status: 1
-    - original_index: 83
-      status: 1
-    - original_index: 84
-      status: 0
-    - original_index: 85
-      status: 1
-    - original_index: 86
-      status: 4
-    - original_index: 87
-      status: 2
-    - original_index: 88
-      status: 3
-    - original_index: 89
-      status: 4
-    - original_index: 90
-      status: 1
-    - original_index: 91
-      status: 1
-    - original_index: 92
-      status: 0
-    - original_index: 93
-      status: 4
-    - original_index: 94
-      status: 4
-    - original_index: 95
-      status: 3
-    - original_index: 96
-      status: 4
-    - original_index: 97
-      status: 4
-    - original_index: 98
-      status: 3
-    - original_index: 99
-      status: 3
-    - original_index: 100
-      status: 3
-    - original_index: 101
-      status: 3
-    - original_index: 102
-      status: 3
-    - original_index: 103
-      status: 3
-    - original_index: 104
-      status: 0
-    - original_index: 105
-      status: 1
-    - original_index: 106
-      status: 4
-    - original_index: 107
-      status: 4
-    - original_index: 108
-      status: 0
-    - original_index: 109
-      status: 2
-    - original_index: 110
-      status: 4
-    - original_index: 111
-      status: 3
-    - original_index: 112
-      status: 2
-    - original_index: 113
-      status: 0
-    - original_index: 114
-      status: 1
-    - original_index: 115
-      status: 3
-    - original_index: 116
-      status: 2
-    - original_index: 117
-      status: 0
-    - original_index: 118
-      status: 1
-    - original_index: 119
-      status: 4
-    - original_index: 120
-      status: 2
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 4
-    - original_index: 124
-      status: 2
-    - original_index: 125
-      status: 2
-    - original_index: 126
-      status: 1
-    - original_index: 127
-      status: 0
-    - original_index: 128
-      status: 2
-    - original_index: 129
-      status: 4
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 3
-    - original_index: 132
-      status: 1
-    - original_index: 133
-      status: 4
-    - original_index: 134
-      status: 3
-    - original_index: 135
-      status: 4
-    - original_index: 136
-      status: 4
-    - original_index: 137
-      status: 4
-    - original_index: 138
-      status: 1
-    - original_index: 139
-      status: 0
-    - original_index: 140
-      status: 4
-    - original_index: 141
-      status: 1
-    - original_index: 142
-      status: 0
-    - original_index: 143
-      status: 4
-    - original_index: 144
-      status: 1
-    - original_index: 145
-      status: 2
-    - original_index: 146
-      status: 2
-    - original_index: 147
-      status: 4
-    - original_index: 148
-      status: 4
-    - original_index: 149
-      status: 2
-    - original_index: 150
-      status: 0
-    - original_index: 151
-      status: 2
-    - original_index: 152
-      status: 3
-    - original_index: 153
-      status: 3
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 1
-    - original_index: 156
-      status: 4
-    - original_index: 157
-      status: 0
-    - original_index: 158
-      status: 3
-    - original_index: 159
-      status: 1
-    - original_index: 160
-      status: 0
-    - original_index: 161
-      status: 0
-    - original_index: 162
-      status: 2
-    - original_index: 163
-      status: 0
-    - original_index: 164
-      status: 1
-    - original_index: 165
-      status: 3
-    - original_index: 166
-      status: 3
-    - original_index: 167
-      status: 3
-    - original_index: 168
-      status: 3
-    - original_index: 169
-      status: 1
-    - original_index: 170
-      status: 2
-    - original_index: 171
-      status: 3
-    - original_index: 172
-      status: 0
-    - original_index: 173
-      status: 2
-    - original_index: 174
-      status: 4
-    - original_index: 175
-      status: 1
-    - original_index: 176
-      status: 1
-    - original_index: 177
-      status: 1
-    - original_index: 178
-      status: 3
-    - original_index: 179
-      status: 2
-    - original_index: 180
-      status: 0
-    - original_index: 181
-      status: 3
-    - original_index: 182
-      status: 3
-    - original_index: 183
-      status: 1
+    - {original_index: 0, status: 0}
+    - {original_index: 1, status: 0}
+    - {original_index: 2, status: 1}
+    - {original_index: 3, status: 2}
+    - {original_index: 4, status: 0}
+    - {original_index: 5, status: 1}
+    - {original_index: 6, status: 4}
+    - {original_index: 7, status: 0}
+    - {original_index: 8, status: 0}
+    - {original_index: 9, status: 2}
+    - {original_index: 10, status: 1}
+    - {original_index: 11, status: 4}
+    - {original_index: 12, status: 3}
+    - {original_index: 13, status: 4}
+    - {original_index: 14, status: 1}
+    - {original_index: 15, status: 4}
+    - {original_index: 16, status: 2}
+    - {original_index: 17, status: 2}
+    - {original_index: 18, status: 3}
+    - {original_index: 19, status: 3}
+    - {original_index: 20, status: 4}
+    - {original_index: 21, status: 0}
+    - {original_index: 22, status: 0}
+    - {original_index: 23, status: 3}
+    - {original_index: 24, status: 3}
+    - {original_index: 25, status: 3}
+    - {original_index: 26, status: 1}
+    - {original_index: 27, status: 0}
+    - {original_index: 28, status: 1}
+    - {original_index: 29, status: 2}
+    - {original_index: 30, status: 2}
+    - {original_index: 31, status: 4}
+    - {original_index: 32, status: 1}
+    - {original_index: 33, status: 3}
+    - {original_index: 34, status: 4}
+    - {original_index: 35, status: 2}
+    - {original_index: 36, status: 3}
+    - {original_index: 37, status: 3}
+    - {original_index: 38, status: 4}
+    - {original_index: 39, status: 1}
+    - {original_index: 40, status: 1}
+    - {original_index: 41, status: 2}
+    - {original_index: 42, status: 1}
+    - {original_index: 43, status: 2}
+    - {original_index: 44, status: 3}
+    - {original_index: 45, status: 3}
+    - {original_index: 46, status: 0}
+    - {original_index: 47, status: 0}
+    - {original_index: 48, status: 3}
+    - {original_index: 49, status: 4}
+    - {original_index: 50, status: 3}
+    - {original_index: 51, status: 3}
+    - {original_index: 52, status: 4}
+    - {original_index: 53, status: 0}
+    - {original_index: 54, status: 1}
+    - {original_index: 55, status: 2}
+    - {original_index: 56, status: 3}
+    - {original_index: 57, status: 0}
+    - {original_index: 58, status: 2}
+    - {original_index: 59, status: 3}
+    - {original_index: 60, status: 2}
+    - {original_index: 61, status: 4}
+    - {original_index: 62, status: 0}
+    - {original_index: 63, status: 3}
+    - {original_index: 64, status: 2}
+    - {original_index: 65, status: 4}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 4}
+    - {original_index: 68, status: 4}
+    - {original_index: 69, status: 3}
+    - {original_index: 70, status: 0}
+    - {original_index: 71, status: 2}
+    - {original_index: 72, status: 1}
+    - {original_index: 73, status: 2}
+    - {original_index: 74, status: 4}
+    - {original_index: 75, status: 3}
+    - {original_index: 76, status: 2}
+    - {original_index: 77, status: 2}
+    - {original_index: 78, status: 1}
+    - {original_index: 79, status: 3}
+    - {original_index: 80, status: 2}
+    - {original_index: 81, status: 4}
+    - {original_index: 82, status: 1}
+    - {original_index: 83, status: 1}
+    - {original_index: 84, status: 0}
+    - {original_index: 85, status: 1}
+    - {original_index: 86, status: 4}
+    - {original_index: 87, status: 2}
+    - {original_index: 88, status: 3}
+    - {original_index: 89, status: 4}
+    - {original_index: 90, status: 1}
+    - {original_index: 91, status: 1}
+    - {original_index: 92, status: 0}
+    - {original_index: 93, status: 4}
+    - {original_index: 94, status: 4}
+    - {original_index: 95, status: 3}
+    - {original_index: 96, status: 4}
+    - {original_index: 97, status: 4}
+    - {original_index: 98, status: 3}
+    - {original_index: 99, status: 3}
+    - {original_index: 100, status: 3}
+    - {original_index: 101, status: 3}
+    - {original_index: 102, status: 3}
+    - {original_index: 103, status: 3}
+    - {original_index: 104, status: 0}
+    - {original_index: 105, status: 1}
+    - {original_index: 106, status: 4}
+    - {original_index: 107, status: 4}
+    - {original_index: 108, status: 0}
+    - {original_index: 109, status: 2}
+    - {original_index: 110, status: 4}
+    - {original_index: 111, status: 3}
+    - {original_index: 112, status: 2}
+    - {original_index: 113, status: 0}
+    - {original_index: 114, status: 1}
+    - {original_index: 115, status: 3}
+    - {original_index: 116, status: 2}
+    - {original_index: 117, status: 0}
+    - {original_index: 118, status: 1}
+    - {original_index: 119, status: 4}
+    - {original_index: 120, status: 2}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 4}
+    - {original_index: 124, status: 2}
+    - {original_index: 125, status: 2}
+    - {original_index: 126, status: 1}
+    - {original_index: 127, status: 0}
+    - {original_index: 128, status: 2}
+    - {original_index: 129, status: 4}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 3}
+    - {original_index: 132, status: 1}
+    - {original_index: 133, status: 4}
+    - {original_index: 134, status: 3}
+    - {original_index: 135, status: 4}
+    - {original_index: 136, status: 4}
+    - {original_index: 137, status: 4}
+    - {original_index: 138, status: 1}
+    - {original_index: 139, status: 0}
+    - {original_index: 140, status: 4}
+    - {original_index: 141, status: 1}
+    - {original_index: 142, status: 0}
+    - {original_index: 143, status: 4}
+    - {original_index: 144, status: 1}
+    - {original_index: 145, status: 2}
+    - {original_index: 146, status: 2}
+    - {original_index: 147, status: 4}
+    - {original_index: 148, status: 4}
+    - {original_index: 149, status: 2}
+    - {original_index: 150, status: 0}
+    - {original_index: 151, status: 2}
+    - {original_index: 152, status: 3}
+    - {original_index: 153, status: 3}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 1}
+    - {original_index: 156, status: 4}
+    - {original_index: 157, status: 0}
+    - {original_index: 158, status: 3}
+    - {original_index: 159, status: 1}
+    - {original_index: 160, status: 0}
+    - {original_index: 161, status: 0}
+    - {original_index: 162, status: 2}
+    - {original_index: 163, status: 0}
+    - {original_index: 164, status: 1}
+    - {original_index: 165, status: 3}
+    - {original_index: 166, status: 3}
+    - {original_index: 167, status: 3}
+    - {original_index: 168, status: 3}
+    - {original_index: 169, status: 1}
+    - {original_index: 170, status: 2}
+    - {original_index: 171, status: 3}
+    - {original_index: 172, status: 0}
+    - {original_index: 173, status: 2}
+    - {original_index: 174, status: 4}
+    - {original_index: 175, status: 1}
+    - {original_index: 176, status: 1}
+    - {original_index: 177, status: 1}
+    - {original_index: 178, status: 3}
+    - {original_index: 179, status: 2}
+    - {original_index: 180, status: 0}
+    - {original_index: 181, status: 3}
+    - {original_index: 182, status: 3}
+    - {original_index: 183, status: 1}
   output:
-  - - committee:
-      - 123
+  - - committee: [123]
       shard: 378
       total_validator_count: 74
-  - - committee:
-      - 20
+  - - committee: [20]
       shard: 379
       total_validator_count: 74
-  - - committee:
-      - 81
+  - - committee: [81]
       shard: 380
       total_validator_count: 74
-  - - committee:
-      - 106
+  - - committee: [106]
       shard: 381
       total_validator_count: 74
-  - - committee:
-      - 10
+  - - committee: [10]
       shard: 382
       total_validator_count: 74
-  - - committee:
-      - 72
+  - - committee: [72]
       shard: 383
       total_validator_count: 74
-  - - committee:
-      - 138
-      - 135
+  - - committee: [138, 135]
       shard: 384
       total_validator_count: 74
-  - - committee:
-      - 13
+  - - committee: [13]
       shard: 385
       total_validator_count: 74
-  - - committee:
-      - 31
+  - - committee: [31]
       shard: 386
       total_validator_count: 74
-  - - committee:
-      - 107
+  - - committee: [107]
       shard: 387
       total_validator_count: 74
-  - - committee:
-      - 14
+  - - committee: [14]
       shard: 388
       total_validator_count: 74
-  - - committee:
-      - 126
+  - - committee: [126]
       shard: 389
       total_validator_count: 74
-  - - committee:
-      - 144
-      - 90
+  - - committee: [144, 90]
       shard: 390
       total_validator_count: 74
-  - - committee:
-      - 6
+  - - committee: [6]
       shard: 391
       total_validator_count: 74
-  - - committee:
-      - 26
+  - - committee: [26]
       shard: 392
       total_validator_count: 74
-  - - committee:
-      - 183
+  - - committee: [183]
       shard: 393
       total_validator_count: 74
-  - - committee:
-      - 34
+  - - committee: [34]
       shard: 394
       total_validator_count: 74
-  - - committee:
-      - 38
+  - - committee: [38]
       shard: 395
       total_validator_count: 74
-  - - committee:
-      - 86
+  - - committee: [86]
       shard: 396
       total_validator_count: 74
-  - - committee:
-      - 175
-      - 82
+  - - committee: [175, 82]
       shard: 397
       total_validator_count: 74
-  - - committee:
-      - 143
+  - - committee: [143]
       shard: 398
       total_validator_count: 74
-  - - committee:
-      - 147
+  - - committee: [147]
       shard: 399
       total_validator_count: 74
-  - - committee:
-      - 74
+  - - committee: [74]
       shard: 400
       total_validator_count: 74
-  - - committee:
-      - 140
+  - - committee: [140]
       shard: 401
       total_validator_count: 74
-  - - committee:
-      - 136
+  - - committee: [136]
       shard: 402
       total_validator_count: 74
-  - - committee:
-      - 11
-      - 155
+  - - committee: [11, 155]
       shard: 403
       total_validator_count: 74
-  - - committee:
-      - 174
+  - - committee: [174]
       shard: 404
       total_validator_count: 74
-  - - committee:
-      - 156
+  - - committee: [156]
       shard: 405
       total_validator_count: 74
-  - - committee:
-      - 68
+  - - committee: [68]
       shard: 406
       total_validator_count: 74
-  - - committee:
-      - 130
+  - - committee: [130]
       shard: 407
       total_validator_count: 74
-  - - committee:
-      - 42
+  - - committee: [42]
       shard: 408
       total_validator_count: 74
-  - - committee:
-      - 110
-      - 159
+  - - committee: [110, 159]
       shard: 409
       total_validator_count: 74
-  - - committee:
-      - 54
+  - - committee: [54]
       shard: 410
       total_validator_count: 74
-  - - committee:
-      - 148
+  - - committee: [148]
       shard: 411
       total_validator_count: 74
-  - - committee:
-      - 154
+  - - committee: [154]
       shard: 412
       total_validator_count: 74
-  - - committee:
-      - 96
+  - - committee: [96]
       shard: 413
       total_validator_count: 74
-  - - committee:
-      - 177
+  - - committee: [177]
       shard: 414
       total_validator_count: 74
-  - - committee:
-      - 28
+  - - committee: [28]
       shard: 415
       total_validator_count: 74
-  - - committee:
-      - 133
-      - 137
+  - - committee: [133, 137]
       shard: 416
       total_validator_count: 74
-  - - committee:
-      - 32
+  - - committee: [32]
       shard: 417
       total_validator_count: 74
-  - - committee:
-      - 78
+  - - committee: [78]
       shard: 418
       total_validator_count: 74
-  - - committee:
-      - 83
+  - - committee: [83]
       shard: 419
       total_validator_count: 74
-  - - committee:
-      - 85
+  - - committee: [85]
       shard: 420
       total_validator_count: 74
-  - - committee:
-      - 93
+  - - committee: [93]
       shard: 421
       total_validator_count: 74
-  - - committee:
-      - 2
-      - 169
+  - - committee: [2, 169]
       shard: 422
       total_validator_count: 74
-  - - committee:
-      - 61
+  - - committee: [61]
       shard: 423
       total_validator_count: 74
-  - - committee:
-      - 5
+  - - committee: [5]
       shard: 424
       total_validator_count: 74
-  - - committee:
-      - 40
+  - - committee: [40]
       shard: 425
       total_validator_count: 74
-  - - committee:
-      - 52
+  - - committee: [52]
       shard: 426
       total_validator_count: 74
-  - - committee:
-      - 67
+  - - committee: [67]
       shard: 427
       total_validator_count: 74
-  - - committee:
-      - 15
+  - - committee: [15]
       shard: 428
       total_validator_count: 74
-  - - committee:
-      - 94
-      - 132
+  - - committee: [94, 132]
       shard: 429
       total_validator_count: 74
-  - - committee:
-      - 91
+  - - committee: [91]
       shard: 430
       total_validator_count: 74
-  - - committee:
-      - 97
+  - - committee: [97]
       shard: 431
       total_validator_count: 74
-  - - committee:
-      - 49
+  - - committee: [49]
       shard: 432
       total_validator_count: 74
-  - - committee:
-      - 89
+  - - committee: [89]
       shard: 433
       total_validator_count: 74
-  - - committee:
-      - 164
+  - - committee: [164]
       shard: 434
       total_validator_count: 74
-  - - committee:
-      - 129
-      - 118
+  - - committee: [129, 118]
       shard: 435
       total_validator_count: 74
-  - - committee:
-      - 119
+  - - committee: [119]
       shard: 436
       total_validator_count: 74
-  - - committee:
-      - 176
+  - - committee: [176]
       shard: 437
       total_validator_count: 74
-  - - committee:
-      - 105
+  - - committee: [105]
       shard: 438
       total_validator_count: 74
-  - - committee:
-      - 65
+  - - committee: [65]
       shard: 439
       total_validator_count: 74
-  - - committee:
-      - 141
+  - - committee: [141]
       shard: 440
       total_validator_count: 74
-  - - committee:
-      - 39
-      - 114
+  - - committee: [39, 114]
       shard: 441
       total_validator_count: 74
   seed: '0xa2cb43c505d74fc9e1af073c677665072308dd06142430203c242aba27ca1da5'
 - input:
     crosslinking_start_shard: 986
     validators:
-    - original_index: 0
-      status: 0
-    - original_index: 1
-      status: 4
-    - original_index: 2
-      status: 2
-    - original_index: 3
-      status: 2
-    - original_index: 4
-      status: 0
-    - original_index: 5
-      status: 3
-    - original_index: 6
-      status: 3
-    - original_index: 7
-      status: 0
-    - original_index: 8
-      status: 4
-    - original_index: 9
-      status: 0
-    - original_index: 10
-      status: 1
-    - original_index: 11
-      status: 3
-    - original_index: 12
-      status: 3
-    - original_index: 13
-      status: 2
-    - original_index: 14
-      status: 3
-    - original_index: 15
-      status: 3
-    - original_index: 16
-      status: 2
-    - original_index: 17
-      status: 1
-    - original_index: 18
-      status: 4
-    - original_index: 19
-      status: 4
-    - original_index: 20
-      status: 1
-    - original_index: 21
-      status: 1
-    - original_index: 22
-      status: 0
-    - original_index: 23
-      status: 1
-    - original_index: 24
-      status: 3
-    - original_index: 25
-      status: 3
-    - original_index: 26
-      status: 4
-    - original_index: 27
-      status: 2
-    - original_index: 28
-      status: 2
-    - original_index: 29
-      status: 3
-    - original_index: 30
-      status: 2
-    - original_index: 31
-      status: 1
-    - original_index: 32
-      status: 0
-    - original_index: 33
-      status: 0
-    - original_index: 34
-      status: 2
-    - original_index: 35
-      status: 3
-    - original_index: 36
-      status: 0
-    - original_index: 37
-      status: 0
-    - original_index: 38
-      status: 3
-    - original_index: 39
-      status: 3
-    - original_index: 40
-      status: 2
-    - original_index: 41
-      status: 4
-    - original_index: 42
-      status: 2
-    - original_index: 43
-      status: 3
-    - original_index: 44
-      status: 0
-    - original_index: 45
-      status: 0
-    - original_index: 46
-      status: 4
-    - original_index: 47
-      status: 1
-    - original_index: 48
-      status: 3
-    - original_index: 49
-      status: 4
-    - original_index: 50
-      status: 2
-    - original_index: 51
-      status: 3
-    - original_index: 52
-      status: 4
-    - original_index: 53
-      status: 1
-    - original_index: 54
-      status: 0
-    - original_index: 55
-      status: 4
-    - original_index: 56
-      status: 2
-    - original_index: 57
-      status: 2
-    - original_index: 58
-      status: 3
-    - original_index: 59
-      status: 4
-    - original_index: 60
-      status: 0
-    - original_index: 61
-      status: 3
-    - original_index: 62
-      status: 3
-    - original_index: 63
-      status: 0
-    - original_index: 64
-      status: 0
-    - original_index: 65
-      status: 3
-    - original_index: 66
-      status: 3
-    - original_index: 67
-      status: 3
-    - original_index: 68
-      status: 2
-    - original_index: 69
-      status: 4
-    - original_index: 70
-      status: 2
-    - original_index: 71
-      status: 3
-    - original_index: 72
-      status: 2
-    - original_index: 73
-      status: 4
-    - original_index: 74
-      status: 4
-    - original_index: 75
-      status: 2
-    - original_index: 76
-      status: 4
-    - original_index: 77
-      status: 2
-    - original_index: 78
-      status: 3
-    - original_index: 79
-      status: 4
-    - original_index: 80
-      status: 1
-    - original_index: 81
-      status: 2
-    - original_index: 82
-      status: 3
-    - original_index: 83
-      status: 3
-    - original_index: 84
-      status: 1
-    - original_index: 85
-      status: 3
-    - original_index: 86
-      status: 3
-    - original_index: 87
-      status: 4
-    - original_index: 88
-      status: 3
-    - original_index: 89
-      status: 1
-    - original_index: 90
-      status: 3
-    - original_index: 91
-      status: 2
-    - original_index: 92
-      status: 4
-    - original_index: 93
-      status: 0
-    - original_index: 94
-      status: 0
-    - original_index: 95
-      status: 3
-    - original_index: 96
-      status: 3
-    - original_index: 97
-      status: 0
-    - original_index: 98
-      status: 1
-    - original_index: 99
-      status: 0
-    - original_index: 100
-      status: 4
-    - original_index: 101
-      status: 0
-    - original_index: 102
-      status: 0
-    - original_index: 103
-      status: 1
-    - original_index: 104
-      status: 4
-    - original_index: 105
-      status: 1
-    - original_index: 106
-      status: 3
-    - original_index: 107
-      status: 3
-    - original_index: 108
-      status: 1
-    - original_index: 109
-      status: 2
-    - original_index: 110
-      status: 1
-    - original_index: 111
-      status: 2
-    - original_index: 112
-      status: 2
-    - original_index: 113
-      status: 4
-    - original_index: 114
-      status: 1
-    - original_index: 115
-      status: 3
-    - original_index: 116
-      status: 3
-    - original_index: 117
-      status: 2
-    - original_index: 118
-      status: 0
-    - original_index: 119
-      status: 3
-    - original_index: 120
-      status: 4
-    - original_index: 121
-      status: 0
-    - original_index: 122
-      status: 0
-    - original_index: 123
-      status: 1
-    - original_index: 124
-      status: 1
-    - original_index: 125
-      status: 4
-    - original_index: 126
-      status: 2
-    - original_index: 127
-      status: 0
-    - original_index: 128
-      status: 4
-    - original_index: 129
-      status: 1
-    - original_index: 130
-      status: 1
-    - original_index: 131
-      status: 1
-    - original_index: 132
-      status: 0
-    - original_index: 133
-      status: 0
-    - original_index: 134
-      status: 4
-    - original_index: 135
-      status: 3
-    - original_index: 136
-      status: 3
-    - original_index: 137
-      status: 4
-    - original_index: 138
-      status: 0
-    - original_index: 139
-      status: 2
-    - original_index: 140
-      status: 4
-    - original_index: 141
-      status: 3
-    - original_index: 142
-      status: 1
-    - original_index: 143
-      status: 4
-    - original_index: 144
-      status: 2
-    - original_index: 145
-      status: 1
-    - original_index: 146
-      status: 3
-    - original_index: 147
-      status: 1
-    - original_index: 148
-      status: 1
-    - original_index: 149
-      status: 4
-    - original_index: 150
-      status: 3
-    - original_index: 151
-      status: 2
-    - original_index: 152
-      status: 1
-    - original_index: 153
-      status: 4
-    - original_index: 154
-      status: 4
-    - original_index: 155
-      status: 0
-    - original_index: 156
-      status: 0
-    - original_index: 157
-      status: 1
-    - original_index: 158
-      status: 0
-    - original_index: 159
-      status: 2
-    - original_index: 160
-      status: 3
-    - original_index: 161
-      status: 2
-    - original_index: 162
-      status: 1
-    - original_index: 163
-      status: 4
-    - original_index: 164
-      status: 3
-    - original_index: 165
-      status: 0
-    - original_index: 166
-      status: 2
-    - original_index: 167
-      status: 3
-    - original_index: 168
-      status: 3
-    - original_index: 169
-      status: 3
-    - original_index: 170
-      status: 2
-    - original_index: 171
-      status: 0
-    - original_index: 172
-      status: 3
-    - original_index: 173
-      status: 2
-    - original_index: 174
-      status: 1
-    - original_index: 175
-      status: 0
-    - original_index: 176
-      status: 0
-    - original_index: 177
-      status: 3
-    - original_index: 178
-      status: 1
-    - original_index: 179
-      status: 3
-    - original_index: 180
-      status: 1
-    - original_index: 181
-      status: 3
-    - original_index: 182
-      status: 2
-    - original_index: 183
-      status: 4
-    - original_index: 184
-      status: 1
-    - original_index: 185
-      status: 3
-    - original_index: 186
-      status: 3
-    - original_index: 187
-      status: 2
-    - original_index: 188
-      status: 3
-    - original_index: 189
-      status: 2
-    - original_index: 190
-      status: 2
-    - original_index: 191
-      status: 4
-    - original_index: 192
-      status: 1
-    - original_index: 193
-      status: 3
-    - original_index: 194
-      status: 3
-    - original_index: 195
-      status: 0
-    - original_index: 196
-      status: 4
-    - original_index: 197
-      status: 2
-    - original_index: 198
-      status: 2
-    - original_index: 199
-      status: 3
-    - original_index: 200
-      status: 4
-    - original_index: 201
-      status: 2
-    - original_index: 202
-      status: 3
-    - original_index: 203
-      status: 4
-    - original_index: 204
-      status: 3
-    - original_index: 205
-      status: 1
-    - original_index: 206
-      status: 2
-    - original_index: 207
-      status: 4
-    - original_index: 208
-      status: 0
-    - original_index: 209
-      status: 3
-    - original_index: 210
-      status: 3
-    - original_index: 211
-      status: 3
-    - original_index: 212
-      status: 0
-    - original_index: 213
-      status: 3
-    - original_index: 214
-      status: 3
-    - original_index: 215
-      status: 4
-    - original_index: 216
-      status: 3
-    - original_index: 217
-      status: 1
-    - original_index: 218
-      status: 4
-    - original_index: 219
-      status: 0
-    - original_index: 220
-      status: 1
-    - original_index: 221
-      status: 1
-    - original_index: 222
-      status: 0
-    - original_index: 223
-      status: 2
-    - original_index: 224
-      status: 1
-    - original_index: 225
-      status: 0
-    - original_index: 226
-      status: 4
-    - original_index: 227
-      status: 4
-    - original_index: 228
-      status: 4
-    - original_index: 229
-      status: 4
-    - original_index: 230
-      status: 1
-    - original_index: 231
-      status: 3
-    - original_index: 232
-      status: 0
-    - original_index: 233
-      status: 4
-    - original_index: 234
-      status: 4
-    - original_index: 235
-      status: 0
-    - original_index: 236
-      status: 2
-    - original_index: 237
-      status: 2
-    - original_index: 238
-      status: 4
-    - original_index: 239
-      status: 2
-    - original_index: 240
-      status: 1
-    - original_index: 241
-      status: 4
-    - original_index: 242
-      status: 3
-    - original_index: 243
-      status: 3
-    - original_index: 244
-      status: 1
-    - original_index: 245
-      status: 3
-    - original_index: 246
-      status: 0
-    - original_index: 247
-      status: 3
-    - original_index: 248
-      status: 4
-    - original_index: 249
-      status: 2
-    - original_index: 250
-      status: 0
-    - original_index: 251
-      status: 0
-    - original_index: 252
-      status: 0
-    - original_index: 253
-      status: 1
-    - original_index: 254
-      status: 3
-    - original_index: 255
-      status: 2
-    - original_index: 256
-      status: 1
-    - original_index: 257
-      status: 3
-    - original_index: 258
-      status: 3
-    - original_index: 259
-      status: 1
-    - original_index: 260
-      status: 3
-    - original_index: 261
-      status: 3
-    - original_index: 262
-      status: 2
-    - original_index: 263
-      status: 1
-    - original_index: 264
-      status: 2
-    - original_index: 265
-      status: 4
-    - original_index: 266
-      status: 4
-    - original_index: 267
-      status: 2
-    - original_index: 268
-      status: 0
-    - original_index: 269
-      status: 4
-    - original_index: 270
-      status: 2
-    - original_index: 271
-      status: 3
-    - original_index: 272
-      status: 3
-    - original_index: 273
-      status: 1
-    - original_index: 274
-      status: 3
-    - original_index: 275
-      status: 1
-    - original_index: 276
-      status: 4
-    - original_index: 277
-      status: 2
-    - original_index: 278
-      status: 0
-    - original_index: 279
-      status: 1
-    - original_index: 280
-      status: 2
-    - original_index: 281
-      status: 0
-    - original_index: 282
-      status: 4
-    - original_index: 283
-      status: 1
-    - original_index: 284
-      status: 0
-    - original_index: 285
-      status: 0
-    - original_index: 286
-      status: 4
-    - original_index: 287
-      status: 3
-    - original_index: 288
-      status: 4
-    - original_index: 289
-      status: 0
-    - original_index: 290
-      status: 4
-    - original_index: 291
-      status: 3
-    - original_index: 292
-      status: 4
-    - original_index: 293
-      status: 4
-    - original_index: 294
-      status: 4
-    - original_index: 295
-      status: 0
-    - original_index: 296
-      status: 0
-    - original_index: 297
-      status: 0
-    - original_index: 298
-      status: 3
-    - original_index: 299
-      status: 0
-    - original_index: 300
-      status: 0
-    - original_index: 301
-      status: 1
-    - original_index: 302
-      status: 2
-    - original_index: 303
-      status: 2
-    - original_index: 304
-      status: 4
-    - original_index: 305
-      status: 2
-    - original_index: 306
-      status: 4
-    - original_index: 307
-      status: 2
-    - original_index: 308
-      status: 0
-    - original_index: 309
-      status: 3
-    - original_index: 310
-      status: 1
-    - original_index: 311
-      status: 2
-    - original_index: 312
-      status: 3
-    - original_index: 313
-      status: 0
-    - original_index: 314
-      status: 1
-    - original_index: 315
-      status: 1
-    - original_index: 316
-      status: 3
-    - original_index: 317
-      status: 0
-    - original_index: 318
-      status: 0
-    - original_index: 319
-      status: 2
-    - original_index: 320
-      status: 4
-    - original_index: 321
-      status: 1
-    - original_index: 322
-      status: 4
-    - original_index: 323
-      status: 2
-    - original_index: 324
-      status: 1
-    - original_index: 325
-      status: 4
-    - original_index: 326
-      status: 0
-    - original_index: 327
-      status: 1
-    - original_index: 328
-      status: 3
-    - original_index: 329
-      status: 4
-    - original_index: 330
-      status: 0
-    - original_index: 331
-      status: 1
-    - original_index: 332
-      status: 1
-    - original_index: 333
-      status: 1
-    - original_index: 334
-      status: 1
-    - original_index: 335
-      status: 4
-    - original_index: 336
-      status: 2
-    - original_index: 337
-      status: 3
-    - original_index: 338
-      status: 4
-    - original_index: 339
-      status: 0
-    - original_index: 340
-      status: 1
-    - original_index: 341
-      status: 2
-    - original_index: 342
-      status: 1
-    - original_index: 343
-      status: 4
-    - original_index: 344
-      status: 2
-    - original_index: 345
-      status: 2
-    - original_index: 346
-      status: 1
-    - original_index: 347
-      status: 3
-    - original_index: 348
-      status: 4
-    - original_index: 349
-      status: 0
-    - original_index: 350
-      status: 2
-    - original_index: 351
-      status: 3
-    - original_index: 352
-      status: 1
-    - original_index: 353
-      status: 1
-    - original_index: 354
-      status: 1
-    - original_index: 355
-      status: 4
-    - original_index: 356
-      status: 1
-    - original_index: 357
-      status: 0
-    - original_index: 358
-      status: 2
-    - original_index: 359
-      status: 1
-    - original_index: 360
-      status: 4
-    - original_index: 361
-      status: 3
-    - original_index: 362
-      status: 0
-    - original_index: 363
-      status: 4
-    - original_index: 364
-      status: 0
-    - original_index: 365
-      status: 2
-    - original_index: 366
-      status: 1
-    - original_index: 367
-      status: 1
-    - original_index: 368
-      status: 4
-    - original_index: 369
-      status: 1
-    - original_index: 370
-      status: 0
-    - original_index: 371
-      status: 2
-    - original_index: 372
-      status: 2
-    - original_index: 373
-      status: 2
-    - original_index: 374
-      status: 2
-    - original_index: 375
-      status: 1
-    - original_index: 376
-      status: 4
-    - original_index: 377
-      status: 2
+    - {original_index: 0, status: 0}
+    - {original_index: 1, status: 4}
+    - {original_index: 2, status: 2}
+    - {original_index: 3, status: 2}
+    - {original_index: 4, status: 0}
+    - {original_index: 5, status: 3}
+    - {original_index: 6, status: 3}
+    - {original_index: 7, status: 0}
+    - {original_index: 8, status: 4}
+    - {original_index: 9, status: 0}
+    - {original_index: 10, status: 1}
+    - {original_index: 11, status: 3}
+    - {original_index: 12, status: 3}
+    - {original_index: 13, status: 2}
+    - {original_index: 14, status: 3}
+    - {original_index: 15, status: 3}
+    - {original_index: 16, status: 2}
+    - {original_index: 17, status: 1}
+    - {original_index: 18, status: 4}
+    - {original_index: 19, status: 4}
+    - {original_index: 20, status: 1}
+    - {original_index: 21, status: 1}
+    - {original_index: 22, status: 0}
+    - {original_index: 23, status: 1}
+    - {original_index: 24, status: 3}
+    - {original_index: 25, status: 3}
+    - {original_index: 26, status: 4}
+    - {original_index: 27, status: 2}
+    - {original_index: 28, status: 2}
+    - {original_index: 29, status: 3}
+    - {original_index: 30, status: 2}
+    - {original_index: 31, status: 1}
+    - {original_index: 32, status: 0}
+    - {original_index: 33, status: 0}
+    - {original_index: 34, status: 2}
+    - {original_index: 35, status: 3}
+    - {original_index: 36, status: 0}
+    - {original_index: 37, status: 0}
+    - {original_index: 38, status: 3}
+    - {original_index: 39, status: 3}
+    - {original_index: 40, status: 2}
+    - {original_index: 41, status: 4}
+    - {original_index: 42, status: 2}
+    - {original_index: 43, status: 3}
+    - {original_index: 44, status: 0}
+    - {original_index: 45, status: 0}
+    - {original_index: 46, status: 4}
+    - {original_index: 47, status: 1}
+    - {original_index: 48, status: 3}
+    - {original_index: 49, status: 4}
+    - {original_index: 50, status: 2}
+    - {original_index: 51, status: 3}
+    - {original_index: 52, status: 4}
+    - {original_index: 53, status: 1}
+    - {original_index: 54, status: 0}
+    - {original_index: 55, status: 4}
+    - {original_index: 56, status: 2}
+    - {original_index: 57, status: 2}
+    - {original_index: 58, status: 3}
+    - {original_index: 59, status: 4}
+    - {original_index: 60, status: 0}
+    - {original_index: 61, status: 3}
+    - {original_index: 62, status: 3}
+    - {original_index: 63, status: 0}
+    - {original_index: 64, status: 0}
+    - {original_index: 65, status: 3}
+    - {original_index: 66, status: 3}
+    - {original_index: 67, status: 3}
+    - {original_index: 68, status: 2}
+    - {original_index: 69, status: 4}
+    - {original_index: 70, status: 2}
+    - {original_index: 71, status: 3}
+    - {original_index: 72, status: 2}
+    - {original_index: 73, status: 4}
+    - {original_index: 74, status: 4}
+    - {original_index: 75, status: 2}
+    - {original_index: 76, status: 4}
+    - {original_index: 77, status: 2}
+    - {original_index: 78, status: 3}
+    - {original_index: 79, status: 4}
+    - {original_index: 80, status: 1}
+    - {original_index: 81, status: 2}
+    - {original_index: 82, status: 3}
+    - {original_index: 83, status: 3}
+    - {original_index: 84, status: 1}
+    - {original_index: 85, status: 3}
+    - {original_index: 86, status: 3}
+    - {original_index: 87, status: 4}
+    - {original_index: 88, status: 3}
+    - {original_index: 89, status: 1}
+    - {original_index: 90, status: 3}
+    - {original_index: 91, status: 2}
+    - {original_index: 92, status: 4}
+    - {original_index: 93, status: 0}
+    - {original_index: 94, status: 0}
+    - {original_index: 95, status: 3}
+    - {original_index: 96, status: 3}
+    - {original_index: 97, status: 0}
+    - {original_index: 98, status: 1}
+    - {original_index: 99, status: 0}
+    - {original_index: 100, status: 4}
+    - {original_index: 101, status: 0}
+    - {original_index: 102, status: 0}
+    - {original_index: 103, status: 1}
+    - {original_index: 104, status: 4}
+    - {original_index: 105, status: 1}
+    - {original_index: 106, status: 3}
+    - {original_index: 107, status: 3}
+    - {original_index: 108, status: 1}
+    - {original_index: 109, status: 2}
+    - {original_index: 110, status: 1}
+    - {original_index: 111, status: 2}
+    - {original_index: 112, status: 2}
+    - {original_index: 113, status: 4}
+    - {original_index: 114, status: 1}
+    - {original_index: 115, status: 3}
+    - {original_index: 116, status: 3}
+    - {original_index: 117, status: 2}
+    - {original_index: 118, status: 0}
+    - {original_index: 119, status: 3}
+    - {original_index: 120, status: 4}
+    - {original_index: 121, status: 0}
+    - {original_index: 122, status: 0}
+    - {original_index: 123, status: 1}
+    - {original_index: 124, status: 1}
+    - {original_index: 125, status: 4}
+    - {original_index: 126, status: 2}
+    - {original_index: 127, status: 0}
+    - {original_index: 128, status: 4}
+    - {original_index: 129, status: 1}
+    - {original_index: 130, status: 1}
+    - {original_index: 131, status: 1}
+    - {original_index: 132, status: 0}
+    - {original_index: 133, status: 0}
+    - {original_index: 134, status: 4}
+    - {original_index: 135, status: 3}
+    - {original_index: 136, status: 3}
+    - {original_index: 137, status: 4}
+    - {original_index: 138, status: 0}
+    - {original_index: 139, status: 2}
+    - {original_index: 140, status: 4}
+    - {original_index: 141, status: 3}
+    - {original_index: 142, status: 1}
+    - {original_index: 143, status: 4}
+    - {original_index: 144, status: 2}
+    - {original_index: 145, status: 1}
+    - {original_index: 146, status: 3}
+    - {original_index: 147, status: 1}
+    - {original_index: 148, status: 1}
+    - {original_index: 149, status: 4}
+    - {original_index: 150, status: 3}
+    - {original_index: 151, status: 2}
+    - {original_index: 152, status: 1}
+    - {original_index: 153, status: 4}
+    - {original_index: 154, status: 4}
+    - {original_index: 155, status: 0}
+    - {original_index: 156, status: 0}
+    - {original_index: 157, status: 1}
+    - {original_index: 158, status: 0}
+    - {original_index: 159, status: 2}
+    - {original_index: 160, status: 3}
+    - {original_index: 161, status: 2}
+    - {original_index: 162, status: 1}
+    - {original_index: 163, status: 4}
+    - {original_index: 164, status: 3}
+    - {original_index: 165, status: 0}
+    - {original_index: 166, status: 2}
+    - {original_index: 167, status: 3}
+    - {original_index: 168, status: 3}
+    - {original_index: 169, status: 3}
+    - {original_index: 170, status: 2}
+    - {original_index: 171, status: 0}
+    - {original_index: 172, status: 3}
+    - {original_index: 173, status: 2}
+    - {original_index: 174, status: 1}
+    - {original_index: 175, status: 0}
+    - {original_index: 176, status: 0}
+    - {original_index: 177, status: 3}
+    - {original_index: 178, status: 1}
+    - {original_index: 179, status: 3}
+    - {original_index: 180, status: 1}
+    - {original_index: 181, status: 3}
+    - {original_index: 182, status: 2}
+    - {original_index: 183, status: 4}
+    - {original_index: 184, status: 1}
+    - {original_index: 185, status: 3}
+    - {original_index: 186, status: 3}
+    - {original_index: 187, status: 2}
+    - {original_index: 188, status: 3}
+    - {original_index: 189, status: 2}
+    - {original_index: 190, status: 2}
+    - {original_index: 191, status: 4}
+    - {original_index: 192, status: 1}
+    - {original_index: 193, status: 3}
+    - {original_index: 194, status: 3}
+    - {original_index: 195, status: 0}
+    - {original_index: 196, status: 4}
+    - {original_index: 197, status: 2}
+    - {original_index: 198, status: 2}
+    - {original_index: 199, status: 3}
+    - {original_index: 200, status: 4}
+    - {original_index: 201, status: 2}
+    - {original_index: 202, status: 3}
+    - {original_index: 203, status: 4}
+    - {original_index: 204, status: 3}
+    - {original_index: 205, status: 1}
+    - {original_index: 206, status: 2}
+    - {original_index: 207, status: 4}
+    - {original_index: 208, status: 0}
+    - {original_index: 209, status: 3}
+    - {original_index: 210, status: 3}
+    - {original_index: 211, status: 3}
+    - {original_index: 212, status: 0}
+    - {original_index: 213, status: 3}
+    - {original_index: 214, status: 3}
+    - {original_index: 215, status: 4}
+    - {original_index: 216, status: 3}
+    - {original_index: 217, status: 1}
+    - {original_index: 218, status: 4}
+    - {original_index: 219, status: 0}
+    - {original_index: 220, status: 1}
+    - {original_index: 221, status: 1}
+    - {original_index: 222, status: 0}
+    - {original_index: 223, status: 2}
+    - {original_index: 224, status: 1}
+    - {original_index: 225, status: 0}
+    - {original_index: 226, status: 4}
+    - {original_index: 227, status: 4}
+    - {original_index: 228, status: 4}
+    - {original_index: 229, status: 4}
+    - {original_index: 230, status: 1}
+    - {original_index: 231, status: 3}
+    - {original_index: 232, status: 0}
+    - {original_index: 233, status: 4}
+    - {original_index: 234, status: 4}
+    - {original_index: 235, status: 0}
+    - {original_index: 236, status: 2}
+    - {original_index: 237, status: 2}
+    - {original_index: 238, status: 4}
+    - {original_index: 239, status: 2}
+    - {original_index: 240, status: 1}
+    - {original_index: 241, status: 4}
+    - {original_index: 242, status: 3}
+    - {original_index: 243, status: 3}
+    - {original_index: 244, status: 1}
+    - {original_index: 245, status: 3}
+    - {original_index: 246, status: 0}
+    - {original_index: 247, status: 3}
+    - {original_index: 248, status: 4}
+    - {original_index: 249, status: 2}
+    - {original_index: 250, status: 0}
+    - {original_index: 251, status: 0}
+    - {original_index: 252, status: 0}
+    - {original_index: 253, status: 1}
+    - {original_index: 254, status: 3}
+    - {original_index: 255, status: 2}
+    - {original_index: 256, status: 1}
+    - {original_index: 257, status: 3}
+    - {original_index: 258, status: 3}
+    - {original_index: 259, status: 1}
+    - {original_index: 260, status: 3}
+    - {original_index: 261, status: 3}
+    - {original_index: 262, status: 2}
+    - {original_index: 263, status: 1}
+    - {original_index: 264, status: 2}
+    - {original_index: 265, status: 4}
+    - {original_index: 266, status: 4}
+    - {original_index: 267, status: 2}
+    - {original_index: 268, status: 0}
+    - {original_index: 269, status: 4}
+    - {original_index: 270, status: 2}
+    - {original_index: 271, status: 3}
+    - {original_index: 272, status: 3}
+    - {original_index: 273, status: 1}
+    - {original_index: 274, status: 3}
+    - {original_index: 275, status: 1}
+    - {original_index: 276, status: 4}
+    - {original_index: 277, status: 2}
+    - {original_index: 278, status: 0}
+    - {original_index: 279, status: 1}
+    - {original_index: 280, status: 2}
+    - {original_index: 281, status: 0}
+    - {original_index: 282, status: 4}
+    - {original_index: 283, status: 1}
+    - {original_index: 284, status: 0}
+    - {original_index: 285, status: 0}
+    - {original_index: 286, status: 4}
+    - {original_index: 287, status: 3}
+    - {original_index: 288, status: 4}
+    - {original_index: 289, status: 0}
+    - {original_index: 290, status: 4}
+    - {original_index: 291, status: 3}
+    - {original_index: 292, status: 4}
+    - {original_index: 293, status: 4}
+    - {original_index: 294, status: 4}
+    - {original_index: 295, status: 0}
+    - {original_index: 296, status: 0}
+    - {original_index: 297, status: 0}
+    - {original_index: 298, status: 3}
+    - {original_index: 299, status: 0}
+    - {original_index: 300, status: 0}
+    - {original_index: 301, status: 1}
+    - {original_index: 302, status: 2}
+    - {original_index: 303, status: 2}
+    - {original_index: 304, status: 4}
+    - {original_index: 305, status: 2}
+    - {original_index: 306, status: 4}
+    - {original_index: 307, status: 2}
+    - {original_index: 308, status: 0}
+    - {original_index: 309, status: 3}
+    - {original_index: 310, status: 1}
+    - {original_index: 311, status: 2}
+    - {original_index: 312, status: 3}
+    - {original_index: 313, status: 0}
+    - {original_index: 314, status: 1}
+    - {original_index: 315, status: 1}
+    - {original_index: 316, status: 3}
+    - {original_index: 317, status: 0}
+    - {original_index: 318, status: 0}
+    - {original_index: 319, status: 2}
+    - {original_index: 320, status: 4}
+    - {original_index: 321, status: 1}
+    - {original_index: 322, status: 4}
+    - {original_index: 323, status: 2}
+    - {original_index: 324, status: 1}
+    - {original_index: 325, status: 4}
+    - {original_index: 326, status: 0}
+    - {original_index: 327, status: 1}
+    - {original_index: 328, status: 3}
+    - {original_index: 329, status: 4}
+    - {original_index: 330, status: 0}
+    - {original_index: 331, status: 1}
+    - {original_index: 332, status: 1}
+    - {original_index: 333, status: 1}
+    - {original_index: 334, status: 1}
+    - {original_index: 335, status: 4}
+    - {original_index: 336, status: 2}
+    - {original_index: 337, status: 3}
+    - {original_index: 338, status: 4}
+    - {original_index: 339, status: 0}
+    - {original_index: 340, status: 1}
+    - {original_index: 341, status: 2}
+    - {original_index: 342, status: 1}
+    - {original_index: 343, status: 4}
+    - {original_index: 344, status: 2}
+    - {original_index: 345, status: 2}
+    - {original_index: 346, status: 1}
+    - {original_index: 347, status: 3}
+    - {original_index: 348, status: 4}
+    - {original_index: 349, status: 0}
+    - {original_index: 350, status: 2}
+    - {original_index: 351, status: 3}
+    - {original_index: 352, status: 1}
+    - {original_index: 353, status: 1}
+    - {original_index: 354, status: 1}
+    - {original_index: 355, status: 4}
+    - {original_index: 356, status: 1}
+    - {original_index: 357, status: 0}
+    - {original_index: 358, status: 2}
+    - {original_index: 359, status: 1}
+    - {original_index: 360, status: 4}
+    - {original_index: 361, status: 3}
+    - {original_index: 362, status: 0}
+    - {original_index: 363, status: 4}
+    - {original_index: 364, status: 0}
+    - {original_index: 365, status: 2}
+    - {original_index: 366, status: 1}
+    - {original_index: 367, status: 1}
+    - {original_index: 368, status: 4}
+    - {original_index: 369, status: 1}
+    - {original_index: 370, status: 0}
+    - {original_index: 371, status: 2}
+    - {original_index: 372, status: 2}
+    - {original_index: 373, status: 2}
+    - {original_index: 374, status: 2}
+    - {original_index: 375, status: 1}
+    - {original_index: 376, status: 4}
+    - {original_index: 377, status: 2}
   output:
-  - - committee:
-      - 162
-      - 74
+  - - committee: [162, 74]
       shard: 986
       total_validator_count: 148
-  - - committee:
-      - 205
-      - 76
+  - - committee: [205, 76]
       shard: 987
       total_validator_count: 148
-  - - committee:
-      - 352
-      - 100
+  - - committee: [352, 100]
       shard: 988
       total_validator_count: 148
-  - - committee:
-      - 324
-      - 47
-      - 73
+  - - committee: [324, 47, 73]
       shard: 989
       total_validator_count: 148
-  - - committee:
-      - 110
-      - 31
+  - - committee: [110, 31]
       shard: 990
       total_validator_count: 148
-  - - committee:
-      - 343
-      - 203
+  - - committee: [343, 203]
       shard: 991
       total_validator_count: 148
-  - - committee:
-      - 259
-      - 230
-      - 293
+  - - committee: [259, 230, 293]
       shard: 992
       total_validator_count: 148
-  - - committee:
-      - 233
-      - 353
+  - - committee: [233, 353]
       shard: 993
       total_validator_count: 148
-  - - committee:
-      - 356
-      - 108
+  - - committee: [356, 108]
       shard: 994
       total_validator_count: 148
-  - - committee:
-      - 273
-      - 315
-      - 152
+  - - committee: [273, 315, 152]
       shard: 995
       total_validator_count: 148
-  - - committee:
-      - 275
-      - 147
+  - - committee: [275, 147]
       shard: 996
       total_validator_count: 148
-  - - committee:
-      - 49
-      - 143
+  - - committee: [49, 143]
       shard: 997
       total_validator_count: 148
-  - - committee:
-      - 369
-      - 332
-      - 333
+  - - committee: [369, 332, 333]
       shard: 998
       total_validator_count: 148
-  - - committee:
-      - 105
-      - 192
+  - - committee: [105, 192]
       shard: 999
       total_validator_count: 148
-  - - committee:
-      - 148
-      - 363
+  - - committee: [148, 363]
       shard: 1000
       total_validator_count: 148
-  - - committee:
-      - 220
-      - 80
-      - 142
+  - - committee: [220, 80, 142]
       shard: 1001
       total_validator_count: 148
-  - - committee:
-      - 331
-      - 184
+  - - committee: [331, 184]
       shard: 1002
       total_validator_count: 148
-  - - committee:
-      - 338
-      - 17
+  - - committee: [338, 17]
       shard: 1003
       total_validator_count: 148
-  - - committee:
-      - 217
-      - 367
+  - - committee: [217, 367]
       shard: 1004
       total_validator_count: 148
-  - - committee:
-      - 266
-      - 196
-      - 321
+  - - committee: [266, 196, 321]
       shard: 1005
       total_validator_count: 148
-  - - committee:
-      - 46
-      - 228
+  - - committee: [46, 228]
       shard: 1006
       total_validator_count: 148
-  - - committee:
-      - 329
-      - 301
+  - - committee: [329, 301]
       shard: 1007
       total_validator_count: 148
-  - - committee:
-      - 200
-      - 98
-      - 137
+  - - committee: [200, 98, 137]
       shard: 1008
       total_validator_count: 148
-  - - committee:
-      - 123
-      - 227
+  - - committee: [123, 227]
       shard: 1009
       total_validator_count: 148
-  - - committee:
-      - 340
-      - 248
+  - - committee: [340, 248]
       shard: 1010
       total_validator_count: 148
-  - - committee:
-      - 140
-      - 191
-      - 18
+  - - committee: [140, 191, 18]
       shard: 1011
       total_validator_count: 148
-  - - committee:
-      - 129
-      - 240
+  - - committee: [129, 240]
       shard: 1012
       total_validator_count: 148
-  - - committee:
-      - 276
-      - 92
+  - - committee: [276, 92]
       shard: 1013
       total_validator_count: 148
-  - - committee:
-      - 157
-      - 114
-      - 325
+  - - committee: [157, 114, 325]
       shard: 1014
       total_validator_count: 148
-  - - committee:
-      - 265
-      - 241
+  - - committee: [265, 241]
       shard: 1015
       total_validator_count: 148
-  - - committee:
-      - 229
-      - 178
+  - - committee: [229, 178]
       shard: 1016
       total_validator_count: 148
-  - - committee:
-      - 124
-      - 131
-      - 180
+  - - committee: [124, 131, 180]
       shard: 1017
       total_validator_count: 148
-  - - committee:
-      - 103
-      - 79
+  - - committee: [103, 79]
       shard: 1018
       total_validator_count: 148
-  - - committee:
-      - 238
-      - 130
+  - - committee: [238, 130]
       shard: 1019
       total_validator_count: 148
-  - - committee:
-      - 55
-      - 290
+  - - committee: [55, 290]
       shard: 1020
       total_validator_count: 148
-  - - committee:
-      - 69
-      - 218
-      - 366
+  - - committee: [69, 218, 366]
       shard: 1021
       total_validator_count: 148
-  - - committee:
-      - 335
-      - 149
+  - - committee: [335, 149]
       shard: 1022
       total_validator_count: 148
-  - - committee:
-      - 368
-      - 327
+  - - committee: [368, 327]
       shard: 1023
       total_validator_count: 148
-  - - committee:
-      - 322
-      - 256
-      - 376
+  - - committee: [322, 256, 376]
       shard: 0
       total_validator_count: 148
-  - - committee:
-      - 282
-      - 226
+  - - committee: [282, 226]
       shard: 1
       total_validator_count: 148
-  - - committee:
-      - 224
-      - 306
+  - - committee: [224, 306]
       shard: 2
       total_validator_count: 148
-  - - committee:
-      - 314
-      - 8
-      - 134
+  - - committee: [314, 8, 134]
       shard: 3
       total_validator_count: 148
-  - - committee:
-      - 263
-      - 279
+  - - committee: [263, 279]
       shard: 4
       total_validator_count: 148
-  - - committee:
-      - 163
-      - 183
+  - - committee: [163, 183]
       shard: 5
       total_validator_count: 148
-  - - committee:
-      - 304
-      - 125
-      - 19
+  - - committee: [304, 125, 19]
       shard: 6
       total_validator_count: 148
-  - - committee:
-      - 234
-      - 23
+  - - committee: [234, 23]
       shard: 7
       total_validator_count: 148
-  - - committee:
-      - 113
-      - 360
+  - - committee: [113, 360]
       shard: 8
       total_validator_count: 148
-  - - committee:
-      - 286
-      - 342
-      - 253
+  - - committee: [286, 342, 253]
       shard: 9
       total_validator_count: 148
-  - - committee:
-      - 375
-      - 145
+  - - committee: [375, 145]
       shard: 10
       total_validator_count: 148
-  - - committee:
-      - 41
-      - 84
+  - - committee: [41, 84]
       shard: 11
       total_validator_count: 148
-  - - committee:
-      - 215
-      - 120
+  - - committee: [215, 120]
       shard: 12
       total_validator_count: 148
-  - - committee:
-      - 20
-      - 89
-      - 334
+  - - committee: [20, 89, 334]
       shard: 13
       total_validator_count: 148
-  - - committee:
-      - 320
-      - 354
+  - - committee: [320, 354]
       shard: 14
       total_validator_count: 148
-  - - committee:
-      - 359
-      - 269
+  - - committee: [359, 269]
       shard: 15
       total_validator_count: 148
-  - - committee:
-      - 153
-      - 310
-      - 87
+  - - committee: [153, 310, 87]
       shard: 16
       total_validator_count: 148
-  - - committee:
-      - 221
-      - 26
+  - - committee: [221, 26]
       shard: 17
       total_validator_count: 148
-  - - committee:
-      - 355
-      - 283
+  - - committee: [355, 283]
       shard: 18
       total_validator_count: 148
-  - - committee:
-      - 288
-      - 59
-      - 346
+  - - committee: [288, 59, 346]
       shard: 19
       total_validator_count: 148
-  - - committee:
-      - 154
-      - 128
+  - - committee: [154, 128]
       shard: 20
       total_validator_count: 148
-  - - committee:
-      - 292
-      - 104
+  - - committee: [292, 104]
       shard: 21
       total_validator_count: 148
-  - - committee:
-      - 10
-      - 348
-      - 52
+  - - committee: [10, 348, 52]
       shard: 22
       total_validator_count: 148
-  - - committee:
-      - 174
-      - 53
+  - - committee: [174, 53]
       shard: 23
       total_validator_count: 148
-  - - committee:
-      - 207
-      - 21
+  - - committee: [207, 21]
       shard: 24
       total_validator_count: 148
-  - - committee:
-      - 244
-      - 294
-      - 1
+  - - committee: [244, 294, 1]
       shard: 25
       total_validator_count: 148
   seed: '0xfe331725ea135ef16c8289d503c6c653938ba23e88ca435dbba2e8733402898c'

--- a/test_vectors_generator/test_vector_shuffling.yml
+++ b/test_vectors_generator/test_vector_shuffling.yml
@@ -1,0 +1,9894 @@
+fork: tchaikovsky
+summary: Test vectors for shuffling a list based upon a seed using `shuffle`
+test_suite: shuffle
+title: Shuffling Algorithm Tests
+version: 1.0
+test_cases:
+- input:
+    crosslinking_start_shard: 210
+    validators:
+    - original_index: 0
+      status: [2]
+    - original_index: 1
+      status: [4]
+    - original_index: 2
+      status: [0]
+    - original_index: 3
+      status: [0]
+    - original_index: 4
+      status: [2]
+    - original_index: 5
+      status: [2]
+    - original_index: 6
+      status: [4]
+    - original_index: 7
+      status: [2]
+    - original_index: 8
+      status: [3]
+    - original_index: 9
+      status: [1]
+    - original_index: 10
+      status: [0]
+    - original_index: 11
+      status: [3]
+    - original_index: 12
+      status: [3]
+    - original_index: 13
+      status: [4]
+    - original_index: 14
+      status: [4]
+    - original_index: 15
+      status: [4]
+    - original_index: 16
+      status: [1]
+    - original_index: 17
+      status: [1]
+    - original_index: 18
+      status: [1]
+    - original_index: 19
+      status: [1]
+    - original_index: 20
+      status: [3]
+    - original_index: 21
+      status: [2]
+    - original_index: 22
+      status: [3]
+    - original_index: 23
+      status: [0]
+    - original_index: 24
+      status: [2]
+    - original_index: 25
+      status: [4]
+    - original_index: 26
+      status: [0]
+    - original_index: 27
+      status: [2]
+    - original_index: 28
+      status: [4]
+    - original_index: 29
+      status: [0]
+    - original_index: 30
+      status: [0]
+    - original_index: 31
+      status: [4]
+    - original_index: 32
+      status: [2]
+    - original_index: 33
+      status: [1]
+    - original_index: 34
+      status: [4]
+    - original_index: 35
+      status: [1]
+    - original_index: 36
+      status: [4]
+    - original_index: 37
+      status: [2]
+    - original_index: 38
+      status: [2]
+    - original_index: 39
+      status: [1]
+    - original_index: 40
+      status: [2]
+    - original_index: 41
+      status: [4]
+    - original_index: 42
+      status: [0]
+    - original_index: 43
+      status: [4]
+    - original_index: 44
+      status: [0]
+    - original_index: 45
+      status: [3]
+    - original_index: 46
+      status: [0]
+    - original_index: 47
+      status: [4]
+    - original_index: 48
+      status: [4]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [0]
+    - original_index: 51
+      status: [1]
+    - original_index: 52
+      status: [3]
+    - original_index: 53
+      status: [3]
+    - original_index: 54
+      status: [0]
+    - original_index: 55
+      status: [4]
+    - original_index: 56
+      status: [3]
+    - original_index: 57
+      status: [1]
+    - original_index: 58
+      status: [1]
+    - original_index: 59
+      status: [3]
+    - original_index: 60
+      status: [1]
+    - original_index: 61
+      status: [0]
+    - original_index: 62
+      status: [0]
+    - original_index: 63
+      status: [1]
+    - original_index: 64
+      status: [0]
+    - original_index: 65
+      status: [0]
+    - original_index: 66
+      status: [4]
+    - original_index: 67
+      status: [1]
+    - original_index: 68
+      status: [2]
+    - original_index: 69
+      status: [0]
+    - original_index: 70
+      status: [1]
+    - original_index: 71
+      status: [4]
+    - original_index: 72
+      status: [2]
+    - original_index: 73
+      status: [1]
+    - original_index: 74
+      status: [1]
+    - original_index: 75
+      status: [4]
+    - original_index: 76
+      status: [1]
+    - original_index: 77
+      status: [1]
+    - original_index: 78
+      status: [1]
+    - original_index: 79
+      status: [1]
+    - original_index: 80
+      status: [0]
+    - original_index: 81
+      status: [4]
+    - original_index: 82
+      status: [4]
+    - original_index: 83
+      status: [0]
+    - original_index: 84
+      status: [1]
+    - original_index: 85
+      status: [3]
+    - original_index: 86
+      status: [4]
+    - original_index: 87
+      status: [2]
+    - original_index: 88
+      status: [0]
+    - original_index: 89
+      status: [1]
+    - original_index: 90
+      status: [4]
+    - original_index: 91
+      status: [3]
+    - original_index: 92
+      status: [1]
+    - original_index: 93
+      status: [2]
+    - original_index: 94
+      status: [4]
+    - original_index: 95
+      status: [2]
+    - original_index: 96
+      status: [2]
+    - original_index: 97
+      status: [2]
+    - original_index: 98
+      status: [3]
+    - original_index: 99
+      status: [3]
+    - original_index: 100
+      status: [3]
+    - original_index: 101
+      status: [0]
+    - original_index: 102
+      status: [2]
+    - original_index: 103
+      status: [0]
+    - original_index: 104
+      status: [4]
+    - original_index: 105
+      status: [1]
+    - original_index: 106
+      status: [1]
+    - original_index: 107
+      status: [3]
+    - original_index: 108
+      status: [0]
+    - original_index: 109
+      status: [3]
+    - original_index: 110
+      status: [1]
+    - original_index: 111
+      status: [3]
+    - original_index: 112
+      status: [4]
+    - original_index: 113
+      status: [3]
+    - original_index: 114
+      status: [3]
+    - original_index: 115
+      status: [4]
+    - original_index: 116
+      status: [0]
+    - original_index: 117
+      status: [1]
+    - original_index: 118
+      status: [0]
+    - original_index: 119
+      status: [3]
+    - original_index: 120
+      status: [3]
+    - original_index: 121
+      status: [1]
+    - original_index: 122
+      status: [4]
+    - original_index: 123
+      status: [2]
+    - original_index: 124
+      status: [0]
+    - original_index: 125
+      status: [3]
+    - original_index: 126
+      status: [2]
+    - original_index: 127
+      status: [3]
+    - original_index: 128
+      status: [0]
+    - original_index: 129
+      status: [4]
+    - original_index: 130
+      status: [3]
+    - original_index: 131
+      status: [1]
+    - original_index: 132
+      status: [3]
+    - original_index: 133
+      status: [3]
+    - original_index: 134
+      status: [4]
+    - original_index: 135
+      status: [3]
+    - original_index: 136
+      status: [0]
+    - original_index: 137
+      status: [0]
+    - original_index: 138
+      status: [1]
+    - original_index: 139
+      status: [0]
+    - original_index: 140
+      status: [2]
+    - original_index: 141
+      status: [4]
+    - original_index: 142
+      status: [1]
+    - original_index: 143
+      status: [3]
+    - original_index: 144
+      status: [1]
+    - original_index: 145
+      status: [3]
+    - original_index: 146
+      status: [2]
+    - original_index: 147
+      status: [4]
+    - original_index: 148
+      status: [2]
+    - original_index: 149
+      status: [2]
+    - original_index: 150
+      status: [0]
+    - original_index: 151
+      status: [3]
+    - original_index: 152
+      status: [2]
+    - original_index: 153
+      status: [3]
+    - original_index: 154
+      status: [1]
+    - original_index: 155
+      status: [3]
+    - original_index: 156
+      status: [0]
+    - original_index: 157
+      status: [2]
+    - original_index: 158
+      status: [1]
+    - original_index: 159
+      status: [3]
+    - original_index: 160
+      status: [2]
+    - original_index: 161
+      status: [2]
+    - original_index: 162
+      status: [1]
+    - original_index: 163
+      status: [3]
+    - original_index: 164
+      status: [0]
+    - original_index: 165
+      status: [2]
+    - original_index: 166
+      status: [1]
+    - original_index: 167
+      status: [3]
+    - original_index: 168
+      status: [2]
+    - original_index: 169
+      status: [2]
+    - original_index: 170
+      status: [2]
+    - original_index: 171
+      status: [0]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [0]
+    - original_index: 174
+      status: [3]
+    - original_index: 175
+      status: [4]
+    - original_index: 176
+      status: [1]
+    - original_index: 177
+      status: [4]
+    - original_index: 178
+      status: [4]
+    - original_index: 179
+      status: [3]
+    - original_index: 180
+      status: [3]
+    - original_index: 181
+      status: [0]
+    - original_index: 182
+      status: [1]
+    - original_index: 183
+      status: [2]
+    - original_index: 184
+      status: [4]
+    - original_index: 185
+      status: [1]
+    - original_index: 186
+      status: [4]
+    - original_index: 187
+      status: [0]
+    - original_index: 188
+      status: [0]
+    - original_index: 189
+      status: [4]
+    - original_index: 190
+      status: [3]
+    - original_index: 191
+      status: [2]
+    - original_index: 192
+      status: [4]
+    - original_index: 193
+      status: [3]
+    - original_index: 194
+      status: [1]
+    - original_index: 195
+      status: [2]
+    - original_index: 196
+      status: [0]
+    - original_index: 197
+      status: [4]
+    - original_index: 198
+      status: [4]
+    - original_index: 199
+      status: [2]
+    - original_index: 200
+      status: [0]
+    - original_index: 201
+      status: [4]
+    - original_index: 202
+      status: [4]
+    - original_index: 203
+      status: [4]
+    - original_index: 204
+      status: [4]
+    - original_index: 205
+      status: [0]
+    - original_index: 206
+      status: [1]
+    - original_index: 207
+      status: [4]
+    - original_index: 208
+      status: [4]
+    - original_index: 209
+      status: [3]
+    - original_index: 210
+      status: [0]
+    - original_index: 211
+      status: [3]
+    - original_index: 212
+      status: [2]
+    - original_index: 213
+      status: [1]
+    - original_index: 214
+      status: [4]
+    - original_index: 215
+      status: [3]
+    - original_index: 216
+      status: [0]
+    - original_index: 217
+      status: [3]
+    - original_index: 218
+      status: [0]
+    - original_index: 219
+      status: [3]
+    - original_index: 220
+      status: [1]
+    - original_index: 221
+      status: [3]
+    - original_index: 222
+      status: [3]
+    - original_index: 223
+      status: [2]
+    - original_index: 224
+      status: [3]
+    - original_index: 225
+      status: [2]
+    - original_index: 226
+      status: [2]
+    - original_index: 227
+      status: [2]
+    - original_index: 228
+      status: [1]
+    - original_index: 229
+      status: [0]
+    - original_index: 230
+      status: [4]
+    - original_index: 231
+      status: [2]
+    - original_index: 232
+      status: [0]
+    - original_index: 233
+      status: [4]
+    - original_index: 234
+      status: [2]
+    - original_index: 235
+      status: [2]
+    - original_index: 236
+      status: [0]
+    - original_index: 237
+      status: [1]
+    - original_index: 238
+      status: [0]
+    - original_index: 239
+      status: [0]
+    - original_index: 240
+      status: [2]
+    - original_index: 241
+      status: [0]
+    - original_index: 242
+      status: [3]
+    - original_index: 243
+      status: [3]
+    - original_index: 244
+      status: [2]
+    - original_index: 245
+      status: [4]
+    - original_index: 246
+      status: [0]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [1]
+    - original_index: 249
+      status: [0]
+    - original_index: 250
+      status: [3]
+    - original_index: 251
+      status: [4]
+    - original_index: 252
+      status: [2]
+    - original_index: 253
+      status: [4]
+    - original_index: 254
+      status: [0]
+    - original_index: 255
+      status: [1]
+    - original_index: 256
+      status: [4]
+    - original_index: 257
+      status: [1]
+    - original_index: 258
+      status: [0]
+    - original_index: 259
+      status: [0]
+    - original_index: 260
+      status: [4]
+    - original_index: 261
+      status: [3]
+    - original_index: 262
+      status: [3]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [1]
+    - original_index: 265
+      status: [4]
+    - original_index: 266
+      status: [1]
+    - original_index: 267
+      status: [3]
+    - original_index: 268
+      status: [1]
+    - original_index: 269
+      status: [0]
+    - original_index: 270
+      status: [4]
+    - original_index: 271
+      status: [3]
+    - original_index: 272
+      status: [3]
+    - original_index: 273
+      status: [0]
+    - original_index: 274
+      status: [2]
+    - original_index: 275
+      status: [1]
+    - original_index: 276
+      status: [3]
+    - original_index: 277
+      status: [4]
+    - original_index: 278
+      status: [1]
+    - original_index: 279
+      status: [3]
+    - original_index: 280
+      status: [3]
+    - original_index: 281
+      status: [3]
+    - original_index: 282
+      status: [0]
+    - original_index: 283
+      status: [4]
+    - original_index: 284
+      status: [2]
+    - original_index: 285
+      status: [3]
+    - original_index: 286
+      status: [0]
+    - original_index: 287
+      status: [0]
+    - original_index: 288
+      status: [0]
+    - original_index: 289
+      status: [1]
+    - original_index: 290
+      status: [4]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [1]
+    - original_index: 293
+      status: [4]
+    - original_index: 294
+      status: [2]
+    - original_index: 295
+      status: [0]
+    - original_index: 296
+      status: [4]
+    - original_index: 297
+      status: [2]
+    - original_index: 298
+      status: [3]
+    - original_index: 299
+      status: [0]
+    - original_index: 300
+      status: [1]
+    - original_index: 301
+      status: [2]
+    - original_index: 302
+      status: [0]
+    - original_index: 303
+      status: [4]
+    - original_index: 304
+      status: [0]
+    - original_index: 305
+      status: [4]
+    - original_index: 306
+      status: [4]
+    - original_index: 307
+      status: [2]
+    - original_index: 308
+      status: [1]
+    - original_index: 309
+      status: [3]
+    - original_index: 310
+      status: [4]
+    - original_index: 311
+      status: [3]
+    - original_index: 312
+      status: [2]
+    - original_index: 313
+      status: [3]
+    - original_index: 314
+      status: [3]
+    - original_index: 315
+      status: [4]
+    - original_index: 316
+      status: [3]
+    - original_index: 317
+      status: [2]
+    - original_index: 318
+      status: [2]
+    - original_index: 319
+      status: [1]
+    - original_index: 320
+      status: [3]
+    - original_index: 321
+      status: [0]
+    - original_index: 322
+      status: [3]
+    - original_index: 323
+      status: [2]
+    - original_index: 324
+      status: [1]
+    - original_index: 325
+      status: [0]
+    - original_index: 326
+      status: [1]
+    - original_index: 327
+      status: [3]
+    - original_index: 328
+      status: [2]
+    - original_index: 329
+      status: [0]
+    - original_index: 330
+      status: [0]
+    - original_index: 331
+      status: [0]
+    - original_index: 332
+      status: [1]
+    - original_index: 333
+      status: [1]
+    - original_index: 334
+      status: [2]
+    - original_index: 335
+      status: [2]
+    - original_index: 336
+      status: [0]
+    - original_index: 337
+      status: [3]
+    - original_index: 338
+      status: [1]
+    - original_index: 339
+      status: [0]
+    - original_index: 340
+      status: [3]
+    - original_index: 341
+      status: [2]
+    - original_index: 342
+      status: [0]
+    - original_index: 343
+      status: [0]
+    - original_index: 344
+      status: [2]
+    - original_index: 345
+      status: [3]
+    - original_index: 346
+      status: [0]
+    - original_index: 347
+      status: [0]
+    - original_index: 348
+      status: [4]
+    - original_index: 349
+      status: [4]
+    - original_index: 350
+      status: [2]
+    - original_index: 351
+      status: [0]
+    - original_index: 352
+      status: [1]
+    - original_index: 353
+      status: [1]
+    - original_index: 354
+      status: [3]
+    - original_index: 355
+      status: [0]
+    - original_index: 356
+      status: [1]
+    - original_index: 357
+      status: [0]
+    - original_index: 358
+      status: [1]
+    - original_index: 359
+      status: [1]
+    - original_index: 360
+      status: [3]
+    - original_index: 361
+      status: [4]
+    - original_index: 362
+      status: [0]
+    - original_index: 363
+      status: [0]
+    - original_index: 364
+      status: [3]
+    - original_index: 365
+      status: [4]
+    - original_index: 366
+      status: [4]
+    - original_index: 367
+      status: [4]
+    - original_index: 368
+      status: [0]
+    - original_index: 369
+      status: [2]
+    - original_index: 370
+      status: [4]
+    - original_index: 371
+      status: [4]
+    - original_index: 372
+      status: [1]
+    - original_index: 373
+      status: [0]
+    - original_index: 374
+      status: [2]
+    - original_index: 375
+      status: [2]
+    - original_index: 376
+      status: [3]
+    - original_index: 377
+      status: [4]
+    - original_index: 378
+      status: [4]
+    - original_index: 379
+      status: [0]
+    - original_index: 380
+      status: [1]
+    - original_index: 381
+      status: [3]
+    - original_index: 382
+      status: [2]
+    - original_index: 383
+      status: [4]
+    - original_index: 384
+      status: [0]
+    - original_index: 385
+      status: [1]
+    - original_index: 386
+      status: [2]
+    - original_index: 387
+      status: [1]
+    - original_index: 388
+      status: [3]
+    - original_index: 389
+      status: [3]
+    - original_index: 390
+      status: [0]
+    - original_index: 391
+      status: [3]
+    - original_index: 392
+      status: [4]
+    - original_index: 393
+      status: [1]
+    - original_index: 394
+      status: [3]
+    - original_index: 395
+      status: [1]
+    - original_index: 396
+      status: [0]
+    - original_index: 397
+      status: [1]
+    - original_index: 398
+      status: [0]
+    - original_index: 399
+      status: [4]
+    - original_index: 400
+      status: [4]
+    - original_index: 401
+      status: [3]
+    - original_index: 402
+      status: [4]
+    - original_index: 403
+      status: [1]
+    - original_index: 404
+      status: [0]
+    - original_index: 405
+      status: [3]
+    - original_index: 406
+      status: [1]
+    - original_index: 407
+      status: [3]
+  output:
+  - - committee: [131, 104]
+      shard: 210
+      total_validator_count: 160
+  - - committee: [1, 256, 16]
+      shard: 211
+      total_validator_count: 160
+  - - committee: [175, 255]
+      shard: 212
+      total_validator_count: 160
+  - - committee: [51, 333, 9]
+      shard: 213
+      total_validator_count: 160
+  - - committee: [182, 117]
+      shard: 214
+      total_validator_count: 160
+  - - committee: [400, 366, 399]
+      shard: 215
+      total_validator_count: 160
+  - - committee: [278, 214]
+      shard: 216
+      total_validator_count: 160
+  - - committee: [177, 352, 387]
+      shard: 217
+      total_validator_count: 160
+  - - committee: [106, 35]
+      shard: 218
+      total_validator_count: 160
+  - - committee: [293, 14, 33]
+      shard: 219
+      total_validator_count: 160
+  - - committee: [34, 122]
+      shard: 220
+      total_validator_count: 160
+  - - committee: [178, 305, 372]
+      shard: 221
+      total_validator_count: 160
+  - - committee: [358, 296]
+      shard: 222
+      total_validator_count: 160
+  - - committee: [115, 74, 393]
+      shard: 223
+      total_validator_count: 160
+  - - committee: [94, 192]
+      shard: 224
+      total_validator_count: 160
+  - - committee: [397, 202, 186]
+      shard: 225
+      total_validator_count: 160
+  - - committee: [81, 76]
+      shard: 226
+      total_validator_count: 160
+  - - committee: [90, 266, 58]
+      shard: 227
+      total_validator_count: 160
+  - - committee: [283, 47]
+      shard: 228
+      total_validator_count: 160
+  - - committee: [110, 89, 265]
+      shard: 229
+      total_validator_count: 160
+  - - committee: [201, 237]
+      shard: 230
+      total_validator_count: 160
+  - - committee: [75, 25, 263]
+      shard: 231
+      total_validator_count: 160
+  - - committee: [303, 86]
+      shard: 232
+      total_validator_count: 160
+  - - committee: [17, 82, 138]
+      shard: 233
+      total_validator_count: 160
+  - - committee: [338, 365]
+      shard: 234
+      total_validator_count: 160
+  - - committee: [308, 55, 332]
+      shard: 235
+      total_validator_count: 160
+  - - committee: [370, 275]
+      shard: 236
+      total_validator_count: 160
+  - - committee: [377, 57, 147]
+      shard: 237
+      total_validator_count: 160
+  - - committee: [112, 141]
+      shard: 238
+      total_validator_count: 160
+  - - committee: [204, 233, 207]
+      shard: 239
+      total_validator_count: 160
+  - - committee: [206, 78]
+      shard: 240
+      total_validator_count: 160
+  - - committee: [253, 367, 73]
+      shard: 241
+      total_validator_count: 160
+  - - committee: [402, 158]
+      shard: 242
+      total_validator_count: 160
+  - - committee: [248, 105, 70]
+      shard: 243
+      total_validator_count: 160
+  - - committee: [292, 289]
+      shard: 244
+      total_validator_count: 160
+  - - committee: [315, 395, 380]
+      shard: 245
+      total_validator_count: 160
+  - - committee: [60, 220]
+      shard: 246
+      total_validator_count: 160
+  - - committee: [213, 13, 121]
+      shard: 247
+      total_validator_count: 160
+  - - committee: [142, 31]
+      shard: 248
+      total_validator_count: 160
+  - - committee: [230, 129, 353]
+      shard: 249
+      total_validator_count: 160
+  - - committee: [378, 77]
+      shard: 250
+      total_validator_count: 160
+  - - committee: [15, 92, 166]
+      shard: 251
+      total_validator_count: 160
+  - - committee: [277, 260]
+      shard: 252
+      total_validator_count: 160
+  - - committee: [349, 403, 406]
+      shard: 253
+      total_validator_count: 160
+  - - committee: [185, 36]
+      shard: 254
+      total_validator_count: 160
+  - - committee: [28, 18, 270]
+      shard: 255
+      total_validator_count: 160
+  - - committee: [39, 197]
+      shard: 256
+      total_validator_count: 160
+  - - committee: [383, 134, 228]
+      shard: 257
+      total_validator_count: 160
+  - - committee: [257, 79]
+      shard: 258
+      total_validator_count: 160
+  - - committee: [319, 245, 144]
+      shard: 259
+      total_validator_count: 160
+  - - committee: [84, 356]
+      shard: 260
+      total_validator_count: 160
+  - - committee: [359, 184, 324]
+      shard: 261
+      total_validator_count: 160
+  - - committee: [67, 41]
+      shard: 262
+      total_validator_count: 160
+  - - committee: [290, 63, 176]
+      shard: 263
+      total_validator_count: 160
+  - - committee: [385, 154]
+      shard: 264
+      total_validator_count: 160
+  - - committee: [66, 43, 162]
+      shard: 265
+      total_validator_count: 160
+  - - committee: [306, 251]
+      shard: 266
+      total_validator_count: 160
+  - - committee: [310, 189, 208]
+      shard: 267
+      total_validator_count: 160
+  - - committee: [198, 48]
+      shard: 268
+      total_validator_count: 160
+  - - committee: [348, 19, 392]
+      shard: 269
+      total_validator_count: 160
+  - - committee: [326, 71]
+      shard: 270
+      total_validator_count: 160
+  - - committee: [268, 203, 264]
+      shard: 271
+      total_validator_count: 160
+  - - committee: [361, 6]
+      shard: 272
+      total_validator_count: 160
+  - - committee: [300, 194, 371]
+      shard: 273
+      total_validator_count: 160
+  seed: '0xc0c7f226fbd574a8c63dc26864c27833ea931e7c70b34409ba765f3d2031633d'
+- input:
+    crosslinking_start_shard: 102
+    validators:
+    - original_index: 0
+      status: [3]
+    - original_index: 1
+      status: [2]
+    - original_index: 2
+      status: [4]
+    - original_index: 3
+      status: [4]
+    - original_index: 4
+      status: [3]
+    - original_index: 5
+      status: [1]
+    - original_index: 6
+      status: [0]
+    - original_index: 7
+      status: [4]
+    - original_index: 8
+      status: [3]
+    - original_index: 9
+      status: [3]
+    - original_index: 10
+      status: [3]
+    - original_index: 11
+      status: [3]
+    - original_index: 12
+      status: [4]
+    - original_index: 13
+      status: [2]
+    - original_index: 14
+      status: [1]
+    - original_index: 15
+      status: [1]
+    - original_index: 16
+      status: [3]
+    - original_index: 17
+      status: [4]
+    - original_index: 18
+      status: [1]
+    - original_index: 19
+      status: [1]
+    - original_index: 20
+      status: [3]
+    - original_index: 21
+      status: [0]
+    - original_index: 22
+      status: [4]
+    - original_index: 23
+      status: [0]
+    - original_index: 24
+      status: [2]
+    - original_index: 25
+      status: [4]
+    - original_index: 26
+      status: [1]
+    - original_index: 27
+      status: [1]
+    - original_index: 28
+      status: [3]
+    - original_index: 29
+      status: [4]
+    - original_index: 30
+      status: [1]
+    - original_index: 31
+      status: [0]
+    - original_index: 32
+      status: [2]
+    - original_index: 33
+      status: [3]
+    - original_index: 34
+      status: [4]
+    - original_index: 35
+      status: [2]
+    - original_index: 36
+      status: [2]
+    - original_index: 37
+      status: [4]
+    - original_index: 38
+      status: [1]
+    - original_index: 39
+      status: [4]
+    - original_index: 40
+      status: [4]
+    - original_index: 41
+      status: [2]
+    - original_index: 42
+      status: [0]
+    - original_index: 43
+      status: [2]
+    - original_index: 44
+      status: [4]
+    - original_index: 45
+      status: [0]
+    - original_index: 46
+      status: [1]
+    - original_index: 47
+      status: [4]
+    - original_index: 48
+      status: [0]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [1]
+    - original_index: 51
+      status: [3]
+    - original_index: 52
+      status: [0]
+    - original_index: 53
+      status: [3]
+    - original_index: 54
+      status: [0]
+    - original_index: 55
+      status: [2]
+    - original_index: 56
+      status: [2]
+    - original_index: 57
+      status: [3]
+    - original_index: 58
+      status: [4]
+    - original_index: 59
+      status: [3]
+    - original_index: 60
+      status: [0]
+    - original_index: 61
+      status: [1]
+    - original_index: 62
+      status: [0]
+    - original_index: 63
+      status: [0]
+    - original_index: 64
+      status: [3]
+    - original_index: 65
+      status: [4]
+    - original_index: 66
+      status: [1]
+    - original_index: 67
+      status: [0]
+    - original_index: 68
+      status: [3]
+    - original_index: 69
+      status: [2]
+    - original_index: 70
+      status: [3]
+    - original_index: 71
+      status: [4]
+    - original_index: 72
+      status: [3]
+    - original_index: 73
+      status: [1]
+    - original_index: 74
+      status: [0]
+    - original_index: 75
+      status: [4]
+    - original_index: 76
+      status: [0]
+    - original_index: 77
+      status: [3]
+    - original_index: 78
+      status: [4]
+    - original_index: 79
+      status: [3]
+    - original_index: 80
+      status: [3]
+    - original_index: 81
+      status: [0]
+    - original_index: 82
+      status: [3]
+    - original_index: 83
+      status: [1]
+    - original_index: 84
+      status: [4]
+    - original_index: 85
+      status: [0]
+    - original_index: 86
+      status: [2]
+    - original_index: 87
+      status: [1]
+    - original_index: 88
+      status: [4]
+    - original_index: 89
+      status: [4]
+    - original_index: 90
+      status: [4]
+    - original_index: 91
+      status: [3]
+    - original_index: 92
+      status: [3]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [4]
+    - original_index: 95
+      status: [3]
+    - original_index: 96
+      status: [2]
+    - original_index: 97
+      status: [2]
+    - original_index: 98
+      status: [2]
+    - original_index: 99
+      status: [3]
+    - original_index: 100
+      status: [2]
+    - original_index: 101
+      status: [2]
+    - original_index: 102
+      status: [1]
+    - original_index: 103
+      status: [2]
+    - original_index: 104
+      status: [3]
+    - original_index: 105
+      status: [3]
+    - original_index: 106
+      status: [3]
+    - original_index: 107
+      status: [0]
+    - original_index: 108
+      status: [3]
+    - original_index: 109
+      status: [2]
+    - original_index: 110
+      status: [1]
+    - original_index: 111
+      status: [4]
+    - original_index: 112
+      status: [3]
+    - original_index: 113
+      status: [4]
+    - original_index: 114
+      status: [2]
+    - original_index: 115
+      status: [4]
+    - original_index: 116
+      status: [0]
+    - original_index: 117
+      status: [1]
+    - original_index: 118
+      status: [2]
+    - original_index: 119
+      status: [1]
+    - original_index: 120
+      status: [0]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [3]
+    - original_index: 124
+      status: [3]
+    - original_index: 125
+      status: [3]
+    - original_index: 126
+      status: [1]
+    - original_index: 127
+      status: [4]
+    - original_index: 128
+      status: [2]
+    - original_index: 129
+      status: [1]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [1]
+    - original_index: 132
+      status: [0]
+    - original_index: 133
+      status: [3]
+    - original_index: 134
+      status: [3]
+    - original_index: 135
+      status: [4]
+    - original_index: 136
+      status: [3]
+    - original_index: 137
+      status: [1]
+    - original_index: 138
+      status: [1]
+    - original_index: 139
+      status: [1]
+    - original_index: 140
+      status: [3]
+    - original_index: 141
+      status: [1]
+    - original_index: 142
+      status: [3]
+    - original_index: 143
+      status: [2]
+    - original_index: 144
+      status: [4]
+    - original_index: 145
+      status: [2]
+    - original_index: 146
+      status: [2]
+    - original_index: 147
+      status: [0]
+    - original_index: 148
+      status: [3]
+    - original_index: 149
+      status: [3]
+    - original_index: 150
+      status: [1]
+    - original_index: 151
+      status: [0]
+    - original_index: 152
+      status: [2]
+    - original_index: 153
+      status: [0]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [1]
+    - original_index: 156
+      status: [2]
+    - original_index: 157
+      status: [0]
+    - original_index: 158
+      status: [3]
+    - original_index: 159
+      status: [2]
+    - original_index: 160
+      status: [2]
+    - original_index: 161
+      status: [3]
+    - original_index: 162
+      status: [1]
+    - original_index: 163
+      status: [0]
+    - original_index: 164
+      status: [3]
+    - original_index: 165
+      status: [3]
+    - original_index: 166
+      status: [0]
+    - original_index: 167
+      status: [1]
+    - original_index: 168
+      status: [0]
+    - original_index: 169
+      status: [1]
+    - original_index: 170
+      status: [0]
+    - original_index: 171
+      status: [0]
+    - original_index: 172
+      status: [2]
+    - original_index: 173
+      status: [2]
+    - original_index: 174
+      status: [3]
+    - original_index: 175
+      status: [0]
+    - original_index: 176
+      status: [4]
+    - original_index: 177
+      status: [1]
+    - original_index: 178
+      status: [4]
+    - original_index: 179
+      status: [1]
+    - original_index: 180
+      status: [1]
+    - original_index: 181
+      status: [3]
+    - original_index: 182
+      status: [2]
+    - original_index: 183
+      status: [2]
+    - original_index: 184
+      status: [1]
+    - original_index: 185
+      status: [0]
+    - original_index: 186
+      status: [3]
+    - original_index: 187
+      status: [2]
+    - original_index: 188
+      status: [0]
+    - original_index: 189
+      status: [1]
+    - original_index: 190
+      status: [0]
+    - original_index: 191
+      status: [2]
+    - original_index: 192
+      status: [2]
+    - original_index: 193
+      status: [0]
+    - original_index: 194
+      status: [2]
+    - original_index: 195
+      status: [1]
+    - original_index: 196
+      status: [0]
+    - original_index: 197
+      status: [1]
+    - original_index: 198
+      status: [0]
+    - original_index: 199
+      status: [0]
+    - original_index: 200
+      status: [3]
+    - original_index: 201
+      status: [1]
+    - original_index: 202
+      status: [1]
+    - original_index: 203
+      status: [2]
+    - original_index: 204
+      status: [3]
+    - original_index: 205
+      status: [0]
+    - original_index: 206
+      status: [0]
+    - original_index: 207
+      status: [3]
+    - original_index: 208
+      status: [1]
+    - original_index: 209
+      status: [2]
+    - original_index: 210
+      status: [3]
+    - original_index: 211
+      status: [1]
+    - original_index: 212
+      status: [3]
+    - original_index: 213
+      status: [3]
+    - original_index: 214
+      status: [3]
+    - original_index: 215
+      status: [4]
+    - original_index: 216
+      status: [4]
+    - original_index: 217
+      status: [2]
+    - original_index: 218
+      status: [4]
+    - original_index: 219
+      status: [3]
+    - original_index: 220
+      status: [1]
+    - original_index: 221
+      status: [2]
+    - original_index: 222
+      status: [1]
+    - original_index: 223
+      status: [4]
+    - original_index: 224
+      status: [3]
+    - original_index: 225
+      status: [4]
+    - original_index: 226
+      status: [4]
+    - original_index: 227
+      status: [3]
+    - original_index: 228
+      status: [0]
+    - original_index: 229
+      status: [3]
+    - original_index: 230
+      status: [4]
+    - original_index: 231
+      status: [2]
+    - original_index: 232
+      status: [3]
+    - original_index: 233
+      status: [3]
+    - original_index: 234
+      status: [2]
+    - original_index: 235
+      status: [4]
+    - original_index: 236
+      status: [3]
+    - original_index: 237
+      status: [2]
+    - original_index: 238
+      status: [4]
+    - original_index: 239
+      status: [1]
+    - original_index: 240
+      status: [4]
+    - original_index: 241
+      status: [2]
+    - original_index: 242
+      status: [1]
+    - original_index: 243
+      status: [3]
+    - original_index: 244
+      status: [4]
+    - original_index: 245
+      status: [0]
+    - original_index: 246
+      status: [1]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [0]
+    - original_index: 249
+      status: [0]
+    - original_index: 250
+      status: [1]
+    - original_index: 251
+      status: [2]
+    - original_index: 252
+      status: [0]
+    - original_index: 253
+      status: [4]
+    - original_index: 254
+      status: [0]
+    - original_index: 255
+      status: [2]
+    - original_index: 256
+      status: [4]
+    - original_index: 257
+      status: [3]
+    - original_index: 258
+      status: [1]
+    - original_index: 259
+      status: [0]
+    - original_index: 260
+      status: [0]
+    - original_index: 261
+      status: [1]
+    - original_index: 262
+      status: [4]
+    - original_index: 263
+      status: [3]
+    - original_index: 264
+      status: [2]
+    - original_index: 265
+      status: [4]
+    - original_index: 266
+      status: [0]
+    - original_index: 267
+      status: [2]
+    - original_index: 268
+      status: [3]
+    - original_index: 269
+      status: [1]
+    - original_index: 270
+      status: [4]
+    - original_index: 271
+      status: [0]
+    - original_index: 272
+      status: [2]
+    - original_index: 273
+      status: [2]
+    - original_index: 274
+      status: [1]
+    - original_index: 275
+      status: [0]
+    - original_index: 276
+      status: [0]
+    - original_index: 277
+      status: [2]
+    - original_index: 278
+      status: [0]
+    - original_index: 279
+      status: [2]
+    - original_index: 280
+      status: [0]
+    - original_index: 281
+      status: [3]
+    - original_index: 282
+      status: [3]
+    - original_index: 283
+      status: [3]
+    - original_index: 284
+      status: [0]
+    - original_index: 285
+      status: [2]
+    - original_index: 286
+      status: [2]
+    - original_index: 287
+      status: [4]
+    - original_index: 288
+      status: [2]
+    - original_index: 289
+      status: [3]
+    - original_index: 290
+      status: [3]
+    - original_index: 291
+      status: [1]
+    - original_index: 292
+      status: [2]
+    - original_index: 293
+      status: [1]
+    - original_index: 294
+      status: [3]
+    - original_index: 295
+      status: [1]
+    - original_index: 296
+      status: [0]
+    - original_index: 297
+      status: [2]
+    - original_index: 298
+      status: [3]
+    - original_index: 299
+      status: [0]
+    - original_index: 300
+      status: [3]
+    - original_index: 301
+      status: [0]
+    - original_index: 302
+      status: [4]
+    - original_index: 303
+      status: [4]
+    - original_index: 304
+      status: [4]
+    - original_index: 305
+      status: [3]
+    - original_index: 306
+      status: [4]
+    - original_index: 307
+      status: [0]
+    - original_index: 308
+      status: [2]
+    - original_index: 309
+      status: [3]
+    - original_index: 310
+      status: [3]
+    - original_index: 311
+      status: [3]
+    - original_index: 312
+      status: [4]
+    - original_index: 313
+      status: [4]
+    - original_index: 314
+      status: [0]
+    - original_index: 315
+      status: [4]
+    - original_index: 316
+      status: [4]
+    - original_index: 317
+      status: [1]
+    - original_index: 318
+      status: [0]
+    - original_index: 319
+      status: [2]
+    - original_index: 320
+      status: [3]
+    - original_index: 321
+      status: [4]
+    - original_index: 322
+      status: [2]
+    - original_index: 323
+      status: [3]
+    - original_index: 324
+      status: [3]
+    - original_index: 325
+      status: [3]
+    - original_index: 326
+      status: [4]
+    - original_index: 327
+      status: [4]
+    - original_index: 328
+      status: [1]
+    - original_index: 329
+      status: [1]
+    - original_index: 330
+      status: [0]
+    - original_index: 331
+      status: [0]
+    - original_index: 332
+      status: [4]
+    - original_index: 333
+      status: [4]
+    - original_index: 334
+      status: [1]
+    - original_index: 335
+      status: [3]
+    - original_index: 336
+      status: [0]
+    - original_index: 337
+      status: [2]
+    - original_index: 338
+      status: [2]
+    - original_index: 339
+      status: [1]
+    - original_index: 340
+      status: [2]
+    - original_index: 341
+      status: [4]
+    - original_index: 342
+      status: [2]
+    - original_index: 343
+      status: [0]
+    - original_index: 344
+      status: [1]
+    - original_index: 345
+      status: [3]
+    - original_index: 346
+      status: [2]
+    - original_index: 347
+      status: [0]
+    - original_index: 348
+      status: [2]
+    - original_index: 349
+      status: [2]
+    - original_index: 350
+      status: [3]
+    - original_index: 351
+      status: [3]
+    - original_index: 352
+      status: [3]
+    - original_index: 353
+      status: [2]
+    - original_index: 354
+      status: [3]
+    - original_index: 355
+      status: [0]
+    - original_index: 356
+      status: [4]
+    - original_index: 357
+      status: [1]
+    - original_index: 358
+      status: [2]
+    - original_index: 359
+      status: [4]
+    - original_index: 360
+      status: [0]
+    - original_index: 361
+      status: [1]
+    - original_index: 362
+      status: [1]
+    - original_index: 363
+      status: [3]
+    - original_index: 364
+      status: [3]
+    - original_index: 365
+      status: [3]
+    - original_index: 366
+      status: [4]
+    - original_index: 367
+      status: [3]
+    - original_index: 368
+      status: [3]
+    - original_index: 369
+      status: [2]
+    - original_index: 370
+      status: [1]
+    - original_index: 371
+      status: [0]
+    - original_index: 372
+      status: [2]
+    - original_index: 373
+      status: [2]
+    - original_index: 374
+      status: [0]
+    - original_index: 375
+      status: [4]
+    - original_index: 376
+      status: [3]
+    - original_index: 377
+      status: [0]
+    - original_index: 378
+      status: [2]
+    - original_index: 379
+      status: [3]
+    - original_index: 380
+      status: [1]
+    - original_index: 381
+      status: [4]
+    - original_index: 382
+      status: [4]
+    - original_index: 383
+      status: [2]
+    - original_index: 384
+      status: [4]
+    - original_index: 385
+      status: [0]
+    - original_index: 386
+      status: [0]
+    - original_index: 387
+      status: [2]
+    - original_index: 388
+      status: [1]
+    - original_index: 389
+      status: [4]
+    - original_index: 390
+      status: [3]
+    - original_index: 391
+      status: [4]
+    - original_index: 392
+      status: [2]
+    - original_index: 393
+      status: [1]
+    - original_index: 394
+      status: [3]
+    - original_index: 395
+      status: [4]
+    - original_index: 396
+      status: [2]
+    - original_index: 397
+      status: [4]
+    - original_index: 398
+      status: [0]
+    - original_index: 399
+      status: [4]
+    - original_index: 400
+      status: [4]
+    - original_index: 401
+      status: [2]
+    - original_index: 402
+      status: [3]
+    - original_index: 403
+      status: [0]
+    - original_index: 404
+      status: [2]
+    - original_index: 405
+      status: [4]
+    - original_index: 406
+      status: [4]
+    - original_index: 407
+      status: [1]
+    - original_index: 408
+      status: [0]
+    - original_index: 409
+      status: [2]
+    - original_index: 410
+      status: [1]
+    - original_index: 411
+      status: [3]
+    - original_index: 412
+      status: [3]
+    - original_index: 413
+      status: [4]
+    - original_index: 414
+      status: [2]
+    - original_index: 415
+      status: [2]
+    - original_index: 416
+      status: [0]
+    - original_index: 417
+      status: [1]
+    - original_index: 418
+      status: [0]
+    - original_index: 419
+      status: [1]
+    - original_index: 420
+      status: [2]
+    - original_index: 421
+      status: [4]
+    - original_index: 422
+      status: [2]
+    - original_index: 423
+      status: [0]
+    - original_index: 424
+      status: [3]
+    - original_index: 425
+      status: [1]
+    - original_index: 426
+      status: [2]
+    - original_index: 427
+      status: [4]
+    - original_index: 428
+      status: [4]
+    - original_index: 429
+      status: [2]
+    - original_index: 430
+      status: [4]
+    - original_index: 431
+      status: [2]
+    - original_index: 432
+      status: [1]
+    - original_index: 433
+      status: [0]
+    - original_index: 434
+      status: [3]
+    - original_index: 435
+      status: [3]
+    - original_index: 436
+      status: [0]
+    - original_index: 437
+      status: [1]
+    - original_index: 438
+      status: [0]
+    - original_index: 439
+      status: [1]
+    - original_index: 440
+      status: [1]
+    - original_index: 441
+      status: [1]
+    - original_index: 442
+      status: [3]
+    - original_index: 443
+      status: [3]
+    - original_index: 444
+      status: [0]
+    - original_index: 445
+      status: [0]
+    - original_index: 446
+      status: [4]
+    - original_index: 447
+      status: [4]
+    - original_index: 448
+      status: [0]
+    - original_index: 449
+      status: [2]
+    - original_index: 450
+      status: [4]
+    - original_index: 451
+      status: [2]
+    - original_index: 452
+      status: [4]
+    - original_index: 453
+      status: [3]
+    - original_index: 454
+      status: [2]
+    - original_index: 455
+      status: [2]
+    - original_index: 456
+      status: [0]
+    - original_index: 457
+      status: [1]
+    - original_index: 458
+      status: [1]
+    - original_index: 459
+      status: [3]
+    - original_index: 460
+      status: [3]
+    - original_index: 461
+      status: [2]
+    - original_index: 462
+      status: [1]
+    - original_index: 463
+      status: [4]
+    - original_index: 464
+      status: [0]
+    - original_index: 465
+      status: [0]
+    - original_index: 466
+      status: [1]
+    - original_index: 467
+      status: [0]
+  output:
+  - - committee: [202, 39]
+      shard: 102
+      total_validator_count: 173
+  - - committee: [384, 417, 46]
+      shard: 103
+      total_validator_count: 173
+  - - committee: [119, 235, 400]
+      shard: 104
+      total_validator_count: 173
+  - - committee: [84, 457]
+      shard: 105
+      total_validator_count: 173
+  - - committee: [381, 184, 61]
+      shard: 106
+      total_validator_count: 173
+  - - committee: [19, 291, 391]
+      shard: 107
+      total_validator_count: 173
+  - - committee: [65, 370]
+      shard: 108
+      total_validator_count: 173
+  - - committee: [102, 246, 362]
+      shard: 109
+      total_validator_count: 173
+  - - committee: [113, 44, 58]
+      shard: 110
+      total_validator_count: 173
+  - - committee: [293, 446, 162]
+      shard: 111
+      total_validator_count: 173
+  - - committee: [427, 262]
+      shard: 112
+      total_validator_count: 173
+  - - committee: [216, 393, 447]
+      shard: 113
+      total_validator_count: 173
+  - - committee: [397, 2, 27]
+      shard: 114
+      total_validator_count: 173
+  - - committee: [425, 265]
+      shard: 115
+      total_validator_count: 173
+  - - committee: [389, 223, 180]
+      shard: 116
+      total_validator_count: 173
+  - - committee: [287, 154, 115]
+      shard: 117
+      total_validator_count: 173
+  - - committee: [304, 90]
+      shard: 118
+      total_validator_count: 173
+  - - committee: [244, 250, 117]
+      shard: 119
+      total_validator_count: 173
+  - - committee: [110, 239, 155]
+      shard: 120
+      total_validator_count: 173
+  - - committee: [17, 178, 189]
+      shard: 121
+      total_validator_count: 173
+  - - committee: [240, 225]
+      shard: 122
+      total_validator_count: 173
+  - - committee: [3, 356, 357]
+      shard: 123
+      total_validator_count: 173
+  - - committee: [261, 407, 208]
+      shard: 124
+      total_validator_count: 173
+  - - committee: [7, 270]
+      shard: 125
+      total_validator_count: 173
+  - - committee: [25, 274, 14]
+      shard: 126
+      total_validator_count: 173
+  - - committee: [321, 312, 333]
+      shard: 127
+      total_validator_count: 173
+  - - committee: [135, 344]
+      shard: 128
+      total_validator_count: 173
+  - - committee: [332, 326, 126]
+      shard: 129
+      total_validator_count: 173
+  - - committee: [195, 226, 71]
+      shard: 130
+      total_validator_count: 173
+  - - committee: [87, 306, 139]
+      shard: 131
+      total_validator_count: 173
+  - - committee: [395, 256]
+      shard: 132
+      total_validator_count: 173
+  - - committee: [258, 405, 359]
+      shard: 133
+      total_validator_count: 173
+  - - committee: [419, 253, 47]
+      shard: 134
+      total_validator_count: 173
+  - - committee: [269, 220]
+      shard: 135
+      total_validator_count: 173
+  - - committee: [421, 138, 66]
+      shard: 136
+      total_validator_count: 173
+  - - committee: [222, 78, 75]
+      shard: 137
+      total_validator_count: 173
+  - - committee: [366, 458, 430]
+      shard: 138
+      total_validator_count: 173
+  - - committee: [334, 26]
+      shard: 139
+      total_validator_count: 173
+  - - committee: [169, 137, 327]
+      shard: 140
+      total_validator_count: 173
+  - - committee: [452, 130, 89]
+      shard: 141
+      total_validator_count: 173
+  - - committee: [450, 131]
+      shard: 142
+      total_validator_count: 173
+  - - committee: [328, 218, 230]
+      shard: 143
+      total_validator_count: 173
+  - - committee: [176, 466, 167]
+      shard: 144
+      total_validator_count: 173
+  - - committee: [179, 30]
+      shard: 145
+      total_validator_count: 173
+  - - committee: [329, 341, 50]
+      shard: 146
+      total_validator_count: 173
+  - - committee: [238, 463, 215]
+      shard: 147
+      total_validator_count: 173
+  - - committee: [440, 141, 111]
+      shard: 148
+      total_validator_count: 173
+  - - committee: [303, 439]
+      shard: 149
+      total_validator_count: 173
+  - - committee: [315, 410, 38]
+      shard: 150
+      total_validator_count: 173
+  - - committee: [382, 94, 29]
+      shard: 151
+      total_validator_count: 173
+  - - committee: [150, 12]
+      shard: 152
+      total_validator_count: 173
+  - - committee: [437, 15, 428]
+      shard: 153
+      total_validator_count: 173
+  - - committee: [83, 40, 302]
+      shard: 154
+      total_validator_count: 173
+  - - committee: [413, 201]
+      shard: 155
+      total_validator_count: 173
+  - - committee: [399, 129, 197]
+      shard: 156
+      total_validator_count: 173
+  - - committee: [5, 388, 295]
+      shard: 157
+      total_validator_count: 173
+  - - committee: [375, 34, 462]
+      shard: 158
+      total_validator_count: 173
+  - - committee: [73, 127]
+      shard: 159
+      total_validator_count: 173
+  - - committee: [177, 406, 313]
+      shard: 160
+      total_validator_count: 173
+  - - committee: [144, 432, 339]
+      shard: 161
+      total_validator_count: 173
+  - - committee: [361, 37]
+      shard: 162
+      total_validator_count: 173
+  - - committee: [316, 88, 22]
+      shard: 163
+      total_validator_count: 173
+  - - committee: [18, 317, 242]
+      shard: 164
+      total_validator_count: 173
+  - - committee: [380, 211, 441]
+      shard: 165
+      total_validator_count: 173
+  seed: '0xadb35f3fc2880d220e520120a032bbaa0f4bd7a5fcf1c2269de21075e7a46471'
+- input:
+    crosslinking_start_shard: 133
+    validators:
+    - original_index: 0
+      status: [2]
+    - original_index: 1
+      status: [0]
+    - original_index: 2
+      status: [4]
+    - original_index: 3
+      status: [2]
+    - original_index: 4
+      status: [4]
+    - original_index: 5
+      status: [2]
+    - original_index: 6
+      status: [0]
+    - original_index: 7
+      status: [3]
+    - original_index: 8
+      status: [1]
+    - original_index: 9
+      status: [0]
+    - original_index: 10
+      status: [2]
+    - original_index: 11
+      status: [1]
+    - original_index: 12
+      status: [0]
+    - original_index: 13
+      status: [3]
+    - original_index: 14
+      status: [2]
+    - original_index: 15
+      status: [2]
+    - original_index: 16
+      status: [0]
+    - original_index: 17
+      status: [0]
+    - original_index: 18
+      status: [3]
+    - original_index: 19
+      status: [4]
+    - original_index: 20
+      status: [1]
+    - original_index: 21
+      status: [2]
+    - original_index: 22
+      status: [4]
+    - original_index: 23
+      status: [0]
+    - original_index: 24
+      status: [0]
+    - original_index: 25
+      status: [0]
+    - original_index: 26
+      status: [2]
+    - original_index: 27
+      status: [3]
+    - original_index: 28
+      status: [0]
+    - original_index: 29
+      status: [3]
+    - original_index: 30
+      status: [4]
+    - original_index: 31
+      status: [1]
+    - original_index: 32
+      status: [0]
+    - original_index: 33
+      status: [1]
+    - original_index: 34
+      status: [4]
+    - original_index: 35
+      status: [0]
+    - original_index: 36
+      status: [3]
+    - original_index: 37
+      status: [0]
+    - original_index: 38
+      status: [4]
+    - original_index: 39
+      status: [1]
+    - original_index: 40
+      status: [0]
+    - original_index: 41
+      status: [3]
+    - original_index: 42
+      status: [2]
+    - original_index: 43
+      status: [3]
+    - original_index: 44
+      status: [4]
+    - original_index: 45
+      status: [0]
+    - original_index: 46
+      status: [3]
+    - original_index: 47
+      status: [3]
+    - original_index: 48
+      status: [4]
+    - original_index: 49
+      status: [3]
+    - original_index: 50
+      status: [3]
+    - original_index: 51
+      status: [4]
+    - original_index: 52
+      status: [1]
+    - original_index: 53
+      status: [3]
+    - original_index: 54
+      status: [3]
+    - original_index: 55
+      status: [1]
+    - original_index: 56
+      status: [0]
+    - original_index: 57
+      status: [0]
+    - original_index: 58
+      status: [0]
+    - original_index: 59
+      status: [0]
+    - original_index: 60
+      status: [2]
+    - original_index: 61
+      status: [2]
+    - original_index: 62
+      status: [1]
+    - original_index: 63
+      status: [3]
+    - original_index: 64
+      status: [4]
+    - original_index: 65
+      status: [4]
+    - original_index: 66
+      status: [4]
+    - original_index: 67
+      status: [3]
+    - original_index: 68
+      status: [3]
+    - original_index: 69
+      status: [3]
+    - original_index: 70
+      status: [4]
+    - original_index: 71
+      status: [3]
+    - original_index: 72
+      status: [3]
+    - original_index: 73
+      status: [1]
+    - original_index: 74
+      status: [2]
+    - original_index: 75
+      status: [3]
+    - original_index: 76
+      status: [2]
+    - original_index: 77
+      status: [3]
+    - original_index: 78
+      status: [3]
+    - original_index: 79
+      status: [3]
+    - original_index: 80
+      status: [2]
+    - original_index: 81
+      status: [2]
+    - original_index: 82
+      status: [2]
+    - original_index: 83
+      status: [4]
+    - original_index: 84
+      status: [0]
+    - original_index: 85
+      status: [0]
+    - original_index: 86
+      status: [1]
+    - original_index: 87
+      status: [2]
+    - original_index: 88
+      status: [2]
+    - original_index: 89
+      status: [4]
+    - original_index: 90
+      status: [4]
+    - original_index: 91
+      status: [4]
+    - original_index: 92
+      status: [2]
+    - original_index: 93
+      status: [0]
+    - original_index: 94
+      status: [4]
+    - original_index: 95
+      status: [0]
+    - original_index: 96
+      status: [1]
+    - original_index: 97
+      status: [1]
+    - original_index: 98
+      status: [4]
+    - original_index: 99
+      status: [3]
+    - original_index: 100
+      status: [4]
+    - original_index: 101
+      status: [4]
+    - original_index: 102
+      status: [3]
+    - original_index: 103
+      status: [4]
+    - original_index: 104
+      status: [0]
+    - original_index: 105
+      status: [1]
+    - original_index: 106
+      status: [0]
+    - original_index: 107
+      status: [1]
+    - original_index: 108
+      status: [1]
+    - original_index: 109
+      status: [3]
+    - original_index: 110
+      status: [3]
+    - original_index: 111
+      status: [0]
+    - original_index: 112
+      status: [0]
+    - original_index: 113
+      status: [0]
+    - original_index: 114
+      status: [1]
+    - original_index: 115
+      status: [3]
+    - original_index: 116
+      status: [2]
+    - original_index: 117
+      status: [0]
+    - original_index: 118
+      status: [0]
+    - original_index: 119
+      status: [4]
+    - original_index: 120
+      status: [2]
+    - original_index: 121
+      status: [1]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [4]
+    - original_index: 124
+      status: [3]
+    - original_index: 125
+      status: [0]
+    - original_index: 126
+      status: [4]
+    - original_index: 127
+      status: [0]
+    - original_index: 128
+      status: [0]
+    - original_index: 129
+      status: [0]
+    - original_index: 130
+      status: [3]
+    - original_index: 131
+      status: [0]
+    - original_index: 132
+      status: [4]
+    - original_index: 133
+      status: [1]
+    - original_index: 134
+      status: [1]
+    - original_index: 135
+      status: [1]
+    - original_index: 136
+      status: [4]
+    - original_index: 137
+      status: [1]
+    - original_index: 138
+      status: [0]
+    - original_index: 139
+      status: [3]
+    - original_index: 140
+      status: [2]
+    - original_index: 141
+      status: [4]
+    - original_index: 142
+      status: [2]
+    - original_index: 143
+      status: [0]
+    - original_index: 144
+      status: [4]
+    - original_index: 145
+      status: [2]
+    - original_index: 146
+      status: [3]
+    - original_index: 147
+      status: [4]
+    - original_index: 148
+      status: [1]
+    - original_index: 149
+      status: [1]
+    - original_index: 150
+      status: [0]
+    - original_index: 151
+      status: [1]
+    - original_index: 152
+      status: [3]
+    - original_index: 153
+      status: [2]
+    - original_index: 154
+      status: [2]
+    - original_index: 155
+      status: [2]
+    - original_index: 156
+      status: [3]
+    - original_index: 157
+      status: [0]
+    - original_index: 158
+      status: [3]
+    - original_index: 159
+      status: [0]
+    - original_index: 160
+      status: [1]
+    - original_index: 161
+      status: [0]
+    - original_index: 162
+      status: [2]
+    - original_index: 163
+      status: [0]
+    - original_index: 164
+      status: [2]
+    - original_index: 165
+      status: [1]
+    - original_index: 166
+      status: [1]
+    - original_index: 167
+      status: [4]
+    - original_index: 168
+      status: [1]
+    - original_index: 169
+      status: [2]
+    - original_index: 170
+      status: [4]
+    - original_index: 171
+      status: [1]
+    - original_index: 172
+      status: [1]
+    - original_index: 173
+      status: [4]
+    - original_index: 174
+      status: [0]
+    - original_index: 175
+      status: [3]
+    - original_index: 176
+      status: [2]
+    - original_index: 177
+      status: [3]
+    - original_index: 178
+      status: [0]
+    - original_index: 179
+      status: [4]
+    - original_index: 180
+      status: [1]
+    - original_index: 181
+      status: [0]
+    - original_index: 182
+      status: [0]
+    - original_index: 183
+      status: [0]
+    - original_index: 184
+      status: [4]
+    - original_index: 185
+      status: [1]
+    - original_index: 186
+      status: [3]
+    - original_index: 187
+      status: [0]
+    - original_index: 188
+      status: [3]
+    - original_index: 189
+      status: [1]
+    - original_index: 190
+      status: [4]
+    - original_index: 191
+      status: [3]
+    - original_index: 192
+      status: [2]
+    - original_index: 193
+      status: [0]
+    - original_index: 194
+      status: [2]
+    - original_index: 195
+      status: [4]
+    - original_index: 196
+      status: [1]
+    - original_index: 197
+      status: [3]
+    - original_index: 198
+      status: [1]
+    - original_index: 199
+      status: [4]
+    - original_index: 200
+      status: [1]
+    - original_index: 201
+      status: [3]
+    - original_index: 202
+      status: [2]
+    - original_index: 203
+      status: [1]
+    - original_index: 204
+      status: [2]
+    - original_index: 205
+      status: [4]
+    - original_index: 206
+      status: [0]
+    - original_index: 207
+      status: [3]
+    - original_index: 208
+      status: [1]
+    - original_index: 209
+      status: [1]
+    - original_index: 210
+      status: [0]
+    - original_index: 211
+      status: [3]
+    - original_index: 212
+      status: [1]
+    - original_index: 213
+      status: [1]
+    - original_index: 214
+      status: [2]
+    - original_index: 215
+      status: [1]
+    - original_index: 216
+      status: [4]
+    - original_index: 217
+      status: [2]
+    - original_index: 218
+      status: [1]
+    - original_index: 219
+      status: [4]
+    - original_index: 220
+      status: [0]
+    - original_index: 221
+      status: [3]
+    - original_index: 222
+      status: [2]
+    - original_index: 223
+      status: [0]
+    - original_index: 224
+      status: [0]
+    - original_index: 225
+      status: [4]
+    - original_index: 226
+      status: [3]
+    - original_index: 227
+      status: [2]
+    - original_index: 228
+      status: [1]
+    - original_index: 229
+      status: [2]
+    - original_index: 230
+      status: [3]
+    - original_index: 231
+      status: [1]
+    - original_index: 232
+      status: [1]
+    - original_index: 233
+      status: [1]
+    - original_index: 234
+      status: [4]
+    - original_index: 235
+      status: [2]
+    - original_index: 236
+      status: [2]
+    - original_index: 237
+      status: [0]
+    - original_index: 238
+      status: [1]
+    - original_index: 239
+      status: [1]
+    - original_index: 240
+      status: [0]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [4]
+    - original_index: 243
+      status: [2]
+    - original_index: 244
+      status: [0]
+    - original_index: 245
+      status: [4]
+    - original_index: 246
+      status: [1]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [0]
+    - original_index: 249
+      status: [0]
+    - original_index: 250
+      status: [0]
+    - original_index: 251
+      status: [1]
+    - original_index: 252
+      status: [3]
+    - original_index: 253
+      status: [1]
+    - original_index: 254
+      status: [4]
+    - original_index: 255
+      status: [3]
+    - original_index: 256
+      status: [0]
+    - original_index: 257
+      status: [1]
+    - original_index: 258
+      status: [0]
+    - original_index: 259
+      status: [2]
+    - original_index: 260
+      status: [4]
+    - original_index: 261
+      status: [1]
+    - original_index: 262
+      status: [0]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [1]
+    - original_index: 265
+      status: [0]
+    - original_index: 266
+      status: [4]
+    - original_index: 267
+      status: [3]
+    - original_index: 268
+      status: [1]
+    - original_index: 269
+      status: [1]
+    - original_index: 270
+      status: [1]
+    - original_index: 271
+      status: [2]
+    - original_index: 272
+      status: [0]
+    - original_index: 273
+      status: [0]
+    - original_index: 274
+      status: [0]
+    - original_index: 275
+      status: [4]
+    - original_index: 276
+      status: [0]
+    - original_index: 277
+      status: [2]
+    - original_index: 278
+      status: [2]
+    - original_index: 279
+      status: [0]
+    - original_index: 280
+      status: [4]
+    - original_index: 281
+      status: [2]
+    - original_index: 282
+      status: [3]
+    - original_index: 283
+      status: [2]
+    - original_index: 284
+      status: [4]
+    - original_index: 285
+      status: [4]
+    - original_index: 286
+      status: [3]
+    - original_index: 287
+      status: [4]
+    - original_index: 288
+      status: [3]
+    - original_index: 289
+      status: [3]
+    - original_index: 290
+      status: [0]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [0]
+    - original_index: 293
+      status: [2]
+    - original_index: 294
+      status: [2]
+    - original_index: 295
+      status: [4]
+    - original_index: 296
+      status: [1]
+    - original_index: 297
+      status: [4]
+    - original_index: 298
+      status: [4]
+    - original_index: 299
+      status: [4]
+    - original_index: 300
+      status: [3]
+    - original_index: 301
+      status: [2]
+    - original_index: 302
+      status: [3]
+    - original_index: 303
+      status: [2]
+    - original_index: 304
+      status: [0]
+    - original_index: 305
+      status: [2]
+    - original_index: 306
+      status: [2]
+    - original_index: 307
+      status: [2]
+    - original_index: 308
+      status: [4]
+    - original_index: 309
+      status: [2]
+    - original_index: 310
+      status: [4]
+    - original_index: 311
+      status: [1]
+    - original_index: 312
+      status: [0]
+    - original_index: 313
+      status: [1]
+    - original_index: 314
+      status: [0]
+    - original_index: 315
+      status: [4]
+    - original_index: 316
+      status: [0]
+    - original_index: 317
+      status: [4]
+    - original_index: 318
+      status: [1]
+    - original_index: 319
+      status: [1]
+    - original_index: 320
+      status: [2]
+    - original_index: 321
+      status: [2]
+    - original_index: 322
+      status: [4]
+    - original_index: 323
+      status: [3]
+    - original_index: 324
+      status: [4]
+    - original_index: 325
+      status: [4]
+    - original_index: 326
+      status: [3]
+    - original_index: 327
+      status: [3]
+    - original_index: 328
+      status: [4]
+    - original_index: 329
+      status: [2]
+    - original_index: 330
+      status: [3]
+    - original_index: 331
+      status: [0]
+    - original_index: 332
+      status: [2]
+    - original_index: 333
+      status: [1]
+    - original_index: 334
+      status: [4]
+    - original_index: 335
+      status: [0]
+    - original_index: 336
+      status: [0]
+    - original_index: 337
+      status: [4]
+    - original_index: 338
+      status: [1]
+    - original_index: 339
+      status: [2]
+    - original_index: 340
+      status: [1]
+    - original_index: 341
+      status: [4]
+    - original_index: 342
+      status: [1]
+    - original_index: 343
+      status: [2]
+    - original_index: 344
+      status: [0]
+    - original_index: 345
+      status: [4]
+    - original_index: 346
+      status: [4]
+    - original_index: 347
+      status: [1]
+    - original_index: 348
+      status: [4]
+    - original_index: 349
+      status: [1]
+    - original_index: 350
+      status: [1]
+    - original_index: 351
+      status: [4]
+  output:
+  - - committee: [126, 346]
+      shard: 133
+      total_validator_count: 146
+  - - committee: [171, 328]
+      shard: 134
+      total_validator_count: 146
+  - - committee: [105, 121]
+      shard: 135
+      total_validator_count: 146
+  - - committee: [209, 173, 66]
+      shard: 136
+      total_validator_count: 146
+  - - committee: [52, 242]
+      shard: 137
+      total_validator_count: 146
+  - - committee: [347, 199]
+      shard: 138
+      total_validator_count: 146
+  - - committee: [198, 232]
+      shard: 139
+      total_validator_count: 146
+  - - committee: [263, 55, 269]
+      shard: 140
+      total_validator_count: 146
+  - - committee: [20, 233]
+      shard: 141
+      total_validator_count: 146
+  - - committee: [225, 94]
+      shard: 142
+      total_validator_count: 146
+  - - committee: [338, 196, 239]
+      shard: 143
+      total_validator_count: 146
+  - - committee: [185, 144]
+      shard: 144
+      total_validator_count: 146
+  - - committee: [219, 180]
+      shard: 145
+      total_validator_count: 146
+  - - committee: [324, 297]
+      shard: 146
+      total_validator_count: 146
+  - - committee: [22, 96, 342]
+      shard: 147
+      total_validator_count: 146
+  - - committee: [160, 285]
+      shard: 148
+      total_validator_count: 146
+  - - committee: [103, 200]
+      shard: 149
+      total_validator_count: 146
+  - - committee: [266, 208, 351]
+      shard: 150
+      total_validator_count: 146
+  - - committee: [257, 350]
+      shard: 151
+      total_validator_count: 146
+  - - committee: [245, 345]
+      shard: 152
+      total_validator_count: 146
+  - - committee: [134, 48]
+      shard: 153
+      total_validator_count: 146
+  - - committee: [349, 62, 275]
+      shard: 154
+      total_validator_count: 146
+  - - committee: [34, 114]
+      shard: 155
+      total_validator_count: 146
+  - - committee: [284, 167]
+      shard: 156
+      total_validator_count: 146
+  - - committee: [319, 31, 147]
+      shard: 157
+      total_validator_count: 146
+  - - committee: [340, 348]
+      shard: 158
+      total_validator_count: 146
+  - - committee: [98, 246]
+      shard: 159
+      total_validator_count: 146
+  - - committee: [51, 315]
+      shard: 160
+      total_validator_count: 146
+  - - committee: [30, 241, 119]
+      shard: 161
+      total_validator_count: 146
+  - - committee: [189, 251]
+      shard: 162
+      total_validator_count: 146
+  - - committee: [205, 70]
+      shard: 163
+      total_validator_count: 146
+  - - committee: [44, 317, 90]
+      shard: 164
+      total_validator_count: 146
+  - - committee: [19, 295]
+      shard: 165
+      total_validator_count: 146
+  - - committee: [296, 231]
+      shard: 166
+      total_validator_count: 146
+  - - committee: [64, 4]
+      shard: 167
+      total_validator_count: 146
+  - - committee: [165, 38, 8]
+      shard: 168
+      total_validator_count: 146
+  - - committee: [135, 195]
+      shard: 169
+      total_validator_count: 146
+  - - committee: [89, 151]
+      shard: 170
+      total_validator_count: 146
+  - - committee: [168, 253]
+      shard: 171
+      total_validator_count: 146
+  - - committee: [310, 280, 333]
+      shard: 172
+      total_validator_count: 146
+  - - committee: [11, 337]
+      shard: 173
+      total_validator_count: 146
+  - - committee: [261, 268]
+      shard: 174
+      total_validator_count: 146
+  - - committee: [318, 184, 170]
+      shard: 175
+      total_validator_count: 146
+  - - committee: [228, 149]
+      shard: 176
+      total_validator_count: 146
+  - - committee: [190, 132]
+      shard: 177
+      total_validator_count: 146
+  - - committee: [107, 238]
+      shard: 178
+      total_validator_count: 146
+  - - committee: [123, 334, 179]
+      shard: 179
+      total_validator_count: 146
+  - - committee: [108, 148]
+      shard: 180
+      total_validator_count: 146
+  - - committee: [91, 166]
+      shard: 181
+      total_validator_count: 146
+  - - committee: [172, 325, 73]
+      shard: 182
+      total_validator_count: 146
+  - - committee: [213, 322]
+      shard: 183
+      total_validator_count: 146
+  - - committee: [254, 203]
+      shard: 184
+      total_validator_count: 146
+  - - committee: [270, 308]
+      shard: 185
+      total_validator_count: 146
+  - - committee: [260, 100, 65]
+      shard: 186
+      total_validator_count: 146
+  - - committee: [311, 298]
+      shard: 187
+      total_validator_count: 146
+  - - committee: [133, 97]
+      shard: 188
+      total_validator_count: 146
+  - - committee: [2, 136, 33]
+      shard: 189
+      total_validator_count: 146
+  - - committee: [218, 86]
+      shard: 190
+      total_validator_count: 146
+  - - committee: [141, 264]
+      shard: 191
+      total_validator_count: 146
+  - - committee: [137, 215]
+      shard: 192
+      total_validator_count: 146
+  - - committee: [234, 101, 212]
+      shard: 193
+      total_validator_count: 146
+  - - committee: [216, 39]
+      shard: 194
+      total_validator_count: 146
+  - - committee: [299, 313]
+      shard: 195
+      total_validator_count: 146
+  - - committee: [83, 287, 341]
+      shard: 196
+      total_validator_count: 146
+  seed: '0x1e91ab35b1106e8984dfc0dfa36018004f880b431c2a14f66354bf0192292ffa'
+- input:
+    crosslinking_start_shard: 323
+    validators:
+    - original_index: 0
+      status: [0]
+    - original_index: 1
+      status: [3]
+    - original_index: 2
+      status: [2]
+    - original_index: 3
+      status: [3]
+    - original_index: 4
+      status: [2]
+    - original_index: 5
+      status: [2]
+    - original_index: 6
+      status: [2]
+    - original_index: 7
+      status: [2]
+    - original_index: 8
+      status: [4]
+    - original_index: 9
+      status: [3]
+    - original_index: 10
+      status: [1]
+    - original_index: 11
+      status: [1]
+    - original_index: 12
+      status: [2]
+    - original_index: 13
+      status: [3]
+    - original_index: 14
+      status: [1]
+    - original_index: 15
+      status: [1]
+    - original_index: 16
+      status: [2]
+    - original_index: 17
+      status: [0]
+    - original_index: 18
+      status: [2]
+    - original_index: 19
+      status: [2]
+    - original_index: 20
+      status: [2]
+    - original_index: 21
+      status: [0]
+    - original_index: 22
+      status: [2]
+    - original_index: 23
+      status: [2]
+    - original_index: 24
+      status: [2]
+    - original_index: 25
+      status: [1]
+    - original_index: 26
+      status: [3]
+    - original_index: 27
+      status: [1]
+    - original_index: 28
+      status: [3]
+    - original_index: 29
+      status: [0]
+    - original_index: 30
+      status: [4]
+    - original_index: 31
+      status: [4]
+    - original_index: 32
+      status: [2]
+    - original_index: 33
+      status: [3]
+    - original_index: 34
+      status: [0]
+    - original_index: 35
+      status: [0]
+    - original_index: 36
+      status: [0]
+    - original_index: 37
+      status: [0]
+    - original_index: 38
+      status: [3]
+    - original_index: 39
+      status: [4]
+    - original_index: 40
+      status: [1]
+    - original_index: 41
+      status: [2]
+    - original_index: 42
+      status: [1]
+    - original_index: 43
+      status: [4]
+    - original_index: 44
+      status: [3]
+    - original_index: 45
+      status: [3]
+    - original_index: 46
+      status: [4]
+    - original_index: 47
+      status: [0]
+    - original_index: 48
+      status: [4]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [4]
+    - original_index: 51
+      status: [0]
+    - original_index: 52
+      status: [0]
+    - original_index: 53
+      status: [1]
+    - original_index: 54
+      status: [1]
+    - original_index: 55
+      status: [3]
+    - original_index: 56
+      status: [0]
+    - original_index: 57
+      status: [1]
+    - original_index: 58
+      status: [4]
+    - original_index: 59
+      status: [1]
+    - original_index: 60
+      status: [4]
+    - original_index: 61
+      status: [0]
+    - original_index: 62
+      status: [3]
+    - original_index: 63
+      status: [0]
+    - original_index: 64
+      status: [2]
+    - original_index: 65
+      status: [1]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [0]
+    - original_index: 68
+      status: [4]
+    - original_index: 69
+      status: [2]
+    - original_index: 70
+      status: [0]
+    - original_index: 71
+      status: [3]
+    - original_index: 72
+      status: [0]
+    - original_index: 73
+      status: [3]
+    - original_index: 74
+      status: [4]
+    - original_index: 75
+      status: [4]
+    - original_index: 76
+      status: [2]
+    - original_index: 77
+      status: [0]
+    - original_index: 78
+      status: [4]
+    - original_index: 79
+      status: [4]
+    - original_index: 80
+      status: [1]
+    - original_index: 81
+      status: [2]
+    - original_index: 82
+      status: [0]
+    - original_index: 83
+      status: [4]
+    - original_index: 84
+      status: [3]
+    - original_index: 85
+      status: [2]
+    - original_index: 86
+      status: [0]
+    - original_index: 87
+      status: [1]
+    - original_index: 88
+      status: [1]
+    - original_index: 89
+      status: [4]
+    - original_index: 90
+      status: [2]
+    - original_index: 91
+      status: [3]
+    - original_index: 92
+      status: [3]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [3]
+    - original_index: 95
+      status: [2]
+    - original_index: 96
+      status: [2]
+    - original_index: 97
+      status: [3]
+    - original_index: 98
+      status: [4]
+    - original_index: 99
+      status: [0]
+    - original_index: 100
+      status: [3]
+    - original_index: 101
+      status: [2]
+    - original_index: 102
+      status: [4]
+    - original_index: 103
+      status: [2]
+    - original_index: 104
+      status: [2]
+    - original_index: 105
+      status: [4]
+    - original_index: 106
+      status: [3]
+    - original_index: 107
+      status: [1]
+    - original_index: 108
+      status: [1]
+    - original_index: 109
+      status: [4]
+    - original_index: 110
+      status: [0]
+    - original_index: 111
+      status: [3]
+    - original_index: 112
+      status: [4]
+    - original_index: 113
+      status: [1]
+    - original_index: 114
+      status: [1]
+    - original_index: 115
+      status: [4]
+    - original_index: 116
+      status: [1]
+    - original_index: 117
+      status: [3]
+    - original_index: 118
+      status: [3]
+    - original_index: 119
+      status: [4]
+    - original_index: 120
+      status: [0]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [2]
+    - original_index: 123
+      status: [4]
+    - original_index: 124
+      status: [2]
+    - original_index: 125
+      status: [2]
+    - original_index: 126
+      status: [1]
+    - original_index: 127
+      status: [4]
+    - original_index: 128
+      status: [3]
+    - original_index: 129
+      status: [4]
+    - original_index: 130
+      status: [2]
+    - original_index: 131
+      status: [4]
+    - original_index: 132
+      status: [0]
+    - original_index: 133
+      status: [4]
+    - original_index: 134
+      status: [0]
+    - original_index: 135
+      status: [3]
+    - original_index: 136
+      status: [0]
+    - original_index: 137
+      status: [4]
+    - original_index: 138
+      status: [4]
+    - original_index: 139
+      status: [3]
+    - original_index: 140
+      status: [2]
+    - original_index: 141
+      status: [4]
+    - original_index: 142
+      status: [3]
+    - original_index: 143
+      status: [2]
+    - original_index: 144
+      status: [1]
+    - original_index: 145
+      status: [0]
+    - original_index: 146
+      status: [4]
+    - original_index: 147
+      status: [2]
+    - original_index: 148
+      status: [4]
+    - original_index: 149
+      status: [2]
+    - original_index: 150
+      status: [2]
+    - original_index: 151
+      status: [4]
+    - original_index: 152
+      status: [3]
+    - original_index: 153
+      status: [0]
+    - original_index: 154
+      status: [0]
+    - original_index: 155
+      status: [2]
+    - original_index: 156
+      status: [0]
+    - original_index: 157
+      status: [3]
+    - original_index: 158
+      status: [3]
+    - original_index: 159
+      status: [4]
+    - original_index: 160
+      status: [2]
+    - original_index: 161
+      status: [3]
+    - original_index: 162
+      status: [2]
+    - original_index: 163
+      status: [4]
+    - original_index: 164
+      status: [2]
+    - original_index: 165
+      status: [4]
+    - original_index: 166
+      status: [4]
+    - original_index: 167
+      status: [1]
+    - original_index: 168
+      status: [4]
+    - original_index: 169
+      status: [3]
+    - original_index: 170
+      status: [4]
+    - original_index: 171
+      status: [3]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [1]
+    - original_index: 174
+      status: [4]
+    - original_index: 175
+      status: [4]
+    - original_index: 176
+      status: [4]
+    - original_index: 177
+      status: [2]
+    - original_index: 178
+      status: [3]
+    - original_index: 179
+      status: [3]
+    - original_index: 180
+      status: [0]
+    - original_index: 181
+      status: [0]
+    - original_index: 182
+      status: [0]
+    - original_index: 183
+      status: [2]
+    - original_index: 184
+      status: [3]
+    - original_index: 185
+      status: [2]
+    - original_index: 186
+      status: [3]
+    - original_index: 187
+      status: [1]
+    - original_index: 188
+      status: [0]
+    - original_index: 189
+      status: [3]
+    - original_index: 190
+      status: [3]
+    - original_index: 191
+      status: [1]
+    - original_index: 192
+      status: [2]
+    - original_index: 193
+      status: [3]
+    - original_index: 194
+      status: [3]
+    - original_index: 195
+      status: [2]
+    - original_index: 196
+      status: [2]
+    - original_index: 197
+      status: [3]
+    - original_index: 198
+      status: [0]
+    - original_index: 199
+      status: [4]
+    - original_index: 200
+      status: [3]
+    - original_index: 201
+      status: [3]
+    - original_index: 202
+      status: [1]
+    - original_index: 203
+      status: [4]
+    - original_index: 204
+      status: [2]
+    - original_index: 205
+      status: [4]
+    - original_index: 206
+      status: [2]
+    - original_index: 207
+      status: [0]
+    - original_index: 208
+      status: [2]
+    - original_index: 209
+      status: [1]
+    - original_index: 210
+      status: [0]
+    - original_index: 211
+      status: [2]
+    - original_index: 212
+      status: [2]
+    - original_index: 213
+      status: [2]
+    - original_index: 214
+      status: [0]
+    - original_index: 215
+      status: [2]
+    - original_index: 216
+      status: [1]
+    - original_index: 217
+      status: [0]
+    - original_index: 218
+      status: [0]
+    - original_index: 219
+      status: [1]
+    - original_index: 220
+      status: [3]
+    - original_index: 221
+      status: [2]
+    - original_index: 222
+      status: [3]
+    - original_index: 223
+      status: [3]
+    - original_index: 224
+      status: [1]
+    - original_index: 225
+      status: [4]
+    - original_index: 226
+      status: [4]
+    - original_index: 227
+      status: [0]
+    - original_index: 228
+      status: [1]
+    - original_index: 229
+      status: [3]
+    - original_index: 230
+      status: [2]
+    - original_index: 231
+      status: [3]
+    - original_index: 232
+      status: [0]
+    - original_index: 233
+      status: [2]
+    - original_index: 234
+      status: [0]
+    - original_index: 235
+      status: [4]
+    - original_index: 236
+      status: [4]
+    - original_index: 237
+      status: [3]
+    - original_index: 238
+      status: [1]
+    - original_index: 239
+      status: [3]
+    - original_index: 240
+      status: [3]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [0]
+    - original_index: 243
+      status: [0]
+    - original_index: 244
+      status: [0]
+    - original_index: 245
+      status: [1]
+    - original_index: 246
+      status: [0]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [0]
+    - original_index: 249
+      status: [3]
+    - original_index: 250
+      status: [1]
+    - original_index: 251
+      status: [0]
+    - original_index: 252
+      status: [0]
+    - original_index: 253
+      status: [2]
+    - original_index: 254
+      status: [1]
+    - original_index: 255
+      status: [2]
+    - original_index: 256
+      status: [0]
+    - original_index: 257
+      status: [1]
+    - original_index: 258
+      status: [4]
+    - original_index: 259
+      status: [2]
+    - original_index: 260
+      status: [0]
+    - original_index: 261
+      status: [4]
+    - original_index: 262
+      status: [0]
+    - original_index: 263
+      status: [3]
+    - original_index: 264
+      status: [3]
+    - original_index: 265
+      status: [3]
+    - original_index: 266
+      status: [3]
+    - original_index: 267
+      status: [2]
+    - original_index: 268
+      status: [0]
+    - original_index: 269
+      status: [2]
+    - original_index: 270
+      status: [4]
+    - original_index: 271
+      status: [1]
+    - original_index: 272
+      status: [3]
+    - original_index: 273
+      status: [3]
+    - original_index: 274
+      status: [3]
+    - original_index: 275
+      status: [4]
+    - original_index: 276
+      status: [1]
+    - original_index: 277
+      status: [2]
+    - original_index: 278
+      status: [3]
+    - original_index: 279
+      status: [0]
+    - original_index: 280
+      status: [4]
+    - original_index: 281
+      status: [2]
+    - original_index: 282
+      status: [0]
+    - original_index: 283
+      status: [0]
+    - original_index: 284
+      status: [0]
+    - original_index: 285
+      status: [1]
+    - original_index: 286
+      status: [0]
+    - original_index: 287
+      status: [3]
+    - original_index: 288
+      status: [1]
+    - original_index: 289
+      status: [2]
+    - original_index: 290
+      status: [0]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [2]
+    - original_index: 293
+      status: [2]
+    - original_index: 294
+      status: [1]
+    - original_index: 295
+      status: [4]
+    - original_index: 296
+      status: [4]
+    - original_index: 297
+      status: [3]
+    - original_index: 298
+      status: [1]
+    - original_index: 299
+      status: [2]
+    - original_index: 300
+      status: [1]
+    - original_index: 301
+      status: [0]
+    - original_index: 302
+      status: [1]
+    - original_index: 303
+      status: [2]
+    - original_index: 304
+      status: [0]
+    - original_index: 305
+      status: [2]
+    - original_index: 306
+      status: [0]
+    - original_index: 307
+      status: [4]
+    - original_index: 308
+      status: [0]
+    - original_index: 309
+      status: [0]
+    - original_index: 310
+      status: [1]
+    - original_index: 311
+      status: [0]
+    - original_index: 312
+      status: [1]
+    - original_index: 313
+      status: [4]
+    - original_index: 314
+      status: [2]
+    - original_index: 315
+      status: [4]
+    - original_index: 316
+      status: [3]
+    - original_index: 317
+      status: [2]
+    - original_index: 318
+      status: [0]
+    - original_index: 319
+      status: [3]
+    - original_index: 320
+      status: [2]
+    - original_index: 321
+      status: [3]
+    - original_index: 322
+      status: [2]
+    - original_index: 323
+      status: [4]
+    - original_index: 324
+      status: [1]
+    - original_index: 325
+      status: [4]
+    - original_index: 326
+      status: [2]
+    - original_index: 327
+      status: [1]
+    - original_index: 328
+      status: [0]
+    - original_index: 329
+      status: [0]
+    - original_index: 330
+      status: [1]
+    - original_index: 331
+      status: [4]
+    - original_index: 332
+      status: [4]
+    - original_index: 333
+      status: [0]
+    - original_index: 334
+      status: [4]
+    - original_index: 335
+      status: [2]
+    - original_index: 336
+      status: [1]
+    - original_index: 337
+      status: [1]
+    - original_index: 338
+      status: [1]
+    - original_index: 339
+      status: [0]
+    - original_index: 340
+      status: [1]
+    - original_index: 341
+      status: [0]
+    - original_index: 342
+      status: [3]
+    - original_index: 343
+      status: [0]
+    - original_index: 344
+      status: [3]
+    - original_index: 345
+      status: [1]
+    - original_index: 346
+      status: [4]
+    - original_index: 347
+      status: [3]
+    - original_index: 348
+      status: [1]
+    - original_index: 349
+      status: [2]
+    - original_index: 350
+      status: [0]
+    - original_index: 351
+      status: [3]
+    - original_index: 352
+      status: [3]
+    - original_index: 353
+      status: [2]
+    - original_index: 354
+      status: [0]
+    - original_index: 355
+      status: [0]
+    - original_index: 356
+      status: [3]
+    - original_index: 357
+      status: [4]
+    - original_index: 358
+      status: [1]
+    - original_index: 359
+      status: [1]
+    - original_index: 360
+      status: [4]
+    - original_index: 361
+      status: [4]
+    - original_index: 362
+      status: [2]
+    - original_index: 363
+      status: [0]
+    - original_index: 364
+      status: [4]
+    - original_index: 365
+      status: [1]
+    - original_index: 366
+      status: [1]
+    - original_index: 367
+      status: [0]
+    - original_index: 368
+      status: [4]
+    - original_index: 369
+      status: [4]
+    - original_index: 370
+      status: [4]
+    - original_index: 371
+      status: [1]
+    - original_index: 372
+      status: [2]
+    - original_index: 373
+      status: [0]
+    - original_index: 374
+      status: [3]
+    - original_index: 375
+      status: [1]
+    - original_index: 376
+      status: [2]
+    - original_index: 377
+      status: [2]
+    - original_index: 378
+      status: [1]
+    - original_index: 379
+      status: [2]
+    - original_index: 380
+      status: [1]
+    - original_index: 381
+      status: [1]
+    - original_index: 382
+      status: [2]
+    - original_index: 383
+      status: [0]
+    - original_index: 384
+      status: [3]
+    - original_index: 385
+      status: [0]
+    - original_index: 386
+      status: [2]
+    - original_index: 387
+      status: [0]
+    - original_index: 388
+      status: [4]
+    - original_index: 389
+      status: [3]
+    - original_index: 390
+      status: [4]
+    - original_index: 391
+      status: [1]
+    - original_index: 392
+      status: [0]
+    - original_index: 393
+      status: [2]
+    - original_index: 394
+      status: [4]
+    - original_index: 395
+      status: [4]
+    - original_index: 396
+      status: [3]
+    - original_index: 397
+      status: [3]
+    - original_index: 398
+      status: [0]
+    - original_index: 399
+      status: [2]
+    - original_index: 400
+      status: [3]
+    - original_index: 401
+      status: [2]
+    - original_index: 402
+      status: [2]
+    - original_index: 403
+      status: [3]
+    - original_index: 404
+      status: [4]
+    - original_index: 405
+      status: [2]
+    - original_index: 406
+      status: [2]
+    - original_index: 407
+      status: [3]
+    - original_index: 408
+      status: [3]
+    - original_index: 409
+      status: [4]
+    - original_index: 410
+      status: [1]
+    - original_index: 411
+      status: [4]
+    - original_index: 412
+      status: [4]
+    - original_index: 413
+      status: [0]
+    - original_index: 414
+      status: [2]
+    - original_index: 415
+      status: [3]
+    - original_index: 416
+      status: [1]
+    - original_index: 417
+      status: [2]
+    - original_index: 418
+      status: [1]
+    - original_index: 419
+      status: [4]
+    - original_index: 420
+      status: [1]
+    - original_index: 421
+      status: [2]
+    - original_index: 422
+      status: [4]
+    - original_index: 423
+      status: [0]
+    - original_index: 424
+      status: [4]
+    - original_index: 425
+      status: [0]
+    - original_index: 426
+      status: [3]
+    - original_index: 427
+      status: [3]
+    - original_index: 428
+      status: [2]
+    - original_index: 429
+      status: [0]
+    - original_index: 430
+      status: [4]
+  output:
+  - - committee: [151, 209]
+      shard: 323
+      total_validator_count: 158
+  - - committee: [176, 340]
+      shard: 324
+      total_validator_count: 158
+  - - committee: [191, 53, 271]
+      shard: 325
+      total_validator_count: 158
+  - - committee: [412, 325]
+      shard: 326
+      total_validator_count: 158
+  - - committee: [163, 375, 409]
+      shard: 327
+      total_validator_count: 158
+  - - committee: [357, 337]
+      shard: 328
+      total_validator_count: 158
+  - - committee: [170, 202, 187]
+      shard: 329
+      total_validator_count: 158
+  - - committee: [148, 424]
+      shard: 330
+      total_validator_count: 158
+  - - committee: [107, 368, 330]
+      shard: 331
+      total_validator_count: 158
+  - - committee: [225, 168]
+      shard: 332
+      total_validator_count: 158
+  - - committee: [416, 381, 87]
+      shard: 333
+      total_validator_count: 158
+  - - committee: [366, 395]
+      shard: 334
+      total_validator_count: 158
+  - - committee: [105, 313, 116]
+      shard: 335
+      total_validator_count: 158
+  - - committee: [10, 380]
+      shard: 336
+      total_validator_count: 158
+  - - committee: [114, 365, 276]
+      shard: 337
+      total_validator_count: 158
+  - - committee: [80, 361]
+      shard: 338
+      total_validator_count: 158
+  - - committee: [98, 25]
+      shard: 339
+      total_validator_count: 158
+  - - committee: [257, 378, 167]
+      shard: 340
+      total_validator_count: 158
+  - - committee: [133, 165]
+      shard: 341
+      total_validator_count: 158
+  - - committee: [119, 166, 298]
+      shard: 342
+      total_validator_count: 158
+  - - committee: [338, 203]
+      shard: 343
+      total_validator_count: 158
+  - - committee: [57, 241, 307]
+      shard: 344
+      total_validator_count: 158
+  - - committee: [30, 235]
+      shard: 345
+      total_validator_count: 158
+  - - committee: [173, 144, 108]
+      shard: 346
+      total_validator_count: 158
+  - - committee: [159, 324]
+      shard: 347
+      total_validator_count: 158
+  - - committee: [68, 288, 254]
+      shard: 348
+      total_validator_count: 158
+  - - committee: [39, 50]
+      shard: 349
+      total_validator_count: 158
+  - - committee: [300, 358, 123]
+      shard: 350
+      total_validator_count: 158
+  - - committee: [79, 46]
+      shard: 351
+      total_validator_count: 158
+  - - committee: [302, 371, 430]
+      shard: 352
+      total_validator_count: 158
+  - - committee: [54, 228]
+      shard: 353
+      total_validator_count: 158
+  - - committee: [88, 258, 113]
+      shard: 354
+      total_validator_count: 158
+  - - committee: [336, 89]
+      shard: 355
+      total_validator_count: 158
+  - - committee: [236, 418]
+      shard: 356
+      total_validator_count: 158
+  - - committee: [102, 369, 40]
+      shard: 357
+      total_validator_count: 158
+  - - committee: [146, 419]
+      shard: 358
+      total_validator_count: 158
+  - - committee: [216, 75, 109]
+      shard: 359
+      total_validator_count: 158
+  - - committee: [205, 199]
+      shard: 360
+      total_validator_count: 158
+  - - committee: [15, 238, 270]
+      shard: 361
+      total_validator_count: 158
+  - - committee: [280, 65]
+      shard: 362
+      total_validator_count: 158
+  - - committee: [275, 346, 327]
+      shard: 363
+      total_validator_count: 158
+  - - committee: [312, 410]
+      shard: 364
+      total_validator_count: 158
+  - - committee: [391, 332, 411]
+      shard: 365
+      total_validator_count: 158
+  - - committee: [59, 323]
+      shard: 366
+      total_validator_count: 158
+  - - committee: [245, 60, 388]
+      shard: 367
+      total_validator_count: 158
+  - - committee: [141, 74]
+      shard: 368
+      total_validator_count: 158
+  - - committee: [48, 394, 226]
+      shard: 369
+      total_validator_count: 158
+  - - committee: [250, 126]
+      shard: 370
+      total_validator_count: 158
+  - - committee: [8, 78]
+      shard: 371
+      total_validator_count: 158
+  - - committee: [175, 31, 261]
+      shard: 372
+      total_validator_count: 158
+  - - committee: [131, 420]
+      shard: 373
+      total_validator_count: 158
+  - - committee: [296, 370, 404]
+      shard: 374
+      total_validator_count: 158
+  - - committee: [129, 422]
+      shard: 375
+      total_validator_count: 158
+  - - committee: [138, 115, 127]
+      shard: 376
+      total_validator_count: 158
+  - - committee: [390, 359]
+      shard: 377
+      total_validator_count: 158
+  - - committee: [83, 224, 345]
+      shard: 378
+      total_validator_count: 158
+  - - committee: [174, 295]
+      shard: 379
+      total_validator_count: 158
+  - - committee: [219, 331, 42]
+      shard: 380
+      total_validator_count: 158
+  - - committee: [294, 14]
+      shard: 381
+      total_validator_count: 158
+  - - committee: [27, 364, 334]
+      shard: 382
+      total_validator_count: 158
+  - - committee: [58, 11]
+      shard: 383
+      total_validator_count: 158
+  - - committee: [112, 348, 360]
+      shard: 384
+      total_validator_count: 158
+  - - committee: [310, 285]
+      shard: 385
+      total_validator_count: 158
+  - - committee: [43, 137, 315]
+      shard: 386
+      total_validator_count: 158
+  seed: '0x3e0145d6c946e5121aa6a8f761d1647d093fb976f2497361897012dfa6dc0190'
+- input:
+    crosslinking_start_shard: 233
+    validators:
+    - original_index: 0
+      status: [3]
+    - original_index: 1
+      status: [0]
+    - original_index: 2
+      status: [1]
+    - original_index: 3
+      status: [3]
+    - original_index: 4
+      status: [3]
+    - original_index: 5
+      status: [2]
+    - original_index: 6
+      status: [4]
+    - original_index: 7
+      status: [2]
+    - original_index: 8
+      status: [4]
+    - original_index: 9
+      status: [4]
+    - original_index: 10
+      status: [2]
+    - original_index: 11
+      status: [4]
+    - original_index: 12
+      status: [2]
+    - original_index: 13
+      status: [1]
+    - original_index: 14
+      status: [1]
+    - original_index: 15
+      status: [2]
+    - original_index: 16
+      status: [2]
+    - original_index: 17
+      status: [1]
+    - original_index: 18
+      status: [4]
+    - original_index: 19
+      status: [2]
+    - original_index: 20
+      status: [1]
+    - original_index: 21
+      status: [2]
+    - original_index: 22
+      status: [3]
+    - original_index: 23
+      status: [4]
+    - original_index: 24
+      status: [3]
+    - original_index: 25
+      status: [1]
+    - original_index: 26
+      status: [0]
+    - original_index: 27
+      status: [1]
+    - original_index: 28
+      status: [0]
+    - original_index: 29
+      status: [4]
+    - original_index: 30
+      status: [4]
+    - original_index: 31
+      status: [0]
+    - original_index: 32
+      status: [3]
+    - original_index: 33
+      status: [3]
+    - original_index: 34
+      status: [1]
+    - original_index: 35
+      status: [2]
+    - original_index: 36
+      status: [4]
+    - original_index: 37
+      status: [4]
+    - original_index: 38
+      status: [1]
+    - original_index: 39
+      status: [3]
+    - original_index: 40
+      status: [4]
+    - original_index: 41
+      status: [2]
+    - original_index: 42
+      status: [2]
+    - original_index: 43
+      status: [3]
+    - original_index: 44
+      status: [4]
+    - original_index: 45
+      status: [4]
+    - original_index: 46
+      status: [3]
+    - original_index: 47
+      status: [1]
+    - original_index: 48
+      status: [3]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [3]
+    - original_index: 51
+      status: [0]
+    - original_index: 52
+      status: [2]
+    - original_index: 53
+      status: [4]
+    - original_index: 54
+      status: [1]
+    - original_index: 55
+      status: [2]
+    - original_index: 56
+      status: [4]
+    - original_index: 57
+      status: [1]
+    - original_index: 58
+      status: [2]
+    - original_index: 59
+      status: [2]
+    - original_index: 60
+      status: [1]
+    - original_index: 61
+      status: [3]
+    - original_index: 62
+      status: [3]
+    - original_index: 63
+      status: [3]
+    - original_index: 64
+      status: [1]
+    - original_index: 65
+      status: [1]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [3]
+    - original_index: 68
+      status: [2]
+    - original_index: 69
+      status: [2]
+    - original_index: 70
+      status: [0]
+    - original_index: 71
+      status: [4]
+    - original_index: 72
+      status: [4]
+    - original_index: 73
+      status: [1]
+    - original_index: 74
+      status: [4]
+    - original_index: 75
+      status: [1]
+    - original_index: 76
+      status: [4]
+    - original_index: 77
+      status: [0]
+    - original_index: 78
+      status: [4]
+    - original_index: 79
+      status: [2]
+    - original_index: 80
+      status: [2]
+    - original_index: 81
+      status: [4]
+    - original_index: 82
+      status: [4]
+    - original_index: 83
+      status: [0]
+    - original_index: 84
+      status: [1]
+    - original_index: 85
+      status: [1]
+    - original_index: 86
+      status: [1]
+    - original_index: 87
+      status: [2]
+    - original_index: 88
+      status: [1]
+    - original_index: 89
+      status: [2]
+    - original_index: 90
+      status: [1]
+    - original_index: 91
+      status: [2]
+    - original_index: 92
+      status: [2]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [1]
+    - original_index: 95
+      status: [0]
+    - original_index: 96
+      status: [0]
+    - original_index: 97
+      status: [0]
+    - original_index: 98
+      status: [0]
+    - original_index: 99
+      status: [4]
+    - original_index: 100
+      status: [2]
+    - original_index: 101
+      status: [4]
+    - original_index: 102
+      status: [0]
+    - original_index: 103
+      status: [3]
+    - original_index: 104
+      status: [2]
+    - original_index: 105
+      status: [2]
+    - original_index: 106
+      status: [4]
+    - original_index: 107
+      status: [3]
+    - original_index: 108
+      status: [3]
+    - original_index: 109
+      status: [3]
+    - original_index: 110
+      status: [1]
+    - original_index: 111
+      status: [0]
+    - original_index: 112
+      status: [2]
+    - original_index: 113
+      status: [4]
+    - original_index: 114
+      status: [2]
+    - original_index: 115
+      status: [2]
+    - original_index: 116
+      status: [4]
+    - original_index: 117
+      status: [2]
+    - original_index: 118
+      status: [4]
+    - original_index: 119
+      status: [3]
+    - original_index: 120
+      status: [1]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [3]
+    - original_index: 124
+      status: [2]
+    - original_index: 125
+      status: [0]
+    - original_index: 126
+      status: [1]
+    - original_index: 127
+      status: [4]
+    - original_index: 128
+      status: [3]
+    - original_index: 129
+      status: [2]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [1]
+    - original_index: 132
+      status: [0]
+    - original_index: 133
+      status: [4]
+    - original_index: 134
+      status: [3]
+    - original_index: 135
+      status: [2]
+    - original_index: 136
+      status: [1]
+    - original_index: 137
+      status: [0]
+    - original_index: 138
+      status: [1]
+    - original_index: 139
+      status: [4]
+    - original_index: 140
+      status: [2]
+    - original_index: 141
+      status: [3]
+    - original_index: 142
+      status: [0]
+    - original_index: 143
+      status: [3]
+    - original_index: 144
+      status: [0]
+    - original_index: 145
+      status: [0]
+    - original_index: 146
+      status: [4]
+    - original_index: 147
+      status: [0]
+    - original_index: 148
+      status: [4]
+    - original_index: 149
+      status: [1]
+    - original_index: 150
+      status: [0]
+    - original_index: 151
+      status: [2]
+    - original_index: 152
+      status: [3]
+    - original_index: 153
+      status: [2]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [2]
+    - original_index: 156
+      status: [1]
+    - original_index: 157
+      status: [1]
+    - original_index: 158
+      status: [3]
+    - original_index: 159
+      status: [2]
+    - original_index: 160
+      status: [4]
+    - original_index: 161
+      status: [4]
+    - original_index: 162
+      status: [2]
+    - original_index: 163
+      status: [1]
+    - original_index: 164
+      status: [1]
+    - original_index: 165
+      status: [0]
+    - original_index: 166
+      status: [0]
+    - original_index: 167
+      status: [4]
+    - original_index: 168
+      status: [4]
+    - original_index: 169
+      status: [1]
+    - original_index: 170
+      status: [0]
+    - original_index: 171
+      status: [1]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [3]
+    - original_index: 174
+      status: [4]
+    - original_index: 175
+      status: [3]
+    - original_index: 176
+      status: [0]
+    - original_index: 177
+      status: [0]
+    - original_index: 178
+      status: [2]
+    - original_index: 179
+      status: [4]
+    - original_index: 180
+      status: [1]
+    - original_index: 181
+      status: [1]
+    - original_index: 182
+      status: [3]
+    - original_index: 183
+      status: [0]
+    - original_index: 184
+      status: [4]
+    - original_index: 185
+      status: [0]
+    - original_index: 186
+      status: [4]
+    - original_index: 187
+      status: [0]
+    - original_index: 188
+      status: [3]
+    - original_index: 189
+      status: [0]
+    - original_index: 190
+      status: [2]
+    - original_index: 191
+      status: [2]
+    - original_index: 192
+      status: [4]
+    - original_index: 193
+      status: [1]
+    - original_index: 194
+      status: [1]
+    - original_index: 195
+      status: [2]
+    - original_index: 196
+      status: [4]
+    - original_index: 197
+      status: [0]
+    - original_index: 198
+      status: [3]
+    - original_index: 199
+      status: [4]
+    - original_index: 200
+      status: [1]
+    - original_index: 201
+      status: [4]
+    - original_index: 202
+      status: [2]
+    - original_index: 203
+      status: [3]
+    - original_index: 204
+      status: [2]
+    - original_index: 205
+      status: [1]
+    - original_index: 206
+      status: [3]
+    - original_index: 207
+      status: [0]
+    - original_index: 208
+      status: [1]
+    - original_index: 209
+      status: [0]
+    - original_index: 210
+      status: [3]
+    - original_index: 211
+      status: [1]
+    - original_index: 212
+      status: [2]
+    - original_index: 213
+      status: [1]
+    - original_index: 214
+      status: [4]
+    - original_index: 215
+      status: [2]
+    - original_index: 216
+      status: [1]
+    - original_index: 217
+      status: [3]
+    - original_index: 218
+      status: [0]
+    - original_index: 219
+      status: [4]
+    - original_index: 220
+      status: [2]
+    - original_index: 221
+      status: [2]
+    - original_index: 222
+      status: [0]
+    - original_index: 223
+      status: [1]
+    - original_index: 224
+      status: [2]
+    - original_index: 225
+      status: [3]
+    - original_index: 226
+      status: [4]
+    - original_index: 227
+      status: [2]
+    - original_index: 228
+      status: [2]
+    - original_index: 229
+      status: [2]
+    - original_index: 230
+      status: [2]
+    - original_index: 231
+      status: [4]
+    - original_index: 232
+      status: [0]
+    - original_index: 233
+      status: [1]
+    - original_index: 234
+      status: [1]
+    - original_index: 235
+      status: [2]
+    - original_index: 236
+      status: [1]
+    - original_index: 237
+      status: [4]
+    - original_index: 238
+      status: [1]
+    - original_index: 239
+      status: [0]
+    - original_index: 240
+      status: [1]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [3]
+    - original_index: 243
+      status: [1]
+    - original_index: 244
+      status: [2]
+    - original_index: 245
+      status: [3]
+    - original_index: 246
+      status: [0]
+    - original_index: 247
+      status: [2]
+    - original_index: 248
+      status: [3]
+    - original_index: 249
+      status: [3]
+    - original_index: 250
+      status: [4]
+    - original_index: 251
+      status: [2]
+    - original_index: 252
+      status: [4]
+    - original_index: 253
+      status: [4]
+    - original_index: 254
+      status: [0]
+    - original_index: 255
+      status: [0]
+    - original_index: 256
+      status: [2]
+    - original_index: 257
+      status: [3]
+    - original_index: 258
+      status: [4]
+    - original_index: 259
+      status: [1]
+    - original_index: 260
+      status: [2]
+    - original_index: 261
+      status: [2]
+    - original_index: 262
+      status: [2]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [4]
+    - original_index: 265
+      status: [4]
+    - original_index: 266
+      status: [0]
+    - original_index: 267
+      status: [3]
+    - original_index: 268
+      status: [2]
+    - original_index: 269
+      status: [0]
+    - original_index: 270
+      status: [0]
+    - original_index: 271
+      status: [1]
+    - original_index: 272
+      status: [3]
+    - original_index: 273
+      status: [4]
+    - original_index: 274
+      status: [2]
+    - original_index: 275
+      status: [4]
+    - original_index: 276
+      status: [4]
+    - original_index: 277
+      status: [2]
+    - original_index: 278
+      status: [0]
+    - original_index: 279
+      status: [0]
+    - original_index: 280
+      status: [3]
+    - original_index: 281
+      status: [4]
+    - original_index: 282
+      status: [1]
+    - original_index: 283
+      status: [4]
+    - original_index: 284
+      status: [0]
+    - original_index: 285
+      status: [0]
+    - original_index: 286
+      status: [1]
+    - original_index: 287
+      status: [0]
+    - original_index: 288
+      status: [3]
+    - original_index: 289
+      status: [2]
+    - original_index: 290
+      status: [1]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [1]
+    - original_index: 293
+      status: [1]
+    - original_index: 294
+      status: [1]
+    - original_index: 295
+      status: [2]
+    - original_index: 296
+      status: [0]
+    - original_index: 297
+      status: [4]
+    - original_index: 298
+      status: [3]
+    - original_index: 299
+      status: [1]
+    - original_index: 300
+      status: [3]
+    - original_index: 301
+      status: [1]
+    - original_index: 302
+      status: [0]
+    - original_index: 303
+      status: [4]
+    - original_index: 304
+      status: [1]
+    - original_index: 305
+      status: [4]
+    - original_index: 306
+      status: [1]
+    - original_index: 307
+      status: [3]
+    - original_index: 308
+      status: [2]
+    - original_index: 309
+      status: [3]
+    - original_index: 310
+      status: [2]
+    - original_index: 311
+      status: [1]
+    - original_index: 312
+      status: [2]
+    - original_index: 313
+      status: [0]
+    - original_index: 314
+      status: [3]
+    - original_index: 315
+      status: [2]
+    - original_index: 316
+      status: [1]
+    - original_index: 317
+      status: [1]
+    - original_index: 318
+      status: [1]
+    - original_index: 319
+      status: [0]
+    - original_index: 320
+      status: [2]
+    - original_index: 321
+      status: [2]
+    - original_index: 322
+      status: [2]
+    - original_index: 323
+      status: [0]
+    - original_index: 324
+      status: [2]
+    - original_index: 325
+      status: [0]
+    - original_index: 326
+      status: [2]
+    - original_index: 327
+      status: [3]
+    - original_index: 328
+      status: [1]
+    - original_index: 329
+      status: [3]
+    - original_index: 330
+      status: [3]
+    - original_index: 331
+      status: [3]
+    - original_index: 332
+      status: [1]
+    - original_index: 333
+      status: [2]
+    - original_index: 334
+      status: [3]
+    - original_index: 335
+      status: [0]
+    - original_index: 336
+      status: [0]
+    - original_index: 337
+      status: [2]
+    - original_index: 338
+      status: [1]
+    - original_index: 339
+      status: [2]
+    - original_index: 340
+      status: [1]
+    - original_index: 341
+      status: [4]
+    - original_index: 342
+      status: [2]
+    - original_index: 343
+      status: [1]
+    - original_index: 344
+      status: [1]
+    - original_index: 345
+      status: [3]
+    - original_index: 346
+      status: [4]
+    - original_index: 347
+      status: [1]
+    - original_index: 348
+      status: [0]
+    - original_index: 349
+      status: [3]
+    - original_index: 350
+      status: [0]
+    - original_index: 351
+      status: [3]
+    - original_index: 352
+      status: [2]
+    - original_index: 353
+      status: [2]
+    - original_index: 354
+      status: [1]
+    - original_index: 355
+      status: [3]
+    - original_index: 356
+      status: [3]
+    - original_index: 357
+      status: [4]
+    - original_index: 358
+      status: [0]
+    - original_index: 359
+      status: [2]
+    - original_index: 360
+      status: [4]
+    - original_index: 361
+      status: [1]
+    - original_index: 362
+      status: [2]
+    - original_index: 363
+      status: [1]
+    - original_index: 364
+      status: [4]
+    - original_index: 365
+      status: [3]
+    - original_index: 366
+      status: [0]
+    - original_index: 367
+      status: [2]
+    - original_index: 368
+      status: [3]
+    - original_index: 369
+      status: [0]
+    - original_index: 370
+      status: [2]
+    - original_index: 371
+      status: [0]
+    - original_index: 372
+      status: [3]
+    - original_index: 373
+      status: [0]
+    - original_index: 374
+      status: [0]
+    - original_index: 375
+      status: [0]
+    - original_index: 376
+      status: [2]
+    - original_index: 377
+      status: [4]
+    - original_index: 378
+      status: [4]
+    - original_index: 379
+      status: [3]
+    - original_index: 380
+      status: [4]
+    - original_index: 381
+      status: [3]
+    - original_index: 382
+      status: [2]
+    - original_index: 383
+      status: [0]
+    - original_index: 384
+      status: [0]
+    - original_index: 385
+      status: [1]
+    - original_index: 386
+      status: [2]
+    - original_index: 387
+      status: [2]
+    - original_index: 388
+      status: [4]
+    - original_index: 389
+      status: [0]
+    - original_index: 390
+      status: [0]
+    - original_index: 391
+      status: [1]
+    - original_index: 392
+      status: [3]
+    - original_index: 393
+      status: [3]
+    - original_index: 394
+      status: [3]
+    - original_index: 395
+      status: [4]
+    - original_index: 396
+      status: [4]
+    - original_index: 397
+      status: [3]
+    - original_index: 398
+      status: [4]
+    - original_index: 399
+      status: [0]
+    - original_index: 400
+      status: [4]
+    - original_index: 401
+      status: [3]
+    - original_index: 402
+      status: [1]
+    - original_index: 403
+      status: [4]
+    - original_index: 404
+      status: [0]
+    - original_index: 405
+      status: [1]
+    - original_index: 406
+      status: [3]
+    - original_index: 407
+      status: [0]
+    - original_index: 408
+      status: [4]
+    - original_index: 409
+      status: [0]
+    - original_index: 410
+      status: [0]
+    - original_index: 411
+      status: [3]
+    - original_index: 412
+      status: [0]
+    - original_index: 413
+      status: [2]
+    - original_index: 414
+      status: [0]
+    - original_index: 415
+      status: [4]
+    - original_index: 416
+      status: [3]
+    - original_index: 417
+      status: [0]
+    - original_index: 418
+      status: [0]
+    - original_index: 419
+      status: [1]
+    - original_index: 420
+      status: [3]
+    - original_index: 421
+      status: [4]
+    - original_index: 422
+      status: [3]
+    - original_index: 423
+      status: [1]
+    - original_index: 424
+      status: [2]
+    - original_index: 425
+      status: [4]
+    - original_index: 426
+      status: [0]
+    - original_index: 427
+      status: [4]
+    - original_index: 428
+      status: [0]
+    - original_index: 429
+      status: [0]
+    - original_index: 430
+      status: [0]
+    - original_index: 431
+      status: [4]
+    - original_index: 432
+      status: [3]
+    - original_index: 433
+      status: [4]
+    - original_index: 434
+      status: [2]
+    - original_index: 435
+      status: [3]
+    - original_index: 436
+      status: [2]
+    - original_index: 437
+      status: [3]
+    - original_index: 438
+      status: [4]
+    - original_index: 439
+      status: [4]
+    - original_index: 440
+      status: [1]
+    - original_index: 441
+      status: [4]
+    - original_index: 442
+      status: [1]
+    - original_index: 443
+      status: [1]
+    - original_index: 444
+      status: [3]
+    - original_index: 445
+      status: [2]
+    - original_index: 446
+      status: [3]
+    - original_index: 447
+      status: [0]
+    - original_index: 448
+      status: [4]
+    - original_index: 449
+      status: [1]
+    - original_index: 450
+      status: [4]
+    - original_index: 451
+      status: [4]
+    - original_index: 452
+      status: [4]
+    - original_index: 453
+      status: [3]
+    - original_index: 454
+      status: [1]
+    - original_index: 455
+      status: [4]
+    - original_index: 456
+      status: [4]
+    - original_index: 457
+      status: [2]
+    - original_index: 458
+      status: [0]
+    - original_index: 459
+      status: [1]
+    - original_index: 460
+      status: [3]
+    - original_index: 461
+      status: [3]
+    - original_index: 462
+      status: [2]
+    - original_index: 463
+      status: [4]
+    - original_index: 464
+      status: [1]
+    - original_index: 465
+      status: [0]
+    - original_index: 466
+      status: [2]
+    - original_index: 467
+      status: [4]
+    - original_index: 468
+      status: [4]
+    - original_index: 469
+      status: [1]
+    - original_index: 470
+      status: [2]
+    - original_index: 471
+      status: [1]
+    - original_index: 472
+      status: [4]
+    - original_index: 473
+      status: [2]
+    - original_index: 474
+      status: [0]
+    - original_index: 475
+      status: [2]
+    - original_index: 476
+      status: [1]
+    - original_index: 477
+      status: [0]
+    - original_index: 478
+      status: [3]
+    - original_index: 479
+      status: [1]
+    - original_index: 480
+      status: [0]
+    - original_index: 481
+      status: [3]
+    - original_index: 482
+      status: [0]
+    - original_index: 483
+      status: [0]
+  output:
+  - - committee: [304, 340, 201]
+      shard: 233
+      total_validator_count: 198
+  - - committee: [113, 451, 456]
+      shard: 234
+      total_validator_count: 198
+  - - committee: [459, 450, 361]
+      shard: 235
+      total_validator_count: 198
+  - - committee: [29, 281, 74]
+      shard: 236
+      total_validator_count: 198
+  - - committee: [347, 237, 193]
+      shard: 237
+      total_validator_count: 198
+  - - committee: [297, 354, 292]
+      shard: 238
+      total_validator_count: 198
+  - - committee: [211, 258, 293]
+      shard: 239
+      total_validator_count: 198
+  - - committee: [276, 400, 8]
+      shard: 240
+      total_validator_count: 198
+  - - committee: [316, 243, 64]
+      shard: 241
+      total_validator_count: 198
+  - - committee: [17, 303, 205]
+      shard: 242
+      total_validator_count: 198
+  - - committee: [378, 90, 171, 226]
+      shard: 243
+      total_validator_count: 198
+  - - committee: [126, 20, 431]
+      shard: 244
+      total_validator_count: 198
+  - - committee: [391, 455, 427]
+      shard: 245
+      total_validator_count: 198
+  - - committee: [13, 174, 363]
+      shard: 246
+      total_validator_count: 198
+  - - committee: [259, 240, 433]
+      shard: 247
+      total_validator_count: 198
+  - - committee: [9, 380, 441]
+      shard: 248
+      total_validator_count: 198
+  - - committee: [396, 65, 425]
+      shard: 249
+      total_validator_count: 198
+  - - committee: [449, 357, 164]
+      shard: 250
+      total_validator_count: 198
+  - - committee: [421, 306, 328]
+      shard: 251
+      total_validator_count: 198
+  - - committee: [139, 344, 94]
+      shard: 252
+      total_validator_count: 198
+  - - committee: [464, 157, 264]
+      shard: 253
+      total_validator_count: 198
+  - - committee: [317, 283, 440, 439]
+      shard: 254
+      total_validator_count: 198
+  - - committee: [341, 265, 60]
+      shard: 255
+      total_validator_count: 198
+  - - committee: [208, 305, 443]
+      shard: 256
+      total_validator_count: 198
+  - - committee: [442, 88, 311]
+      shard: 257
+      total_validator_count: 198
+  - - committee: [360, 181, 405]
+      shard: 258
+      total_validator_count: 198
+  - - committee: [120, 241, 110]
+      shard: 259
+      total_validator_count: 198
+  - - committee: [472, 36, 25]
+      shard: 260
+      total_validator_count: 198
+  - - committee: [467, 146, 346]
+      shard: 261
+      total_validator_count: 198
+  - - committee: [53, 192, 438]
+      shard: 262
+      total_validator_count: 198
+  - - committee: [34, 184, 273]
+      shard: 263
+      total_validator_count: 198
+  - - committee: [82, 136, 364, 44]
+      shard: 264
+      total_validator_count: 198
+  - - committee: [30, 194, 199]
+      shard: 265
+      total_validator_count: 198
+  - - committee: [263, 131, 196]
+      shard: 266
+      total_validator_count: 198
+  - - committee: [290, 6, 388]
+      shard: 267
+      total_validator_count: 198
+  - - committee: [299, 454, 479]
+      shard: 268
+      total_validator_count: 198
+  - - committee: [37, 471, 332]
+      shard: 269
+      total_validator_count: 198
+  - - committee: [385, 161, 415]
+      shard: 270
+      total_validator_count: 198
+  - - committee: [179, 294, 54]
+      shard: 271
+      total_validator_count: 198
+  - - committee: [403, 186, 73]
+      shard: 272
+      total_validator_count: 198
+  - - committee: [377, 2, 85]
+      shard: 273
+      total_validator_count: 198
+  - - committee: [84, 133, 71]
+      shard: 274
+      total_validator_count: 198
+  - - committee: [81, 219, 27, 338]
+      shard: 275
+      total_validator_count: 198
+  - - committee: [233, 180, 130]
+      shard: 276
+      total_validator_count: 198
+  - - committee: [167, 236, 250]
+      shard: 277
+      total_validator_count: 198
+  - - committee: [18, 286, 148]
+      shard: 278
+      total_validator_count: 198
+  - - committee: [200, 402, 149]
+      shard: 279
+      total_validator_count: 198
+  - - committee: [223, 271, 75]
+      shard: 280
+      total_validator_count: 198
+  - - committee: [138, 213, 469]
+      shard: 281
+      total_validator_count: 198
+  - - committee: [238, 101, 253]
+      shard: 282
+      total_validator_count: 198
+  - - committee: [57, 14, 116]
+      shard: 283
+      total_validator_count: 198
+  - - committee: [154, 398, 118]
+      shard: 284
+      total_validator_count: 198
+  - - committee: [156, 47, 127]
+      shard: 285
+      total_validator_count: 198
+  - - committee: [423, 56, 160, 395]
+      shard: 286
+      total_validator_count: 198
+  - - committee: [252, 169, 463]
+      shard: 287
+      total_validator_count: 198
+  - - committee: [106, 72, 234]
+      shard: 288
+      total_validator_count: 198
+  - - committee: [214, 275, 76]
+      shard: 289
+      total_validator_count: 198
+  - - committee: [282, 23, 408]
+      shard: 290
+      total_validator_count: 198
+  - - committee: [45, 452, 38]
+      shard: 291
+      total_validator_count: 198
+  - - committee: [168, 301, 343]
+      shard: 292
+      total_validator_count: 198
+  - - committee: [78, 476, 419]
+      shard: 293
+      total_validator_count: 198
+  - - committee: [40, 11, 99]
+      shard: 294
+      total_validator_count: 198
+  - - committee: [86, 468, 163]
+      shard: 295
+      total_validator_count: 198
+  - - committee: [448, 216, 318, 231]
+      shard: 296
+      total_validator_count: 198
+  seed: '0xeefb66740fd23df786731edb105354862abc8bc52ee4d0bffe8b7bc2d61f22d7'
+- input:
+    crosslinking_start_shard: 400
+    validators:
+    - original_index: 0
+      status: [0]
+    - original_index: 1
+      status: [4]
+    - original_index: 2
+      status: [0]
+    - original_index: 3
+      status: [3]
+    - original_index: 4
+      status: [1]
+    - original_index: 5
+      status: [2]
+    - original_index: 6
+      status: [1]
+    - original_index: 7
+      status: [2]
+    - original_index: 8
+      status: [2]
+    - original_index: 9
+      status: [2]
+    - original_index: 10
+      status: [1]
+    - original_index: 11
+      status: [0]
+    - original_index: 12
+      status: [3]
+    - original_index: 13
+      status: [0]
+    - original_index: 14
+      status: [2]
+    - original_index: 15
+      status: [4]
+    - original_index: 16
+      status: [4]
+    - original_index: 17
+      status: [4]
+    - original_index: 18
+      status: [2]
+    - original_index: 19
+      status: [2]
+    - original_index: 20
+      status: [2]
+    - original_index: 21
+      status: [1]
+    - original_index: 22
+      status: [1]
+    - original_index: 23
+      status: [4]
+    - original_index: 24
+      status: [1]
+    - original_index: 25
+      status: [2]
+    - original_index: 26
+      status: [1]
+    - original_index: 27
+      status: [3]
+    - original_index: 28
+      status: [0]
+    - original_index: 29
+      status: [0]
+    - original_index: 30
+      status: [3]
+    - original_index: 31
+      status: [4]
+    - original_index: 32
+      status: [1]
+    - original_index: 33
+      status: [1]
+    - original_index: 34
+      status: [0]
+    - original_index: 35
+      status: [4]
+    - original_index: 36
+      status: [3]
+    - original_index: 37
+      status: [0]
+    - original_index: 38
+      status: [4]
+    - original_index: 39
+      status: [4]
+    - original_index: 40
+      status: [3]
+    - original_index: 41
+      status: [2]
+    - original_index: 42
+      status: [3]
+    - original_index: 43
+      status: [1]
+    - original_index: 44
+      status: [3]
+    - original_index: 45
+      status: [1]
+    - original_index: 46
+      status: [1]
+    - original_index: 47
+      status: [3]
+    - original_index: 48
+      status: [0]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [0]
+    - original_index: 51
+      status: [4]
+    - original_index: 52
+      status: [1]
+    - original_index: 53
+      status: [1]
+    - original_index: 54
+      status: [1]
+    - original_index: 55
+      status: [1]
+    - original_index: 56
+      status: [2]
+    - original_index: 57
+      status: [3]
+    - original_index: 58
+      status: [3]
+    - original_index: 59
+      status: [4]
+    - original_index: 60
+      status: [2]
+    - original_index: 61
+      status: [0]
+    - original_index: 62
+      status: [2]
+    - original_index: 63
+      status: [3]
+    - original_index: 64
+      status: [3]
+    - original_index: 65
+      status: [0]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [0]
+    - original_index: 68
+      status: [2]
+    - original_index: 69
+      status: [4]
+    - original_index: 70
+      status: [3]
+    - original_index: 71
+      status: [3]
+    - original_index: 72
+      status: [3]
+    - original_index: 73
+      status: [2]
+    - original_index: 74
+      status: [1]
+    - original_index: 75
+      status: [3]
+    - original_index: 76
+      status: [4]
+    - original_index: 77
+      status: [2]
+    - original_index: 78
+      status: [3]
+    - original_index: 79
+      status: [0]
+    - original_index: 80
+      status: [2]
+    - original_index: 81
+      status: [0]
+    - original_index: 82
+      status: [1]
+    - original_index: 83
+      status: [3]
+    - original_index: 84
+      status: [1]
+    - original_index: 85
+      status: [4]
+    - original_index: 86
+      status: [4]
+    - original_index: 87
+      status: [1]
+    - original_index: 88
+      status: [4]
+    - original_index: 89
+      status: [4]
+    - original_index: 90
+      status: [2]
+    - original_index: 91
+      status: [1]
+    - original_index: 92
+      status: [3]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [2]
+    - original_index: 95
+      status: [3]
+    - original_index: 96
+      status: [3]
+    - original_index: 97
+      status: [4]
+    - original_index: 98
+      status: [4]
+    - original_index: 99
+      status: [4]
+    - original_index: 100
+      status: [2]
+    - original_index: 101
+      status: [3]
+    - original_index: 102
+      status: [0]
+    - original_index: 103
+      status: [0]
+    - original_index: 104
+      status: [2]
+    - original_index: 105
+      status: [3]
+    - original_index: 106
+      status: [1]
+    - original_index: 107
+      status: [4]
+    - original_index: 108
+      status: [2]
+    - original_index: 109
+      status: [3]
+    - original_index: 110
+      status: [2]
+    - original_index: 111
+      status: [2]
+    - original_index: 112
+      status: [4]
+    - original_index: 113
+      status: [0]
+    - original_index: 114
+      status: [0]
+    - original_index: 115
+      status: [4]
+    - original_index: 116
+      status: [0]
+    - original_index: 117
+      status: [1]
+    - original_index: 118
+      status: [0]
+    - original_index: 119
+      status: [3]
+    - original_index: 120
+      status: [0]
+    - original_index: 121
+      status: [2]
+    - original_index: 122
+      status: [2]
+    - original_index: 123
+      status: [1]
+    - original_index: 124
+      status: [3]
+    - original_index: 125
+      status: [3]
+    - original_index: 126
+      status: [2]
+    - original_index: 127
+      status: [3]
+    - original_index: 128
+      status: [4]
+    - original_index: 129
+      status: [3]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [2]
+    - original_index: 132
+      status: [0]
+    - original_index: 133
+      status: [0]
+    - original_index: 134
+      status: [1]
+    - original_index: 135
+      status: [4]
+    - original_index: 136
+      status: [3]
+    - original_index: 137
+      status: [1]
+    - original_index: 138
+      status: [2]
+    - original_index: 139
+      status: [0]
+    - original_index: 140
+      status: [4]
+    - original_index: 141
+      status: [1]
+    - original_index: 142
+      status: [1]
+    - original_index: 143
+      status: [0]
+    - original_index: 144
+      status: [0]
+    - original_index: 145
+      status: [4]
+    - original_index: 146
+      status: [1]
+    - original_index: 147
+      status: [2]
+    - original_index: 148
+      status: [4]
+    - original_index: 149
+      status: [3]
+    - original_index: 150
+      status: [3]
+    - original_index: 151
+      status: [3]
+    - original_index: 152
+      status: [2]
+    - original_index: 153
+      status: [0]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [4]
+    - original_index: 156
+      status: [0]
+    - original_index: 157
+      status: [1]
+    - original_index: 158
+      status: [2]
+    - original_index: 159
+      status: [0]
+    - original_index: 160
+      status: [2]
+    - original_index: 161
+      status: [0]
+    - original_index: 162
+      status: [3]
+    - original_index: 163
+      status: [1]
+    - original_index: 164
+      status: [2]
+    - original_index: 165
+      status: [0]
+    - original_index: 166
+      status: [1]
+    - original_index: 167
+      status: [0]
+    - original_index: 168
+      status: [4]
+    - original_index: 169
+      status: [0]
+    - original_index: 170
+      status: [3]
+    - original_index: 171
+      status: [3]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [3]
+    - original_index: 174
+      status: [0]
+    - original_index: 175
+      status: [0]
+    - original_index: 176
+      status: [3]
+    - original_index: 177
+      status: [3]
+    - original_index: 178
+      status: [4]
+    - original_index: 179
+      status: [4]
+    - original_index: 180
+      status: [2]
+    - original_index: 181
+      status: [3]
+    - original_index: 182
+      status: [2]
+    - original_index: 183
+      status: [0]
+    - original_index: 184
+      status: [2]
+    - original_index: 185
+      status: [0]
+    - original_index: 186
+      status: [4]
+    - original_index: 187
+      status: [4]
+    - original_index: 188
+      status: [4]
+    - original_index: 189
+      status: [2]
+    - original_index: 190
+      status: [2]
+    - original_index: 191
+      status: [3]
+    - original_index: 192
+      status: [4]
+    - original_index: 193
+      status: [3]
+    - original_index: 194
+      status: [2]
+    - original_index: 195
+      status: [2]
+    - original_index: 196
+      status: [4]
+    - original_index: 197
+      status: [3]
+    - original_index: 198
+      status: [4]
+    - original_index: 199
+      status: [0]
+    - original_index: 200
+      status: [4]
+    - original_index: 201
+      status: [4]
+    - original_index: 202
+      status: [3]
+    - original_index: 203
+      status: [1]
+    - original_index: 204
+      status: [0]
+    - original_index: 205
+      status: [2]
+    - original_index: 206
+      status: [3]
+    - original_index: 207
+      status: [1]
+    - original_index: 208
+      status: [1]
+    - original_index: 209
+      status: [2]
+    - original_index: 210
+      status: [3]
+    - original_index: 211
+      status: [0]
+    - original_index: 212
+      status: [0]
+    - original_index: 213
+      status: [4]
+    - original_index: 214
+      status: [3]
+    - original_index: 215
+      status: [2]
+    - original_index: 216
+      status: [2]
+    - original_index: 217
+      status: [3]
+    - original_index: 218
+      status: [1]
+    - original_index: 219
+      status: [0]
+    - original_index: 220
+      status: [3]
+    - original_index: 221
+      status: [1]
+    - original_index: 222
+      status: [0]
+    - original_index: 223
+      status: [1]
+    - original_index: 224
+      status: [1]
+    - original_index: 225
+      status: [2]
+    - original_index: 226
+      status: [2]
+    - original_index: 227
+      status: [2]
+    - original_index: 228
+      status: [4]
+    - original_index: 229
+      status: [0]
+    - original_index: 230
+      status: [2]
+    - original_index: 231
+      status: [4]
+    - original_index: 232
+      status: [4]
+    - original_index: 233
+      status: [4]
+    - original_index: 234
+      status: [4]
+    - original_index: 235
+      status: [2]
+    - original_index: 236
+      status: [4]
+    - original_index: 237
+      status: [4]
+    - original_index: 238
+      status: [0]
+    - original_index: 239
+      status: [4]
+    - original_index: 240
+      status: [1]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [4]
+    - original_index: 243
+      status: [4]
+    - original_index: 244
+      status: [3]
+    - original_index: 245
+      status: [1]
+    - original_index: 246
+      status: [2]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [4]
+    - original_index: 249
+      status: [1]
+    - original_index: 250
+      status: [1]
+    - original_index: 251
+      status: [1]
+    - original_index: 252
+      status: [0]
+    - original_index: 253
+      status: [3]
+    - original_index: 254
+      status: [0]
+    - original_index: 255
+      status: [2]
+    - original_index: 256
+      status: [4]
+    - original_index: 257
+      status: [1]
+    - original_index: 258
+      status: [1]
+    - original_index: 259
+      status: [3]
+    - original_index: 260
+      status: [3]
+    - original_index: 261
+      status: [0]
+    - original_index: 262
+      status: [4]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [1]
+    - original_index: 265
+      status: [3]
+    - original_index: 266
+      status: [2]
+    - original_index: 267
+      status: [0]
+    - original_index: 268
+      status: [2]
+    - original_index: 269
+      status: [2]
+    - original_index: 270
+      status: [0]
+    - original_index: 271
+      status: [0]
+    - original_index: 272
+      status: [4]
+    - original_index: 273
+      status: [2]
+    - original_index: 274
+      status: [4]
+    - original_index: 275
+      status: [1]
+    - original_index: 276
+      status: [1]
+    - original_index: 277
+      status: [0]
+    - original_index: 278
+      status: [4]
+    - original_index: 279
+      status: [2]
+    - original_index: 280
+      status: [3]
+    - original_index: 281
+      status: [1]
+    - original_index: 282
+      status: [0]
+    - original_index: 283
+      status: [3]
+    - original_index: 284
+      status: [2]
+    - original_index: 285
+      status: [2]
+    - original_index: 286
+      status: [1]
+    - original_index: 287
+      status: [0]
+    - original_index: 288
+      status: [3]
+    - original_index: 289
+      status: [2]
+    - original_index: 290
+      status: [4]
+    - original_index: 291
+      status: [0]
+    - original_index: 292
+      status: [3]
+    - original_index: 293
+      status: [2]
+    - original_index: 294
+      status: [3]
+    - original_index: 295
+      status: [1]
+    - original_index: 296
+      status: [1]
+    - original_index: 297
+      status: [1]
+    - original_index: 298
+      status: [2]
+    - original_index: 299
+      status: [2]
+    - original_index: 300
+      status: [0]
+    - original_index: 301
+      status: [3]
+    - original_index: 302
+      status: [2]
+    - original_index: 303
+      status: [3]
+    - original_index: 304
+      status: [3]
+    - original_index: 305
+      status: [0]
+    - original_index: 306
+      status: [2]
+    - original_index: 307
+      status: [1]
+    - original_index: 308
+      status: [4]
+    - original_index: 309
+      status: [4]
+    - original_index: 310
+      status: [2]
+    - original_index: 311
+      status: [1]
+    - original_index: 312
+      status: [3]
+    - original_index: 313
+      status: [0]
+    - original_index: 314
+      status: [2]
+    - original_index: 315
+      status: [1]
+    - original_index: 316
+      status: [0]
+    - original_index: 317
+      status: [2]
+    - original_index: 318
+      status: [3]
+    - original_index: 319
+      status: [2]
+    - original_index: 320
+      status: [2]
+    - original_index: 321
+      status: [3]
+    - original_index: 322
+      status: [0]
+    - original_index: 323
+      status: [4]
+    - original_index: 324
+      status: [0]
+    - original_index: 325
+      status: [3]
+    - original_index: 326
+      status: [2]
+    - original_index: 327
+      status: [3]
+    - original_index: 328
+      status: [1]
+    - original_index: 329
+      status: [4]
+    - original_index: 330
+      status: [2]
+    - original_index: 331
+      status: [1]
+    - original_index: 332
+      status: [0]
+    - original_index: 333
+      status: [4]
+    - original_index: 334
+      status: [2]
+    - original_index: 335
+      status: [1]
+    - original_index: 336
+      status: [1]
+    - original_index: 337
+      status: [0]
+    - original_index: 338
+      status: [0]
+    - original_index: 339
+      status: [0]
+    - original_index: 340
+      status: [4]
+    - original_index: 341
+      status: [4]
+    - original_index: 342
+      status: [0]
+    - original_index: 343
+      status: [1]
+    - original_index: 344
+      status: [1]
+    - original_index: 345
+      status: [0]
+    - original_index: 346
+      status: [1]
+    - original_index: 347
+      status: [1]
+    - original_index: 348
+      status: [4]
+    - original_index: 349
+      status: [0]
+    - original_index: 350
+      status: [4]
+    - original_index: 351
+      status: [1]
+    - original_index: 352
+      status: [0]
+    - original_index: 353
+      status: [0]
+    - original_index: 354
+      status: [0]
+    - original_index: 355
+      status: [3]
+    - original_index: 356
+      status: [2]
+    - original_index: 357
+      status: [0]
+    - original_index: 358
+      status: [3]
+    - original_index: 359
+      status: [3]
+    - original_index: 360
+      status: [2]
+    - original_index: 361
+      status: [3]
+    - original_index: 362
+      status: [0]
+    - original_index: 363
+      status: [3]
+    - original_index: 364
+      status: [1]
+    - original_index: 365
+      status: [1]
+    - original_index: 366
+      status: [3]
+    - original_index: 367
+      status: [0]
+    - original_index: 368
+      status: [4]
+    - original_index: 369
+      status: [4]
+    - original_index: 370
+      status: [3]
+    - original_index: 371
+      status: [4]
+    - original_index: 372
+      status: [2]
+    - original_index: 373
+      status: [2]
+    - original_index: 374
+      status: [3]
+    - original_index: 375
+      status: [3]
+    - original_index: 376
+      status: [0]
+    - original_index: 377
+      status: [0]
+    - original_index: 378
+      status: [3]
+    - original_index: 379
+      status: [1]
+    - original_index: 380
+      status: [2]
+    - original_index: 381
+      status: [0]
+    - original_index: 382
+      status: [2]
+    - original_index: 383
+      status: [2]
+    - original_index: 384
+      status: [1]
+    - original_index: 385
+      status: [1]
+    - original_index: 386
+      status: [1]
+    - original_index: 387
+      status: [4]
+    - original_index: 388
+      status: [4]
+    - original_index: 389
+      status: [3]
+    - original_index: 390
+      status: [0]
+    - original_index: 391
+      status: [3]
+    - original_index: 392
+      status: [3]
+    - original_index: 393
+      status: [3]
+    - original_index: 394
+      status: [2]
+    - original_index: 395
+      status: [1]
+    - original_index: 396
+      status: [1]
+    - original_index: 397
+      status: [2]
+    - original_index: 398
+      status: [1]
+    - original_index: 399
+      status: [1]
+    - original_index: 400
+      status: [3]
+    - original_index: 401
+      status: [4]
+    - original_index: 402
+      status: [1]
+    - original_index: 403
+      status: [0]
+    - original_index: 404
+      status: [4]
+    - original_index: 405
+      status: [0]
+    - original_index: 406
+      status: [4]
+    - original_index: 407
+      status: [4]
+    - original_index: 408
+      status: [0]
+    - original_index: 409
+      status: [3]
+  output:
+  - - committee: [82, 200]
+      shard: 400
+      total_validator_count: 157
+  - - committee: [365, 286]
+      shard: 401
+      total_validator_count: 157
+  - - committee: [350, 248, 106]
+      shard: 402
+      total_validator_count: 157
+  - - committee: [208, 234]
+      shard: 403
+      total_validator_count: 157
+  - - committee: [74, 84, 278]
+      shard: 404
+      total_validator_count: 157
+  - - committee: [148, 351]
+      shard: 405
+      total_validator_count: 157
+  - - committee: [53, 140, 31]
+      shard: 406
+      total_validator_count: 157
+  - - committee: [272, 154]
+      shard: 407
+      total_validator_count: 157
+  - - committee: [107, 6, 388]
+      shard: 408
+      total_validator_count: 157
+  - - committee: [128, 251]
+      shard: 409
+      total_validator_count: 157
+  - - committee: [335, 346]
+      shard: 410
+      total_validator_count: 157
+  - - committee: [54, 85, 371]
+      shard: 411
+      total_validator_count: 157
+  - - committee: [347, 10]
+      shard: 412
+      total_validator_count: 157
+  - - committee: [55, 341, 245]
+      shard: 413
+      total_validator_count: 157
+  - - committee: [308, 281]
+      shard: 414
+      total_validator_count: 157
+  - - committee: [198, 157, 134]
+      shard: 415
+      total_validator_count: 157
+  - - committee: [256, 86]
+      shard: 416
+      total_validator_count: 157
+  - - committee: [51, 16, 99]
+      shard: 417
+      total_validator_count: 157
+  - - committee: [228, 142]
+      shard: 418
+      total_validator_count: 157
+  - - committee: [186, 223, 23]
+      shard: 419
+      total_validator_count: 157
+  - - committee: [123, 32]
+      shard: 420
+      total_validator_count: 157
+  - - committee: [276, 343]
+      shard: 421
+      total_validator_count: 157
+  - - committee: [258, 52, 166]
+      shard: 422
+      total_validator_count: 157
+  - - committee: [33, 386]
+      shard: 423
+      total_validator_count: 157
+  - - committee: [344, 274, 35]
+      shard: 424
+      total_validator_count: 157
+  - - committee: [311, 241]
+      shard: 425
+      total_validator_count: 157
+  - - committee: [348, 91, 130]
+      shard: 426
+      total_validator_count: 157
+  - - committee: [231, 196]
+      shard: 427
+      total_validator_count: 157
+  - - committee: [340, 329, 97]
+      shard: 428
+      total_validator_count: 157
+  - - committee: [384, 213]
+      shard: 429
+      total_validator_count: 157
+  - - committee: [26, 168, 239]
+      shard: 430
+      total_validator_count: 157
+  - - committee: [224, 398]
+      shard: 431
+      total_validator_count: 157
+  - - committee: [207, 406]
+      shard: 432
+      total_validator_count: 157
+  - - committee: [137, 404, 22]
+      shard: 433
+      total_validator_count: 157
+  - - committee: [145, 368]
+      shard: 434
+      total_validator_count: 157
+  - - committee: [141, 263, 328]
+      shard: 435
+      total_validator_count: 157
+  - - committee: [43, 115]
+      shard: 436
+      total_validator_count: 157
+  - - committee: [87, 69, 187]
+      shard: 437
+      total_validator_count: 157
+  - - committee: [385, 203]
+      shard: 438
+      total_validator_count: 157
+  - - committee: [1, 323, 188]
+      shard: 439
+      total_validator_count: 157
+  - - committee: [402, 290]
+      shard: 440
+      total_validator_count: 157
+  - - committee: [46, 257, 243]
+      shard: 441
+      total_validator_count: 157
+  - - committee: [15, 236]
+      shard: 442
+      total_validator_count: 157
+  - - committee: [218, 250]
+      shard: 443
+      total_validator_count: 157
+  - - committee: [38, 98, 17]
+      shard: 444
+      total_validator_count: 157
+  - - committee: [146, 233]
+      shard: 445
+      total_validator_count: 157
+  - - committee: [240, 163, 315]
+      shard: 446
+      total_validator_count: 157
+  - - committee: [331, 45]
+      shard: 447
+      total_validator_count: 157
+  - - committee: [275, 76, 135]
+      shard: 448
+      total_validator_count: 157
+  - - committee: [178, 192]
+      shard: 449
+      total_validator_count: 157
+  - - committee: [401, 379, 112]
+      shard: 450
+      total_validator_count: 157
+  - - committee: [333, 39]
+      shard: 451
+      total_validator_count: 157
+  - - committee: [364, 24, 296]
+      shard: 452
+      total_validator_count: 157
+  - - committee: [155, 249]
+      shard: 453
+      total_validator_count: 157
+  - - committee: [232, 59]
+      shard: 454
+      total_validator_count: 157
+  - - committee: [264, 336, 88]
+      shard: 455
+      total_validator_count: 157
+  - - committee: [307, 89]
+      shard: 456
+      total_validator_count: 157
+  - - committee: [242, 407, 399]
+      shard: 457
+      total_validator_count: 157
+  - - committee: [179, 262]
+      shard: 458
+      total_validator_count: 157
+  - - committee: [387, 117, 396]
+      shard: 459
+      total_validator_count: 157
+  - - committee: [201, 309]
+      shard: 460
+      total_validator_count: 157
+  - - committee: [297, 369, 221]
+      shard: 461
+      total_validator_count: 157
+  - - committee: [237, 295]
+      shard: 462
+      total_validator_count: 157
+  - - committee: [4, 395, 21]
+      shard: 463
+      total_validator_count: 157
+  seed: '0xebeb8f9a88f523bc0d4ce17deee159c9791c919c3d8884187a66935c7af5665e'
+- input:
+    crosslinking_start_shard: 669
+    validators:
+    - original_index: 0
+      status: [1]
+    - original_index: 1
+      status: [1]
+    - original_index: 2
+      status: [0]
+    - original_index: 3
+      status: [1]
+    - original_index: 4
+      status: [4]
+    - original_index: 5
+      status: [3]
+    - original_index: 6
+      status: [1]
+    - original_index: 7
+      status: [4]
+    - original_index: 8
+      status: [4]
+    - original_index: 9
+      status: [1]
+    - original_index: 10
+      status: [2]
+    - original_index: 11
+      status: [2]
+    - original_index: 12
+      status: [0]
+    - original_index: 13
+      status: [2]
+    - original_index: 14
+      status: [3]
+    - original_index: 15
+      status: [4]
+    - original_index: 16
+      status: [0]
+    - original_index: 17
+      status: [4]
+    - original_index: 18
+      status: [4]
+    - original_index: 19
+      status: [0]
+    - original_index: 20
+      status: [4]
+    - original_index: 21
+      status: [3]
+    - original_index: 22
+      status: [3]
+    - original_index: 23
+      status: [2]
+    - original_index: 24
+      status: [4]
+    - original_index: 25
+      status: [2]
+    - original_index: 26
+      status: [3]
+    - original_index: 27
+      status: [2]
+    - original_index: 28
+      status: [1]
+    - original_index: 29
+      status: [4]
+    - original_index: 30
+      status: [1]
+    - original_index: 31
+      status: [1]
+    - original_index: 32
+      status: [4]
+    - original_index: 33
+      status: [1]
+    - original_index: 34
+      status: [2]
+    - original_index: 35
+      status: [0]
+    - original_index: 36
+      status: [0]
+    - original_index: 37
+      status: [4]
+    - original_index: 38
+      status: [4]
+    - original_index: 39
+      status: [4]
+    - original_index: 40
+      status: [3]
+    - original_index: 41
+      status: [4]
+    - original_index: 42
+      status: [0]
+    - original_index: 43
+      status: [0]
+    - original_index: 44
+      status: [3]
+    - original_index: 45
+      status: [1]
+    - original_index: 46
+      status: [3]
+    - original_index: 47
+      status: [4]
+    - original_index: 48
+      status: [2]
+    - original_index: 49
+      status: [0]
+    - original_index: 50
+      status: [2]
+    - original_index: 51
+      status: [2]
+    - original_index: 52
+      status: [0]
+    - original_index: 53
+      status: [1]
+    - original_index: 54
+      status: [1]
+    - original_index: 55
+      status: [4]
+    - original_index: 56
+      status: [2]
+    - original_index: 57
+      status: [2]
+    - original_index: 58
+      status: [1]
+    - original_index: 59
+      status: [4]
+    - original_index: 60
+      status: [2]
+    - original_index: 61
+      status: [4]
+    - original_index: 62
+      status: [0]
+    - original_index: 63
+      status: [4]
+    - original_index: 64
+      status: [2]
+    - original_index: 65
+      status: [0]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [1]
+    - original_index: 68
+      status: [4]
+    - original_index: 69
+      status: [1]
+    - original_index: 70
+      status: [4]
+    - original_index: 71
+      status: [2]
+    - original_index: 72
+      status: [3]
+    - original_index: 73
+      status: [4]
+    - original_index: 74
+      status: [4]
+    - original_index: 75
+      status: [1]
+    - original_index: 76
+      status: [2]
+    - original_index: 77
+      status: [4]
+    - original_index: 78
+      status: [4]
+    - original_index: 79
+      status: [4]
+    - original_index: 80
+      status: [1]
+    - original_index: 81
+      status: [0]
+    - original_index: 82
+      status: [4]
+    - original_index: 83
+      status: [3]
+    - original_index: 84
+      status: [2]
+    - original_index: 85
+      status: [2]
+    - original_index: 86
+      status: [4]
+    - original_index: 87
+      status: [2]
+    - original_index: 88
+      status: [1]
+    - original_index: 89
+      status: [3]
+    - original_index: 90
+      status: [3]
+    - original_index: 91
+      status: [1]
+    - original_index: 92
+      status: [3]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [3]
+    - original_index: 95
+      status: [2]
+    - original_index: 96
+      status: [4]
+    - original_index: 97
+      status: [3]
+    - original_index: 98
+      status: [4]
+    - original_index: 99
+      status: [4]
+    - original_index: 100
+      status: [0]
+    - original_index: 101
+      status: [0]
+    - original_index: 102
+      status: [3]
+    - original_index: 103
+      status: [4]
+    - original_index: 104
+      status: [4]
+    - original_index: 105
+      status: [2]
+    - original_index: 106
+      status: [3]
+    - original_index: 107
+      status: [3]
+    - original_index: 108
+      status: [1]
+    - original_index: 109
+      status: [2]
+    - original_index: 110
+      status: [3]
+    - original_index: 111
+      status: [4]
+    - original_index: 112
+      status: [1]
+    - original_index: 113
+      status: [1]
+    - original_index: 114
+      status: [4]
+    - original_index: 115
+      status: [4]
+    - original_index: 116
+      status: [1]
+    - original_index: 117
+      status: [2]
+    - original_index: 118
+      status: [3]
+    - original_index: 119
+      status: [4]
+    - original_index: 120
+      status: [1]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [0]
+    - original_index: 124
+      status: [0]
+    - original_index: 125
+      status: [0]
+    - original_index: 126
+      status: [2]
+    - original_index: 127
+      status: [3]
+    - original_index: 128
+      status: [4]
+    - original_index: 129
+      status: [2]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [1]
+    - original_index: 132
+      status: [2]
+    - original_index: 133
+      status: [4]
+    - original_index: 134
+      status: [4]
+    - original_index: 135
+      status: [2]
+    - original_index: 136
+      status: [4]
+    - original_index: 137
+      status: [2]
+    - original_index: 138
+      status: [3]
+    - original_index: 139
+      status: [3]
+    - original_index: 140
+      status: [4]
+    - original_index: 141
+      status: [4]
+    - original_index: 142
+      status: [0]
+    - original_index: 143
+      status: [0]
+    - original_index: 144
+      status: [2]
+    - original_index: 145
+      status: [3]
+    - original_index: 146
+      status: [4]
+    - original_index: 147
+      status: [2]
+    - original_index: 148
+      status: [2]
+    - original_index: 149
+      status: [3]
+    - original_index: 150
+      status: [3]
+    - original_index: 151
+      status: [1]
+    - original_index: 152
+      status: [1]
+    - original_index: 153
+      status: [2]
+    - original_index: 154
+      status: [3]
+    - original_index: 155
+      status: [4]
+    - original_index: 156
+      status: [4]
+    - original_index: 157
+      status: [0]
+    - original_index: 158
+      status: [4]
+    - original_index: 159
+      status: [2]
+    - original_index: 160
+      status: [0]
+    - original_index: 161
+      status: [3]
+    - original_index: 162
+      status: [3]
+    - original_index: 163
+      status: [1]
+    - original_index: 164
+      status: [3]
+    - original_index: 165
+      status: [4]
+    - original_index: 166
+      status: [1]
+    - original_index: 167
+      status: [1]
+    - original_index: 168
+      status: [1]
+    - original_index: 169
+      status: [3]
+    - original_index: 170
+      status: [1]
+    - original_index: 171
+      status: [2]
+    - original_index: 172
+      status: [3]
+    - original_index: 173
+      status: [3]
+    - original_index: 174
+      status: [4]
+    - original_index: 175
+      status: [4]
+    - original_index: 176
+      status: [1]
+    - original_index: 177
+      status: [4]
+    - original_index: 178
+      status: [4]
+    - original_index: 179
+      status: [1]
+    - original_index: 180
+      status: [4]
+    - original_index: 181
+      status: [0]
+    - original_index: 182
+      status: [4]
+    - original_index: 183
+      status: [1]
+    - original_index: 184
+      status: [0]
+    - original_index: 185
+      status: [4]
+    - original_index: 186
+      status: [0]
+    - original_index: 187
+      status: [3]
+    - original_index: 188
+      status: [3]
+    - original_index: 189
+      status: [1]
+    - original_index: 190
+      status: [0]
+    - original_index: 191
+      status: [0]
+    - original_index: 192
+      status: [2]
+    - original_index: 193
+      status: [1]
+    - original_index: 194
+      status: [2]
+    - original_index: 195
+      status: [4]
+    - original_index: 196
+      status: [4]
+    - original_index: 197
+      status: [1]
+    - original_index: 198
+      status: [2]
+    - original_index: 199
+      status: [4]
+    - original_index: 200
+      status: [2]
+    - original_index: 201
+      status: [1]
+    - original_index: 202
+      status: [0]
+    - original_index: 203
+      status: [2]
+    - original_index: 204
+      status: [2]
+    - original_index: 205
+      status: [1]
+    - original_index: 206
+      status: [3]
+    - original_index: 207
+      status: [4]
+    - original_index: 208
+      status: [1]
+    - original_index: 209
+      status: [1]
+    - original_index: 210
+      status: [0]
+    - original_index: 211
+      status: [3]
+    - original_index: 212
+      status: [2]
+    - original_index: 213
+      status: [2]
+    - original_index: 214
+      status: [2]
+    - original_index: 215
+      status: [1]
+    - original_index: 216
+      status: [2]
+    - original_index: 217
+      status: [1]
+    - original_index: 218
+      status: [1]
+    - original_index: 219
+      status: [3]
+    - original_index: 220
+      status: [4]
+    - original_index: 221
+      status: [0]
+    - original_index: 222
+      status: [2]
+    - original_index: 223
+      status: [3]
+    - original_index: 224
+      status: [4]
+    - original_index: 225
+      status: [2]
+    - original_index: 226
+      status: [0]
+    - original_index: 227
+      status: [3]
+    - original_index: 228
+      status: [1]
+    - original_index: 229
+      status: [2]
+    - original_index: 230
+      status: [1]
+    - original_index: 231
+      status: [0]
+    - original_index: 232
+      status: [4]
+    - original_index: 233
+      status: [4]
+    - original_index: 234
+      status: [1]
+    - original_index: 235
+      status: [4]
+    - original_index: 236
+      status: [4]
+    - original_index: 237
+      status: [4]
+    - original_index: 238
+      status: [0]
+    - original_index: 239
+      status: [2]
+    - original_index: 240
+      status: [0]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [3]
+    - original_index: 243
+      status: [4]
+    - original_index: 244
+      status: [3]
+    - original_index: 245
+      status: [3]
+    - original_index: 246
+      status: [3]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [0]
+    - original_index: 249
+      status: [2]
+    - original_index: 250
+      status: [4]
+    - original_index: 251
+      status: [1]
+    - original_index: 252
+      status: [1]
+    - original_index: 253
+      status: [1]
+    - original_index: 254
+      status: [3]
+    - original_index: 255
+      status: [3]
+    - original_index: 256
+      status: [0]
+    - original_index: 257
+      status: [3]
+    - original_index: 258
+      status: [3]
+    - original_index: 259
+      status: [3]
+    - original_index: 260
+      status: [3]
+    - original_index: 261
+      status: [3]
+    - original_index: 262
+      status: [4]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [1]
+    - original_index: 265
+      status: [1]
+    - original_index: 266
+      status: [3]
+    - original_index: 267
+      status: [3]
+    - original_index: 268
+      status: [3]
+    - original_index: 269
+      status: [1]
+    - original_index: 270
+      status: [1]
+    - original_index: 271
+      status: [1]
+    - original_index: 272
+      status: [1]
+    - original_index: 273
+      status: [3]
+    - original_index: 274
+      status: [0]
+    - original_index: 275
+      status: [3]
+    - original_index: 276
+      status: [4]
+    - original_index: 277
+      status: [0]
+    - original_index: 278
+      status: [4]
+    - original_index: 279
+      status: [4]
+    - original_index: 280
+      status: [0]
+    - original_index: 281
+      status: [4]
+    - original_index: 282
+      status: [1]
+    - original_index: 283
+      status: [0]
+    - original_index: 284
+      status: [1]
+    - original_index: 285
+      status: [1]
+    - original_index: 286
+      status: [1]
+    - original_index: 287
+      status: [2]
+    - original_index: 288
+      status: [4]
+    - original_index: 289
+      status: [0]
+    - original_index: 290
+      status: [0]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [0]
+    - original_index: 293
+      status: [3]
+    - original_index: 294
+      status: [1]
+    - original_index: 295
+      status: [0]
+    - original_index: 296
+      status: [3]
+    - original_index: 297
+      status: [4]
+    - original_index: 298
+      status: [3]
+    - original_index: 299
+      status: [3]
+    - original_index: 300
+      status: [2]
+    - original_index: 301
+      status: [3]
+    - original_index: 302
+      status: [1]
+    - original_index: 303
+      status: [0]
+    - original_index: 304
+      status: [4]
+    - original_index: 305
+      status: [0]
+    - original_index: 306
+      status: [1]
+    - original_index: 307
+      status: [4]
+    - original_index: 308
+      status: [4]
+    - original_index: 309
+      status: [4]
+    - original_index: 310
+      status: [4]
+    - original_index: 311
+      status: [2]
+    - original_index: 312
+      status: [1]
+    - original_index: 313
+      status: [2]
+    - original_index: 314
+      status: [4]
+    - original_index: 315
+      status: [2]
+    - original_index: 316
+      status: [0]
+    - original_index: 317
+      status: [1]
+    - original_index: 318
+      status: [2]
+    - original_index: 319
+      status: [2]
+    - original_index: 320
+      status: [4]
+    - original_index: 321
+      status: [3]
+    - original_index: 322
+      status: [1]
+    - original_index: 323
+      status: [0]
+    - original_index: 324
+      status: [1]
+    - original_index: 325
+      status: [0]
+    - original_index: 326
+      status: [4]
+    - original_index: 327
+      status: [0]
+    - original_index: 328
+      status: [3]
+    - original_index: 329
+      status: [1]
+    - original_index: 330
+      status: [2]
+    - original_index: 331
+      status: [1]
+    - original_index: 332
+      status: [0]
+    - original_index: 333
+      status: [3]
+    - original_index: 334
+      status: [3]
+    - original_index: 335
+      status: [4]
+    - original_index: 336
+      status: [4]
+    - original_index: 337
+      status: [1]
+    - original_index: 338
+      status: [0]
+    - original_index: 339
+      status: [0]
+    - original_index: 340
+      status: [1]
+    - original_index: 341
+      status: [0]
+    - original_index: 342
+      status: [4]
+    - original_index: 343
+      status: [3]
+    - original_index: 344
+      status: [3]
+    - original_index: 345
+      status: [2]
+    - original_index: 346
+      status: [2]
+    - original_index: 347
+      status: [3]
+    - original_index: 348
+      status: [3]
+    - original_index: 349
+      status: [0]
+    - original_index: 350
+      status: [0]
+    - original_index: 351
+      status: [4]
+    - original_index: 352
+      status: [2]
+    - original_index: 353
+      status: [3]
+    - original_index: 354
+      status: [3]
+    - original_index: 355
+      status: [4]
+    - original_index: 356
+      status: [1]
+    - original_index: 357
+      status: [0]
+    - original_index: 358
+      status: [4]
+    - original_index: 359
+      status: [2]
+    - original_index: 360
+      status: [0]
+    - original_index: 361
+      status: [3]
+    - original_index: 362
+      status: [0]
+    - original_index: 363
+      status: [0]
+    - original_index: 364
+      status: [4]
+    - original_index: 365
+      status: [2]
+    - original_index: 366
+      status: [3]
+    - original_index: 367
+      status: [3]
+    - original_index: 368
+      status: [4]
+    - original_index: 369
+      status: [0]
+    - original_index: 370
+      status: [4]
+    - original_index: 371
+      status: [2]
+    - original_index: 372
+      status: [3]
+    - original_index: 373
+      status: [3]
+    - original_index: 374
+      status: [3]
+    - original_index: 375
+      status: [2]
+    - original_index: 376
+      status: [4]
+    - original_index: 377
+      status: [0]
+    - original_index: 378
+      status: [0]
+    - original_index: 379
+      status: [1]
+    - original_index: 380
+      status: [0]
+    - original_index: 381
+      status: [4]
+    - original_index: 382
+      status: [4]
+    - original_index: 383
+      status: [4]
+  output:
+  - - committee: [130, 151]
+      shard: 669
+      total_validator_count: 173
+  - - committee: [302, 336, 163]
+      shard: 670
+      total_validator_count: 173
+  - - committee: [234, 262, 179]
+      shard: 671
+      total_validator_count: 173
+  - - committee: [54, 77]
+      shard: 672
+      total_validator_count: 173
+  - - committee: [59, 232, 205]
+      shard: 673
+      total_validator_count: 173
+  - - committee: [0, 356, 337]
+      shard: 674
+      total_validator_count: 173
+  - - committee: [141, 133]
+      shard: 675
+      total_validator_count: 173
+  - - committee: [17, 114, 30]
+      shard: 676
+      total_validator_count: 173
+  - - committee: [312, 368, 177]
+      shard: 677
+      total_validator_count: 173
+  - - committee: [250, 252, 284]
+      shard: 678
+      total_validator_count: 173
+  - - committee: [111, 331]
+      shard: 679
+      total_validator_count: 173
+  - - committee: [174, 272, 68]
+      shard: 680
+      total_validator_count: 173
+  - - committee: [209, 310, 45]
+      shard: 681
+      total_validator_count: 173
+  - - committee: [306, 108]
+      shard: 682
+      total_validator_count: 173
+  - - committee: [74, 379, 75]
+      shard: 683
+      total_validator_count: 173
+  - - committee: [317, 335, 370]
+      shard: 684
+      total_validator_count: 173
+  - - committee: [182, 47]
+      shard: 685
+      total_validator_count: 173
+  - - committee: [88, 383, 241]
+      shard: 686
+      total_validator_count: 173
+  - - committee: [119, 170, 189]
+      shard: 687
+      total_validator_count: 173
+  - - committee: [146, 63, 128]
+      shard: 688
+      total_validator_count: 173
+  - - committee: [308, 9]
+      shard: 689
+      total_validator_count: 173
+  - - committee: [236, 199, 178]
+      shard: 690
+      total_validator_count: 173
+  - - committee: [185, 230, 80]
+      shard: 691
+      total_validator_count: 173
+  - - committee: [53, 37]
+      shard: 692
+      total_validator_count: 173
+  - - committee: [140, 7, 98]
+      shard: 693
+      total_validator_count: 173
+  - - committee: [131, 314, 233]
+      shard: 694
+      total_validator_count: 173
+  - - committee: [31, 324]
+      shard: 695
+      total_validator_count: 173
+  - - committee: [265, 69, 8]
+      shard: 696
+      total_validator_count: 173
+  - - committee: [208, 269, 286]
+      shard: 697
+      total_validator_count: 173
+  - - committee: [329, 3, 196]
+      shard: 698
+      total_validator_count: 173
+  - - committee: [281, 220]
+      shard: 699
+      total_validator_count: 173
+  - - committee: [297, 307, 309]
+      shard: 700
+      total_validator_count: 173
+  - - committee: [82, 67, 116]
+      shard: 701
+      total_validator_count: 173
+  - - committee: [224, 285]
+      shard: 702
+      total_validator_count: 173
+  - - committee: [33, 55, 39]
+      shard: 703
+      total_validator_count: 173
+  - - committee: [381, 197, 243]
+      shard: 704
+      total_validator_count: 173
+  - - committee: [207, 120, 134]
+      shard: 705
+      total_validator_count: 173
+  - - committee: [41, 253]
+      shard: 706
+      total_validator_count: 173
+  - - committee: [18, 166, 193]
+      shard: 707
+      total_validator_count: 173
+  - - committee: [322, 24, 168]
+      shard: 708
+      total_validator_count: 173
+  - - committee: [304, 112]
+      shard: 709
+      total_validator_count: 173
+  - - committee: [155, 271, 136]
+      shard: 710
+      total_validator_count: 173
+  - - committee: [73, 91, 6]
+      shard: 711
+      total_validator_count: 173
+  - - committee: [276, 28]
+      shard: 712
+      total_validator_count: 173
+  - - committee: [103, 320, 235]
+      shard: 713
+      total_validator_count: 173
+  - - committee: [264, 70, 78]
+      shard: 714
+      total_validator_count: 173
+  - - committee: [282, 4, 263]
+      shard: 715
+      total_validator_count: 173
+  - - committee: [158, 237]
+      shard: 716
+      total_validator_count: 173
+  - - committee: [176, 201, 215]
+      shard: 717
+      total_validator_count: 173
+  - - committee: [278, 326, 79]
+      shard: 718
+      total_validator_count: 173
+  - - committee: [113, 355]
+      shard: 719
+      total_validator_count: 173
+  - - committee: [218, 376, 364]
+      shard: 720
+      total_validator_count: 173
+  - - committee: [183, 104, 61]
+      shard: 721
+      total_validator_count: 173
+  - - committee: [288, 279]
+      shard: 722
+      total_validator_count: 173
+  - - committee: [156, 152, 58]
+      shard: 723
+      total_validator_count: 173
+  - - committee: [358, 175, 180]
+      shard: 724
+      total_validator_count: 173
+  - - committee: [340, 115, 32]
+      shard: 725
+      total_validator_count: 173
+  - - committee: [270, 195]
+      shard: 726
+      total_validator_count: 173
+  - - committee: [15, 38, 294]
+      shard: 727
+      total_validator_count: 173
+  - - committee: [251, 29, 86]
+      shard: 728
+      total_validator_count: 173
+  - - committee: [20, 165]
+      shard: 729
+      total_validator_count: 173
+  - - committee: [351, 96, 99]
+      shard: 730
+      total_validator_count: 173
+  - - committee: [342, 217, 1]
+      shard: 731
+      total_validator_count: 173
+  - - committee: [167, 382, 228]
+      shard: 732
+      total_validator_count: 173
+  seed: '0x6ff9fde4cd621a9359ee5f08929d2188ed5f72b59aa71c3d10453ccde114d1b6'
+- input:
+    crosslinking_start_shard: 946
+    validators:
+    - original_index: 0
+      status: [2]
+    - original_index: 1
+      status: [2]
+    - original_index: 2
+      status: [1]
+    - original_index: 3
+      status: [4]
+    - original_index: 4
+      status: [1]
+    - original_index: 5
+      status: [1]
+    - original_index: 6
+      status: [0]
+    - original_index: 7
+      status: [4]
+    - original_index: 8
+      status: [4]
+    - original_index: 9
+      status: [1]
+    - original_index: 10
+      status: [0]
+    - original_index: 11
+      status: [1]
+    - original_index: 12
+      status: [4]
+    - original_index: 13
+      status: [0]
+    - original_index: 14
+      status: [2]
+    - original_index: 15
+      status: [0]
+    - original_index: 16
+      status: [2]
+    - original_index: 17
+      status: [0]
+    - original_index: 18
+      status: [3]
+    - original_index: 19
+      status: [1]
+    - original_index: 20
+      status: [2]
+    - original_index: 21
+      status: [4]
+    - original_index: 22
+      status: [4]
+    - original_index: 23
+      status: [1]
+    - original_index: 24
+      status: [4]
+    - original_index: 25
+      status: [2]
+    - original_index: 26
+      status: [3]
+    - original_index: 27
+      status: [4]
+    - original_index: 28
+      status: [4]
+    - original_index: 29
+      status: [3]
+    - original_index: 30
+      status: [2]
+    - original_index: 31
+      status: [3]
+    - original_index: 32
+      status: [0]
+    - original_index: 33
+      status: [0]
+    - original_index: 34
+      status: [1]
+    - original_index: 35
+      status: [0]
+    - original_index: 36
+      status: [0]
+    - original_index: 37
+      status: [2]
+    - original_index: 38
+      status: [0]
+    - original_index: 39
+      status: [1]
+    - original_index: 40
+      status: [4]
+    - original_index: 41
+      status: [1]
+    - original_index: 42
+      status: [3]
+    - original_index: 43
+      status: [0]
+    - original_index: 44
+      status: [0]
+    - original_index: 45
+      status: [4]
+    - original_index: 46
+      status: [0]
+    - original_index: 47
+      status: [0]
+    - original_index: 48
+      status: [1]
+    - original_index: 49
+      status: [1]
+    - original_index: 50
+      status: [1]
+    - original_index: 51
+      status: [4]
+    - original_index: 52
+      status: [3]
+    - original_index: 53
+      status: [1]
+    - original_index: 54
+      status: [2]
+    - original_index: 55
+      status: [0]
+    - original_index: 56
+      status: [1]
+    - original_index: 57
+      status: [1]
+    - original_index: 58
+      status: [1]
+    - original_index: 59
+      status: [4]
+    - original_index: 60
+      status: [1]
+    - original_index: 61
+      status: [3]
+    - original_index: 62
+      status: [1]
+    - original_index: 63
+      status: [1]
+    - original_index: 64
+      status: [3]
+    - original_index: 65
+      status: [4]
+    - original_index: 66
+      status: [4]
+    - original_index: 67
+      status: [3]
+    - original_index: 68
+      status: [4]
+    - original_index: 69
+      status: [1]
+    - original_index: 70
+      status: [1]
+    - original_index: 71
+      status: [0]
+    - original_index: 72
+      status: [3]
+    - original_index: 73
+      status: [4]
+    - original_index: 74
+      status: [0]
+    - original_index: 75
+      status: [1]
+    - original_index: 76
+      status: [0]
+    - original_index: 77
+      status: [2]
+    - original_index: 78
+      status: [2]
+    - original_index: 79
+      status: [3]
+    - original_index: 80
+      status: [0]
+    - original_index: 81
+      status: [4]
+    - original_index: 82
+      status: [4]
+    - original_index: 83
+      status: [0]
+    - original_index: 84
+      status: [2]
+    - original_index: 85
+      status: [0]
+    - original_index: 86
+      status: [2]
+    - original_index: 87
+      status: [0]
+    - original_index: 88
+      status: [0]
+    - original_index: 89
+      status: [0]
+    - original_index: 90
+      status: [2]
+    - original_index: 91
+      status: [3]
+    - original_index: 92
+      status: [2]
+    - original_index: 93
+      status: [3]
+    - original_index: 94
+      status: [3]
+    - original_index: 95
+      status: [0]
+    - original_index: 96
+      status: [2]
+    - original_index: 97
+      status: [1]
+    - original_index: 98
+      status: [0]
+    - original_index: 99
+      status: [0]
+    - original_index: 100
+      status: [4]
+    - original_index: 101
+      status: [4]
+    - original_index: 102
+      status: [4]
+    - original_index: 103
+      status: [1]
+    - original_index: 104
+      status: [2]
+    - original_index: 105
+      status: [3]
+    - original_index: 106
+      status: [3]
+    - original_index: 107
+      status: [0]
+    - original_index: 108
+      status: [1]
+    - original_index: 109
+      status: [0]
+    - original_index: 110
+      status: [1]
+    - original_index: 111
+      status: [1]
+    - original_index: 112
+      status: [2]
+    - original_index: 113
+      status: [3]
+    - original_index: 114
+      status: [1]
+    - original_index: 115
+      status: [2]
+    - original_index: 116
+      status: [4]
+    - original_index: 117
+      status: [3]
+    - original_index: 118
+      status: [0]
+    - original_index: 119
+      status: [0]
+    - original_index: 120
+      status: [3]
+    - original_index: 121
+      status: [2]
+    - original_index: 122
+      status: [1]
+    - original_index: 123
+      status: [1]
+    - original_index: 124
+      status: [0]
+    - original_index: 125
+      status: [2]
+    - original_index: 126
+      status: [0]
+    - original_index: 127
+      status: [3]
+    - original_index: 128
+      status: [0]
+    - original_index: 129
+      status: [2]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [3]
+    - original_index: 132
+      status: [4]
+    - original_index: 133
+      status: [0]
+    - original_index: 134
+      status: [3]
+    - original_index: 135
+      status: [4]
+    - original_index: 136
+      status: [2]
+    - original_index: 137
+      status: [4]
+    - original_index: 138
+      status: [3]
+    - original_index: 139
+      status: [0]
+    - original_index: 140
+      status: [1]
+    - original_index: 141
+      status: [1]
+    - original_index: 142
+      status: [2]
+    - original_index: 143
+      status: [2]
+    - original_index: 144
+      status: [3]
+    - original_index: 145
+      status: [0]
+    - original_index: 146
+      status: [0]
+    - original_index: 147
+      status: [2]
+    - original_index: 148
+      status: [3]
+    - original_index: 149
+      status: [1]
+    - original_index: 150
+      status: [3]
+    - original_index: 151
+      status: [4]
+    - original_index: 152
+      status: [3]
+    - original_index: 153
+      status: [1]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [2]
+    - original_index: 156
+      status: [0]
+    - original_index: 157
+      status: [4]
+    - original_index: 158
+      status: [4]
+    - original_index: 159
+      status: [2]
+    - original_index: 160
+      status: [0]
+    - original_index: 161
+      status: [0]
+    - original_index: 162
+      status: [1]
+    - original_index: 163
+      status: [2]
+    - original_index: 164
+      status: [4]
+    - original_index: 165
+      status: [2]
+    - original_index: 166
+      status: [1]
+    - original_index: 167
+      status: [0]
+    - original_index: 168
+      status: [3]
+    - original_index: 169
+      status: [2]
+    - original_index: 170
+      status: [0]
+    - original_index: 171
+      status: [3]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [3]
+    - original_index: 174
+      status: [0]
+    - original_index: 175
+      status: [3]
+    - original_index: 176
+      status: [0]
+    - original_index: 177
+      status: [1]
+    - original_index: 178
+      status: [0]
+    - original_index: 179
+      status: [4]
+    - original_index: 180
+      status: [4]
+    - original_index: 181
+      status: [0]
+    - original_index: 182
+      status: [4]
+    - original_index: 183
+      status: [0]
+    - original_index: 184
+      status: [2]
+    - original_index: 185
+      status: [2]
+    - original_index: 186
+      status: [2]
+    - original_index: 187
+      status: [4]
+    - original_index: 188
+      status: [1]
+    - original_index: 189
+      status: [2]
+    - original_index: 190
+      status: [4]
+    - original_index: 191
+      status: [2]
+    - original_index: 192
+      status: [4]
+    - original_index: 193
+      status: [1]
+    - original_index: 194
+      status: [0]
+    - original_index: 195
+      status: [0]
+    - original_index: 196
+      status: [2]
+    - original_index: 197
+      status: [3]
+    - original_index: 198
+      status: [3]
+    - original_index: 199
+      status: [3]
+    - original_index: 200
+      status: [1]
+    - original_index: 201
+      status: [1]
+    - original_index: 202
+      status: [2]
+    - original_index: 203
+      status: [4]
+    - original_index: 204
+      status: [1]
+    - original_index: 205
+      status: [4]
+    - original_index: 206
+      status: [0]
+    - original_index: 207
+      status: [2]
+    - original_index: 208
+      status: [2]
+    - original_index: 209
+      status: [0]
+    - original_index: 210
+      status: [0]
+    - original_index: 211
+      status: [2]
+    - original_index: 212
+      status: [4]
+    - original_index: 213
+      status: [2]
+    - original_index: 214
+      status: [1]
+    - original_index: 215
+      status: [4]
+    - original_index: 216
+      status: [2]
+    - original_index: 217
+      status: [0]
+    - original_index: 218
+      status: [1]
+    - original_index: 219
+      status: [0]
+    - original_index: 220
+      status: [3]
+    - original_index: 221
+      status: [1]
+    - original_index: 222
+      status: [1]
+    - original_index: 223
+      status: [1]
+    - original_index: 224
+      status: [3]
+    - original_index: 225
+      status: [4]
+    - original_index: 226
+      status: [3]
+    - original_index: 227
+      status: [0]
+    - original_index: 228
+      status: [1]
+    - original_index: 229
+      status: [0]
+    - original_index: 230
+      status: [2]
+    - original_index: 231
+      status: [3]
+    - original_index: 232
+      status: [3]
+    - original_index: 233
+      status: [1]
+    - original_index: 234
+      status: [4]
+    - original_index: 235
+      status: [1]
+    - original_index: 236
+      status: [3]
+    - original_index: 237
+      status: [0]
+    - original_index: 238
+      status: [3]
+    - original_index: 239
+      status: [1]
+    - original_index: 240
+      status: [2]
+    - original_index: 241
+      status: [2]
+    - original_index: 242
+      status: [4]
+    - original_index: 243
+      status: [2]
+    - original_index: 244
+      status: [2]
+    - original_index: 245
+      status: [1]
+    - original_index: 246
+      status: [1]
+    - original_index: 247
+      status: [4]
+    - original_index: 248
+      status: [1]
+    - original_index: 249
+      status: [4]
+    - original_index: 250
+      status: [3]
+    - original_index: 251
+      status: [4]
+    - original_index: 252
+      status: [3]
+    - original_index: 253
+      status: [1]
+    - original_index: 254
+      status: [4]
+    - original_index: 255
+      status: [2]
+    - original_index: 256
+      status: [4]
+    - original_index: 257
+      status: [0]
+    - original_index: 258
+      status: [0]
+    - original_index: 259
+      status: [2]
+    - original_index: 260
+      status: [0]
+    - original_index: 261
+      status: [4]
+    - original_index: 262
+      status: [0]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [3]
+    - original_index: 265
+      status: [4]
+    - original_index: 266
+      status: [1]
+    - original_index: 267
+      status: [4]
+    - original_index: 268
+      status: [1]
+    - original_index: 269
+      status: [4]
+    - original_index: 270
+      status: [2]
+    - original_index: 271
+      status: [2]
+    - original_index: 272
+      status: [3]
+    - original_index: 273
+      status: [1]
+    - original_index: 274
+      status: [2]
+    - original_index: 275
+      status: [2]
+    - original_index: 276
+      status: [1]
+    - original_index: 277
+      status: [4]
+    - original_index: 278
+      status: [2]
+    - original_index: 279
+      status: [4]
+    - original_index: 280
+      status: [2]
+    - original_index: 281
+      status: [4]
+    - original_index: 282
+      status: [1]
+    - original_index: 283
+      status: [2]
+    - original_index: 284
+      status: [4]
+    - original_index: 285
+      status: [3]
+    - original_index: 286
+      status: [1]
+    - original_index: 287
+      status: [0]
+    - original_index: 288
+      status: [2]
+    - original_index: 289
+      status: [0]
+    - original_index: 290
+      status: [2]
+    - original_index: 291
+      status: [2]
+    - original_index: 292
+      status: [4]
+    - original_index: 293
+      status: [0]
+    - original_index: 294
+      status: [1]
+    - original_index: 295
+      status: [1]
+    - original_index: 296
+      status: [2]
+    - original_index: 297
+      status: [0]
+    - original_index: 298
+      status: [4]
+    - original_index: 299
+      status: [1]
+    - original_index: 300
+      status: [1]
+    - original_index: 301
+      status: [2]
+    - original_index: 302
+      status: [1]
+    - original_index: 303
+      status: [3]
+    - original_index: 304
+      status: [3]
+    - original_index: 305
+      status: [1]
+    - original_index: 306
+      status: [3]
+    - original_index: 307
+      status: [1]
+    - original_index: 308
+      status: [4]
+    - original_index: 309
+      status: [2]
+    - original_index: 310
+      status: [0]
+    - original_index: 311
+      status: [3]
+    - original_index: 312
+      status: [3]
+    - original_index: 313
+      status: [2]
+    - original_index: 314
+      status: [2]
+    - original_index: 315
+      status: [0]
+    - original_index: 316
+      status: [3]
+    - original_index: 317
+      status: [2]
+    - original_index: 318
+      status: [2]
+    - original_index: 319
+      status: [1]
+    - original_index: 320
+      status: [4]
+    - original_index: 321
+      status: [3]
+    - original_index: 322
+      status: [3]
+    - original_index: 323
+      status: [0]
+    - original_index: 324
+      status: [2]
+    - original_index: 325
+      status: [4]
+    - original_index: 326
+      status: [2]
+    - original_index: 327
+      status: [4]
+    - original_index: 328
+      status: [1]
+    - original_index: 329
+      status: [3]
+    - original_index: 330
+      status: [2]
+    - original_index: 331
+      status: [0]
+    - original_index: 332
+      status: [0]
+    - original_index: 333
+      status: [4]
+    - original_index: 334
+      status: [0]
+    - original_index: 335
+      status: [0]
+    - original_index: 336
+      status: [2]
+    - original_index: 337
+      status: [1]
+    - original_index: 338
+      status: [4]
+    - original_index: 339
+      status: [4]
+    - original_index: 340
+      status: [4]
+    - original_index: 341
+      status: [2]
+    - original_index: 342
+      status: [4]
+    - original_index: 343
+      status: [3]
+    - original_index: 344
+      status: [4]
+    - original_index: 345
+      status: [4]
+    - original_index: 346
+      status: [4]
+    - original_index: 347
+      status: [3]
+    - original_index: 348
+      status: [2]
+    - original_index: 349
+      status: [0]
+    - original_index: 350
+      status: [1]
+    - original_index: 351
+      status: [4]
+    - original_index: 352
+      status: [3]
+    - original_index: 353
+      status: [2]
+    - original_index: 354
+      status: [3]
+    - original_index: 355
+      status: [2]
+    - original_index: 356
+      status: [0]
+    - original_index: 357
+      status: [3]
+    - original_index: 358
+      status: [3]
+    - original_index: 359
+      status: [1]
+    - original_index: 360
+      status: [3]
+    - original_index: 361
+      status: [1]
+    - original_index: 362
+      status: [2]
+    - original_index: 363
+      status: [0]
+    - original_index: 364
+      status: [0]
+    - original_index: 365
+      status: [2]
+    - original_index: 366
+      status: [4]
+    - original_index: 367
+      status: [0]
+    - original_index: 368
+      status: [1]
+    - original_index: 369
+      status: [2]
+    - original_index: 370
+      status: [1]
+    - original_index: 371
+      status: [4]
+    - original_index: 372
+      status: [1]
+    - original_index: 373
+      status: [2]
+    - original_index: 374
+      status: [2]
+    - original_index: 375
+      status: [2]
+    - original_index: 376
+      status: [1]
+    - original_index: 377
+      status: [2]
+    - original_index: 378
+      status: [2]
+    - original_index: 379
+      status: [0]
+    - original_index: 380
+      status: [1]
+    - original_index: 381
+      status: [0]
+    - original_index: 382
+      status: [1]
+    - original_index: 383
+      status: [0]
+    - original_index: 384
+      status: [1]
+    - original_index: 385
+      status: [2]
+    - original_index: 386
+      status: [1]
+    - original_index: 387
+      status: [2]
+    - original_index: 388
+      status: [1]
+    - original_index: 389
+      status: [4]
+    - original_index: 390
+      status: [2]
+    - original_index: 391
+      status: [2]
+    - original_index: 392
+      status: [1]
+    - original_index: 393
+      status: [4]
+    - original_index: 394
+      status: [2]
+    - original_index: 395
+      status: [4]
+    - original_index: 396
+      status: [1]
+    - original_index: 397
+      status: [2]
+    - original_index: 398
+      status: [1]
+    - original_index: 399
+      status: [4]
+    - original_index: 400
+      status: [0]
+    - original_index: 401
+      status: [1]
+    - original_index: 402
+      status: [2]
+    - original_index: 403
+      status: [0]
+    - original_index: 404
+      status: [3]
+    - original_index: 405
+      status: [1]
+    - original_index: 406
+      status: [2]
+    - original_index: 407
+      status: [1]
+    - original_index: 408
+      status: [2]
+    - original_index: 409
+      status: [3]
+    - original_index: 410
+      status: [0]
+    - original_index: 411
+      status: [0]
+    - original_index: 412
+      status: [2]
+    - original_index: 413
+      status: [0]
+    - original_index: 414
+      status: [2]
+    - original_index: 415
+      status: [0]
+    - original_index: 416
+      status: [4]
+    - original_index: 417
+      status: [0]
+    - original_index: 418
+      status: [2]
+    - original_index: 419
+      status: [3]
+    - original_index: 420
+      status: [1]
+    - original_index: 421
+      status: [4]
+    - original_index: 422
+      status: [2]
+    - original_index: 423
+      status: [3]
+    - original_index: 424
+      status: [0]
+    - original_index: 425
+      status: [2]
+    - original_index: 426
+      status: [0]
+    - original_index: 427
+      status: [3]
+    - original_index: 428
+      status: [4]
+    - original_index: 429
+      status: [4]
+    - original_index: 430
+      status: [2]
+    - original_index: 431
+      status: [3]
+    - original_index: 432
+      status: [1]
+    - original_index: 433
+      status: [2]
+    - original_index: 434
+      status: [2]
+    - original_index: 435
+      status: [2]
+    - original_index: 436
+      status: [4]
+    - original_index: 437
+      status: [4]
+    - original_index: 438
+      status: [2]
+    - original_index: 439
+      status: [3]
+    - original_index: 440
+      status: [0]
+    - original_index: 441
+      status: [0]
+    - original_index: 442
+      status: [3]
+    - original_index: 443
+      status: [0]
+    - original_index: 444
+      status: [3]
+    - original_index: 445
+      status: [3]
+    - original_index: 446
+      status: [3]
+    - original_index: 447
+      status: [3]
+    - original_index: 448
+      status: [3]
+    - original_index: 449
+      status: [0]
+    - original_index: 450
+      status: [2]
+    - original_index: 451
+      status: [2]
+    - original_index: 452
+      status: [1]
+    - original_index: 453
+      status: [0]
+    - original_index: 454
+      status: [0]
+    - original_index: 455
+      status: [1]
+    - original_index: 456
+      status: [1]
+    - original_index: 457
+      status: [1]
+    - original_index: 458
+      status: [4]
+    - original_index: 459
+      status: [3]
+  output:
+  - - committee: [100, 368]
+      shard: 946
+      total_validator_count: 183
+  - - committee: [253, 395, 249]
+      shard: 947
+      total_validator_count: 183
+  - - committee: [2, 401, 286]
+      shard: 948
+      total_validator_count: 183
+  - - committee: [215, 366, 225]
+      shard: 949
+      total_validator_count: 183
+  - - committee: [399, 359, 350]
+      shard: 950
+      total_validator_count: 183
+  - - committee: [24, 223, 3]
+      shard: 951
+      total_validator_count: 183
+  - - committee: [407, 200, 75]
+      shard: 952
+      total_validator_count: 183
+  - - committee: [328, 437]
+      shard: 953
+      total_validator_count: 183
+  - - committee: [135, 300, 59]
+      shard: 954
+      total_validator_count: 183
+  - - committee: [102, 456, 239]
+      shard: 955
+      total_validator_count: 183
+  - - committee: [222, 295, 4]
+      shard: 956
+      total_validator_count: 183
+  - - committee: [396, 51, 110]
+      shard: 957
+      total_validator_count: 183
+  - - committee: [421, 57, 345]
+      shard: 958
+      total_validator_count: 183
+  - - committee: [66, 247, 65]
+      shard: 959
+      total_validator_count: 183
+  - - committee: [254, 388]
+      shard: 960
+      total_validator_count: 183
+  - - committee: [265, 190, 339]
+      shard: 961
+      total_validator_count: 183
+  - - committee: [12, 34, 149]
+      shard: 962
+      total_validator_count: 183
+  - - committee: [279, 298, 193]
+      shard: 963
+      total_validator_count: 183
+  - - committee: [246, 266, 337]
+      shard: 964
+      total_validator_count: 183
+  - - committee: [277, 325, 452]
+      shard: 965
+      total_validator_count: 183
+  - - committee: [69, 340, 269]
+      shard: 966
+      total_validator_count: 183
+  - - committee: [284, 263]
+      shard: 967
+      total_validator_count: 183
+  - - committee: [162, 27, 7]
+      shard: 968
+      total_validator_count: 183
+  - - committee: [49, 23, 180]
+      shard: 969
+      total_validator_count: 183
+  - - committee: [429, 212, 221]
+      shard: 970
+      total_validator_count: 183
+  - - committee: [22, 245, 130]
+      shard: 971
+      total_validator_count: 183
+  - - committee: [384, 19, 97]
+      shard: 972
+      total_validator_count: 183
+  - - committee: [111, 458, 41]
+      shard: 973
+      total_validator_count: 183
+  - - committee: [386, 157]
+      shard: 974
+      total_validator_count: 183
+  - - committee: [248, 140, 405]
+      shard: 975
+      total_validator_count: 183
+  - - committee: [73, 251, 398]
+      shard: 976
+      total_validator_count: 183
+  - - committee: [371, 116, 428]
+      shard: 977
+      total_validator_count: 183
+  - - committee: [108, 39, 235]
+      shard: 978
+      total_validator_count: 183
+  - - committee: [416, 48, 308]
+      shard: 979
+      total_validator_count: 183
+  - - committee: [56, 103, 299]
+      shard: 980
+      total_validator_count: 183
+  - - committee: [158, 201]
+      shard: 981
+      total_validator_count: 183
+  - - committee: [351, 455, 282]
+      shard: 982
+      total_validator_count: 183
+  - - committee: [177, 81, 179]
+      shard: 983
+      total_validator_count: 183
+  - - committee: [9, 53, 218]
+      shard: 984
+      total_validator_count: 183
+  - - committee: [5, 182, 261]
+      shard: 985
+      total_validator_count: 183
+  - - committee: [58, 457, 233]
+      shard: 986
+      total_validator_count: 183
+  - - committee: [294, 242, 342]
+      shard: 987
+      total_validator_count: 183
+  - - committee: [346, 50]
+      shard: 988
+      total_validator_count: 183
+  - - committee: [151, 68, 11]
+      shard: 989
+      total_validator_count: 183
+  - - committee: [389, 204, 302]
+      shard: 990
+      total_validator_count: 183
+  - - committee: [273, 361, 228]
+      shard: 991
+      total_validator_count: 183
+  - - committee: [45, 205, 372]
+      shard: 992
+      total_validator_count: 183
+  - - committee: [305, 268, 141]
+      shard: 993
+      total_validator_count: 183
+  - - committee: [256, 267, 276]
+      shard: 994
+      total_validator_count: 183
+  - - committee: [338, 234]
+      shard: 995
+      total_validator_count: 183
+  - - committee: [154, 203, 187]
+      shard: 996
+      total_validator_count: 183
+  - - committee: [8, 307, 370]
+      shard: 997
+      total_validator_count: 183
+  - - committee: [70, 166, 192]
+      shard: 998
+      total_validator_count: 183
+  - - committee: [380, 132, 344]
+      shard: 999
+      total_validator_count: 183
+  - - committee: [281, 376, 327]
+      shard: 1000
+      total_validator_count: 183
+  - - committee: [137, 114, 214]
+      shard: 1001
+      total_validator_count: 183
+  - - committee: [101, 21]
+      shard: 1002
+      total_validator_count: 183
+  - - committee: [60, 393, 63]
+      shard: 1003
+      total_validator_count: 183
+  - - committee: [188, 392, 432]
+      shard: 1004
+      total_validator_count: 183
+  - - committee: [123, 420, 40]
+      shard: 1005
+      total_validator_count: 183
+  - - committee: [62, 320, 292]
+      shard: 1006
+      total_validator_count: 183
+  - - committee: [436, 319, 333]
+      shard: 1007
+      total_validator_count: 183
+  - - committee: [153, 28, 122]
+      shard: 1008
+      total_validator_count: 183
+  - - committee: [82, 164, 382]
+      shard: 1009
+      total_validator_count: 183
+  seed: '0x9d162fc672c9aba987488027bea4cbc77375dc5ab7c620ce42b3bb35f1445aa8'
+- input:
+    crosslinking_start_shard: 378
+    validators:
+    - original_index: 0
+      status: [0]
+    - original_index: 1
+      status: [0]
+    - original_index: 2
+      status: [1]
+    - original_index: 3
+      status: [2]
+    - original_index: 4
+      status: [0]
+    - original_index: 5
+      status: [1]
+    - original_index: 6
+      status: [4]
+    - original_index: 7
+      status: [0]
+    - original_index: 8
+      status: [0]
+    - original_index: 9
+      status: [2]
+    - original_index: 10
+      status: [1]
+    - original_index: 11
+      status: [4]
+    - original_index: 12
+      status: [3]
+    - original_index: 13
+      status: [4]
+    - original_index: 14
+      status: [1]
+    - original_index: 15
+      status: [4]
+    - original_index: 16
+      status: [2]
+    - original_index: 17
+      status: [2]
+    - original_index: 18
+      status: [3]
+    - original_index: 19
+      status: [3]
+    - original_index: 20
+      status: [4]
+    - original_index: 21
+      status: [0]
+    - original_index: 22
+      status: [0]
+    - original_index: 23
+      status: [3]
+    - original_index: 24
+      status: [3]
+    - original_index: 25
+      status: [3]
+    - original_index: 26
+      status: [1]
+    - original_index: 27
+      status: [0]
+    - original_index: 28
+      status: [1]
+    - original_index: 29
+      status: [2]
+    - original_index: 30
+      status: [2]
+    - original_index: 31
+      status: [4]
+    - original_index: 32
+      status: [1]
+    - original_index: 33
+      status: [3]
+    - original_index: 34
+      status: [4]
+    - original_index: 35
+      status: [2]
+    - original_index: 36
+      status: [3]
+    - original_index: 37
+      status: [3]
+    - original_index: 38
+      status: [4]
+    - original_index: 39
+      status: [1]
+    - original_index: 40
+      status: [1]
+    - original_index: 41
+      status: [2]
+    - original_index: 42
+      status: [1]
+    - original_index: 43
+      status: [2]
+    - original_index: 44
+      status: [3]
+    - original_index: 45
+      status: [3]
+    - original_index: 46
+      status: [0]
+    - original_index: 47
+      status: [0]
+    - original_index: 48
+      status: [3]
+    - original_index: 49
+      status: [4]
+    - original_index: 50
+      status: [3]
+    - original_index: 51
+      status: [3]
+    - original_index: 52
+      status: [4]
+    - original_index: 53
+      status: [0]
+    - original_index: 54
+      status: [1]
+    - original_index: 55
+      status: [2]
+    - original_index: 56
+      status: [3]
+    - original_index: 57
+      status: [0]
+    - original_index: 58
+      status: [2]
+    - original_index: 59
+      status: [3]
+    - original_index: 60
+      status: [2]
+    - original_index: 61
+      status: [4]
+    - original_index: 62
+      status: [0]
+    - original_index: 63
+      status: [3]
+    - original_index: 64
+      status: [2]
+    - original_index: 65
+      status: [4]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [4]
+    - original_index: 68
+      status: [4]
+    - original_index: 69
+      status: [3]
+    - original_index: 70
+      status: [0]
+    - original_index: 71
+      status: [2]
+    - original_index: 72
+      status: [1]
+    - original_index: 73
+      status: [2]
+    - original_index: 74
+      status: [4]
+    - original_index: 75
+      status: [3]
+    - original_index: 76
+      status: [2]
+    - original_index: 77
+      status: [2]
+    - original_index: 78
+      status: [1]
+    - original_index: 79
+      status: [3]
+    - original_index: 80
+      status: [2]
+    - original_index: 81
+      status: [4]
+    - original_index: 82
+      status: [1]
+    - original_index: 83
+      status: [1]
+    - original_index: 84
+      status: [0]
+    - original_index: 85
+      status: [1]
+    - original_index: 86
+      status: [4]
+    - original_index: 87
+      status: [2]
+    - original_index: 88
+      status: [3]
+    - original_index: 89
+      status: [4]
+    - original_index: 90
+      status: [1]
+    - original_index: 91
+      status: [1]
+    - original_index: 92
+      status: [0]
+    - original_index: 93
+      status: [4]
+    - original_index: 94
+      status: [4]
+    - original_index: 95
+      status: [3]
+    - original_index: 96
+      status: [4]
+    - original_index: 97
+      status: [4]
+    - original_index: 98
+      status: [3]
+    - original_index: 99
+      status: [3]
+    - original_index: 100
+      status: [3]
+    - original_index: 101
+      status: [3]
+    - original_index: 102
+      status: [3]
+    - original_index: 103
+      status: [3]
+    - original_index: 104
+      status: [0]
+    - original_index: 105
+      status: [1]
+    - original_index: 106
+      status: [4]
+    - original_index: 107
+      status: [4]
+    - original_index: 108
+      status: [0]
+    - original_index: 109
+      status: [2]
+    - original_index: 110
+      status: [4]
+    - original_index: 111
+      status: [3]
+    - original_index: 112
+      status: [2]
+    - original_index: 113
+      status: [0]
+    - original_index: 114
+      status: [1]
+    - original_index: 115
+      status: [3]
+    - original_index: 116
+      status: [2]
+    - original_index: 117
+      status: [0]
+    - original_index: 118
+      status: [1]
+    - original_index: 119
+      status: [4]
+    - original_index: 120
+      status: [2]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [4]
+    - original_index: 124
+      status: [2]
+    - original_index: 125
+      status: [2]
+    - original_index: 126
+      status: [1]
+    - original_index: 127
+      status: [0]
+    - original_index: 128
+      status: [2]
+    - original_index: 129
+      status: [4]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [3]
+    - original_index: 132
+      status: [1]
+    - original_index: 133
+      status: [4]
+    - original_index: 134
+      status: [3]
+    - original_index: 135
+      status: [4]
+    - original_index: 136
+      status: [4]
+    - original_index: 137
+      status: [4]
+    - original_index: 138
+      status: [1]
+    - original_index: 139
+      status: [0]
+    - original_index: 140
+      status: [4]
+    - original_index: 141
+      status: [1]
+    - original_index: 142
+      status: [0]
+    - original_index: 143
+      status: [4]
+    - original_index: 144
+      status: [1]
+    - original_index: 145
+      status: [2]
+    - original_index: 146
+      status: [2]
+    - original_index: 147
+      status: [4]
+    - original_index: 148
+      status: [4]
+    - original_index: 149
+      status: [2]
+    - original_index: 150
+      status: [0]
+    - original_index: 151
+      status: [2]
+    - original_index: 152
+      status: [3]
+    - original_index: 153
+      status: [3]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [1]
+    - original_index: 156
+      status: [4]
+    - original_index: 157
+      status: [0]
+    - original_index: 158
+      status: [3]
+    - original_index: 159
+      status: [1]
+    - original_index: 160
+      status: [0]
+    - original_index: 161
+      status: [0]
+    - original_index: 162
+      status: [2]
+    - original_index: 163
+      status: [0]
+    - original_index: 164
+      status: [1]
+    - original_index: 165
+      status: [3]
+    - original_index: 166
+      status: [3]
+    - original_index: 167
+      status: [3]
+    - original_index: 168
+      status: [3]
+    - original_index: 169
+      status: [1]
+    - original_index: 170
+      status: [2]
+    - original_index: 171
+      status: [3]
+    - original_index: 172
+      status: [0]
+    - original_index: 173
+      status: [2]
+    - original_index: 174
+      status: [4]
+    - original_index: 175
+      status: [1]
+    - original_index: 176
+      status: [1]
+    - original_index: 177
+      status: [1]
+    - original_index: 178
+      status: [3]
+    - original_index: 179
+      status: [2]
+    - original_index: 180
+      status: [0]
+    - original_index: 181
+      status: [3]
+    - original_index: 182
+      status: [3]
+    - original_index: 183
+      status: [1]
+  output:
+  - - committee: [123]
+      shard: 378
+      total_validator_count: 74
+  - - committee: [20]
+      shard: 379
+      total_validator_count: 74
+  - - committee: [81]
+      shard: 380
+      total_validator_count: 74
+  - - committee: [106]
+      shard: 381
+      total_validator_count: 74
+  - - committee: [10]
+      shard: 382
+      total_validator_count: 74
+  - - committee: [72]
+      shard: 383
+      total_validator_count: 74
+  - - committee: [138, 135]
+      shard: 384
+      total_validator_count: 74
+  - - committee: [13]
+      shard: 385
+      total_validator_count: 74
+  - - committee: [31]
+      shard: 386
+      total_validator_count: 74
+  - - committee: [107]
+      shard: 387
+      total_validator_count: 74
+  - - committee: [14]
+      shard: 388
+      total_validator_count: 74
+  - - committee: [126]
+      shard: 389
+      total_validator_count: 74
+  - - committee: [144, 90]
+      shard: 390
+      total_validator_count: 74
+  - - committee: [6]
+      shard: 391
+      total_validator_count: 74
+  - - committee: [26]
+      shard: 392
+      total_validator_count: 74
+  - - committee: [183]
+      shard: 393
+      total_validator_count: 74
+  - - committee: [34]
+      shard: 394
+      total_validator_count: 74
+  - - committee: [38]
+      shard: 395
+      total_validator_count: 74
+  - - committee: [86]
+      shard: 396
+      total_validator_count: 74
+  - - committee: [175, 82]
+      shard: 397
+      total_validator_count: 74
+  - - committee: [143]
+      shard: 398
+      total_validator_count: 74
+  - - committee: [147]
+      shard: 399
+      total_validator_count: 74
+  - - committee: [74]
+      shard: 400
+      total_validator_count: 74
+  - - committee: [140]
+      shard: 401
+      total_validator_count: 74
+  - - committee: [136]
+      shard: 402
+      total_validator_count: 74
+  - - committee: [11, 155]
+      shard: 403
+      total_validator_count: 74
+  - - committee: [174]
+      shard: 404
+      total_validator_count: 74
+  - - committee: [156]
+      shard: 405
+      total_validator_count: 74
+  - - committee: [68]
+      shard: 406
+      total_validator_count: 74
+  - - committee: [130]
+      shard: 407
+      total_validator_count: 74
+  - - committee: [42]
+      shard: 408
+      total_validator_count: 74
+  - - committee: [110, 159]
+      shard: 409
+      total_validator_count: 74
+  - - committee: [54]
+      shard: 410
+      total_validator_count: 74
+  - - committee: [148]
+      shard: 411
+      total_validator_count: 74
+  - - committee: [154]
+      shard: 412
+      total_validator_count: 74
+  - - committee: [96]
+      shard: 413
+      total_validator_count: 74
+  - - committee: [177]
+      shard: 414
+      total_validator_count: 74
+  - - committee: [28]
+      shard: 415
+      total_validator_count: 74
+  - - committee: [133, 137]
+      shard: 416
+      total_validator_count: 74
+  - - committee: [32]
+      shard: 417
+      total_validator_count: 74
+  - - committee: [78]
+      shard: 418
+      total_validator_count: 74
+  - - committee: [83]
+      shard: 419
+      total_validator_count: 74
+  - - committee: [85]
+      shard: 420
+      total_validator_count: 74
+  - - committee: [93]
+      shard: 421
+      total_validator_count: 74
+  - - committee: [2, 169]
+      shard: 422
+      total_validator_count: 74
+  - - committee: [61]
+      shard: 423
+      total_validator_count: 74
+  - - committee: [5]
+      shard: 424
+      total_validator_count: 74
+  - - committee: [40]
+      shard: 425
+      total_validator_count: 74
+  - - committee: [52]
+      shard: 426
+      total_validator_count: 74
+  - - committee: [67]
+      shard: 427
+      total_validator_count: 74
+  - - committee: [15]
+      shard: 428
+      total_validator_count: 74
+  - - committee: [94, 132]
+      shard: 429
+      total_validator_count: 74
+  - - committee: [91]
+      shard: 430
+      total_validator_count: 74
+  - - committee: [97]
+      shard: 431
+      total_validator_count: 74
+  - - committee: [49]
+      shard: 432
+      total_validator_count: 74
+  - - committee: [89]
+      shard: 433
+      total_validator_count: 74
+  - - committee: [164]
+      shard: 434
+      total_validator_count: 74
+  - - committee: [129, 118]
+      shard: 435
+      total_validator_count: 74
+  - - committee: [119]
+      shard: 436
+      total_validator_count: 74
+  - - committee: [176]
+      shard: 437
+      total_validator_count: 74
+  - - committee: [105]
+      shard: 438
+      total_validator_count: 74
+  - - committee: [65]
+      shard: 439
+      total_validator_count: 74
+  - - committee: [141]
+      shard: 440
+      total_validator_count: 74
+  - - committee: [39, 114]
+      shard: 441
+      total_validator_count: 74
+  seed: '0xa2cb43c505d74fc9e1af073c677665072308dd06142430203c242aba27ca1da5'
+- input:
+    crosslinking_start_shard: 986
+    validators:
+    - original_index: 0
+      status: [0]
+    - original_index: 1
+      status: [4]
+    - original_index: 2
+      status: [2]
+    - original_index: 3
+      status: [2]
+    - original_index: 4
+      status: [0]
+    - original_index: 5
+      status: [3]
+    - original_index: 6
+      status: [3]
+    - original_index: 7
+      status: [0]
+    - original_index: 8
+      status: [4]
+    - original_index: 9
+      status: [0]
+    - original_index: 10
+      status: [1]
+    - original_index: 11
+      status: [3]
+    - original_index: 12
+      status: [3]
+    - original_index: 13
+      status: [2]
+    - original_index: 14
+      status: [3]
+    - original_index: 15
+      status: [3]
+    - original_index: 16
+      status: [2]
+    - original_index: 17
+      status: [1]
+    - original_index: 18
+      status: [4]
+    - original_index: 19
+      status: [4]
+    - original_index: 20
+      status: [1]
+    - original_index: 21
+      status: [1]
+    - original_index: 22
+      status: [0]
+    - original_index: 23
+      status: [1]
+    - original_index: 24
+      status: [3]
+    - original_index: 25
+      status: [3]
+    - original_index: 26
+      status: [4]
+    - original_index: 27
+      status: [2]
+    - original_index: 28
+      status: [2]
+    - original_index: 29
+      status: [3]
+    - original_index: 30
+      status: [2]
+    - original_index: 31
+      status: [1]
+    - original_index: 32
+      status: [0]
+    - original_index: 33
+      status: [0]
+    - original_index: 34
+      status: [2]
+    - original_index: 35
+      status: [3]
+    - original_index: 36
+      status: [0]
+    - original_index: 37
+      status: [0]
+    - original_index: 38
+      status: [3]
+    - original_index: 39
+      status: [3]
+    - original_index: 40
+      status: [2]
+    - original_index: 41
+      status: [4]
+    - original_index: 42
+      status: [2]
+    - original_index: 43
+      status: [3]
+    - original_index: 44
+      status: [0]
+    - original_index: 45
+      status: [0]
+    - original_index: 46
+      status: [4]
+    - original_index: 47
+      status: [1]
+    - original_index: 48
+      status: [3]
+    - original_index: 49
+      status: [4]
+    - original_index: 50
+      status: [2]
+    - original_index: 51
+      status: [3]
+    - original_index: 52
+      status: [4]
+    - original_index: 53
+      status: [1]
+    - original_index: 54
+      status: [0]
+    - original_index: 55
+      status: [4]
+    - original_index: 56
+      status: [2]
+    - original_index: 57
+      status: [2]
+    - original_index: 58
+      status: [3]
+    - original_index: 59
+      status: [4]
+    - original_index: 60
+      status: [0]
+    - original_index: 61
+      status: [3]
+    - original_index: 62
+      status: [3]
+    - original_index: 63
+      status: [0]
+    - original_index: 64
+      status: [0]
+    - original_index: 65
+      status: [3]
+    - original_index: 66
+      status: [3]
+    - original_index: 67
+      status: [3]
+    - original_index: 68
+      status: [2]
+    - original_index: 69
+      status: [4]
+    - original_index: 70
+      status: [2]
+    - original_index: 71
+      status: [3]
+    - original_index: 72
+      status: [2]
+    - original_index: 73
+      status: [4]
+    - original_index: 74
+      status: [4]
+    - original_index: 75
+      status: [2]
+    - original_index: 76
+      status: [4]
+    - original_index: 77
+      status: [2]
+    - original_index: 78
+      status: [3]
+    - original_index: 79
+      status: [4]
+    - original_index: 80
+      status: [1]
+    - original_index: 81
+      status: [2]
+    - original_index: 82
+      status: [3]
+    - original_index: 83
+      status: [3]
+    - original_index: 84
+      status: [1]
+    - original_index: 85
+      status: [3]
+    - original_index: 86
+      status: [3]
+    - original_index: 87
+      status: [4]
+    - original_index: 88
+      status: [3]
+    - original_index: 89
+      status: [1]
+    - original_index: 90
+      status: [3]
+    - original_index: 91
+      status: [2]
+    - original_index: 92
+      status: [4]
+    - original_index: 93
+      status: [0]
+    - original_index: 94
+      status: [0]
+    - original_index: 95
+      status: [3]
+    - original_index: 96
+      status: [3]
+    - original_index: 97
+      status: [0]
+    - original_index: 98
+      status: [1]
+    - original_index: 99
+      status: [0]
+    - original_index: 100
+      status: [4]
+    - original_index: 101
+      status: [0]
+    - original_index: 102
+      status: [0]
+    - original_index: 103
+      status: [1]
+    - original_index: 104
+      status: [4]
+    - original_index: 105
+      status: [1]
+    - original_index: 106
+      status: [3]
+    - original_index: 107
+      status: [3]
+    - original_index: 108
+      status: [1]
+    - original_index: 109
+      status: [2]
+    - original_index: 110
+      status: [1]
+    - original_index: 111
+      status: [2]
+    - original_index: 112
+      status: [2]
+    - original_index: 113
+      status: [4]
+    - original_index: 114
+      status: [1]
+    - original_index: 115
+      status: [3]
+    - original_index: 116
+      status: [3]
+    - original_index: 117
+      status: [2]
+    - original_index: 118
+      status: [0]
+    - original_index: 119
+      status: [3]
+    - original_index: 120
+      status: [4]
+    - original_index: 121
+      status: [0]
+    - original_index: 122
+      status: [0]
+    - original_index: 123
+      status: [1]
+    - original_index: 124
+      status: [1]
+    - original_index: 125
+      status: [4]
+    - original_index: 126
+      status: [2]
+    - original_index: 127
+      status: [0]
+    - original_index: 128
+      status: [4]
+    - original_index: 129
+      status: [1]
+    - original_index: 130
+      status: [1]
+    - original_index: 131
+      status: [1]
+    - original_index: 132
+      status: [0]
+    - original_index: 133
+      status: [0]
+    - original_index: 134
+      status: [4]
+    - original_index: 135
+      status: [3]
+    - original_index: 136
+      status: [3]
+    - original_index: 137
+      status: [4]
+    - original_index: 138
+      status: [0]
+    - original_index: 139
+      status: [2]
+    - original_index: 140
+      status: [4]
+    - original_index: 141
+      status: [3]
+    - original_index: 142
+      status: [1]
+    - original_index: 143
+      status: [4]
+    - original_index: 144
+      status: [2]
+    - original_index: 145
+      status: [1]
+    - original_index: 146
+      status: [3]
+    - original_index: 147
+      status: [1]
+    - original_index: 148
+      status: [1]
+    - original_index: 149
+      status: [4]
+    - original_index: 150
+      status: [3]
+    - original_index: 151
+      status: [2]
+    - original_index: 152
+      status: [1]
+    - original_index: 153
+      status: [4]
+    - original_index: 154
+      status: [4]
+    - original_index: 155
+      status: [0]
+    - original_index: 156
+      status: [0]
+    - original_index: 157
+      status: [1]
+    - original_index: 158
+      status: [0]
+    - original_index: 159
+      status: [2]
+    - original_index: 160
+      status: [3]
+    - original_index: 161
+      status: [2]
+    - original_index: 162
+      status: [1]
+    - original_index: 163
+      status: [4]
+    - original_index: 164
+      status: [3]
+    - original_index: 165
+      status: [0]
+    - original_index: 166
+      status: [2]
+    - original_index: 167
+      status: [3]
+    - original_index: 168
+      status: [3]
+    - original_index: 169
+      status: [3]
+    - original_index: 170
+      status: [2]
+    - original_index: 171
+      status: [0]
+    - original_index: 172
+      status: [3]
+    - original_index: 173
+      status: [2]
+    - original_index: 174
+      status: [1]
+    - original_index: 175
+      status: [0]
+    - original_index: 176
+      status: [0]
+    - original_index: 177
+      status: [3]
+    - original_index: 178
+      status: [1]
+    - original_index: 179
+      status: [3]
+    - original_index: 180
+      status: [1]
+    - original_index: 181
+      status: [3]
+    - original_index: 182
+      status: [2]
+    - original_index: 183
+      status: [4]
+    - original_index: 184
+      status: [1]
+    - original_index: 185
+      status: [3]
+    - original_index: 186
+      status: [3]
+    - original_index: 187
+      status: [2]
+    - original_index: 188
+      status: [3]
+    - original_index: 189
+      status: [2]
+    - original_index: 190
+      status: [2]
+    - original_index: 191
+      status: [4]
+    - original_index: 192
+      status: [1]
+    - original_index: 193
+      status: [3]
+    - original_index: 194
+      status: [3]
+    - original_index: 195
+      status: [0]
+    - original_index: 196
+      status: [4]
+    - original_index: 197
+      status: [2]
+    - original_index: 198
+      status: [2]
+    - original_index: 199
+      status: [3]
+    - original_index: 200
+      status: [4]
+    - original_index: 201
+      status: [2]
+    - original_index: 202
+      status: [3]
+    - original_index: 203
+      status: [4]
+    - original_index: 204
+      status: [3]
+    - original_index: 205
+      status: [1]
+    - original_index: 206
+      status: [2]
+    - original_index: 207
+      status: [4]
+    - original_index: 208
+      status: [0]
+    - original_index: 209
+      status: [3]
+    - original_index: 210
+      status: [3]
+    - original_index: 211
+      status: [3]
+    - original_index: 212
+      status: [0]
+    - original_index: 213
+      status: [3]
+    - original_index: 214
+      status: [3]
+    - original_index: 215
+      status: [4]
+    - original_index: 216
+      status: [3]
+    - original_index: 217
+      status: [1]
+    - original_index: 218
+      status: [4]
+    - original_index: 219
+      status: [0]
+    - original_index: 220
+      status: [1]
+    - original_index: 221
+      status: [1]
+    - original_index: 222
+      status: [0]
+    - original_index: 223
+      status: [2]
+    - original_index: 224
+      status: [1]
+    - original_index: 225
+      status: [0]
+    - original_index: 226
+      status: [4]
+    - original_index: 227
+      status: [4]
+    - original_index: 228
+      status: [4]
+    - original_index: 229
+      status: [4]
+    - original_index: 230
+      status: [1]
+    - original_index: 231
+      status: [3]
+    - original_index: 232
+      status: [0]
+    - original_index: 233
+      status: [4]
+    - original_index: 234
+      status: [4]
+    - original_index: 235
+      status: [0]
+    - original_index: 236
+      status: [2]
+    - original_index: 237
+      status: [2]
+    - original_index: 238
+      status: [4]
+    - original_index: 239
+      status: [2]
+    - original_index: 240
+      status: [1]
+    - original_index: 241
+      status: [4]
+    - original_index: 242
+      status: [3]
+    - original_index: 243
+      status: [3]
+    - original_index: 244
+      status: [1]
+    - original_index: 245
+      status: [3]
+    - original_index: 246
+      status: [0]
+    - original_index: 247
+      status: [3]
+    - original_index: 248
+      status: [4]
+    - original_index: 249
+      status: [2]
+    - original_index: 250
+      status: [0]
+    - original_index: 251
+      status: [0]
+    - original_index: 252
+      status: [0]
+    - original_index: 253
+      status: [1]
+    - original_index: 254
+      status: [3]
+    - original_index: 255
+      status: [2]
+    - original_index: 256
+      status: [1]
+    - original_index: 257
+      status: [3]
+    - original_index: 258
+      status: [3]
+    - original_index: 259
+      status: [1]
+    - original_index: 260
+      status: [3]
+    - original_index: 261
+      status: [3]
+    - original_index: 262
+      status: [2]
+    - original_index: 263
+      status: [1]
+    - original_index: 264
+      status: [2]
+    - original_index: 265
+      status: [4]
+    - original_index: 266
+      status: [4]
+    - original_index: 267
+      status: [2]
+    - original_index: 268
+      status: [0]
+    - original_index: 269
+      status: [4]
+    - original_index: 270
+      status: [2]
+    - original_index: 271
+      status: [3]
+    - original_index: 272
+      status: [3]
+    - original_index: 273
+      status: [1]
+    - original_index: 274
+      status: [3]
+    - original_index: 275
+      status: [1]
+    - original_index: 276
+      status: [4]
+    - original_index: 277
+      status: [2]
+    - original_index: 278
+      status: [0]
+    - original_index: 279
+      status: [1]
+    - original_index: 280
+      status: [2]
+    - original_index: 281
+      status: [0]
+    - original_index: 282
+      status: [4]
+    - original_index: 283
+      status: [1]
+    - original_index: 284
+      status: [0]
+    - original_index: 285
+      status: [0]
+    - original_index: 286
+      status: [4]
+    - original_index: 287
+      status: [3]
+    - original_index: 288
+      status: [4]
+    - original_index: 289
+      status: [0]
+    - original_index: 290
+      status: [4]
+    - original_index: 291
+      status: [3]
+    - original_index: 292
+      status: [4]
+    - original_index: 293
+      status: [4]
+    - original_index: 294
+      status: [4]
+    - original_index: 295
+      status: [0]
+    - original_index: 296
+      status: [0]
+    - original_index: 297
+      status: [0]
+    - original_index: 298
+      status: [3]
+    - original_index: 299
+      status: [0]
+    - original_index: 300
+      status: [0]
+    - original_index: 301
+      status: [1]
+    - original_index: 302
+      status: [2]
+    - original_index: 303
+      status: [2]
+    - original_index: 304
+      status: [4]
+    - original_index: 305
+      status: [2]
+    - original_index: 306
+      status: [4]
+    - original_index: 307
+      status: [2]
+    - original_index: 308
+      status: [0]
+    - original_index: 309
+      status: [3]
+    - original_index: 310
+      status: [1]
+    - original_index: 311
+      status: [2]
+    - original_index: 312
+      status: [3]
+    - original_index: 313
+      status: [0]
+    - original_index: 314
+      status: [1]
+    - original_index: 315
+      status: [1]
+    - original_index: 316
+      status: [3]
+    - original_index: 317
+      status: [0]
+    - original_index: 318
+      status: [0]
+    - original_index: 319
+      status: [2]
+    - original_index: 320
+      status: [4]
+    - original_index: 321
+      status: [1]
+    - original_index: 322
+      status: [4]
+    - original_index: 323
+      status: [2]
+    - original_index: 324
+      status: [1]
+    - original_index: 325
+      status: [4]
+    - original_index: 326
+      status: [0]
+    - original_index: 327
+      status: [1]
+    - original_index: 328
+      status: [3]
+    - original_index: 329
+      status: [4]
+    - original_index: 330
+      status: [0]
+    - original_index: 331
+      status: [1]
+    - original_index: 332
+      status: [1]
+    - original_index: 333
+      status: [1]
+    - original_index: 334
+      status: [1]
+    - original_index: 335
+      status: [4]
+    - original_index: 336
+      status: [2]
+    - original_index: 337
+      status: [3]
+    - original_index: 338
+      status: [4]
+    - original_index: 339
+      status: [0]
+    - original_index: 340
+      status: [1]
+    - original_index: 341
+      status: [2]
+    - original_index: 342
+      status: [1]
+    - original_index: 343
+      status: [4]
+    - original_index: 344
+      status: [2]
+    - original_index: 345
+      status: [2]
+    - original_index: 346
+      status: [1]
+    - original_index: 347
+      status: [3]
+    - original_index: 348
+      status: [4]
+    - original_index: 349
+      status: [0]
+    - original_index: 350
+      status: [2]
+    - original_index: 351
+      status: [3]
+    - original_index: 352
+      status: [1]
+    - original_index: 353
+      status: [1]
+    - original_index: 354
+      status: [1]
+    - original_index: 355
+      status: [4]
+    - original_index: 356
+      status: [1]
+    - original_index: 357
+      status: [0]
+    - original_index: 358
+      status: [2]
+    - original_index: 359
+      status: [1]
+    - original_index: 360
+      status: [4]
+    - original_index: 361
+      status: [3]
+    - original_index: 362
+      status: [0]
+    - original_index: 363
+      status: [4]
+    - original_index: 364
+      status: [0]
+    - original_index: 365
+      status: [2]
+    - original_index: 366
+      status: [1]
+    - original_index: 367
+      status: [1]
+    - original_index: 368
+      status: [4]
+    - original_index: 369
+      status: [1]
+    - original_index: 370
+      status: [0]
+    - original_index: 371
+      status: [2]
+    - original_index: 372
+      status: [2]
+    - original_index: 373
+      status: [2]
+    - original_index: 374
+      status: [2]
+    - original_index: 375
+      status: [1]
+    - original_index: 376
+      status: [4]
+    - original_index: 377
+      status: [2]
+  output:
+  - - committee: [162, 74]
+      shard: 986
+      total_validator_count: 148
+  - - committee: [205, 76]
+      shard: 987
+      total_validator_count: 148
+  - - committee: [352, 100]
+      shard: 988
+      total_validator_count: 148
+  - - committee: [324, 47, 73]
+      shard: 989
+      total_validator_count: 148
+  - - committee: [110, 31]
+      shard: 990
+      total_validator_count: 148
+  - - committee: [343, 203]
+      shard: 991
+      total_validator_count: 148
+  - - committee: [259, 230, 293]
+      shard: 992
+      total_validator_count: 148
+  - - committee: [233, 353]
+      shard: 993
+      total_validator_count: 148
+  - - committee: [356, 108]
+      shard: 994
+      total_validator_count: 148
+  - - committee: [273, 315, 152]
+      shard: 995
+      total_validator_count: 148
+  - - committee: [275, 147]
+      shard: 996
+      total_validator_count: 148
+  - - committee: [49, 143]
+      shard: 997
+      total_validator_count: 148
+  - - committee: [369, 332, 333]
+      shard: 998
+      total_validator_count: 148
+  - - committee: [105, 192]
+      shard: 999
+      total_validator_count: 148
+  - - committee: [148, 363]
+      shard: 1000
+      total_validator_count: 148
+  - - committee: [220, 80, 142]
+      shard: 1001
+      total_validator_count: 148
+  - - committee: [331, 184]
+      shard: 1002
+      total_validator_count: 148
+  - - committee: [338, 17]
+      shard: 1003
+      total_validator_count: 148
+  - - committee: [217, 367]
+      shard: 1004
+      total_validator_count: 148
+  - - committee: [266, 196, 321]
+      shard: 1005
+      total_validator_count: 148
+  - - committee: [46, 228]
+      shard: 1006
+      total_validator_count: 148
+  - - committee: [329, 301]
+      shard: 1007
+      total_validator_count: 148
+  - - committee: [200, 98, 137]
+      shard: 1008
+      total_validator_count: 148
+  - - committee: [123, 227]
+      shard: 1009
+      total_validator_count: 148
+  - - committee: [340, 248]
+      shard: 1010
+      total_validator_count: 148
+  - - committee: [140, 191, 18]
+      shard: 1011
+      total_validator_count: 148
+  - - committee: [129, 240]
+      shard: 1012
+      total_validator_count: 148
+  - - committee: [276, 92]
+      shard: 1013
+      total_validator_count: 148
+  - - committee: [157, 114, 325]
+      shard: 1014
+      total_validator_count: 148
+  - - committee: [265, 241]
+      shard: 1015
+      total_validator_count: 148
+  - - committee: [229, 178]
+      shard: 1016
+      total_validator_count: 148
+  - - committee: [124, 131, 180]
+      shard: 1017
+      total_validator_count: 148
+  - - committee: [103, 79]
+      shard: 1018
+      total_validator_count: 148
+  - - committee: [238, 130]
+      shard: 1019
+      total_validator_count: 148
+  - - committee: [55, 290]
+      shard: 1020
+      total_validator_count: 148
+  - - committee: [69, 218, 366]
+      shard: 1021
+      total_validator_count: 148
+  - - committee: [335, 149]
+      shard: 1022
+      total_validator_count: 148
+  - - committee: [368, 327]
+      shard: 1023
+      total_validator_count: 148
+  - - committee: [322, 256, 376]
+      shard: 0
+      total_validator_count: 148
+  - - committee: [282, 226]
+      shard: 1
+      total_validator_count: 148
+  - - committee: [224, 306]
+      shard: 2
+      total_validator_count: 148
+  - - committee: [314, 8, 134]
+      shard: 3
+      total_validator_count: 148
+  - - committee: [263, 279]
+      shard: 4
+      total_validator_count: 148
+  - - committee: [163, 183]
+      shard: 5
+      total_validator_count: 148
+  - - committee: [304, 125, 19]
+      shard: 6
+      total_validator_count: 148
+  - - committee: [234, 23]
+      shard: 7
+      total_validator_count: 148
+  - - committee: [113, 360]
+      shard: 8
+      total_validator_count: 148
+  - - committee: [286, 342, 253]
+      shard: 9
+      total_validator_count: 148
+  - - committee: [375, 145]
+      shard: 10
+      total_validator_count: 148
+  - - committee: [41, 84]
+      shard: 11
+      total_validator_count: 148
+  - - committee: [215, 120]
+      shard: 12
+      total_validator_count: 148
+  - - committee: [20, 89, 334]
+      shard: 13
+      total_validator_count: 148
+  - - committee: [320, 354]
+      shard: 14
+      total_validator_count: 148
+  - - committee: [359, 269]
+      shard: 15
+      total_validator_count: 148
+  - - committee: [153, 310, 87]
+      shard: 16
+      total_validator_count: 148
+  - - committee: [221, 26]
+      shard: 17
+      total_validator_count: 148
+  - - committee: [355, 283]
+      shard: 18
+      total_validator_count: 148
+  - - committee: [288, 59, 346]
+      shard: 19
+      total_validator_count: 148
+  - - committee: [154, 128]
+      shard: 20
+      total_validator_count: 148
+  - - committee: [292, 104]
+      shard: 21
+      total_validator_count: 148
+  - - committee: [10, 348, 52]
+      shard: 22
+      total_validator_count: 148
+  - - committee: [174, 53]
+      shard: 23
+      total_validator_count: 148
+  - - committee: [207, 21]
+      shard: 24
+      total_validator_count: 148
+  - - committee: [244, 294, 1]
+      shard: 25
+      total_validator_count: 148
+  seed: '0xfe331725ea135ef16c8289d503c6c653938ba23e88ca435dbba2e8733402898c'

--- a/test_vectors_generator/tgen_shuffling.py
+++ b/test_vectors_generator/tgen_shuffling.py
@@ -59,10 +59,18 @@ from enum import IntEnum
 import random
 
 Hash32 = NewType('Hash32', bytes)
-from hashlib import blake2b
 
+## See https://github.com/ethereum/eth2.0-specs/pull/227
+## and https://github.com/ethereum/eth2.0-specs/issues/151
+## Hashing as been changed from Blake2b-512[:32] to Keccak256
+
+# from hashlib import blake2b
+# def hash(x):
+#     return blake2b(x).digest()[:32]
+
+from eth_utils import keccak
 def hash(x):
-    return blake2b(x).digest()[:32]
+    return keccak(x)
 
 class ValidatorStatus(IntEnum):
     PENDING_ACTIVATION = 0
@@ -278,7 +286,7 @@ if __name__ == '__main__':
 
     # Config
     random.seed(int("0xEF00BEAC", 16))
-    num_val = 15 # Number of validators
+    num_val = 256 # Number of validators
 
 
     seedhash = bytes(random.randint(0, 255) for byte in range(32))

--- a/test_vectors_generator/tgen_shuffling.py
+++ b/test_vectors_generator/tgen_shuffling.py
@@ -319,6 +319,11 @@ def toStrShardComs(shard_comms: List[List[ShardAndCommittee]]) -> str:
 #
 # ################################################################
 
+## Try to deal with enums - otherwise for "ValidatorStatus.Active" you get [1], instead of 1
+def yaml_ValidatorStatus(dumper, data):
+    return dumper.represent_data(data.value)
+yaml.add_representer(ValidatorStatus, yaml_ValidatorStatus)
+
 if __name__ == '__main__':
     import sys, random
 
@@ -355,4 +360,4 @@ if __name__ == '__main__':
     # yaml.dump(test_cases, sys.stdout)
     with open('test_vector_shuffling.yml', 'w') as outfile:
         yaml.dump(metadata, outfile, default_flow_style=False) # Dump at top level
-        yaml.dump({'test_cases': test_cases}, outfile)
+        yaml.dump({'test_cases': test_cases}, outfile, default_flow_style=False)

--- a/test_vectors_generator/tgen_shuffling.py
+++ b/test_vectors_generator/tgen_shuffling.py
@@ -360,4 +360,4 @@ if __name__ == '__main__':
     # yaml.dump(test_cases, sys.stdout)
     with open('test_vector_shuffling.yml', 'w') as outfile:
         yaml.dump(metadata, outfile, default_flow_style=False) # Dump at top level
-        yaml.dump({'test_cases': test_cases}, outfile, default_flow_style=False)
+        yaml.dump({'test_cases': test_cases}, outfile)         # default_flow_style will unravel "ValidatorRecord" and "committee" line, exploding file size


### PR DESCRIPTION
This implement a proof-of-concept YAML test vector generator.

As mentioned by @chfast, it's probably best for the test cases to be generated as artifacts during CI to avoid polluting the codebase. This single test adds ~11k lines for example.~ 6k lines (after https://github.com/status-im/nim-beacon-chain/pull/31/commits/4853ff30034e1858ccba1c31694a0fd2089d8313).

Anyway, the main goal is to re-sparkle testing discussion. This format can be generated, now are clients able to consume it?

Cc @djrtwo, @zscole, @rauljordan, @paulhauner

Reference spec for testing: https://github.com/ethereum/eth2.0-specs/blob/f122dd79e709c27b9259b9bd06bd95f5f45303b4/specs/test-format.md

```yaml
title: Shuffling Algorithm Tests
summary: Test vectors for shuffling a list based upon a seed using `shuffle`
test_suite: shuffle
fork: tchaikovsky
version: 1.0

test_cases:
- input: []
  output: []
  seed: !!binary ""
- name: boring_list
  description: List with a single element, 0
  input: [0]
  output: [0]
  seed: !!binary ""
- input: [255]
  output: [255]
  seed: !!binary ""
- input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
  output: [1, 6, 4, 1, 6, 6, 2, 2, 4, 5]
  seed: !!binary ""
- input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
  output: [4, 7, 10, 13, 3, 1, 2, 9, 12, 6, 11, 8, 5]
  seed: !!binary ""
- input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
  output: [6, 65, 2, 5, 4, 2, 6, 6, 1, 1]
  seed: !!binary |
    JlAYJ5H2j8g7PLiPHZI/rTS1uAvKiieOrifPN6Moso0=
```