### PR TITLE
disable CaseTransition warnings

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -35,4 +35,4 @@
 @end
 
 -d:nimOldCaseObjects # https://github.com/status-im/nim-confutils/issues/9
-
+--warning[CaseTransition]:off


### PR DESCRIPTION
This is a follow-up to https://github.com/status-im/nim-confutils/issues/9:
```
nim-beacon-chain/beacon_chain/spec/crypto.nim(95, 15) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-confutils/confutils.nim(598, 27) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-confutils/confutils.nim(600, 27) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-rocksdb/rocksdb.nim(87, 13) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-rocksdb/rocksdb.nim(97, 15) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-rocksdb/rocksdb.nim(179, 15) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
nim-beacon-chain/vendor/nim-rocksdb/rocksdb.nim(227, 13) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
```

According to what @zah wrote:
> The new more restrictive behavior of the Nim case object makes life too difficult for libraries such as nim-seriazation and nim-confutils. For this reason, I recommend setting -d:nimOldCaseObjects globally for all of our projects. I'll try to negotiate a new Nim feature that will solve the problem in the long run.

This warning appears basically spurious for Nimbus-related projects, and adds noise to noticing/prioritizing more relevant warnings. Evidently, if/when one stops using `d:nimOldCaseObjects`, outright (runtime) errors will occur, so these warnings aren't useful even as reminders for then.

This is the penultimate remaining class of warnings I've spotted in a `make clean && make test && make beacon_node` build, leaving only some `Deprecated` warnings.