### PR TITLE
cleanups, state_sim justification/finalization checks, and optimizations

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -60,8 +60,8 @@ task test, "Run all tests":
   buildBinary "all_fixtures_require_ssz", "tests/official/", "-r -d:release -d:chronicles_log_level=DEBUG -d:const_preset=minimal"
   buildBinary "all_fixtures_require_ssz", "tests/official/", "-r -d:release -d:chronicles_log_level=DEBUG -d:const_preset=mainnet"
 
-  # State sim; getting into 3rd epoch useful
-  buildBinary "state_sim", "research/", "-r -d:release", "--validators=128 --slots=24"
+  # State sim; getting into 4th epoch useful to trigger consensus checks
+  buildBinary "state_sim", "research/", "-r -d:release", "--validators=128 --slots=40"
 
 task sync_lfs_tests, "Sync LFS json tests":
   # Syncs the json test files (but not the EF yaml tests)

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -174,7 +174,7 @@ type
     slots*: uint64 # number of slots that are suspected missing
     tries*: int
 
-  BlockRef* = ref object {.acyclic.}
+  BlockRef* {.acyclic.} = ref object
     ## Node in object graph guaranteed to lead back to tail block, and to have
     ## a corresponding entry in database.
     ## Block graph should form a tree - in particular, there are no cycles.

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -197,7 +197,7 @@ else:
   proc createEth2Node*(conf: BeaconNodeConf,
                        bootstrapNodes: seq[BootstrapAddr]): Future[Eth2Node] {.async.} =
     var
-      (extIp, extTcpPort, extUdpPort) = setupNat(conf)
+      (extIp, extTcpPort, _) = setupNat(conf)
       hostAddress = tcpEndPoint(globalListeningAddr, Port conf.tcpPort)
       announcedAddresses = if extIp == globalListeningAddr: @[]
                            else: @[tcpEndPoint(extIp, extTcpPort)]

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -308,7 +308,7 @@ type
     root*: Eth2Digest # hash_tree_root (not signing_root!)
 
   StateCache* = object
-    crosslink_committee_cache*:
+    beacon_committee_cache*:
       Table[tuple[a: int, b: Eth2Digest], seq[ValidatorIndex]]
     active_validator_indices_cache*:
       Table[Epoch, seq[ValidatorIndex]]

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -232,10 +232,11 @@ proc process_justification_and_finalization*(
       cat = "finalization"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.1/specs/core/0_beacon-chain.md#rewards-and-penalties-1
-func get_base_reward(state: BeaconState, index: ValidatorIndex): Gwei =
-  let
-    total_balance = get_total_active_balance(state)
-    effective_balance = state.validators[index].effective_balance
+func get_base_reward(state: BeaconState, index: ValidatorIndex,
+    total_balance: auto): Gwei =
+  # Spec function recalculates total_balance every time, which creates an
+  # O(n^2) situation.
+  let effective_balance = state.validators[index].effective_balance
   effective_balance * BASE_REWARD_FACTOR div
     integer_squareroot(total_balance) div BASE_REWARDS_PER_EPOCH
 
@@ -274,9 +275,10 @@ func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
     for index in eligible_validator_indices:
       if index in unslashed_attesting_indices:
         rewards[index] +=
-          get_base_reward(state, index) * attesting_balance div total_balance
+          get_base_reward(state, index, total_balance) * attesting_balance div
+            total_balance
       else:
-        penalties[index] += get_base_reward(state, index)
+        penalties[index] += get_base_reward(state, index, total_balance)
 
   # Proposer and inclusion delay micro-rewards
   ## This depends on matching_source_attestations being an indexable seq, not a
@@ -309,11 +311,12 @@ func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
       if a.inclusion_delay < attestation.inclusion_delay:
         attestation = a
 
-    let proposer_reward =
-      (get_base_reward(state, index) div PROPOSER_REWARD_QUOTIENT).Gwei
+    let
+      base_reward = get_base_reward(state, index, total_balance)
+      proposer_reward = (base_reward div PROPOSER_REWARD_QUOTIENT).Gwei
 
     rewards[attestation.proposer_index.int] += proposer_reward
-    let max_attester_reward = get_base_reward(state, index) - proposer_reward
+    let max_attester_reward = base_reward - proposer_reward
 
     rewards[index] += max_attester_reward div attestation.inclusion_delay
 
@@ -325,7 +328,7 @@ func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
         state, matching_target_attestations, stateCache)
     for index in eligible_validator_indices:
       penalties[index] +=
