### PR TITLE
implement bulk of 0.5.0 state transition function

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -46,7 +46,7 @@ type
   Epoch* = distinct uint64
 
 const
-  SPEC_VERSION* = "0.4.0" ## \
+  SPEC_VERSION* = "0.5.0" ## \
   ## Spec version we're aiming to be compatible with, right now
   ## TODO: improve this scheme once we can negotiate versions in protocol
 
@@ -179,6 +179,7 @@ const
 type
   ValidatorIndex* = range[0'u32 .. 0xFFFFFF'u32] # TODO: wrap-around
 
+  Shard* = uint64
   Gwei* = uint64
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#proposerslashing
@@ -227,7 +228,7 @@ type
     aggregate_signature*: ValidatorSig ##\
     ## BLS aggregate signature
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#attestationdata
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#attestationdata
   AttestationData* = object
     # LMD GHOST vote
     slot*: Slot
@@ -235,13 +236,8 @@ type
 
     # FFG vote
     source_epoch*: Epoch
+    source_root*: Eth2Digest
     target_root*: Eth2Digest
-
-    ## TODO epoch_boundary_root and justified_block_root are creatures of new
-    ## epoch processing and don't function quite as straightforwardly as just
-    ## renamings, so do that as part of epoch processing change.
-    epoch_boundary_root*: Eth2Digest
-    justified_block_root*: Eth2Digest
 
     # Crosslink vote
     shard*: uint64
@@ -620,14 +616,13 @@ func shortLog*(v: BeaconBlock): tuple[
 
 func shortLog*(v: AttestationData): tuple[
       slot: uint64, beacon_block_root: string, source_epoch: uint64,
-      target_root: string, epoch_boundary_root: string,
-      justified_block_root: string, shard: uint64,
+      target_root: string, source_root: string, shard: uint64,
       previous_crosslink_epoch: uint64, previous_crosslink_data_root: string,
       crosslink_data_root: string
     ] = (
       humaneSlotNum(v.slot), shortLog(v.beacon_block_root),
       humaneEpochNum(v.source_epoch), shortLog(v.target_root),
-      shortLog(v.epoch_boundary_root), shortLog(v.justified_block_root),
+      shortLog(v.source_root),
       v.shard, humaneEpochNum(v.previous_crosslink.epoch),
       shortLog(v.previous_crosslink.crosslink_data_root),
       shortLog(v.crosslink_data_root)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -122,10 +122,10 @@ func get_next_epoch_committee_count(state: BeaconState): uint64 =
   )
   get_epoch_committee_count(len(next_active_validators))
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_previous_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_previous_epoch
 func get_previous_epoch*(state: BeaconState): Epoch =
   ## Return the previous epoch of the given ``state``.
-  max(get_current_epoch(state) - 1, GENESIS_EPOCH)
+  get_current_epoch(state) - 1
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_crosslink_committees_at_slot
 func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
@@ -137,12 +137,7 @@ func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
   ## ``slot`` in the next epoch -- with and without a `registry_change`
 
   let
-    # TODO: the + 1 here works around a bug, remove when upgrading to
-    #       some more recent version:
-    # https://github.com/ethereum/eth2.0-specs/pull/732
-    # TODO remove +1 along with rest of epoch reorganization, then
-    # remove this 0.4.0 tag.
-    epoch = slot_to_epoch(slot + 1)
+    epoch = slot_to_epoch(slot)
     current_epoch = get_current_epoch(state)
     previous_epoch = get_previous_epoch(state)
     next_epoch = current_epoch + 1


### PR DESCRIPTION
`nimble test` (obviously) works.

`research/state_sim` seems to works out as far as I let it run.

`USE_MULTITAIL="yes" ./tests/simulation/start.sh` has run stably for a while for me.

This isn't, by any means, all of what's left of 0.5.0. The main slot/epoch aspect left is that https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#per-slot-processing says
> At every slot > `GENESIS_SLOT`

increment `state.slot`. Since currently, that means it never changes `state.slot` at all (I text-searched through the 0.5.0 spec for `state.slot` and didn't see at a glance where/how it'd ever get incremented from `GENESIS_SLOT`). https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#on-genesis specifically sets `slot` as `GENESIS_SLOT`, not as `GENESIS_SLOT + 1` or similar. So I don't know.

In any case, this all works at least as well for me as previous versions.