### PR TITLE
Isolate fork choice API

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -175,14 +175,7 @@ proc updateHead(node: BeaconNode) =
     headSlot = node.state.data.slot
 
   # LRB fork choice - latest resolved block :)
-  for ph in node.potentialHeads:
-    let blck = node.blockPool.get(ph)
-    if blck.isNone():
-      continue
-    if blck.get().data.slot >= headSlot:
-      head = blck.get().refs
-      headSlot = blck.get().data.slot
-  node.potentialHeads.setLen(0)
+  fork_choice.lastResolvedBlock(node, head, headSlot)
 
   if head.root == node.state.blck.root:
     debug "No new head found",

--- a/beacon_chain/fork_choice.nim
+++ b/beacon_chain/fork_choice.nim
@@ -2,7 +2,22 @@ import
   deques, options, sequtils, tables,
   chronicles,
   ./spec/[beaconstate, datatypes, crypto, digest, helpers, validator], extras,
-  ./beacon_node_types, ./beacon_chain_db, ./ssz
+  ./beacon_node_types, ./beacon_chain_db, ./ssz,
+  ./attestation_pool, ./block_pool
+
+proc lastResolvedBlock*(
+        node: BeaconNode,
+        head: var BlockRef,
+        headSlot: var Slot) =
+  # Last resolved block fork choice
+  for ph in node.potentialHeads:
+    let blck = node.blockPool.get(ph)
+    if blck.isNone():
+      continue
+    if blck.get().data.slot >= headSlot:
+      head = blck.get().refs
+      headSlot = blck.get().data.slot
+  node.potentialHeads.setLen(0)
 
 # ##################################################################
 # Specs


### PR DESCRIPTION
Related to #168 

I think it would be good to isolate a fork choice API similar to https://github.com/sigp/lighthouse/tree/b2926b4ed0f60213de02452f8fcf1bc09a3b62bf/eth2/fork_choice/src.

This would also help for "stateless" testing and experimenting with various implementations including the optimized bitwise lmd ghost.