### PR TITLE
fix double incrementing of proposer.randao_layers

### DIFF
--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -787,8 +787,6 @@ proc updateState*(state: BeaconState, latest_block: BeaconBlock,
       else:
         false
     else:
-      let proposer_index = get_beacon_proposer_index(new_state, new_state.slot)
-      new_state.validator_registry[proposer_index].randao_layers += 1
       # Skip all other per-slot processing. Move directly to epoch processing
       # prison. Do not do any slot updates when passing go.
       true

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -787,8 +787,8 @@ proc updateState*(state: BeaconState, latest_block: BeaconBlock,
       else:
         false
     else:
-      # Skip all other per-slot processing. Move directly to epoch processing
-      # prison. Do not do any slot updates when passing go.
+      # Skip all per-block processing. Move directly to epoch processing
+      # prison. Do not do any block updates when passing go.
       true
 
   # Heavy updates that happen for every epoch - these never fail (or so we hope)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -71,12 +71,13 @@ suite "Block processing":
     let
       state = on_startup(makeInitialDeposits(), 0, Eth2Digest())
       latest_block = makeGenesisBlock(state)
-      expected_proposer_index = get_beacon_proposer_index(state, state.slot + 1)
-      previous_randao_layers = state.validator_registry[expected_proposer_index].randao_layers
+      proposer_index = get_beacon_proposer_index(state, state.slot + 1)
+      previous_randao_layers = state.validator_registry[proposer_index].randao_layers
       new_state = updateState(state, latest_block, none(BeaconBlock))
+      updated_proposer = new_state.state.validator_registry[proposer_index]
+
     check:
-      new_state.state.validator_registry[expected_proposer_index].randao_layers ==
-        previous_randao_layers + 1
+      updated_proposer.randao_layers == previous_randao_layers + 1
 
   test "Proposer randao layers unchanged, empty block":
     let
@@ -86,7 +87,7 @@ suite "Block processing":
       previous_randao_layers = state.validator_registry[proposer_index].randao_layers
       new_block = makeBlock(state, latest_block)
       new_state = updateState(state, latest_block, some(new_block))
+      updated_proposer = new_state.state.validator_registry[proposer_index]
 
     check:
-      new_state.state.validator_registry[proposer_index].randao_layers ==
-        previous_randao_layers
+      updated_proposer.randao_layers == previous_randao_layers

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -66,3 +66,27 @@ suite "Block processing":
 
     check:
       state.slot == latest_block.slot
+
+  test "Increments proposer randao_layers, no block":
+    let
+      state = on_startup(makeInitialDeposits(), 0, Eth2Digest())
+      latest_block = makeGenesisBlock(state)
+      expected_proposer_index = get_beacon_proposer_index(state, state.slot + 1)
+      previous_randao_layers = state.validator_registry[expected_proposer_index].randao_layers
+      new_state = updateState(state, latest_block, none(BeaconBlock))
+    check:
+      new_state.state.validator_registry[expected_proposer_index].randao_layers ==
+        previous_randao_layers + 1
+
+  test "Proposer randao layers unchanged, empty block":
+    let
+      state = on_startup(makeInitialDeposits(), 0, Eth2Digest())
+      latest_block = makeGenesisBlock(state)
+      proposer_index = get_beacon_proposer_index(state, state.slot + 1)
+      previous_randao_layers = state.validator_registry[proposer_index].randao_layers
+      new_block = makeBlock(state, latest_block)
+      new_state = updateState(state, latest_block, some(new_block))
+
+    check:
+      new_state.state.validator_registry[proposer_index].randao_layers ==
+        previous_randao_layers


### PR DESCRIPTION
# Issue
`proposer.randao_layers` was being incremented in the per-block processing as well as the per-slot processing. This was due to a recent change in where this was happening in the spec -- the new location was added but the old one remained.

# solution
Removed the `randao_layers` increment within the block-processing flow

I added a couple of sanity tests on this. I'm not too content with the formatting of the tests, but there aren't any state transition tests that check for specific state updates (other than slot incremented) that I can just use as a guide. I suppose as more state transition tests are added, a general flow will emerge and these tests can be adapted to fit that flow.