### PR TITLE
~50% speedup by fast-pathing Eth2Digest merkle hashing

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -258,8 +258,8 @@ func is_valid_genesis_state*(state: BeaconState): bool =
     return false
   return true
 
-# TODO candidate for spec?
-# https://github.com/ethereum/eth2.0-specs/blob/0.5.1/specs/core/0_beacon-chain.md#on-genesis
+# TODO this is now a non-spec helper function, and it's not really accurate
+# so only usable/used in research/ and tests/
 func get_initial_beacon_block*(state: BeaconState): BeaconBlock =
   BeaconBlock(
     slot: GENESIS_SLOT,

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -139,7 +139,7 @@ func writeFixedSized(c: var WriteCursor, x: auto) =
       c.append x
     else:
       for elem in x:
-        trs "WRITING FIXED SIZE ARRAY ELEMENENT"
+        trs "WRITING FIXED SIZE ARRAY ELEMENT"
         c.writeFixedSized toSszType(elem)
   elif x is tuple|object:
     enumInstanceSerializedFields(x, fieldName, field):
@@ -508,7 +508,12 @@ func bitlistHashTreeRoot(merkelizer: SszChunksMerkelizer, x: BitSeq): Eth2Digest
   mixInLength contentsHash, x.len
 
 func hashTreeRootImpl[T](x: T): Eth2Digest =
-  when (T is BasicType) or (when T is array: ElemType(T) is BasicType else: false):
+  when (when T is array: ElemType(T) is byte and
+      sizeof(T) == sizeof(Eth2Digest) else: false):
+    # TODO is this sizeof comparison guranteed? it's whole structure vs field
+    trs "ETH2DIGEST; IDENTITY MAPPING"
+    Eth2Digest(data: x)
+  elif (T is BasicType) or (when T is array: ElemType(T) is BasicType else: false):
     trs "FIXED TYPE; USE CHUNK STREAM"
     merkelizeSerializedChunks x
   elif T is string or (when T is (seq|openarray): ElemType(T) is BasicType else: false):


### PR DESCRIPTION
There's more performance to be mined by this general strategy, but this is particularly low-hanging fruit. An obvious step, for example, is for standalone, basic types, and `uint64` in particular, but after looking at where Merkle hashing time got spent under `mainnet` settings, it was predominantly `BeaconState`, and specifically,
```
    block_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]

    ...

    state_roots*: array[SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
    historical_roots*: List[Eth2Digest, HISTORICAL_ROOTS_LIMIT]

    eth1_data_votes*: List[Eth1Data, SLOTS_PER_ETH1_VOTING_PERIOD]

    ...

    # Shuffling
    randao_mixes*: array[EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
```

When I run `time make test` before this change (it's reasonable stable between runs; I did each of these multiple times):
```
:....... slot: 32 epoch: 4
:....... slot: 40 epoch: 5
:done!
Validators: 128, epoch length: 8
Validators per attestation (mean): 4.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
      16.852,        3.284,        9.263,       22.990,           35, Process non-epoch slot with block
      22.871,        2.727,       18.161,       24.619,            5, Process epoch slot with block
       1.108,        0.598,        0.023,        2.264,           40, Tree-hash block
       0.037,        0.014,        0.025,        0.076,           40, Retrieve committee once using get_beacon_committee
      11.925,        0.248,       11.439,       12.999,         1280, Combine committee attestations

real    4m53.761s
user    7m39.533s
sys     0m8.852s
```

And with this change applied:
```
NOT 2019-11-26 15:58:26+01:00 Exit: validator has exited                 tid=144536
  [OK] [Invalid] validator_already_exited
NOT 2019-11-26 15:58:26+01:00 Exit: not in validator set long enough     tid=144536
  [OK] [Invalid] validator_not_active_long_enough
[NimScript] exec: nim c --out:./build/state_sim -r -d:release --verbosity:0 --hints:off --warnings:off -d:usePcreHeader --passL:"-lpcre" research/state_sim.nim --validators=128 --slots=40
:....... slot: 8 epoch: 1
:....... slot: 16 epoch: 2
:....... slot: 24 epoch: 3
:....... slot: 32 epoch: 4
:....... slot: 40 epoch: 5
:done!
Validators: 128, epoch length: 8
Validators per attestation (mean): 4.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
      14.402,        2.677,        8.708,       18.731,           35, Process non-epoch slot with block
      19.694,        2.641,       15.107,       21.247,            5, Process epoch slot with block
       0.980,        0.522,        0.019,        1.806,           40, Tree-hash block
       0.028,        0.011,        0.022,        0.052,           40, Retrieve committee once using get_beacon_committee
      10.643,        0.099,       10.436,       11.403,         1280, Combine committee attestations

real    2m23.408s
user    3m29.529s
sys     0m4.379s
```

For `all_fixtures_require_ssz` on `mainnet` settings specifically:
```
NOT 2019-11-26 15:22:49+01:00 Exit: validator not active                 tid=124451
  [OK] [Invalid] validator_not_active
NOT 2019-11-26 15:22:49+01:00 Exit: validator has exited                 tid=124451
  [OK] [Invalid] validator_already_exited
NOT 2019-11-26 15:22:49+01:00 Exit: not in validator set long enough     tid=124451
  [OK] [Invalid] validator_not_active_long_enough

real    0m56.918s
user    0m56.857s
sys     0m0.052s
```
before and
```
real    0m25.817s
user    0m25.545s
sys     0m0.061s
```
after. This fixes the pathological behavior in the test mentioned in https://github.com/status-im/nim-beacon-chain/issues/452 -- testing that very specifically, before it takes 13 seconds for me, and after, about 2.5 seconds.