### PR TITLE
use signed_root as canonical block root

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -59,7 +59,7 @@ proc putState*(db: BeaconChainDB, value: BeaconState) =
   db.putState(hash_tree_root(value), value)
 
 proc putBlock*(db: BeaconChainDB, value: BeaconBlock) =
-  db.putBlock(hash_tree_root(value), value)
+  db.putBlock(signed_root(value), value)
 
 proc putHeadBlock*(db: BeaconChainDB, key: Eth2Digest) =
   db.backend.put(subkey(kHeadBlock), key.data) # TODO head block?

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -219,7 +219,7 @@ func get_temporary_block_header*(blck: BeaconBlock): BeaconBlockHeader =
   ## Return the block header corresponding to a block with ``state_root`` set
   ## to ``ZERO_HASH``.
   BeaconBlockHeader(
-    slot: blck.slot.uint64,
+    slot: blck.slot,
     previous_block_root: blck.previous_block_root,
     state_root: ZERO_HASH,
     block_body_root: hash_tree_root(blck.body),
@@ -230,7 +230,7 @@ func get_temporary_block_header*(blck: BeaconBlock): BeaconBlockHeader =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#on-genesis
 func get_empty_block*(): BeaconBlock =
   # Nim default values fill this in mostly correctly.
-  result.slot = GENESIS_SLOT
+  BeaconBlock(slot: GENESIS_SLOT)
 
 func get_genesis_beacon_state*(
     genesis_validator_deposits: openArray[Deposit],
@@ -323,7 +323,7 @@ func get_genesis_beacon_state*(
   state
 
 # TODO candidate for spec?
-# https://github.com/ethereum/eth2.0-specs/blob/0.4.0/specs/core/0_beacon-chain.md#on-genesis
+# https://github.com/ethereum/eth2.0-specs/blob/0.5.1/specs/core/0_beacon-chain.md#on-genesis
 func get_initial_beacon_block*(state: BeaconState): BeaconBlock =
   BeaconBlock(
     slot: GENESIS_SLOT,

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -328,7 +328,7 @@ type
 
   #https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#beaconblockheader
   BeaconBlockHeader* = object
-    slot*: uint64
+    slot*: Slot
     previous_block_root*: Eth2Digest
     state_root*: Eth2Digest
     block_body_root*: Eth2Digest

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -28,7 +28,7 @@ proc signBlockProposal*(v: AttachedValidator, fork: Fork,
                         blck: BeaconBlock): Future[ValidatorSig] {.async.} =
   if v.kind == inProcess:
     await sleepAsync(1)
-    result = bls_sign(v.privKey, signed_root(blck),
+    result = bls_sign(v.privKey, signed_root(blck).data,
       get_domain(fork, slot_to_epoch(blck.slot), DOMAIN_BEACON_BLOCK))
   else:
     # TODO:

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -60,7 +60,7 @@ cli do(slots = 1945,
   var
     attestations: array[MIN_ATTESTATION_INCLUSION_DELAY, seq[Attestation]]
     state = genesisState
-    latest_block_root = hash_tree_root(genesisBlock)
+    latest_block_root = signed_root(genesisBlock)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
     r: Rand
@@ -90,7 +90,7 @@ cli do(slots = 1945,
     withTimer(timers[t]):
       blck = addBlock(state, latest_block_root, body, flags)
     latest_block_root = withTimerRet(timers[tHashBlock]):
-      hash_tree_root(blck)
+      signed_root(blck)
 
     if attesterRatio > 0.0:
       # attesterRatio is the fraction of attesters that actually do their

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -28,7 +28,7 @@ suite "Attestation pool processing":
       pool = AttestationPool.init(blockPool)
       state = blockPool.loadTailState()
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    advanceState(state.data, state.blck.root)
+    advanceState(state.data)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
@@ -51,7 +51,7 @@ suite "Attestation pool processing":
       pool = AttestationPool.init(blockPool)
       state = blockPool.loadTailState()
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    advanceState(state.data, state.blck.root)
+    advanceState(state.data)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
@@ -60,7 +60,7 @@ suite "Attestation pool processing":
       attestation1 = makeAttestation(
         state.data, state.blck.root, crosslink_committees1[0].committee[0])
 
-    advanceState(state.data, state.blck.root)
+    advanceState(state.data)
 
     let
       crosslink_committees2 =

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -25,7 +25,7 @@ suite "Beacon chain DB":
 
     let
       blck = BeaconBlock()
-      root = hash_tree_root(blck)
+      root = signed_root(blck)
 
     db.putBlock(blck)
 
@@ -58,11 +58,11 @@ suite "Beacon chain DB":
 
     let
       a0 = BeaconBlock(slot: GENESIS_SLOT + 0)
-      a0r = hash_tree_root(a0)
+      a0r = signed_root(a0)
       a1 = BeaconBlock(slot: GENESIS_SLOT + 1, previous_block_root: a0r)
-      a1r = hash_tree_root(a1)
+      a1r = signed_root(a1)
       a2 = BeaconBlock(slot: GENESIS_SLOT + 2, previous_block_root: a1r)
-      a2r = hash_tree_root(a2)
+      a2r = signed_root(a2)
 
     doAssert toSeq(db.getAncestors(a0r)) == []
     doAssert toSeq(db.getAncestors(a2r)) == []

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -36,7 +36,7 @@ suite "Block pool processing":
 
     let
       b1 = makeBlock(state.data, state.blck.root, BeaconBlockBody())
-      b1Root = hash_tree_root(b1)
+      b1Root = signed_root(b1)
 
     # TODO the return value is ugly here, need to fix and test..
     discard pool.add(state, b1Root, b1)
@@ -55,9 +55,9 @@ suite "Block pool processing":
 
     let
       b1 = addBlock(state.data, state.blck.root, BeaconBlockBody(), {})
-      b1Root = hash_tree_root(b1)
+      b1Root = signed_root(b1)
       b2 = addBlock(state.data, b1Root, BeaconBlockBody(), {})
-      b2Root = hash_tree_root(b2)
+      b2Root = signed_root(b2)
 
     discard pool.add(state, b2Root, b2)
 


### PR DESCRIPTION
* no need to pass prev_block_root when updating state
* some Slot fixes
* fix `hash_tree_root` for Slot, Epoch
* detect missing hash_tree_root type support
* remove some <0.5 state checks