### PR TITLE
[Interop branch] Log improvements - part 1

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -45,6 +45,8 @@ declareGauge beacon_pending_exits, "Number of pending voluntary exits in local o
 declareGauge beacon_previous_epoch_orphaned_blocks, "Number of blocks orphaned in the previous epoch" # On epoch transition
 declareCounter beacon_reorgs_total, "Total occurrences of reorganizations of the chain" # On fork choice
 
+logScope: topics = "beacnode"
+
 proc onBeaconBlock*(node: BeaconNode, blck: BeaconBlock) {.gcsafe.}
 
 func localValidatorsDir(conf: BeaconNodeConf): string =
@@ -340,6 +342,8 @@ proc sendAttestation(node: BeaconNode,
                      attestationData: AttestationData,
                      committeeLen: int,
                      indexInCommittee: int) {.async.} =
+  logScope: pcs = "send_attestation"
+
   let
     validatorSignature = await validator.signAttestation(attestationData, state)
 
@@ -365,22 +369,20 @@ proc sendAttestation(node: BeaconNode,
     validator = shortLog(validator),
     signature = shortLog(validatorSignature),
     indexInCommittee = indexInCommittee,
-    service = "beacon_node",
-    category = "attestation",
-    process = "send_attestation"
+    cat = "consensus"
 
 proc proposeBlock(node: BeaconNode,
                   validator: AttachedValidator,
                   head: BlockRef,
                   slot: Slot): Future[BlockRef] {.async.} =
+  logScope: pcs = "block_proposal"
+
   if head.slot > slot:
-    notice "[Block Pool] Skipping proposal, we've already selected a newer head",
+    notice "Skipping proposal, we've already selected a newer head",
       headSlot = shortLog(head.slot),
       headBlockRoot = shortLog(head.root),
       slot = shortLog(slot),
-      service = "beacon_node",
-      category = "block_proposal",
-      process = "skip_proposal"
+      cat = "fastforward"
     return head
 
   if head.slot == slot:
@@ -389,9 +391,7 @@ proc proposeBlock(node: BeaconNode,
     warn "Found head at same slot as we're supposed to propose for!",
       headSlot = shortLog(head.slot),
       headBlockRoot = shortLog(head.root),
-      service = "beacon_node",
-      category = "block_proposal",
-      process = "proposal_conflict"
+      cat = "consensus_conflict"
     # TODO investigate how and when this happens.. maybe it shouldn't be an
     #      assert?
     doAssert false, "head slot matches proposal slot (!)"
@@ -457,18 +457,14 @@ proc proposeBlock(node: BeaconNode,
     warn "Unable to add proposed block to block pool",
       newBlock = shortLog(newBlock),
       blockRoot = shortLog(blockRoot),
-      service = "beacon_node",
-      category = "block_proposal",
-      process = "propose_block"
+      cat = "bug"
     return head
 
-  info "[Beacon node] Block proposed",
+  info "Block proposed",
     blck = shortLog(newBlock),
     blockRoot = shortLog(newBlockRef.root),
     validator = shortLog(validator),
-    service = "beacon_node",
-    category = "block_proposal",
-    process = "propose_block"
+    cat = "consensus"
 
   SSZ.saveFile(
     node.config.dataDir / "dump" / "block-" & $newBlock.slot & ".ssz", newBlock)
@@ -484,12 +480,12 @@ proc onAttestation(node: BeaconNode, attestation: Attestation) =
   # We received an attestation from the network but don't know much about it
   # yet - in particular, we haven't verified that it belongs to particular chain
   # we're on, or that it follows the rules of the protocol
-  debug "[Beacon node] Attestation received",
+  logScope: pcs = "on_attestation"
+
+  debug "Attestation received",
     attestationData = shortLog(attestation.data),
     signature = shortLog(attestation.signature),
-    service = "beacon_node",
-    category = "attestation",
-    process = "attestation_received"
+    cat = "consensus" # Tag "consensus|attestation"?
 
   if (let attestedBlock = node.blockPool.getOrResolve(
         attestation.data.beacon_block_root); attestedBlock != nil):
@@ -498,13 +494,11 @@ proc onAttestation(node: BeaconNode, attestation: Attestation) =
       head = node.blockPool.head
 
     if not wallSlot.afterGenesis or wallSlot.slot < head.blck.slot:
-      warn "[Beacon node] Received attestation before genesis or head - clock is wrong?",
+      warn "Received attestation before genesis or head - clock is wrong?",
         afterGenesis = wallSlot.afterGenesis,
         wallSlot = shortLog(wallSlot.slot),
         headSlot = shortLog(head.blck.slot),
-        service = "beacon_node",
-        category = "attestation",
-        process = "clock_drift"
+        cat = "clock_drift" # Tag "attestation|clock_drift"?
       return
 
     # TODO seems reasonable to use the latest head state here.. needs thinking
@@ -523,12 +517,11 @@ proc onBeaconBlock(node: BeaconNode, blck: BeaconBlock) =
   # We received a block but don't know much about it yet - in particular, we
   # don't know if it's part of the chain we're currently building.
   let blockRoot = signing_root(blck)
-  debug "[Beacon node] Block received",
+  debug "Block received",
     blck = shortLog(blck),
     blockRoot = shortLog(blockRoot),
-    service = "beacon_node",
-    category = "block_listener",
-    process = "receive_block"
+    cat = "block_listener",
+    pcs = "receive_block"
 
   if node.blockPool.add(node.stateCache, blockRoot, blck).isNil:
     return
@@ -543,6 +536,7 @@ proc onBeaconBlock(node: BeaconNode, blck: BeaconBlock) =
 proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
   ## Perform all attestations that the validators attached to this node should
   ## perform during the given slot
+  logScope: pcs = "on_attestation"
 
   if slot + SLOTS_PER_EPOCH < head.slot:
     # The latest block we know about is a lot newer than the slot we're being
@@ -566,12 +560,10 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
       attestationHeadSlot = shortLog(attestationHead.slot),
       attestationSlot = shortLog(slot)
 
-  trace "[Beacon Node] Checking attestations",
+  trace "Checking attestations",
     attestationHeadRoot = shortLog(attestationHead.blck.root),
     attestationSlot = shortLog(slot),
-    service = "beacon_node",
-    category = "attestation",
-    process = "checking_attestation"
+    cat = "attestation"
 
   # Collect data to send before node.stateCache grows stale
   var attestations: seq[tuple[
@@ -628,13 +620,12 @@ proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
     if validator != nil:
       return await proposeBlock(node, validator, head, slot)
 
-    trace "[Beacon Node] Expecting block proposal",
+    trace "Expecting block proposal",
       headRoot = shortLog(head.root),
       slot = shortLog(slot),
       proposer = shortLog(state.validators[proposerIdx].pubKey),
-      service = "beacon_node",
-      category = "block_proposal",
-      process = "wait_for_proposal"
+      cat = "consensus",
+      pcs = "wait_for_proposal"
 
   return head
 
@@ -645,30 +636,28 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
   ##           start work from
   ## scheduledSlot: the slot that we were aiming for, in terms of timing
 
+  logScope: pcs = "slot_start"
+
   let
     # The slot we should be at, according to the clock
     beaconTime = node.beaconClock.now()
     wallSlot = beaconTime.toSlot()
 
-  debug "[Beacon node] Slot start",
+  debug "Slot start",
     lastSlot = shortLog(lastSlot),
     scheduledSlot = shortLog(scheduledSlot),
     beaconTime = shortLog(beaconTime),
-    service = "beacon_node",
-    category = "scheduling",
-    process = "slot_start"
+    cat = "scheduling"
 
   if not wallSlot.afterGenesis or (wallSlot.slot < lastSlot):
     # This can happen if the system clock changes time for example, and it's
     # pretty bad
     # TODO shut down? time either was or is bad, and PoS relies on accuracy..
-    warn "[Beacon Node] Beacon clock time moved back, rescheduling slot actions",
+    warn "Beacon clock time moved back, rescheduling slot actions",
       beaconTime = shortLog(beaconTime),
       lastSlot = shortLog(lastSlot),
       scheduledSlot = shortLog(scheduledSlot),
-      service = "beacon_node",
-      category = "scheduling",
-      process = "clock_drift"
+      cat = "clock_drift" # tag "scheduling|clock_drift"?
 
     let
       slot = Slot(
@@ -694,13 +683,11 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     # TODO how long should the period be? Using an epoch because that's roughly
     #      how long attestations remain interesting
     # TODO should we shut down instead? clearly we're unable to keep up
-    warn "[Beacon node] Unable to keep up, skipping ahead without doing work",
+    warn "Unable to keep up, skipping ahead without doing work",
       lastSlot = shortLog(lastSlot),
       slot = shortLog(slot),
       scheduledSlot = shortLog(scheduledSlot),
-      service = "beacon_node",
-      category = "scheduling",
-      process = "overwhelmed"
+      cat = "overload"
 
     addTimer(saturate(node.beaconClock.fromNow(nextSlot))) do (p: pointer):
       # We pass the current slot here to indicate that work should be skipped!
@@ -739,13 +726,11 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     # TODO maybe even collect all work synchronously to avoid unnecessary
     #      state rewinds while waiting for async operations like validator
     #      signature..
-    notice "[Beacon node] Catching up",
+    notice "Catching up",
       curSlot = shortLog(curSlot),
       lastSlot = shortLog(lastSlot),
       slot = shortLog(slot),
-      service = "beacon_node",
-      category = "scheduling",
-      process = "catching_up"
+      cat = "overload"
 
     # For every slot we're catching up, we'll propose then send
     # attestations - head should normally be advancing along the same branch
@@ -783,9 +768,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     trace "Waiting to send attestations",
       slot = shortLog(slot),
       fromNow = shortLog(fromNow),
-      service = "beacon_node",
-      category = "scheduling",
-      process = "attestation_in_future"
+      cat = "scheduling"
 
     await sleepAsync(fromNow)
 
@@ -825,13 +808,11 @@ proc run*(node: BeaconNode) =
                 else: GENESIS_SLOT + 1
     fromNow = saturate(node.beaconClock.fromNow(startSlot))
 
-  info "[Beacon node] Scheduling first slot action",
+  info "Scheduling first slot action",
     beaconTime = shortLog(node.beaconClock.now()),
     nextSlot = shortLog(startSlot),
     fromNow = shortLog(fromNow),
-    service = "beacon_node",
-    category = "scheduling",
-    process = "first_slot"
+    cat = "scheduling"
 
   addTimer(fromNow) do (p: pointer):
     asyncCheck node.onSlotStart(startSlot - 1, startSlot)
@@ -865,9 +846,8 @@ proc start(node: BeaconNode, headState: BeaconState) =
     SLOTS_PER_EPOCH,
     SECONDS_PER_SLOT,
     SPEC_VERSION,
-    service = "beacon_node",
-    category = "init",
-    process = "init_beacon_node"
+    cat = "init",
+    pcs = "start_beacon_node"
 
   node.addLocalValidators(headState)
   node.run()

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -45,7 +45,7 @@ declareGauge beacon_pending_exits, "Number of pending voluntary exits in local o
 declareGauge beacon_previous_epoch_orphaned_blocks, "Number of blocks orphaned in the previous epoch" # On epoch transition
 declareCounter beacon_reorgs_total, "Total occurrences of reorganizations of the chain" # On fork choice
 
-logScope: topics = "beacnode"
+logScope: topics = "beacnde"
 
 proc onBeaconBlock*(node: BeaconNode, blck: BeaconBlock) {.gcsafe.}
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -324,20 +324,9 @@ proc updateHead(node: BeaconNode, slot: Slot): BlockRef =
   let
     justifiedHead = node.blockPool.latestJustifiedBlock()
 
-  debug "Preparing for fork choice",
-    justifiedHeadRoot = shortLog(justifiedHead.blck.root),
-    justifiedHeadSlot = shortLog(justifiedHead.slot),
-    justifiedHeadEpoch = shortLog(justifiedHead.slot.compute_epoch_of_slot),
-    connectedPeers = node.network.peersCount
-
   let newHead = node.blockPool.withState(
       node.justifiedStateCache, justifiedHead):
     lmdGhost(node.attestationPool, state, justifiedHead.blck)
-
-  info "Fork chosen",
-    newHeadSlot = shortLog(newHead.slot),
-    newHeadEpoch = shortLog(newHead.slot.computeEpochOfSlot),
-    newHeadBlockRoot = shortLog(newHead.root)
 
   node.blockPool.updateHead(node.stateCache, newHead)
   beacon_head_slot.set slot.int64
@@ -553,7 +542,7 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
       attestationHeadSlot = shortLog(attestationHead.slot),
       attestationSlot = shortLog(slot)
 
-  debug "Checking attestations",
+  trace "Checking attestations",
     attestationHeadRoot = shortLog(attestationHead.blck.root),
     attestationSlot = shortLog(slot)
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -707,7 +707,7 @@ proc preInit*(
   let
     blockRoot = signing_root(blck)
 
-  notice "[Block Pool] Creating new database from snapshot",
+  notice "[Block Pool] New database from snapshot",
     blockRoot = shortLog(blockRoot),
     stateRoot = shortLog(blck.state_root),
     fork = state.fork,

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -182,7 +182,7 @@ proc addResolvedBlock(
       justified: blockRef.findAncestorBySlot(justifiedSlot)))
     pool.heads.add(foundHead.get())
 
-  info "Block resolved",
+  info "[Block pool] Block resolved",
     blck = shortLog(blck),
     blockRoot = shortLog(blockRoot),
     justifiedRoot = shortLog(foundHead.get().justified.blck.root),


### PR DESCRIPTION
Part 1 of log improvements (#437) so that we don't drawn other implementers teams in messages
Target is interop branch.

The main changes are:
- the service/category/process, this will make it easier to filter the logs in the future. Everything should be rediscussed so that we have something that makes sense and easy to navigate through.
  For example maybe we should use trigrams for service code as we're really short on characters per line
- AFAIK chronicles priority is trace/debug/info/notice/warn/error:
  - Some logs were deleted as they were duplicate of logs given by a procedure called just after i.e. "Slot start"/"Scheduling slot action"
  - some were very noisy "Fork chosen"/"Preparing for fork choice"/"Updated head", only the result was kept.
- A couple of logs relegated to tracing (growing attestation pool, ignoring subset attestation, checking attestations)

No logic was changed in this PR, future changes:

1. skip block received/attestation received for our own block/attestation.
2. try to make most non-warning messages fit on a single line of a laptop screen.
  