### PR TITLE
remove UnusedImport spam

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1,6 +1,6 @@
 import
   # Standard library
-  os, net, tables, strutils, times, strformat, memfiles,
+  os, net, tables, random, strutils, times, strformat, memfiles,
 
   # Nimble packages
   stew/[objects, bitseqs, byteutils], stew/ranges/ptr_arith,

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1,6 +1,6 @@
 import
   # Standard library
-  os, net, tables, random, strutils, times, strformat, memfiles,
+  os, net, tables, strutils, times, strformat, memfiles,
 
   # Nimble packages
   stew/[objects, bitseqs, byteutils], stew/ranges/ptr_arith,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  tables, algorithm, math, options, sequtils,
+  tables, algorithm, math, sequtils,
   json_serialization/std/sets, chronicles, stew/bitseqs,
   ../extras, ../ssz,
   ./crypto, ./datatypes, ./digest, ./helpers, ./validator

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -45,7 +45,6 @@
 
 
 import
-  sequtils,
   stew/[endians2, objects, byteutils], hashes, nimcrypto/utils,
   blscurve, json_serialization,
   ../version, digest,

--- a/tests/mocking/merkle_minimal.nim
+++ b/tests/mocking/merkle_minimal.nim
@@ -10,7 +10,7 @@
 
 import
   # Specs
-  ../../beacon_chain/spec/[datatypes, digest, beaconstate, helpers],
+  ../../beacon_chain/spec/[datatypes, digest],
   ../../beacon_chain/ssz,
   # shims
   stew/objects

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -14,7 +14,7 @@ import
   # 0.19.6 shims
   stew/objects, # import default
   # Specs
-  ../../beacon_chain/spec/[datatypes, crypto, helpers, digest, beaconstate],
+  ../../beacon_chain/spec/[datatypes, crypto, helpers, digest],
   # Internals
   ../../beacon_chain/[ssz, extras],
   # Mocking procs

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -10,13 +10,11 @@
 
 import
   # Specs
-  ../../beacon_chain/spec/[datatypes, beaconstate, digest],
+  ../../beacon_chain/spec/[datatypes, beaconstate],
   # Internals
   ../../beacon_chain/[extras, interop],
   # Mocking procs
-  ./mock_deposits,
-  # Helpers
-  ../helpers/digest_helpers
+  ./mock_deposits
 
 
 proc initGenesisState*(num_validators: uint64, genesis_time: uint64 = 0): BeaconState =

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -5,9 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard libs
-  os, unittest, endians,
+  os, unittest,
   # Status libs
   blscurve, stew/byteutils,
   # Beacon chain internals

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest,

--- a/tests/official/test_fixture_sanity_slots.nim
+++ b/tests/official/test_fixture_sanity_slots.nim
@@ -5,9 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
-  os, unittest, strutils,
+  os, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/datatypes,
   ../../beacon_chain/state_transition,

--- a/tests/official/test_fixture_shuffling.nim
+++ b/tests/official/test_fixture_shuffling.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest, sequtils,

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   os, unittest, strutils,

--- a/tests/spec_block_processing/test_genesis.nim
+++ b/tests/spec_block_processing/test_genesis.nim
@@ -10,15 +10,17 @@
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_beacon-chain.md#genesis
 # ---------------------------------------------------------------
 
+{.used.}
+
 import
   # Standard library
   unittest,
   # Specs
-  ../../beacon_chain/spec/[beaconstate, datatypes, helpers, validator, digest],
+  ../../beacon_chain/spec/datatypes,
   # Internals
-  ../../beacon_chain/[ssz, extras, state_transition],
+  ../../beacon_chain/ssz,
   # Mock helpers
-  ../mocking/[mock_deposits, mock_genesis],
+  ../mocking/mock_genesis,
   ../testutil
 
 

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -9,15 +9,15 @@
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_beacon-chain.md#attestations
 # ---------------------------------------------------------------
 
+{.used.}
+
 import
   # Standard library
-  unittest, math,
+  unittest,
   # shims 0.19.6
   stew/objects, # import default
   # Specs
   ../../beacon_chain/spec/[beaconstate, datatypes, helpers, validator],
-  # Internals
-  ../../beacon_chain/[state_transition],
   # Mock helpers
   ../mocking/[mock_genesis, mock_attestations, mock_state, mock_blocks],
   ../testutil

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -10,13 +10,15 @@
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.1/specs/core/0_beacon-chain.md#deposits
 # ---------------------------------------------------------------
 
+{.used.}
+
 import
   # Standard library
   unittest, math,
   # Specs
-  ../../beacon_chain/spec/[beaconstate, datatypes, crypto, helpers, validator],
+  ../../beacon_chain/spec/[beaconstate, datatypes, crypto],
   # Internals
