### PR TITLE
state processing fixes

### DIFF
--- a/beacon_chain/fork_choice.nim
+++ b/beacon_chain/fork_choice.nim
@@ -37,6 +37,8 @@ proc lmdGhost*(
     var res: uint64
     for validator_index, target in attestation_targets.items():
       if get_ancestor(target, blck.slot) == blck:
+        # The div on the balance is to chop off the insignification bits that
+        # fluctuate a lot epoch to epoch to have a more stable fork choice
         res += get_effective_balance(start_state, validator_index) div
             FORK_CHOICE_BALANCE_INCREMENT
     res

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -280,7 +280,7 @@ func get_attestation_participants*(state: BeaconState,
   ## Return the participant indices at for the ``attestation_data`` and
   ## ``bitfield``.
   let crosslink_committees = get_crosslink_committees_at_slot(
-    state, attestation_data.slot.Slot)
+    state, attestation_data.slot)
   doAssert anyIt(
     crosslink_committees,
     it[1] == attestation_data.shard)
@@ -367,7 +367,7 @@ proc checkAttestation*(
   ## at the current slot. When acting as a proposer, the same rules need to
   ## be followed!
 
-  let attestation_data_slot = attestation.data.slot.Slot
+  let attestation_data_slot = attestation.data.slot
 
   if not (attestation.data.slot >= GENESIS_SLOT):
     warn("Attestation predates genesis slot",
@@ -388,7 +388,7 @@ proc checkAttestation*(
     return
 
   let expected_justified_epoch =
-    if slot_to_epoch(attestation.data.slot.Slot + 1) >= get_current_epoch(state):
+    if slot_to_epoch(attestation.data.slot + 1) >= get_current_epoch(state):
       state.justified_epoch
     else:
       state.previous_justified_epoch
@@ -477,7 +477,7 @@ proc checkAttestation*(
           data: attestation.data, custody_bit: true)),
       ],
       attestation.aggregate_signature,
-      get_domain(state.fork, slot_to_epoch(attestation.data.slot.Slot),
+      get_domain(state.fork, slot_to_epoch(attestation.data.slot),
                  DOMAIN_ATTESTATION),
     )
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -572,10 +572,27 @@ ethTimeUnit Slot
 ethTimeUnit Epoch
 
 func humaneSlotNum*(s: Slot): uint64 =
-  s.Slot - GENESIS_SLOT
+  s - GENESIS_SLOT
 
 func humaneEpochNum*(e: Epoch): uint64 =
-  e.Epoch - GENESIS_EPOCH
+  e - GENESIS_EPOCH
+
+func shortLog*(v: BeaconBlock): tuple[
+    slot: uint64, parent_root: string, state_root: string,
+    randao_reveal: string, #[ eth1_data ]#
+    proposer_slashings_len: int, attester_slashings_len: int,
+    attestations_len: int,
+    deposits_len: int,
+    voluntary_exits_len: int,
+    transfers_len: int,
+    signature: string
+  ] = (
+    humaneSlotNum(v.slot), shortLog(v.parent_root), shortLog(v.state_root),
+    shortLog(v.randao_reveal), v.body.proposer_slashings.len(),
+    v.body.attester_slashings.len(), v.body.attestations.len(),
+    v.body.deposits.len(), v.body.voluntary_exits.len(), v.body.transfers.len(),
+    shortLog(v.signature)
+  )
 
 import nimcrypto, json_serialization
 export json_serialization

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -135,8 +135,8 @@ func is_double_vote*(attestation_data_1: AttestationData,
   ## target.
   let
     # RLP artifact
-    target_epoch_1 = slot_to_epoch(attestation_data_1.slot.Slot)
-    target_epoch_2 = slot_to_epoch(attestation_data_2.slot.Slot)
+    target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
+    target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
   target_epoch_1 == target_epoch_2
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_surround_vote
@@ -147,8 +147,8 @@ func is_surround_vote*(attestation_data_1: AttestationData,
     source_epoch_1 = attestation_data_1.justified_epoch
     source_epoch_2 = attestation_data_2.justified_epoch
     # RLP artifact
-    target_epoch_1 = slot_to_epoch(attestation_data_1.slot.Slot)
-    target_epoch_2 = slot_to_epoch(attestation_data_2.slot.Slot)
+    target_epoch_1 = slot_to_epoch(attestation_data_1.slot)
+    target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
 
   source_epoch_1 < source_epoch_2 and target_epoch_2 < target_epoch_1
 

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -547,7 +547,7 @@ func processEpoch(state: var BeaconState) =
   let
     current_epoch = get_current_epoch(state)
     previous_epoch = get_previous_epoch(state)
-    next_epoch = (current_epoch + 1).Epoch
+    next_epoch = (current_epoch + 1)
 
     # Spec grabs this later, but it's part of current_total_balance
     active_validator_indices =
@@ -611,7 +611,7 @@ func processEpoch(state: var BeaconState) =
   let
     previous_epoch_head_attestations =
       previous_epoch_attestations.filterIt(
-        it.data.beacon_block_root == get_block_root(state, it.data.slot.Slot))
+        it.data.beacon_block_root == get_block_root(state, it.data.slot))
 
     previous_epoch_head_attester_indices =
       toSet(get_attester_indices(state, previous_epoch_head_attestations))
@@ -1033,7 +1033,7 @@ proc advanceState*(
 proc skipSlots*(state: var BeaconState, parentRoot: Eth2Digest, slot: Slot,
     afterSlot: proc (state: BeaconState) = nil) =
   if state.slot < slot:
-    debug "Advancing state past slot gap",
+    debug "Advancing state with empty slots",
       targetSlot = humaneSlotNum(slot),
       stateSlot = humaneSlotNum(state.slot)
 


### PR DESCRIPTION
* remove some redundant state updates
* when attesting late, use correct state / head
* don't send out obsolete attestations
* don't propose obsolete blocks
* remove some more resundant state updates :)
* simplify block logging (experimental)
* document fork choice division
* fix some Slot / Epoch conversion warnings