### PR TITLE
Mostly convert to using distinct Slot type

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -161,13 +161,13 @@ proc slotIndex(
       attestationSlot =  $humaneSlotNum(attestationSlot)
     pool.startingSlot = state.finalized_epoch.get_epoch_start_slot()
 
-  if pool.startingSlot + pool.slots.len.Slot <= attestationSlot:
+  if pool.startingSlot + pool.slots.len.uint64 <= attestationSlot:
     debug "Growing attestation pool",
       attestationSlot =  $humaneSlotNum(attestationSlot),
       startingSlot = $humaneSlotNum(pool.startingSlot)
 
     # Make sure there's a pool entry for every slot, even when there's a gap
-    while pool.startingSlot + pool.slots.len.Slot <= attestationSlot:
+    while pool.startingSlot + pool.slots.len.uint64 <= attestationSlot:
       pool.slots.addLast(SlotData())
 
   if pool.startingSlot < state.finalized_epoch.get_epoch_start_slot():
@@ -193,7 +193,7 @@ proc add*(pool: var AttestationPool,
 
   let
     attestationSlot = attestation.data.slot
-    idx = pool.slotIndex(state, attestationSlot)
+    idx = pool.slotIndex(state, attestationSlot.Slot)
     slotData = addr pool.slots[idx]
     validation = Validation(
       aggregation_bitfield: attestation.aggregation_bitfield,
@@ -279,11 +279,11 @@ proc getAttestationsForBlock*(pool: AttestationPool,
     attestationSlot = newBlockSlot - MIN_ATTESTATION_INCLUSION_DELAY
 
   if attestationSlot < pool.startingSlot or
-      attestationSlot >= pool.startingSlot + pool.slots.len.Slot:
+      attestationSlot >= pool.startingSlot + pool.slots.len.uint64:
     info "No attestations",
       attestationSlot = humaneSlotNum(attestationSlot),
       startingSlot = humaneSlotNum(pool.startingSlot),
-      endingSlot = humaneSlotNum(pool.startingSlot + pool.slots.len.Slot)
+      endingSlot = humaneSlotNum(pool.startingSlot + pool.slots.len.uint64)
 
     return
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -308,7 +308,7 @@ proc proposeBlock(node: BeaconNode,
   newBlock.state_root = Eth2Digest(data: hash_tree_root(state))
 
   let proposal = Proposal(
-    slot: slot,
+    slot: slot.uint64,
     shard: BEACON_CHAIN_SHARD_NUMBER,
     block_root: Eth2Digest(data: signed_root(newBlock, "signature")),
     signature: ValidatorSig(),
@@ -441,7 +441,7 @@ proc scheduleEpochActions(node: BeaconNode, epoch: Epoch) =
   let start = if epoch == GENESIS_EPOCH: 1.uint64 else: 0.uint64
 
   for i in start ..< SLOTS_PER_EPOCH:
-    let slot = epoch * SLOTS_PER_EPOCH + i
+    let slot = (epoch * SLOTS_PER_EPOCH + i).Slot
     nextState.slot = slot # ugly trick, see get_beacon_proposer_index
 
     block: # Schedule block proposals

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -54,7 +54,7 @@ proc init*(T: type BlockPool, db: BeaconChainDB): BlockPool =
   var blocksBySlot = initTable[uint64, seq[BlockRef]]()
   for _, b in tables.pairs(blocks):
     let slot = db.getBlock(b.root).get().slot
-    blocksBySlot.mgetOrPut(slot, @[]).add(b)
+    blocksBySlot.mgetOrPut(slot.uint64, @[]).add(b)
 
   BlockPool(
     pending: initTable[Eth2Digest, BeaconBlock](),
@@ -146,7 +146,7 @@ proc add*(
 
     pool.blocks[blockRoot] = blockRef
 
-    pool.addSlotMapping(blck.slot, blockRef)
+    pool.addSlotMapping(blck.slot.uint64, blockRef)
 
     # Resolved blocks should be stored in database
     pool.db.putBlock(blockRoot, blck)
@@ -229,8 +229,8 @@ proc getOrResolve*(pool: var BlockPool, root: Eth2Digest): BlockRef =
   if result.isNil:
     pool.unresolved[root] = UnresolvedBlock()
 
-iterator blockRootsForSlot*(pool: BlockPool, slot: uint64): Eth2Digest =
-  for br in pool.blocksBySlot.getOrDefault(slot, @[]):
+iterator blockRootsForSlot*(pool: BlockPool, slot: uint64|Slot): Eth2Digest =
+  for br in pool.blocksBySlot.getOrDefault(slot.uint64, @[]):
     yield br.root
 
 proc checkUnresolved*(pool: var BlockPool): seq[Eth2Digest] =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -120,13 +120,13 @@ func merkle_root*(values: openArray[Eth2Digest]): Eth2Digest =
   o[1]
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#slot_to_epoch
-func slot_to_epoch*(slot: Slot): Epoch =
-  slot div SLOTS_PER_EPOCH
+func slot_to_epoch*(slot: Slot|uint64): Epoch =
+  (slot div SLOTS_PER_EPOCH).Epoch
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_epoch_start_slot
 func get_epoch_start_slot*(epoch: Epoch): Slot =
   # Return the starting slot of the given ``epoch``.
-  epoch * SLOTS_PER_EPOCH
+  (epoch * SLOTS_PER_EPOCH).Slot
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_double_vote
 func is_double_vote*(attestation_data_1: AttestationData,
@@ -134,8 +134,9 @@ func is_double_vote*(attestation_data_1: AttestationData,
   ## Check if ``attestation_data_1`` and ``attestation_data_2`` have the same
   ## target.
   let
-    target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
-    target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
+    # RLP artifact
+    target_epoch_1 = slot_to_epoch(attestation_data_1.slot.Slot)
+    target_epoch_2 = slot_to_epoch(attestation_data_2.slot.Slot)
   target_epoch_1 == target_epoch_2
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_surround_vote
@@ -145,8 +146,9 @@ func is_surround_vote*(attestation_data_1: AttestationData,
   let
     source_epoch_1 = attestation_data_1.justified_epoch
     source_epoch_2 = attestation_data_2.justified_epoch
-    target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
-    target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
+    # RLP artifact
+    target_epoch_1 = slot_to_epoch(attestation_data_1.slot.Slot)
+    target_epoch_2 = slot_to_epoch(attestation_data_2.slot.Slot)
 
   source_epoch_1 < source_epoch_2 and target_epoch_2 < target_epoch_1
 

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -126,7 +126,7 @@ func get_previous_epoch*(state: BeaconState): Epoch =
   max(get_current_epoch(state) - 1, GENESIS_EPOCH)
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_crosslink_committees_at_slot
-func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot,
+func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
                                        registry_change: bool = false):
     seq[CrosslinkCommittee] =
   ## Returns the list of ``(committee, shard)`` tuples for the ``slot``.

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -24,7 +24,7 @@ type
 
 func toHeader(b: BeaconBlock): BeaconBlockHeader =
   BeaconBlockHeader(
-    slot: b.slot,
+    slot: b.slot.uint64,
     parent_root: b.parent_root,
     state_root: b.state_root,
     randao_reveal: b.randao_reveal,
@@ -35,7 +35,7 @@ func toHeader(b: BeaconBlock): BeaconBlockHeader =
 
 proc fromHeaderAndBody(b: var BeaconBlock, h: BeaconBlockHeader, body: BeaconBlockBody) =
   assert(hash_tree_root_final(body) == h.body)
-  b.slot = h.slot
+  b.slot = h.slot.Slot
   b.parent_root = h.parent_root
   b.state_root = h.state_root
   b.randao_reveal = h.randao_reveal
@@ -76,7 +76,7 @@ p2pProtocol BeaconSync(version = 1,
       latestFinalizedRoot: Eth2Digest # TODO
       latestFinalizedEpoch: uint64 = node.state.data.finalized_epoch
       bestRoot: Eth2Digest # TODO
-      bestSlot: uint64 = node.state.data.slot
+      bestSlot: uint64 = node.state.data.slot.uint64
 
     let m = await handshake(peer, timeout = 500,
                             status(networkId, latestFinalizedRoot,

--- a/research/serialized_sizes.nim
+++ b/research/serialized_sizes.nim
@@ -15,7 +15,7 @@ proc stateSize(deposits: int, maxContent = false) =
     #      attestations it may hold, so we'll just add so many of them
     state.latest_attestations.setLen(MAX_ATTESTATIONS * SLOTS_PER_EPOCH * 2)
     let
-      crosslink_committees = get_crosslink_committees_at_slot(state, 0)
+      crosslink_committees = get_crosslink_committees_at_slot(state, 0.Slot)
       validatorsPerCommittee =
         len(crosslink_committees[0].committee) # close enough..
     for a in state.latest_attestations.mitems():

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -36,6 +36,8 @@ template withTimerRet(stats: var RunningStat, body: untyped): untyped =
 
   tmp
 
+proc `%`*(x: Slot): JsonNode {.borrow.}
+
 proc writeJson*(prefix, slot, v: auto) =
   var f: File
   defer: close(f)
@@ -80,7 +82,7 @@ cli do(slots = 1945,
     attestations[attestations_idx] = @[]
 
     let t =
-      if (state.slot + 2.Slot) mod SLOTS_PER_EPOCH == 0: tEpoch
+      if (state.slot + 2) mod SLOTS_PER_EPOCH == 0: tEpoch
       else: tBlock
 
     withTimer(timers[t]):

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -57,11 +57,12 @@ suite "Beacon chain DB":
     check: x == y
 
     let
-      a0 = BeaconBlock(slot: 0)
+      # TODO Not GENESIS_SLOT?
+      a0 = BeaconBlock(slot: 0.Slot)
       a0r = hash_tree_root_final(a0)
-      a1 = BeaconBlock(slot: 1, parent_root: a0r)
+      a1 = BeaconBlock(slot: 1.Slot, parent_root: a0r)
       a1r = hash_tree_root_final(a1)
-      a2 = BeaconBlock(slot: 2, parent_root: a1r)
+      a2 = BeaconBlock(slot: 2.Slot, parent_root: a1r)
       a2r = hash_tree_root_final(a2)
 
     doAssert toSeq(db.getAncestors(a0r)) == []

--- a/tests/test_ssz.nim
+++ b/tests/test_ssz.nim
@@ -74,8 +74,9 @@ suite "Simple serialization":
   SSZ.roundripTest [1, 2, 3]
   SSZ.roundripTest @[1, 2, 3]
   SSZ.roundripTest SigKey.random().getKey()
-  SSZ.roundripTest BeaconBlock(slot: 42, signature: sign(SigKey.random(), 0'u64, ""))
-  SSZ.roundripTest BeaconState(slot: 42)
+  SSZ.roundripTest BeaconBlock(
+    slot: 42.Slot, signature: sign(SigKey.random(), 0'u64, ""))
+  SSZ.roundripTest BeaconState(slot: 42.Slot)
 
 suite "Tree hashing":
   # TODO Nothing but smoke tests for now..

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -120,7 +120,7 @@ proc addBlock*(
     # Once we've collected all the state data, we sign the block data along with
     # some book-keeping values
     signed_data = Proposal(
-      slot: new_block.slot,
+      slot: new_block.slot.uint64,
       shard: BEACON_CHAIN_SHARD_NUMBER,
       block_root: Eth2Digest(data: signed_root(new_block, "signature")),
       signature: ValidatorSig(),


### PR DESCRIPTION
Some RLP serialization issues here create a tradeoff in implementation. This explains most of the `Slot|uint64` type signatures. Crucially, using `Slot` works, and `Slot` and Epoch` won't be confusable.

Furthermore, my understanding is that a complete libp2p implementation will allow switching away from RLP entirely, rendering these workarounds moot and removable.