### PR TITLE
remove unused epoch template

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -482,9 +482,6 @@ type
   # TODO: not in spec
   CrosslinkCommittee* = tuple[committee: seq[ValidatorIndex], shard: uint64]
 
-template epoch*(slot: int|uint64): auto =
-  slot div SLOTS_PER_EPOCH
-
 when true:
   # TODO: Remove these once RLP serialization is no longer used
   import nimcrypto, eth/rlp, json_serialization


### PR DESCRIPTION
This template is unused at the moment and has been replaced by `slot_to_epoch`