### PR TITLE
Fix TRACE chronicles_log_level

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -35,7 +35,8 @@
 import # TODO - cleanup imports
   algorithm, collections/sets, chronicles, math, options, sequtils, sets, tables,
   ../extras, ../ssz, ../beacon_node_types,
-  beaconstate, crypto, datatypes, digest, helpers, validator
+  beaconstate, crypto, datatypes, digest, helpers, validator,
+  state_transition_helpers
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#block-header
 proc process_block_header*(
@@ -262,14 +263,6 @@ proc processAttesterSlashings(state: var BeaconState, blck: BeaconBlock,
     if not process_attester_slashing(state, attester_slashing, stateCache):
       return false
   return true
-
-func get_attesting_indices(
-    state: BeaconState, attestations: openarray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
-  result = initSet[ValidatorIndex]()
-  for a in attestations:
-    result = result.union(get_attesting_indices(
-      state, a.data, a.aggregation_bits, stateCache))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.6.3/specs/core/0_beacon-chain.md#attestations
 proc processAttestations*(

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -36,17 +36,13 @@ import # TODO - cleanup imports
   algorithm, math, options, sequtils, tables,
   stew/[bitseqs, bitops2], chronicles, json_serialization/std/sets,
   ../extras, ../ssz, ../beacon_node_types,
-  beaconstate, crypto, datatypes, digest, helpers, validator
+  beaconstate, crypto, datatypes, digest, helpers, validator,
+  state_transition_helpers
 
 # Logging utilities
 # --------------------------------------------------------
 
 logScope: topics = "consens"
-
-# TODO: gather all logging utilities
-#       from crypto, digest, etc in a single file
-func shortLog(x: Checkpoint): string =
-  "(epoch: " & $x.epoch & ", root: \"" & shortLog(x.root) & "\")"
 
 # Spec
 # --------------------------------------------------------
@@ -80,22 +76,6 @@ func get_matching_head_attestations(state: BeaconState, epoch: Epoch):
      it.data.beacon_block_root ==
        get_block_root_at_slot(state, get_attestation_data_slot(state, it.data))
   )
-
-func get_attesting_indices(
-    state: BeaconState, attestations: openarray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
-  result = initSet[ValidatorIndex]()
-  for a in attestations:
-    result = result.union(get_attesting_indices(
-      state, a.data, a.aggregation_bits, stateCache))
-
-func get_unslashed_attesting_indices*(
-    state: BeaconState, attestations: openarray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
-  result = get_attesting_indices(state, attestations, stateCache)
-  for index in result:
-    if state.validators[index].slashed:
-      result.excl index
 
 func get_attesting_balance(
     state: BeaconState, attestations: seq[PendingAttestation],

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -1,0 +1,40 @@
+# beacon_chain
+# Copyright (c) 2018-2019 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  sets,
+  # Internals
+  ./datatypes, ./digest, ./beaconstate
+
+# Logging utilities
+# --------------------------------------------------------
+
+# TODO: gather all logging utilities
+#       from crypto, digest, etc in a single file
+func shortLog*(x: Checkpoint): string =
+  "(epoch: " & $x.epoch & ", root: \"" & shortLog(x.root) & "\")"
+
+# Helpers used in epoch transition and trace-level block transition
+# --------------------------------------------------------
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#helper-functions-1
+func get_attesting_indices*(
+    state: BeaconState, attestations: openarray[PendingAttestation],
+    stateCache: var StateCache): HashSet[ValidatorIndex] =
+  result = initSet[ValidatorIndex]()
+  for a in attestations:
+    result = result.union(get_attesting_indices(
+      state, a.data, a.aggregation_bits, stateCache))
+
+func get_unslashed_attesting_indices*(
+    state: BeaconState, attestations: openarray[PendingAttestation],
+    stateCache: var StateCache): HashSet[ValidatorIndex] =
+  result = get_attesting_indices(state, attestations, stateCache)
+  for index in result:
+    if state.validators[index].slashed:
+      result.excl index


### PR DESCRIPTION
The project could not be compiled with `-d:chronicles_log_level=TRACE` because that required get_unslashed_attesting_indices visibility in state_transition_blocks:

https://github.com/status-im/nim-beacon-chain/blob/b100ceef5679036211d01bd322d04325cd38a0f2/beacon_chain/spec/state_transition_block.nim#L328-L337

This PR splits those functions in a new file to limit coupling between blocks and epochs transitions.

Furthermore `get_attesting_indices` was defined in both state_transition_block and state_transition_epoch