### PR TITLE
Prepare for v0.8.3 tests: submodules + LFS script + Appveyor updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,6 +6,11 @@ environment:
   # disable LFS file downloading during regular cloning
   GIT_LFS_SKIP_SMUDGE: 1
 
+init: # Scripts called at the very beginning
+  # Enable paths > 260 characters
+  - ps: Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
+  - git config --global core.longpaths true
+
 cache:
   - NimBinaries
   - p2pdCache
@@ -20,8 +25,6 @@ platform:
   - x64
 
 install:
-  # Enable paths > 260 characters
-  - ps: Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
   - git submodule update --init --recursive
   # use the newest versions documented here: https://www.appveyor.com/docs/windows-images-software/#mingw-msys-cygwin
   - IF "%PLATFORM%" == "x86" SET PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,8 @@ platform:
   - x64
 
 install:
+  # Enable paths > 260 characters
+  - ps: Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
   - git submodule update --init --recursive
   # use the newest versions documented here: https://www.appveyor.com/docs/windows-images-software/#mingw-msys-cygwin
   - IF "%PLATFORM%" == "x86" SET PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;%PATH%
@@ -39,4 +41,3 @@ test_script:
   - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% DISABLE_LFS_SCRIPT=1 DISABLE_GO_CHECKS=1 test
 
 deploy: off
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,21 +36,6 @@
 	url = https://github.com/status-im/nim-web3.git
 	ignore = dirty
 	branch = master
-[submodule "vendor/Nim"]
-	path = vendor/Nim
-	url = https://github.com/status-im/Nim.git
-	ignore = dirty
-	branch = nimbus
-[submodule "vendor/Nim-csources"]
-	ignore = dirty
-	branch = master
-	path = vendor/Nim-csources
-	url = https://github.com/nim-lang/csources.git
-[submodule "vendor/nimble"]
-	path = vendor/nimble
-	url = https://github.com/nim-lang/nimble.git
-	ignore = dirty
-	branch = master
 [submodule "vendor/nim-nat-traversal"]
 	path = vendor/nim-nat-traversal
 	url = https://github.com/status-im/nim-nat-traversal.git

--- a/scripts/process_lfs.sh
+++ b/scripts/process_lfs.sh
@@ -9,10 +9,14 @@
 
 set -e
 
-ARCHIVE_NAME="json_tests.tar.xz"
+ARCHIVE_NAME_v0_8_1="json_tests_v0.8.1.tar.xz"
+ARCHIVE_NAME_v0_8_3="json_tests_v0.8.3.tar.xz"
+
+LFS_DIR_v0_8_1="json_tests_v0.8.1"
+LFS_DIR_v0_8_3="json_tests_v0.8.3"
+
 TMP_CACHE_DIR="tmpcache"
 SUBREPO_DIR="tests/official/fixtures"
-LFS_DIR="json_tests"
 # verbosity level
 [[ -z "$V" ]] && V=0
 [[ -z "$BUILD_MSG" ]] && BUILD_MSG="Downloading LFS files"
@@ -42,20 +46,21 @@ download_lfs_files() {
 
 	pushd "${SUBREPO_DIR}"
 	git lfs install # redundant after running it once per repo, but fast enough not to worry about detecting whether it ran before
-	git lfs pull -I "${LFS_DIR}" # we just care about test fixtures converted from YAML to JSON
+	git lfs pull -I "${LFS_DIR_v0_8_1},${LFS_DIR_v0_8_3}" # we just care about test fixtures converted from YAML to JSON
 	popd
 }
 
-UPDATE_CACHE=0
+# TODO: Use a function
 if [[ -n "${CACHE_DIR}" ]]; then
-	if [[ -e "${CACHE_DIR}/${ARCHIVE_NAME}" ]]; then
+  UPDATE_CACHE=0 # v0.8.1 tests
+	if [[ -e "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_1}" ]]; then
 		# compare the archive's mtime to the date of the last commit
-		if [[ $(stat ${STAT_FORMAT} "${CACHE_DIR}/${ARCHIVE_NAME}") -gt $(cd "${SUBREPO_DIR}"; git log --pretty=format:%cd -n 1 --date=unix "${LFS_DIR}") ]]; then
+		if [[ $(stat ${STAT_FORMAT} "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_1}") -gt $(cd "${SUBREPO_DIR}"; git log --pretty=format:%cd -n 1 --date=unix "${LFS_DIR_v0_8_1}") ]]; then
 			# the cache is valid
-			echo "Copying cached files into ${SUBREPO_DIR}/${LFS_DIR}/"
+			echo "Copying cached files into ${SUBREPO_DIR}/${LFS_DIR_v0_8_1}/"
 			mkdir -p "${TMP_CACHE_DIR}"