-        BASE_REWARDS_PER_EPOCH.uint64 * get_base_reward(state, index)
+        BASE_REWARDS_PER_EPOCH.uint64 * get_base_reward(state, index, total_balance)
       if index notin matching_target_attesting_indices:
         penalties[index] +=
           state.validators[index].effective_balance *
@@ -426,9 +429,7 @@ proc process_epoch*(state: var BeaconState) =
 
   ## Caching here for get_beacon_committee(...) can break otherwise, since
   ## get_active_validator_indices(...) usually changes.
-  # TODO is this cache still necessary/useful? presumably not, but can't remove
-  # quite yet
-  clear(per_epoch_cache.crosslink_committee_cache)
+  clear(per_epoch_cache.beacon_committee_cache)
 
   # @process_reveal_deadlines
   # @process_challenge_deadlines

--- a/beacon_chain/time.nim
+++ b/beacon_chain/time.nim
@@ -52,7 +52,7 @@ func toSlot*(t: BeaconTime): tuple[afterGenesis: bool, slot: Slot] =
     (false, Slot(uint64(-ti) div SECONDS_PER_SLOT))
 
 func toBeaconTime*(c: BeaconClock, t: Time): BeaconTime =
-  BeaconTime(times.seconds(t - c.genesis))
+  BeaconTime(times.inSeconds(t - c.genesis))
 
 func toSlot*(c: BeaconClock, t: Time): tuple[afterGenesis: bool, slot: Slot] =
   c.toBeaconTime(t).toSlot()

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -45,7 +45,7 @@ suite "Attestation pool processing" & preset():
         beacon_committee = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation = makeAttestation(
-          state.data.data, state.blck.root, beacon_committee[0])
+          state.data.data, state.blck.root, beacon_committee[0], cache)
 
       pool.add(state.data.data, state.blck, attestation)
 
@@ -65,7 +65,7 @@ suite "Attestation pool processing" & preset():
         bc0 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0])
+          state.data.data, state.blck.root, bc0[0], cache)
 
       process_slots(state.data, state.data.data.slot + 1)
 
@@ -73,7 +73,7 @@ suite "Attestation pool processing" & preset():
         bc1 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc1[0])
+          state.data.data, state.blck.root, bc1[0], cache)
 
       # test reverse order
       pool.add(state.data.data, state.blck, attestation1)
@@ -95,9 +95,9 @@ suite "Attestation pool processing" & preset():
         bc0 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0])
+          state.data.data, state.blck.root, bc0[0], cache)
         attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1])
+          state.data.data, state.blck.root, bc0[1], cache)
 
       pool.add(state.data.data, state.blck, attestation0)
       pool.add(state.data.data, state.blck, attestation1)
@@ -119,9 +119,9 @@ suite "Attestation pool processing" & preset():
         bc0 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0])
+          state.data.data, state.blck.root, bc0[0], cache)
         attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1])
+          state.data.data, state.blck.root, bc0[1], cache)
 
       attestation0.combine(attestation1, {skipValidation})
 
@@ -144,9 +144,9 @@ suite "Attestation pool processing" & preset():
         bc0 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0, cache)
         attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0])
+          state.data.data, state.blck.root, bc0[0], cache)
         attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1])