-  ../../beacon_chain/[ssz, extras, state_transition],
+  ../../beacon_chain/[ssz, extras],
   # Mock helpers
   ../mocking/[mock_deposits, mock_genesis],
   ../testutil, ../helpers/math_helpers

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -7,7 +7,7 @@
 
 import
   # Specs
-  ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator, helpers],
+  ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator],
   # Internals
   ../../beacon_chain/[state_transition]
 

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -10,8 +10,6 @@ import
   strformat,
   # Specs
   ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator, helpers],
-  # Internals
-  ../../beacon_chain/[state_transition],
   # Test helpers
   ../helpers/digest_helpers
 

--- a/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
+++ b/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
@@ -5,15 +5,15 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
-  strformat, unittest,
+  unittest,
   # Vendored packages
   stew/bitops2,
   # Specs
-  ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator, helpers],
-  # Internals
-  ../../beacon_chain/[state_transition],
+  ../../beacon_chain/spec/datatypes,
   # Test helpers
   ../mocking/[mock_genesis],
   ./epoch_utils,

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -5,8 +5,10 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
-  options, sequtils, unittest,
+  options, unittest,
   ./testutil,
   ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, helpers, validator],
   ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, extras, state_transition, ssz]

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -5,7 +5,9 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import  options, unittest, sequtils, strutils, eth/trie/[db],
+{.used.}
+
+import  options, unittest, sequtils, eth/trie/[db],
   ../beacon_chain/[beacon_chain_db, extras, interop, ssz],
   ../beacon_chain/spec/[beaconstate, datatypes, digest, crypto],
   # test utilies

--- a/tests/test_beacon_node.nim
+++ b/tests/test_beacon_node.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   unittest,
   ../beacon_chain/beacon_node

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -5,10 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
-  sequtils, unittest,
+  unittest,
   ./testutil,
-  ../beacon_chain/extras,
   ../beacon_chain/spec/[beaconstate, datatypes, digest]
 
 suite "Beacon state" & preset():

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -5,11 +5,13 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   options, sequtils, unittest,
   ./testutil,
-  ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, helpers, validator],
-  ../beacon_chain/[beacon_node_types, block_pool, beacon_chain_db, extras, state_transition, ssz]
+  ../beacon_chain/spec/[beaconstate, datatypes, digest],
+  ../beacon_chain/[beacon_node_types, block_pool, beacon_chain_db, extras, ssz]
 
 suite "Block pool processing" & preset():
   let

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -5,8 +5,10 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
-  sequtils, unittest,
+  unittest,
   ../beacon_chain/spec/[helpers]
 
 suite "Spec helpers":

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -1,7 +1,9 @@
+{.used.}
+
 import
   unittest, stint, blscurve, stew/byteutils,
   ../beacon_chain/[extras, interop, ssz],
-  ../beacon_chain/spec/[beaconstate, digest, crypto, helpers, datatypes]
+  ../beacon_chain/spec/[beaconstate, crypto, helpers, datatypes]
 
 # Interop test yaml, found here:
 # https://github.com/ethereum/eth2.0-pm/blob/a0b9d22fad424574b1307828f867b30237758468/interop/mocked_start/keygen_10_validators.yaml

--- a/tests/test_ssz.nim
+++ b/tests/test_ssz.nim
@@ -5,9 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
-  unittest, sequtils, options,
-  stint, nimcrypto, eth/common, blscurve, serialization/testing/generic_suite,
+  unittest, options,
+  stint, nimcrypto, eth/common, serialization/testing/generic_suite,
   ../beacon_chain/spec/[datatypes, digest],
   ../beacon_chain/ssz, ../beacon_chain/ssz/[navigator, dynamic_navigator]
 

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -5,11 +5,13 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
-  options, sequtils, unittest, chronicles,
+  options, unittest, chronicles,
   ./testutil,
-  ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, helpers, validator],
-  ../beacon_chain/[extras, state_transition, ssz]
+  ../beacon_chain/spec/[beaconstate, datatypes, digest, validator],
+  ../beacon_chain/[state_transition, ssz]
 
 suite "Block processing" & preset():
   ## For now just test that we can compile and execute block processing with

--- a/tests/test_sync_protocol.nim
+++ b/tests/test_sync_protocol.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   unittest,
   ../beacon_chain/sync_protocol

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   unittest,
   ../beacon_chain/spec/[datatypes, crypto],


### PR DESCRIPTION
Tested with `LOG_LEVEL=TRACE`.

The only change outside the `tests/` directory is removing imports from `beacon_chain/spec/beaconstate.nim` and `beacon_chain/spec/crypto.nim`.