### PR TITLE
Add non-attesting-validators instrumentation in process_justification_and_finalization(...)

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -301,8 +301,10 @@ type
     current_crosslinks*: array[SHARD_COUNT, Crosslink]
 
     # Finality
-    justification_bits*: uint64 ##\
+    justification_bits*: uint8 ##\
     ## Bit set for every recent justified epoch
+    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
+    ## with ssz/hashing.
 
     previous_justified_checkpoint*: Checkpoint ##\
     ## Previous epoch snapshot

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -55,7 +55,7 @@ func process_slot(state: var BeaconState) =
     signing_root(state.latest_block_header)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_beacon-chain.md#beacon-chain-state-transition-function
-func process_slots*(state: var BeaconState, slot: Slot) =
+proc process_slots*(state: var BeaconState, slot: Slot) =
   doAssert state.slot <= slot
 
   # Catch up to the target slot


### PR DESCRIPTION
Debug seems to fit https://github.com/status-im/nim-beacon-chain/issues/205 .

The `process_justification_and_finalization(...)` update itself to 0.8.1 should be fine -- it's just a refactoring -- but it would be nice to avoid turning all those `func`s into `proc`s. This is one reason I don't use more `chronicles` logging -- it's contagious this way. Not sure if there's a kind of `debugEcho` escape hatch. Otherwise, it's still probably good to have something like this, which can be removed, than not to have it at all.

This is mainly why I split this into https://github.com/status-im/nim-beacon-chain/pull/323/commits/6c0dfa7534129cba15b0bec38955e9e0a61e0cc5 (which is a reasonably clean 0.8.1 spec update) and https://github.com/status-im/nim-beacon-chain/pull/323/commits/7f2e84c72f373619b9d3a35c4b259aad546f7ded (the sort of thing I've been doing offline, ad-hoc, but for obvious reasons, this is the first time I've put one in a PR).

There's also https://github.com/status-im/nim-beacon-chain/pull/324 which just does the 0.8.1 update of this function.