### PR TITLE
move attesting up from halfway to one third of the way through slots

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -789,14 +789,20 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     #      the work for the whole slot using a monotonic clock instead, then deal
     #      with any clock discrepancies once only, at the start of slot timer
     #      processing..
+
+    # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/validator/0_beacon-chain-validator.md#attesting
+    # A validator should create and broadcast the attestation to the
+    # associated attestation subnet one-third of the way through the slot
+    # during which the validator is assigned―that is, SECONDS_PER_SLOT / 3
+    # seconds after the start of slot.
     let
       attestationStart = node.beaconClock.fromNow(slot)
-      halfSlot = seconds(int64(SECONDS_PER_SLOT div 2))
+      thirdSlot = seconds(int64(SECONDS_PER_SLOT div 3))
 
-    if attestationStart.inFuture or attestationStart.offset <= halfSlot:
+    if attestationStart.inFuture or attestationStart.offset <= thirdSlot:
       let fromNow =
-        if attestationStart.inFuture: attestationStart.offset + halfSlot
-        else: halfSlot - attestationStart.offset
+        if attestationStart.inFuture: attestationStart.offset + thirdSlot
+        else: thirdSlot - attestationStart.offset
 
       trace "Waiting to send attestations",
         slot = shortLog(slot),

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -797,7 +797,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     # seconds after the start of slot.
     let
       attestationStart = node.beaconClock.fromNow(slot)
-      thirdSlot = seconds(int64(SECONDS_PER_SLOT div 3))
+      thirdSlot = seconds(int64(SECONDS_PER_SLOT)) div 3
 
     if attestationStart.inFuture or attestationStart.offset <= thirdSlot:
       let fromNow =

--- a/beacon_chain/time.nim
+++ b/beacon_chain/time.nim
@@ -60,8 +60,6 @@ func toSlot*(c: BeaconClock, t: Time): tuple[afterGenesis: bool, slot: Slot] =
 func toBeaconTime*(s: Slot, offset = chronos.seconds(0)): BeaconTime =
   BeaconTime(int64(uint64(s) * SECONDS_PER_SLOT) + seconds(offset))
 
-# TODO on Travis ARM64 CIs, this claims to have side effects, but neither Linux
-# nor Mac OS x86 CIs exhibit this behavior.
 proc now*(c: BeaconClock): BeaconTime =
   ## Current time, in slots - this may end up being less than GENESIS_SLOT(!)
   toBeaconTime(c, getTime())


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/specs/validator/0_beacon-chain-validator.md#attesting says:
> A validator should create and broadcast the attestation to the associated attestation subnet one-third of the way through the slot during which the validator is assigned―that is, `SECONDS_PER_SLOT / 3` seconds after the start of slot.

This is somewhat part of the naive/simple attestation PR sequence along with https://github.com/status-im/nim-beacon-chain/pull/629 -- due to https://github.com/status-im/nim-beacon-chain/pull/638 `beacon_node` changes enough to make it worthwhile to split out changes to existing code from new modules.

The remaining timing-related change is to broadcast aggregations at 2/3 through each slot, by a similar wait-for-slot-to-start-then-schedule-2/3-through, but that's waiting for the combination of https://github.com/status-im/nim-beacon-chain/pull/638 and https://github.com/status-im/nim-beacon-chain/pull/629 to land, to avoid pointless/predictable merge conflicts.