### PR TITLE
beacon_node: print name, version and Git revision [skip ci]

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -910,6 +910,8 @@ when hasPrompt:
       # createThread(t, processPromptCommands, addr p)
 
 when isMainModule:
+  echo "$# ($#)\p" % [clientId, gitRevision]
+
   randomize()
   let config = BeaconNodeConf.load(version = fullVersionStr())
 

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -4,7 +4,7 @@ import
   version, conf
 
 const
-  clientId = "Nimbus beacon node v" & fullVersionStr()
+  clientId* = "Nimbus beacon node v" & fullVersionStr()
 
 export
   version

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -27,6 +27,8 @@ const
     # launch the beacon_node with metrics enabled during the interop lock-in.
     # We'll disable it once the lock-in is over.
 
+  gitRevision* = staticExec("git rev-parse --short HEAD")
+
 template versionAsStr*: string =
   $versionMajor & "." & $versionMinor & "." & $versionBuild
 


### PR DESCRIPTION
Looks like this:
`Nimbus beacon node v0.3.0_libp2p_daemon (a6d9caf)`