### PR TITLE
Allow faster slots

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -107,7 +107,7 @@ const
 
   # Time parameters
   # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#time-parameters
-  SLOT_DURATION* = 6'u64 ## \
+  SLOT_DURATION*{.intdefine.} = 6'u64 # Compile with -d:SLOT_DURATION=1 for 6x faster slots
   ## TODO consistent time unit across projects, similar to C++ chrono?
 
   MIN_ATTESTATION_INCLUSION_DELAY* = 2'u64^2 ##\

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -25,14 +25,15 @@ mkdir -p $BUILD_OUTPUTS_DIR
 
 BEACON_NODE_BIN=$BUILD_OUTPUTS_DIR/beacon_node
 VALIDATOR_KEYGEN_BIN=$BUILD_OUTPUTS_DIR/validator_keygen
+SLOT_DURATION="-d:SLOT_DURATION=1" # Default is 6
 
 if [[ -z "$SKIP_BUILDS" ]]; then
-  nim c -o:"$VALIDATOR_KEYGEN_BIN" -d:release beacon_chain/validator_keygen
-  nim c -o:"$BEACON_NODE_BIN" beacon_chain/beacon_node
+  nim c -o:"$VALIDATOR_KEYGEN_BIN" "$SLOT_DURATION" -d:release beacon_chain/validator_keygen
+  nim c -o:"$BEACON_NODE_BIN" "$SLOT_DURATION" beacon_chain/beacon_node
 fi
 
 if [ ! -f $STARTUP_FILE ]; then
-  $VALIDATOR_KEYGEN_BIN --validators=$NUMBER_OF_VALIDATORS --outputDir="$SIMULATION_DIR" --startupDelay=2
+  $VALIDATOR_KEYGEN_BIN --validators=$NUMBER_OF_VALIDATORS --outputDir="$SIMULATION_DIR" # --startupDelay=2
 fi
 
 if [ ! -f $SNAPSHOT_FILE ]; then

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -25,7 +25,7 @@ mkdir -p $BUILD_OUTPUTS_DIR
 
 BEACON_NODE_BIN=$BUILD_OUTPUTS_DIR/beacon_node
 VALIDATOR_KEYGEN_BIN=$BUILD_OUTPUTS_DIR/validator_keygen
-SLOT_DURATION="-d:SLOT_DURATION=1" # Default is 6
+SLOT_DURATION="-d:SLOT_DURATION=3" # Default is 6
 
 if [[ -z "$SKIP_BUILDS" ]]; then
   nim c -o:"$VALIDATOR_KEYGEN_BIN" "$SLOT_DURATION" -d:release beacon_chain/validator_keygen


### PR DESCRIPTION
Allow compile-time flag configured faster slot time.

By default simulation is 2x faster, unfortunately due to the state after the latest merge I'm not sure how fast we can accelerate the simulation.