### PR TITLE
Some speedups

### DIFF
--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -36,7 +36,7 @@ func shortLog*(x: Eth2Digest): string =
   result = ($x)[0..7]
 
 func eth2hash*(v: openArray[byte]): Eth2Digest =
-  var ctx: Eth2Hash
+  var ctx: keccak256 # use explicit type so we can rely on init being useless
   # We can avoid this step for Keccak/SHA3 digests because `ctx` is already
   # empty, but if digest will be changed next line must be enabled.
   # ctx.init()
@@ -47,8 +47,8 @@ template withEth2Hash*(body: untyped): Eth2Digest =
   ## This little helper will init the hash function and return the sliced
   ## hash:
   ## let hashOfData = withHash: h.update(data)
-  var h  {.inject.}: Eth2Hash
-  h.init()
+  var h  {.inject.}: keccak256
+  # TODO no need, as long as using keccak256: h.init()
   body
   var res = h.finish()
   res

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -229,16 +229,17 @@ func get_crosslink_committees_at_slot*(state: BeaconState, slot: Slot|uint64,
      (slot_start_shard + i.uint64) mod SHARD_COUNT
     )
 
-func get_crosslink_committees_at_slot_cached*(
+iterator get_crosslink_committees_at_slot_cached*(
   state: BeaconState, slot: Slot|uint64,
   registry_change: bool = false, cache: var auto):
-    seq[CrosslinkCommittee] =
+    CrosslinkCommittee =
   let key = (slot.uint64, registry_change)
   if key in cache:
-    return cache[key]
+    for v in cache[key]: yield v
   #debugEcho "get_crosslink_committees_at_slot_cached: MISS"
-  result = get_crosslink_committees_at_slot(state, slot, registry_change)
+  let result = get_crosslink_committees_at_slot(state, slot, registry_change)
   cache[key] = result
+  for v in result: yield v
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_beacon_proposer_index
 func get_beacon_proposer_index*(state: BeaconState, slot: Slot): ValidatorIndex =

--- a/tests/test_ssz.nim
+++ b/tests/test_ssz.nim
@@ -79,12 +79,17 @@ suite "Simple serialization":
   SSZ.roundripTest BeaconState(slot: 42.Slot)
 
 suite "Tree hashing":
-  # TODO Nothing but smoke tests for now..
+  # TODO The test values are taken from an earlier version of SSZ and have
+  #      nothing to do with upstream - needs verification and proper test suite
 
   test "Hash BeaconBlock":
     let vr = BeaconBlock()
-    check: hash_tree_root(vr) != Eth2Digest()
+    check:
+      $hash_tree_root(vr) ==
+        "1BD5D8577A7806CC524C367808C53AE2480F35A3C4BB11A90D6E1AC304E27201"
 
   test "Hash BeaconState":
-    let vr = BeaconBlock()
-    check: hash_tree_root(vr) != Eth2Digest()
+    let vr = BeaconState()
+    check:
+      $hash_tree_root(vr) ==
+        "DC751EF09987283D52483C75690234DDD75FFDAF1A844CD56FE1173465B5597A"


### PR DESCRIPTION
ok, this is a bit funny, but..

removing all memory allocations from SSZ nets a 3-4x speedup.. in non-epoch processing. almost no difference in epoch processing.

removing a few memory allocations (by turning some functions into iterators, essentially): 4x speedup on epoch transitions, very little on non-epoch

with this branch, I'm guessing 2-3k validators on testnet1 would be viable, but I'm kind of hesitant.. the ssz changes are fine, they're pretty standard except for the array hack, while the spec changes are a bit more invasive. not sure it's worth risking the testnet launch at this point, the numbers are not _that_convincing.

starting point:
```
[arnetheduck@tempus research]$ ./state_sim --validators=2500 --slots=256
:............................................................... slot: 64 epoch: 1
:............................................................... slot: 128 epoch: 2
:............................................................... slot: 192 epoch: 3
:............................................................... slot: 256 epoch: 4
:done!
Validators: 2500, epoch length: 64
Validators per attestation (mean): 39.06250000000002
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
     310.456,        7.161,      291.775,      327.845,          252, Process non-epoch slot with block
   12381.094,     9401.685,     6912.115,    26458.883,            4, Process epoch slot with block
       0.099,        0.141,        0.028,        0.566,          256, Tree-hash block
       0.108,        0.119,        0.069,        0.593,          256, Retrieve committe once using get_crosslink_committees_at_slot
       4.799,        0.250,        4.363,        5.562,          256, Combine committee attestations
```

with ssz changes only:
```
[arnetheduck@tempus research]$ ./state_sim --validators=2500 --slots=256
:............................................................... slot: 64 epoch: 1
:............................................................... slot: 128 epoch: 2
:............................................................... slot: 192 epoch: 3
:............................................................... slot: 256 epoch: 4
:done!
Validators: 2500, epoch length: 64
Validators per attestation (mean): 39.06250000000002
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      84.390,        1.012,       78.028,       86.756,          252, Process non-epoch slot with block
   10753.046,     8191.728,     5824.076,    23007.651,            4, Process epoch slot with block
       0.024,        0.002,        0.014,        0.039,          256, Tree-hash block
       0.097,        0.106,        0.061,        0.627,          256, Retrieve committe once using get_crosslink_committees_at_slot
       3.460,        0.322,        3.009,        5.886,          256, Combine committee attestations

```

ssz + iterator
```
[arnetheduck@tempus research]$ ./state_sim --validators=2500 --slots=256
:............................................................... slot: 64 epoch: 1
:............................................................... slot: 128 epoch: 2
:............................................................... slot: 192 epoch: 3
:............................................................... slot: 256 epoch: 4
:done!
Validators: 2500, epoch length: 64
Validators per attestation (mean): 39.06250000000002
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      82.945,        1.879,       77.022,       87.901,          252, Process non-epoch slot with block
    2544.668,      975.502,     1310.901,     3697.310,            4, Process epoch slot with block
       0.024,        0.002,        0.014,        0.039,          256, Tree-hash block
       0.098,        0.103,        0.058,        0.543,          256, Retrieve committe once using get_crosslink_committees_at_slot
       3.422,        0.382,        2.909,        6.095,          256, Combine committee attestations
```