### PR TITLE
remove getCurrentExceptionMsg()

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -146,9 +146,9 @@ proc commitGenesisState(node: BeaconNode, tailState: BeaconState) =
     let tailBlock = get_initial_beacon_block(tailState)
     BlockPool.preInit(node.db, tailState, tailBlock)
 
-  except:
+  except CatchableError as e:
     stderr.write "Failed to initialize database\n"
-    stderr.write getCurrentExceptionMsg(), "\n"
+    stderr.write e.msg, "\n"
     quit 1
 
 proc addBootstrapNode(node: BeaconNode, bootstrapNode: BootstrapAddr) =

--- a/beacon_chain/inspector.nim
+++ b/beacon_chain/inspector.nim
@@ -250,9 +250,9 @@ proc run(conf: InspectorConf) {.async.} =
     info InspectorIdent & " started", peerID = getPeerId(identity.peer, conf),
                                       bound = identity.addresses,
                                       options = flags
-  except:
+  except CatchableError as e:
     error "Could not initialize p2pd daemon",
-          exception = getCurrentExceptionMsg()
+          exception = e.msg
     quit(1)
 
   try:
@@ -265,8 +265,8 @@ proc run(conf: InspectorConf) {.async.} =
       let t = await api.pubsubSubscribe(filter, pubsubLogger)
       info "Subscribed to custom topic", topic = filter
       subs.add((ticket: t, future: t.transp.join()))
-  except:
-    error "Could not subscribe to topics", exception = getCurrentExceptionMsg()
+  except CatchableError as e:
+    error "Could not subscribe to topics", exception = e.msg
     quit(1)
 
   # Starting DHT resolver task

--- a/beacon_chain/libp2p_backend.nim
+++ b/beacon_chain/libp2p_backend.nim
@@ -147,7 +147,7 @@ proc disconnectAndRaise(peer: Peer,
 template reraiseAsPeerDisconnected(peer: Peer, errMsgExpr: static string,
                                    reason = FaultOrError): auto =
   const errMsg = errMsgExpr
-  debug errMsg, err = getCurrentExceptionMsg()
+  debug errMsg
   disconnectAndRaise(peer, reason, errMsg)
 
 proc registerProtocol(protocol: ProtocolInfo) =

--- a/beacon_chain/libp2p_daemon_backend.nim
+++ b/beacon_chain/libp2p_daemon_backend.nim
@@ -147,7 +147,7 @@ proc disconnectAndRaise(peer: Peer,
 template reraiseAsPeerDisconnected(peer: Peer, errMsgExpr: static string,
                                    reason = FaultOrError): auto =
   const errMsg = errMsgExpr
-  debug errMsg, err = getCurrentExceptionMsg()
+  debug errMsg
   disconnectAndRaise(peer, reason, errMsg)
 
 proc registerProtocol(protocol: ProtocolInfo) =

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -233,5 +233,6 @@ proc handleInitialStatus(peer: Peer,
           error "Did not get any blocks from peer. Aborting sync."
           break
 
-  except CatchableError:
-    warn "Failed to sync with peer", peer, err = getCurrentExceptionMsg()
+  except CatchableError as e:
+    warn "Failed to sync with peer", peer, err = e.msg
+


### PR DESCRIPTION
...and also bump a submodule.

In a couple of unused templates, I removed `err = getCurrentExceptionMsg()` from logging, because there's already an error message parameter and we can always add a new `exception` param, if we want it separate.