### PR TITLE
Docker changes [skip ci]

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,65 +1,46 @@
-FROM statusteam/nim-base AS build
+FROM debian:bullseye-slim AS build
+
+SHELL ["/bin/bash", "-c"]
 
 RUN apt-get -qq update \
- && apt-get -qq -y install build-essential make wget 2>/dev/null >/dev/null
+ && apt-get -qq -y install build-essential make wget librocksdb-dev libpcre3-dev golang-go git &>/dev/null \
+ && apt-get -qq clean
 
-RUN export GO_TAR_GZ=go1.12.6.linux-amd64.tar.gz \
- && cd /tmp/ \
- && wget --progress=dot:giga https://dl.google.com/go/$GO_TAR_GZ \
- && tar -xf $GO_TAR_GZ \
- && mv go /usr/local \
- && rm $GO_TAR_GZ
-
-ARG GIT_REVISION
-
-RUN export GOROOT=/usr/local/go \
- && export PATH=$GOROOT/bin:$PATH \
+# let Docker cache this between Git revision and testnet version changes
+RUN cd /root \
  && git clone https://github.com/status-im/nim-beacon-chain.git \
  && cd nim-beacon-chain \
- && git reset --hard ${GIT_REVISION} \
- && { make 2>/dev/null >/dev/null || true; } \
- && make -j8 update \
- && make deps \
- && cp vendor/go/bin/p2pd /usr/bin/p2pd \
- && cp docker/run_in_docker.sh /usr/bin/run_beacon_node.sh
+ && { make &>/dev/null || true; } \
+ && make -j$(nproc) update \
+ && make deps
 
-ARG NETWORK
+ARG GIT_REVISION
 ARG NETWORK_NIM_FLAGS
 
-RUN cd nim-beacon-chain \
- && ./env.sh nim \
-      -o:/usr/bin/beacon_node \
-      -d:release \
-      -d:insecure \
-      --debugger:native \
-      --debugInfo \
-      --verbosity:0 \
-      --hints:off \
-      --warnings:off \
-      ${NETWORK_NIM_FLAGS} \
-      -d:"chronicles_log_level=DEBUG" \
-      -d:"testnet_servers_image" \
-      c beacon_chain/beacon_node.nim
+RUN cd /root/nim-beacon-chain \
+ && git fetch \
+ && git reset --hard ${GIT_REVISION} \
+ && make -j$(nproc) update \
+ && make LOG_LEVEL=DEBUG NIMFLAGS="-d:release -d:insecure -d:testnet_servers_image ${NETWORK_NIM_FLAGS}" beacon_node
 
 # --------------------------------- #
 # Starting new image to reduce size #
 # --------------------------------- #
-FROM debian:9-slim
+FROM debian:bullseye-slim
+
+SHELL ["/bin/bash", "-c"]
 
 RUN apt-get -qq update \
- && apt-get -qq -y install librocksdb-dev psmisc 2>/dev/null >/dev/null \
+ && apt-get -qq -y install librocksdb-dev libpcre3 psmisc &>/dev/null \
  && apt-get -qq clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY --from=build /usr/bin/beacon_node /usr/bin/beacon_node
-COPY --from=build /usr/bin/run_beacon_node.sh /usr/bin/run_beacon_node.sh
-COPY --from=build /usr/bin/p2pd /usr/bin/p2pd
+COPY run_in_docker.sh /usr/bin/run_beacon_node.sh
+COPY --from=build /root/nim-beacon-chain/build/beacon_node /usr/bin/beacon_node
+COPY --from=build /root/nim-beacon-chain/vendor/go/bin/p2pd /usr/bin/p2pd
 
 MAINTAINER Zahary Karadjov <zahary@status.im>
 LABEL description="Nimbus installation that can act as an ETH2 network bootstrap node."
-
-ARG GIT_REVISION
-RUN echo Built from Git revision: ${GIT_REVISION}
 
 # TODO: This custom entry script is necessary only because we must clean up
 #       temporary files left by previous executions of the Go daeamon.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,3 +1,5 @@
+SHELL := bash # the shell used internally by "make"
+
 # These default settings can be overriden by exporting env variables
 
 GIT_REVISION      ?= $(shell git rev-parse HEAD)
@@ -7,16 +9,23 @@ NETWORK_NIM_FLAGS ?= $(shell ../scripts/load-testnet-nim-flags.sh $(NETWORK))
 IMAGE_TAG       ?= $(NETWORK)
 IMAGE_NAME      ?= statusteam/nimbus_beacon_node:$(IMAGE_TAG)
 
+CURRENT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+COMPUTER_SAYS_NO = { echo "I'm sorry, Dave. I'm afraid I can't do that."; exit 1; }
+
 build:
+	@ DOCKER_BUILDKIT=1 \
 	docker build \
 		--build-arg="GIT_REVISION=$(GIT_REVISION)" \
-		--build-arg="NETWORK=$(NETWORK)" \
 		--build-arg="NETWORK_NIM_FLAGS=$(NETWORK_NIM_FLAGS)" \
-		-t $(IMAGE_NAME) .
+		-t $(IMAGE_NAME) \
+		--progress=plain \
+		.
 
 push: build
-	docker push $(IMAGE_NAME)
+	+@ $(MAKE) push-last
 
 push-last:
+	@ [[ "$(CURRENT_BRANCH)" != "master" && "$(NETWORK)" == "testnet0" ]] && $(COMPUTER_SAYS_NO) || true
+	@ [[ "$(CURRENT_BRANCH)" != "devel" && "$(NETWORK)" == "testnet1" ]] && $(COMPUTER_SAYS_NO) || true
 	docker push $(IMAGE_NAME)
 

--- a/scripts/load-testnet-nim-flags.sh
+++ b/scripts/load-testnet-nim-flags.sh
@@ -18,7 +18,6 @@ add_var () {
 add_var CONST_PRESET
 add_var NETWORK_TYPE
 add_var SLOTS_PER_EPOCH
-add_var SLOTS_PER_EPOCH
 add_var MAX_COMMITTEES_PER_SLOT
 
 echo $NIM_FLAGS


### PR DESCRIPTION
- use a Debian Bullseye image
- use the distro's packages whenever possible
- cache as much as possible of the Git repos and tool binaries locally
- restrict Docker image pushing to specific branches; no build restrictions, to allow for easy development