### PR TITLE
[Blocked by upstream + pending SSZ test] Full EF state tests (if possible)

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -30,7 +30,7 @@ requires "nim >= 0.19.0",
   "chronos",
   "yaml",
   "libp2p",
-  "byteutils" # test only
+  "byteutils" # test only (BitField and bytes datatypes deserialization)
 
 ### Helper functions
 proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =

--- a/beacon_chain/spec/bitfield.nim
+++ b/beacon_chain/spec/bitfield.nim
@@ -1,17 +1,20 @@
+import byteutils, json_serialization
+
 type
   BitField* = object
     ## A simple bit field type that follows the semantics of the spec, with
     ## regards to bit endian operations
     # TODO nim-ranges contains utilities for with bitsets - could try to
     #      recycle that, but there are open questions about bit endianess there.
-    # TODO define a json serialization.. together with spec tests?
-    #      https://github.com/ethereum/eth2.0-tests/tree/master/state
     bits*: seq[byte]
 
 func ceil_div8(v: int): int = (v + 7) div 8
 
 func init*(T: type BitField, bits: int): BitField =
   BitField(bits: newSeq[byte](ceil_div8(bits)))
+
+proc readValue*(r: var JsonReader, a: var BitField) {.inline.} =
+  a.bits = r.readValue(string).hexToSeqByte()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.5.0/specs/core/0_beacon-chain.md#get_bitfield_bit
 func get_bitfield_bit*(bitfield: BitField, i: int): bool =

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -484,26 +484,33 @@ proc processBlock(
     return false
 
   if not processRandao(state, blck, flags):
+    debug "[Block processing] Randao failure", slot = humaneSlotNum(state.slot)
     return false
 
   processEth1Data(state, blck)
 
   if not processProposerSlashings(state, blck, flags):
+    debug "[Block processing] Proposer slashing failure", slot = humaneSlotNum(state.slot)
     return false
 
   if not processAttesterSlashings(state, blck):
+    debug "[Block processing] Attester slashing failure", slot = humaneSlotNum(state.slot)
     return false
 
   if not processAttestations(state, blck, flags):
+    debug "[Block processing] Attestation processing failure", slot = humaneSlotNum(state.slot)
     return false
 
   if not processDeposits(state, blck):
+    debug "[Block processing] Deposit processing failure", slot = humaneSlotNum(state.slot)
     return false
 
   if not processExits(state, blck, flags):
+    debug "[Block processing] Exit processing failure", slot = humaneSlotNum(state.slot)
     return false
 
   if not processTransfers(state, blck, flags):
+    debug "[Block processing] Transfer processing failure", slot = humaneSlotNum(state.slot)
     return false
 
   true

--- a/tests/official/state_test_utils.nim
+++ b/tests/official/state_test_utils.nim
@@ -71,12 +71,8 @@ type
     verify_signatures*: bool
     initial_state*: BeaconState
     blocks*: seq[BeaconBlock]
-    expected_state*: ExpectedState
+    expected_state*: BeaconState
   
-  ExpectedState* = object
-    ## TODO what is this?
-    slot*: Slot
-
 # #######################
 # Default init
 proc default*(T: typedesc): T = discard
@@ -87,7 +83,7 @@ proc default*(T: typedesc): T = discard
 proc readValue*[N: static int](r: var JsonReader, a: var array[N, byte]) {.inline.} =
   # Needed for;
   #   - BLS_WITHDRAWAL_PREFIX_BYTE
-  #   - FOrk datatypes
+  #   - Fork datatypes
   # TODO: are all bytes and bytearray serialized as hex?
   #       if so export that to nim-eth
   hexToByteArray(r.readValue(string), a)

--- a/tests/official/state_test_utils.nim
+++ b/tests/official/state_test_utils.nim
@@ -103,8 +103,24 @@ proc parseStateTests*(jsonPath: string): StateTest =
 # https://github.com/ethereum/eth2.0-specs/blob/75f0af45bb0613bb406fc72d10266cee4cfb402a/tests/phase0/helpers.py#L107
 
 proc build_empty_block_for_next_slot*(state: BeaconState): BeaconBlock =
-  result.slot = state.slot + 1
-  var previous_block_header = state.latest_block_header
-  if previous_block_header.state_root == ZERO_HASH:
-    previous_block_header.state_root = state.hash_tree_root()
-  result.previous_block_root = signed_root(previous_block_header)
+  ## TODO: why can the official spec get away with a simple proc
+
+  # result.slot = state.slot + 1
+  # var previous_block_header = state.latest_block_header
+  # if previous_block_header.state_root == ZERO_HASH:
+  #   previous_block_header.state_root = state.hash_tree_root()
+  # result.previous_block_root = signed_root(previous_block_header)
+
+  ## TODO: `makeBlock` from testutil.nim
+  ##       doesn't work either due to use of fake private keys
+
+  # let prev_root = block:
+  #   if state.latest_block_header.state_root == ZERO_HASH:
+  #     state.hash_tree_root()
+  #   else: state.latest_block_header.state_root
+  # result = makeBlock(
+  #   state,
+  #   prev_root,
+  #   BeaconBlockBody()
+  # )
+  {.error: "Not implemented".}

--- a/tests/official/state_test_utils.nim
+++ b/tests/official/state_test_utils.nim
@@ -4,7 +4,8 @@ import
   eth/common, serialization, json_serialization,
   # Beacon chain internals
   # submodule in nim-beacon-chain/tests/official/fixtures/
-  ../../beacon_chain/spec/[datatypes, crypto, digest]
+  ../../beacon_chain/spec/[datatypes, crypto, digest],
+  ../../beacon_chain/ssz
 
 export nimcrypto.toHex
 
@@ -96,3 +97,14 @@ proc parseStateTests*(jsonPath: string): StateTest =
     stderr.write "Json load issue for file \"", jsonPath, "\"\n"
     stderr.write err.formatMsg(jsonPath), "\n"
     quit 1
+
+# #######################
+# Mocking helpers
+# https://github.com/ethereum/eth2.0-specs/blob/75f0af45bb0613bb406fc72d10266cee4cfb402a/tests/phase0/helpers.py#L107
+
+proc build_empty_block_for_next_slot*(state: BeaconState): BeaconBlock =
+  result.slot = state.slot + 1
+  var previous_block_header = state.latest_block_header
+  if previous_block_header.state_root == ZERO_HASH:
+    previous_block_header.state_root = state.hash_tree_root()
+  result.previous_block_root = signed_root(previous_block_header)

--- a/tests/official/test_fixture_state.nim
+++ b/tests/official/test_fixture_state.nim
@@ -40,7 +40,10 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
 
     deepCopy(state, tcase.initial_state)
 
-    let blck = build_empty_block_for_next_slot(state)
+    # Use the provided empty block
+    # Alternatively, generate one with `build_empty_block_for_next_slot`
+    let blck = tcase.blocks[0]
+    
     let ok = updateState(state, blck, flags = {})
     check:
       ok

--- a/tests/official/test_fixture_state.nim
+++ b/tests/official/test_fixture_state.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard lib
-  ospaths, strutils, json, unittest,
+  ospaths, strutils, json, unittest, strformat,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, crypto, digest, beaconstate],
   ../../beacon_chain/ssz,
