### PR TITLE
More 0.5.1 spec updates 

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -420,13 +420,8 @@ proc proposeBlock(node: BeaconNode,
 
   newBlock.state_root = node.state.root
 
-  let proposal = Proposal(
-    slot: slot.uint64,
-    block_root: Eth2Digest(data: signed_root(newBlock)),
-    signature: ValidatorSig(),
-  )
   newBlock.signature =
-    await validator.signBlockProposal(node.state.data.fork, proposal)
+    await validator.signBlockProposal(node.state.data.fork, newBlock)
 
   # TODO what are we waiting for here? broadcast should never block, and never
   #      fail...
@@ -434,7 +429,7 @@ proc proposeBlock(node: BeaconNode,
 
   info "Block proposed",
     blck = shortLog(newBlock),
-    blockRoot = shortLog(proposal.block_root),
+    blockRoot = shortLog(Eth2Digest(data: signed_root(newBlock))),
     validator = shortValidatorKey(node, validator.idx),
     idx = validator.idx
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -360,17 +360,6 @@ type
     voluntary_exits*: seq[VoluntaryExit]
     transfers*: seq[Transfer]
 
-  # https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#proposal
-  Proposal* = object
-    slot*: uint64 ##\
-    ## Slot number
-
-    block_root*: Eth2Digest ##\
-    ## Block root
-
-    signature*: ValidatorSig ##\
-    ## Signature
-
   # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconstate
   BeaconState* = object
     slot*: Slot

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -46,7 +46,7 @@ type
   Epoch* = distinct uint64
 
 const
-  SPEC_VERSION* = "0.5.0" ## \
+  SPEC_VERSION* = "0.5.1" ## \
   ## Spec version we're aiming to be compatible with, right now
   ## TODO: improve this scheme once we can negotiate versions in protocol
 
@@ -360,7 +360,7 @@ type
     voluntary_exits*: seq[VoluntaryExit]
     transfers*: seq[Transfer]
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconstate
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#beaconstate
   BeaconState* = object
     slot*: Slot
     genesis_time*: uint64
@@ -411,9 +411,6 @@ type
     latest_block_header*: BeaconBlockHeader ##\
     ## `latest_block_header.state_root == ZERO_HASH` temporarily
     historical_roots*: seq[Eth2Digest]
-
-    # TOOD remove, gone in 0.5
-    latest_attestations*: seq[PendingAttestation]
 
     # Ethereum 1.0 chain data
     latest_eth1_data*: Eth1Data

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -132,7 +132,7 @@ func get_active_validator_indices*(validators: openArray[Validator], epoch: Epoc
     if is_active_validator(val, epoch):
       result.add idx.ValidatorIndex
 
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#get_epoch_committee_count
+# https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#get_epoch_committee_count
 func get_epoch_committee_count*(active_validator_count: int): uint64 =
   clamp(
     active_validator_count div SLOTS_PER_EPOCH div TARGET_COMMITTEE_SIZE,

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -25,13 +25,11 @@ proc getValidator*(pool: ValidatorPool,
   pool.validators.getOrDefault(validatorKey)
 
 proc signBlockProposal*(v: AttachedValidator, fork: Fork,
-                        proposal: Proposal): Future[ValidatorSig] {.async.} =
+                        blck: BeaconBlock): Future[ValidatorSig] {.async.} =
   if v.kind == inProcess:
     await sleepAsync(1)
-    let proposalRoot = hash_tree_root_final(proposal)
-
-    result = bls_sign(v.privKey, signed_root(proposal),
-      get_domain(fork, slot_to_epoch(proposal.slot), DOMAIN_BEACON_BLOCK))
+    result = bls_sign(v.privKey, signed_root(blck),
+      get_domain(fork, slot_to_epoch(blck.slot), DOMAIN_BEACON_BLOCK))
   else:
     # TODO:
     # send RPC

--- a/research/serialized_sizes.nim
+++ b/research/serialized_sizes.nim
@@ -10,16 +10,20 @@ proc stateSize(deposits: int, maxContent = false) =
       deposits, {skipValidation}), 0, Eth1Data(), {skipValidation})
 
   if maxContent:
-    # TODO verify this is correct, but generally we collect up to two epochs
-    #      of attestations, and each block has a cap on the number of
-    #      attestations it may hold, so we'll just add so many of them
-    state.latest_attestations.setLen(MAX_ATTESTATIONS * SLOTS_PER_EPOCH * 2)
-    let
-      crosslink_committees = get_crosslink_committees_at_slot(state, 0.Slot)
-      validatorsPerCommittee =
-        len(crosslink_committees[0].committee) # close enough..
-    for a in state.latest_attestations.mitems():
-      a.aggregation_bitfield = BitField.init(validatorsPerCommittee)
+    # TODO: state.latest_attestations was removed
+    #       in https://github.com/status-im/nim-beacon-chain/pull/195
+    raise newException(ValueError, "Not supported at the moment")
+
+    # # TODO verify this is correct, but generally we collect up to two epochs
+    # #      of attestations, and each block has a cap on the number of
+    # #      attestations it may hold, so we'll just add so many of them
+    # state.latest_attestations.setLen(MAX_ATTESTATIONS * SLOTS_PER_EPOCH * 2)
+    # let
+    #   crosslink_committees = get_crosslink_committees_at_slot(state, 0.Slot)
+    #   validatorsPerCommittee =
+    #     len(crosslink_committees[0].committee) # close enough..
+    # for a in state.latest_attestations.mitems():
+    #   a.aggregation_bitfield = BitField.init(validatorsPerCommittee)
   echo "Validators: ", deposits, ", total: ", SSZ.encode(state).len
 
 dispatch(stateSize)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -101,7 +101,7 @@ suite "Block processing":
     discard updateState(state, previous_block_root, new_block, {})
 
     check:
-      state.latest_attestations.len == 1
+      state.current_epoch_attestations.len == 1
 
     while state.slot < 191:
       advanceState(state, previous_block_root)


### PR DESCRIPTION
I'm pretty sure that the `beacon_node` simulator is never calling
```
await validator.signBlockProposal(node.state.data.fork, newBlock)
```
as I can put `doAssert false` in it, but it's consistent with the version in `tests/testutil.nim`, so it might actually work.

This depended on https://github.com/status-im/nim-beacon-chain/pull/194

Also, `get_winning_root_and_participants` is basically pulling in all `participants` from `state_sim` (and probably regardless, but I didn't try to check the `beacon_node`), because as defined by https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#helper-functions-1 it depends on the uniqueness of roots per shard:
```
    def get_attestations_for(root) -> List[PendingAttestation]:
        return [a for a in valid_attestations if a.data.crosslink_data_root == root]
```

Where our crosslink data roots are always `ZERO_HASH`, regardless of shard, so it just pulls in validators across every shard, all the time, which throws off the crosslink 2/3 quorum/vote logic:
```
            winning_root, participants = get_winning_root_and_participants(state, shard)
            participating_balance = get_total_balance(state, participants)
            total_balance = get_total_balance(state, crosslink_committee)
            if 3 * participating_balance >= 2 * total_balance:
                state.latest_crosslinks[shard] = Crosslink(
                    epoch=slot_to_epoch(slot),
                    crosslink_data_root=winning_root
                )
```

Because `participating_balance` ends up being `MAX_VALIDATOR_BALANCE * num_validators`, and basically always reaches quorum (because it's counting across all shards, so gets all validators, vs the much smaller committee size). So it's probably setting `state.latest_crosslink[shard]` to `Crosslink(current epoch, ZERO_HASH)` every single epoch processing.

One approach would be to just set the hash to the shard number or similar, but that seems almost as hacky as the current approach, and not intrinsically more correct. Another approach is to is to use `Attestation.data.shard` and also match the `shard` parameter of the `get_winning_root_and_participants` function. Both of these have tradeoffs. The slightly more fix-root-cause one probably is not to have some `generateFakeCrosslinkDataRoot(shard: Shard): Eth2Digest` function which is more or less an identity/conversion using `int_to_bytes32`.