### PR TITLE
Misc cleanups (including warning removal)

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -13,7 +13,6 @@ skipDirs      = @["nfuzz"]
 bin           = @[
   "beacon_chain/beacon_node",
   "research/serialized_sizes",
-  "research/state_sim",
   ]
 
 ### Dependencies

--- a/beacon_chain/request_manager.nim
+++ b/beacon_chain/request_manager.nim
@@ -47,6 +47,5 @@ proc fetchAncestorBlocks*(requestManager: RequestManager,
 
   const ParallelRequests = 2
 
-  var fetchComplete = false
   for peer in requestManager.network.randomPeers(ParallelRequests, BeaconSync):
     traceAsyncErrors peer.fetchAncestorBlocksFromPeer(roots.sample(), responseHandler)


### PR DESCRIPTION
Regarding `reraiseAsPeerDisconnected`:
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_backend.nim#L147-L151
and
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_daemon_backend.nim#L147-L151

As pertains `writeSizePrefix`:
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_backend.nim#L306-L314
and
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_daemon_backend.nim#L329-L337

Apropos `p2pStreamName`:
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_backend.nim#L402-L404
and
https://github.com/status-im/nim-beacon-chain/blob/013147464bd078bbe95216c7a1881a1c66416db7/beacon_chain/libp2p_daemon_backend.nim#L425-L427

Apropos https://github.com/status-im/nim-beacon-chain/issues/364 it reduces CI time by not potentially and pointlessly building `state_sim` twice, when it's run as part of the CI tasks section later on.