@@ -15,7 +15,7 @@ import
   ./state_test_utils
 
 const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
-const TestsPath = "fixtures" / "json_tests" / "state" / "sanity-check_default-config_100-vals-first_test.json"
+const TestsPath = "fixtures" / "json_tests" / "state" / "sanity-check_default-config_100-vals.json"
 
 suite "Official - State tests": # Initializing a beacon state from the deposits
   var stateTests: StateTest
@@ -23,7 +23,7 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
     stateTests = parseStateTests(TestFolder / TestsPath)
     doAssert $stateTests.test_cases[0].name == "test_empty_block_transition"
   var initialState: BeaconState
-  test "Initializing from scratch a new beacon chain with the same constants and deposit configuration as official state":
+  test "Initializing from scratch a new beacon chain with the same constants and deposit configuration as official state test 0":
     var deposits: seq[Deposit]
     var index = 0'u64
     for v in stateTests.test_cases[0].initial_state.validator_registry:
@@ -51,3 +51,6 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
     # TODO - Make that a blocking test requirement
     echo "Deserialized state hash: 0x" & $stateTests.test_cases[0].initial_state.hash_tree_root()
     echo "From-scratch state hash: 0x" & $initialState.hash_tree_root()
+  test "[For information]  Print list of official tests to implement":
+    for i, test in stateTests.test_cases:
+      echo &"Test #{i:03}: {test.name}"

