### PR TITLE
head block selection fixes

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -171,14 +171,17 @@ type
     tail*: BlockRef ##\
     ## The earliest finalized block we know about
 
-    head*: BlockRef ##\
+    head*: Head ##\
     ## The latest block we know about, that's been chosen as a head by the fork
     ## choice rule
 
-    finalizedHead*: BlockRef ##\
+    finalizedHead*: BlockSlot ##\
     ## The latest block that was finalized according to the block in head
+    ## Ancestors of this block are guaranteed to have 1 child only.
 
     db*: BeaconChainDB
+
+    heads*: seq[Head]
 
   MissingBlock* = object
     slots*: uint64 # number of slots that are suspected missing
@@ -196,16 +199,9 @@ type
     ## Not nil, except for the tail
 
     children*: seq[BlockRef]
+    # TODO do we strictly need this?
 
     slot*: Slot # TODO could calculate this by walking to root, but..
-
-    justified*: bool ##\
-    ## True iff there exists a descendant of this block that generates a state
-    ## that points back to this block in its `justified_epoch` field.
-    finalized*: bool ##\
-    ## True iff there exists a descendant of this block that generates a state
-    ## that points back to this block in its `finalized_epoch` field.
-    ## Ancestors of this block are guaranteed to have 1 child only.
 
   BlockData* = object
     ## Body and graph in one
@@ -235,6 +231,10 @@ type
     ## the chain progresses anyway, producing a new state for every slot.
     blck*: BlockRef
     slot*: Slot
+
+  Head* = object
+    blck*: BlockRef
+    justified*: BlockSlot
 
   # #############################################
   #

--- a/beacon_chain/spec/bitfield.nim
+++ b/beacon_chain/spec/bitfield.nim
@@ -13,8 +13,9 @@ func ceil_div8(v: int): int = (v + 7) div 8
 func init*(T: type BitField, bits: int): BitField =
   BitField(bits: newSeq[byte](ceil_div8(bits)))
 
-proc readValue*(r: var JsonReader, a: var BitField) {.inline.} =
-  a.bits = r.readValue(string).hexToSeqByte()
+# TODO fix this for state tests..
+#proc readValue*(r: var JsonReader, a: var BitField) {.inline.} =
+#  a.bits = r.readValue(string).hexToSeqByte()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.6.0/specs/core/0_beacon-chain.md#get_bitfield_bit
 func get_bitfield_bit*(bitfield: BitField, i: int): bool =


### PR DESCRIPTION
* track justified and head blocks correctly in presence of blank slots
* fix new block state root
* keep list of viable heads instead of walking children
* disable json bitfield deserializer (needs a corresponding serializer)
* fix handshake best & finalized root