### PR TITLE
More safe 0.7.0 updates

### DIFF
--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -95,7 +95,7 @@ func get_current_epoch*(state: BeaconState): Epoch =
   doAssert state.slot >= GENESIS_SLOT, $state.slot
   slot_to_epoch(state.slot)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#get_randao_mix
+# https://github.com/ethereum/eth2.0-specs/blob/v0.7.0/specs/core/0_beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: BeaconState,
                      epoch: Epoch): Eth2Digest =
     ## Returns the randao mix at a recent ``epoch``.
@@ -112,7 +112,7 @@ func get_active_index_root(state: BeaconState, epoch: Epoch): Eth2Digest =
   ## intentional
   state.latest_active_index_roots[epoch mod LATEST_ACTIVE_INDEX_ROOTS_LENGTH]
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#bytes_to_int
+# https://github.com/ethereum/eth2.0-specs/blob/v0.7.0/specs/core/0_beacon-chain.md#bytes_to_int
 func bytes_to_int*(data: openarray[byte]): uint64 =
   doAssert data.len == 8
 

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -201,11 +201,11 @@ proc processAttesterSlashings(state: var BeaconState, blck: BeaconBlock): bool =
       notice "CaspSlash: surround or double vote check failed"
       return false
 
-    if not verify_indexed_attestation(state, attestation_1):
+    if not validate_indexed_attestation(state, attestation_1):
       notice "CaspSlash: invalid votes 1"
       return false
 
-    if not verify_indexed_attestation(state, attestation_2):
+    if not validate_indexed_attestation(state, attestation_2):
       notice "CaspSlash: invalid votes 2"
       return false
 

--- a/beacon_chain/time.nim
+++ b/beacon_chain/time.nim
@@ -14,7 +14,7 @@ type
     ## which blocks are valid - in particular, blocks are not valid if they
     ## come from the future as seen from the local clock.
     ##
-    ## https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_fork-choice.md#beacon-chain-processing
+    ## https://github.com/ethereum/eth2.0-specs/blob/v0.7.0/specs/core/0_fork-choice.md#beacon-chain-processing
     ##
     # TODO replace time in chronos with a proper unit type, then this code can
     #      follow:


### PR DESCRIPTION
This should complete (unless I find others, but I was systematic about this) the trivial mark-to-current-spec-without-behavior-change updates, for some reasonable value of trivial.

I don't address any SSZ aspects -- @zah has said he's addressing that aspect.

`validate_indexed_attestation` isn't totally obvious at a glance, but it's a combination of:
- renaming from `verify_indexed_attestation(...)` to `validate_indexed_attestation(...)`
- renaming local variables `custody_bit_[01]_indices ` to `bit_[01]_indices `
- changing the comments (so each section has its own)
- and re-ordering the sequence in which the various (identical) checks are performed

`processRandao` and `processEth1Data` switch from using `BeaconBlock`s to `BeaconBlockBody`s, which trivially but noisily changes each `blck.body.foo` to `body.foo` in each function, and `bar(blck)` to `bar(blck.body)` at callsites.

I've aligned `process_slot` with its spec name; it had been called `cacheState` (of which there are two copies, one of which operates on a `HashedBeaconState` but which work basically similarly, and which both just see comment/function name updates).