### PR TITLE
switch some proc to func, add some infrastructure, update based on spec name changes

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -195,7 +195,7 @@ proc processBlocks*(node: BeaconNode) {.async.} =
       node.attestations.discardHistoryToSlot(b.slot.int)
 
   node.network.subscribe(topicAttestations) do (a: Attestation):
-    # Attestations are verified as a aggregated group
+    # Attestations are verified as aggregated groups
     node.attestations.add(getAttestationCandidate a, node.beaconState)
 
 when isMainModule:

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -195,12 +195,8 @@ proc processBlocks*(node: BeaconNode) {.async.} =
       node.attestations.discardHistoryToSlot(b.slot.int)
 
   node.network.subscribe(topicAttestations) do (a: Attestation):
-    # TODO
-    #
-    # 1. Validate the attestation
-
-    # node.attestations.add(a, node.beaconState)
-    discard
+    # Attestations are verified as a aggregated group
+    node.attestations.add(getAttestationCandidate a, node.beaconState)
 
 when isMainModule:
   let config = BeaconNodeConf.load()

--- a/beacon_chain/fork_choice.nim
+++ b/beacon_chain/fork_choice.nim
@@ -56,13 +56,18 @@ proc discardHistoryToSlot*(pool: var AttestationPool, slot: int) =
   let slotIdx = int(slot - pool.startingSlot)
   pool.attestations.shrink(fromFirst = slotIdx + 1)
 
-proc getLatestAttestation*(pool: AttestationPool, validator: ValidatorRecord) =
+func getAttestationCandidate*(attestation: Attestation): AttestationCandidate =
+  # TODO: not complete AttestationCandidate object
+  result.data = attestation.data
+  result.signature = attestation.aggregate_signature
+
+func getLatestAttestation*(pool: AttestationPool, validator: ValidatorRecord) =
   discard
 
-proc getLatestAttestationTarget*() =
+func getLatestAttestationTarget*() =
   discard
 
-proc forkChoice*(pool: AttestationPool, oldHead, newBlock: BeaconBlock): bool =
+func forkChoice*(pool: AttestationPool, oldHead, newBlock: BeaconBlock): bool =
   # This will return true if the new block is accepted over the old head block
   discard
 


### PR DESCRIPTION
According to the current spec, there's just not that much to do in terms of BLS signature aggregation. As structured by https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#attestations-1 aggregation specifically occurs in per-block processing.

While it might make sense to move things around, and I tried some variations of that before rewriting it in this more minimal way, for now, simply adding an attestation via `node.attestations.add` but not actually aggregating until `processBlocks` 
There's some in `processCasperSlashings` as well, partially enabled in this PR.

This is intended as spec-matching approach.

I prefer `func` to `proc` where, conceptually, it fits, as a default, so switched some `procs` to `funcs.