### PR TITLE
remove get_crosslink_committee(...) and rest of shard-world

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -487,7 +487,7 @@ proc process_attestation*(
     false
 
 proc makeAttestationData*(
-    state: BeaconState, shard: uint64,
+    state: BeaconState, slot: Slot, committee_index: uint64,
     beacon_block_root: Eth2Digest): AttestationData =
   ## Create an attestation / vote for the block `beacon_block_root` using the
   ## data in `state` to fill in the rest of the fields.
@@ -502,11 +502,12 @@ proc makeAttestationData*(
     epoch_boundary_block_root =
       if start_slot == state.slot: beacon_block_root
       else: get_block_root_at_slot(state, start_slot)
-    (a_slot, a_index) = get_slot_and_index(state, current_epoch, shard)
+
+  doAssert slot.compute_epoch_at_slot == current_epoch
 
   AttestationData(
-    slot: a_slot,
-    index: a_index,
+    slot: slot,
+    index: committee_index,
     beacon_block_root: beacon_block_root,
     source: state.current_justified_checkpoint,
     target: Checkpoint(

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -82,9 +82,6 @@ type
   ValidatorIndex* = distinct uint32
   Gwei* = uint64
 
-  # TODO remove
-  Shard* = uint64
-
   BitList*[maxLen: static int] = distinct BitSeq
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/specs/core/0_beacon-chain.md#proposerslashing
@@ -287,7 +284,6 @@ type
     ## VALIDATOR_REGISTRY_LIMIT
 
     # Shuffling
-    start_shard* {.dontSerialize.}: Shard
     randao_mixes*: array[EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
 
     # Slashings
@@ -374,9 +370,6 @@ type
       Table[tuple[a: int, b: Eth2Digest], seq[ValidatorIndex]]
     active_validator_indices_cache*:
       Table[Epoch, seq[ValidatorIndex]]
-    start_shard_cache*: Table[Epoch, Shard]
-
-    # TODO still used?
     committee_count_cache*: Table[Epoch, uint64]
 
 when networkBackend == rlpxBackend:
@@ -647,12 +640,6 @@ chronicles.formatIt Slot: it.shortLog
 chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt AttestationData: it.shortLog
-
-# TODO remove
-const SHARD_COUNT* = (MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH).uint64
-
-static:
-  doAssert SHARD_COUNT.int == MAX_COMMITTEES_PER_SLOT * SLOTS_PER_EPOCH
 
 import json_serialization
 export json_serialization

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -191,64 +191,6 @@ type
     voluntary_exits*: List[VoluntaryExit, MAX_VOLUNTARY_EXITS]
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/specs/core/0_beacon-chain.md#beaconstate
-  BeaconStateNew* = object
-    # Versioning
-    genesis_time*: uint64
-    slot*: Slot
-    fork*: Fork
-
-    # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
-
-    block_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
-
-    state_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
-
-    historical_roots*: seq[Eth2Digest]  ##\
-    ## model List with HISTORICAL_ROOTS_LIMIT limit as seq
-    ## TODO bound explicitly somewhere
-
-    # Eth1
-    eth1_data*: Eth1Data
-
-    eth1_data_votes*: seq[Eth1Data] ##\
-    ## As with `hitorical_roots`, this is a `List`. TODO bound explicitly.
-
-    eth1_deposit_index*: uint64
-
-    # Registry
-    validators*: seq[Validator]
-    balances*: seq[uint64] ##\
-    ## Validator balances in Gwei!
-    ## Also more `List`s which need to be bounded explicitly at
-    ## VALIDATOR_REGISTRY_LIMIT
-
-    # Randomness
-    randao_mixes*: array[EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
-
-    # Slashings
-    slashings*: array[EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
-
-    # Attestations
-    previous_epoch_attestations*: seq[PendingAttestation]
-    current_epoch_attestations*: seq[PendingAttestation]
-
-    # Finality
-    justification_bits*: uint8 ##\
-    ## Bit set for every recent justified epoch
-    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
-    ## with ssz/hashing.
-
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
-
-    current_justified_checkpoint*: Checkpoint
-    finalized_checkpoint*: Checkpoint
-
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/specs/core/0_beacon-chain.md#beaconstate
   BeaconState* = object
     # Versioning
     genesis_time*: uint64
@@ -510,54 +452,6 @@ proc `$`*(x: ValidatorIndex): auto = $(x.int64)
 
 ethTimeUnit Slot
 ethTimeUnit Epoch
-
-func GetOldBeaconState*(newState: BeaconStateNew): BeaconState =
-  BeaconState(
-    genesis_time: newState.genesis_time,
-    slot: newState.slot,
-    fork: newState.fork,
-    latest_block_header: newState.latest_block_header,
-    block_roots: newState.block_roots,
-    state_roots: newState.state_roots,
-    historical_roots: newState.historical_roots,
-    eth1_data: newState.eth1_data,
-    eth1_data_votes: newState.eth1_data_votes,
-    eth1_deposit_index: newState.eth1_deposit_index,
-    validators: newState.validators,
-    balances: newState.balances,
-    randao_mixes: newState.randao_mixes,
-    slashings: newState.slashings,
-    previous_epoch_attestations: newState.previous_epoch_attestations,
-    current_epoch_attestations: newState.current_epoch_attestations,
-    justification_bits: newState.justification_bits,
-    previous_justified_checkpoint: newState.previous_justified_checkpoint,
-    current_justified_checkpoint: newState.current_justified_checkpoint,
-    finalized_checkpoint: newState.finalized_checkpoint
-  )
-
-func GetNewBeaconState*(oldState: BeaconState): BeaconStateNew =
-  BeaconStateNew(
-    genesis_time: oldState.genesis_time,
-    slot: oldState.slot,
-    fork: oldState.fork,
-    latest_block_header: oldState.latest_block_header,
-    block_roots: oldState.block_roots,
-    state_roots: oldState.state_roots,
-    historical_roots: oldState.historical_roots,
-    eth1_data: oldState.eth1_data,
-    eth1_data_votes: oldState.eth1_data_votes,
-    eth1_deposit_index: oldState.eth1_deposit_index,
-    validators: oldState.validators,
-    balances: oldState.balances,
-    randao_mixes: oldState.randao_mixes,
-    slashings: oldState.slashings,
-    previous_epoch_attestations: oldState.previous_epoch_attestations,
-    current_epoch_attestations: oldState.current_epoch_attestations,
-    justification_bits: oldState.justification_bits,
-    previous_justified_checkpoint: oldState.previous_justified_checkpoint,
-    current_justified_checkpoint: oldState.current_justified_checkpoint,
-    finalized_checkpoint: oldState.finalized_checkpoint
-  )
 
 Json.useCustomSerialization(BeaconState.justification_bits):
   read:

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -398,13 +398,6 @@ proc process_final_updates*(state: var BeaconState) =
     )
     state.historical_roots.add (hash_tree_root(historical_batch))
 
-  # TODO remove this when start_shard finally goes away, but doesn't
-  # interfere with 0.9.0. Gone after 0.8.4.
-  # Update start shard
-  state.start_shard =
-    (state.start_shard + get_shard_delta(state, current_epoch)) mod
-      SHARD_COUNT
-
   # Rotate current/previous epoch attestations
   state.previous_epoch_attestations = state.current_epoch_attestations
   state.current_epoch_attestations = @[]

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -41,7 +41,7 @@ cli do(slots = 448'u,
        validators = SLOTS_PER_EPOCH * 9, # One per shard is minimum
        json_interval = SLOTS_PER_EPOCH,
        prefix = 0,
-       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.9,
+       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.75,
        validate = true):
   let
     flags = if validate: {} else: {skipValidation}
@@ -99,9 +99,8 @@ cli do(slots = 448'u,
           mapIt(
             0'u64 .. (get_committee_count_at_slot(state, state.slot) *
               SLOTS_PER_EPOCH - 1),
-            get_crosslink_committee(state, epoch,
-              (it + get_start_shard(state, epoch)) mod SHARD_COUNT,
-              cache))
+            get_beacon_committee(state, epoch.compute_start_slot_at_epoch + (it mod SLOTS_PER_EPOCH),
+              it div SLOTS_PER_EPOCH, cache))
 
       for scas in scass:
         var

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -23,7 +23,7 @@ import
 proc mockAttestationData(
        state: BeaconState,
        slot: Slot,
-       shard: Shard): AttestationData =
+       index: uint64): AttestationData =
   doAssert state.slot >= slot
 
   if slot == state.slot:
@@ -47,13 +47,8 @@ proc mockAttestationData(
 
   let target_epoch = compute_epoch_at_slot(slot)
 
-  # Constructed to be provide exact equivalent index... to compute_committee(...)
-  # as using epoch/shard.
-  let (r_slot, r_index) = get_slot_and_index(state, target_epoch, shard)
-  doAssert r_slot == slot
-  doAssert r_index == 0
   result.slot = slot
-  result.index = r_index
+  result.index = index
 
   result.target = Checkpoint(
     epoch: target_epoch, root: epoch_boundary_root
@@ -105,14 +100,8 @@ proc mockAttestationImpl(
   var cache = get_empty_per_epoch_cache()
 
   let
-    epoch = compute_epoch_at_slot(slot)
-    epoch_start_shard = get_start_shard(state, epoch)
     committees_per_slot = get_committee_count_at_slot(
-      state, epoch.compute_start_slot_at_epoch)
-    shard = (
-      epoch_start_shard +
-      committees_per_slot * (slot mod SLOTS_PER_EPOCH)
-    ) mod SHARD_COUNT
+      state, slot)
 
     beacon_committee = get_beacon_committee(
       state,
@@ -122,7 +111,7 @@ proc mockAttestationImpl(
     )
     committee_size = beacon_committee.len
 
-  result.data = mockAttestationData(state, slot, shard)
+  result.data = mockAttestationData(state, slot, 0)
   result.aggregation_bits = init(CommitteeValidatorsBits, committee_size)
 
   # fillAggregateAttestation

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -50,7 +50,9 @@ proc mockAttestationData(
   # Constructed to be provide exact equivalent index... to compute_committee(...)
   # as using epoch/shard.
   let (r_slot, r_index) = get_slot_and_index(state, target_epoch, shard)
-  result.slot = r_slot
+  doAssert r_slot == slot
+  doAssert r_index == 0
+  result.slot = slot
   result.index = r_index
 
   result.target = Checkpoint(

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -40,29 +40,24 @@ template runTest(testName: string, identifier: untyped) =
       prefix = "[Invalid] "
 
     test prefix & testName & " (" & astToStr(identifier) & ")":
-      var stateRef, postRef: ref BeaconStateNew
-      var sr_pre, sr_post: ref BeaconState
+      var stateRef, postRef: ref BeaconState
       var depositRef: ref Deposit
       new depositRef
       new stateRef
-      new sr_pre
-      new sr_post
 
       depositRef[] = parseTest(testDir/"deposit.ssz", SSZ, Deposit)
-      stateRef[] = parseTest(testDir/"pre.ssz", SSZ, BeaconStateNew)
-      sr_pre[] = GetOldBeaconState(stateRef[])
+      stateRef[] = parseTest(testDir/"pre.ssz", SSZ, BeaconState)
 
       if existsFile(testDir/"post.ssz"):
         new postRef
-        postRef[] = parseTest(testDir/"post.ssz", SSZ, BeaconStateNew)
-        sr_post[] = GetOldBeaconState(postRef[])
+        postRef[] = parseTest(testDir/"post.ssz", SSZ, BeaconState)
 
       if postRef.isNil:
         expect(AssertionError):
-          let done = process_deposit(sr_pre[], depositRef[], flags)
+          discard process_deposit(stateRef[], depositRef[], flags)
       else:
-        let done = process_deposit(sr_pre[], depositRef[], flags)
-        reportDiff(sr_pre, sr_post)
+        discard process_deposit(stateRef[], depositRef[], flags)
+        reportDiff(stateRef, postRef)
 
   `testImpl _ operations_deposits _ identifier`()
 

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -46,12 +46,7 @@ template runValidTest(testName: string, identifier: untyped, num_blocks: int): u
 
       # Checks:
       # check: stateRef.hash_tree_root() == postRef.hash_tree_root()
-      var sr_pre, sr_post: ref BeaconStateNew
-      new sr_pre
-      new sr_post
-      sr_pre[] = GetNewBeaconState(stateRef[])
-      sr_post[] = GetNewBeaconState(postRef[])
-      reportDiff(sr_pre, sr_post)
+      reportDiff(stateRef, postRef)
 
   `testImpl _ blck _ identifier`()
 

--- a/tests/official/test_fixture_sanity_slots.nim
+++ b/tests/official/test_fixture_sanity_slots.nim
@@ -39,12 +39,7 @@ template runTest(testName: string, identifier: untyped, num_slots: uint64): unty
       process_slots(stateRef[], stateRef.slot + num_slots)
       # check: stateRef.hash_tree_root() == postRef.hash_tree_root()
 
-      var sr_pre, sr_post: ref BeaconStateNew
-      new sr_pre
-      new sr_post
-      sr_pre[] = GetNewBeaconState(stateRef[])
-      sr_post[] = GetNewBeaconState(postRef[])
-      reportDiff(sr_pre, sr_post)
+      reportDiff(stateRef, postRef)
 
   `testImpl _ slots _ identifier`()
 

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -50,12 +50,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
           else:
             transitionProc(stateRef[])
 
-          var sr_pre, sr_post: ref BeaconStateNew
-          new sr_pre
-          new sr_post
-          sr_pre[] = GetNewBeaconState(stateRef[])
-          sr_post[] = GetNewBeaconState(postRef[])
-          reportDiff(sr_pre, sr_post)
+          reportDiff(stateRef, postRef)
 
   `suiteImpl _ transitionProc`()
 

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -6,9 +6,11 @@ NODE_ID=${1}
 shift
 
 # Read in variables
+# shellcheck source=/dev/null
 source "$(dirname "$0")/vars.sh"
 
 # set up the environment
+# shellcheck source=/dev/null
 source "${SIM_ROOT}/../../env.sh"
 
 cd "$GIT_ROOT"

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -3,9 +3,11 @@
 set -eo pipefail
 
 # Read in variables
+# shellcheck source=/dev/null
 source "$(dirname "$0")/vars.sh"
 
 # set up the environment
+# shellcheck source=/dev/null
 source "${SIM_ROOT}/../../env.sh"
 
 cd "$SIM_ROOT"

--- a/tests/spec_block_processing/test_genesis.nim
+++ b/tests/spec_block_processing/test_genesis.nim
@@ -31,21 +31,21 @@ import
 
 suite "[Unit - Spec - Genesis] Genesis block checks " & preset():
   test "is_valid_genesis_state for a valid state":
-    let state = initGenesisState(
+    discard initGenesisState(
       num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
       genesis_time = MIN_GENESIS_TIME
     )
     discard "TODO"
 
   test "Invalid genesis time":
-    let state = initGenesisState(
+    discard initGenesisState(
       num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
       genesis_time = MIN_GENESIS_TIME.uint64 - 1
     )
     discard "TODO"
 
   test "Not enough validators":
-    let state = initGenesisState(
+    discard initGenesisState(
       num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT.uint64 - 1,
       genesis_time = MIN_GENESIS_TIME.uint64 - 1
     )


### PR DESCRIPTION
- It's structured as the first two commits demonstrating via `doAssert` the exact functional equivalence of the new and old code, so it should be forward and backward compatible testnet-wise. The remaining commits remove the scaffolding and the old shard/epoch-based code from 0.8.x.

- Additionally, it removes a few more declared but unreferenced variables and adds some ShellCheck annotations to network simulation scripts to avoid false positives: https://github.com/koalaman/shellcheck/wiki/SC1090.