### PR TITLE
[Ssz to 0.9.0 - part 1] Generic types - hashTreeRoot tests

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -50,6 +50,10 @@ task test, "Run all tests":
   # Minimal config
   buildBinary "all_tests", "tests/", "-r -d:release -d:chronicles_log_level=ERROR -d:const_preset=minimal"
 
+  # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
+  buildBinary "test_fixture_ssz_generic_types", "tests/official/", "-r -d:release -d:chronicles_log_level=DEBUG"
+
+  # Consensus object SSZ tests
   buildBinary "test_fixture_ssz_static", "tests/official/", "-r -d:release -d:chronicles_log_level=DEBUG -d:const_preset=minimal"
   buildBinary "test_fixture_ssz_static", "tests/official/", "-r -d:release -d:chronicles_log_level=DEBUG -d:const_preset=mainnet"
 

--- a/tests/official/fixtures_utils_v0_8_1.nim
+++ b/tests/official/fixtures_utils_v0_8_1.nim
@@ -10,7 +10,7 @@ import
   os, strutils,
   # Status libs
   stew/byteutils,
-  eth/common, serialization, json_serialization,
+  serialization, json_serialization,
   # Beacon chain internals
   ../../beacon_chain/spec/datatypes
 

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -15,9 +15,8 @@ import
   yaml,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, digest],
-  ../../beacon_chain/ssz,
+  ../../beacon_chain/ssz
   # Test utilities
-  ../testutil
 
 # Parsing definitions
 # ------------------------------------------------------------------------
@@ -134,6 +133,7 @@ proc checkVector(sszSubType, dir: string, expectedHash: SSZHashTreeRoot) =
   var typeIdent: string
   var size: int
   let wasMatched = scanf(sszSubType, "vec_$+_$i", typeIdent, size)
+  assert wasMatched
   testVector(typeIdent, size)
 
 type BitContainer[N: static int] = BitList[N] or BitArray[N]
