### PR TITLE
get get_epoch_start_slot(...)/AttestationData up to 0.7.1

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -117,9 +117,8 @@ type
     signature*: ValidatorSig ##\
     ## BLS aggregate signature
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.6.2/specs/core/0_beacon-chain.md#attestationdata
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attestationdata
   AttestationData* = object
-    slot*: Slot # TODO remove this, once figure out attestation pool issues
     # LMD GHOST vote
     beacon_block_root*: Eth2Digest
 

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -118,7 +118,6 @@ func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
     start = (len(indices).uint64 * index) div count
     endIdx = (len(indices).uint64 * (index + 1)) div count
     key = (indices.len, seed)
-  doAssert endIdx.int - start.int > 0
 
   if key notin stateCache.crosslink_committee_cache:
     stateCache.crosslink_committee_cache[key] =

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -40,7 +40,7 @@ suite "Attestation pool processing" & preset():
       let
         # Create an attestation for slot 1!
         crosslink_committee = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 1, cache)
         attestation = makeAttestation(
           state.data.data, state.blck.root, crosslink_committee[0])
 
@@ -61,7 +61,7 @@ suite "Attestation pool processing" & preset():
       let
         # Create an attestation for slot 1!
         cc0 = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 1, cache)
         attestation0 = makeAttestation(
           state.data.data, state.blck.root, cc0[0])
 
@@ -69,7 +69,7 @@ suite "Attestation pool processing" & preset():
 
       let
         cc1 = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 2, cache)
         attestation1 = makeAttestation(
           state.data.data, state.blck.root, cc1[0])
 
@@ -77,7 +77,8 @@ suite "Attestation pool processing" & preset():
       pool.add(state.data.data, attestation1)
       pool.add(state.data.data, attestation0)
 
-      for i in 0..<MIN_ATTESTATION_INCLUSION_DELAY.int - 1: advanceState(state.data)
+      for i in 0..<MIN_ATTESTATION_INCLUSION_DELAY.int - 1:
+        advanceState(state.data)
 
       let attestations = pool.getAttestationsForBlock(
         state.data.data, state.data.data.slot + 1)
@@ -91,7 +92,7 @@ suite "Attestation pool processing" & preset():
       let
         # Create an attestation for slot 1!
         cc0 = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 1, cache)
         attestation0 = makeAttestation(
           state.data.data, state.blck.root, cc0[0])
         attestation1 = makeAttestation(
@@ -115,7 +116,7 @@ suite "Attestation pool processing" & preset():
       var
         # Create an attestation for slot 1!
         cc0 = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 1, cache)
         attestation0 = makeAttestation(
           state.data.data, state.blck.root, cc0[0])
         attestation1 = makeAttestation(
@@ -140,7 +141,7 @@ suite "Attestation pool processing" & preset():
       var
         # Create an attestation for slot 1!
         cc0 = get_crosslink_committee(state.data.data,
-          slot_to_epoch(state.data.data.slot), 0, cache)
+          slot_to_epoch(state.data.data.slot), 1, cache)
         attestation0 = makeAttestation(
           state.data.data, state.blck.root, cc0[0])
         attestation1 = makeAttestation(


### PR DESCRIPTION
Which requires:
- remove `get_epoch_start_slot(...)` kludge and update to work as 0.7.1 specifies
- update `AttestationData` to 0.7.1 (being the last data structure, I believe, remaining for such)
- fix `state_sim` to work with new get_epoch_start_slot/AttestationData/etc setup where it can't stuff all shards' attestations from same slot in the same `MIN_ATTESTATION_INCLUSION_DELAY`-sized rotating/circular buffer of `seq[Attestation]`s without more involved shuffling of shard/slot calculation order
- fix attestation pool testing to be consistent with `get_epoch_start_slot(...)`

For `state_sim`, this replaces the circular buffer with a bounded-size hash table. It's less elegant, but IMO for a test harness, clarity's worthwhile. I spent a little too much time debugging where/how `get_epoch_start_slot(...)` assumptions collided with the circular buffer assumptions to want to keep it. I'm open to re-instating it as things freeze if it becomes a performance issue.

Being that this removes the old `slot` field from `AttestationData` to render it consistent with 0.7.1, this might require another testnet restart, along the lines `Crosslink` losing `epoch`.

Incidentally:
- remove unused `get_attestation_participants_cached(...)` from pre-0.7, probably 0.5 even.
- remove potentially spurious/certainly not-in-spec assertion from `compute_committee(...)` which @zah reported hitting. If the issue's real, hopefully it turns up elsewhere, and if it's real but no other assertion/etc is catching it, it can be reinserted, but this is a start. If/when this PR is merged, https://github.com/status-im/nim-beacon-chain/pull/300 can/should be closed, as it's a strict subset of this PR.