### PR TITLE
[WIP] [FUZZING] Libnfuzz update

### DIFF
--- a/nfuzz/README.md
+++ b/nfuzz/README.md
@@ -24,10 +24,10 @@ integration with [beacon-fuzz](https://github.com/sigp/beacon-fuzz)) we can pass
 additional Nim arguments, e.g.:
 
 ```bash
-make libnfuzz.a NIMFLAGS="--cc:clang --passC:'-fsanitize=fuzzer' --passL='-fsanitize=fuzzer'"
+make libnfuzz.a NIMFLAGS="--cc:clang --passC:'-fsanitize=fuzzer-no-link' --passL='-fsanitize=fuzzer'"
 ```
 
-Other useful options might include: `--clang.path:<path>`, `--clang.exe:<exe>`, `--clang.linkerexe:<exe>`.
+Other useful options might include: `--clang.path:<path>`, `--clang.exe:<exe>`, `--clang.linkerexe:<exe>`, `-d:const_preset=mainnet`
 
 It might also deem useful to lower the log level, e.g. by adding `-d:chronicles_log_level=fatal`.
 

--- a/nfuzz/libnfuzz.h
+++ b/nfuzz/libnfuzz.h
@@ -12,9 +12,13 @@ extern "C" {
 void NimMain();
 
 /** Supported fuzzing tests */
+bool nfuzz_attestation(uint8_t* input_ptr, size_t input_size,
+  uint8_t* output_ptr, size_t* output_size);
+bool nfuzz_attester_slashing(uint8_t* input_ptr, size_t input_size,
+  uint8_t* output_ptr, size_t* output_size);
 bool nfuzz_block(uint8_t* input_ptr, size_t input_size,
   uint8_t* output_ptr, size_t* output_size);
-bool nfuzz_attestation(uint8_t* input_ptr, size_t input_size,
+bool nfuzz_block_header(uint8_t* input_ptr, size_t input_size,
   uint8_t* output_ptr, size_t* output_size);
 bool nfuzz_shuffle(uint8_t* seed_ptr, uint64_t* output_ptr, size_t output_size);
 

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -109,7 +109,7 @@ proc nfuzz_block(input: openArray[byte], output: ptr byte,
     raise newException(FuzzCrashError, "SSZ deserialisation failed, likely bug in preprocessing.", e)
 
   try:
-    result = state_transition(data.state, data.beaconBlock, {skipValidation})
+    result = state_transition(data.state, data.beaconBlock, {})
   except IOError as e:
     # TODO why an IOError?
     raise newException(FuzzCrashError, "Unexpected IOError in state transition", e)
@@ -140,7 +140,8 @@ proc nfuzz_block_header(input: openArray[byte], output: ptr byte,
     raise newException(FuzzCrashError, "SSZ deserialisation failed, likely bug in preprocessing.", e)
 
   try:
-    result = process_block_header(data.state, data.beaconBlock, {skipValidation}, cache)
+    # TODO disable bls
+    result = process_block_header(data.state, data.beaconBlock, {}, cache)
   except IOError as e:
     # TODO why an IOError? - is this expected/should we return false?
     raise newException(FuzzCrashError, "Unexpected IOError in block header processing", e)

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -4,7 +4,8 @@ import
   ../beacon_chain/spec/[datatypes, helpers, digest, validator, beaconstate, state_transition_block],
 # Required for deserialisation of ValidatorSig in Attestation due to
 # https://github.com/nim-lang/Nim/issues/11225
-  ../beacon_chain/spec/crypto
+  ../beacon_chain/spec/crypto,
+  ../beacon_chain/extras
 
 type
   BlockInput = object
@@ -62,7 +63,7 @@ proc nfuzz_attestation(input: openArray[byte], output: ptr byte,
 
   try:
     result = process_attestation(data.state, data.attestation,
-      flags = {}, cache)
+      {skipValidation}, cache)
   except ValueError:
     # TODO is a ValueError indicative of correct or incorrect processing code?
     # If correct (but given invalid input), we should return false
@@ -108,7 +109,7 @@ proc nfuzz_block(input: openArray[byte], output: ptr byte,
     raise newException(FuzzCrashError, "SSZ deserialisation failed, likely bug in preprocessing.", e)
 
   try:
-    result = state_transition(data.state, data.beaconBlock, flags = {})
+    result = state_transition(data.state, data.beaconBlock, {skipValidation})
   except IOError as e:
     # TODO why an IOError?
     raise newException(FuzzCrashError, "Unexpected IOError in state transition", e)
@@ -139,7 +140,7 @@ proc nfuzz_block_header(input: openArray[byte], output: ptr byte,
     raise newException(FuzzCrashError, "SSZ deserialisation failed, likely bug in preprocessing.", e)
 
   try:
-    result = process_block_header(data.state, data.beaconBlock, flags = {}, cache)
+    result = process_block_header(data.state, data.beaconBlock, {skipValidation}, cache)
   except IOError as e:
     # TODO why an IOError? - is this expected/should we return false?
     raise newException(FuzzCrashError, "Unexpected IOError in block header processing", e)


### PR DESCRIPTION
Implements `block_header` and `attester_slashing` to complete implementation of all currently complete [`beacon-fuzz`](https://github.com/sigp/beacon-fuzz) fuzzing targets.

Adjusts exception and defect handling as discussed - so exceptions indicating a bug are allowed to crash.