### PR TITLE
More 0.7.1 updates

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -38,7 +38,7 @@ proc validate(
 
   # TODO half of this stuff is from beaconstate.validateAttestation - merge?
 
-  let attestationSlot = get_attestation_slot(state, attestation)
+  let attestationSlot = get_attestation_data_slot(state, attestation.data)
 
   if attestationSlot < state.finalized_epoch.get_epoch_start_slot():
     debug "Old attestation",
@@ -99,7 +99,7 @@ proc validate(
         ],
         attestation.signature,
         get_domain(state, DOMAIN_ATTESTATION,
-                   slot_to_epoch(get_attestation_slot(state, attestation))),
+          slot_to_epoch(get_attestation_data_slot(state, attestation.data))),
       ):
       notice "Invalid signature", participants
       return false
@@ -174,7 +174,7 @@ proc add*(pool: var AttestationPool,
   # TODO inefficient data structures..
 
   let
-    attestationSlot = get_attestation_slot(state, attestation)
+    attestationSlot = get_attestation_data_slot(state, attestation.data)
     idx = pool.slotIndex(state, attestationSlot)
     slotData = addr pool.slots[idx]
     validation = Validation(
@@ -326,7 +326,7 @@ proc resolve*(pool: var AttestationPool, state: BeaconState) =
   var resolved: seq[Attestation]
 
   for k, v in pool.unresolved.mpairs():
-    let attestation_slot = get_attestation_slot(state, v.attestation)
+    let attestation_slot = get_attestation_data_slot(state, v.attestation.data)
     if v.tries > 8 or attestation_slot < pool.startingSlot:
       done.add(k)
     else:

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -130,9 +130,7 @@ type
     target_root*: Eth2Digest
 
     # Crosslink vote
-    shard*: uint64
-    previous_crosslink_root*: Eth2Digest
-    crosslink_data_root*: Eth2Digest
+    crosslink*: Crosslink
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attestationdataandcustodybit
   AttestationDataAndCustodyBit* = object
@@ -309,16 +307,20 @@ type
     effective_balance*: uint64 ##\
     ## Effective balance
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#crosslink
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#crosslink
   Crosslink* = object
-    epoch*: Epoch ##\
-    ## Epoch number
+    shard*: Shard ##\
+    ## Shard number
 
-    previous_crosslink_root*: Eth2Digest ##\
+    start_epoch*: Epoch
+    end_epoch*: Epoch ##\
+    ## Crosslinking data from epochs [start....end-1]
+
+    parent_root*: Eth2Digest ##\
     ## Root of the previous crosslink
 
-    crosslink_data_root*: Eth2Digest ##\
-    ## Shard data since the previous crosslink
+    data_root*: Eth2Digest ##\
+    ## Root of the crosslinked shard data since the previous crosslink
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#pendingattestation
   PendingAttestation* = object
@@ -451,8 +453,7 @@ func shortLog*(v: AttestationData): auto =
       shortLog(v.beacon_block_root),
       humaneEpochNum(v.source_epoch), shortLog(v.target_root),
       shortLog(v.source_root),
-      v.shard, v.previous_crosslink_root,
-      shortLog(v.crosslink_data_root)
+      v.crosslink
     )
 
 chronicles.formatIt Slot: it.humaneSlotNum


### PR DESCRIPTION
- replace get_attestation_slot(...) with 0.7.1 get_attestation_data_slot(...) and update all callers
- update AttestationData to be almost 0.7.1, except nonextistent slot field
- update Crosslink and get_winning_crosslink_and_attesting_indices(...) to 0.7.1