### PR TITLE
verify blocks before storing in block pool / database

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -112,7 +112,7 @@ proc containsBlock*(
 
 proc containsState*(
     db: BeaconChainDB, key: Eth2Digest): bool =
-  db.backend.contains(subkey(BeaconBlock, key))
+  db.backend.contains(subkey(BeaconState, key))
 
 iterator getAncestors*(db: BeaconChainDB, root: Eth2Digest):
     tuple[root: Eth2Digest, blck: BeaconBlock] =

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -1006,14 +1006,16 @@ proc verifyStateRoot(state: BeaconState, blck: BeaconBlock): bool =
   else:
     true
 
-proc updateState*(state: var BeaconState, previous_block_root: Eth2Digest,
-    new_block: Option[BeaconBlock], flags: UpdateFlags): bool =
+proc updateState*(
+    state: var BeaconState, previous_block_root: Eth2Digest,
+    new_block: BeaconBlock, flags: UpdateFlags): bool =
   ## Time in the beacon chain moves by slots. Every time (haha.) that happens,
   ## we will update the beacon state. Normally, the state updates will be driven
   ## by the contents of a new block, but it may happen that the block goes
   ## missing - the state updates happen regardless.
+  ##
   ## Each call to this function will advance the state by one slot - new_block,
-  ## if present, must match that slot.
+  ## must match that slot. If the update fails, the state will remain unchanged.
   ##
   ## The flags are used to specify that certain validations should be skipped
   ## for the new block. This is done during block proposal, to create a state
@@ -1025,59 +1027,67 @@ proc updateState*(state: var BeaconState, previous_block_root: Eth2Digest,
   #      One reason to keep it this way is that you need to look ahead if you're
   #      the block proposer, though in reality we only need a partial update for
   #      that
+  # TODO There's a discussion about what this function should do, and when:
+  #      https://github.com/ethereum/eth2.0-specs/issues/284
+
   # TODO check to which extent this copy can be avoided (considering forks etc),
   #      for now, it serves as a reminder that we need to handle invalid blocks
   #      somewhere..
-  # TODO many functions will mutate `state` partially without rolling back
+  #      many functions will mutate `state` partially without rolling back
   #      the changes in case of failure (look out for `var BeaconState` and
   #      bool return values...)
-  # TODO There's a discussion about what this function should do, and when:
-  #      https://github.com/ethereum/eth2.0-specs/issues/284
   var old_state = state
 
   # Per-slot updates - these happen regardless if there is a block or not
   processSlot(state, previous_block_root)
 
-  if new_block.isSome():
-    # Block updates - these happen when there's a new block being suggested
-    # by the block proposer. Every actor in the network will update its state
-    # according to the contents of this block - but first they will validate
-    # that the block is sane.
-    # TODO what should happen if block processing fails?
-    #      https://github.com/ethereum/eth2.0-specs/issues/293
-    if processBlock(state, new_block.get(), flags):
-      # Block ok so far, proceed with state update
-      processEpoch(state)
-
-      # This is a bit awkward - at the end of processing we verify that the
-      # state we arrive at is what the block producer thought it would be -
-      # meaning that potentially, it could fail verification
-      if skipValidation in flags or verifyStateRoot(state, new_block.get()):
-        # State root is what it should be - we're done!
-        return true
-
-    # Block processing failed, have to start over
-    state = old_state
-    processSlot(state, previous_block_root)
+  # Block updates - these happen when there's a new block being suggested
+  # by the block proposer. Every actor in the network will update its state
+  # according to the contents of this block - but first they will validate
+  # that the block is sane.
+  # TODO what should happen if block processing fails?
+  #      https://github.com/ethereum/eth2.0-specs/issues/293
+  if processBlock(state, new_block, flags):
+    # Block ok so far, proceed with state update
     processEpoch(state)
-    false
-  else:
-    # Skip all per-block processing. Move directly to epoch processing
-    # prison. Do not do any block updates when passing go.
 
-    # Heavy updates that happen for every epoch - these never fail (or so we hope)
-    processEpoch(state)
-    true
+    # This is a bit awkward - at the end of processing we verify that the
+    # state we arrive at is what the block producer thought it would be -
+    # meaning that potentially, it could fail verification
+    if skipValidation in flags or verifyStateRoot(state, new_block):
+      # State root is what it should be - we're done!
+      return true
 
-proc skipSlots*(state: var BeaconState, parentRoot: Eth2Digest, slot: Slot) =
+  # Block processing failed, roll back changes
+  state = old_state
+  false
+
+proc advanceState*(
+    state: var BeaconState, previous_block_root: Eth2Digest) =
+  ## Sometimes we need to update the state even though we don't have a block at
+  ## hand - this happens for example when a block proposer fails to produce a
+  ## a block.
+  # TODO In the current spec, this can fail only when the state is inconsistent
+  #      or buggy - how do we handle that? crash?
+
+  # Per-slot updates - these happen regardless if there is a block or not
+  processSlot(state, previous_block_root)
+
+  # Heavy updates that happen for every epoch - these never fail (or so we hope)
+  processEpoch(state)
+
+proc skipSlots*(state: var BeaconState, parentRoot: Eth2Digest, slot: Slot,
+    afterSlot: proc (state: BeaconState) = nil) =
   if state.slot < slot:
-    info "Advancing state past slot gap",
+    debug "Advancing state past slot gap",
       targetSlot = humaneSlotNum(slot),
       stateSlot = humaneSlotNum(state.slot)
 
     while state.slot < slot:
-      let ok = updateState(state, parentRoot, none[BeaconBlock](), {})
-      doAssert ok, "Empty block state update should never fail!"
+      advanceState(state, parentRoot)
+
+      if not afterSlot.isNil:
+        afterSlot(state)
 
 # TODO document this:
 

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -46,7 +46,7 @@ cli do(slots = 1945,
        validators = SLOTS_PER_EPOCH, # One per shard is minimum
        json_interval = SLOTS_PER_EPOCH,
        prefix = 0,
-       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.0,
+       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.9,
        validate = false):
   let
     flags = if validate: {} else: {skipValidation}

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -29,8 +29,7 @@ suite "Attestation pool processing":
       pool = AttestationPool.init(blockPool)
       state = blockPool.loadTailState()
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    discard updateState(
-        state.data, state.blck.root, none(BeaconBlock), {skipValidation})
+    advanceState(state.data, state.blck.root)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
@@ -47,14 +46,12 @@ suite "Attestation pool processing":
     check:
       attestations.len == 1
 
-
   test "Attestations may arrive in any order":
     var
       pool = AttestationPool.init(blockPool)
       state = blockPool.loadTailState()
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    discard updateState(
-        state.data, state.blck.root, none(BeaconBlock), {skipValidation})
+    advanceState(state.data, state.blck.root)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
@@ -63,8 +60,7 @@ suite "Attestation pool processing":
       attestation1 = makeAttestation(
         state.data, state.blck.root, crosslink_committees1[0].committee[0])
 
-    discard updateState(
-        state.data, state.blck.root, none(BeaconBlock), {skipValidation})
+    advanceState(state.data, state.blck.root)
 
     let
       crosslink_committees2 =

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -10,18 +10,50 @@ import  options, unittest, sequtils, strutils, eth/trie/[db],
   ../beacon_chain/spec/[datatypes, digest, crypto]
 
 suite "Beacon chain DB":
-  var
-    db = init(BeaconChainDB, newMemoryDB())
 
   test "empty database":
+    var
+      db = init(BeaconChainDB, newMemoryDB())
+
     check:
       db.getState(Eth2Digest()).isNone
       db.getBlock(Eth2Digest()).isNone
 
-  test "find ancestors":
-    var x: ValidatorSig
-    var y = init(ValidatorSig, x.getBytes())
+  test "sanity check blocks":
+    var
+      db = init(BeaconChainDB, newMemoryDB())
 
+    let
+      blck = BeaconBlock()
+      root = hash_tree_root_final(blck)
+
+    db.putBlock(blck)
+
+    check:
+      db.containsBlock(root)
+      db.getBlock(root).get() == blck
+
+  test "sanity check states":
+    var
+      db = init(BeaconChainDB, newMemoryDB())
+
+    let
+      state = BeaconState()
+      root = hash_tree_root_final(state)
+
+    db.putState(state)
+
+    check:
+      db.containsState(root)
+      db.getState(root).get() == state
+
+  test "find ancestors":
+    var
+      db = init(BeaconChainDB, newMemoryDB())
+      x: ValidatorSig
+      y = init(ValidatorSig, x.getBytes())
+
+     # Silly serialization check that fails without the right import
     check: x == y
 
     let

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -12,7 +12,7 @@ import
   ../beacon_chain/[block_pool, beacon_chain_db, extras, state_transition, ssz]
 
 suite "Block pool processing":
-  var
+  let
     genState = get_genesis_beacon_state(
       makeInitialDeposits(flags = {skipValidation}), 0, Eth1Data(),
         {skipValidation})
@@ -38,7 +38,7 @@ suite "Block pool processing":
       b1Root = hash_tree_root_final(b1)
 
     # TODO the return value is ugly here, need to fix and test..
-    discard pool.add(b1Root, b1)
+    discard pool.add(state, b1Root, b1)
 
     let b1Ref = pool.get(b1Root)
 
@@ -53,19 +53,18 @@ suite "Block pool processing":
       state = pool.loadTailState()
 
     let
-      b1 = addBlock(
-        state.data, state.blck.root, BeaconBlockBody(), {skipValidation})
+      b1 = addBlock(state.data, state.blck.root, BeaconBlockBody(), {})
       b1Root = hash_tree_root_final(b1)
-      b2 = addBlock(state.data, b1Root, BeaconBlockBody(), {skipValidation})
+      b2 = addBlock(state.data, b1Root, BeaconBlockBody(), {})
       b2Root = hash_tree_root_final(b2)
 
-    discard pool.add(b2Root, b2)
+    discard pool.add(state, b2Root, b2)
 
     check:
       pool.get(b2Root).isNone() # Unresolved, shouldn't show up
       b1Root in pool.checkUnresolved()
 
-    discard pool.add(b1Root, b1)
+    discard pool.add(state, b1Root, b1)
 
     let
       b1r = pool.get(b1Root)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -25,24 +25,19 @@ suite "Block processing":
   test "Passes from genesis state, no block":
     var
       state = genesisState
-      proposer_index = getNextBeaconProposerIndex(state)
       previous_block_root = hash_tree_root_final(genesisBlock)
-    let block_ok =
-      updateState(state, previous_block_root, none(BeaconBlock), {})
-    check:
-      block_ok
 
+    advanceState(state, previous_block_root)
+    check:
       state.slot == genesisState.slot + 1
 
   test "Passes from genesis state, empty block":
     var
       state = genesisState
-      proposer_index = getNextBeaconProposerIndex(state)
       previous_block_root = hash_tree_root_final(genesisBlock)
       new_block = makeBlock(state, previous_block_root, BeaconBlockBody())
 
-    let block_ok = updateState(
-      state, previous_block_root, some(new_block), {})
+    let block_ok = updateState(state, previous_block_root, new_block, {})
 
     check:
       block_ok
@@ -55,10 +50,7 @@ suite "Block processing":
       previous_block_root = hash_tree_root_final(genesisBlock)
 
     for i in 1..SLOTS_PER_EPOCH.int:
-      let block_ok = updateState(
-        state, previous_block_root, none(BeaconBlock), {})
-      check:
-        block_ok
+      advanceState(state, previous_block_root)
 
     check:
       state.slot == genesisState.slot + SLOTS_PER_EPOCH
@@ -72,7 +64,7 @@ suite "Block processing":
       var new_block = makeBlock(state, previous_block_root, BeaconBlockBody())
 
       let block_ok = updateState(
-        state, previous_block_root, some(new_block), {})
+        state, previous_block_root, new_block, {})
 
       check:
         block_ok
@@ -88,8 +80,7 @@ suite "Block processing":
       previous_block_root = hash_tree_root_final(genesisBlock)
 
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    discard updateState(
-        state, previous_block_root, none(BeaconBlock), {})
+    advanceState(state, previous_block_root)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
@@ -101,21 +92,19 @@ suite "Block processing":
     # Some time needs to pass before attestations are included - this is
     # to let the attestation propagate properly to interested participants
     while state.slot < GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY + 1:
-      discard updateState(
-        state, previous_block_root, none(BeaconBlock), {})
+      advanceState(state, previous_block_root)
 
     let
       new_block = makeBlock(state, previous_block_root, BeaconBlockBody(
         attestations: @[attestation]
       ))
-    discard updateState(state, previous_block_root, some(new_block), {})
+    discard updateState(state, previous_block_root, new_block, {})
 
     check:
       state.latest_attestations.len == 1
 
     while state.slot < 191:
-      discard updateState(
-        state, previous_block_root, none(BeaconBlock), {})
+      advanceState(state, previous_block_root)
 
     # Would need to process more epochs for the attestation to be removed from
     # the state! (per above bug)

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -107,7 +107,7 @@ proc addBlock*(
     )
 
   let block_ok = updateState(
-    state, previous_block_root, some(new_block), {skipValidation})
+    state, previous_block_root, new_block, {skipValidation})
   assert block_ok
 
   # Ok, we have the new state as it would look with the block applied - now we
@@ -174,7 +174,7 @@ proc makeAttestation*(
       shard: sac.shard,
       beacon_block_root: beacon_block_root,
       epoch_boundary_root: Eth2Digest(), # TODO
-      latest_crosslink: Crosslink(epoch: state.latest_crosslinks[sac.shard].epoch), # TODO
+      latest_crosslink: state.latest_crosslinks[sac.shard],
       shard_block_root: Eth2Digest(), # TODO
       justified_epoch: state.justified_epoch,
       justified_block_root: get_block_root(state, get_epoch_start_slot(state.justified_epoch)),


### PR DESCRIPTION
* fix state db lookup typo
* fix randao reveal slot when proposing blocks
* only store blocks that can be applied to a state
* store state at every epoch boundary (yes, needs pruning!)
* split out state advancement function when there's no block
* default state sim to 0.9 attestation ratio