### PR TITLE
Ctrl+C handling and:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 *.la
 *.exe
 *.dll
+
+/scripts/testnet*.sh
+

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TOOLS := beacon_node validator_keygen bench_bls_sig_agggregation state_sim
 TOOLS_DIRS := beacon_chain benchmarks research
 TOOLS_CSV := $(subst $(SPACE),$(COMMA),$(TOOLS))
 
-.PHONY: all sanity-checks deps nat-libs test $(TOOLS) clean_eth2_network_simulation_files eth2_network_simulation clean-testnet0 testnet0-nocleaning testnet0 clean-testnet1 testnet1-nocleaning testnet1 clean
+.PHONY: all sanity-checks deps nat-libs p2pd test $(TOOLS) clean_eth2_network_simulation_files eth2_network_simulation clean-testnet0 testnet0-nocleaning testnet0 clean-testnet1 testnet1-nocleaning testnet1 clean
 
 all: | $(TOOLS)
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ build:
 nat-libs: | deps
 	+ $(MAKE) --silent -C ../../ nat-libs
 
+p2pd: | deps
+	+ $(MAKE) --silent -C ../../ vendor/go/bin/p2pd
+
 # Windows 10 with WSL enabled, but no distro installed, fails if "../../nimble.sh" is executed directly
 # in a Makefile recipe but works when prefixing it with `bash`. No idea how the PATH is overridden.
 test: | build deps nat-libs
@@ -50,7 +53,7 @@ clean_eth2_network_simulation_files:
 eth2_network_simulation: | beacon_node validator_keygen clean_eth2_network_simulation_files
 	SKIP_BUILDS=1 GIT_ROOT="$$PWD" BUILD_OUTPUTS_DIR="./build" tests/simulation/start.sh
 
-testnet0 testnet1: | build deps nat-libs
+testnet0 testnet1: | build deps nat-libs p2pd
 	../../env.sh scripts/build_testnet_node.sh $@
 
 clean-testnet0:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ eth2_network_simulation: | beacon_node validator_keygen clean_eth2_network_simul
 	SKIP_BUILDS=1 GIT_ROOT="$$PWD" BUILD_OUTPUTS_DIR="./build" tests/simulation/start.sh
 
 testnet0 testnet1: | build deps nat-libs p2pd
-	../../env.sh scripts/build_testnet_node.sh $@
+	NIM_PARAMS="$(NIM_PARAMS)" ../../env.sh scripts/build_testnet_node.sh $@
 
 clean-testnet0:
 	rm -rf ~/.cache/nimbus/BeaconNode/testnet0

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -723,6 +723,15 @@ when isMainModule:
   if config.logLevel != LogLevel.NONE:
     setLogLevel(config.logLevel)
 
+  ## Ctrl+C handling
+  proc controlCHandler() {.noconv.} =
+    when defined(windows):
+      # workaround for https://github.com/nim-lang/Nim/issues/4057
+      setupForeignThreadGc()
+    debug "Shutting down after having received SIGINT"
+    quit(1)
+  setControlCHook(controlCHandler)
+
   case config.cmd
   of createTestnet:
     var deposits: seq[Deposit]

--- a/scripts/build_testnet_node.sh
+++ b/scripts/build_testnet_node.sh
@@ -27,7 +27,7 @@ fi
 echo
 echo "Done! You're now ready to connect to $NETWORK_NAME by running:"
 echo
-echo "    $BEACON_NODE_BIN"
+echo "    ../../env.sh $BEACON_NODE_BIN"
 echo
 echo "Database and configuration files will be placed in:"
 echo

--- a/scripts/build_testnet_node.sh
+++ b/scripts/build_testnet_node.sh
@@ -3,7 +3,7 @@
 
 [ -z "$1" ] && { echo "Usage: `basename $0` testnetX"; exit 1; }
 
-set -eu
+set -e
 
 cd $(dirname "$0")
 
@@ -12,11 +12,13 @@ source "$NETWORK_NAME.env"
 
 cd ..
 
-NIM_FLAGS="-d:release --lineTrace:on -d:chronicles_log_level=DEBUG -d:network_type=$NETWORK_TYPE -d:SECONDS_PER_SLOT=$SECONDS_PER_SLOT -d:SHARD_COUNT=$SHARD_COUNT -d:SLOTS_PER_EPOCH=$SLOTS_PER_EPOCH -d:DEFAULT_NETWORK=$NETWORK_NAME --hints:off --verbosity:0"
+# the NIM_PARAMS env var will be set in the Makefile, based on NIMFLAGS passed on the `make` command line
+# (i.e.: make NIMFLAGS="--stackTrace:on" testnet1).
+OUR_NIM_FLAGS="-d:release --lineTrace:on -d:chronicles_log_level=DEBUG -d:network_type=$NETWORK_TYPE -d:SECONDS_PER_SLOT=$SECONDS_PER_SLOT -d:SHARD_COUNT=$SHARD_COUNT -d:SLOTS_PER_EPOCH=$SLOTS_PER_EPOCH -d:DEFAULT_NETWORK=$NETWORK_NAME $NIM_PARAMS"
 
 BEACON_NODE_BIN="build/${NETWORK_NAME}_node"
 
-CMD="nim c $NIM_FLAGS -o:$BEACON_NODE_BIN beacon_chain/beacon_node"
+CMD="nim c $OUR_NIM_FLAGS -o:$BEACON_NODE_BIN beacon_chain/beacon_node"
 echo "$CMD"
 $CMD
 
@@ -24,10 +26,20 @@ if [ ! -d ~/.cache/nimbus/BeaconNode/${NETWORK_NAME}/validators ]; then
   $BEACON_NODE_BIN --network=$NETWORK_NAME importValidator
 fi
 
+# simple wrapper script
+BEACON_NODE_SCRIPT="scripts/${NETWORK_NAME}.sh"
+cat > "$BEACON_NODE_SCRIPT" <<EOF
+#!/bin/bash
+
+cd \$(dirname "\$0")/..
+../../env.sh $BEACON_NODE_BIN "\$@"
+EOF
+chmod 755 "$BEACON_NODE_SCRIPT"
+
 echo
 echo "Done! You're now ready to connect to $NETWORK_NAME by running:"
 echo
-echo "    ../../env.sh $BEACON_NODE_BIN"
+echo "    $BEACON_NODE_SCRIPT"
 echo
 echo "Database and configuration files will be placed in:"
 echo


### PR DESCRIPTION
- added a "quitProc" for shutting down the p2pd process, after seeing it
  survive an unhandled exception (this required a global var for the
  DaemonApi instance)
- Makefile testnet0/1 targets now depend on the "p2pd" binary
- prefixed the testnet command line in the build script message with
  "../../env.sh" so it can find the superproject's "p2pd"

(turns out @tersec was right to complain about the Makefile user experience)