### PR TITLE
Fix simulation regression due to custody_bitfield

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -181,7 +181,10 @@ proc makeAttestation(node: BeaconNode,
   var attestation = Attestation(
     data: attestationData,
     aggregate_signature: validatorSignature,
-    aggregation_bitfield: participationBitfield)
+    aggregation_bitfield: participationBitfield,
+    # Stub in phase0
+    custody_bitfield: newSeq[byte](participationBitfield.len)
+  )
 
   await node.network.broadcast(topicAttestations, attestation)
 


### PR DESCRIPTION
As seen in #106 and #105:

The phase 0 stub `custody_bitfield` is read in `checkAttestation` following #104:

https://github.com/status-im/nim-beacon-chain/pull/104/files#diff-8491da098fcb79b0774953064b352de1R370

This crashes the simulation because beacon_node never initialized this field. (And the tests as well, see #106)