### PR TITLE
Ssz fixes

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -357,6 +357,8 @@ macro fieldMaxLen*(x: typed): untyped =
                 "compact_validators",
                 "aggregation_bits",
                 "custody_bits": int64(MAX_VALIDATORS_PER_COMMITTEE)
+             # IndexedAttestation
+             of "attesting_indices": MAX_VALIDATORS_PER_COMMITTEE
              # BeaconBlockBody
              of "proposer_slashings": MAX_PROPOSER_SLASHINGS
              of "attester_slashings": MAX_ATTESTER_SLASHINGS

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -352,15 +352,18 @@ macro fieldMaxLen*(x: typed): untyped =
     return newLit(0)
 
   let size = case $x[1]
+             # Obsolete
              of "pubkeys",
                 "compact_validators",
                 "aggregation_bits",
                 "custody_bits": int64(MAX_VALIDATORS_PER_COMMITTEE)
+             # BeaconBlockBody
              of "proposer_slashings": MAX_PROPOSER_SLASHINGS
              of "attester_slashings": MAX_ATTESTER_SLASHINGS
              of "attestations": MAX_ATTESTATIONS
              of "deposits": MAX_DEPOSITS
              of "voluntary_exits": MAX_VOLUNTARY_EXITS
+             # BeaconState
              of "historical_roots": HISTORICAL_ROOTS_LIMIT
              of "eth1_data_votes": SLOTS_PER_ETH1_VOTING_PERIOD
              of "validators": VALIDATOR_REGISTRY_LIMIT

--- a/tests/helpers/debug_ssz.nim
+++ b/tests/helpers/debug_ssz.nim
@@ -20,9 +20,9 @@ import
 # ---------------------------------------------
 
 const
-  FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
+  FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / "official"/"fixtures"
   SSZDir = FixturesDir/"tests-v0.9.1"/const_preset/"phase0"/"ssz_static"
-  UnitTestDir = SSZDir/"Attestation"/"ssz_lengthy"/"case_12"
+  UnitTestDir = SSZDir/"IndexedAttestation"/"ssz_zero"/"case_0"
 
 type
   SSZHashTreeRoot = object
@@ -72,4 +72,11 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 echo "Current preset: ", const_preset
 
 let hash = loadExpectedHashTreeRoot(UnitTestDir)
-checkSSZ(Attestation, UnitTestDir, hash)
+checkSSZ(IndexedAttestation, UnitTestDir, hash)
+
+echo "\n\n"
+var deserialized: ref IndexedAttestation
+new deserialized
+deserialized[] = SSZ.loadFile(UnitTestDir/"serialized.ssz", IndexedAttestation)
+
+echo deserialized.data.hashTreeRoot()

--- a/tests/helpers/debug_ssz.nim
+++ b/tests/helpers/debug_ssz.nim
@@ -22,7 +22,7 @@ import
 const
   FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / "official"/"fixtures"
   SSZDir = FixturesDir/"tests-v0.9.1"/const_preset/"phase0"/"ssz_static"
-  UnitTestDir = SSZDir/"IndexedAttestation"/"ssz_zero"/"case_0"
+  UnitTestDir = SSZDir/"Validator"/"ssz_zero"/"case_0"
 
 type
   SSZHashTreeRoot = object
@@ -72,11 +72,11 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 echo "Current preset: ", const_preset
 
 let hash = loadExpectedHashTreeRoot(UnitTestDir)
-checkSSZ(IndexedAttestation, UnitTestDir, hash)
+checkSSZ(Validator, UnitTestDir, hash)
 
 echo "\n\n"
-var deserialized: ref IndexedAttestation
+var deserialized: ref Validator
 new deserialized
-deserialized[] = SSZ.loadFile(UnitTestDir/"serialized.ssz", IndexedAttestation)
+deserialized[] = SSZ.loadFile(UnitTestDir/"serialized.ssz", Validator)
 
