### PR TITLE
Bls official tests

### DIFF
--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -21,4 +21,5 @@ import # Unit test
 import # Official fixtures
   # TODO - re-enable
   #./official/test_fixture_state
-  ./official/test_fixture_shuffling
+  ./official/test_fixture_shuffling,
+  ./official/test_fixture_bls

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -110,24 +110,12 @@ proc readValue*[N: static int](r: var JsonReader, a: var array[N, byte]) {.inlin
 proc readValue*(r: var JsonReader, a: var ValidatorIndex) {.inline.} =
   a = r.readValue(uint32)
 
-# TODO: cannot pass a typedesc
-# proc parseTests*(jsonPath: string, T: typedesc[Tests]): T =
-#   # TODO: due to generic early symbol resolution
-#   #       we cannot use a generic proc
-#   #       Otherwise we get:
-#   #       "Error: undeclared identifier: 'ReaderType'"
-#   #       Templates, even untyped don't work
-#   try:
-#     result = Json.loadFile(jsonPath, T)
-#   except SerializationError as err:
-#     writeStackTrace()
-#     stderr.write "Json load issue for file \"", jsonPath, "\"\n"
-#     stderr.write err.formatMsg(jsonPath), "\n"
-#     quit 1
-
-proc parseTests*(jsonPath: string): ShufflingTests =
+export
+  # TODO: workaround https://github.com/status-im/nim-serialization/issues/4
+  json_serialization 
+proc parseTests*(jsonPath: string, T: typedesc[Tests]): T =
   try:
-    result = Json.loadFile(jsonPath, ShufflingTests)
+    result = Json.loadFile(jsonPath, T)
   except SerializationError as err:
     writeStackTrace()
     stderr.write "Json load issue for file \"", jsonPath, "\"\n"

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -16,15 +16,25 @@ import
   ./fixtures_utils
 
 const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
-const TestsPath = "fixtures" / "json_tests" / "bls" / "priv_to_pub" / "priv_to_pub.json"
-
-var blsPrivToPubTests: Tests[BLSPrivToPub]
+const TestsPath = "fixtures" / "json_tests" / "bls"
+var
+  blsPrivToPubTests: Tests[BLSPrivToPub]
+  blsSignMsgTests: Tests[BLSSignMsg]
 
 suite "Official - BLS tests":
-  test "Parsing the official BLS priv_to_pub tests":
-    blsPrivToPubTests = parseTestsBLSPrivToPub(TestFolder / TestsPath)
+  test "Parsing the official BLS tests":
+    blsPrivToPubTests = parseTestsBLSPrivToPub(TestFolder / TestsPath / "priv_to_pub" / "priv_to_pub.json")
+    blsSignMsgTests = parseTestsBLSSignMsg(TestFolder / TestsPath / "sign_msg" / "sign_msg.json")
 
   test "Private to public key conversion":
     for t in blsPrivToPubTests.test_cases:
       let implResult = t.input.pubkey()
+      check: implResult == t.output
+
+  test "Message signing":
+    for t in blsSignMsgTests.test_cases:
+      let implResult = t.input.privkey.bls_sign(
+        t.input.message,
+        uint64(t.input.domain)
+        )
       check: implResult == t.output

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -20,11 +20,15 @@ const TestsPath = "fixtures" / "json_tests" / "bls"
 var
   blsPrivToPubTests: Tests[BLSPrivToPub]
   blsSignMsgTests: Tests[BLSSignMsg]
+  blsAggSigTests: Tests[BLSAggSig]
+  blsAggPubKeyTests: Tests[BLSAggPubKey]
 
 suite "Official - BLS tests":
   test "Parsing the official BLS tests":
     blsPrivToPubTests = parseTestsBLSPrivToPub(TestFolder / TestsPath / "priv_to_pub" / "priv_to_pub.json")
     blsSignMsgTests = parseTestsBLSSignMsg(TestFolder / TestsPath / "sign_msg" / "sign_msg.json")
+    blsAggSigTests = parseTestsBLSAggSig(TestFolder / TestsPath / "aggregate_sigs" / "aggregate_sigs.json")
+    blsAggPubKeyTests = parseTestsBLSAggPubKey(TestFolder / TestsPath / "aggregate_pubkeys" / "aggregate_pubkeys.json")
 
   test "Private to public key conversion":
     for t in blsPrivToPubTests.test_cases:
@@ -37,4 +41,14 @@ suite "Official - BLS tests":
         t.input.message,
         uint64(t.input.domain)
         )
