### PR TITLE
Crypto refactor [Abandonned, side-effect or `==` issue, need 0.20 / 1.0]

### DIFF
--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -16,7 +16,7 @@ func get_eth1data_stub*(deposit_count: uint64, current_epoch: Epoch): Eth1Data =
     block_hash: hash_tree_root(hash_tree_root(voting_period).data),
   )
 
-when ValidatorPrivKey is BlsValue:
+when ValidatorPrivKey is LazyBls:
   func makeInteropPrivKey*(i: int): ValidatorPrivKey =
     discard
     {.fatal: "todo/unused?".}

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -47,9 +47,9 @@ func decrease_balance*(
       state.balances[index] - delta
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/core/0_beacon-chain.md#deposits
-func process_deposit*(
+proc process_deposit*(
     state: var BeaconState, deposit: Deposit, flags: UpdateFlags = {}): bool =
-  # Process an Eth1 deposit, registering a validator or increasing its balance.
+  ## Process an Eth1 deposit, registering a validator or increasing its balance.
 
   # Verify the Merkle branch
   # TODO enable this check, but don't use doAssert
@@ -202,7 +202,7 @@ func get_compact_committees_root*(state: BeaconState, epoch: Epoch): Eth2Digest 
   hash_tree_root(committees)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#genesis
-func initialize_beacon_state_from_eth1*(
+proc initialize_beacon_state_from_eth1*(
     eth1_block_hash: Eth2Digest,
     eth1_timestamp: uint64,
     deposits: openArray[Deposit],

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -234,7 +234,7 @@ func initialize_beacon_state_from_eth1*(
       BeaconBlockHeader(
         body_root: hash_tree_root(BeaconBlockBody()),
         # TODO - Pure BLSSig cannot be zero: https://github.com/status-im/nim-beacon-chain/issues/374
-        signature: BlsValue[Signature](kind: OpaqueBlob)
+        signature: LazyBls[Signature](kind: OpaqueBlob)
       )
   )
 

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -61,8 +61,10 @@ export
 
 type
   LazyBlsType* = enum
-    Real
+    # We want OpaqueBlob to be the default
+    # - https://github.com/status-im/nim-beacon-chain/issues/412
     OpaqueBlob
+    Real
 
   LazyBls*[T] = object
     # This is a wrapper to handle potentially invalid
@@ -73,8 +75,11 @@ type
     #
     # Values are lazily checked and transformed into concrete BLS value
     # on usage, to avoid a huge startup cost (if we have parse a state with
-    # thousands of signatures for example)
+    # thousands of signatures for example or load a state from a database)
+    alreadyChecked: bool
     case kind*: LazyBlsType
+    # Note: this requires a temporary buffer
+    #       for conversion between OpaqueBlob and Real
     of Real:
       blsValue*: T
     of OpaqueBlob:
@@ -83,24 +88,17 @@ type
       else:
         blob*: array[48, byte]
 
-  ValidatorPubKey* = LazyBls[blscurve.VerKey]
-  # ValidatorPubKey* = blscurve.VerKey
-
-  # ValidatorPubKey* = array[48, byte]
-  # The use of byte arrays proved to be a dead end pretty quickly.
-  # Plenty of code needs to be modified for a successful build and
-  # the changes will negatively affect the performance.
-
-  # ValidatorPrivKey* = LazyBls[blscurve.SigKey]
   ValidatorPrivKey* = blscurve.SigKey
-
+  ValidatorPubKey* = LazyBls[blscurve.VerKey]
   ValidatorSig* = LazyBls[blscurve.Signature]
 
   BlsCurveType* = VerKey|SigKey|Signature
   ValidatorPKI* = ValidatorPrivKey|ValidatorPubKey|ValidatorSig
 
 proc init*[T](BLS: type LazyBls[T], val: auto): BLS =
-  result.kind = LazyBlsType.Real
+  # Val can be T or an array of bytes
+  result.kind = Real
+  result.alreadyChecked = true
   result.blsValue = init(T, val)
 
 func `$`*(x: LazyBls): string =
@@ -111,8 +109,41 @@ func `$`*(x: LazyBls): string =
     # due to the mechanics of the `shortLog` function.
     "r:" & toHex(x.blob, true)
 
-func `==`*(a, b: LazyBls): bool =
-  if a.kind != b.kind: return false
+proc unsafePromote*[T](a: LazyBls[T]) =
+  ## Try promoting an opaque blob to its corresponding
+  ## BLS value.
+  ##
+  ## ⚠️ Warning - unsafe.
+  ## At a low-level we mutate the input but all API like
+  ## bls_sign, bls_verify assume that their inputs are immutable
+
+  if a.alreadyChecked:
+    return
+  assert a.kind == OpaqueBlob
+
+  # Try if valid BLS value
+  var buffer: T
+  let success = blscurve.init(buffer, a.blob) # Stew symbol conflict: https://github.com/status-im/nim-stew/issues/9
+
+  # # Unsafe hidden mutation of the input
+  let ptr_a = a.unsafeAddr
+
+  if true:
+    ptr_a.kind = Real
+    ptr_a.blsValue = buffer
+  # TODO: chronicles trace
+  ptr_a.alreadyChecked = true
+
+proc `==`*(a, b: LazyBls): bool =
+  # TODO: We can't unsafePromote here as it
+  #       it has side-effect https://github.com/status-im/nim-blscurve/issues/27
+  #       and you get ../vendor/nimbus-build-system/vendor/Nim/lib/system.nim(2474, 6) Error: '==' can have side effects
+  #
+  #       Furthermore, the "{.noSideEffect.}: body" syntax only exist in 0.20+
+  # unsafePromote(a)
+  # unsafePromote(b)
+  if a.kind != b.kind:
+    return false
   if a.kind == Real:
     return a.blsValue == b.blsValue
   else:
@@ -146,48 +177,43 @@ template `==`*[T](a: T, b: LazyBls[T]): bool =
   a == b.blsValue
 
 func pubKey*(pk: ValidatorPrivKey): ValidatorPubKey =
-  when ValidatorPubKey is LazyBls:
-    ValidatorPubKey(kind: Real, blsValue: pk.getKey())
-  elif ValidatorPubKey is array:
-    pk.getKey.getBytes
-  else:
-    pk.getKey
-
-proc init(T: type VerKey): VerKey =
-  result.point.inf()
-
-proc init(T: type SigKey): SigKey =
-  result.point.inf()
+  ValidatorPubKey(
+    kind: Real,
+    alreadyChecked: true,
+    blsValue: pk.getKey()
+  )
 
 proc combine*[T](values: openarray[LazyBls[T]]): LazyBls[T] =
-  result = LazyBls[T](kind: Real, blsValue: T.init())
+  result.kind = Real
+  result.alreadyChecked = true
+  init(result.blsValue)
 
-  for value in values:
-    result.blsValue.combine(value.blsValue)
+  for i in 0 ..< values.len:
+    unsafePromote(values[i])
+    result.blsValue.combine(values[i].blsValue)
 
 proc combine*[T](x: var LazyBls[T], other: LazyBls[T]) =
   doAssert x.kind == Real and other.kind == Real
   x.blsValue.combine(other.blsValue)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/bls_signature.md#bls_aggregate_pubkeys
-func bls_aggregate_pubkeys*(keys: openArray[ValidatorPubKey]): ValidatorPubKey =
+proc bls_aggregate_pubkeys*(keys: openArray[ValidatorPubKey]): ValidatorPubKey =
   keys.combine()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/bls_signature.md#bls_verify
-func bls_verify*(
+proc bls_verify*(
     pubkey: ValidatorPubKey, msg: openArray[byte], sig: ValidatorSig,
     domain: Domain): bool =
   # name from spec!
+  unsafePromote(sig)
   if sig.kind != Real:
     # Invalid signatures are possible in deposits (discussed with Danny)
     return false
-  when ValidatorPubKey is LazyBls:
-    if sig.kind != Real or pubkey.kind != Real:
-      # TODO: chronicles warning
-      return false
-    sig.blsValue.verify(msg, domain, pubkey.blsValue)
-  else:
-    sig.verify(msg, domain, pubkey)
+  unsafePromote(pubkey)
+  if pubkey.kind != Real:
+    # TODO: chronicles warning
+    return false
+  sig.blsValue.verify(msg, domain, pubkey.blsValue)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/bls_signature.md#bls_verify_multiple
 proc bls_verify_multiple*(
@@ -214,34 +240,24 @@ proc bls_verify_multiple*(
 
   true
 
-when ValidatorPrivKey is LazyBls:
-  func bls_sign*(key: ValidatorPrivKey, msg: openarray[byte],
-                 domain: Domain): ValidatorSig =
-    # name from spec!
-    if key.kind == Real:
-      ValidatorSig(kind: Real, blsValue: key.blsValue.sign(domain, msg))
-    else:
-      ValidatorSig(kind: OpaqueBlob)
-else:
-  func bls_sign*(key: ValidatorPrivKey, msg: openarray[byte],
-                 domain: Domain): ValidatorSig =
-    # name from spec!
-    ValidatorSig(kind: Real, blsValue: key.sign(domain, msg))
+func bls_sign*(key: ValidatorPrivKey, msg: openarray[byte],
+                domain: Domain): ValidatorSig =
+  # name from spec!
+  ValidatorSig(
+    kind: Real,
+    alreadyChecked: true,
+    blsValue: key.sign(domain, msg)
+  )
 
 proc fromBytes*[T](R: type LazyBls[T], bytes: openarray[byte]): R =
-  # This is a workaround, so that we can deserialize the serialization of a
-  # default-initialized LazyBls without raising an exception
+  # TODO: spurious memcpy checks:
+  #   - for result initialization (would need {.noInit.})
+  #   - when we assign toArray to result.blob
+  result.kind = OpaqueBlob
+  result.blob = toArray(result.blob.len, bytes)
   when defined(ssz_testing):
-    # Only for SSZ parsing tests, everything is an opaque blob
-    R(kind: OpaqueBlob, blob: toArray(result.blob.len, bytes))
-  else:
-    # Try if valid BLS value
-    let success = init(result.blsValue, bytes)
-    if not success:
-      # TODO: chronicles trace
-      result = R(kind: OpaqueBlob)
-      assert result.blob.len == bytes.len
-      result.blob[result.blob.low .. result.blob.high] = bytes
+    # Only for SSZ parsing tests, everything is and must stay an opaque blob
+    result.alreadyChecked = true
 
 proc initFromBytes*[T](val: var LazyBls[T], bytes: openarray[byte]) =
   val = fromBytes(LazyBls[T], bytes)
@@ -250,68 +266,47 @@ proc initFromBytes*(val: var BlsCurveType, bytes: openarray[byte]) =
   val = init(type(val), bytes)
 
 proc writeValue*(writer: var JsonWriter, value: ValidatorPubKey) {.inline.} =
-  when value is LazyBls:
-    doAssert value.kind == Real
-    writer.writeValue($value.blsValue)
-  else:
-    writer.writeValue($value)
+  doAssert value.kind == Real
+  writer.writeValue($value.blsValue)
+
 
 proc readValue*(reader: var JsonReader, value: var ValidatorPubKey) {.inline.} =
   value.initFromBytes(fromHex reader.readValue(string))
 
 proc writeValue*(writer: var JsonWriter, value: ValidatorSig) {.inline.} =
-  when value is LazyBls:
-    if value.kind == Real:
-      writer.writeValue($value.blsValue)
-    else:
-      # Workaround: https://github.com/status-im/nim-beacon-chain/issues/374
-      let asHex = toHex(value.blob, true)
-      # echo "[Warning] writing raw opaque signature: ", asHex
-      writer.writeValue(asHex)
+  if value.kind == Real:
+    writer.writeValue($value.blsValue)
   else:
-    writer.writeValue($value)
+    # Workaround: https://github.com/status-im/nim-beacon-chain/issues/374
+    let asHex = toHex(value.blob, true)
+    # echo "[Warning] writing raw opaque signature: ", asHex
+    writer.writeValue(asHex)
 
 proc readValue*(reader: var JsonReader, value: var ValidatorSig) {.inline.} =
   value.initFromBytes(fromHex reader.readValue(string))
 
 proc writeValue*(writer: var JsonWriter, value: ValidatorPrivKey) {.inline.} =
-  when value is LazyBls:
-    doAssert value.kind == Real
-    writer.writeValue($value.blsValue)
-  else:
-    writer.writeValue($value)
+  writer.writeValue($value)
 
 proc readValue*(reader: var JsonReader, value: var ValidatorPrivKey) {.inline.} =
   value.initFromBytes(fromHex reader.readValue(string))
 
-when ValidatorPrivKey is LazyBls:
-  proc newPrivKey*(): ValidatorPrivKey =
-    ValidatorPrivKey(kind: Real, blsValue: SigKey.random())
-else:
-  proc newPrivKey*(): ValidatorPrivKey =
-    SigKey.random()
+proc newPrivKey*(): ValidatorPrivKey =
+  SigKey.random()
 
 when networkBackend == rlpxBackend:
   import eth/rlp
 
-  when ValidatorPubKey is LazyBls:
-    proc append*(writer: var RlpWriter, value: ValidatorPubKey) =
-      writer.append if value.kind == Real: value.blsValue.getBytes()
-                    else: value.blob
-  else:
-    proc append*(writer: var RlpWriter, value: ValidatorPubKey) =
-      writer.append value.getBytes()
+  proc append*(writer: var RlpWriter, value: ValidatorPubKey) =
+    writer.append if value.kind == Real: value.blsValue.getBytes()
+                  else: value.blob
 
   proc read*(rlp: var Rlp, T: type ValidatorPubKey): T {.inline.} =
     result.initFromBytes rlp.toBytes.toOpenArray
 
-  when ValidatorSig is LazyBls:
-    proc append*(writer: var RlpWriter, value: ValidatorSig) =
-      writer.append if value.kind == Real: value.blsValue.getBytes()
-                    else: value.blob
-  else:
-    proc append*(writer: var RlpWriter, value: ValidatorSig) =
-      writer.append value.getBytes()
+  proc append*(writer: var RlpWriter, value: ValidatorSig) =
+    writer.append if value.kind == Real: value.blsValue.getBytes()
+                  else: value.blob
 
   proc read*(rlp: var Rlp, T: type ValidatorSig): T {.inline.} =
     result.initFromBytes rlp.toBytes.toOpenArray

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -169,7 +169,7 @@ func bls_aggregate_pubkeys*(keys: openArray[ValidatorPubKey]): ValidatorPubKey =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/bls_signature.md#bls_verify
 func bls_verify*(
     pubkey: ValidatorPubKey, msg: openArray[byte], sig: ValidatorSig,
-    domain: uint64): bool =
+    domain: Domain): bool =
   # name from spec!
   if sig.kind != Real:
     # Invalid signatures are possible in deposits (discussed with Danny)
@@ -185,7 +185,7 @@ func bls_verify*(
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/bls_signature.md#bls_verify_multiple
 proc bls_verify_multiple*(
     pubkeys: seq[ValidatorPubKey], message_hashes: openArray[Eth2Digest],
-    sig: ValidatorSig, domain: uint64): bool =
+    sig: ValidatorSig, domain: Domain): bool =
   # {.noSideEffect.} - https://github.com/status-im/nim-chronicles/issues/62
   let L = len(pubkeys)
   doAssert L == len(message_hashes)
@@ -209,7 +209,7 @@ proc bls_verify_multiple*(
 
 when ValidatorPrivKey is BlsValue:
   func bls_sign*(key: ValidatorPrivKey, msg: openarray[byte],
-                 domain: uint64): ValidatorSig =
+                 domain: Domain): ValidatorSig =
     # name from spec!
     if key.kind == Real:
       ValidatorSig(kind: Real, blsValue: key.blsValue.sign(domain, msg))
@@ -217,7 +217,7 @@ when ValidatorPrivKey is BlsValue:
       ValidatorSig(kind: OpaqueBlob)
 else:
   func bls_sign*(key: ValidatorPrivKey, msg: openarray[byte],
-                 domain: uint64): ValidatorSig =
+                 domain: Domain): ValidatorSig =
     # name from spec!
     ValidatorSig(kind: Real, blsValue: key.sign(domain, msg))
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -76,7 +76,6 @@ type
   ValidatorIndex* = range[0'u32 .. 0xFFFFFF'u32] # TODO: wrap-around
   Shard* = uint64
   Gwei* = uint64
-  Domain* = uint64
 
   BitList*[maxLen: static int] = distinct BitSeq
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -7,7 +7,13 @@
 
 # Uncategorized helper functions from the spec
 
-import ./datatypes, ./digest, sequtils, math, endians
+import
+  # Standard lib
+  sequtils, math, endians,
+  # Third-party
+  blscurve, # defines Domain
+  # Internal
+  ./datatypes, ./digest
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#integer_squareroot
 func integer_squareroot*(n: SomeInteger): SomeInteger =
@@ -142,11 +148,9 @@ func int_to_bytes4*(x: uint64): array[4, byte] =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#compute_domain
 func compute_domain*(
     domain_type: DomainType,
-    fork_version: array[4, byte] = [0'u8, 0, 0, 0]): uint64 =
-  var buf: array[8, byte]
-  buf[0..3] = int_to_bytes4(domain_type.uint64)
-  buf[4..7] = fork_version
-  bytes_to_int(buf)
+    fork_version: array[4, byte] = [0'u8, 0, 0, 0]): Domain =
+  result[0..3] = int_to_bytes4(domain_type.uint64)
+  result[4..7] = fork_version
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.3/specs/core/0_beacon-chain.md#get_domain
 func get_domain*(

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -68,7 +68,7 @@ proc process_block_header*(
     body_root: hash_tree_root(blck.body),
     # signature is always zeroed
     # TODO - Pure BLSSig cannot be zero: https://github.com/status-im/nim-beacon-chain/issues/374
-    signature: BlsValue[Signature](kind: OpaqueBlob)
+    signature: LazyBls[Signature](kind: OpaqueBlob)
   )
 
 

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -103,7 +103,7 @@ template toSszType*(x: auto): auto =
 
   when x is Slot|Epoch|ValidatorIndex|enum: uint64(x)
   elif x is Eth2Digest: x.data
-  elif x is BlsValue|BlsCurveType: getBytes(x)
+  elif x is LazyBls|BlsCurveType: getBytes(x)
   elif x is BitSeq|BitList: Bytes(x)
   elif x is ref|ptr: toSszType x[]
   elif x is Option: toSszType x.get
@@ -270,7 +270,7 @@ template checkEof(n: int) =
   if not r.stream[].ensureBytes(n):
     raise newException(UnexpectedEofError, "SSZ has insufficient number of bytes")
 
-template fromSszBytes*(T: type BlsValue, bytes: openarray[byte]): auto =
+template fromSszBytes*(T: type LazyBls, bytes: openarray[byte]): auto =
   fromBytes(T, bytes)
 
 template fromSszBytes*[T; N](_: type TypeWithMaxLen[T, N],

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -16,8 +16,8 @@ import
 # (fully generic available - see also https://github.com/status-im/nim-beacon-chain/commit/993789bad684721bd7c74ea14b35c2d24dbb6e51)
 # ----------------------------------------------------------------
 
-proc `==`*[T](a, b: BlsValue[T]): bool =
-  ## We sometimes need to compare real BlsValue
+proc `==`*[T](a, b: LazyBls[T]): bool =
+  ## We sometimes need to compare real LazyBls
   ## from parsed opaque blobs that are not really on the BLS curve
   ## and full of zeros
   if a.kind == Real:
@@ -97,7 +97,7 @@ proc inspectType(tImpl, xSubField, ySubField: NimNode, stmts: var NimNode) =
     elif $tImpl in builtinTypes:
       compareStmt(xSubField, ySubField, stmts)
     elif $tImpl in ["ValidatorSig", "ValidatorPubKey"]:
-      # Workaround BlsValue being a case object
+      # Workaround LazyBls being a case object
       compareStmt(xSubField, ySubField, stmts)
     else:
       inspectType(tImpl.getTypeImpl(), xSubField, ySubField, stmts)

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -16,9 +16,6 @@ import
   ./fixtures_utils
 
 type
-  Domain = distinct uint64
-    ## Domains have custom hex serialization
-
   BLSPrivToPub* = object
     input*: ValidatorPrivKey
     output*: ValidatorPubKey
@@ -42,12 +39,10 @@ type
 
 proc readValue*(r: var JsonReader, a: var Domain) {.inline.} =
   ## Custom deserializer for Domain
-  ## They are uint64 stored in hex values
   # Furthermore Nim parseHex doesn't support uint
   # until https://github.com/nim-lang/Nim/pull/11067
   # (0.20)
-  let be_uint = hexToPaddedByteArray[8](r.readValue(string))
-  bigEndian64(a.addr, be_uint.unsafeAddr)
+  a = hexToPaddedByteArray[8](r.readValue(string))
 
 const BLSDir = JsonTestsDir/"general"/"phase0"/"bls"
 
@@ -64,7 +59,7 @@ suite "Official - BLS tests":
       let t = parseTest(file, Json, BLSSignMsg)
       let implResult = t.input.privkey.bls_sign(
         t.input.message,
-        uint64(t.input.domain)
+        t.input.domain
       )
       check: implResult == t.output
 

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -21,7 +21,7 @@ suite "Zero signature sanity checks":
 
   # test "SSZ serialization round-trip doesn't un-zero the signature":
 
-  #   let zeroSig = BlsValue[Signature](kind: OpaqueBlob)
+  #   let zeroSig = LazyBls[Signature](kind: OpaqueBlob)
   #   check:
   #     block:
   #       var allZeros = true
@@ -37,7 +37,7 @@ suite "Zero signature sanity checks":
   test "SSZ serialization roundtrip of BeaconBlockHeader":
 
     let defaultBlockHeader = BeaconBlockHeader(
-      signature: BlsValue[Signature](kind: OpaqueBlob)
+      signature: LazyBls[Signature](kind: OpaqueBlob)
     )
 
     check:

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -55,7 +55,7 @@ func makeDeposit(i: int, flags: UpdateFlags): Deposit =
     privkey = makeFakeValidatorPrivKey(i)
     pubkey = privkey.pubKey()
     withdrawal_credentials = makeFakeHash(i)
-    domain = 3'u64
+    domain = compute_domain(DOMAIN_DEPOSIT)
 
   result = Deposit(
     data: DepositData(

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -16,12 +16,12 @@ import
 func preset*(): string =
   " [Preset: " & const_preset & ']'
 
-when ValidatorPrivKey is BlsValue:
+when ValidatorPrivKey is LazyBls:
   func makeFakeValidatorPrivKey*(i: int): ValidatorPrivKey =
     # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
     # lighthouse.
     # TODO: switch to https://github.com/ethereum/eth2.0-pm/issues/60
-    result.kind = BlsValueType.Real
+    result.kind = LazyBlsType.Real
     var bytes = uint64(i + 1000).toBytesLE()
     copyMem(addr result.blsValue.x[0], addr bytes[0], sizeof(bytes))
 else:


### PR DESCRIPTION
Implemented:
  - bump nim-blscurve following https://github.com/status-im/nim-blscurve/commit/154676758e9e4e334a5a92a4200c89d938574330#diff-e61e8e98354e05029270f6408b0f7ec8R705
  - use `array[8, byte]` instead of `uint64` for Domain


TODO:

- reimplement the interop deposit signature mock start https://github.com/status-im/nim-beacon-chain/pull/406
- refactor the OpaqueBlob in crypto.nim for lazy evaluation
