### PR TITLE
Add Epoch Processing to nbench

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -351,7 +351,7 @@ func process_rewards_and_penalties(
     decrease_balance(state, i.ValidatorIndex, penalties[i])
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#slashings
-func process_slashings*(state: var BeaconState) =
+func process_slashings*(state: var BeaconState) {.nbench.}=
   let
     epoch = get_current_epoch(state)
     total_balance = get_total_active_balance(state)

--- a/nbench/README.md
+++ b/nbench/README.md
@@ -24,13 +24,25 @@ Features
 
 ```
 nim c -d:const_preset=mainnet -d:nbench -d:release -o:build/nbench nbench/nbench.nim
-export SCENARIOS=tests/official/fixtures/tests-v0.9.3/mainnet/phase0
+export SCENARIOS=tests/official/fixtures/tests-v0.9.4/mainnet/phase0
 
 # Full state transition
 build/nbench cmdFullStateTransition -d="${SCENARIOS}"/sanity/blocks/pyspec_tests/voluntary_exit/ -q=2
 
 # Slot processing
 build/nbench cmdSlotProcessing -d="${SCENARIOS}"/sanity/slots/pyspec_tests/slots_1
+
+# Justification-Finalisation
+build/nbench cmdEpochProcessing --epochProcessingCat=catJustificationFinalization -d="${SCENARIOS}"/epoch_processing/justification_and_finalization/pyspec_tests/234_ok_support/
+
+# Registry updates
+build/nbench cmdEpochProcessing --epochProcessingCat=catRegistryUpdates -d="${SCENARIOS}"/epoch_processing/registry_updates/pyspec_tests/activation_queue_efficiency/
+
+# Slashings
+build/nbench cmdEpochProcessing --epochProcessingCat=catSlashings -d="${SCENARIOS}"/epoch_processing/slashings/pyspec_tests/max_penalties/
+
+# Final updates
+build/nbench cmdEpochProcessing --epochProcessingCat=catFinalUpdates -d="${SCENARIOS}"/epoch_processing/final_updates/pyspec_tests/effective_balance_hysteresis/
 
 # Block header processing
 build/nbench cmdBlockProcessing --blockProcessingCat=catBlockHeader -d="${SCENARIOS}"/operations/block_header/pyspec_tests/proposer_slashed/
@@ -59,7 +71,7 @@ Furthermore benchmarks are run in parallel and might interfere which each other.
 ```
 nim c -d:const_preset=mainnet -d:nbench -d:release -o:build/nbench nbench/nbench.nim
 nim c -o:build/nbench_tests nbench/nbench_official_fixtures.nim
-nbench_tests --nbench=build/nbench --tests=tests/official/fixtures/tests-v0.9.4/mainnet/
+build/nbench_tests --nbench=build/nbench --tests=tests/official/fixtures/tests-v0.9.4/mainnet/
 ```
 
 ## TODO Reporting

--- a/nbench/nbench.nim
+++ b/nbench/nbench.nim
@@ -99,6 +99,28 @@ proc main() =
       )
     else:
       quit "Unsupported"
+  of cmdEpochProcessing:
+    case scenario.epochProcessingCat
+    of catJustificationFinalization:
+      runProcessJustificationFinalization(
+        scenario.scenarioDir.string,
+        scenario.preState
+      )
+    of catRegistryUpdates:
+      runProcessRegistryUpdates(
+        scenario.scenarioDir.string,
+        scenario.preState
+      )
+    of catSlashings:
+      runProcessSlashings(
+        scenario.scenarioDir.string,
+        scenario.preState
+      )
+    of catFinalUpdates:
+      runProcessFinalUpdates(
+        scenario.scenarioDir.string,
+        scenario.preState
+      )
   else:
     quit "Unsupported"
 


### PR DESCRIPTION
This allows nbench to be used on all EF consensus tests (full transition, slot, epoch and blocks).

Follow-up on that:
- Reuse the "scenarios" logic in ncli to enable more granularity than the full state_transition
- Create `ncli_test` and change `nbench` to `ncli_bench` for an unified suite of command-line ETH2 utilities
- Update the tests to use `ncli_test`, like the current `nbench_official_fixtures` this allows to start one process per test, self_contained, easily parallel, only one compilation and no need to deal with unittest.