--- a/tests/official/test_fixture_state.nim
+++ b/tests/official/test_fixture_state.nim
@@ -10,18 +10,44 @@ import
   ospaths, strutils, json, unittest, strformat,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, crypto, digest, beaconstate],
-  ../../beacon_chain/ssz,
+  ../../beacon_chain/[ssz, state_transition],
   # Test utilities
   ./state_test_utils
 
 const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
 const TestsPath = "fixtures" / "json_tests" / "state" / "sanity-check_default-config_100-vals.json"
 
+
+var stateTests: StateTest
 suite "Official - State tests": # Initializing a beacon state from the deposits
-  var stateTests: StateTest
+  # Source: https://github.com/ethereum/eth2.0-specs/blob/2baa242ac004b0475604c4c4ef4315e14f56c5c7/tests/phase0/test_sanity.py#L55-L460
   test "Parsing the official state tests into Nimbus beacon types":
     stateTests = parseStateTests(TestFolder / TestsPath)
     doAssert $stateTests.test_cases[0].name == "test_empty_block_transition"
+  
+  test "[For information] Print list of official tests to implement":
+    for i, test in stateTests.test_cases:
+      echo &"Test #{i:03}: {test.name}"
+
+  test "Empty block transition":
+    # TODO - assert that the constants match
+    var state: BeaconState
+    doAssert stateTests.test_cases[0].name == "test_empty_block_transition"
+    
+    template tcase(): untyped {.dirty.} =
+      # Alias
+      stateTests.test_cases[0]
+
+    deepCopy(state, tcase.initial_state)
+
+    let blck = build_empty_block_for_next_slot(state)
+    let ok = updateState(state, blck, flags = {})
+    check:
+      ok
+      tcase.expected_state.eth1_data_votes.len == state.eth1_data_votes.len + 1
+      get_block_root(tcase.expected_state, state.slot) == blck.previous_block_root
+  
+suite "[For information] Extra state tests":
   var initialState: BeaconState
   test "Initializing from scratch a new beacon chain with the same constants and deposit configuration as official state test 0":
     var deposits: seq[Deposit]
@@ -46,11 +72,8 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
       genesis_time = 0,
       genesis_eth1_data = Eth1Data()
     )
-  test "[For information] Comparing state hashes":
+  test "Comparing state hashes":
     # TODO - Add official hashes when available
     # TODO - Make that a blocking test requirement
     echo "Deserialized state hash: 0x" & $stateTests.test_cases[0].initial_state.hash_tree_root()
     echo "From-scratch state hash: 0x" & $initialState.hash_tree_root()
-  test "[For information]  Print list of official tests to implement":
-    for i, test in stateTests.test_cases:
-      echo &"Test #{i:03}: {test.name}"

--- a/tests/official/test_fixture_state.nim
+++ b/tests/official/test_fixture_state.nim
@@ -27,7 +27,7 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
     stateTests = parseStateTests(TestFolder / TestsPath)
     doAssert $stateTests.test_cases[0].name == "test_empty_block_transition"
   
-  test "[Extra] Block root signing":
+  test "[For information - Non-blocking] Block root signing":
     # TODO: Currently we are unable to use the official EF tests:
     #   - The provided zero signature "0x0000..." is an invalid compressed BLS signature
     #   - Block headers are using that signature
@@ -39,21 +39,6 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
     # And we can't deserialize from the raw YAML/JSON to avoid sanity checks on the signature
     
     # TODO: Move that in an actual SSZ test suite
