### PR TITLE
rm some less-useful debug and tracing noise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ install:
   - cd go-libp2p-daemon
   # - git checkout v0.0.1
   - go install ./...
-  - cd $HOME/build/status-im/nim-libp2p
 
 script:
   - nimble install -y --depsOnly

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       before_install:
         - export GOPATH=$HOME/go
         - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-     -os: osx
+    - os: osx
       before_install:
         - export GOPATH=$HOME/go
         - launchctl setenv LIBRARY_PATH /usr/local/lib # for RocksDB

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
   - cd go-libp2p-daemon
   # - git checkout v0.0.1
   - go install ./...
+  - cd ..
 
 script:
   - nimble install -y --depsOnly

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ matrix:
     - os: linux
       sudo: required
       before_install:
+        - export GOPATH=$HOME/go
         - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-    - os: osx
+     -os: osx
       before_install:
+        - export GOPATH=$HOME/go
         - launchctl setenv LIBRARY_PATH /usr/local/lib # for RocksDB
 
 install:
@@ -32,7 +34,7 @@ install:
   # flexibility to apply patches
   - curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus/devel/build_nim.sh
   - env MAKE="make -j2" bash build_nim.sh Nim csources dist/nimble NimBinaries
-  - export PATH=$PWD/Nim/bin:$PATH
+  - export PATH=$PWD/Nim/bin:$GOPATH/bin:$PATH
 
   # build our own rocksdb to test with a fixed version that we think works
   - curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus/devel/build_rocksdb.sh
@@ -40,6 +42,12 @@ install:
 
   # LFS test fixtures
   - scripts/process_lfs.sh jsonTestsCache
+
+  - git clone https://github.com/libp2p/go-libp2p-daemon
+  - cd go-libp2p-daemon
+  # - git checkout v0.0.1
+  - go install ./...
+  - cd $HOME/build/status-im/nim-libp2p
 
 script:
   - nimble install -y --depsOnly

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -203,8 +203,6 @@ proc add*(pool: var AttestationPool,
         info "Attestation resolved",
           attestationData = shortLog(attestation.data),
           validations = a.validations.len(),
-          validatorIndex = get_attesting_indices(
-            state, attestation.data, attestation.aggregation_bits, cache),
           current_epoch = get_current_epoch(state),
           target_epoch = attestation.data.target.epoch,
           stateSlot = state.slot
@@ -223,8 +221,6 @@ proc add*(pool: var AttestationPool,
 
     info "Attestation resolved",
       attestationData = shortLog(attestation.data),
-      validatorIndex = get_attesting_indices(
-        state, attestation.data, attestation.aggregation_bits, cache),
       current_epoch = get_current_epoch(state),
       target_epoch = attestation.data.target.epoch,
       stateSlot = state.slot,

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -458,7 +458,7 @@ func process_slashings(state: var BeaconState) =
       decrease_balance(state, index.ValidatorIndex, penalty)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.2/specs/core/0_beacon-chain.md#final-updates
-proc process_final_updates(state: var BeaconState) =
+func process_final_updates(state: var BeaconState) =
   let
     current_epoch = get_current_epoch(state)
     next_epoch = current_epoch + 1

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -190,8 +190,6 @@ func get_winning_crosslink_and_attesting_indices(
 proc process_justification_and_finalization(
     state: var BeaconState, stateCache: var StateCache) =
   if get_current_epoch(state) <= GENESIS_EPOCH + 1:
-    debug "process_justification_and_finalization early exit",
-      current_epoch = get_current_epoch(state)
     return
 
   let
@@ -235,11 +233,7 @@ proc process_justification_and_finalization(
       difference(active_validator_indices,
         toSet(mapIt(get_unslashed_attesting_indices(state,
           matching_target_attestations_previous, stateCache), it.int))),
-    prev_attestating_indices=
-      mapIt(get_attesting_indices(state, state.previous_epoch_attestations, stateCache), it.int),
     prev_attestations_len=len(state.previous_epoch_attestations),
-    cur_attestating_indices=
-      mapIt(get_attesting_indices(state, state.current_epoch_attestations, stateCache), it.int),
     cur_attestations_len=len(state.current_epoch_attestations),
     num_active_validators=len(active_validator_indices),
     required_balance = get_total_active_balance(state) * 2,
@@ -517,14 +511,8 @@ proc process_final_updates(state: var BeaconState) =
       SHARD_COUNT
 
   # Rotate current/previous epoch attestations
-  trace "Rotating epoch attestations",
-    current_epoch = get_current_epoch(state)
-
   state.previous_epoch_attestations = state.current_epoch_attestations
   state.current_epoch_attestations = @[]
-
-  trace "Rotated epoch attestations",
-    current_epoch = get_current_epoch(state)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.2/specs/core/0_beacon-chain.md#per-epoch-processing
 proc process_epoch*(state: var BeaconState) =

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -64,13 +64,7 @@ proc process_slots*(state: var BeaconState, slot: Slot) =
     if (state.slot + 1) mod SLOTS_PER_EPOCH == 0:
       # Note: Genesis epoch = 0, no need to test if before Genesis
       process_epoch(state)
-    trace "process_slots: Incrementing slot",
-      state_slot_now = state.slot,
-      state_slot_next = state.slot + 1,
-      cur_epoch = get_current_epoch(state)
     state.slot += 1
-    trace "process_slots: Incremented slot",
-      cur_epoch = get_current_epoch(state)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#state-root-verification
 proc verifyStateRoot(state: BeaconState, blck: BeaconBlock): bool =
@@ -178,10 +172,6 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot) =
     if (state.data.slot + 1) mod SLOTS_PER_EPOCH == 0:
       # Note: Genesis epoch = 0, no need to test if before Genesis
       process_epoch(state.data)
-    trace "process_slots_HashedBeaconState_: Incrementing slot",
-      state_slot_now = state.data.slot,
-      state_slot_next = state.data.slot + 1,
-      cur_epoch = get_current_epoch(state.data)
     state.data.slot += 1
 
 proc state_transition*(


### PR DESCRIPTION
In theory, the `validatorIndex` ones should be useful, but (1) possible to replace by using signature as primary key, and (2) broke at some point insofar as they just print some outline of a data structure.

The Travis CI changes are so that `beacon_node`/etc can become part of CI, in particular finalization tests.