### PR TITLE
add copyright header to state_sim and run it in mainnet config

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -61,5 +61,6 @@ task test, "Run all tests":
   buildBinary "all_fixtures_require_ssz", "tests/official/", "-r -d:release -d:chronicles_log_level=TRACE -d:const_preset=mainnet"
 
   # State sim; getting into 4th epoch useful to trigger consensus checks
-  buildBinary "state_sim", "research/", "-r -d:release", "--validators=128 --slots=40"
+  buildBinary "state_sim", "research/", "-r -d:release", "--validators=1024 --slots=32"
+  buildBinary "state_sim", "research/", "-r -d:release -d:const_preset=mainnet", "--validators=1024 --slots=128"
 

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2019 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   confutils, stats, times, std/monotimes,
   strformat,


### PR DESCRIPTION
This aligns it with the other CI tests, which must both work in mainnet and minimal.

Timingwise, it seemed useful to bump things to at least 512 validators -- once there, 1024 took was only 20% longer for twice the validators, which is both interesting and made it worthwhile.

The mainnet config takes about 3x as long for me to run, which seems reasonable.

Each executes 4 full epochs -- enough to check one epoch for finalizing and two for justifying.