### PR TITLE
remove a lot of XDeclaredButNotUsed spam from SSZ

### DIFF
--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -61,9 +61,9 @@ proc fromSszBytes*[N](T: type BitList[N], bytes: openarray[byte]): auto =
 proc readSszValue*(input: openarray[byte], T: type): T =
   mixin fromSszBytes, toSszType
 
-  type T = type(result)
+  type T {.used.}= type(result)
 
-  template readOffset(n: int): int =
+  template readOffset(n: int): int {.used.}=
     int fromSszBytes(uint32, input[n ..< n + offsetSize])
 
   when useListType and result is List:
@@ -158,4 +158,3 @@ proc readSszValue*(input: openarray[byte], T: type): T =
 
   else:
     unsupported T
-


### PR DESCRIPTION
The following in particular trigger a lot of spam

https://github.com/status-im/nim-beacon-chain/compare/ssz-declared-not-used?expand=1#diff-597e8dc63cc8115a15eafc7c59b1bb5aR64-R67

`Chunk`, `checkEof` and `paddingBytes` seem to be leftovers