### PR TITLE
[WIP] Fix some issues after introducing "humaneEpochNumber"

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -288,8 +288,8 @@ proc scheduleEpochActions(node: BeaconNode, epoch: uint64) =
   ## This schedules the required block proposals and
   ## attestations from our attached validators.
   doAssert node != nil
-  doAssert epoch >= GENESIS_EPOCH, $epoch
-  
+  doAssert epoch >= GENESIS_EPOCH, "Epoch: " & $epoch & ", humane epoch: " & $humaneSlotNum(epoch)
+
   debug "Scheduling epoch actions", epoch = humaneEpochNum(epoch)
 
   # TODO: this copy of the state shouldn't be necessary, but please
@@ -327,12 +327,11 @@ proc scheduleEpochActions(node: BeaconNode, epoch: uint64) =
   node.lastScheduledEpoch = epoch
   let
     nextEpoch = epoch + 1
-    humaneNextEpoch = humaneEpochNum(nextEpoch)
     at = node.beaconState.slotMiddle(nextEpoch * EPOCH_LENGTH)
 
   info "Scheduling next epoch update",
     fromNow = (at - fastEpochTime()) div 1000,
-    humaneNextEpoch
+    epoch = humaneEpochNum(nextEpoch)
 
   addTimer(at) do (p: pointer):
     if node.lastScheduledEpoch != nextEpoch:

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -288,7 +288,8 @@ proc scheduleEpochActions(node: BeaconNode, epoch: uint64) =
   ## This schedules the required block proposals and
   ## attestations from our attached validators.
   doAssert node != nil
-
+  doAssert epoch >= GENESIS_EPOCH, $epoch
+  
   debug "Scheduling epoch actions", epoch = humaneEpochNum(epoch)
 
   # TODO: this copy of the state shouldn't be necessary, but please
@@ -325,12 +326,13 @@ proc scheduleEpochActions(node: BeaconNode, epoch: uint64) =
 
   node.lastScheduledEpoch = epoch
   let
-    nextEpoch = humaneEpochNum(epoch + 1)
+    nextEpoch = epoch + 1
+    humaneNextEpoch = humaneEpochNum(nextEpoch)
     at = node.beaconState.slotMiddle(nextEpoch * EPOCH_LENGTH)
 
   info "Scheduling next epoch update",
     fromNow = (at - fastEpochTime()) div 1000,
-    nextEpoch
+    humaneNextEpoch
 
   addTimer(at) do (p: pointer):
     if node.lastScheduledEpoch != nextEpoch:

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -159,6 +159,7 @@ func get_current_epoch_committee_count*(state: BeaconState): uint64 =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: BeaconState): EpochNumber =
   # Return the current epoch of the given ``state``.
