### PR TITLE
update get_attesting_indices(...) to 0.8.3; mark IndexedAttestation, Attestation, PendingAttestation, and get_randao_mix(...) as 0.8.3; rm duplicate/dead code get_unslashed_attesting_indices(...)

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -414,19 +414,17 @@ func is_valid_indexed_attestation*(
     ),
   )
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_attesting_indices
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#get_attesting_indices
 func get_attesting_indices*(state: BeaconState,
-                            attestation_data: AttestationData,
+                            data: AttestationData,
                             bits: CommitteeValidatorsBits,
                             stateCache: var StateCache):
                             HashSet[ValidatorIndex] =
-  ## Return the sorted attesting indices corresponding to ``attestation_data``
-  ## and ``bitfield``.
+  # Return the set of attesting indices corresponding to ``data`` and ``bits``.
   result = initSet[ValidatorIndex]()
   let committee =
     get_crosslink_committee(
-      state, attestation_data.target.epoch, attestation_data.crosslink.shard,
-      stateCache)
+      state, data.target.epoch, data.crosslink.shard, stateCache)
   for i, index in committee:
     if bits[i]:
       result.incl index

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -100,33 +100,25 @@ type
 
   CustodyBitIndices* = List[uint64, MAX_VALIDATORS_PER_COMMITTEE]
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#indexedattestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#indexedattestation
   IndexedAttestation* = object
-    # These probably should be seq[ValidatorIndex], but that throws RLP errors
-    custody_bit_0_indices*: CustodyBitIndices
-    custody_bit_1_indices*: CustodyBitIndices
+    custody_bit_0_indices*: CustodyBitIndices ##\
+    ## Indices with custody bit equal to 0
 
-    data*: AttestationData ## \
-    ## Attestation data
+    custody_bit_1_indices*: CustodyBitIndices ##\
+    ## Indices with custody bit equal to 1
 
-    signature*: ValidatorSig ## \
-    ## Aggregate signature
+    data*: AttestationData
+    signature*: ValidatorSig
 
   CommitteeValidatorsBits* = BitList[MAX_VALIDATORS_PER_COMMITTEE]
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#attestation
   Attestation* = object
-    aggregation_bits*: CommitteeValidatorsBits ##\
-    ## Attester aggregation bitfield
-
-    data*: AttestationData ##\
-    ## Attestation data
-
-    custody_bits*: CommitteeValidatorsBits ##\
-    ## Custody bitfield
-
-    signature*: ValidatorSig ##\
-    ## BLS aggregate signature
+    aggregation_bits*: CommitteeValidatorsBits
+    data*: AttestationData
+    custody_bits*: CommitteeValidatorsBits
+    signature*: ValidatorSig
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#checkpoint
   Checkpoint* = object
@@ -356,12 +348,12 @@ type
 
     data_root*: Eth2Digest
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#pendingattestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#pendingattestation
   PendingAttestation* = object
-    aggregation_bits*: CommitteeValidatorsBits ## Attester participation bitfield
-    data*: AttestationData                     ## Attestation data
-    inclusion_delay*: uint64                   ## Inclusion delay
-    proposer_index*: uint64                    ## Proposer index
+    aggregation_bits*: CommitteeValidatorsBits
+    data*: AttestationData
+    inclusion_delay*: uint64
+    proposer_index*: uint64
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#historicalbatch
   HistoricalBatch* = object

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -98,7 +98,7 @@ func get_current_epoch*(state: BeaconState): Epoch =
   doAssert state.slot >= GENESIS_SLOT, $state.slot
   compute_epoch_of_slot(state.slot)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#get_randao_mix
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: BeaconState,
                      epoch: Epoch): Eth2Digest =
     ## Returns the randao mix at a recent ``epoch``.

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -247,14 +247,6 @@ func get_attesting_indices(
     result = result.union(get_attesting_indices(
       state, a.data, a.aggregation_bits, stateCache))
 
-func get_unslashed_attesting_indices(
-    state: BeaconState, attestations: openarray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
-  result = get_attesting_indices(state, attestations, stateCache)
-  for index in result:
-    if state.validators[index].slashed:
-      result.excl index
-
 # https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#attestations
 proc processAttestations*(
     state: var BeaconState, blck: BeaconBlock, flags: UpdateFlags,


### PR DESCRIPTION
Looking at remaining pre-0.8.3-marked code:
```
beacon_chain/spec/state_transition_block.nim:317:# https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#deposits
beacon_chain/spec/beaconstate.nim:49:# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#deposits
beacon_chain/spec/state_transition_block.nim:377:# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#transfers
beacon_chain/spec/state_transition_block.nim:198:# https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#attester-slashings
beacon_chain/spec/state_transition_block.nim:140:# https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#proposer-slashings
beacon_chain/spec/state_transition_block.nim:330:# https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#voluntary-exits
beacon_chain/spec/state_transition_block.nim:250:# https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#attestations
```

All but a couple are related to the `process_operations` refactoring from https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#operations whereby the max operations per block limit checks are lifted to the callers. They should not affect interop.