### PR TITLE
update to spec version 0.10.0

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -89,7 +89,7 @@ func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
     blck = blck.parent
 
 func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
-  ## https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_fork-choice.md#get_ancestor
+  ## https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/fork-choice.md#get_ancestor
   ## Return ancestor at slot, or nil if queried block is older
   var blck = blck
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -52,7 +52,7 @@ else:
   {.fatal: "Preset \"" & const_preset ".nim\" is not supported.".}
 
 const
-  SPEC_VERSION* = "0.9.4" ## \
+  SPEC_VERSION* = "0.10.0" ## \
   ## Spec version we're aiming to be compatible with, right now
   ## TODO: improve this scheme once we can negotiate versions in protocol
 
@@ -215,7 +215,7 @@ type
     deposits*: List[Deposit, MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#beaconstate
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/beacon-chain.md#beaconstate
   BeaconState* = object
     # Versioning
     genesis_time*: uint64
@@ -320,6 +320,11 @@ type
     deposit_count*: uint64
     block_hash*: Eth2Digest
 
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/beacon-chain.md#signingroot
+  SigningRoot* = object
+    object_root*: Eth2Digest
+    domain*: uint64
+
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#signedvoluntaryexit
   SignedVoluntaryExit* = object
     message*: VoluntaryExit
@@ -340,6 +345,11 @@ type
     aggregator_index*: uint64
     aggregate*: Attestation
     selection_proof*: ValidatorSig
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/validator.md#eth1block
+  Eth1Block* = object
+    timestamp*: uint64
+    # All other eth1 block fields
 
   # TODO to be replaced with some magic hash caching
   HashedBeaconState* = object
@@ -377,6 +387,7 @@ template foreachSpecType*(op: untyped) =
   op BeaconState
   op Deposit
   op DepositData
+  op Eth1Block
   op Eth1Data
   op Fork
   op HistoricalBatch
@@ -386,6 +397,7 @@ template foreachSpecType*(op: untyped) =
   op SignedBeaconBlock
   op SignedBeaconBlockHeader
   op SignedVoluntaryExit
+  op SigningRoot
   op Validator
   op VoluntaryExit
 

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -72,11 +72,13 @@ const
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/configs/mainnet.yaml#L62
 
   GENESIS_SLOT* = 0.Slot
+  GENESIS_FORK_VERSION* = 0x00000000
   BLS_WITHDRAWAL_PREFIX* = 0'u8
 
   # Time parameters
   # ---------------------------------------------------------------
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/configs/mainnet.yaml#L69
+  MIN_GENESIS_DELAY* = 86400 # 86400 seconds (1 day)
 
   SECONDS_PER_SLOT*{.intdefine.} = 12'u64 # Compile with -d:SECONDS_PER_SLOT=1 for 12x faster slots
   ## TODO consistent time unit across projects, similar to C++ chrono?
@@ -163,6 +165,7 @@ const
   TARGET_AGGREGATORS_PER_COMMITTEE* = 16 # validators
   RANDOM_SUBNETS_PER_VALIDATOR* = 1 # subnet
   EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION* = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* = 14 # estimate from Eth1 mainnet)
 
   # Phase 1 - Sharding
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -61,11 +61,16 @@ const
 
   # Unchanged
   GENESIS_SLOT* = 0.Slot
+  GENESIS_FORK_VERSION* = 0x01000000
   BLS_WITHDRAWAL_PREFIX* = 0'u8
 
   # Time parameters
   # ---------------------------------------------------------------
   # https://github.com/ethereum/eth2.0-specs/blob/v0.9.2/configs/minimal.yaml#L69
+  # Changed: Faster to spin up testnets, but does not give validator
+  # reasonable warning time for genesis
+  MIN_GENESIS_DELAY* = 300
+
   # Unchanged
   SECONDS_PER_SLOT*{.intdefine.} = 6'u64
 
@@ -143,6 +148,7 @@ const
   TARGET_AGGREGATORS_PER_COMMITTEE* = 16 # validators
   RANDOM_SUBNETS_PER_VALIDATOR* = 1 # subnet
   EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION* = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* = 14 # estimate from Eth1 mainnet)
 
   # Phase 1 - Sharding
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -63,7 +63,7 @@ declareGauge epoch_transition_final_updates, "Epoch transition final updates tim
 # Spec
 # --------------------------------------------------------
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#get_total_active_balance
+# https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/beacon-chain.md#get_total_active_balance
 func get_total_active_balance*(state: BeaconState): Gwei =
   # Return the combined effective balance of the active validators.
   # TODO it calls get_total_balance with set(g_a_v_i(...))
@@ -441,7 +441,7 @@ proc process_epoch*(state: var BeaconState) {.nbench.}=
 
   # @update_period_committee
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#final-updates
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/beacon-chain.md#final-updates
   process_final_updates(state)
 
   # @after_process_final_updates

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -36,7 +36,7 @@ proc readValue*(r: var JsonReader, a: var seq[byte]) {.inline.} =
 
 const
   FixturesDir* = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
-  SszTestsDir* = FixturesDir/"tests-v0.9.4"
+  SszTestsDir* = FixturesDir/"tests-v0.10.0"
 
 proc parseTest*(path: string, Format: typedesc[Json or SSZ], T: typedesc): T =
   try:

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -20,7 +20,7 @@ const
   SpecDir = currentSourcePath.rsplit(DirSep, 1)[0] /
                   ".."/".."/"beacon_chain"/"spec"
   FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
-  Config = FixturesDir/"tests-v0.9.4"/const_preset/"config.yaml"
+  Config = FixturesDir/"tests-v0.10.0"/const_preset/"config.yaml"
 
 type
   CheckedType = SomeInteger or Slot or Epoch
@@ -116,8 +116,11 @@ proc checkConfig() =
         let domain = parseEnum[DomainType](constant)
         let value = parseU32LEHex(value.getStr())
         check: uint32(domain) == value
+      elif constant == "GENESIS_FORK_VERSION":
+        let value = parseU32LEHex(value.getStr())
+        check: ConstsToCheck[constant] == value
       else:
         check: ConstsToCheck[constant] == value.getBiggestInt().uint64()
 
-suite "Official - 0.9.4 - constants & config " & preset():
+suite "Official - 0.10.0 - constants & config " & preset():
   checkConfig()

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -26,7 +26,7 @@ import
 
 const
   FixturesDir = currentSourcePath.rsplit(DirSep, 1)[0] / "fixtures"
-  SSZDir = FixturesDir/"tests-v0.9.4"/const_preset/"phase0"/"ssz_static"
+  SSZDir = FixturesDir/"tests-v0.10.0"/const_preset/"phase0"/"ssz_static"
 
 type
   SSZHashTreeRoot = object
@@ -87,6 +87,7 @@ proc runSSZtests() =
           of "Deposit": checkSSZ(Deposit, path, hash)
           of "DepositData": checkSSZ(DepositData, path, hash)
           of "DepositMessage": checkSSZ(DepositMessage, path, hash)
+          of "Eth1Block": checkSSZ(Eth1Block, path, hash)
           of "Eth1Data": checkSSZ(Eth1Data, path, hash)
           of "Fork": checkSSZ(Fork, path, hash)
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
@@ -97,10 +98,11 @@ proc runSSZtests() =
           of "SignedBeaconBlockHeader":
             checkSSZ(SignedBeaconBlockHeader, path, hash)
           of "SignedVoluntaryExit": checkSSZ(SignedVoluntaryExit, path, hash)
+          of "SigningRoot": checkSSZ(SigningRoot, path, hash)
           of "Validator": checkSSZ(Validator, path, hash)
           of "VoluntaryExit": checkSSZ(VoluntaryExit, path, hash)
           else:
             raise newException(ValueError, "Unsupported test: " & sszType)
 
-suite "Official - 0.9.4 - SSZ consensus objects " & preset():
+suite "Official - 0.10.0 - SSZ consensus objects " & preset():
   runSSZtests()


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/releases/tag/v0.10.0

Two things remain:

- `ssz_generic` tests, which are still tied to 0.9.4, since that's where the tests live.
- Also, the remaining BLS updates from https://github.com/ethereum/eth2.0-specs/pull/1532