### PR TITLE
Use block, slot tuple to idenfiy fork

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -220,6 +220,13 @@ type
     ## The block associated with the state found in data - in particular,
     ## blck.state_root == root
 
+  BlockSlot* = object
+    ## Unique identifier for a particular fork in the block chain - normally,
+    ## there's a block for every slot, but in the case a block is not produced,
+    ## the chain progresses anyway, producing a new state for every slot.
+    blck*: BlockRef
+    slot*: Slot
+
   # #############################################
   #
   #              Validator Pool
@@ -254,4 +261,3 @@ type
 
 proc userValidatorsRange*(d: NetworkMetadata): HSlice[int, int] =
   0 .. d.lastUserValidator.int
-

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -128,8 +128,10 @@ func get_previous_epoch*(state: BeaconState): Epoch =
   # Note: This is allowed to underflow internally (this is why GENESIS_EPOCH != 0)
   #       however when interfacing with peers for example for attestations
   #       this should not underflow.
+  # TODO or not - it causes issues: https://github.com/ethereum/eth2.0-specs/issues/849
+
   let epoch = get_current_epoch(state)
-  epoch - 1
+  max(GENESIS_EPOCH, epoch - 1) # TODO max here to work around the above issue
 
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_crosslink_committees_at_slot

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -166,7 +166,7 @@ proc writeValue*(w: var SszWriter, obj: auto) =
   mixin writeValue
 
   when obj is ValidatorIndex|BasicType:
-    w.stream.append obj.toBytesSSZ
+    w.stream.append obj.toSSZType().toBytesSSZ
   elif obj is enum:
     w.stream.append uint64(obj).toBytesSSZ
   else:

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -33,6 +33,10 @@ suite "Beacon chain DB":
       db.containsBlock(root)
       db.getBlock(root).get() == blck
 
+    db.putStateRoot(root, blck.slot, root)
+    check:
+      db.getStateRoot(root, blck.slot).get() == root
+
   test "sanity check states":
     var
       db = init(BeaconChainDB, newMemoryDB())

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -8,8 +8,10 @@
 import
   options, sequtils,
   eth/trie/[db],
-  ../beacon_chain/[beacon_chain_db, extras, ssz, state_transition, validator_pool],
-  ../beacon_chain/spec/[beaconstate, bitfield, crypto, datatypes, digest, helpers, validator]
+  ../beacon_chain/[beacon_chain_db, block_pool, extras, ssz, state_transition,
+    validator_pool, beacon_node_types],
+  ../beacon_chain/spec/[beaconstate, bitfield, crypto, datatypes, digest,
+    helpers, validator]
 
 func makeFakeValidatorPrivKey*(i: int): ValidatorPrivKey =
   var i = i + 1 # 0 does not work, as private key...
@@ -194,7 +196,5 @@ proc makeTestDB*(tailState: BeaconState, tailBlock: BeaconBlock): BeaconChainDB 
     tailRoot = signed_root(tailBlock)
 
   result = init(BeaconChainDB, newMemoryDB())
-  result.putState(tailState)
-  result.putBlock(tailBlock)
-  result.putTailBlock(tailRoot)
-  result.putHeadBlock(tailRoot)
+  BlockPool.preInit(result, tailState, tailBlock)
+


### PR DESCRIPTION
this is the beginning of tracking block-slots more precisely, so we can
the justification epoch slot bug.

* avoid asyncDiscard (swallows assertions)
* fix attestation delay
* fix several state root cache bugs
* introduce workaround for genesis epoch spec issue