### PR TITLE
Use environment variables

### DIFF
--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -10,8 +10,8 @@ trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 # Set a default value for the env vars usually supplied by nimbus Makefile
 
-NUM_VALIDATORS=${1:-100}
-NUM_NODES=${2:-9}
+NUM_VALIDATORS=${VALIDATORS:-100}
+NUM_NODES=${NODES:-9}
 
 cd $SIM_ROOT
 mkdir -p "$SIMULATION_DIR"


### PR DESCRIPTION
Passing along no-name command line arguments when using make (from Nimbus) would need make target revamps that are a bit clumsy AFAIK, so using environment variables in the spirit of USE_MULTITAIL to get the number of validators and nodes makes more sense to me.

This lets us run the sim from nim-beacon-chain with

```bash
VALIDATORS=512 NODES=100 USE_MULTITAIL="yes" tests/simulation/start.sh
```

and from Nimbus with:

```bash
VALIDATORS=512 NODES=100 USE_MULTITAIL="yes" make eth2_network_simulation
```

Also makes for a more verbose launch process.