### PR TITLE
begin 0.5.0 spec update: parent_root -> previous_block_root, BeaconState.justified_epoch -> BeaconState.current_justified_epoch, DOMAIN_PROPOSAL -> DOMAIN_BEACON_BLOCK, temporarily rename BeaconBlockHeader to BeaconBlockHeaderRLP to allow for gradual re-merging without disrupting RLP; mark a few unchanged functions and data types, implement get_temporary_block_header/get_empty_block/should_update_validator_registry/processBlockHeader/cacheState; update a few others

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -108,4 +108,4 @@ iterator getAncestors*(db: BeaconChainDB, root: Eth2Digest):
   while (let blck = db.getBlock(root); blck.isSome()):
     yield (root, blck.get())
 
-    root = blck.get().parent_root
+    root = blck.get().previous_block_root

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -10,8 +10,8 @@ import
   ../extras, ../ssz,
   ./crypto, ./datatypes, ./digest, ./helpers, ./validator
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_effective_balance
-func get_effective_balance*(state: BeaconState, index: ValidatorIndex): uint64 =
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_effective_balance
+func get_effective_balance*(state: BeaconState, index: ValidatorIndex): Gwei =
   ## Return the effective balance (also known as "balance at stake") for a
   ## validator with the given ``index``.
   min(state.validator_balances[index], MAX_DEPOSIT_AMOUNT)
@@ -67,7 +67,7 @@ func get_delayed_activation_exit_epoch*(epoch: Epoch): Epoch =
   ## takes effect.
   epoch + 1 + ACTIVATION_EXIT_DELAY
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#activate_validator
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#activate_validator
 func activate_validator(state: var BeaconState,
                         index: ValidatorIndex,
                         is_genesis: bool) =
@@ -107,7 +107,7 @@ func reduce_balance*(balance: var uint64, amount: uint64) =
   # Not in spec, but useful to avoid underflow.
   balance -= min(amount, balance)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#slash_validator
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#slash_validator
 func slash_validator*(state: var BeaconState, index: ValidatorIndex) =
   ## Slash the validator with index ``index``.
   ## Note that this function mutates ``state``.
