### PR TITLE
fix issue #367 and remove too-small range type usage for ValidatorIndex

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -307,7 +307,7 @@ proc addLocalValidators(node: BeaconNode, state: BeaconState) =
   info "Local validators attached ", count = node.attachedValidators.count
 
 proc getAttachedValidator(
-    node: BeaconNode, state: BeaconState, idx: int): AttachedValidator =
+    node: BeaconNode, state: BeaconState, idx: ValidatorIndex): AttachedValidator =
   let validatorKey = state.validators[idx].pubkey
   node.attachedValidators.getValidator(validatorKey)
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -621,7 +621,7 @@ proc process_attestation*(
         data: attestation.data,
         aggregation_bits: attestation.aggregation_bits,
         inclusion_delay: state.slot - attestation_slot,
-        proposer_index: get_beacon_proposer_index(state, stateCache),
+        proposer_index: get_beacon_proposer_index(state, stateCache).uint64,
       )
 
     if attestation.data.target.epoch == get_current_epoch(state):

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -39,7 +39,7 @@ type
   SszWriter* = object
     stream: OutputStreamVar
 
-  BasicType = char|bool|SomeUnsignedInt|StUint
+  BasicType = char|bool|SomeUnsignedInt|StUint|ValidatorIndex
 
   SszChunksMerkelizer = ref object of RootObj
     combinedChunks: array[maxChunkTreeDepth, Eth2Digest]

--- a/tests/official/test_fixture_shuffling.nim
+++ b/tests/official/test_fixture_shuffling.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard library
-  os, unittest,
+  os, unittest, sequtils,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, validator, digest],
   # Test utilities
@@ -18,7 +18,7 @@ type
   Shuffling* = object
     seed*: Eth2Digest
     count*: uint64
-    mapping*: seq[ValidatorIndex]
+    mapping*: seq[uint64]
 
 const ShufflingDir = JsonTestsDir/const_preset/"phase0"/"shuffling"/"core"/"shuffle"
 
@@ -27,4 +27,4 @@ suite "Official - Shuffling tests [Preset: " & preset():
     for file in walkDirRec(ShufflingDir):
       let t = parseTest(file, Json, Shuffling)
       let implResult = get_shuffled_seq(t.seed, t.count)
-      check: implResult == t.mapping
+      check: implResult == mapIt(t.mapping, it.ValidatorIndex)


### PR DESCRIPTION
This isn't ideal -- it's neither `int64` nor `uint64` -- but in the interest of both remaining within the bounds of the apparently word-size indexing ability of `seq` and keeping consistent behavior across 32-bit and 64-bit platforms, while maximizing the portion of the `1 shl 40` validator size potential in the spec, `uint32` seemed reasonable.