### PR TITLE
Proto changes to facilitate backward sync

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -292,6 +292,10 @@ proc add*(
           (parentSlot.uint64 mod SLOTS_PER_EPOCH.uint64))
   )
 
+proc getRef*(pool: BlockPool, root: Eth2Digest): BlockRef =
+  ## Retrieve a resolved block reference, if available
+  result = pool.blocks.getOrDefault(root)
+
 proc get*(pool: BlockPool, blck: BlockRef): BlockData =
   ## Retrieve the associated block body of a block reference
   doAssert (not blck.isNil), "Trying to get nil BlockRef"
@@ -303,7 +307,7 @@ proc get*(pool: BlockPool, blck: BlockRef): BlockData =
 
 proc get*(pool: BlockPool, root: Eth2Digest): Option[BlockData] =
   ## Retrieve a resolved block reference and its associated body, if available
-  let refs = pool.blocks.getOrDefault(root)
+  let refs = pool.getRef(root)
 
   if not refs.isNil:
     some(pool.get(refs))
@@ -313,7 +317,7 @@ proc get*(pool: BlockPool, root: Eth2Digest): Option[BlockData] =
 proc getOrResolve*(pool: var BlockPool, root: Eth2Digest): BlockRef =
   ## Fetch a block ref, or nil if not found (will be added to list of
   ## blocks-to-resolve)
-  result = pool.blocks.getOrDefault(root)
+  result = pool.getRef(root)
 
   if result.isNil:
     pool.missing[root] = MissingBlock(slots: 1)

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -235,22 +235,7 @@ type
     block_body_root*: Eth2Digest
     signature*: ValidatorSig
 
-  BeaconBlockHeaderRLP* = object
-    ## Same as BeaconBlock, except `body` is the `hash_tree_root` of the
-    ## associated BeaconBlockBody.
-    # TODO: Dry it up with BeaconBlock
-    # TODO: As a first step, don't change RLP output; only previous user,
-    # but as with others, randao_reveal and eth1_data move to body.
-    # This is from before spec had a version.
-    slot*: uint64
-    parent_root*: Eth2Digest
-    state_root*: Eth2Digest
-    randao_reveal*: ValidatorSig
-    eth1_data*: Eth1Data
-    signature*: ValidatorSig
-    body*: Eth2Digest
-
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.6.2/specs/core/0_beacon-chain.md#beaconblockbody
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.6.1/specs/core/0_beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
     randao_reveal*: ValidatorSig
     eth1_data*: Eth1Data

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -187,7 +187,7 @@ p2pProtocol BeaconSync(version = 1,
 
         headers = newSeqOfCap[BeaconBlockHeader](blockRefs.len)
         for i in blockRefs.high .. 0:
-          headers.add(db.getBlock(blockRefs[i].root).get.toHeader)
+          headers.add(blockPool.get(blockRefs[i]).data.toHeader)
       else:
         # TODO: This branch has to be revisited and possibly somehow merged with the
         # branch above once we can traverse the best chain forward

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -176,7 +176,7 @@ p2pProtocol BeaconSync(version = 1,
           discard
 
         let blockPool = peer.networkState.node.blockPool
-        var br = blockPool.blocks.getOrDefault(blockRoot)
+        var br = blockPool.getRef(blockRoot)
         var blockRefs = newSeqOfCap[BlockRef](maxHeaders)
 
         while not br.isNil:


### PR DESCRIPTION
- Added `backward` flag to `getBeaconBlockHeaders` message
- Use `getBeaconBlockHeaders` for backward sync
- Simplified forward sync (don't request roots)