@@ -155,7 +155,22 @@ func update_shuffling_cache*(state: var BeaconState) =
     state.shuffling_cache.shuffling_1 = shuffling_seq
   state.shuffling_cache.index = 1 - state.shuffling_cache.index
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_temporary_block_header
+func get_temporary_block_header*(blck: BeaconBlock): BeaconBlockHeader =
+  ## Return the block header corresponding to a block with ``state_root`` set
+  ## to ``ZERO_HASH``.
+  BeaconBlockHeader(
+    slot: blck.slot.uint64,
+    previous_block_root: blck.previous_block_root,
+    state_root: ZERO_HASH,
+    block_body_root: hash_tree_root_final(blck.body),
+    signature: blck.signature)
+
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#on-genesis
+func get_empty_block*(): BeaconBlock =
+  # Nim default values fill this in fine, mostly.
+  result.slot = GENESIS_SLOT
+
 func get_genesis_beacon_state*(
     genesis_validator_deposits: openArray[Deposit],
     genesis_time: uint64,
@@ -204,7 +219,7 @@ func get_genesis_beacon_state*(
 
     # Finality
     previous_justified_epoch: GENESIS_EPOCH,
-    justified_epoch: GENESIS_EPOCH,
+    current_justified_epoch: GENESIS_EPOCH,
     justification_bitfield: 0,
     finalized_epoch: GENESIS_EPOCH,
 
@@ -214,6 +229,7 @@ func get_genesis_beacon_state*(
     # Recent state
     # latest_block_roots, latest_active_index_roots, latest_slashed_balances,
     # latest_attestations, and batched_block_roots automatically initialized.
+    latest_block_header: get_temporary_block_header(get_empty_block()),
   )
 
   for i in 0 ..< SHARD_COUNT:
@@ -304,7 +320,6 @@ func process_ejections*(state: var BeaconState) =
   ## Iterate through the validator registry and eject active validators with
   ## balance below ``EJECTION_BALANCE``
   for index in get_active_validator_indices(
-      # Spec bug in 0.4.0: is just current_epoch(state)
       state.validator_registry, get_current_epoch(state)):
     if state.validator_balances[index] < EJECTION_BALANCE:
       exit_validator(state, index)
@@ -314,7 +329,17 @@ func get_total_balance*(state: BeaconState, validators: auto): Gwei =
   # Return the combined effective balance of an array of validators.
   foldl(validators, a + get_effective_balance(state, b), 0'u64)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#validator-registry-and-shuffling-seed-data
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#validator-registry-and-shuffling-seed-data
+func should_update_validator_registry*(state: BeaconState): bool =
+  # Must have finalized a new block
+  if state.finalized_epoch <= state.validator_registry_update_epoch:
+    return false
+  # Must have processed new crosslinks on all shards of the current epoch
+  allIt(0 ..< get_current_epoch_committee_count(state).int,
+        not (state.latest_crosslinks[
+          ((state.current_shuffling_start_shard + it.uint64) mod
+            SHARD_COUNT).int].epoch <= state.validator_registry_update_epoch))
+
 func update_validator_registry*(state: var BeaconState) =
   ## Update validator registry.
   ## Note that this function mutates ``state``.
@@ -389,7 +414,7 @@ proc checkAttestation*(
 
   let expected_justified_epoch =
     if slot_to_epoch(attestation.data.slot + 1) >= get_current_epoch(state):
-      state.justified_epoch
+      state.current_justified_epoch
     else:
       state.previous_justified_epoch
 
@@ -511,7 +536,7 @@ proc makeAttestationData*(
     epoch_boundary_root =
       if epoch_start_slot == state.slot: beacon_block_root
       else: get_block_root(state, epoch_start_slot)
-    justified_slot = get_epoch_start_slot(state.justified_epoch)
+    justified_slot = get_epoch_start_slot(state.current_justified_epoch)
     justified_block_root = get_block_root(state, justified_slot)
 
   AttestationData(
@@ -521,6 +546,6 @@ proc makeAttestationData*(
     epoch_boundary_root: epoch_boundary_root,
     crosslink_data_root: Eth2Digest(), # Stub in phase0
     latest_crosslink: state.latest_crosslinks[shard],
-    justified_epoch: state.justified_epoch,
+    justified_epoch: state.current_justified_epoch,
     justified_block_root: justified_block_root,
   )

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -61,7 +61,7 @@ func process_deposit(state: var BeaconState, deposit: Deposit) =
 
     state.validator_balances[index] += amount
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_delayed_activation_exit_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_delayed_activation_exit_epoch
 func get_delayed_activation_exit_epoch*(epoch: Epoch): Epoch =
   ## Return the epoch at which an activation or exit triggered in ``epoch``
   ## takes effect.
@@ -81,7 +81,7 @@ func activate_validator(state: var BeaconState,
     else:
       get_delayed_activation_exit_epoch(get_current_epoch(state))
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#initiate_validator_exit
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#initiate_validator_exit
 func initiate_validator_exit*(state: var BeaconState,
                               index: ValidatorIndex) =
   ## Initiate exit for the validator with the given ``index``.
@@ -267,14 +267,14 @@ func get_initial_beacon_block*(state: BeaconState): BeaconBlock =
     # initialized to default values.
   )
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_block_root
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_block_root
 func get_block_root*(state: BeaconState,
                      slot: Slot): Eth2Digest =
   # Return the block root at a recent ``slot``.
 
-  doAssert state.slot <= slot + LATEST_BLOCK_ROOTS_LENGTH
+  doAssert state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
   doAssert slot < state.slot
-  state.latest_block_roots[slot mod LATEST_BLOCK_ROOTS_LENGTH]
+  state.latest_block_roots[slot mod SLOTS_PER_HISTORICAL_ROOT]
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_attestation_participants
 func get_attestation_participants*(state: BeaconState,
@@ -324,7 +324,7 @@ func process_ejections*(state: var BeaconState) =
     if state.validator_balances[index] < EJECTION_BALANCE:
       exit_validator(state, index)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_total_balance
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_total_balance
 func get_total_balance*(state: BeaconState, validators: auto): Gwei =
   # Return the combined effective balance of an array of validators.
   foldl(validators, a + get_effective_balance(state, b), 0'u64)
@@ -513,7 +513,7 @@ proc checkAttestation*(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#prepare_validator_for_withdrawal
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#prepare_validator_for_withdrawal
 func prepare_validator_for_withdrawal*(state: var BeaconState, index: ValidatorIndex) =
   ## Set the validator with the given ``index`` as withdrawable
   ## ``MIN_VALIDATOR_WITHDRAWABILITY_DELAY`` after the current epoch.

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -78,14 +78,14 @@ func bls_aggregate_pubkeys*(keys: openArray[ValidatorPubKey]): ValidatorPubKey =
     else:
       result.combine(key)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/bls_signature.md#bls_verify
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/bls_signature.md#bls_verify
 func bls_verify*(
     pubkey: ValidatorPubKey, msg: openArray[byte], sig: ValidatorSig,
     domain: uint64): bool =
   # name from spec!
   sig.verify(msg, domain, pubkey)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/bls_signature.md#bls_verify_multiple
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/bls_signature.md#bls_verify_multiple
 func bls_verify_multiple*(
     pubkeys: seq[ValidatorPubKey], message_hashes: seq[array[0..31, byte]],
     sig: ValidatorSig, domain: uint64): bool =

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -68,7 +68,7 @@ template hash*(k: ValidatorPubKey|ValidatorPrivKey): Hash =
 
 func pubKey*(pk: ValidatorPrivKey): ValidatorPubKey = pk.getKey()
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/bls_signature.md#bls_aggregate_pubkeys
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/bls_signature.md#bls_aggregate_pubkeys
 func bls_aggregate_pubkeys*(keys: openArray[ValidatorPubKey]): ValidatorPubKey =
   var empty = true
   for key in keys:

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -82,11 +82,11 @@ const
   SHUFFLE_ROUND_COUNT* = 90
 
   # Deposit contract
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#deposit-contract
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#deposit-contract
   DEPOSIT_CONTRACT_TREE_DEPTH* = 2^5
 
   # Gwei values
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#gwei-values
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#gwei-values
   MIN_DEPOSIT_AMOUNT* = 2'u64^0 * 10'u64^9 ##\
   ## Minimum amounth of ETH that can be deposited in one call - deposits can
   ## be used either to top up an existing validator or commit to a new one
@@ -267,7 +267,7 @@ type
     deposit_data*: DepositData ##\
     ## Data
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#depositdata
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#depositdata
   DepositData* = object
     amount*: uint64 ## Amount in Gwei
     timestamp*: uint64 # Timestamp from deposit contract
@@ -280,7 +280,7 @@ type
     proof_of_possession*: ValidatorSig ##\
     ## A BLS signature of this `DepositInput`
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#voluntaryexit
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#voluntaryexit
   VoluntaryExit* = object
     # Minimum epoch for processing exit
     epoch*: Epoch
@@ -468,7 +468,7 @@ type
     slashed*: bool ##\
     ## Was the validator slashed
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#crosslink
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#crosslink
   Crosslink* = object
     epoch*: Epoch ##\
     ## Epoch number
@@ -483,7 +483,7 @@ type
     custody_bitfield*: seq[byte]              # Custody bitfield
     inclusion_slot*: Slot                     # Inclusion slot
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#fork
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#fork
   Fork* = object
     previous_version*: uint64                     # Previous fork version
     current_version*: uint64                      # Current fork version

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -106,8 +106,7 @@ const
   ## processing is done
   ## Compile with -d:SLOTS_PER_EPOCH=4 for shorter epochs
 
-  # Initial values
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#initial-values
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#initial-values
   GENESIS_FORK_VERSION* = 0'u64
   GENESIS_SLOT* = (2'u64^32).Slot
   GENESIS_EPOCH* = (GENESIS_SLOT.uint64 div SLOTS_PER_EPOCH).Epoch ##\
@@ -146,18 +145,20 @@ const
   EPOCHS_PER_ETH1_VOTING_PERIOD* = 2'u64^4 ##\
   ## epochs (~1.7 hours)
 
+  SLOTS_PER_HISTORICAL_ROOT* = 8192 ##\
+  ## slots (13 hours)
+
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY* = 2'u64^8 ##\
   ## epochs (~27 hours)
 
-  # State list lengths
   # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#state-list-lengths
-  LATEST_BLOCK_ROOTS_LENGTH* = 2'u64^13
-  LATEST_RANDAO_MIXES_LENGTH* = 2'u64^13
+  # TODO LATEST_BLOCK_ROOTS_LENGTH -> SLOTS_PER_HISTORICAL_ROOT?
+  LATEST_BLOCK_ROOTS_LENGTH* = 8192
+  LATEST_RANDAO_MIXES_LENGTH* = 8192
   LATEST_ACTIVE_INDEX_ROOTS_LENGTH* = 8192 # 2'u64^13, epochs
   LATEST_SLASHED_EXIT_LENGTH* = 8192 # epochs
 
-  # Reward and penalty quotients
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#reward-and-penalty-quotients
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#reward-and-penalty-quotients
   BASE_REWARD_QUOTIENT* = 2'u64^5 ##\
   ## The `BASE_REWARD_QUOTIENT` parameter dictates the per-epoch reward. It
   ## corresponds to ~2.54% annual interest assuming 10 million participating
@@ -167,7 +168,6 @@ const
   INACTIVITY_PENALTY_QUOTIENT* = 2'u64^24
   MIN_PENALTY_QUOTIENT* = 32 # 2^5
 
-  # Max transactions per block
   # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#max-transactions-per-block
   MAX_PROPOSER_SLASHINGS* = 2^4
   MAX_ATTESTER_SLASHINGS* = 2^0
@@ -181,16 +181,16 @@ type
 
   Gwei* = uint64
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#proposerslashing
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#proposerslashing
   ProposerSlashing* = object
     proposer_index*: uint64 ##\
     ## Proposer index
 
-    proposal_1*: Proposal ##\
-    # First proposal
+    header_1*: BeaconBlockHeader ##\
+    # First block header
 
-    proposal_2*: Proposal ##\
-    # Second proposal
+    header_2*: BeaconBlockHeader ##\
+    # Second block header
 
   # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#attesterslashing
   AttesterSlashing* = object
@@ -253,7 +253,7 @@ type
     justified_block_root*: Eth2Digest ##\
     ## Hash of the last justified beacon block
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#attestationdataandcustodybit
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#attestationdataandcustodybit
   AttestationDataAndCustodyBit* = object
     data*: AttestationData
     custody_bit*: bool
@@ -314,7 +314,7 @@ type
     signature*: ValidatorSig ##\
     ## Sender signature
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#beaconblock
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconblock
   BeaconBlock* = object
     ## For each slot, a proposer is chosen from the validator pool to propose
     ## a new block. Once the block as been proposed, it is transmitted to
@@ -323,26 +323,33 @@ type
     ## is formed.
 
     slot*: Slot
-    parent_root*: Eth2Digest ##\
+
+    previous_block_root*: Eth2Digest ##\
     ##\ Root hash of the previous block
 
     state_root*: Eth2Digest ##\
     ## The state root, _after_ this block has been processed
-
-    randao_reveal*: ValidatorSig ##\
-    ## Proposer RANDAO reveal
-
-    eth1_data*: Eth1Data
 
     body*: BeaconBlockBody
 
     signature*: ValidatorSig ##\
     ## Proposer signature
 
+  #https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconblockheader
   BeaconBlockHeader* = object
+    slot*: uint64
+    previous_block_root*: Eth2Digest
+    state_root*: Eth2Digest
+    block_body_root*: Eth2Digest
+    signature*: ValidatorSig
+
+  BeaconBlockHeaderRLP* = object
     ## Same as BeaconBlock, except `body` is the `hash_tree_root` of the
     ## associated BeaconBlockBody.
     # TODO: Dry it up with BeaconBlock
+    # TODO: As a first step, don't change RLP output; only previous user,
+    # but as with others, randao_reveal and eth1_data move to body.
+    # This is from before spec had a version.
     slot*: uint64
     parent_root*: Eth2Digest
     state_root*: Eth2Digest
@@ -351,8 +358,10 @@ type
     signature*: ValidatorSig
     body*: Eth2Digest
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#beaconblockbody
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
+    randao_reveal*: ValidatorSig
+    eth1_data*: Eth1Data
     proposer_slashings*: seq[ProposerSlashing]
     attester_slashings*: seq[AttesterSlashing]
     attestations*: seq[Attestation]
@@ -374,7 +383,7 @@ type
     signature*: ValidatorSig ##\
     ## Signature
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#beaconstate
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconstate
   BeaconState* = object
     slot*: Slot
     genesis_time*: uint64
@@ -393,7 +402,7 @@ type
     ## For light clients to easily track delta
 
     # Randomness and committees
-    latest_randao_mixes*: array[LATEST_BLOCK_ROOTS_LENGTH.int, Eth2Digest]
+    latest_randao_mixes*: array[LATEST_RANDAO_MIXES_LENGTH, Eth2Digest]
     previous_shuffling_start_shard*: uint64
     current_shuffling_start_shard*: uint64
     previous_shuffling_epoch*: Epoch
@@ -402,20 +411,31 @@ type
     current_shuffling_seed*: Eth2Digest
 
     # Finality
+    previous_epoch_attestations*: seq[PendingAttestation]
+    current_epoch_attestations*: seq[PendingAttestation]
     previous_justified_epoch*: Epoch
-    justified_epoch*: Epoch
+    current_justified_epoch*: Epoch
+    previous_justified_root*: Eth2Digest
+    current_justified_root*: Eth2Digest
     justification_bitfield*: uint64
     finalized_epoch*: Epoch
+    finalized_root*: Eth2Digest
 
     # Recent state
     latest_crosslinks*: array[SHARD_COUNT, Crosslink]
-    latest_block_roots*: array[LATEST_BLOCK_ROOTS_LENGTH.int, Eth2Digest] ##\
+    latest_block_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
     ## Needed to process attestations, older to newer
-    latest_active_index_roots*: array[LATEST_ACTIVE_INDEX_ROOTS_LENGTH.int, Eth2Digest]
+    latest_state_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    latest_active_index_roots*: array[LATEST_ACTIVE_INDEX_ROOTS_LENGTH, Eth2Digest]
 
     latest_slashed_balances*: array[LATEST_SLASHED_EXIT_LENGTH, uint64] ##\
     ## Balances penalized in the current withdrawal period
 
+    latest_block_header*: BeaconBlockHeader ##\
+    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+    historical_roots*: seq[Eth2Digest]
+
+    # TOOD remove these, gone in 0.5
     latest_attestations*: seq[PendingAttestation]
     batched_block_roots*: seq[Eth2Digest]
 
@@ -479,7 +499,7 @@ type
     block_hash*: Eth2Digest ##\
     ## Block hash
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#eth1datavote
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#eth1datavote
   Eth1DataVote* = object
     eth1_data*: Eth1Data ##\
     ## Data being voted for
@@ -493,13 +513,13 @@ type
     Activation = 0
     Exit = 1
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#signature-domains
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#signature-domains
   SignatureDomain* {.pure.} = enum
-    DOMAIN_DEPOSIT = 0
-    DOMAIN_ATTESTATION = 1
-    DOMAIN_PROPOSAL = 2
-    DOMAIN_EXIT = 3
-    DOMAIN_RANDAO = 4
+    DOMAIN_BEACON_BLOCK = 0
+    DOMAIN_RANDAO = 1
+    DOMAIN_ATTESTATION = 2
+    DOMAIN_DEPOSIT = 3
+    DOMAIN_VOLUNTARY_EXIT = 4
     DOMAIN_TRANSFER = 5
 
   # TODO: not in spec
@@ -578,8 +598,8 @@ func humaneEpochNum*(e: Epoch): uint64 =
   e - GENESIS_EPOCH
 
 func shortLog*(v: BeaconBlock): tuple[
-    slot: uint64, parent_root: string, state_root: string,
-    randao_reveal: string, #[ eth1_data ]#
+    slot: uint64, previous_block_root: string, state_root: string,
+    #[ eth1_data ]#
     proposer_slashings_len: int, attester_slashings_len: int,
     attestations_len: int,
     deposits_len: int,
@@ -587,8 +607,8 @@ func shortLog*(v: BeaconBlock): tuple[
     transfers_len: int,
     signature: string
   ] = (
-    humaneSlotNum(v.slot), shortLog(v.parent_root), shortLog(v.state_root),
-    shortLog(v.randao_reveal), v.body.proposer_slashings.len(),
+    humaneSlotNum(v.slot), shortLog(v.previous_block_root),
+    shortLog(v.state_root), v.body.proposer_slashings.len(),
     v.body.attester_slashings.len(), v.body.attestations.len(),
     v.body.deposits.len(), v.body.voluntary_exits.len(), v.body.transfers.len(),
     shortLog(v.signature)

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -151,9 +151,7 @@ const
   MIN_VALIDATOR_WITHDRAWABILITY_DELAY* = 2'u64^8 ##\
   ## epochs (~27 hours)
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#state-list-lengths
-  # TODO LATEST_BLOCK_ROOTS_LENGTH -> SLOTS_PER_HISTORICAL_ROOT?
-  LATEST_BLOCK_ROOTS_LENGTH* = 8192
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#state-list-lengths
   LATEST_RANDAO_MIXES_LENGTH* = 8192
   LATEST_ACTIVE_INDEX_ROOTS_LENGTH* = 8192 # 2'u64^13, epochs
   LATEST_SLASHED_EXIT_LENGTH* = 8192 # epochs
@@ -168,7 +166,7 @@ const
   INACTIVITY_PENALTY_QUOTIENT* = 2'u64^24
   MIN_PENALTY_QUOTIENT* = 32 # 2^5
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#max-transactions-per-block
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#max-transactions-per-block
   MAX_PROPOSER_SLASHINGS* = 2^4
   MAX_ATTESTER_SLASHINGS* = 2^0
   MAX_ATTESTATIONS* = 2^7
@@ -199,7 +197,7 @@ type
     slashable_attestation_2*: SlashableAttestation ## \
     ## Second slashable attestation
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#slashableattestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#slashableattestation
   SlashableAttestation* = object
     validator_indices*: seq[uint64] ##\
     ## Validator indices
@@ -275,7 +273,7 @@ type
     timestamp*: uint64 # Timestamp from deposit contract
     deposit_input*: DepositInput
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#depositinput
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#depositinput
   DepositInput* = object
     pubkey*: ValidatorPubKey
     withdrawal_credentials*: Eth2Digest
@@ -447,7 +445,7 @@ type
     # Not in spec. TODO: don't serialize or deserialize this.
     shuffling_cache*: ShufflingCache
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#validator
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#validator
   Validator* = object
     pubkey*: ValidatorPubKey ##\
     ## BLS public key
@@ -478,7 +476,7 @@ type
     crosslink_data_root*: Eth2Digest ##\
     ## Shard data since the previous crosslink
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#pendingattestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#pendingattestation
   PendingAttestation* = object
     aggregation_bitfield*: seq[byte]          # Attester participation bitfield
     data*: AttestationData                    # Attestation data
@@ -491,7 +489,7 @@ type
     current_version*: uint64                      # Current fork version
     epoch*: Epoch                                 # Fork epoch number
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#eth1data
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#eth1data
   Eth1Data* = object
     deposit_root*: Eth2Digest ##\
     ## Data being voted for

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -7,7 +7,7 @@
 
 # Serenity hash function / digest
 #
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#hash
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#hash
 #
 # In Phase 0 the beacon chain is deployed with the same hash function as
 # Ethereum 1.0, i.e. Keccak-256 (also incorrectly known as SHA3).

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -21,7 +21,7 @@ func get_bitfield_bit*(bitfield: openarray[byte], i: int): byte =
   doAssert i div 8 < bitfield.len, "i: " & $i & " i div 8: " & $(i div 8)
   (bitfield[i div 8] shr (7 - (i mod 8))) mod 2
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#verify_bitfield
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#verify_bitfield
 func verify_bitfield*(bitfield: openarray[byte], committee_size: int): bool =
   # Verify ``bitfield`` against the ``committee_size``.
   if len(bitfield) != (committee_size + 7) div 8:
@@ -81,8 +81,8 @@ func get_domain*(
   # Get the domain number that represents the fork meta and signature domain.
   (get_fork_version(fork, epoch) shl 32) + domain_type.uint32
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_power_of_two
-func is_power_of_2*(v: uint64): bool = (v and (v-1)) == 0
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#is_power_of_two
+func is_power_of_2*(v: uint64): bool = (v > 0'u64) and (v and (v-1)) == 0
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#merkle_root
 func merkle_root*(values: openArray[Eth2Digest]): Eth2Digest =
@@ -119,16 +119,16 @@ func merkle_root*(values: openArray[Eth2Digest]): Eth2Digest =
 
   o[1]
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#slot_to_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#slot_to_epoch
 func slot_to_epoch*(slot: Slot|uint64): Epoch =
   (slot div SLOTS_PER_EPOCH).Epoch
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_epoch_start_slot
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_epoch_start_slot
 func get_epoch_start_slot*(epoch: Epoch): Slot =
   # Return the starting slot of the given ``epoch``.
   (epoch * SLOTS_PER_EPOCH).Slot
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_double_vote
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#is_double_vote
 func is_double_vote*(attestation_data_1: AttestationData,
                      attestation_data_2: AttestationData): bool =
   ## Check if ``attestation_data_1`` and ``attestation_data_2`` have the same
@@ -139,7 +139,7 @@ func is_double_vote*(attestation_data_1: AttestationData,
     target_epoch_2 = slot_to_epoch(attestation_data_2.slot)
   target_epoch_1 == target_epoch_2
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_surround_vote
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#is_surround_vote
 func is_surround_vote*(attestation_data_1: AttestationData,
                        attestation_data_2: AttestationData): bool =
   ## Check if ``attestation_data_1`` surrounds ``attestation_data_2``.
@@ -179,7 +179,7 @@ func get_current_epoch_committee_count*(state: BeaconState): uint64 =
   )
   get_epoch_committee_count(len(current_active_validators))
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_current_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: BeaconState): Epoch =
   # Return the current epoch of the given ``state``.
   doAssert state.slot >= GENESIS_SLOT, $state.slot
@@ -216,7 +216,7 @@ func bytes_to_int*(data: seq[byte]): uint64 =
   for i in countdown(7, 0):
     result = result * 256 + data[i]
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#int_to_bytes1-int_to_bytes2-
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#int_to_bytes1-int_to_bytes2-
 # Have 1, 4, and 32-byte versions. 2+ more and maybe worth metaprogramming.
 func int_to_bytes32*(x: uint64): array[32, byte] =
   ## Little-endian data representation

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -34,7 +34,7 @@ func verify_bitfield*(bitfield: openarray[byte], committee_size: int): bool =
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#split
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#split
 func split*[T](lst: openArray[T], N: Positive): seq[seq[T]] =
   ## split lst in N pieces, with each piece having `len(lst) div N` or
   ## `len(lst) div N + 1` pieces
@@ -56,9 +56,11 @@ func get_new_recent_block_roots*(old_block_roots: seq[Eth2Digest],
 
 func ceil_div8*(v: int): int = (v + 7) div 8 # TODO use a proper bitarray!
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#integer_squareroot
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#integer_squareroot
 func integer_squareroot*(n: SomeInteger): SomeInteger =
   ## The largest integer ``x`` such that ``x**2`` is less than ``n``.
+  doAssert n >= 0'u64
+
   var
     x = n
     y = (x + 1) div 2
@@ -242,7 +244,7 @@ func int_to_bytes4*(x: uint64): array[4, byte] =
   result[2] = ((x shr 16) and 0xff).byte
   result[3] = ((x shr 24) and 0xff).byte
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#generate_seed
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#generate_seed
 func generate_seed*(state: BeaconState, epoch: Epoch): Eth2Digest =
   # Generate a seed for the given ``epoch``.
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -14,7 +14,7 @@ import ./datatypes, ./digest, sequtils, math
 func bitSet*(bitfield: var openArray[byte], index: int) =
   bitfield[index div 8] = bitfield[index div 8] or 1'u8 shl (7 - (index mod 8))
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_bitfield_bit
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_bitfield_bit
 func get_bitfield_bit*(bitfield: openarray[byte], i: int): byte =
   # Extract the bit in ``bitfield`` at position ``i``.
   doAssert 0 <= i div 8, "i: " & $i & " i div 8: " & $(i div 8)
@@ -152,7 +152,7 @@ func is_surround_vote*(attestation_data_1: AttestationData,
 
   source_epoch_1 < source_epoch_2 and target_epoch_2 < target_epoch_1
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#is_active_validator
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#is_active_validator
 func is_active_validator*(validator: Validator, epoch: Epoch): bool =
   ### Check if ``validator`` is active
   validator.activation_epoch <= epoch and epoch < validator.exit_epoch
@@ -170,7 +170,7 @@ func get_epoch_committee_count*(active_validator_count: int): uint64 =
     active_validator_count div SLOTS_PER_EPOCH div TARGET_COMMITTEE_SIZE,
     1, SHARD_COUNT div SLOTS_PER_EPOCH).uint64 * SLOTS_PER_EPOCH
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_current_epoch_committee_count
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_current_epoch_committee_count
 func get_current_epoch_committee_count*(state: BeaconState): uint64 =
   # Return the number of committees in the current epoch of the given ``state``.
   let current_active_validators = get_active_validator_indices(
@@ -185,7 +185,7 @@ func get_current_epoch*(state: BeaconState): Epoch =
   doAssert state.slot >= GENESIS_SLOT, $state.slot
   slot_to_epoch(state.slot)
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_randao_mix
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: BeaconState,
                      epoch: Epoch): Eth2Digest =
     ## Returns the randao mix at a recent ``epoch``.
@@ -196,7 +196,7 @@ func get_randao_mix*(state: BeaconState,
 
     state.latest_randao_mixes[epoch mod LATEST_RANDAO_MIXES_LENGTH]
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_active_index_root
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_active_index_root
 func get_active_index_root(state: BeaconState, epoch: Epoch): Eth2Digest =
   # Returns the index root at a recent ``epoch``.
 

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -140,8 +140,6 @@ func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
     # TODO: the + 1 here works around a bug, remove when upgrading to
     #       some more recent version:
     # https://github.com/ethereum/eth2.0-specs/pull/732
-    # It's not 100% clear to me regarding 0.4.0; waiting until 0.5.0 to remove
-    # TODO recheck
     epoch = slot_to_epoch(slot + 1)
     current_epoch = get_current_epoch(state)
     previous_epoch = get_previous_epoch(state)
@@ -217,7 +215,7 @@ func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
      (slot_start_shard + i.uint64) mod SHARD_COUNT
     )
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_beacon_proposer_index
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_beacon_proposer_index
 func get_beacon_proposer_index*(state: BeaconState, slot: Slot): ValidatorIndex =
   ## From Casper RPJ mini-spec:
   ## When slot i begins, validator Vidx is expected
@@ -232,6 +230,15 @@ func get_beacon_proposer_index*(state: BeaconState, slot: Slot): ValidatorIndex 
   #      because presently, `state.slot += 1` happens before this function
   #      is called - see also testutil.getNextBeaconProposerIndex
   # TODO is the above still true? the shuffling has changed since it was written
+  let
+    epoch = slot_to_epoch(slot)
+    current_epoch = get_current_epoch(state)
+    previous_epoch = get_previous_epoch(state)
+    next_epoch = current_epoch + 1
+
+  doAssert previous_epoch <= epoch
+  doAssert epoch <= next_epoch
+
   let (first_committee, _) = get_crosslink_committees_at_slot(state, slot)[0]
   let idx = int(slot mod uint64(first_committee.len))
   first_committee[idx]

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -103,7 +103,7 @@ func get_shuffling*(seed: Eth2Digest,
   result = split(shuffled_seq, committees_per_epoch)
   doAssert result.len() == committees_per_epoch # what split should do..
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_previous_epoch_committee_count
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_previous_epoch_committee_count
 func get_previous_epoch_committee_count(state: BeaconState): uint64 =
   ## Return the number of committees in the previous epoch of the given
   ## ``state``.
@@ -113,7 +113,7 @@ func get_previous_epoch_committee_count(state: BeaconState): uint64 =
   )
   get_epoch_committee_count(len(previous_active_validators))
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_next_epoch_committee_count
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_next_epoch_committee_count
 func get_next_epoch_committee_count(state: BeaconState): uint64 =
   ## Return the number of committees in the next epoch of the given ``state``.
   let next_active_validators = get_active_validator_indices(

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -315,14 +315,15 @@ func hash_tree_root*[T: object|tuple](x: T): array[32, byte] =
       h.update hash_tree_root(field.toSSZType)
 
 # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/simple-serialize.md#signed-roots
-func signed_root*[T: object](x: T, field_name: string): array[32, byte] =
+func signed_root*[T: object](x: T, ignored: string = "sig"): array[32, byte] =
   # TODO write tests for this (check vs hash_tree_root)
 
   var found_field_name = false
 
+  ## TODO this isn't how 0.5 defines signed_root, but works well enough
   withHash:
     for name, field in x.fieldPairs:
-      if name == field_name:
+      if name == "signature":
         found_field_name = true
         break
       h.update hash_tree_root(field.toSSZType)

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -429,9 +429,9 @@ func processSlot(state: var BeaconState, previous_block_root: Eth2Digest) =
     cacheState(state)
 
   # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#block-roots
-  state.latest_block_roots[(state.slot - 1) mod LATEST_BLOCK_ROOTS_LENGTH] =
+  state.latest_block_roots[(state.slot - 1) mod SLOTS_PER_HISTORICAL_ROOT] =
     previous_block_root
-  if state.slot mod LATEST_BLOCK_ROOTS_LENGTH == 0:
+  if state.slot mod SLOTS_PER_HISTORICAL_ROOT == 0:
     state.batched_block_roots.add(merkle_root(state.latest_block_roots))
 
 proc processBlock(
@@ -455,7 +455,7 @@ proc processBlock(
   # blockless slot processing.
   # TODO compare with check in processBlockHeader, might be redundant
   let stateParentRoot =
-    state.latest_block_roots[(state.slot - 1) mod LATEST_BLOCK_ROOTS_LENGTH]
+    state.latest_block_roots[(state.slot - 1) mod SLOTS_PER_HISTORICAL_ROOT]
   if not (blck.previous_block_root == stateParentRoot):
     notice "Unexpected parent root",
       blockParentRoot = blck.previous_block_root,

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -31,7 +31,7 @@ proc signBlockProposal*(v: AttachedValidator, fork: Fork,
     let proposalRoot = hash_tree_root_final(proposal)
 
     result = bls_sign(v.privKey, signed_root(proposal, "signature"),
-      get_domain(fork, slot_to_epoch(proposal.slot), DOMAIN_PROPOSAL))
+      get_domain(fork, slot_to_epoch(proposal.slot), DOMAIN_BEACON_BLOCK))
   else:
     # TODO:
     # send RPC

--- a/research/fork_choice_rule/lmd_ghost.nim
+++ b/research/fork_choice_rule/lmd_ghost.nim
@@ -56,7 +56,7 @@ func hash(x: BlockHash): Hash =
   result = cast[array[num_hashes, Hash]](x)[0]
 
 func get_parent(store: Store, blck: BeaconBlock): BeaconBlock =
-  store.verified_blocks[blck.parent_root]
+  store.verified_blocks[blck.previous_block_root]
 
 func get_ancestor(store: Store, blck: BeaconBlock, slot: uint64): BeaconBlock =
   ## Find the ancestor with a specific slot number

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -57,12 +57,11 @@ suite "Beacon chain DB":
     check: x == y
 
     let
-      # TODO Not GENESIS_SLOT?
-      a0 = BeaconBlock(slot: 0.Slot)
+      a0 = BeaconBlock(slot: GENESIS_SLOT + 0)
       a0r = hash_tree_root_final(a0)
-      a1 = BeaconBlock(slot: 1.Slot, parent_root: a0r)
+      a1 = BeaconBlock(slot: GENESIS_SLOT + 1, previous_block_root: a0r)
       a1r = hash_tree_root_final(a1)
-      a2 = BeaconBlock(slot: 2.Slot, parent_root: a1r)
+      a2 = BeaconBlock(slot: GENESIS_SLOT + 2, previous_block_root: a1r)
       a2r = hash_tree_root_final(a2)
 
     doAssert toSeq(db.getAncestors(a0r)) == []


### PR DESCRIPTION
This works at least as well for me across `nimble test`, `state_sim` with `validate=true`, and `USE_MULTITAIL="yes" ./tests/simulation/start.sh` as the status quo ante.

It has a few ugly hacks pending more complete 0.5.0 integration -- e.g., `signed_root`'s default value/overloading allows it to be called by both 0.4.0 and 0.5.0 callers with correct results.

The main known issue right now is that if one puts `processBlockHeader` in the critical path where it checks new blocks, its
```
  if not (blck.previous_block_root ==
      hash_tree_root_final(state.latest_block_header)):
    notice "Block header: previous block root mismatch",
      previous_block_root = blck.previous_block_root,
      latest_block_header = state.latest_block_header,
      latest_block_header_root = hash_tree_root_final(state.latest_block_header)
    return false
```

promptly kicks in, because in `nimble test`, the block pool tests all operate on hashes of the block as a whole, while this operates on the block header -- e.g., the "parent hash"/"previous block hash" it passes to `makeBlock`, which becomes part of that comparison, is a hash of in one case a whole genesis block, not just its block header. Wrapping that in a `hash_tree_root_final(get_temporary_block_header(...))` does get it through a bit more, but at that point, it's clear things need a bit more rethinking.

Fixing that properly is worth doing separately from this already messy (mostly due to diffusely distributed renamings) PR.