### PR TITLE
Fix BLS verification and add `bad_merkle_proof` deposit operations proof

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1113,7 +1113,7 @@ when isMainModule:
                  else: waitFor getLatestEth1BlockHash(config.depositWeb3Url)
     var
       initialState = initialize_beacon_state_from_eth1(
-        eth1Hash, startTime, deposits, {skipValidation})
+        eth1Hash, startTime, deposits, {skipValidation, skipMerkleValidation})
 
     # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state
     initialState.genesis_time = startTime

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -25,5 +25,15 @@ type
     ## TODO need to be careful here, easy to assume that slot number change is
     ##      enough, vs advancing the state - however, making a full state copy
     ##      is expensive also :/
+    skipMerkleValidation ##\
+    ## When processing deposits, skip verifying the Merkle proof trees of each
+    ## deposit. This is a holdover from both interop issues with the malformed
+    ## proofs and, more currently, nim-beacon-chain's creation of proofs which
+    ## are inconsistent with the current specification. Furthermore several of
+    ## the mocking interfaces deliberately do not create Merkle proofs. Whilst
+    ## this seems less than entirely justifiable, for now enable keeping those
+    ## in place while minimizing the tech debt they create. One, in principle,
+    ## should be able to remove this flag entirely. It is not intrinsically an
+    ## expensive operation to perform.
 
   UpdateFlags* = set[UpdateFlag]

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -160,8 +160,10 @@ func bls_verify*(
       return false
     # TODO bls_verify_multiple(...) used to have this workaround, and now it
     # lives here. No matter the signature, there's also no meaningful way to
-    # verify it -- it's a kind of vacuous truth. No pubkey/sig pairs.
-    if pubkey == default(ValidatorPubKey):
+    # verify it -- it's a kind of vacuous truth. No pubkey/sig pairs. Sans a
+    # getBytes() or similar mechanism, pubKey == default(ValidatorPubKey) is
+    # a way to create many false positive matches. This seems odd.
+    if pubkey.getBytes() == default(ValidatorPubKey).getBytes():
       return true
 
     sig.blsValue.verify(msg, domain, pubkey.blsValue)

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -79,7 +79,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   let
     genesisState =
       initialize_beacon_state_from_eth1(
-        Eth2Digest(), 0, deposits, {skipValidation})
+        Eth2Digest(), 0, deposits, {skipMerkleValidation})
     genesisBlock = get_initial_beacon_block(genesisState)
 
   echo "Starting simulation..."

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -25,7 +25,7 @@ proc initGenesisState*(num_validators: uint64, genesis_time: uint64 = 0): Beacon
     )
 
   initialize_beacon_state_from_eth1(
-    eth1BlockHash, 0, deposits, {skipValidation})
+    eth1BlockHash, 0, deposits, {skipValidation, skipMerkleValidation})
 
 when isMainModule:
   # Smoke test

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -53,8 +53,7 @@ template runTest(testName: string, identifier: untyped) =
         postRef[] = parseTest(testDir/"post.ssz", SSZ, BeaconState)
 
       if postRef.isNil:
-        expect(AssertionError):
-          discard process_deposit(stateRef[], depositRef[], flags)
+        check not process_deposit(stateRef[], depositRef[], flags)
       else:
         discard process_deposit(stateRef[], depositRef[], flags)
         reportDiff(stateRef, postRef)
@@ -62,17 +61,19 @@ template runTest(testName: string, identifier: untyped) =
   `testImpl _ operations_deposits _ identifier`()
 
 suite "Official - Operations - Deposits " & preset():
-  runTest("new deposit under max", new_deposit_under_max)
+  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/minimal/phase0/operations/deposit/pyspec_tests
+  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/mainnet/phase0/operations/deposit/pyspec_tests
+  runTest("bad merkle proof", bad_merkle_proof)
+  runTest("invalid signature new deposit", invalid_sig_new_deposit)
+  runTest("invalid signature other version", invalid_sig_other_version)
+  runTest("invalid signature top-up", invalid_sig_top_up)
+  runTest("invalid withdrawal credentials top-up",
+    invalid_withdrawal_credentials_top_up)
   runTest("new deposit max", new_deposit_max)
   runTest("new deposit over max", new_deposit_over_max)
-  runTest("invalid signature new deposit", invalid_sig_new_deposit)
+  runTest("new deposit under max", new_deposit_under_max)
   runTest("success top-up", success_top_up)
-  runTest("invalid signature top-up", invalid_sig_top_up)
-  runTest("invalid withdrawal credentials top-up", invalid_withdrawal_credentials_top_up)
-
   when false:
-    # TODO - those should give an exception but do not
-    #        probably because skipValidation is too strong
-    #        https://github.com/status-im/nim-beacon-chain/issues/407
-    runTest("wrong deposit for deposit count", wrong_deposit_for_deposit_count)
-    runTest("bad merkle proof", bad_merkle_proof)
+    # TODO
+    runTest("valid signature but forked state", valid_sig_but_forked_state)
+  runTest("wrong deposit for deposit count", wrong_deposit_for_deposit_count)

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -56,7 +56,8 @@ suite "[Unit - Spec - Block processing] Deposits " & preset():
 
       # State transition
       # ----------------------------------------