-echo deserialized.data.hashTreeRoot()
+echo deserialized[].hashTreeRoot()

--- a/tests/official/debug_ssz.nim
+++ b/tests/official/debug_ssz.nim
@@ -1,0 +1,75 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  os, unittest, strutils, streams,
+  # Status libraries
+  stint, stew/bitseqs,
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../beacon_chain/spec/[datatypes, digest, crypto],
+  ../../beacon_chain/ssz
+
+# Config
+# ---------------------------------------------
+
+const
+  FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
+  SSZDir = FixturesDir/"tests-v0.9.1"/const_preset/"phase0"/"ssz_static"
+  UnitTestDir = SSZDir/"Attestation"/"ssz_lengthy"/"case_12"
+
+type
+  SSZHashTreeRoot = object
+    # The test files have the values at the "root"
+    # so we **must** use "root" as a field name
+    root: string
+    # Some have a signing_root field
+    signing_root: string
+
+# Make signing root optional
+setDefaultValue(SSZHashTreeRoot, signing_root, "")
+
+# Parsing + Test
+# ---------------------------------------------
+
+type Skip = enum
+  SkipNone
+  SkipHashTreeRoot
+  SkipSigningRoot
+
+proc checkSSZ(T: typedesc, dir: string, expectedHash: SSZHashTreeRoot, skip = SkipNone) =
+  # Deserialize into a ref object to not fill Nim stack
+  var deserialized: ref T
+  new deserialized
+  deserialized[] = SSZ.loadFile(dir/"serialized.ssz", T)
+
+  echo "\n\nObject: ", T
+  echo "---------------------------------------"
+  echo deserialized[]
+
+  if not(skip == SkipHashTreeRoot):
+    check: expectedHash.root == "0x" & toLowerASCII($deserialized.hashTreeRoot())
+  if expectedHash.signing_root != "" and not(skip == SkipSigningRoot):
+    check: expectedHash.signing_root == "0x" & toLowerASCII($deserialized[].signingRoot())
+
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+  var s = openFileStream(dir/"roots.yaml")
+  yaml.load(s, result)
+  s.close()
+
+# Manual checks
+# ---------------------------------------------
+
+# Compile with -d:ssz_testing for consensus objects
+# as they are always an Opaque Blob even if they might seem like a valid BLS signature
+
+echo "Current preset: ", const_preset
+
+let hash = loadExpectedHashTreeRoot(UnitTestDir)
+checkSSZ(Attestation, UnitTestDir, hash)

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -43,28 +43,29 @@ setDefaultValue(SSZHashTreeRoot, signing_root, "")
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 const Unsupported = toHashSet([
     "AggregateAndProof",    # Type for signature aggregation - not implemented
-    "Attestation",          # RangeError on deserialization
-    # "AttestationData",
-    "AttesterSlashing",     # RangeError on deserialization
-    "BeaconBlock",          # RangeError on deserialization
-    "BeaconBlockBody",      # RangeError on deserialization
-    # "BeaconBlockHeader",  # HashTreeRoot KO - SigningRook OK
-    "BeaconState",          # HashTreeRoot KO
-    # "Checkpoint",
-    "Deposit",              # HashTreeRoot KO
-    "DepositData",          # HashTreeRoot KO - SigningRoot KO
-    # "Eth1Data",
-    # "Fork",
-    # "HistoricalBatch",    # OK
-    "IndexedAttestation",   # RangeError on deserialization
-    # "PendingAttestation", # OK
-    "ProposerSlashing",     # HashTreeRoot KO
+    # "Attestation",        #
+    # "AttestationData",    #
+    "AttesterSlashing",     # HashTreeRoot KO
+    "BeaconBlock",          # HashTreeRoot KO
+    "BeaconBlockBody",      # HashTreeRoot KO
+    # "BeaconBlockHeader",  #
+    # "BeaconState",        # OK on minimal, KO on mainnet
+    # "Checkpoint",         #
+    # "Deposit",            #
+    # "DepositData",        #
+    # "Eth1Data",           #
+    # "Fork",               #
+    # "HistoricalBatch",    #
+    "IndexedAttestation",   # HashTreeRoot KO
+    # "PendingAttestation", # OK on minimal, KO on mainnet
+    # "ProposerSlashing",   #
     "Validator",            # HashTreeRoot KO
-    # "VoluntaryExit"       # hashTreeRoot KO - SigningRoot OK
+    # "VoluntaryExit"       #
   ])
 
 const UnsupportedMainnet = toHashSet([
     "PendingAttestation",   # HashTreeRoot KO
+    "BeaconState",
   ])
 
 type Skip = enum