+          state.data.data, state.blck.root, bc0[1], cache)
 
       attestation0.combine(attestation1, {skipValidation})
 

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -85,10 +85,10 @@ suite "Block processing" & preset():
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
-      crosslink_committee =
+      beacon_committee =
         get_beacon_committee(state, state.slot, 0, cache)
       attestation = makeAttestation(
-        state, previous_block_root, crosslink_committee[0])
+        state, previous_block_root, beacon_committee[0], cache)
 
     # Some time needs to pass before attestations are included - this is
     # to let the attestation propagate properly to interested participants


### PR DESCRIPTION
This does a few things:

- verifies that `state_sim` is justifying and finalizing: it already was, but this just just prevents regressions, and automatically runs as part of the CI suite. Less important than it used to be because we have the official EF unit tests, but it's still a useful intermediate level of integration between them and full-on `beacon_node` with `libp2p`, which explains extending the number of slots simulated in CI to reach when it finalizes;
- fixes 3 more warnings (at this point various depended-upon libraries vastly dominate warning counts when building `nim-beacon-chain`);
- rename `crosslink_committee_cache` to `beacon_committee_cache`;
- fixes `O(n^2)` usage of `get_base_reward(...)`, which seems to have been the main/only noticeable quadratic algorithm left up to 10k validators or so with `state_sim`, which by the mid-thousands of validators leads to a 10x or more speedup on epoch transitions;
- while not part of either slot or epoch processing times as such, `makeAttestation` was quite slow when called in basically repetitive ways from `state_sim`. Something of a `state_sim` artifact, but not using empty caches every call, with no other changes, brought down 4k validator `state_sim` total time in release build from 3m30s to 1m30s. `state_sim` makes lots of attestations, especially lots on the same slots, which can/should reuse information, and now it does.

I also profiled the results of all this throughout, and while this still isn't the sustainable infrastructure to do so -- that wasn't/isn't the point of this PR -- some new results, different from the 0.8 era:
- if `--validate=on`, then that dominates (`bls_sign(...)` specifically) at around 90% of time spent, while in an actual client, `bls_verify(...)` and `bls_aggregate_pubkeys(...)` scaling is what matters more. There's simply not nearly as much message signing going on in an actual client as in `state_sim` with `--validate=on`. There doesn't seem to be an obvious way to get only the `bls_verify(...)` half of this though in a `state_sim` like way, so...

- when `--validate=off`, all that disappears, but Eth1 deposit processing suddenly appears as about half the time spent, given I ran it a few epochs. More, obviously, and that'd drown out the initial deposits. This isn't reflective/representative, as with `--validate=on`, of the actual experience of a client, so I'm not too worried here. To be concrete, it's about 5 minutes to do that part with 8k validators. It scales superlinearly for reasons I didn't investigate, but it's absolutely dominated by SSZ and `hash_tree_root(...)` and an obvious guess is that it keeps re-hashing the same subtrees more often with more deposits;

- looking past all that, non-epoch and epoch slots are much more similar performance-wise now that `get_crosslink_deltas(...)` and `get_winning_crosslink_and_attesting_indices(...)` disappeared. For example:
```
Validators: 4000, epoch length: 8
Validators per attestation (mean): 125.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
     107.672,        8.748,       88.460,      122.530,           42, Process non-epoch slot with block
     151.616,       17.110,      118.458,      163.277,            6, Process epoch slot with block
````
and
```
Validators: 8000, epoch length: 8
Validators per attestation (mean): 250.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
     205.265,       18.409,      167.062,      239.044,           42, Process non-epoch slot with block
     288.256,       34.186,      224.720,      316.199,            6, Process epoch slot with block
```

It's scaling linearly, and rather than the old situation of slots being borderline instant within the slot time constraint, while epochs were repeatedly hitting slot time limits, here they're not that far off. It also helps that while minimal slot times are still 6 seconds, mainnet slot times are 12 seconds, so we shouldn't have acute performance issues.

The ones that remain are largely SSZ/hashing driven, which @mratsim and others have already pointed to resources regarding, for when that becomes a more urgent priority.