@@ -147,6 +147,7 @@ proc testBitContainer(T: typedesc[BitContainer], dir: string, expectedHash: SSZH
 proc checkBitVector(sszSubType, dir: string, expectedHash: SSZHashTreeRoot) =
   var size: int
   let wasMatched = scanf(sszSubType, "bitvec_$i", size)
+  assert wasMatched
   case size
   of 1: testBitContainer(BitArray[1], dir, expectedHash)
   of 2: testBitContainer(BitArray[2], dir, expectedHash)

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -1,0 +1,91 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  os, unittest, strutils, streams, strformat, strscans,
+  # Status libraries
+  stint,
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../beacon_chain/spec/[datatypes, digest],
+  ../../beacon_chain/ssz,
+  # Test utilities
+  ../testutil
+
+const
+  FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
+  SSZDir = FixturesDir/"tests-v0.9.0"/"general"/"phase0"/"ssz_generic"
+
+
+
+type
+  SszKind = enum
+    Basic
+    Complex
+
+  SSZHashTreeRoot = object
+    # The test files have the values at the "root"
+    # so we **must** use "root" as a field name
+    root: string
+    # Containers have a root (thankfully) and signing_root field
+    signing_root: string
+
+# Make signing root optional
+setDefaultValue(SSZHashTreeRoot, signing_root, "")
+
+template checkT(T:typedesc) {.dirty.}=
+  let deserialized = SSZ.loadFile(dir/"serialized.ssz", T)
+  check:
+    expectedHash.root == "0x" & toLowerASCII($deserialized.hashTreeRoot())
+
+proc sszCheck(sszType, sszSubType: string) =
+  let dir = SSZDir/sszType/"valid"/sszSubType
+
+  # Hash tree root
+  var expectedHash: SSZHashTreeRoot
+  var s = openFileStream(dir/"meta.yaml")
+  yaml.load(s, expectedHash)
+  s.close()
+
+  # Deserialization and checks
+  case sszType
+  of "boolean": checkT(bool)
+  of "uints":
+    var bitsize: int
+    let wasMatched = scanf(sszSubType, "uint_$i", bitsize)
+    assert wasMatched
+    case bitsize
+    of 8:  checkT(uint8)
+    of 16: checkT(uint16)
+    of 32: checkT(uint32)
+    of 64: checkT(uint64)
+    of 128: discard # checkT(Stuint[128]) # TODO
+    of 256: discard # checkT(Stuint[256])
+    else:
+      raise newException(ValueError, "unknown uint in test: " & sszSubType)
+  else:
+    discard # TODO
+
+proc runSSZtests() =
+  for pathKind, sszType in walkDir(SSZDir, relative = true):
+    assert pathKind == pcDir
+    test &"Testing {sszType:12} inputs - valid":
+      let path = SSZDir/sszType/"valid"
+      for pathKind, sszSubType in walkDir(path, relative = true):
+        assert pathKind == pcDir
+        sszCheck(sszType, sszSubType)
+
+  # TODO: nim-serialization forces us to use exceptions as control flow
+  #       as we always have to check user supplied inputs
+  # Skipped
+  # test "Testing " & name & " inputs (" & $T & ") - invalid":
+  #   const path = SSZDir/name/"invalid"
+
+suite "Official - 0.9.0 SSZ generic types":
+  runSSZtests()

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -277,5 +277,5 @@ proc runSSZtests() =
   # test "Testing " & name & " inputs (" & $T & ") - invalid":
   #   const path = SSZDir/name/"invalid"
 
-suite "Official - 0.9.0 SSZ generic types":
+suite "Official - 0.9.0 - SSZ generic types":
   runSSZtests()

--- a/tests/official/test_fixture_ssz_uint.nim
+++ b/tests/official/test_fixture_ssz_uint.nim
@@ -7,12 +7,12 @@
 
 import
   # Standard library
-  ospaths, strutils, unittest, sequtils,
+  ospaths, unittest, sequtils,
   # Status libs
   stint, serialization,
   # Beacon chain internals
   ../../beacon_chain/ssz,
-  ../../beacon_chain/spec/[datatypes, validator],
+  ../../beacon_chain/spec/datatypes,
   # Test utilities
   ../testutil,
   ./fixtures_utils_v0_8_1

--- a/tests/official/test_fixture_ssz_uint.nim
+++ b/tests/official/test_fixture_ssz_uint.nim
@@ -95,7 +95,7 @@ proc runSSZUintTest(inputTests: Tests[SSZUint]) =
     else:
       echo "         [Skipped] uint size: ", test.`type`
 
-suite "Official - SSZ unsigned integer tests" & preset():
+suite "Official - 0.8.1 - SSZ unsigned integer tests" & preset():
   block: # "Integers right at or beyond the bounds of the allowed value range"
     let uintBounds = parseTests(TestsDir / "uint_bounds.json", SSZUint)
     test uintBounds.summary & preset():


### PR DESCRIPTION
This initiates the 0.9.0 SSZ test suite

No change were done to the underlying SSZ implementation, failing tests were just skipped.

Scope:
  - generic SSZ containers (no consensus objects like BeaconState)
  - only parsing that should be successful
  - comparing against hashTreeRoot reference only.
    "value" is a bit more involved due to missing YAML deserialization in nim-serialization that would allow direct deserialization into static arrays, bitlists, bitvectors, statically typed integers, ...

Full status is available at: https://github.com/status-im/nim-beacon-chain/issues/518

Summary of blocking issues (CT for compile-time, RT for runtime):
- _CT_: Deserialization of top-level distinct types is "not supported", due to a missing branch. Impacting raw BitList deserialization. Since it's used in consensus objects, I expect that if it's a sub-object deserialization works properly.
- _CT_: ComplexTestStruct bind-once / bind-many rules seem to confuse the compiler on the type to expect: List[uint16, 128] vs List[uint16, 1024] (and the error message just displays SszType instead of List[system.uint16, 1024]
- _CT_: BitsList bind-once / bind-many rules seem to confuse the compiler on the type to expect: BitArray[1] vs BitArray[2]
- **RT**: VarTestStruct: invalid hashTreeRoot in some cases
- _CT_: uint128 and uint256 serialization is not supported

Note on the macro. I don't really like macros in tests because we need to make sure tests are readable so we can be confident in them however writing interleaved case statements to test all combinations of vector of the following types/length would have been super tedious.
```Nim
  let types = ["bool", "uint8", "uint16", "uint32", "uint64"] # "uint128", "uint256"]
  let sizes = [1, 2, 3, 4, 5, 8, 16, 31, 512, 513]
```
A proc/template for the inner case statement (on sizes) is an option.