### PR TITLE
state_sim optimizations

### DIFF
--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -1,8 +1,8 @@
 # beacon_chain
 # Copyright (c) 2019 Status Research & Development GmbH
 # Licensed and distributed under either of
-#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
-#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -206,8 +206,6 @@ proc makeAttestation*(
     flags: UpdateFlags = {}): Attestation =
   let (committee, slot, index) =
     find_beacon_committee(state, validator_index, cache)
-  debugEcho "validator_index = ", validator_index
-  debugEcho "goit index: ", index
   makeAttestation(state, beacon_block_root, committee, slot, index,
     validator_index, cache, flags)
 


### PR DESCRIPTION
- switch out quadratically scaling and wasteful attestation in state_sim to attest only to exactly the correct slots
- avoid pointless committee index interconversion

This results in a for 9-10x increase in state_sim speed at d:release, 60k validators, and validate=off -- comparing with https://github.com/status-im/nim-beacon-chain/pull/590 I get about 9 minutes total now vs 90 minutes, almost all of which (the last 30 seconds maybe) is the Eth1 deposit processing:
```
Hint: /home/user/nim-beacon-chain/research/state_sim --validators=60000 --validate=off [Exec]
:....... slot: 8 epoch: 1
:....... slot: 16 epoch: 2
:....... slot: 24 epoch: 3
:....... slot: 32 epoch: 4
:....... slot: 40 epoch: 5
:....... slot: 48 epoch: 6
:done!
Validators: 60000, epoch length: 8
Validators per attestation (mean): 1875.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    1077.646,        7.972,     1029.197,     1082.653,           42, Process non-epoch slot with block
    1286.323,      100.686,     1085.539,     1342.013,            6, Process epoch slot with block
       0.090,        0.014,        0.019,        0.128,           48, Tree-hash block
       2.622,        3.923,        0.945,       12.266,           48, Retrieve committee once using get_beacon_committee
      15.135,        0.137,       14.757,       15.559,          192, Combine committee attestations
```

The real gains don't really show up there, because it's just doing less of what it doesn't need to now, and mostly what gets measured is the core beacon chain protocol code, but here, it was the `state_sim` wrapper which was inefficient. While the slots are maybe 50% faster than in https://github.com/status-im/nim-beacon-chain/pull/590 that's mostly due to https://github.com/status-im/nim-beacon-chain/pull/595 while the optimizations here are around those calls, and showed up mostly in the overall wall clock time.

For the first time, 100k validators looks completely feasible -- I'm hitting `MAX_VALIDATORS_PER_COMMITTEE == 2048` limits at the moment, though, which the 60k example above already approaches (1875) which is presumably related to `state_sim`'s constant selections. Just proportionally scaling up, it looks like `state_sim` won't work in `minimal` beyond 2^16 validators.