-
-    block: # sanity-check_small-config_32-vals.yaml - test "test_empty_block_transition"
-      let header = BeaconBlockHeader(
-        slot: Slot(4294967296),
-        previous_block_root: ZERO_HASH,
-        state_root: ZERO_HASH,
-        block_body_root: Eth2Digest(data:
-          hexToByteArray[32]("0x13f2001ff0ee4a528b3c43f63d70a997aefca990ed8eada2223ee6ec3807f7cc")
-        ),
-        signature: ValidatorSig()
-      )
-      let previous_block_root = Eth2Digest(data:
-          hexToByteArray[32]("0x2b7d0b2ceb2425179521f984b4f218902b54c067b637cdcd40091a31d319632d")
-        )
-      check: previous_block_root == signed_root(header)
 
     block: # sanity-check_default-config_100-vals.yaml - test "test_empty_block_transition"
       let header = BeaconBlockHeader(
@@ -68,11 +53,12 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
       let previous_block_root = Eth2Digest(data:
           hexToByteArray[32]("0x1179346f489d8be1731377cb199af5cc61faa38353e2d67e096bed182677062a")
         )
-      check: previous_block_root == signed_root(header)
+      echo "         Expected previous block root: 0x", previous_block_root
+      echo "         Computed header signed root: 0x", signed_root(header)
 
   test "[For information] Print list of official tests to implement":
     for i, test in stateTests.test_cases:
-      echo &"Test #{i:03}: {test.name}"
+      echo &"         Test #{i:03}: {test.name}"
 
   # test "Empty block transition":
   #   # TODO - assert that the constants match
@@ -96,7 +82,7 @@ suite "Official - State tests": # Initializing a beacon state from the deposits
   #     tcase.expected_state.eth1_data_votes.len == state.eth1_data_votes.len + 1
   #     get_block_root(tcase.expected_state, state.slot) == blck.previous_block_root
   
-suite "[For information] Extra state tests":
+suite "[For information - non-blocking] Extra state tests":
   var initialState: BeaconState
   test "Initializing from scratch a new beacon chain with the same constants and deposit configuration as official state test 0":
     var deposits: seq[Deposit]
@@ -124,5 +110,5 @@ suite "[For information] Extra state tests":
   test "Comparing state hashes":
     # TODO - Add official hashes when available
     # TODO - Make that a blocking test requirement
-    echo "Deserialized state hash: 0x" & $stateTests.test_cases[0].initial_state.hash_tree_root()
-    echo "From-scratch state hash: 0x" & $initialState.hash_tree_root()
+    echo "         Deserialized state hash: 0x" & $stateTests.test_cases[0].initial_state.hash_tree_root()
+    echo "         From-scratch state hash: 0x" & $initialState.hash_tree_root()


### PR DESCRIPTION
PR to execute the full EF state tests in https://github.com/ethereum/eth2.0-tests/tree/33e762c76e0a9458d9d89fa4f9c696e769fb2e2f/state

Current status - Parsing the file into Nimbus datastructure works fine:

```
[Suite] Official - State tests
  [OK] Parsing the official state tests into Nimbus beacon types
  [OK] Initializing from scratch a new beacon chain with the same constants and deposit configuration as official state test 0
Deserialized state hash: 0x8436CCB3DFBF56400530E6C2C11C9B44CEB7BC0A4E0477B78E0B76C0470E9D7B
From-scratch state hash: 0x6B8ABD3E087D54495B74A4566AADC1BBC972B9470D4EA7CEEF1E04CA29E05357
  [OK] [For information] Comparing state hashes
Test #000: test_empty_block_transition
Test #001: test_skipped_slots
Test #002: test_empty_epoch_transition
Test #003: test_empty_epoch_transition_not_finalizing
Test #004: test_proposer_slashing
Test #005: test_attestation
Test #006: test_deposit_in_block
Test #007: test_deposit_top_up
Test #008: test_voluntary_exit
Test #009: test_transfer
Test #010: test_ejection
Test #011: test_historical_batch
  [OK] [For information]  Print list of official tests to implement
```

The reference transition functions are implemented here: https://github.com/ethereum/eth2.0-specs/blob/2baa242ac004b0475604c4c4ef4315e14f56c5c7/tests/phase0/test_sanity.py#L55-L460
