### PR TITLE
rm some less-useful debug and tracing noise

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -203,8 +203,6 @@ proc add*(pool: var AttestationPool,
         info "Attestation resolved",
           attestationData = shortLog(attestation.data),
           validations = a.validations.len(),
-          validatorIndex = get_attesting_indices(
-            state, attestation.data, attestation.aggregation_bits, cache),
           current_epoch = get_current_epoch(state),
           target_epoch = attestation.data.target.epoch,
           stateSlot = state.slot
@@ -223,8 +221,6 @@ proc add*(pool: var AttestationPool,
 
     info "Attestation resolved",
       attestationData = shortLog(attestation.data),
-      validatorIndex = get_attesting_indices(
-        state, attestation.data, attestation.aggregation_bits, cache),
       current_epoch = get_current_epoch(state),
       target_epoch = attestation.data.target.epoch,
       stateSlot = state.slot,

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -190,8 +190,6 @@ func get_winning_crosslink_and_attesting_indices(
 proc process_justification_and_finalization(
     state: var BeaconState, stateCache: var StateCache) =
   if get_current_epoch(state) <= GENESIS_EPOCH + 1:
-    debug "process_justification_and_finalization early exit",
-      current_epoch = get_current_epoch(state)
     return
 
   let
@@ -235,11 +233,7 @@ proc process_justification_and_finalization(
       difference(active_validator_indices,
         toSet(mapIt(get_unslashed_attesting_indices(state,
           matching_target_attestations_previous, stateCache), it.int))),
-    prev_attestating_indices=
-      mapIt(get_attesting_indices(state, state.previous_epoch_attestations, stateCache), it.int),
     prev_attestations_len=len(state.previous_epoch_attestations),
-    cur_attestating_indices=
-      mapIt(get_attesting_indices(state, state.current_epoch_attestations, stateCache), it.int),
     cur_attestations_len=len(state.current_epoch_attestations),
     num_active_validators=len(active_validator_indices),
     required_balance = get_total_active_balance(state) * 2,
@@ -517,14 +511,8 @@ proc process_final_updates(state: var BeaconState) =
       SHARD_COUNT
 
   # Rotate current/previous epoch attestations
-  trace "Rotating epoch attestations",
-    current_epoch = get_current_epoch(state)
-
   state.previous_epoch_attestations = state.current_epoch_attestations
   state.current_epoch_attestations = @[]
-
-  trace "Rotated epoch attestations",
-    current_epoch = get_current_epoch(state)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.2/specs/core/0_beacon-chain.md#per-epoch-processing
 proc process_epoch*(state: var BeaconState) =

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -64,13 +64,7 @@ proc process_slots*(state: var BeaconState, slot: Slot) =
     if (state.slot + 1) mod SLOTS_PER_EPOCH == 0:
       # Note: Genesis epoch = 0, no need to test if before Genesis
       process_epoch(state)
-    trace "process_slots: Incrementing slot",
-      state_slot_now = state.slot,
-      state_slot_next = state.slot + 1,
-      cur_epoch = get_current_epoch(state)
     state.slot += 1
-    trace "process_slots: Incremented slot",
-      cur_epoch = get_current_epoch(state)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#state-root-verification
 proc verifyStateRoot(state: BeaconState, blck: BeaconBlock): bool =
@@ -178,10 +172,6 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot) =
     if (state.data.slot + 1) mod SLOTS_PER_EPOCH == 0:
       # Note: Genesis epoch = 0, no need to test if before Genesis
       process_epoch(state.data)
-    trace "process_slots_HashedBeaconState_: Incrementing slot",
-      state_slot_now = state.data.slot,
-      state_slot_next = state.data.slot + 1,
-      cur_epoch = get_current_epoch(state.data)
     state.data.slot += 1
 
 proc state_transition*(


### PR DESCRIPTION
In theory, the `validatorIndex` ones should be useful, but (1) possible to replace by using signature as primary key, and (2) broke at some point insofar as they just print some outline of a data structure.

Removes the CI-affecting portions of https://github.com/status-im/nim-beacon-chain/pull/354