### PR TITLE
Test vector download script simplification/cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       before_install:
         - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
         - sudo apt-get -q update
-        - sudo apt-get install -y libpcre3-dev git-lfs librocksdb-dev
+        - sudo apt-get install -y libpcre3-dev librocksdb-dev
     - os: osx
       env:
         - NPROC=2

--- a/scripts/setup_official_tests.sh
+++ b/scripts/setup_official_tests.sh
@@ -9,7 +9,6 @@
 
 set -e
 
-TMP_CACHE_DIR="tmpcache"
 SUBREPO_DIR="tests/official/fixtures"
 # verbosity level
 [[ -z "$V" ]] && V=0
@@ -17,21 +16,6 @@ SUBREPO_DIR="tests/official/fixtures"
 CACHE_DIR="$1" # optional parameter pointing to a CI cache dir. Without it, we just download the LFS files for a local `make test`.
 
 [[ -d "${SUBREPO_DIR}" ]] || { echo "This script should be run from the \"nim-beacon-chain\" repo top dir."; exit 1; }
-
-# macOS quirks
-if uname | grep -qi "darwin"; then
-	ON_MACOS=1
-	STAT_FORMAT="-f %m"
-else
-	ON_MACOS=0
-	STAT_FORMAT="-c %Y"
-fi
-
-# to and from stdout
-DECOMPRESS_XZ="false"
-COMPRESS_XZ="false"
-which 7z &>/dev/null && { DECOMPRESS_XZ="7z e -txz -bd -so"; COMPRESS_XZ="7z a -txz -an -bd -si -so"; }
-which xz &>/dev/null && { DECOMPRESS_XZ="xz -d -c -T 0"; COMPRESS_XZ="xz -c -T 0"; }
 
 # script output
 echo -e "$BUILD_MSG"


### PR DESCRIPTION
`COMPRESS_XZ`, `DECOMPRESS_XZ`, `TMP_CACHE_DIR`, `ON_MACOS`, and `STAT_FORMAT` appear to be completely unused through`nim-beacon-chain` and all its dependencies, except for the Mac OS-workaround `STAT_FORMAT` which is reconstructed independently in `vendor/nimbus-build-system/scripts/build_p2pd.sh`:
```
nim-beacon-chain$ grep -rin COMPRESS_XZ 
nim-beacon-chain$ grep -rin TMP_CACHE_DIR
nim-beacon-chain$ grep -rin ON_MACOS
nim-beacon-chain$ grep -rin STAT_FORMAT
vendor/nimbus-build-system/scripts/build_p2pd.sh:39:    STAT_FORMAT="-f %m"
vendor/nimbus-build-system/scripts/build_p2pd.sh:41:    STAT_FORMAT="-c %Y"
vendor/nimbus-build-system/scripts/build_p2pd.sh:57:    if [[ -e "$TARGET_BINARY" && $(stat $STAT_FORMAT "$TARGET_BINARY") -gt $(cd "$SUBREPO_DIR"; git log --pretty=format:%cd -n 1 --date=unix) ]]; then
vendor/go/pkg/mod/github.com/prometheus/procfs@v0.0.3/ttar:312:            STAT_FORMAT='%a'
vendor/go/pkg/mod/github.com/prometheus/procfs@v0.0.3/ttar:317:            STAT_FORMAT='%OLp'
vendor/go/pkg/mod/github.com/prometheus/procfs@v0.0.3/ttar:320:    stat "${STAT_OPTION}" "${STAT_FORMAT}" "$mfile"
nim-beacon-chain$
```

Removing unused downloads (e.g., `git-lfs`) prevents occasional transient/ephemeral DNS/network/etc failure causing spurious CI failures.