-			${DECOMPRESS_XZ} "${CACHE_DIR}/${ARCHIVE_NAME}" | tar -x -C "${TMP_CACHE_DIR}" -f -
-			cp -a "${TMP_CACHE_DIR}/${LFS_DIR}"/* "${SUBREPO_DIR}/${LFS_DIR}/"
+			${DECOMPRESS_XZ} "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_1}" | tar -x -C "${TMP_CACHE_DIR}" -f -
+			cp -a "${TMP_CACHE_DIR}/${LFS_DIR_v0_8_1}"/* "${SUBREPO_DIR}/${LFS_DIR_v0_8_1}/"
 			rm -rf "${TMP_CACHE_DIR}"
 		else
 			# old cache
@@ -74,13 +79,46 @@ if [[ -n "${CACHE_DIR}" ]]; then
 		download_lfs_files
 		echo "Updating the cache."
 		pushd "${SUBREPO_DIR}"
-		# the archive will contain ${LFS_DIR} as its top dir
-		git archive --format=tar HEAD "${LFS_DIR}" | ${COMPRESS_XZ} > "${ARCHIVE_NAME}"
+		# the archive will contain ${LFS_DIR_v0_8_1} as its top dir
+		git archive --format=tar HEAD "${LFS_DIR_v0_8_1}" | ${COMPRESS_XZ} > "${ARCHIVE_NAME_v0_8_1}"
 		popd
-		mv "${SUBREPO_DIR}/${ARCHIVE_NAME}" "${CACHE_DIR}/"
+		mv "${SUBREPO_DIR}/${ARCHIVE_NAME_v0_8_1}" "${CACHE_DIR}/"
 	fi
+
+  UPDATE_CACHE=0 # v0.8.3 tests
+	if [[ -e "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_3}" ]]; then
+		# compare the archive's mtime to the date of the last commit
+		if [[ $(stat ${STAT_FORMAT} "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_3}") -gt $(cd "${SUBREPO_DIR}"; git log --pretty=format:%cd -n 1 --date=unix "${LFS_DIR_v0_8_3}") ]]; then
+			# the cache is valid
+			echo "Copying cached files into ${SUBREPO_DIR}/${LFS_DIR_v0_8_3}/"
+			mkdir -p "${TMP_CACHE_DIR}"
+			${DECOMPRESS_XZ} "${CACHE_DIR}/${ARCHIVE_NAME_v0_8_3}" | tar -x -C "${TMP_CACHE_DIR}" -f -
+			cp -a "${TMP_CACHE_DIR}/${LFS_DIR_v0_8_3}"/* "${SUBREPO_DIR}/${LFS_DIR_v0_8_3}/"
+			rm -rf "${TMP_CACHE_DIR}"
+		else
+			# old cache
+			echo "Invalidating cache."
+			UPDATE_CACHE=1
+		fi
+	else
+		# creating the archive for the first time
+		mkdir -p "${CACHE_DIR}"
+		UPDATE_CACHE=1
+	fi
+	if [[ "${UPDATE_CACHE}" == "1" ]]; then
+		if [[ "${ON_MACOS}" == "1" ]]; then
+			brew install git-lfs # this takes almost 5 minutes on Travis, so only run it if needed
+		fi
+		download_lfs_files
+		echo "Updating the cache."
+		pushd "${SUBREPO_DIR}"
+		# the archive will contain ${LFS_DIR_v0_8_3} as its top dir
+		git archive --format=tar HEAD "${LFS_DIR_v0_8_3}" | ${COMPRESS_XZ} > "${ARCHIVE_NAME_v0_8_3}"
+		popd
+		mv "${SUBREPO_DIR}/${ARCHIVE_NAME_v0_8_3}" "${CACHE_DIR}/"
+	fi
+
 else
 	# no caching
 	download_lfs_files
 fi
-

--- a/tests/official/fixtures_utils_v0_8_1.nim
+++ b/tests/official/fixtures_utils_v0_8_1.nim
@@ -13,12 +13,14 @@ export  # Workaround:
   #   - https://github.com/nim-lang/Nim/issues/11225
   serialization.readValue
 
+# Process legacy EF test format (up to 0.8.1)
+# -------------------------------------------
+
 type
   # TODO: use ref object to avoid allocating
   #       so much on the stack - pending https://github.com/status-im/nim-json-serialization/issues/3
 
   TestConstants* = object
-    # TODO - 0.5.1 constants
     SHARD_COUNT*: int
     TARGET_COMMITTEE_SIZE*: int
     MAX_BALANCE_CHURN_QUOTIENT*: int
@@ -76,7 +78,7 @@ type
 
 const
   FixturesDir* = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
-  JsonTestsDir* = FixturesDir / "json_tests"
+  JsonTestsDir* = FixturesDir / "json_tests_v0.8.1"
 
 # #######################
 # Default init

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -7,13 +7,13 @@
 
 import
   # Standard libs
-  ospaths, strutils, unittest, endians,
+  ospaths, unittest, endians,
   # Status libs
   blscurve, stew/byteutils,
   # Beacon chain internals
   ../../beacon_chain/spec/crypto,
   # Test utilities
-  ./fixtures_utils
+  ./fixtures_utils_v0_8_1
 
 type
   # # TODO - but already tested in nim-blscurve
@@ -65,8 +65,7 @@ proc readValue*(r: var JsonReader, a: var Domain) {.inline.} =
   let be_uint = hexToPaddedByteArray[8](r.readValue(string))
   bigEndian64(a.addr, be_uint.unsafeAddr)
 
-const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
-const TestsPath = "fixtures" / "json_tests" / "bls"
+const TestsPath = JsonTestsDir / "bls"
 
 var
   blsPrivToPubTests: Tests[BLSPrivToPub]
@@ -76,10 +75,10 @@ var
 
 suite "Official - BLS tests":
   test "Parsing the official BLS tests":
-    blsPrivToPubTests = parseTests(TestFolder / TestsPath / "priv_to_pub" / "priv_to_pub.json", BLSPrivToPub)
-    blsSignMsgTests = parseTests(TestFolder / TestsPath / "sign_msg" / "sign_msg.json", BLSSignMsg)
-    blsAggSigTests = parseTests(TestFolder / TestsPath / "aggregate_sigs" / "aggregate_sigs.json", BLSAggSig)
-    blsAggPubKeyTests = parseTests(TestFolder / TestsPath / "aggregate_pubkeys" / "aggregate_pubkeys.json", BLSAggPubKey)
+    blsPrivToPubTests = parseTests(TestsPath / "priv_to_pub" / "priv_to_pub.json", BLSPrivToPub)
+    blsSignMsgTests = parseTests(TestsPath / "sign_msg" / "sign_msg.json", BLSSignMsg)
+    blsAggSigTests = parseTests(TestsPath / "aggregate_sigs" / "aggregate_sigs.json", BLSAggSig)
+    blsAggPubKeyTests = parseTests(TestsPath / "aggregate_pubkeys" / "aggregate_pubkeys.json", BLSAggPubKey)
 
   test "Private to public key conversion":
     for t in blsPrivToPubTests.test_cases:

--- a/tests/official/test_fixture_shuffling.nim
+++ b/tests/official/test_fixture_shuffling.nim
@@ -7,12 +7,12 @@
 
 import
   # Standard library
-  ospaths, strutils, unittest,
+  ospaths, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, validator, digest],
   # Test utilities
   ../testutil,
-  ./fixtures_utils
+  ./fixtures_utils_v0_8_1
 
 type
   Shuffling* = object
@@ -20,18 +20,16 @@ type
     count*: uint64
     shuffled*: seq[ValidatorIndex]
 
-const TestFolder = currentSourcePath.rsplit(DirSep, 1)[0]
-
 when const_preset == "mainnet":
-  const TestsPath = "fixtures" / "json_tests" / "shuffling" / "core" / "shuffling_full.json"
+  const TestsPath = JsonTestsDir / "shuffling" / "core" / "shuffling_full.json"
 elif const_preset == "minimal":
-  const TestsPath = "fixtures" / "json_tests" / "shuffling" / "core" / "shuffling_minimal.json"
+  const TestsPath = JsonTestsDir / "shuffling" / "core" / "shuffling_minimal.json"
 
 var shufflingTests: Tests[Shuffling]
 
 suite "Official - Shuffling tests [Preset: " & preset():
   test "Parsing the official shuffling tests [Preset: " & preset():
-    shufflingTests = parseTests(TestFolder / TestsPath, Shuffling)
+    shufflingTests = parseTests(TestsPath, Shuffling)
 
   test "Shuffling a sequence of N validators" & preset():
     for t in shufflingTests.test_cases:

--- a/tests/official/test_fixture_ssz_static.nim
+++ b/tests/official/test_fixture_ssz_static.nim
@@ -17,7 +17,7 @@ import
   ../../beacon_chain/spec/[datatypes, validator, digest, crypto],
   # Test utilities
   ../testutil,
-  ./fixtures_utils
+  ./fixtures_utils_v0_8_1
 
 const
   failFast = defined(debug) and false

--- a/tests/official/test_fixture_ssz_uint.nim
+++ b/tests/official/test_fixture_ssz_uint.nim
@@ -15,7 +15,7 @@ import
   ../../beacon_chain/spec/[datatypes, validator],
   # Test utilities
   ../testutil,
-  ./fixtures_utils
+  ./fixtures_utils_v0_8_1
 
 type
   SSZUint* = object


### PR DESCRIPTION
This prepare the repo for v0.8.3 tests.

Due to significant changes in test format, I will keep both 0.8.1 and 0.8.3 tests alive at the same time and gradually transfer them over.

v0.8.1 format for the time being:
- SSZ generic
- SSZ static

will be converted to v0.8.3 format after this PR:
- BLS
- shuffling

v0.8.3 from the get go:
- state tests (will use SSZ and not yaml/json)

This PR updates:
- the fixtures submodule
- the LFS script
- Appveyor

As the new format create paths like:
`fatal: cannot create directory at 'json_tests_v0.8.3/general/phase0/bls/sign_msg/small/sign_msg_0x263dbd792f5b1be47ed85f8938c0f29586af0d3ac7b977f21c278fe1462040e3_0x0000000000000000000000000000000000000000000000000000000000000000_0x0000000000000000': Filename too long`
that windows cannot handle by default

--------------

Note on the Nim, nimble and csources folder.
It seems like those we're not in the repo but `make deps` brought them in.
