### PR TITLE
[WIP, don't merge] outline flow of rest of the attestation aggregation

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -13,7 +13,8 @@ import
   conf, time, state_transition, beacon_chain_db,
   validator_pool, extras, attestation_pool, block_pool, eth2_network,
   beacon_node_types, mainchain_monitor, version, ssz, ssz/dynamic_navigator,
-  sync_protocol, request_manager, validator_keygen, interop, statusbar
+  sync_protocol, request_manager, validator_keygen, interop, statusbar,
+  attestation_aggregation
 
 const
   genesisFile = "genesis.ssz"
@@ -773,6 +774,65 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
       head = node.updateHead()
 
     handleAttestations(node, head, slot)
+
+    # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/validator/0_beacon-chain-validator.md#broadcast-aggregate
+    # If the validator is selected to aggregate (is_aggregator), then they
+    # broadcast their best aggregate to the global aggregate channel
+    # (beacon_aggregate_and_proof) two-thirds of the way through the slot-that
+
+    # Be careful around integer arithmetic, but when in doubt, x/3 rounds down
+    # in general in C-like languages, so safe-ish as long, as we do not insist
+    # on rebroadcasting/aggregating during the same slot.
+    let twoThirdsSlot = seconds(2*int64(SECONDS_PER_SLOT)) div 3
+
+    if attestationStart.offset <= twoThirdsSlot:
+      # TODO check definition of offset, etc make sure this is sane
+      let fromNow = twoThirdsSlot - attestationStart.offset
+
+      trace "Waiting to send aggregated attestations",
+        slot = shortLog(slot),
+        fromNow = shortLog(fromNow),
+        cat = "scheduling"
+
+      await sleepAsync(fromNow)
+
+    # TODO elsewhere this gets put in handleAttestations -- refactor likewise
+    # the exact head isn't that important, since here, it's transitively used
+    # by getAttestionsForBlock(...) which uses it to validate. Any state from
+    # the current/future of relevant attestations is fine. The index is via a
+    # locally attested validator. Unlike in handleAttestations(...) there's a
+    # single one at most per slot (because that's how aggregation attestation
+    # works), so the machinery that has to handle looping across, basically a
+    # set of locally attached validators is in principle not necessary, but a
+    # way to organize this. Then the private key for that validator should be
+    # the corresponding one -- whatver they are, they match.
+    let bs = BlockSlot(blck: head, slot: head.slot)
+    node.blockPool.withState(node.blockPool.tmpState, bs):
+      let committees_per_slot = get_committee_count_at_slot(state, head.slot)
+      var cache = get_empty_per_epoch_cache()
+      for committee_index in 0'u64..<committees_per_slot:
+        let
+          committee = get_beacon_committee(state, slot, committee_index, cache)
+
+        for index_in_committee, validatorIdx in committee:
+          let validator = node.getAttachedValidator(state, validatorIdx)
+          if validator != nil:
+            # This is slightly strange/inverted control flow, since really it's
+            # going to happen once per slot, but this is the best way to get at
+            # the validator index and private key pair.
+            let option_aggregateandproof =
+              aggregate_attestations(node.attestationPool, state,
+                validatorIdx.uint64, # odd, since we have right type here, but
+                                     # spec-specified callee doesn't.
+                # TODO https://github.com/status-im/nim-beacon-chain/issues/545
+                # this assumes in-process private keys
+                validator.privKey)
+
+            # TODO double-check everything here, but also, this is obviously
+            # enough to warrant refactoring, per above.
+            if option_aggregateandproof.isSome:
+              node.network.broadcast(topicAttestations,
+                option_aggregateandproof.get)
 
   # TODO ... and beacon clock might jump here also. sigh.
   let


### PR DESCRIPTION
An existence proof of the availability of the rest of how to this within `nim-beacon-chain`. Obviously needs refactoring, testing, etc.

It's correct but not optimal to ask to aggregate everything and only send when there's a value to the `option`. That's why it's set up that way. Not good approach, but surprisingly not-terribly-wrong either.