### PR TITLE
implement some metrics

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -21,14 +21,6 @@ declareGauge beacon_slot, "Latest slot of the beacon chain state"
 declareGauge beacon_head_slot, "Slot of the head block of the beacon chain"
 declareGauge beacon_head_root, "Root of the head block of the beacon chain"
 
-# TODO Implement these additional metrics (some of the them should be moved to different modules):
-declareGauge beacon_finalized_epoch, "Current finalized epoch" # On epoch transition
-declareGauge beacon_finalized_root, "Current finalized root" # On epoch transition
-declareGauge beacon_current_justified_epoch, "Current justified epoch" # On epoch transition
-declareGauge beacon_current_justified_root, "Current justified root" # On epoch transition
-declareGauge beacon_previous_justified_epoch, "Current previously justified epoch" # On epoch transition
-declareGauge beacon_previous_justified_root, "Current previously justified root" # On epoch transition
-
 declareGauge beacon_current_validators, """Number of status="pending|active|exited|withdrawable" validators in current epoch""" # On epoch transition
 declareGauge beacon_previous_validators, """Number of status="pending|active|exited|withdrawable" validators in previous epoch""" # On epoch transition
 declareGauge beacon_current_live_validators, "Number of active validators that successfully included attestation on chain for current epoch" # On block

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -35,7 +35,7 @@
 import # TODO - cleanup imports
   algorithm, math, options, sequtils, tables,
   stew/[bitseqs, bitops2], chronicles, json_serialization/std/sets,
-  ../extras, ../ssz, ../beacon_node_types,
+  metrics, ../extras, ../ssz, ../beacon_node_types,
   beaconstate, crypto, datatypes, digest, helpers, validator,
   state_transition_helpers
 
@@ -43,6 +43,15 @@ import # TODO - cleanup imports
 # --------------------------------------------------------
 
 logScope: topics = "consens"
+
+# TODO Implement the _root metrics
+# https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md
+declareGauge beacon_finalized_epoch, "Current finalized epoch" # On epoch transition
+declareGauge beacon_finalized_root, "Current finalized root" # On epoch transition
+declareGauge beacon_current_justified_epoch, "Current justified epoch" # On epoch transition
+declareGauge beacon_current_justified_root, "Current justified root" # On epoch transition
+declareGauge beacon_previous_justified_epoch, "Current previously justified epoch" # On epoch transition
+declareGauge beacon_previous_justified_root, "Current previously justified root" # On epoch transition
 
 # Spec
 # --------------------------------------------------------
@@ -600,3 +609,10 @@ proc process_epoch*(state: var BeaconState) =
   process_final_updates(state)
 
   # @after_process_final_updates
+
+  # Once per epoch metrics
+  beacon_finalized_epoch.set(state.finalized_checkpoint.epoch.int64)
+  beacon_current_justified_epoch.set(
+    state.current_justified_checkpoint.epoch.int64)
+  beacon_previous_justified_epoch.set(
+    state.previous_justified_checkpoint.epoch.int64)


### PR DESCRIPTION
Designwise, as long as some of these essentially need to live deep within protocol code to implement them without either extraneous checking or a more complex design with customizable callbacks/hooks/mixins/etc for a target that's primarily targeted as a specific spec and thus doesn't warrant such external programmability, it makes sense to move all of them into `beacon_chain/` code itself.