### PR TITLE
fix Error: expression 'subscribeFor(peer, topic)' is of type 'Future[system.void]' and has to be discarded`

### DIFF
--- a/beacon_chain/gossipsub_protocol.nim
+++ b/beacon_chain/gossipsub_protocol.nim
@@ -34,7 +34,7 @@ p2pProtocol GossipSub(version = 1,
     info "GossipSub Peer connecetd", peer
     let gossipNet = peer.networkState
     for topic, _ in gossipNet.topicSubscribers:
-      peer.subscribeFor(topic)
+      discard peer.subscribeFor(topic)
 
   onPeerDisconnected do (peer: Peer, reason: DisconnectionReason):
     info "GossipSub Peer disconnected"


### PR DESCRIPTION
```
../beacon_chain/gossipsub_protocol.nim(26, 13) template/generic instantiation from here
../beacon_chain/gossipsub_protocol.nim(37, 11) Error: expression 'subscribeFor(peer, topic)' is of type 'Future[system.void]' and has to be discarded
```

Oddly, this has been intermittent for me, but this seems to fix things, by doing exactly what the error message says. If this is a spurious error message, then it needs another workaround, perhaps.