### PR TITLE
More 0.8.0 updates

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -81,15 +81,15 @@ proc validate(
       custody_bit_0_participants = participants
 
       group_public_key = bls_aggregate_pubkeys(
-        participants.mapIt(state.validator_registry[it].pubkey))
+        participants.mapIt(state.validators[it].pubkey))
 
     # Verify that aggregate_signature verifies using the group pubkey.
     if not bls_verify_multiple(
         @[
           bls_aggregate_pubkeys(mapIt(custody_bit_0_participants,
-                                      state.validator_registry[it].pubkey)),
+                                      state.validators[it].pubkey)),
           bls_aggregate_pubkeys(mapIt(custody_bit_1_participants,
-                                      state.validator_registry[it].pubkey)),
+                                      state.validators[it].pubkey)),
         ],
         @[
           hash_tree_root(AttestationDataAndCustodyBit(
@@ -159,7 +159,7 @@ proc updateLatestVotes(
     participants: seq[ValidatorIndex], blck: BlockRef) =
   for validator in participants:
     let
-      pubKey = state.validator_registry[validator].pubkey
+      pubKey = state.validators[validator].pubkey
       current = pool.latestAttestations.getOrDefault(pubKey)
     if current.isNil or current.slot < attestationSlot:
       pool.latestAttestations[pubKey] = blck

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -238,7 +238,7 @@ proc addLocalValidator(
     node: BeaconNode, state: BeaconState, privKey: ValidatorPrivKey) =
   let pubKey = privKey.pubKey()
 
-  let idx = state.validator_registry.findIt(it.pubKey == pubKey)
+  let idx = state.validators.findIt(it.pubKey == pubKey)
   if idx == -1:
     warn "Validator not in registry", pubKey
   else:
@@ -256,7 +256,7 @@ proc addLocalValidators(node: BeaconNode, state: BeaconState) =
 
 proc getAttachedValidator(
     node: BeaconNode, state: BeaconState, idx: int): AttachedValidator =
-  let validatorKey = state.validator_registry[idx].pubkey
+  let validatorKey = state.validators[idx].pubkey
   node.attachedValidators.getValidator(validatorKey)
 
 proc updateHead(node: BeaconNode, slot: Slot): BlockRef =
@@ -507,7 +507,7 @@ proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
     debug "Expecting proposal",
       headRoot = shortLog(head.root),
       slot = humaneSlotNum(slot),
-      proposer = shortLog(state.validator_registry[proposerIdx].pubKey)
+      proposer = shortLog(state.validators[proposerIdx].pubKey)
 
   return head
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -607,7 +607,7 @@ proc preInit*(
     blockRoot = shortLog(blockRoot),
     stateRoot = shortLog(blck.state_root),
     fork = state.fork,
-    validators = state.validator_registry.len()
+    validators = state.validators.len()
 
   db.putState(state)
   db.putBlock(blck)

--- a/beacon_chain/fork_choice.nim
+++ b/beacon_chain/fork_choice.nim
@@ -29,7 +29,7 @@ proc lmdGhost*(
 
   var attestation_targets: seq[tuple[validator: ValidatorIndex, blck: BlockRef]]
   for i in active_validator_indices:
-    let pubKey = start_state.validator_registry[i].pubkey
+    let pubKey = start_state.validators[i].pubkey
     if (let vote = pool.latestAttestation(pubKey); not vote.isNil):
       attestation_targets.add((i, vote))
 
@@ -40,7 +40,7 @@ proc lmdGhost*(
         # The div on the balance is to chop off the insignification bits that
         # fluctuate a lot epoch to epoch to have a more stable fork choice
         res +=
-          start_state.validator_registry[validator_index].effective_balance div
+          start_state.validators[validator_index].effective_balance div
             FORK_CHOICE_BALANCE_INCREMENT
     res
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -253,15 +253,16 @@ func get_initial_beacon_block*(state: BeaconState): BeaconBlock =
     # initialized to default values.
   )
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_attestation_data_slot
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_attestation_data_slot
 func get_attestation_data_slot*(state: BeaconState,
     data: AttestationData, committee_count: uint64): Slot =
+  # Return the slot corresponding to the attestation ``data``.
   let
     offset = (data.crosslink.shard + SHARD_COUNT -
       get_start_shard(state, data.target_epoch)) mod SHARD_COUNT
 
-  compute_start_slot_of_epoch(data.target_epoch) + offset div
-    (committee_count div SLOTS_PER_EPOCH)
+  (compute_start_slot_of_epoch(data.target_epoch) + offset div
+    (committee_count div SLOTS_PER_EPOCH)).Slot
 
 # This is the slower (O(n)), spec-compatible signature.
 func get_attestation_data_slot*(state: BeaconState,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -277,7 +277,7 @@ func get_attestation_data_slot*(state: BeaconState,
     data: AttestationData, committee_count: uint64): Slot =
   let
     offset = (data.crosslink.shard + SHARD_COUNT -
-      get_epoch_start_shard(state, data.target_epoch)) mod SHARD_COUNT
+      get_start_shard(state, data.target_epoch)) mod SHARD_COUNT
 
   compute_start_slot_of_epoch(data.target_epoch) + offset div
     (committee_count div SLOTS_PER_EPOCH)
@@ -595,7 +595,7 @@ proc makeAttestationData*(
     target_epoch: compute_epoch_of_slot(state.slot),
     crosslink: Crosslink(
       # Alternative is to put this offset into all callers
-      shard: shard + get_epoch_start_shard(state, compute_epoch_of_slot(state.slot)),
+      shard: shard + get_start_shard(state, compute_epoch_of_slot(state.slot)),
       parent_root: hash_tree_root(state.current_crosslinks[shard]),
       data_root: Eth2Digest(), # Stub in phase0
     )

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -35,10 +35,11 @@ func increase_balance*(
   # Increase the validator balance at index ``index`` by ``delta``.
   state.balances[index] += delta
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#decrease_balance
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#decrease_balance
 func decrease_balance*(
     state: var BeaconState, index: ValidatorIndex, delta: Gwei) =
-  # Decrease validator balance by ``delta`` with underflow protection.
+  ## Decrease the validator balance at index ``index`` by ``delta``, with
+  ## underflow protection.
   state.balances[index] =
     if delta > state.balances[index]:
       0'u64

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -378,7 +378,9 @@ template ethTimeUnit(typ: type) {.dirty.} =
 
   proc `*`*(x: typ, y: uint64): uint64 {.borrow.}
 
+  proc `+=`*(x: var typ, y: typ) {.borrow.}
   proc `+=`*(x: var typ, y: uint64) {.borrow.}
+  proc `-=`*(x: var typ, y: typ) {.borrow.}
   proc `-=`*(x: var typ, y: uint64) {.borrow.}
 
   # Comparison operators

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -235,50 +235,56 @@ type
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#beaconstate
   BeaconState* = object
-    slot*: Slot
+    # Versioning
     genesis_time*: uint64
-    fork*: Fork ##\
-    ## For versioning hard forks
+    slot*: Slot
+    fork*: Fork
 
-    # Validator registry
+    # History
+    latest_block_header*: BeaconBlockHeader ##\
+    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
+    ## Needed to process attestations, older to newer
+
+    state_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: seq[Eth2Digest]
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*: seq[Eth1Data]
+    eth1_deposit_index*: uint64
+
+    # Registry
     validators*: seq[Validator]
     balances*: seq[uint64] ##\
     ## Validator balances in Gwei!
 
-    # Randomness and committees
-    latest_randao_mixes*: array[LATEST_RANDAO_MIXES_LENGTH, Eth2Digest]
-    latest_start_shard*: Shard
+    # Shuffling
+    start_shard*: Shard
+    randao_mixes*: array[LATEST_RANDAO_MIXES_LENGTH, Eth2Digest]
+    active_index_roots*: array[LATEST_ACTIVE_INDEX_ROOTS_LENGTH, Eth2Digest]
 
-    # Finality
+    # Slashings
+    slashings*: array[LATEST_SLASHED_EXIT_LENGTH, uint64] ##\
+    ## Per-epoch sums of slashed effective balances
+
+    # Attestations
     previous_epoch_attestations*: seq[PendingAttestation]
     current_epoch_attestations*: seq[PendingAttestation]
+
+    # Crosslinks
+    previous_crosslinks*: array[SHARD_COUNT, Crosslink]
+    current_crosslinks*: array[SHARD_COUNT, Crosslink]
+
+    # Finality
+    justification_bits*: uint64
     previous_justified_epoch*: Epoch
     current_justified_epoch*: Epoch
     previous_justified_root*: Eth2Digest
     current_justified_root*: Eth2Digest
-    justification_bitfield*: uint64
     finalized_epoch*: Epoch
     finalized_root*: Eth2Digest
-
-    # Recent state
-    current_crosslinks*: array[SHARD_COUNT, Crosslink]
-    previous_crosslinks*: array[SHARD_COUNT, Crosslink]
-    block_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
-    latest_state_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
-    latest_active_index_roots*: array[LATEST_ACTIVE_INDEX_ROOTS_LENGTH, Eth2Digest]
-
-    latest_slashed_balances*: array[LATEST_SLASHED_EXIT_LENGTH, uint64] ##\
-    ## Balances penalized in the current withdrawal period
-
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
-    historical_roots*: seq[Eth2Digest]
-
-    # Ethereum 1.0 chain data
-    latest_eth1_data*: Eth1Data
-    eth1_data_votes*: seq[Eth1Data]
-    deposit_index*: uint64
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#validator
   Validator* = object

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -241,7 +241,7 @@ type
     ## For versioning hard forks
 
     # Validator registry
-    validator_registry*: seq[Validator]
+    validators*: seq[Validator]
     balances*: seq[uint64] ##\
     ## Validator balances in Gwei!
 
@@ -360,7 +360,7 @@ type
     root*: Eth2Digest # hash_tree_root (not signing_root!)
 
 func shortValidatorKey*(state: BeaconState, validatorIdx: int): string =
-    ($state.validator_registry[validatorIdx].pubkey)[0..7]
+    ($state.validators[validatorIdx].pubkey)[0..7]
 
 template ethTimeUnit(typ: type) {.dirty.} =
   proc `+`*(x: typ, y: uint64): typ {.borrow.}

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -280,31 +280,28 @@ type
     eth1_data_votes*: seq[Eth1Data]
     deposit_index*: uint64
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#validator
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#validator
   Validator* = object
-    pubkey*: ValidatorPubKey ##\
-    ## BLS public key
+    pubkey*: ValidatorPubKey
 
     withdrawal_credentials*: Eth2Digest ##\
-    ## Withdrawal credentials
+    ## Commitment to pubkey for withdrawals and transfers
 
-    activation_eligibility_epoch*: Epoch ##\
-    ## Epoch when validator activated
-
-    activation_epoch*: Epoch ##\
-    ## Epoch when validator activated
-
-    exit_epoch*: Epoch ##\
-    ## Epoch when validator exited
-
-    withdrawable_epoch*: Epoch ##\
-    ## Epoch when validator is eligible to withdraw
+    effective_balance*: uint64 ##\
+    ## Balance at stake
 
     slashed*: bool ##\
     ## Was the validator slashed
 
-    effective_balance*: uint64 ##\
-    ## Effective balance
+    # Status epochs
+    activation_eligibility_epoch*: Epoch ##\
+    ## When criteria for activation were met
+
+    activation_epoch*: Epoch
+    exit_epoch*: Epoch
+
+    withdrawable_epoch*: Epoch ##\
+    ## When validator can withdraw or transfer funds
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#crosslink
   Crosslink* = object

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -74,7 +74,7 @@ type
   Gwei* = uint64
   Domain* = uint64
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#proposerslashing
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#proposerslashing
   ProposerSlashing* = object
     proposer_index*: uint64 ##\
     ## Proposer index
@@ -85,7 +85,7 @@ type
     header_2*: BeaconBlockHeader ##\
     # Second block header
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attesterslashing
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#attesterslashing
   AttesterSlashing* = object
     attestation_1*: IndexedAttestation ## \
     ## First attestation
@@ -118,6 +118,11 @@ type
     signature*: ValidatorSig ##\
     ## BLS aggregate signature
 
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#checkpoint
+  Checkpoint* = object
+    epoch*: Epoch
+    root*: Eth2Digest
+
   # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attestationdata
   AttestationData* = object
     # LMD GHOST vote
@@ -132,10 +137,12 @@ type
     # Crosslink vote
     crosslink*: Crosslink
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attestationdataandcustodybit
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#attestationdataandcustodybit
   AttestationDataAndCustodyBit* = object
     data*: AttestationData
-    custody_bit*: bool
+
+    custody_bit*: bool ##\
+    ## Challengeable bit (SSZ-bool, 1 byte) for the custody of crosslink data
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#deposit
   Deposit* = object
@@ -144,7 +151,7 @@ type
 
     data*: DepositData
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#depositdata
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#depositdata
   DepositData* = object
     pubkey*: ValidatorPubKey ##\
     ## BLS pubkey
@@ -155,6 +162,7 @@ type
     amount*: uint64 ##\
     ## Amount in Gwei
 
+    # TODO remove, not in spec
     dummy*: uint64
 
     signature*: ValidatorSig ##\
@@ -192,7 +200,7 @@ type
     signature*: ValidatorSig ##\
     ## Signature checked against withdrawal pubkey
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#beaconblock
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#beaconblock
   BeaconBlock* = object
     ## For each slot, a proposer is chosen from the validator pool to propose
     ## a new block. Once the block as been proposed, it is transmitted to
@@ -343,7 +351,7 @@ type
     epoch*: Epoch ##\
     ## Fork epoch number
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#eth1data
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#eth1data
   Eth1Data* = object
     deposit_root*: Eth2Digest ##\
     ## Root of the deposit tree

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -67,7 +67,7 @@ func compute_start_slot_of_epoch*(epoch: Epoch): Slot =
   # Return the starting slot of the given ``epoch``.
   (epoch * SLOTS_PER_EPOCH).Slot
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#is_active_validator
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_active_validator
 func is_active_validator*(validator: Validator, epoch: Epoch): bool =
   ### Check if ``validator`` is active
   validator.activation_epoch <= epoch and epoch < validator.exit_epoch

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -100,7 +100,7 @@ func get_randao_mix*(state: BeaconState,
     ## Returns the randao mix at a recent ``epoch``.
     ## ``epoch`` expected to be between (current_epoch -
     ## LATEST_RANDAO_MIXES_LENGTH, current_epoch].
-    state.latest_randao_mixes[epoch mod LATEST_RANDAO_MIXES_LENGTH]
+    state.randao_mixes[epoch mod LATEST_RANDAO_MIXES_LENGTH]
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_active_index_root
 func get_active_index_root(state: BeaconState, epoch: Epoch): Eth2Digest =
@@ -109,7 +109,7 @@ func get_active_index_root(state: BeaconState, epoch: Epoch): Eth2Digest =
   ##  (current_epoch - LATEST_ACTIVE_INDEX_ROOTS_LENGTH + ACTIVATION_EXIT_DELAY, current_epoch + ACTIVATION_EXIT_DELAY].
   ## TODO maybe assert this, but omission of such seems conspicuously
   ## intentional
-  state.latest_active_index_roots[epoch mod LATEST_ACTIVE_INDEX_ROOTS_LENGTH]
+  state.active_index_roots[epoch mod LATEST_ACTIVE_INDEX_ROOTS_LENGTH]
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#bytes_to_int
 func bytes_to_int*(data: openarray[byte]): uint64 =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -76,7 +76,7 @@ func is_active_validator*(validator: Validator, epoch: Epoch): bool =
 func get_active_validator_indices*(state: BeaconState, epoch: Epoch):
     seq[ValidatorIndex] =
   # Get active validator indices at ``epoch``.
-  for idx, val in state.validator_registry:
+  for idx, val in state.validators:
     if is_active_validator(val, epoch):
       result.add idx.ValidatorIndex
 

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -26,7 +26,7 @@ type
 const
   # Misc
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#misc
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#misc
 
   SHARD_COUNT* {.intdefine.} = 1024 ##\
   ## Number of shards supported by the network - validators will jump around
@@ -51,16 +51,11 @@ const
 
   CHURN_LIMIT_QUOTIENT* = 2^16
 
-  BASE_REWARDS_PER_EPOCH* = 5
-
   SHUFFLE_ROUND_COUNT* = 90
 
-  # Deposit contract
-  # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/configs/constant_presets/mainnet.yaml#L24
-
-  DEPOSIT_CONTRACT_ADDRESS = "0x1234567890123456789012345678901234567890"
-    # TODO
+  # Constants (TODO: not actually configurable)
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#constants
+  BASE_REWARDS_PER_EPOCH* = 5
 
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
 

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -41,10 +41,10 @@ const
   # Changed
   SHUFFLE_ROUND_COUNT* = 10
 
-  # Deposit contract
+  # Constants
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#deposit-contract
-
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#constants
+  # TODO "The following values are (non-configurable) constants" ...
   # Unchanged
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -177,7 +177,7 @@ proc processProposerSlashings(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#is_slashable_attestation_data
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#is_slashable_attestation_data
 func is_slashable_attestation_data(
     data_1: AttestationData, data_2: AttestationData): bool =
   ## Check if ``data_1`` and ``data_2`` are slashable according to Casper FFG

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -112,8 +112,8 @@ proc processRandao(
     mix = get_current_epoch(state) mod LATEST_RANDAO_MIXES_LENGTH
     rr = eth2hash(body.randao_reveal.getBytes()).data
 
-  for i, b in state.latest_randao_mixes[mix].data:
-    state.latest_randao_mixes[mix].data[i] = b xor rr[i]
+  for i, b in state.randao_mixes[mix].data:
+    state.randao_mixes[mix].data[i] = b xor rr[i]
 
   true
 
@@ -122,7 +122,7 @@ func processEth1Data(state: var BeaconState, body: BeaconBlockBody) =
   state.eth1_data_votes.add body.eth1_data
   if state.eth1_data_votes.count(body.eth1_data) * 2 >
       SLOTS_PER_ETH1_VOTING_PERIOD:
-    state.latest_eth1_data = body.eth1_data
+    state.eth1_data = body.eth1_data
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#is_slashable_validator
 func is_slashable_validator(validator: Validator, epoch: Epoch): bool =

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -346,7 +346,7 @@ func get_crosslink_deltas(state: BeaconState, cache: var StateCache):
 
   (rewards, penalties)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#rewards-and-penalties-1
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#rewards-and-penalties-1
 func process_rewards_and_penalties(
     state: var BeaconState, cache: var StateCache) =
   if get_current_epoch(state) == GENESIS_EPOCH:
@@ -447,7 +447,7 @@ func processEpoch*(state: var BeaconState) =
   # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#rewards-and-penalties-1
   process_rewards_and_penalties(state, per_epoch_cache)
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#registry-updates
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#registry-updates
   # Don't rely on caching here.
   process_registry_updates(state)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -221,7 +221,7 @@ func process_crosslinks(state: var BeaconState, stateCache: var StateCache) =
     let epoch = epoch_int.Epoch
     for offset in 0'u64 ..< get_epoch_committee_count(state, epoch):
       let
-        shard = (get_epoch_start_shard(state, epoch) + offset) mod SHARD_COUNT
+        shard = (get_start_shard(state, epoch) + offset) mod SHARD_COUNT
         crosslink_committee =
           get_crosslink_committee(state, epoch, shard, stateCache)
         # In general, it'll loop over the same shards twice, and
@@ -327,7 +327,7 @@ func get_crosslink_deltas(state: BeaconState, cache: var StateCache):
   let epoch = get_previous_epoch(state)
   for offset in 0'u64 ..< get_epoch_committee_count(state, epoch):
     let
-      shard = (get_epoch_start_shard(state, epoch) + offset) mod SHARD_COUNT
+      shard = (get_start_shard(state, epoch) + offset) mod SHARD_COUNT
       crosslink_committee =
         get_crosslink_committee(state, epoch, shard, cache)
       (winning_crosslink, attesting_indices) =

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -12,8 +12,8 @@ import
   ./crypto, ./datatypes, ./digest, ./helpers
 
 # TODO: Proceed to renaming and signature changes
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_shuffled_index
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#compute_committee
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_shuffled_index
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_committee
 func get_shuffled_seq*(seed: Eth2Digest,
                        list_size: uint64,
                        ): seq[ValidatorIndex] =
@@ -79,15 +79,14 @@ func get_shuffled_seq*(seed: Eth2Digest,
 
   result = shuffled_active_validator_indices
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_previous_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_previous_epoch
 func get_previous_epoch*(state: BeaconState): Epoch =
-  ## Return the previous epoch of the given ``state``.
-  ## Return the current epoch if it's genesis epoch.
+  # Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
   let current_epoch = get_current_epoch(state)
   if current_epoch == GENESIS_EPOCH:
     current_epoch
   else:
-    current_epoch - 1
+    (current_epoch - 1).Epoch
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_shard_delta
 func get_shard_delta*(state: BeaconState, epoch: Epoch): uint64 =
@@ -112,9 +111,11 @@ func get_start_shard*(state: BeaconState, epoch: Epoch): Shard =
       SHARD_COUNT
   return shard
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#compute_committee
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#compute_committee
 func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
     index: uint64, count: uint64, stateCache: var StateCache): seq[ValidatorIndex] =
+  ## Return the committee corresponding to ``indices``, ``seed``, ``index``,
+  ## and committee ``count``.
 
   let
     start = (len(indices).uint64 * index) div count
@@ -125,7 +126,7 @@ func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
     stateCache.crosslink_committee_cache[key] =
       get_shuffled_seq(seed, len(indices).uint64)
 
-  # These assertions from get_shuffled_index(...)
+  # These assertions from compute_shuffled_index(...)
   let index_count = indices.len().uint64
   doAssert endIdx <= index_count
   doAssert index_count <= 2'u64^40
@@ -133,8 +134,7 @@ func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
   # In spec, this calls get_shuffled_index() every time, but that's wasteful
   mapIt(
     start.int .. (endIdx.int-1),
-    indices[
-      stateCache.crosslink_committee_cache[key][it]])
+    indices[stateCache.crosslink_committee_cache[key][it]])
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_crosslink_committee
 func get_crosslink_committee*(state: BeaconState, epoch: Epoch, shard: Shard,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -90,7 +90,7 @@ func get_previous_epoch*(state: BeaconState): Epoch =
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_shard_delta
 func get_shard_delta*(state: BeaconState, epoch: Epoch): uint64 =
-  ## Return the number of shards to increment ``state.latest_start_shard``
+  ## Return the number of shards to increment ``state.start_shard``
   ## during ``epoch``.
   min(get_epoch_committee_count(state, epoch),
     (SHARD_COUNT - SHARD_COUNT div SLOTS_PER_EPOCH).uint64)
@@ -103,7 +103,7 @@ func get_start_shard*(state: BeaconState, epoch: Epoch): Shard =
   var
     check_epoch = get_current_epoch(state) + 1
     shard =
-      (state.latest_start_shard +
+      (state.start_shard +
        get_shard_delta(state, get_current_epoch(state))) mod SHARD_COUNT
   while check_epoch > epoch:
     check_epoch -= 1.Epoch

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -194,7 +194,7 @@ func get_beacon_proposer_index*(state: BeaconState, stateCache: var StateCache):
         len(first_committee).uint64).int]
       random_byte = (eth2hash(buffer).data)[i mod 32]
       effective_balance =
-        state.validator_registry[candidate_index].effective_balance
+        state.validators[candidate_index].effective_balance
     if effective_balance * MAX_RANDOM_BYTE >=
         MAX_EFFECTIVE_BALANCE * random_byte:
       return candidate_index

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -49,7 +49,7 @@ func advance_slot(state: var BeaconState) =
 func process_slot(state: var BeaconState) =
   # Cache state root
   let previous_state_root = hash_tree_root(state)
-  state.latest_state_roots[state.slot mod SLOTS_PER_HISTORICAL_ROOT] =
+  state.state_roots[state.slot mod SLOTS_PER_HISTORICAL_ROOT] =
     previous_state_root
 
   # Cache latest block header state root
@@ -171,7 +171,7 @@ proc skipSlots*(state: var BeaconState, slot: Slot,
 func process_slot(state: var HashedBeaconState) =
   # Cache state root
   let previous_slot_state_root = state.root
-  state.data.latest_state_roots[state.data.slot mod SLOTS_PER_HISTORICAL_ROOT] =
+  state.data.state_roots[state.data.slot mod SLOTS_PER_HISTORICAL_ROOT] =
     previous_slot_state_root
 
   # Cache latest block header state root

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -106,7 +106,7 @@ cli do(slots = 448,
           mapIt(
             0'u64 .. (get_epoch_committee_count(state, epoch) - 1),
             get_crosslink_committee(state, epoch,
-              (it + get_epoch_start_shard(state, epoch)) mod SHARD_COUNT,
+              (it + get_start_shard(state, epoch)) mod SHARD_COUNT,
               cache))
 
       for scas in scass:

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -15,4 +15,4 @@ suite "Beacon state" & preset():
   test "Smoke test get_genesis_beacon_state" & preset():
     let state = get_genesis_beacon_state(
       makeInitialDeposits(SLOTS_PER_EPOCH, {}), 0, Eth1Data(), {})
-    check: state.validator_registry.len == SLOTS_PER_EPOCH
+    check: state.validators.len == SLOTS_PER_EPOCH

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -147,7 +147,7 @@ proc find_shard_committee(
   var cache = get_empty_per_epoch_cache()
   for shard in 0'u64 ..< get_epoch_committee_count(state, epoch):
     let committee = get_crosslink_committee(state, epoch,
-      (shard + get_epoch_start_shard(state, epoch)) mod SHARD_COUNT, cache)
+      (shard + get_start_shard(state, epoch)) mod SHARD_COUNT, cache)
     if validator_index in committee:
       return (committee, shard)
   doAssert false

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -85,7 +85,7 @@ proc addBlock*(
 
   let
     # Index from the new state, but registry from the old state.. hmm...
-    proposer = state.validator_registry[proposer_index]
+    proposer = state.validators[proposer_index]
     privKey = hackPrivKey(proposer)
 
   # TODO ugly hack; API needs rethinking
@@ -157,7 +157,7 @@ proc makeAttestation*(
     validator_index: ValidatorIndex, flags: UpdateFlags = {}): Attestation =
   let
     (committee, shard) = find_shard_committee(state, validator_index)
-    validator = state.validator_registry[validator_index]
+    validator = state.validators[validator_index]
     sac_index = committee.find(validator_index)
     data = makeAttestationData(state, shard, beacon_block_root)
 


### PR DESCRIPTION
More mostly mechanical updates.

The `+=` updates are because the spec now is more type-careful about Epoch += Epoch vs Epoch += uint64. Should be at least as type-safe as the spec. Ideally, eventually, can remove the Epoch/Slot += and -= uint64.