### PR TITLE
Reduce CI times by 2+ minutes keeping all real tests

### DIFF
--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -598,9 +598,6 @@ func lastFieldName(RecordType: type): string {.compileTime.} =
   enumAllSerializedFields(RecordType):
     result = fieldName
 
-func hasSigningRoot(T: type): bool {.compileTime.} =
-  lastFieldName(T) == "signature"
-
 func signingRoot*(obj: object): Eth2Digest =
   const lastField = lastFieldName(obj.type)
   merkelizeFields:

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -26,7 +26,9 @@ import # Unit test
   ./test_peer_pool
 
 import # Refactor state transition unit tests
-  ./spec_block_processing/test_genesis,
+  # TODO re-enable when useful
+  # ./spec_block_processing/test_genesis,
+  # In mainnet these take 2 minutes and are empty TODOs
   ./spec_block_processing/test_process_deposits,
   ./spec_block_processing/test_process_attestation,
   ./spec_epoch_processing/test_process_justification_and_finalization

--- a/tests/test_peer_connection.nim
+++ b/tests/test_peer_connection.nim
@@ -4,7 +4,7 @@ import
   ../beacon_chain/[conf, eth2_network]
 
 template asyncTest*(name, body: untyped) =
-  test name:
+  timedTest name:
     proc scenario {.async.} = body
     waitFor scenario()
 


### PR DESCRIPTION
For https://github.com/status-im/nim-beacon-chain/issues/364

From a typical Travis 19 minute CI run on 64-bit x86 before this PR, on `all_tests` on mainnet:
```
10 longest individual test durations
------------------------------------
 60.82s for is_valid_genesis_state for a valid state
 60.46s for Invalid genesis time
  9.04s for Passes through epoch update, empty block [Preset: mainnet]
  2.99s for Reverse order block add & get [Preset: mainnet]
  2.52s for Attestations may arrive in any order [Preset: mainnet]
  2.48s for Can add and retrieve simple attestation [Preset: mainnet]
  2.47s for Attestations may overlap, bigger first [Preset: mainnet]
  2.46s for Attestations should be combined [Preset: mainnet]
  2.45s for Attestations may overlap, smaller first [Preset: mainnet]
  1.93s for Passes through epoch update, no block [Preset: mainnet]
  1.63s for sanity check genesis roundtrip [Preset: mainnet]
```

The top two tests take ~10% of the time, for this:
```
  test "is_valid_genesis_state for a valid state":
    discard initGenesisState(
      num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
      genesis_time = MIN_GENESIS_TIME
    )
    discard "TODO"

  test "Invalid genesis time":
    discard initGenesisState(
      num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
      genesis_time = MIN_GENESIS_TIME.uint64 - 1
    )
    discard "TODO"
```
because `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT` on mainnet is 16384.

So pending doing something useful with those -- the logic to detect the difference between invalid and valid for example, doesn't exist, and all results are simply discarded regardless -- those are 2 wasted minutes.

For just testing whether we can create genesis states, we already have, e.g.,
https://github.com/status-im/nim-beacon-chain/blob/362ef752dc5534052b48af36095ea4bc0c8f6f4c/tests/test_beaconstate.nim#L16-L20
and https://github.com/status-im/nim-beacon-chain/blob/devel/tests/test_interop.nim