+  doAssert state.slot >= GENESIS_SLOT, $state.slot 
   slot_to_epoch(state.slot)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#get_randao_mix

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -74,7 +74,9 @@ proc signAttestation*(v: AttachedValidator,
 func genRandaoReveal*(k: ValidatorPrivKey, state: BeaconState, slot: SlotNumber):
     ValidatorSig =
   # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#randao
-  assert slot > state.slot
+
+  # Off-by-one? I often get slot == state.slot but the check was "assert slot >= state.slot" (Mamy)
+  assert slot >= state.slot, "input slot: " & $slot & " - beacon state slot: " & $state.slot
   bls_sign(k, int_to_bytes32(slot_to_epoch(slot)),
     get_domain(state.fork, slot_to_epoch(slot), DOMAIN_RANDAO))
 

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -75,7 +75,7 @@ func genRandaoReveal*(k: ValidatorPrivKey, state: BeaconState, slot: SlotNumber)
     ValidatorSig =
   # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#randao
 
-  # Off-by-one? I often get slot == state.slot but the check was "assert slot >= state.slot" (Mamy)
+  # Off-by-one? I often get slot == state.slot but the check was "assert slot > state.slot" (Mamy)
   assert slot >= state.slot, "input slot: " & $humaneSlotNum(slot) & " - beacon state slot: " & $humaneSlotNum(state.slot)
   bls_sign(k, int_to_bytes32(slot_to_epoch(slot)),
     get_domain(state.fork, slot_to_epoch(slot), DOMAIN_RANDAO))

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -76,7 +76,7 @@ func genRandaoReveal*(k: ValidatorPrivKey, state: BeaconState, slot: SlotNumber)
   # https://github.com/ethereum/eth2.0-specs/blob/v0.2.0/specs/core/0_beacon-chain.md#randao
 
   # Off-by-one? I often get slot == state.slot but the check was "assert slot >= state.slot" (Mamy)
-  assert slot >= state.slot, "input slot: " & $slot & " - beacon state slot: " & $state.slot
+  assert slot >= state.slot, "input slot: " & $humaneSlotNum(slot) & " - beacon state slot: " & $humaneSlotNum(state.slot)
   bls_sign(k, int_to_bytes32(slot_to_epoch(slot)),
     get_domain(state.fork, slot_to_epoch(slot), DOMAIN_RANDAO))
 

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -27,9 +27,9 @@ BEACON_NODE_BIN=$BUILD_OUTPUTS_DIR/beacon_node
 VALIDATOR_KEYGEN_BIN=$BUILD_OUTPUTS_DIR/validator_keygen
 
 # Run with "SHARD_COUNT=4 ./start.sh" to change these
-DEFS="-d:SHARD_COUNT=${SHARD_COUNT:-4} "
-DEFS+="-d:EPOCH_LENGTH=${EPOCH_LENGTH:-8} "
-DEFS+="-d:SLOT_DURATION=${SLOT_DURATION:-3} "
+DEFS="-d:SHARD_COUNT=${SHARD_COUNT:-4} "      # Spec default: 1024
+DEFS+="-d:EPOCH_LENGTH=${EPOCH_LENGTH:-8} "   # Spec default: 64
+DEFS+="-d:SLOT_DURATION=${SLOT_DURATION:-4} " # Spec default: 6
 
 if [[ -z "$SKIP_BUILDS" ]]; then
   nim c -o:"$VALIDATOR_KEYGEN_BIN" $DEFS -d:release beacon_chain/validator_keygen
@@ -43,7 +43,7 @@ fi
 if [ ! -f $SNAPSHOT_FILE ]; then
   $BEACON_NODE_BIN createChain \
     --chainStartupData:$STARTUP_FILE \
-    --out:$SNAPSHOT_FILE # --genesisOffset=2
+    --out:$SNAPSHOT_FILE # --genesisOffset=2 # Delay in seconds
 fi
 
 MASTER_NODE_ADDRESS_FILE="$SIMULATION_DIR/node-0/beacon_node.address"


### PR DESCRIPTION

WIP

- Change simulation slot duration to 4 (3 is too fast and I never get GossipSub peers to connect at the moment)

- The introduction of humaneEpochNum https://github.com/status-im/nim-beacon-chain/pull/116 caused issues.

Right now the simulation is still failing after 1 epoch like after #104 (and unlike the branch https://github.com/status-im/nim-beacon-chain/tree/yglukhov-somewhat-stable-simulation).
The failure reported is 

```
Error: unhandled exception: /home/beta/Programming/Status/nim-beacon-chain/beacon_chain/spec/validator.nim(152, 10) `epoch <= next_epoch` Previous epoch: 0, epoch: 2, Next epoch: 1 [AssertionError]
```

instead of 

```
Error: unhandled exception: /home/beta/Programming/Status/nim-beacon-chain/beacon_chain/spec/validator.nim(95, 10) `epoch <= next_epoch` Previous epoch: 144115188075855872, epoch: 144115188075855874, Next epoch: 144115188075855873 [Assert
```

as reported in https://github.com/status-im/nim-beacon-chain/issues/101