### PR TITLE
Bitfield debugging asserts

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -375,6 +375,21 @@ proc checkAttestation*(
              it.shard == attestation.data.shard),
     it.committee)[0]
 
+  # Extra checks not in specs
+  # https://github.com/status-im/nim-beacon-chain/pull/105#issuecomment-462432544
+  assert attestation.aggregation_bitfield.len == (
+            crosslink_committee.len + 7) div 8, (
+              "Error: got " & $attestation.aggregation_bitfield.len &
+              " but expected " & $((crosslink_committee.len + 7) div 8)
+            )
+
+  assert attestation.custody_bitfield.len == (
+            crosslink_committee.len + 7) div 8, (
+              "Error: got " & $attestation.custody_bitfield.len &
+              " but expected " & $((crosslink_committee.len + 7) div 8)
+            )
+  # End extra checks
+
   assert allIt(0 ..< len(crosslink_committee),
     if get_bitfield_bit(attestation.aggregation_bitfield, it) == 0b0:
       # Should always be true in phase 0, because of above assertion

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -17,6 +17,8 @@ func bitSet*(bitfield: var openArray[byte], index: int) =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#get_bitfield_bit
 func get_bitfield_bit*(bitfield: openarray[byte], i: int): byte =
   # Extract the bit in ``bitfield`` at position ``i``.
+  assert 0 <= i div 8, "i: " & $i & " i div 8: " & $(i div 8)
+  assert i div 8 < bitfield.len, "i: " & $i & " i div 8: " & $(i div 8)
   (bitfield[i div 8] shr (7 - (i mod 8))) mod 2
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.1/specs/core/0_beacon-chain.md#verify_bitfield

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -199,5 +199,6 @@ proc makeAttestation*(
   Attestation(
     data: data,
     aggregation_bitfield: aggregation_bitfield,
-    aggregate_signature: sig
+    aggregate_signature: sig,
+    custody_bitfield: repeat(0'u8, ceil_div8(sac.committee.len))
   )


### PR DESCRIPTION
It seems like after an epoch transition the custody bitfield is not properly initialized.

This is also triggered in the test suite.

Cherry picked from #105 