### PR TITLE
Speed up process_crosslinks(...) and get_crosslink_deltas(...) by 10x - 15x in state_sim

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -373,12 +373,6 @@ type
     block_hash*: Eth2Digest ##\
     ## Block hash
 
-  ## TODO remove or otherwise conditional-compile this, since it's for light
-  ## client but not in spec
-  ValidatorSetDeltaFlags* {.pure.} = enum
-    Activation = 0
-    Exit = 1
-
   # TODO to be replaced with some magic hash caching
   HashedBeaconState* = object
     data*: BeaconState

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -93,7 +93,7 @@ const
   ## TODO consistent time unit across projects, similar to C++ chrono?
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#time-parameters
-  MIN_ATTESTATION_INCLUSION_DELAY* = 2'u64^2 ##\
+  MIN_ATTESTATION_INCLUSION_DELAY* = 1 ##\
   ## (24 seconds)
   ## Number of slots that attestations stay in the attestation
   ## pool before being added to a block.

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -77,7 +77,7 @@ const
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#time-parameters
   # Unchanged
-  MIN_ATTESTATION_INCLUSION_DELAY* = 2'u64^0
+  MIN_ATTESTATION_INCLUSION_DELAY* = 1
 
   # Changed
   SLOTS_PER_EPOCH* {.intdefine.} = 64

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -354,6 +354,7 @@ func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
 
   (rewards, penalties)
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#rewards-and-penalties-1
 func get_crosslink_deltas(state: BeaconState, cache: var StateCache):
     tuple[a: seq[Gwei], b: seq[Gwei]] =
 
@@ -365,7 +366,7 @@ func get_crosslink_deltas(state: BeaconState, cache: var StateCache):
     let
       shard = (get_start_shard(state, epoch) + offset) mod SHARD_COUNT
       crosslink_committee =
-        get_crosslink_committee(state, epoch, shard, cache)
+        toSet(get_crosslink_committee(state, epoch, shard, cache))
       (winning_crosslink, attesting_indices) =
         get_winning_crosslink_and_attesting_indices(
           state, epoch, shard, cache)
@@ -375,10 +376,9 @@ func get_crosslink_deltas(state: BeaconState, cache: var StateCache):
       let base_reward = get_base_reward(state, index)
       if index in attesting_indices:
         rewards[index] +=
-          get_base_reward(state, index) * attesting_balance div
-            committee_balance
+          base_reward * attesting_balance div committee_balance
       else:
-        penalties[index] += get_base_reward(state, index)
+        penalties[index] += base_reward
 
   (rewards, penalties)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -145,6 +145,8 @@ func get_winning_crosslink_and_attesting_indices(
     winning_crosslink_balance = 0.Gwei
 
   for candidate_crosslink in crosslinks:
+    ## TODO when confidence that this exactly reproduces the spec version,
+    ## remove the when false'd scaffolding.
     when false:
       let crosslink_balance_uncached =
         get_attesting_balance(

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -67,7 +67,7 @@ func get_matching_head_attestations(state: BeaconState, epoch: Epoch):
   )
 
 func get_unslashed_attesting_indices(
-    state: BeaconState, attestations: seq[PendingAttestation],
+    state: BeaconState, attestations: openarray[PendingAttestation],
     stateCache: var StateCache): HashSet[ValidatorIndex] =
   result = initSet[ValidatorIndex]()
   for a in attestations:
@@ -135,7 +135,7 @@ func get_winning_crosslink_and_attesting_indices(
     ## on their assigned shards. Still, the right response there is slashed
     ## balances, not crashing clients.
     crosslink_attestation_indices.incl(
-      get_unslashed_attesting_indices(state, @[attestation], stateCache))
+      get_unslashed_attesting_indices(state, [attestation], stateCache))
     attesting_indices[crosslink_key] = crosslink_attestation_indices
 
   ## Winning crosslink has the crosslink data root with the most balance voting
@@ -145,11 +145,12 @@ func get_winning_crosslink_and_attesting_indices(
     winning_crosslink_balance = 0.Gwei
 
   for candidate_crosslink in crosslinks:
-    # let crosslink_balance_uncached =
-    #  get_attesting_balance(
-    #    state,
-    #    filterIt(attestations, it.data.crosslink == candidate_crosslink),
-    #    stateCache)
+    when false:
+      let crosslink_balance_uncached =
+        get_attesting_balance(
+          state,
+          filterIt(attestations, it.data.crosslink == candidate_crosslink),
+          stateCache)
     # TODO verify if one can assume this cached balance always exists here, by
     # doAsserting candidate_crosslink_key in attesting_indices
     let
@@ -163,7 +164,8 @@ func get_winning_crosslink_and_attesting_indices(
           1.Gwei
     ## TODO factor out precalculation mechanism; consider adding compilation
     ## flag to enable long calculation & consistency/assumption checking.
-    # doAssert crosslink_balance == crosslink_balance_uncached
+    when false:
+      doAssert crosslink_balance == crosslink_balance_uncached
     if (crosslink_balance > winning_crosslink_balance or
         (winning_crosslink_balance == crosslink_balance and
          lowerThan(winning_crosslink.data_root,

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -5,6 +5,10 @@ import
   beacon_node_types, eth2_network, beacon_chain_db, block_pool, time, ssz
 
 type
+  ValidatorSetDeltaFlags {.pure.} = enum
+    Activation = 0
+    Exit = 1
+
   ValidatorChangeLogEntry* = object
     case kind*: ValidatorSetDeltaFlags
     of Activation:


### PR DESCRIPTION
Successor PR to https://github.com/status-im/nim-beacon-chain/pull/313 (issues with rebasing conflicts).

This switches inner/outer loop nesting order to get 10-15x function speedup for 128 and 512 validator cases by avoiding accidentally quadratic behavior, while keeping function signature unchanged and allowing easy ongoing verification of correctness of optimization.

This takes `process_crosslinks(...)` processing times down in my testing from 15-16s or so to 1s and from 22-24s to 1.5s. `get_crosslink_deltas(...)` sees similar speedups, since it was also bottlenecked on `get_winning_crosslink_and_attesting_indices(...)`.

The other big epoch time-consumer is `get_attestation_deltas(...)`, which https://github.com/status-im/nim-beacon-chain/pull/314/commits/4590b697abd71fce26f17d39eeffe6a64994e4d0 decreases by 90x or so for me for 512 validators, from 178s to 2s.

Timings I get with 512 validators:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
     197.915,       46.600,      118.005,      309.630,          128, Process non-epoch slot with block
    3224.563,     2258.988,     1627.217,     4821.908,            2, Process epoch slot with block
       1.997,        1.181,        0.027,        4.247,          130, Tree-hash block
       8.371,        0.291,        7.516,        9.636,          130, Retrieve committee once using get_crosslink_committee
      64.856,       18.607,       31.645,      113.677,         8320, Combine committee attestations
```