### PR TITLE
avoid pointless stream usage for main basic type in SSZ objects

### DIFF
--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -511,7 +511,6 @@ func hashTreeRootImpl[T](x: T): Eth2Digest =
   when T is uint64:
     trs "UINT64; LITTLE-ENDIAN IDENTITY MAPPING"
     when system.cpuEndian == bigEndian:
-      var bytes: array[sizeof(x), byte]
       littleEndian64(addr result.data[0], x.unsafeAddr)
     else:
       let valueAddr = unsafeAddr x

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -514,8 +514,7 @@ func hashTreeRootImpl[T](x: T): Eth2Digest =
       littleEndian64(addr result.data[0], x.unsafeAddr)
     else:
       let valueAddr = unsafeAddr x
-      result.data[0..7] =
-        makeOpenArray(cast[ptr byte](valueAddr), sizeof(value))
+      result.data[0..7] = makeOpenArray(cast[ptr byte](valueAddr), 8)
   elif (when T is array: ElemType(T) is byte and
       sizeof(T) == sizeof(Eth2Digest) else: false):
     # TODO is this sizeof comparison guranteed? it's whole structure vs field

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -10,7 +10,7 @@
 
 import
   endians, stew/shims/macros, options, algorithm, options,
-  stew/[bitops2, bitseqs, objects, varints, ptrops], stint,
+  stew/[bitops2, bitseqs, objects, varints, ptrops, ranges/ptr_arith], stint,
   faststreams/input_stream, serialization, serialization/testing/tracing,
   nimcrypto/sha2, blscurve, eth/common,
   ./spec/[crypto, datatypes, digest],
@@ -508,7 +508,16 @@ func bitlistHashTreeRoot(merkelizer: SszChunksMerkelizer, x: BitSeq): Eth2Digest
   mixInLength contentsHash, x.len
 
 func hashTreeRootImpl[T](x: T): Eth2Digest =
-  when (when T is array: ElemType(T) is byte and
+  when T is uint64:
+    trs "UINT64; LITTLE-ENDIAN IDENTITY MAPPING"
+    when system.cpuEndian == bigEndian:
+      var bytes: array[sizeof(x), byte]
+      littleEndian64(addr result.data[0], x.unsafeAddr)
+    else:
+      let valueAddr = unsafeAddr x
+      result.data[0..7] =
+        makeOpenArray(cast[ptr byte](valueAddr), sizeof(value))
+  elif (when T is array: ElemType(T) is byte and
       sizeof(T) == sizeof(Eth2Digest) else: false):
     # TODO is this sizeof comparison guranteed? it's whole structure vs field
     trs "ETH2DIGEST; IDENTITY MAPPING"


### PR DESCRIPTION
This is a little uglier than https://github.com/status-im/nim-beacon-chain/pull/595 but is along the same lines. It doesn't result in nearly the same sort of speedup, as it was simply never the same sort of performance hot-spot, but constructing an entire stream for a single `uint64`, which do appear in the thousands as individual elements in `BeaconState`, still is not ideal:
```
    # Slashings
    slashings*: array[EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
    ## Per-epoch sums of slashed effective balances
```
where `EPOCHS_PER_SLASHINGS_VECTOR` is 8192 on `mainnet`. Every time it was SSZ/Merkle hashing a `BeaconState`, it was creating `EPOCHS_PER_SLASHINGS_VECTOR` output streams anew for this one field alone via:
https://github.com/status-im/nim-beacon-chain/blob/fa22ba22b90814458ba0ee810d946253f1357919/beacon_chain/ssz.nim#L44-L47
https://github.com/status-im/nim-beacon-chain/blob/fa22ba22b90814458ba0ee810d946253f1357919/beacon_chain/ssz.nim#L413-L419
and
https://github.com/status-im/nim-beacon-chain/blob/fa22ba22b90814458ba0ee810d946253f1357919/beacon_chain/ssz.nim#L427-L435

Elsewhere, in `writeFixedSized(...)`, there's code to handle unsigned integers of 8, 16, and 32 bits as well, but those don't show up anymore in SSZ types. They used to, back in 0.5, 0.6, that era, but now pretty much only 64-bit unsigned integers should be required.