### PR TITLE
initial integration of attestation pool with fork choice infrastructure

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -217,7 +217,7 @@ proc processBlocks*(node: BeaconNode) {.async.} =
 
   node.network.subscribe(topicAttestations) do (a: Attestation):
     # Attestations are verified as aggregated groups
-    node.attestations.add(getAttestationCandidate a, node.beaconState)
+    node.attestations.add(getAttestationCandidate(a, node.beaconState), node.beaconState)
 
 var gPidFile: string
 proc createPidFile(filename: string) =

--- a/beacon_chain/fork_choice.nim
+++ b/beacon_chain/fork_choice.nim
@@ -1,19 +1,33 @@
 import
   deques,
-  spec/[datatypes, crypto]
+  tables,
+  milagro_crypto,
+  spec/[datatypes, digest, crypto, validator, beaconstate]
 
 type
+  AttesterIdx* = int
+
   AttestationCandidate* = object
-    validator*: int
+    validator*: AttesterIdx
     data*: AttestationData
+    participation_bitfield*: seq[byte]
     signature*: ValidatorSig
 
   AttestationPool* = object
+    # TODO: check whether still useful/necessary at all;
+    # data structures have different tradeoffs, but need
+    # for this one questionable given need to identify a
+    # ValidatorRecord/index regardless.
     attestations: Deque[seq[AttestationCandidate]]
+
+    # only remember last attestation in given slot for a given attester.
+    attestationsPerValidator: Table[AttesterIdx, AttestationCandidate]
+
     startingSlot: int
 
 proc init*(T: type AttestationPool, startingSlot: int): T =
-  result.attestationsPerSlot = initDeque[seq[AttestationCandidate]]()
+  result.attestations = initDeque[seq[AttestationCandidate]]()
+  result.attestationsPerValidator = initTable[AttesterIdx, AttestationCandidate]()
   result.startingSlot = startingSlot
 
 proc setLen*[T](d: var Deque[T], len: int) =
@@ -26,12 +40,30 @@ proc setLen*[T](d: var Deque[T], len: int) =
   else:
     d.shrink(fromLast = delta)
 
+proc bitfieldUnion(accum: var seq[byte], disjunct: seq[byte]) =
+  # TODO replace with nim-ranges
+  doAssert len(accum) == len(disjunct)
+  for i in 0 ..< len(accum):
+    accum[i] = accum[i] or disjunct[i]
+
 proc add*(pool: var AttestationPool,
           attestation: AttestationCandidate,
           beaconState: BeaconState) =
   # The caller of this function is responsible for ensuring that
   # the attestations will be given in a strictly slot increasing order:
   doAssert attestation.data.slot.int >= pool.startingSlot
+
+  var curAttestation = pool.attestationsPerValidator.getOrDefault(attestation.validator)
+  if attestation.data.slot.int > curAttestation.data.slot.int:
+    pool.attestationsPerValidator[attestation.validator] = attestation
+
+  # TODO: aggregation, for get_latest_attestation/get_latest_attestation_target, needs to
+  # occur later as far as I can tell.
+  # TODO: much more testing
+  #elif curAttestation.data == attestation.data:
+  #  curAttestation.signature = combine(@[curAttestation.signature, attestation.signature])
+  #  curAttestation.participation_bitfield.bitfieldUnion attestation.participation_bitfield
+  #  pool.attestationsPerValidator[attestation.validator] =  curAttestation 
 
   let slotIdxInPool = attestation.data.slot.int - pool.startingSlot
   if slotIdxInPool >= pool.attestations.len:
@@ -56,18 +88,38 @@ proc discardHistoryToSlot*(pool: var AttestationPool, slot: int) =
   let slotIdx = int(slot - pool.startingSlot)
   pool.attestations.shrink(fromFirst = slotIdx + 1)
 
-func getAttestationCandidate*(attestation: Attestation): AttestationCandidate =
-  # TODO: not complete AttestationCandidate object
+  var rmKeys : seq[AttesterIdx] = @[]
+  for k, ac in pool.attestationsPerValidator.pairs:
+    if ac.data.slot.int < slot:
+      rmKeys.add k
+
+  for k in rmKeys:
+    pool.attestationsPerValidator.del(k)
+
+func getAttestationCandidate*(attestation: Attestation, state: BeaconState): AttestationCandidate =
+  # TODO generalize to already-aggreagated attestations, but indications that's not
+  # in initial approach.
+  let participants = get_attestation_participants(state, attestation.data, attestation.participation_bitfield)
+  if participants.len == 0:
+    return
+  result.validator = participants[0]
+
+  result.participation_bitfield = attestation.participation_bitfield
   result.data = attestation.data
   result.signature = attestation.aggregate_signature
-
-func getLatestAttestation*(pool: AttestationPool, validator: ValidatorRecord) =
-  discard
-
-func getLatestAttestationTarget*() =
-  discard
 
 func forkChoice*(pool: AttestationPool, oldHead, newBlock: BeaconBlock): bool =
   # This will return true if the new block is accepted over the old head block
   discard
 
+# Functions from spec
+func get_latest_attestation*(pool: AttestationPool, validator: ValidatorRecord) : AttestationCandidate =
+  let idxs = get_active_validator_indices(@[validator])
+  if idxs.len > 0:
+    return pool.attestationsPerValidator.getOrDefault(idxs[0])
+
+  # TODO error handling, probably with e.g., Some[AttestationCandidate]
+
+func get_latest_attestation_target*(pool: AttestationPool, validator: ValidatorRecord) : Eth2Digest =
+  # TODO verify whether it's this or shard_root
+  get_latest_attestation(pool, validator).data.beacon_block_root

--- a/tests/test_fork_choice.nim
+++ b/tests/test_fork_choice.nim
@@ -6,11 +6,9 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  ./test_beaconstate,
-  ./test_state_transition,
-  ./test_helpers,
-  ./test_ssz,
-  ./test_validator,
-  ./test_beacon_node,
-  ./test_sync_protocol,
-  ./test_fork_choice
+  unittest, nimcrypto, eth_common, milagro_crypto,
+  ../beacon_chain/spec/datatypes, ../beacon_chain/fork_choice
+
+suite "Fork choice rule and attestation pool":
+  test "Smoke test":
+    var pool = init(AttestationPool, 2)


### PR DESCRIPTION
Of all things, this doesn't actually aggregate. I don't see how that's supposed to happen upstream of `get_latest_attestation`, which is the only part this addresses.

This does integrate changes with @zah's minimal attestation pool in `fork_choice`, unlike the previous branch. I'm not entirely convinced this is better, as an architectural design -- it intermixes fork choice and other attestation pool mechanics, unlike  https://github.com/status-im/nim-beacon-chain/tree/WorkPoolUpdates for example, rather than layering them -- but, sure, I'll give this a try.

`attestation_participants` in `AttestationCandidate` would be for use in aggregating, which, see above, I'm not 100% convinced can live in this layer anyway, consistently with spec definitions.