### PR TITLE
Add detailed finalization and justification debug logs

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -322,7 +322,7 @@ proc process_justification_and_finalization*(
      old_current_justified_checkpoint.epoch + 1 == current_epoch:
     state.finalized_checkpoint = old_current_justified_checkpoint
 
-    debug "Finalized with rule 123",
+    debug "Finalized with rule 12",
       current_epoch = current_epoch,
       checkpoint = shortLog(state.finalized_checkpoint),
       cat = "finalization"


### PR DESCRIPTION
On `nim c -r -o:build/test tests/official/test_fixture_state_transition_epoch.nim`

The output is now

```
[Suite] Official - Epoch Processing - Justification & Finalization [Preset: minimal]
  [OK] Justification & Finalization - 123_poor_support [Preset: minimal]
  [OK] Justification & Finalization - 234_poor_support [Preset: minimal]
  [OK] Justification & Finalization - 12_poor_support [Preset: minimal]
DBG 2019-09-23 13:01:38+02:00 Justified with previous epoch              topics="consens" tid=128525 cat=justification checkpoint="(epoch: 3, root: \"bbbbbbbb\")" current_epoch=4 pcs=process_justification_and_finalization
DBG 2019-09-23 13:01:38+02:00 Finalized with rule 234                    topics="consens" tid=128525 cat=finalization checkpoint="(epoch: 1, root: \"dddddddd\")" current_epoch=4 pcs=process_justification_and_finalization
  [OK] Justification & Finalization - 234_ok_support [Preset: minimal]
DBG 2019-09-23 13:01:38+02:00 Justified with previous epoch              topics="consens" tid=128525 cat=justification checkpoint="(epoch: 2, root: \"bbbbbbbb\")" current_epoch=3 pcs=process_justification_and_finalization
DBG 2019-09-23 13:01:38+02:00 Finalized with rule 23                     topics="consens" tid=128525 cat=finalization checkpoint="(epoch: 1, root: \"cccccccc\")" current_epoch=3 pcs=process_justification_and_finalization
  [OK] Justification & Finalization - 23_ok_support [Preset: minimal]
  [OK] Justification & Finalization - 23_poor_support [Preset: minimal]
DBG 2019-09-23 13:01:38+02:00 Justified with current epoch               topics="consens" tid=128525 cat=justification checkpoint="(epoch: 2, root: \"aaaaaaaa\")" current_epoch=2 pcs=process_justification_and_finalization
DBG 2019-09-23 13:01:38+02:00 Finalized with rule 123                    topics="consens" tid=128525 cat=finalization checkpoint="(epoch: 1, root: \"bbbbbbbb\")" current_epoch=2 pcs=process_justification_and_finalization
  [OK] Justification & Finalization - 12_ok_support [Preset: minimal]
DBG 2019-09-23 13:01:38+02:00 Justified with previous epoch              topics="consens" tid=128525 cat=justification checkpoint="(epoch: 4, root: \"bbbbbbbb\")" current_epoch=5 pcs=process_justification_and_finalization
DBG 2019-09-23 13:01:38+02:00 Justified with current epoch               topics="consens" tid=128525 cat=justification checkpoint="(epoch: 5, root: \"aaaaaaaa\")" current_epoch=5 pcs=process_justification_and_finalization
DBG 2019-09-23 13:01:38+02:00 Finalized with rule 123                    topics="consens" tid=128525 cat=finalization checkpoint="(epoch: 3, root: \"cccccccc\")" current_epoch=5 pcs=process_justification_and_finalization
  [OK] Justification & Finalization - 123_ok_support [Preset: minimal]
```

Note that the 12_ok_support test is finalized with rule 123 which might be a bug in upstream test case or a bug in our code.