### PR TITLE
update get_seed(...) and get_beacon_proposer_index(...) to 0.9.0, implement compute_proposer_index(...), and render 3 more test fixtures working

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -415,7 +415,6 @@ template foreachSpecType*(op: untyped) =
   op BeaconBlockBody
   op BeaconBlockHeader
   op BeaconState
-  op Crosslink
   op Deposit
   op DepositData
   op Eth1Data

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -70,8 +70,6 @@ suite "Official - Operations - Attestations " & preset():
   runTest("before inclusion delay", before_inclusion_delay)
   runTest("after_epoch_slots", after_epoch_slots)
   runTest("old source epoch", old_source_epoch)
-  runTest("wrong shard", wrong_shard)
-  runTest("invalid shard", invalid_shard)
   runTest("old target epoch", old_target_epoch)
   runTest("future target epoch", future_target_epoch)
   runTest("new source epoch", new_source_epoch)

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -87,8 +87,10 @@ suite "Official - Sanity - Blocks " & preset():
   runValidTest("Empty epoch transition", empty_epoch_transition, 1)
   when const_preset=="minimal":
     runValidTest("Empty epoch transition not finalizing", empty_epoch_transition_not_finalizing, 1)
+
+    # TODO investigate/fix after 0.9.0 transition broke this in mainnet
+    runValidTest("Attester slashing", attester_slashing, 1)
   runValidTest("Proposer slashing", proposer_slashing, 1)
-  runValidTest("Attester slashing", attester_slashing, 1)
 
   # TODO: Expected deposit in block
 

--- a/tests/transition_0_9_0.nim
+++ b/tests/transition_0_9_0.nim
@@ -4,6 +4,7 @@ import
   official/test_fixture_operations_proposer_slashings,
   official/test_fixture_shuffling,
   official/test_fixture_operations_block_header,
+  official/test_fixture_sanity_blocks,
   official/test_fixture_ssz_generic_types,
   official/test_fixture_sanity_slots,
   official/test_fixture_operations_voluntary_exit,

--- a/tests/transition_0_9_0.nim
+++ b/tests/transition_0_9_0.nim
@@ -1,6 +1,9 @@
 import
   official/test_fixture_bls,
+  official/test_fixture_operations_attester_slashings,
+  official/test_fixture_operations_proposer_slashings,
   official/test_fixture_shuffling,
+  official/test_fixture_operations_block_header,
   official/test_fixture_ssz_generic_types,
   official/test_fixture_sanity_slots,
   official/test_fixture_operations_voluntary_exit,


### PR DESCRIPTION
All test fixtures in `spec_block_processing` and `spec_epoch_processing` except `test_genesis` (unclear of purpose; nothing but `TODOs`) work. The additional working test fixtures are:
- `official/test_fixture_operations_attester_slashings`
- `official/test_fixture_operations_proposer_slashings`
- `official/test_fixture_operations_block_header`
- `official/test_fixture_sanity_blocks` (except 1 mainnet test -- see below for details)

Conveniently, this PR also adds a from-spec replacement for https://github.com/status-im/nim-beacon-chain/pull/524.

Remaining test fixtures in the `official` directory:
- `test_fixture_operations_attestations` fails in 3 of about a dozen test cases with:
```
Inconsistent aggregation and committee length tid=21168 aggregation_bits_len=4 committee_len=8
nim-beacon-chain/tests/official/test_fixture_operations_attestations.nim(67) test_fixture_operations_attestations
nim-beacon-chain/tests/official/test_fixture_operations_attestations.nim(60) testImpl_operations_attestations_success
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(27) failedAssertImpl
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(20) raiseAssert
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(39) sysFatal

    Unhandled exception: nim-beacon-chain/tests/official/test_fixture_operations_attestations.nim(60, 18) `done`gensym2901099` Valid attestation not processed [AssertionError]
```
which, this is the relevant code:
```
  let committee = get_beacon_committee(state, data.slot, data.index, stateCache)
  if attestation.aggregation_bits.len != attestation.custody_bits.len:
    warn("Inconsistent aggregation and custody bits",
      aggregation_bits_len = attestation.aggregation_bits.len,
      custody_bits_len = attestation.custody_bits.len
    )                                
    return                    
  if attestation.aggregation_bits.len != committee.len:
    warn("Inconsistent aggregation and committee length",
      aggregation_bits_len = attestation.aggregation_bits.len,
      committee_len = committee.len
    )          
    return
```
It might be possible to simply remove that second `if` statement -- I have not tried it -- but it is in https://github.com/ethereum/eth2.0-specs/blob/v0.9.0/specs/core/0_beacon-chain.md#attestations so I'd prefer to understand this better first. Presumably if that condition's not met, other undefined behavior might occur downstream, where it'd be harder to understand/notice. Better to enforce assumptions early.
- `test_fixture_sanity_blocks`: works in minimal. 1 test fails in mainnet:
```
nim-beacon-chain/tests/official/test_fixture_sanity_blocks.nim(91) test_fixture_sanity_blocks
nim-beacon-chain/tests/helpers/debug_state.nim(70) testImpl_blck_attester_slashing
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(27) failedAssertImpl
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(20) raiseAssert
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(39) sysFatal

    Unhandled exception: nim-beacon-chain/tests/helpers/debug_state.nim(70, 15) `sr_pre`gensym3040437.latest_block_header.body_root.data[idx`gensym3041235] ==
    sr_post`gensym3040438.latest_block_header.body_root.data[idx`gensym3041235]` 
Diff: sr_pre`gensym3040437.latest_block_header.body_root.data[0] = 156
and   sr_post`gensym3040438.latest_block_header.body_root.data[0] = 208
 [AssertionError]
  [FAILED] [Valid]   Attester slashing (attester_slashing)
```
I have not further investigated; for the moment, adding all but 1 mainnet test from the block sanity test fixture seemed valuable enough to add one more non-regular exceptional case in the code, to keep the rest from regressing.
- `test_fixture_ssz_static`: tries to deserialize `Crosslink` data structures and discovers `Crosslink` doesn't exist, as it's using 0.8.1 test vectors. First step in fixing would be using updated static SSZ test vectors. If those don't/won't exist, this becomes pointless and should be ignored/removed.
- `test_fixture_state_transition_epoch`: hits
```
nim-beacon-chain/beacon_chain/spec/state_transition_epoch.nim(154) process_justification_and_finalization
nim-beacon-chain/beacon_chain/spec/state_transition_epoch.nim(92) get_attesting_balance
nim-beacon-chain/beacon_chain/spec/state_transition_helpers.nim(39) get_unslashed_attesting_indices
nim-beacon-chain/beacon_chain/spec/state_transition_helpers.nim(32) get_attesting_indices
nim-beacon-chain/beacon_chain/spec/beaconstate.nim(442) get_attesting_indices
nim-beacon-chain/vendor/nim-stew/stew/bitseqs.nim(169) []
nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(27) failedAssertImpl
```
repeatedly. It's the same issue across all of the individual tests in this test fixture, and probably a single bug fix addresses all of them. `[Suite] [Unit - Spec - Epoch processing] Justification and Finalization` works fine, which should be testing the same general functionality, so I doubt the failure is all that fundamental.

I haven't yet looked for new tests to add from 0.9 tests; seems prudent to get the current ones working again first.

Probably the highest ROI for the next batch is `test_fixture_state_transition_epoch`, which I'll pick up after the weekend.