### PR TITLE
Log reasons for validator exits

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -103,7 +103,7 @@ func process_deposit*(
   true
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#compute_activation_exit_epoch
-func compute_activation_exit_epoch*(epoch: Epoch): Epoch =
+func compute_activation_exit_epoch(epoch: Epoch): Epoch =
   ## Return the epoch during which validator activations and exits initiated in
   ## ``epoch`` take effect.
   epoch + 1 + MAX_SEED_LOOKAHEAD
@@ -371,7 +371,7 @@ func get_attesting_indices*(state: BeaconState,
       result.incl index
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#get_indexed_attestation
-func get_indexed_attestation*(state: BeaconState, attestation: Attestation,
+func get_indexed_attestation(state: BeaconState, attestation: Attestation,
     stateCache: var StateCache): IndexedAttestation =
   # Return the indexed attestation corresponding to ``attestation``.
   let

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -353,6 +353,15 @@ proc process_voluntary_exit*(
       return false
 
   # Initiate exit
+  debug "Exit: processing voluntary exit (validator_leaving)",
+    index = exit.validator_index,
+    num_validators = state.validators.len,
+    epoch = exit.epoch,
+    current_epoch = get_current_epoch(state),
+    validator_slashed = validator.slashed,
+    validator_withdrawable_epoch = validator.withdrawable_epoch,
+    validator_exit_epoch = validator.exit_epoch,
+    validator_effective_balance = validator.effective_balance
   initiate_validator_exit(state, exit.validator_index.ValidatorIndex)
 
   true

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -270,7 +270,7 @@ proc processAttesterSlashings(state: var BeaconState, blck: BeaconBlock,
   return true
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.8.4/specs/core/0_beacon-chain.md#attestations
-proc processAttestations*(
+proc processAttestations(
     state: var BeaconState, blck: BeaconBlock, flags: UpdateFlags,
     stateCache: var StateCache): bool =
   ## Each block includes a number of attestations that the proposer chose. Each

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -13,11 +13,11 @@ import
 # TODO: Proceed to renaming and signature changes
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#compute_shuffled_index
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#compute_committee
-func get_shuffled_seq*(seed: Eth2Digest,
-                       list_size: uint64,
-                       ): seq[ValidatorIndex] =
+func get_shuffled_seq(seed: Eth2Digest,
+                      list_size: uint64,
+                      ): seq[ValidatorIndex] =
   ## Via https://github.com/protolambda/eth2-shuffle/blob/master/shuffle.go
-  ## Shuffles ``validators`` into crosslink committees seeded by ``seed`` and
+  ## Shuffles ``validators`` into beacon committees, seeded by ``seed`` and
   ## ``slot``.
   ## Returns a list of ``SLOTS_PER_EPOCH * committees_per_slot`` committees
   ## where each committee is itself a list of validator indices.
@@ -147,7 +147,7 @@ func get_empty_per_epoch_cache*(): StateCache =
   result.committee_count_cache = initTable[Epoch, uint64]()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/core/0_beacon-chain.md#compute_proposer_index
-func compute_proposer_index*(state: BeaconState, indices: seq[ValidatorIndex],
+func compute_proposer_index(state: BeaconState, indices: seq[ValidatorIndex],
     seed: Eth2Digest, stateCache: var StateCache): ValidatorIndex =
   # Return from ``indices`` a random index sampled by effective balance.
   const MAX_RANDOM_BYTE = 255

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -10,7 +10,7 @@ type Timers = enum
   tBlock = "Process non-epoch slot with block"
   tEpoch = "Process epoch slot with block"
   tHashBlock = "Tree-hash block"
-  tShuffle = "Retrieve committee once using get_crosslink_committee"
+  tShuffle = "Retrieve committee once using get_beacon_committee"
   tAttest = "Combine committee attestations"
 
 template withTimer(stats: var RunningStat, body: untyped) =

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -130,13 +130,13 @@ proc mockAttestation*(
 
 proc fillAggregateAttestation*(state: BeaconState, attestation: var Attestation) =
   var cache = get_empty_per_epoch_cache()
-  let crosslink_committee = get_beacon_committee(
+  let beacon_committee = get_beacon_committee(
     state,
     attestation.data.slot,
     attestation.data.index,
     cache
   )
-  for i in 0 ..< crosslink_committee.len:
+  for i in 0 ..< beacon_committee.len:
     attestation.aggregation_bits[i] = true
 
 proc add*(state: var BeaconState, attestation: Attestation, slot: Slot) =

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -1,6 +1,8 @@
 # Sanity check on constants
 # ----------------------------------------------------------------
 
+{.used.}
+
 import
   # Standard library
   macros, os, strutils, tables, math, json, streams,

--- a/tests/simulation/tmux_demo.sh
+++ b/tests/simulation/tmux_demo.sh
@@ -2,6 +2,7 @@
 
 # Read in variables
 set -a
+# shellcheck source=/dev/null
 source "$(dirname "$0")/vars.sh"
 
 cd $(dirname "$0")

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -107,10 +107,6 @@ suite "[Unit - Spec - Block processing] Attestations " & preset():
 # - source epoch in the future
 # - invalid current source root
 # - bad source root
-# - non-zero crosslink data root
-# - bad parent crosslink
-# - bad crosslink start epoch
-# - bad crosslink end epoch
 # - inconsistent custody bits length
 # - non-empty custody bits in phase 0
 


### PR DESCRIPTION
This has been coming up in testnets -- they'll run for a few days, then validators just leave.

Regarding global/module `func`/`proc` scope, it's easier for both humans and the Nim compiler to reason about more locally scoped procedures. It also clarifies how the code is layered and points to potentially beneficial refactorings.