### PR TITLE
0.9.0 cleanup

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -164,7 +164,7 @@ proc add*(pool: var AttestationPool,
   # TODO inefficient data structures..
 
   let
-    attestationSlot = get_attestation_data_slot(state, attestation.data)
+    attestationSlot = attestation.data.slot
     idx = pool.slotIndex(state, attestationSlot)
     slotData = addr pool.slots[idx]
     validation = Validation(

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -340,6 +340,16 @@ proc proposeBlock(node: BeaconNode,
       cat = "fastforward"
     return head
 
+  if head.slot == 0 and slot == 0:
+    # TODO there's been a startup assertion, which sometimes (but not always
+    # evidently) crashes exactly one node on simulation startup, the one the
+    # beacon chain proposer index points to first for slot 0. it tries using
+    # slot 0 as required, notices head block's slot is also 0 (which, that's
+    # how it's created; it's never less), and promptly fails, with assertion
+    # occuring downstream via async code. This is most easily reproduced via
+    # make clean_eth2_network_simulation_files && make eth2_network_simulation
+    return head
+
   if head.slot == slot:
     # Weird, we should never see as head the same slot as we're proposing a
     # block for - did someone else steal our slot? why didn't we discard it?

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -666,10 +666,10 @@ chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt AttestationData: it.shortLog
 
 # TODO remove
-const SHARD_COUNT* = MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
+const SHARD_COUNT* = (MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH).uint64
 
 static:
-  doAssert SHARD_COUNT == MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
+  doAssert SHARD_COUNT.int == MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
 
 import json_serialization
 export json_serialization

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -665,6 +665,12 @@ chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt AttestationData: it.shortLog
 
+# TODO remove
+const SHARD_COUNT* = MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
+
+static:
+  doAssert SHARD_COUNT == MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
+
 import json_serialization
 export json_serialization
 export writeValue, readValue

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard lib
-  sequtils, math, endians,
+  math, endians,
   # Third-party
   blscurve, # defines Domain
   # Internal

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -20,13 +20,9 @@ type
 const
   # Misc
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.4/specs/core/0_beacon-chain.md#misc
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/configs/mainnet.yaml#L6
 
-  MAX_COMMITTEES_PER_SLOT* = 64
-
-  # TODO remove
-  SHARD_COUNT* = 2048 ##\
-  ## SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT
+  MAX_COMMITTEES_PER_SLOT* {.intdefine.} = 64
 
   TARGET_COMMITTEE_SIZE* = 2^7 ##\
   ## Number of validators in the committee attesting to one shard

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -20,15 +20,11 @@ type
 const
   # Misc
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.8.4/configs/minimal.yaml#L4
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/configs/minimal.yaml#L4
 
   # Changed
   MAX_COMMITTEES_PER_SLOT* = 4
   TARGET_COMMITTEE_SIZE* = 4
-
-  # TODO remove
-  SHARD_COUNT* = 32 ##\
-  ## SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT
 
   # Unchanged
   MAX_VALIDATORS_PER_COMMITTEE* = 2048

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -32,7 +32,7 @@
 # improvements to be made - other than that, keep things similar to spec for
 # now.
 
-import # TODO - cleanup imports
+import
   math, options, sequtils, tables,
   stew/[bitseqs, bitops2], chronicles, json_serialization/std/sets,
   metrics, ../ssz,
@@ -51,6 +51,13 @@ declareGauge beacon_current_justified_epoch, "Current justified epoch" # On epoc
 declareGauge beacon_current_justified_root, "Current justified root" # On epoch transition
 declareGauge beacon_previous_justified_epoch, "Current previously justified epoch" # On epoch transition
 declareGauge beacon_previous_justified_root, "Current previously justified root" # On epoch transition
+
+# Non-spec
+declareGauge epoch_transition_justification_and_finalization, "Epoch transition justification and finalization time"
+declareGauge epoch_transition_times_rewards_and_penalties, "Epoch transition reward and penalty time"
+declareGauge epoch_transition_registry_updates, "Epoch transition registry updates time"
+declareGauge epoch_transition_slashings, "Epoch transition slashings time"
+declareGauge epoch_transition_final_updates, "Epoch transition final updates time"
 
 # Spec
 # --------------------------------------------------------

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -39,7 +39,6 @@ import
 # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
 declareGauge beacon_current_validators, """Number of status="pending|active|exited|withdrawable" validators in current epoch""" # On epoch transition
 declareGauge beacon_previous_validators, """Number of status="pending|active|exited|withdrawable" validators in previous epoch""" # On epoch transition
-declareGauge beacon_previous_epoch_orphaned_blocks, "Number of blocks orphaned in the previous epoch" # On epoch transition
 
 # Canonical state transition functions
 # ---------------------------------------------------------------

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -125,8 +125,7 @@ cli do(slots = 448'u,
           # by the randomness. We have to delay when the attestation is
           # actually added to the block per the attestation delay rule!
           let target_slot =
-            get_attestation_data_slot(state, attestation.data) +
-            MIN_ATTESTATION_INCLUSION_DELAY - 1
+            attestation.data.slot + MIN_ATTESTATION_INCLUSION_DELAY - 1
 
           ## In principle, should enumerate possible shard/slot combinations by
           ## inverting get_attestation_data_slot(...), but this works. Could be

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -37,7 +37,7 @@ proc readValue*(r: var JsonReader, a: var seq[byte]) {.inline.} =
 const
   FixturesDir* = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
   JsonTestsDir* = FixturesDir/"json_tests_v0.8.3"
-  SszTestsDir* = FixturesDir/"tests-v0.9.0"
+  SszTestsDir* = FixturesDir/"tests-v0.9.1"
 
 proc parseTest*(path: string, Format: typedesc[Json or SSZ], T: typedesc): T =
   try:

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -16,7 +16,7 @@ import
   ./fixtures_utils,
   ../helpers/debug_state
 
-const OperationsAttestationsDir = SszTestsDir/const_preset/"phase0"/"operations"/"attestation"/"pyspec_tests"
+const OperationsAttestationsDir = FixturesDir/"tests-v0.9.0"/const_preset/"phase0"/"operations"/"attestation"/"pyspec_tests"
 
 template runTest(testName: string, identifier: untyped) =
   # We wrap the tests in a proc to avoid running out of globals

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -16,7 +16,7 @@ import
   ./fixtures_utils,
   ../helpers/debug_state
 
-const OpAttSlashingDir = SszTestsDir/const_preset/"phase0"/"operations"/"attester_slashing"/"pyspec_tests"
+const OpAttSlashingDir = FixturesDir/"tests-v0.9.0"/const_preset/"phase0"/"operations"/"attester_slashing"/"pyspec_tests"
 
 template runTest(identifier: untyped) =
   # We wrap the tests in a proc to avoid running out of globals

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -16,7 +16,7 @@ import
   ./fixtures_utils,
   ../helpers/debug_state
 
-const OperationsDepositsDir = FixturesDir/"tests-v0.9.0"/const_preset/"phase0"/"operations"/"deposit"/"pyspec_tests"
+const OperationsDepositsDir = SszTestsDir/const_preset/"phase0"/"operations"/"deposit"/"pyspec_tests"
 
 template runTest(testName: string, identifier: untyped) =
   # We wrap the tests in a proc to avoid running out of globals

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -16,7 +16,7 @@ import
   ./fixtures_utils,
   ../helpers/debug_state
 
-const SanityBlocksDir = SszTestsDir/const_preset/"phase0"/"sanity"/"blocks"/"pyspec_tests"
+const SanityBlocksDir = FixturesDir/"tests-v0.9.0"/const_preset/"phase0"/"sanity"/"blocks"/"pyspec_tests"
 
 template runValidTest(testName: string, identifier: untyped, num_blocks: int): untyped =
   # We wrap the tests in a proc to avoid running out of globals

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -23,7 +23,7 @@ import
 
 const
   FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
-  SSZDir = FixturesDir/"tests-v0.9.0"/"general"/"phase0"/"ssz_generic"
+  SSZDir = FixturesDir/"tests-v0.9.1"/"general"/"phase0"/"ssz_generic"
 
 type
   SSZHashTreeRoot = object

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -19,9 +19,9 @@ NIMFLAGS="-d:chronicles_log_level=DEBUG --hints:off --warnings:off --verbosity:0
 # Run with "SHARD_COUNT=4 ./start.sh" to change these
 DEFS=""
 
-DEFS+="-d:SHARD_COUNT=${SHARD_COUNT:-8} "      # Spec default: 1024
-DEFS+="-d:SLOTS_PER_EPOCH=${SLOTS_PER_EPOCH:-8} "   # Spec default: 64
-DEFS+="-d:SECONDS_PER_SLOT=${SECONDS_PER_SLOT:-4} "  # Spec default: 6
+DEFS+="-d:MAX_COMMITTEES_PER_SLOT=${MAX_COMMITTEES_PER_SLOT:-1} "      # Spec default: 64
+DEFS+="-d:SLOTS_PER_EPOCH=${SLOTS_PER_EPOCH:-16} "   # Spec default: 32
+DEFS+="-d:SECONDS_PER_SLOT=${SECONDS_PER_SLOT:-6} "  # Spec default: 12
 
 LAST_VALIDATOR_NUM=$(( NUM_VALIDATORS - 1 ))
 LAST_VALIDATOR="$VALIDATORS_DIR/v$(printf '%07d' $LAST_VALIDATOR_NUM).deposit.json"

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -68,10 +68,10 @@ suite "Attestation pool processing" & preset():
       process_slots(state.data, state.data.data.slot + 1)
 
       let
-        cc1 = get_crosslink_committee(state.data.data,
-          compute_epoch_at_slot(state.data.data.slot), 2, cache)
+        bc1 = get_beacon_committee(state.data.data,
+          state.data.data.slot, 0, cache)
         attestation1 = makeAttestation(
-          state.data.data, state.blck.root, cc1[0])
+          state.data.data, state.blck.root, bc1[0])
 
       # test reverse order
       pool.add(state.data.data, state.blck, attestation1)


### PR DESCRIPTION
- Fix finalization in network sim which broke when removing `get_committee_count(...)`, because it was based on `SHARD_COUNT` from 0.8 while the newer `get_committee_count_at_slot(...)` uses `MAX_COMMITTEES_PER_SLOT` from 0.9. It now enforces they're consistent, as `tests/simulation/start.sh` had been manually overriding it, but it means that scripts which set `SHARD_COUNT` directly will not work anymore. The new way to adjust that is by adjusting `MAX_COMMITTEES_PER_SLOT`.

- Add a few gauges to be used to time each part of the epoch state transition.

- Remove the 0.8 `get_attestation_data_slot(...)` and the shim layer/function `get_epoch_and_shard(...)` it needed to interact with the slot/index world.

- Remove 2 more `get_crosslink_committee(...)` calls in favor of `get_beacon_committee(..)`. Two remain, both tied to `makeAttestationData(...)`.

- Stop downloading 0.8.3 test vectors.

- Switch all but 3 test fixtures to run off 0.9.1 test vectors. No protocol behavior was modified, only enabling the ones that happen to already be identical between 0.9.0 and 0.9.1.

I'm fine with either of the network sim test settings (4 seconds per slot, 8 slots per epoch, or 6 seconds per slot, 16 slots per epoch) but since the network sim doesn't actually run at all on master for me since I moved it from a few commits ago yesterday, I'd prefer not to gamble on that. Those are the settings I checked. Once the network sim works again, so it can be checked, I'm fine with whatever settings are most convenient.