### PR TITLE
switch more funcs and procs from global to module scope; create scaffolding for non-O(n^2) eth1 deposit processing with assertions for equivalent functionality; fix a few more shellcheck warnings

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -227,12 +227,17 @@ func initialize_beacon_state_from_eth1*(
   state.randao_mixes.fill(eth1_block_hash)
 
   # Process deposits
-  let leaves = deposits.mapIt(it.data)
+  let
+    leaves = deposits.mapIt(it.data)
+    prefix_roots =
+      hash_tree_roots_prefix(leaves, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH)
   for i, deposit in deposits:
     let deposit_data_list = leaves[0..i]
-    state.eth1_data.deposit_root = hash_tree_root(
+    let prev_calc_method_deposit_root = hash_tree_root(
       sszList(deposit_data_list, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH))
 
+    state.eth1_data.deposit_root = prefix_roots[i]
+    doAssert state.eth1_data.deposit_root == prev_calc_method_deposit_root
     discard process_deposit(state, deposit, flags)
 
   # Process activations

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -232,12 +232,7 @@ func initialize_beacon_state_from_eth1*(
     prefix_roots =
       hash_tree_roots_prefix(leaves, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH)
   for i, deposit in deposits:
-    let deposit_data_list = leaves[0..i]
-    let prev_calc_method_deposit_root = hash_tree_root(
-      sszList(deposit_data_list, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH))
-
     state.eth1_data.deposit_root = prefix_roots[i]
-    doAssert state.eth1_data.deposit_root == prev_calc_method_deposit_root
     discard process_deposit(state, deposit, flags)
 
   # Process activations

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -229,11 +229,12 @@ func initialize_beacon_state_from_eth1*(
   # Process deposits
   let
     leaves = deposits.mapIt(it.data)
-    prefix_roots =
-      hash_tree_roots_prefix(leaves, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH)
-  for i, deposit in deposits:
-    state.eth1_data.deposit_root = prefix_roots[i]
-    discard process_deposit(state, deposit, flags)
+  var i = 0
+  for prefix_root in hash_tree_roots_prefix(
+      leaves, 2'i64^DEPOSIT_CONTRACT_TREE_DEPTH):
+    state.eth1_data.deposit_root = prefix_root
+    discard process_deposit(state, deposits[i], flags)
+    i += 1
 
   # Process activations
   for validator_index in 0 ..< state.validators.len:

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -73,7 +73,7 @@ proc init*(T: type SszReader,
            maxObjectSize = defaultMaxObjectSize): T =
   T(stream: stream, maxObjectSize: maxObjectSize)
 
-proc mount(F: type SSZ, stream: ByteStreamVar, T: type): T =
+proc mount*(F: type SSZ, stream: ByteStreamVar, T: type): T =
   mixin readValue
   var reader = init(SszReader, stream)
   reader.readValue(T)

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -574,8 +574,8 @@ func hash_tree_root*(x: auto): Eth2Digest =
 
   trs "HASH TREE ROOT FOR ", name(type x), " = ", "0x", $result
 
-func hash_tree_roots_prefix*[T](lst: openarray[T], limit: auto):
-    seq[Eth2Digest] =
+iterator hash_tree_roots_prefix*[T](lst: openarray[T], limit: auto):
+    Eth2Digest =
   # This is a particular type's instantiation of a general fold, reduce,
   # accumulation, prefix sums, etc family of operations. As long as that
   # Eth1 deposit case is the only notable example -- the usual uses of a
@@ -584,7 +584,7 @@ func hash_tree_roots_prefix*[T](lst: openarray[T], limit: auto):
   var merkelizer = SszChunksMerkelizer(limit: uint64(limit))
   for i, elem in lst:
     merkelizer.addChunk(hash_tree_root(elem).data)
-    result.add mixInLength(merkelizer.getFinalHash(), i + 1)
+    yield mixInLength(merkelizer.getFinalHash(), i + 1)
 
 func lastFieldName(RecordType: type): string {.compileTime.} =
   enumAllSerializedFields(RecordType):

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -73,7 +73,7 @@ proc init*(T: type SszReader,
            maxObjectSize = defaultMaxObjectSize): T =
   T(stream: stream, maxObjectSize: maxObjectSize)
 
-proc mount*(F: type SSZ, stream: ByteStreamVar, T: type): T =
+proc mount(F: type SSZ, stream: ByteStreamVar, T: type): T =
   mixin readValue
   var reader = init(SszReader, stream)
   reader.readValue(T)
@@ -166,7 +166,7 @@ template enumerateSubFields(holder, fieldVar, body: untyped) =
 
 func writeVarSizeType(w: var SszWriter, value: auto) {.gcsafe.}
 
-func beginRecord*(w: var SszWriter, TT: type): auto =
+func beginRecord(w: var SszWriter, TT: type): auto =
   type T = TT
   when isFixedSize(T):
     FixedSizedWriterCtx()
@@ -269,7 +269,7 @@ template fromSszBytes*[T; N](_: type TypeWithMaxLen[T, N],
   mixin fromSszBytes
   fromSszBytes(T, bytes)
 
-func fromSszBytes*(T: type BlsCurveType, bytes: openarray[byte]): auto =
+func fromSszBytes(T: type BlsCurveType, bytes: openarray[byte]): auto =
   init(T, bytes)
 
 proc readValue*(r: var SszReader, val: var auto) =
@@ -327,7 +327,7 @@ func getZeroHashWithoutSideEffect(idx: int): Eth2Digest =
   {.noSideEffect.}:
     zeroHashes[idx]
 
-func addChunk*(merkelizer: SszChunksMerkelizer, data: openarray[byte]) =
+func addChunk(merkelizer: SszChunksMerkelizer, data: openarray[byte]) =
   doAssert data.len > 0 and data.len <= bytesPerChunk
 
   if not getBitLE(merkelizer.totalChunks, 0):
@@ -350,7 +350,7 @@ func addChunk*(merkelizer: SszChunksMerkelizer, data: openarray[byte]) =
 
   inc merkelizer.totalChunks
 
-func getFinalHash*(merkelizer: SszChunksMerkelizer): Eth2Digest =
+func getFinalHash(merkelizer: SszChunksMerkelizer): Eth2Digest =
   let limit = merkelizer.limit
 
   if merkelizer.totalChunks == 0:
@@ -574,11 +574,23 @@ func hash_tree_root*(x: auto): Eth2Digest =
 
   trs "HASH TREE ROOT FOR ", name(type x), " = ", "0x", $result
 
+func hash_tree_roots_prefix*[T](lst: openarray[T], limit: auto):
+    seq[Eth2Digest] =
+  # This is a particular type's instantiation of a general fold, reduce,
+  # accumulation, prefix sums, etc family of operations. As long as that
+  # Eth1 deposit case is the only notable example -- the usual uses of a
+  # list involve, at some point, tree-hashing it -- finalized hashes are
+  # the only abstraction that escapes from this module this way.
+  var merkelizer = SszChunksMerkelizer(limit: uint64(limit))
+  for i, elem in lst:
+    merkelizer.addChunk(hash_tree_root(elem).data)
+    result.add mixInLength(merkelizer.getFinalHash(), i + 1)
+
 func lastFieldName(RecordType: type): string {.compileTime.} =
   enumAllSerializedFields(RecordType):
     result = fieldName
 
-func hasSigningRoot*(T: type): bool {.compileTime.} =
+func hasSigningRoot(T: type): bool {.compileTime.} =
   lastFieldName(T) == "signature"
 
 func signingRoot*(obj: object): Eth2Digest =

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -166,7 +166,7 @@ template enumerateSubFields(holder, fieldVar, body: untyped) =
 
 func writeVarSizeType(w: var SszWriter, value: auto) {.gcsafe.}
 
-func beginRecord(w: var SszWriter, TT: type): auto =
+func beginRecord*(w: var SszWriter, TT: type): auto =
   type T = TT
   when isFixedSize(T):
     FixedSizedWriterCtx()

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -23,9 +23,7 @@ import # Unit test
   ./test_zero_signature
 
 import # Refactor state transition unit tests
-  # ./spec_block_processing/test_genesis, # mostly TODOs,
-  # with initGenesisState(...) tested by test_process_deposits(...),
-  # and mainnet hitting pathological/quadratic eth1 deposit behavior
+  ./spec_block_processing/test_genesis,
   ./spec_block_processing/test_process_deposits,
   ./spec_block_processing/test_process_attestation,
   ./spec_epoch_processing/test_process_justification_and_finalization

--- a/tests/simulation/vars.sh
+++ b/tests/simulation/vars.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
+# https://github.com/koalaman/shellcheck/wiki/SC2034
+# shellcheck disable=2034
+true
+
 PWD_CMD="pwd"
 # get native Windows paths on Mingw
 uname | grep -qi mingw && PWD_CMD="pwd -W"
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 SIM_ROOT="$($PWD_CMD)"
 
 # Set a default value for the env vars usually supplied by a Makefile
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 : ${GIT_ROOT:="$($PWD_CMD)"}
 cd - &>/dev/null
 

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -17,7 +17,7 @@ func preset*(): string =
   " [Preset: " & const_preset & ']'
 
 when ValidatorPrivKey is BlsValue:
-  func makeFakeValidatorPrivKey*(i: int): ValidatorPrivKey =
+  func makeFakeValidatorPrivKey(i: int): ValidatorPrivKey =
     # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
     # lighthouse.
     # TODO: switch to https://github.com/ethereum/eth2.0-pm/issues/60
@@ -25,14 +25,14 @@ when ValidatorPrivKey is BlsValue:
     var bytes = uint64(i + 1000).toBytesLE()
     copyMem(addr result.blsValue.x[0], addr bytes[0], sizeof(bytes))
 else:
-  func makeFakeValidatorPrivKey*(i: int): ValidatorPrivKey =
+  func makeFakeValidatorPrivKey(i: int): ValidatorPrivKey =
     # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
     # lighthouse.
     # TODO: switch to https://github.com/ethereum/eth2.0-pm/issues/60
     var bytes = uint64(i + 1000).toBytesLE()
     copyMem(addr result.x[0], addr bytes[0], sizeof(bytes))
 
-func makeFakeHash*(i: int): Eth2Digest =
+func makeFakeHash(i: int): Eth2Digest =
   var bytes = uint64(i).toBytesLE()
   static: doAssert sizeof(bytes) <= sizeof(result.data)
   copyMem(addr result.data[0], addr bytes[0], sizeof(bytes))


### PR DESCRIPTION
This PR comes in two halves.

The first half sets up scaffolding between the `O(n^2)` and `O(n)`  Eth1 deposit processing. The second half removes the `O(n^2)` deposit processing and re-enables `test_genesis.nim`, which at 2^14 or so validators was well beyond the scope of reasonable run-time with an `O(n^2)` algorithm.

Previously, setting up a release-mode `state_sim` (which starts by doing Eth1 deposits for however many validators are specified) with 8,000 validators took 5 minutes simply to begin iterating over slots. It takes a couple of seconds now.

At 30k validators with `d:release`, `state_sim` takes ~850ms for non-epoch slots and 1100ms for epoch slots:
```
Validators: 30000, epoch length: 8
Validators per attestation (mean): 937.5000000000008
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
     721.283,       60.716,      595.174,      857.587,           42, Process non-epoch slot with block
    1024.737,      116.660,      799.324,     1092.371,            6, Process epoch slot with block
       0.326,        0.236,        0.021,        1.558,           48, Tree-hash block
       2.150,        1.975,        1.270,        7.022,           48, Retrieve committee once using get_beacon_committee
     627.481,      280.811,      146.175,     1377.115,         1536, Combine committee attestations

real    18m57.398s
user    18m54.177s
sys     0m0.263s
```

With 60k validators, max slot times scale about linearly, with non-epoch slots requiring 1.7s of calculation and epoch slots at most 2.2s of calculation, sans cryptography:
```Validators: 60000, epoch length: 8
Validators per attestation (mean): 1875.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    1453.448,      130.208,     1215.352,     1688.426,           42, Process non-epoch slot with block
    2069.224,      239.652,     1599.705,     2230.895,            6, Process epoch slot with block
       0.352,        0.177,        0.021,        0.627,           48, Tree-hash block
       4.341,        3.937,        2.536,       14.027,           48, Retrieve committee once using get_beacon_committee
    3167.905,     1151.941,     1125.542,     6303.238,         1536, Combine committee attestations

real    91m42.856s
user    91m20.231s
sys     0m0.622s
```