-      check: state.process_deposit(deposit, {skipValidation})
+      check: state.process_deposit(deposit,
+        {skipValidation, skipMerkleValidation})
 
       # Check invariants
       # ----------------------------------------
@@ -100,7 +101,8 @@ suite "[Unit - Spec - Block processing] Deposits " & preset():
 
     # State transition
     # ----------------------------------------
-    check: state.process_deposit(deposit, {skipValidation})
+    check: state.process_deposit(deposit,
+      {skipValidation, skipMerkleValidation})
 
     # Check invariants
     # ----------------------------------------

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -111,7 +111,7 @@ when const_preset == "minimal": # Too much stack space used on mainnet
         attestation1 = makeAttestation(
           state.data.data, state.blck.root, bc0[1], cache)
 
-      attestation0.combine(attestation1, {skipValidation})
+      attestation0.combine(attestation1, {})
 
       pool.add(attestation0)
       pool.add(attestation1)
@@ -135,7 +135,7 @@ when const_preset == "minimal": # Too much stack space used on mainnet
         attestation1 = makeAttestation(
           state.data.data, state.blck.root, bc0[1], cache)
 
-      attestation0.combine(attestation1, {skipValidation})
+      attestation0.combine(attestation1, {})
 
       pool.add(attestation1)
       pool.add(attestation0)

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -17,5 +17,5 @@ suite "Beacon state" & preset():
   timedTest "Smoke test initialize_beacon_state_from_eth1" & preset():
     let state = initialize_beacon_state_from_eth1(
       Eth2Digest(), 0,
-      makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipValidation})
+      makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipMerkleValidation})
     check: state.validators.len == SLOTS_PER_EPOCH

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -213,7 +213,7 @@ when const_preset == "minimal": # Too much stack space used on mainnet
             BeaconBlockBody(
               attestations: makeFullAttestations(
                 pool.headState.data.data, pool.head.blck.root,
-                pool.headState.data.data.slot, cache, {skipValidation})))
+                pool.headState.data.data.slot, cache, {})))
         let added = pool.add(hash_tree_root(blck.message), blck)
         pool.updateHead(added)
 

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -150,7 +150,7 @@ suite "Interop":
 
     var
       initialState = initialize_beacon_state_from_eth1(
-        eth1BlockHash, 1570500000, deposits, {skipValidation})
+        eth1BlockHash, 1570500000, deposits, {skipMerkleValidation})
 
     # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state
     initialState.genesis_time = 1570500000

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -22,7 +22,7 @@ suite "Block processing" & preset():
     # TODO bls verification is a bit of a bottleneck here
     genesisState = initialize_beacon_state_from_eth1(
       Eth2Digest(), 0,
-      makeInitialDeposits(), {skipValidation})
+      makeInitialDeposits(), {skipMerkleValidation})
     genesisBlock = get_initial_beacon_block(genesisState)
     genesisRoot = hash_tree_root(genesisBlock.message)
 

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -80,7 +80,8 @@ proc makeTestDB*(validators: int): BeaconChainDB =
   let
     genState = initialize_beacon_state_from_eth1(
       Eth2Digest(), 0,
-      makeInitialDeposits(validators, flags = {skipValidation}), {skipValidation})
+      makeInitialDeposits(validators, flags = {skipValidation}),
+        {skipValidation, skipMerkleValidation})
     genBlock = get_initial_beacon_block(genState)
   makeTestDB(genState, genBlock)
 


### PR DESCRIPTION
- Add `bad_merkle_proof` and `wrong_deposit_for_deposit_count` deposit operations tests; the former, in particular, relates to the https://github.com/status-im/nim-beacon-chain/issues/703 fuzzing results and https://github.com/status-im/nim-beacon-chain/pull/705 partial mitigation. The `bad_merkle_proof` test would have caught it automatically. It's now part of CI.

- The larger-than-seemingly-required scope of this fix is partly due to that when the BLS verification was using `pubKey == default(ValidatorPubKey)` to detect basically the case where `bls_aggregate...(...)` was given an empty list, it was, quite often (always, perhaps) evaluating to `true`, while the modified form `pubkey.getBytes() == default(ValidatorPubKey).getBytes()` appears to operate more correctly. Getting this (more) right was necessary to get the deposit operations tests to function, both the expected successes and failures.

- This better splits the Merkle proof tree validation skipping, which is in principle a kludge that should go away when `nim-beacon-chain` correctly generates Merkle proofs itself for from-`eth1` genesis state creation, from the actually-necessary BLS skipping mechanism to avoid slow, asymmetric cryptography where not useful.

- However, all the changes are careful to only allow disabling of either BLS or Merkle skipping either when (1) it's from an internal source which is implicitly trusted and the purpose isn't to test that functionality; and (2) it's not from external EF test vectors or network sources which are either tests of untrusted input or, directly, untrusted input.

- I note in the `[Suite] SyncManager test suite`:
```
ERR 2020-01-30 21:16:26+00:00 Synchronization failed                     tid=28333 duration=449ms388us138ns errors=3
```
or its equivalent across these. It was there before and, in my testing locally (where I can reproduce it -- it's in the last, failure test) isn't a regression introduced by this PR. Similarly, I tested `make USE_MULTITAIL=yes eth2_network_simulation` and it runs and finalizes correctly.