+      check: implResult == t.output
+
+  test "Aggregating signatures":
+    for t in blsAggSigTests.test_cases:
+      let implResult = t.input.combine()
+      check: implResult == t.output
+
+  test "Aggregating public keys":
+    for t in blsAggPubKeyTests.test_cases:
+      let implResult = t.input.combine()
       check: implResult == t.output

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -11,20 +11,20 @@ import
   # Third parties
 
   # Beacon chain internals
-  ../../beacon_chain/spec/validator,
+  ../../beacon_chain/spec/crypto,
   # Test utilities
   ./fixtures_utils
 
 const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
-const TestsPath = "fixtures" / "json_tests" / "shuffling" / "core" / "shuffling_full.json"
+const TestsPath = "fixtures" / "json_tests" / "bls" / "priv_to_pub" / "priv_to_pub.json"
 
-var shufflingTests: Tests[Shuffling]
+var blsPrivToPubTests: Tests[BLSPrivToPub]
 
-suite "Official - Shuffling tests":
-  test "Parsing the official shuffling tests":
-    shufflingTests = parseTestsShuffling(TestFolder / TestsPath)
+suite "Official - BLS tests":
+  test "Parsing the official BLS priv_to_pub tests":
+    blsPrivToPubTests = parseTestsBLSPrivToPub(TestFolder / TestsPath)
 
-  test "Shuffling a sequence of N validators":
-    for t in shufflingTests.test_cases:
-      let implResult = get_shuffled_seq(t.seed, t.count)
-      check: implResult == t.shuffled
+  test "Private to public key conversion":
+    for t in blsPrivToPubTests.test_cases:
+      let implResult = t.input.pubkey()
+      check: implResult == t.output

--- a/tests/official/test_fixture_shuffling.nim
+++ b/tests/official/test_fixture_shuffling.nim
@@ -22,7 +22,7 @@ var shufflingTests: ShufflingTests
 
 suite "Official - Shuffling tests":
   test "Parsing the official shuffling tests":
-    shufflingTests = parseTests(TestFolder / TestsPath)
+    shufflingTests = parseTests(TestFolder / TestsPath, ShufflingTests)
 
   test "Shuffling a sequence of N validators":
     for t in shufflingTests.test_cases:

--- a/tests/official/test_fixture_state.nim
+++ b/tests/official/test_fixture_state.nim
@@ -24,7 +24,7 @@ var stateTests: StateTests
 suite "Official - State tests": # Initializing a beacon state from the deposits
   # Source: https://github.com/ethereum/eth2.0-specs/blob/2baa242ac004b0475604c4c4ef4315e14f56c5c7/tests/phase0/test_sanity.py#L55-L460
   test "Parsing the official state tests into Nimbus beacon types":
-    stateTests = parseTests(TestFolder / TestsPath, StateTests) # TODO pending typedesc fix in fixture_utils.nim
+    stateTests = parseTests(TestFolder / TestsPath, StateTests)
     doAssert $stateTests.test_cases[0].name == "test_empty_block_transition"
   
   test "[For information - Non-blocking] Block root signing":


### PR DESCRIPTION
This adds the official BLS tests at the beacon chain level.

This was already tested in [nim-blscurve](https://github.com/status-im/nim-blscurve)
but it requires writing a [custom converter](https://github.com/status-im/nim-blscurve/blob/master/tests/test_convert.nim) which is now outdated due to test format change.

Now we can follow upstream test changes more flexibly.