### PR TITLE
disable proposer slashing tests only on 64-bit windows

### DIFF
--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -64,13 +64,16 @@ template runTest(identifier: untyped) =
   `testImpl_proposer_slashing _ identifier`()
 
 suite "Official - Operations - Proposer slashing " & preset():
-  runTest(success)
-  runTest(invalid_sig_1)
-  runTest(invalid_sig_2)
-  runTest(invalid_sig_1_and_2)
-  runTest(invalid_proposer_index)
-  runTest(epochs_are_different)
-  runTest(headers_are_same)
-  runTest(proposer_is_not_activated)
-  runTest(proposer_is_slashed)
-  runTest(proposer_is_withdrawn)
+  # TODO https://github.com/status-im/nim-beacon-chain/issues/435
+  # CI Win64 - "The parameter is incorrect"
+  when not (defined(windows) and sizeof(int) == 8):
+    runTest(success)
+    runTest(invalid_sig_1)
+    runTest(invalid_sig_2)
+    runTest(invalid_sig_1_and_2)
+    runTest(invalid_proposer_index)
+    runTest(epochs_are_different)
+    runTest(headers_are_same)
+    runTest(proposer_is_not_activated)
+    runTest(proposer_is_slashed)
+    runTest(proposer_is_withdrawn)

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -77,3 +77,5 @@ suite "Official - Operations - Proposer slashing " & preset():
     runTest(proposer_is_not_activated)
     runTest(proposer_is_slashed)
     runTest(proposer_is_withdrawn)
+  else:
+    echo "Skipped for Windows 64-bit CI"


### PR DESCRIPTION
Pending https://github.com/status-im/nim-beacon-chain/issues/435 being resolved.