@@ -78,6 +79,7 @@ proc checkSSZ(T: typedesc, dir: string, expectedHash: SSZHashTreeRoot, skip = Sk
   new deserialized
   deserialized[] = SSZ.loadFile(dir/"serialized.ssz", T)
 
+  # echo "Dir: ", dir
   if not(skip == SkipHashTreeRoot):
     check: expectedHash.root == "0x" & toLowerASCII($deserialized.hashTreeRoot())
   if expectedHash.signing_root != "" and not(skip == SkipSigningRoot):
@@ -108,10 +110,6 @@ proc runSSZtests() =
           discard
         continue
 
-    let signingRootOnly = &"                     ↶↶↶ {sszType} - Skipping HashTreeRoot and testing SigningRoot only"
-    if sszType == "BeaconBlockHeader" or sszType == "VoluntaryExit":
-      echo signingRootOnly
-
     test &"  Testing    {sszType:20}   consensus object ✓✓✓":
       let path = SSZDir/sszType
       for pathKind, sszTestKind in walkDir(path, relative = true):
@@ -128,7 +126,7 @@ proc runSSZtests() =
           of "AttesterSlashing": checkSSZ(AttesterSlashing, path, hash)
           of "BeaconBlock": checkSSZ(BeaconBlock, path, hash)
           of "BeaconBlockBody": checkSSZ(BeaconBlockBody, path, hash)
-          of "BeaconBlockHeader": checkSSZ(BeaconBlockHeader, path, hash, SkipHashTreeRoot) # TODO
+          of "BeaconBlockHeader": checkSSZ(BeaconBlockHeader, path, hash)
           of "BeaconState": checkSSZ(BeaconState, path, hash)
           of "Checkpoint": checkSSZ(Checkpoint, path, hash)
           of "Deposit": checkSSZ(Deposit, path, hash)
@@ -140,7 +138,7 @@ proc runSSZtests() =
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
           of "Validator": checkSSZ(VoluntaryExit, path, hash)
-          of "VoluntaryExit": checkSSZ(VoluntaryExit, path, hash, SkipHashTreeRoot) # TODO
+          of "VoluntaryExit": checkSSZ(VoluntaryExit, path, hash)
           else:
             raise newException(ValueError, "Unsupported test: " & sszType)
 

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -66,6 +66,11 @@ const Unsupported = toHashSet([
 const UnsupportedMainnet = toHashSet([
     "PendingAttestation",   # HashTreeRoot KO
     "BeaconState",
+    "AttesterSlashing",
+    "BeaconBlockBody",
+    "IndexedAttestation",
+    "Attestation",
+    "BeaconBlock"
   ])
 
 type Skip = enum

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -49,7 +49,7 @@ const Unsupported = toHashSet([
     # "BeaconBlock",        #
     # "BeaconBlockBody",    #
     # "BeaconBlockHeader",  #
-    # "BeaconState",        # OK on minimal, KO on mainnet
+    # "BeaconState",        #
     # "Checkpoint",         #
     # "Deposit",            #
     # "DepositData",        #
@@ -57,9 +57,9 @@ const Unsupported = toHashSet([
     # "Fork",               #
     # "HistoricalBatch",    #
     # "IndexedAttestation", #
-    # "PendingAttestation", # OK on minimal, KO on mainnet
+    # "PendingAttestation", #
     # "ProposerSlashing",   #
-    "Validator",            # HashTreeRoot KO
+    # "Validator",            # HashTreeRoot KO
     # "VoluntaryExit"       #
   ])
 
@@ -84,7 +84,6 @@ proc checkSSZ(T: typedesc, dir: string, expectedHash: SSZHashTreeRoot, skip = Sk
   new deserialized
   deserialized[] = SSZ.loadFile(dir/"serialized.ssz", T)
 
-  # echo "Dir: ", dir
   if not(skip == SkipHashTreeRoot):
     check: expectedHash.root == "0x" & toLowerASCII($deserialized.hashTreeRoot())
   if expectedHash.signing_root != "" and not(skip == SkipSigningRoot):
@@ -142,7 +141,7 @@ proc runSSZtests() =
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
-          of "Validator": checkSSZ(VoluntaryExit, path, hash)
+          of "Validator": checkSSZ(Validator, path, hash)
           of "VoluntaryExit": checkSSZ(VoluntaryExit, path, hash)
           else:
             raise newException(ValueError, "Unsupported test: " & sszType)

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -45,9 +45,9 @@ const Unsupported = toHashSet([
     "AggregateAndProof",    # Type for signature aggregation - not implemented
     # "Attestation",        #
     # "AttestationData",    #
-    "AttesterSlashing",     # HashTreeRoot KO
-    "BeaconBlock",          # HashTreeRoot KO
-    "BeaconBlockBody",      # HashTreeRoot KO
+    # "AttesterSlashing",   #
+    # "BeaconBlock",        #
+    # "BeaconBlockBody",    #
     # "BeaconBlockHeader",  #
     # "BeaconState",        # OK on minimal, KO on mainnet
     # "Checkpoint",         #
@@ -56,7 +56,7 @@ const Unsupported = toHashSet([
     # "Eth1Data",           #
     # "Fork",               #
     # "HistoricalBatch",    #
-    "IndexedAttestation",   # HashTreeRoot KO
+    # "IndexedAttestation", #
     # "PendingAttestation", # OK on minimal, KO on mainnet
     # "ProposerSlashing",   #
     "Validator",            # HashTreeRoot KO

--- a/tests/official/test_fixture_ssz_consensus_objects.nim.cfg
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim.cfg
@@ -1,0 +1,1 @@
+-d:ssz_testing


### PR DESCRIPTION
This makes us generates proper SSZ deserialization on preset minimal for all types
preset mainnet is not OK yet.

I've kept the obsolete fields names in the macro that implicitly declare some fields as TypeWithMaxLen.
I did try removing them a branch:
- 1 with List as seq https://github.com/status-im/nim-beacon-chain/blob/576ee79200f55a4fca06f5123152cb0f69355114/beacon_chain/spec/datatypes.nim#L349-L376
And try to not depend on them by using distinct seq:
- https://github.com/status-im/nim-beacon-chain/blob/stash-changing-list-to-distinct-seq

But both branches triggered several regressions on the already passing SSZ tests.
So that will be done in later PRs.

---------

I feel like the SSZ code has become quite hard to debug (see https://github.com/status-im/nim-beacon-chain/issues/557#issuecomment-555054039)
- Lots of templates and auto indirection
- Error messages with typedesc param is worse than with generics
- int/int64/static int64 issues with large constants
- Workarounds for Nim bugs in dependent type/generic/static resolution.

Note that some are not needed anymore with Nim v1 and actually any change should start by disabling it as the code won't compile otherwise: https://github.com/status-im/nim-beacon-chain/blob/6f2d980bff28153672ae79ba5c9f3ff091848b58/beacon_chain/ssz.nim#L85-L94

I wonder if a macro that select according to the nested types would not be simpler than the recursive dependently-typed templates collection that we have now, and also easier to debug as a `toStrLit` call would display the full serialization/deserialization code. It may also be faster to compile as the current code is probably quite taxing on semcheck.