### PR TITLE
Fix genesis blockheader zero signature (supercedes #395) - part 1

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -229,7 +229,11 @@ func initialize_beacon_state_from_eth1*(
     eth1_data:
       Eth1Data(block_hash: eth1_block_hash, deposit_count: uint64(len(deposits))),
     latest_block_header:
-      BeaconBlockHeader(body_root: hash_tree_root(BeaconBlockBody())),
+      BeaconBlockHeader(
+        body_root: hash_tree_root(BeaconBlockBody()),
+        # TODO - Pure BLSSig cannot be zero: https://github.com/status-im/nim-beacon-chain/issues/374
+        signature: BlsValue[Signature](kind: OpaqueBlob)
+      )
   )
 
   # Process deposits

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -220,7 +220,7 @@ proc fromBytes*[T](R: type BlsValue[T], bytes: openarray[byte]): R =
     R(kind: OpaqueBlob, blob: toArray(result.blob.len, bytes))
   else:
     if bytes.allIt(it == 0):
-      R(kind: Real)
+      R(kind: OpaqueBlob)
     else:
       R(kind: Real, blsValue: init(T, bytes))
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -15,8 +15,9 @@ import # Unit test
   ./test_interop,
   ./test_ssz,
   ./test_state_transition,
-  ./test_sync_protocol
+  ./test_sync_protocol,
   # ./test_validator # Empty!
+  ./test_zero_signature
 
 import # Refactor state transition unit tests
   ./spec_block_processing/test_genesis,

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -1,0 +1,53 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  unittest,
+  ../beacon_chain/spec/[datatypes, crypto],
+  ../beacon_chain/ssz
+
+# Sanity checks to make sure all the workarounds introduced
+# to deal with https://github.com/status-im/nim-beacon-chain/issues/374
+# and https://github.com/ethereum/eth2.0-specs/issues/1396
+# don't blow up.
+
+suite "Zero signature sanity checks":
+  # Using signature directly triggers a bug
+  # in object_serialization/stew: https://github.com/status-im/nim-beacon-chain/issues/396
+
+  # test "SSZ serialization round-trip doesn't un-zero the signature":
+
+  #   let zeroSig = BlsValue[Signature](kind: OpaqueBlob)
+  #   check:
+  #     block:
+  #       var allZeros = true
+  #       for val in zeroSig.blob:
+  #         allZeros = allZeros and val == 0
+  #       allZeros
+
+  #   let sszZeroSig = SSZ.encode(zeroSig)
+  #   let deserZeroSig = SSZ.decode(sszZeroSig, ValidatorSig)
+
+  #   check(zeroSIg == deserZeroSig)
+
+  test "SSZ serialization roundtrip of BeaconBlockHeader":
+
+    let defaultBlockHeader = BeaconBlockHeader(
+      signature: BlsValue[Signature](kind: OpaqueBlob)
+    )
+
+    check:
+      block:
+        var allZeros = true
+        for val in defaultBlockHeader.signature.blob:
+          allZeros = allZeros and val == 0
+        allZeros
+
+    let sszDefaultBlockHeader = SSZ.encode(defaultBlockHeader)
+    let deserBlockHeader = SSZ.decode(sszDefaultBlockHeader, BeaconBlockHeader)
+
+    check(defaultBlockHeader == deserBlockHeader)


### PR DESCRIPTION
Split commits from #399 

Keep only the commits that don't require a huge change in the old outdated test suite (and state_sim)