### PR TITLE
switch attestations, proposer slashings, and slots sanity tests to automatically scan for available test vectors

### DIFF
--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -20,13 +20,13 @@ import
 
 const OperationsAttestationsDir = SszTestsDir/const_preset/"phase0"/"operations"/"attestation"/"pyspec_tests"
 
-template runTest(testName: string, identifier: untyped) =
+proc runTest(identifier: string) =
   # We wrap the tests in a proc to avoid running out of globals
   # in the future: Nim supports up to 3500 globals
   # but unittest with the macro/templates put everything as globals
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
 
-  const testDir = OperationsAttestationsDir / astToStr(identifier)
+  let testDir = OperationsAttestationsDir / identifier
 
   proc `testImpl _ operations_attestations _ identifier`() =
 
@@ -39,7 +39,7 @@ template runTest(testName: string, identifier: untyped) =
     else:
       prefix = "[Invalid] "
 
-    timedTest prefix & testName & " (" & astToStr(identifier) & ")":
+    timedTest prefix & identifier:
       var stateRef, postRef: ref BeaconState
       var attestationRef: ref Attestation
       new attestationRef
@@ -66,27 +66,5 @@ template runTest(testName: string, identifier: untyped) =
   `testImpl _ operations_attestations _ identifier`()
 
 suite "Official - Operations - Attestations " & preset():
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/minimal/phase0/operations/attestation/pyspec_tests
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/mainnet/phase0/operations/attestation/pyspec_tests
-  runTest("after_epoch_slots", after_epoch_slots)
-  runTest("bad source root", bad_source_root)
-  runTest("before inclusion delay", before_inclusion_delay)
-  runTest("empty aggregation bits", empty_aggregation_bits)
-  runTest("future target epoch", future_target_epoch)
-  runTest("invalid attestation signature", invalid_attestation_signature)
-  runTest("invalid current source root", invalid_current_source_root)
-  runTest("invalid index", invalid_index)
-  runTest("mismatched target and slot", mismatched_target_and_slot)
-  runTest("new source epoch", new_source_epoch)
-  runTest("old source epoch", old_source_epoch)
-  runTest("old target epoch", old_target_epoch)
-  runTest("source root is target root", source_root_is_target_root)
-  runTest("success", success)
-  runTest("success multi-proposer index interations",
-    success_multi_proposer_index_iterations)
-  runTest("success previous epoch", success_previous_epoch)
-  runTest("too few aggregation bits", too_few_aggregation_bits)
-  runTest("too many aggregation bits", too_many_aggregation_bits)
-  runTest("wrong index for committee signature",
-    wrong_index_for_committee_signature)
-  runTest("wrong index for slot", wrong_index_for_slot)
+  for kind, path in walkDir(OperationsAttestationsDir, true):
+    runTest(path)

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -20,13 +20,13 @@ import
 
 const OpProposerSlashingDir = SszTestsDir/const_preset/"phase0"/"operations"/"proposer_slashing"/"pyspec_tests"
 
-template runTest(identifier: untyped) =
+proc runTest(identifier: string) =
   # We wrap the tests in a proc to avoid running out of globals
   # in the future: Nim supports up to 3500 globals
   # but unittest with the macro/templates put everything as globals
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
 
-  const testDir = OpProposerSlashingDir / astToStr(identifier)
+  let testDir = OpProposerSlashingDir / identifier
 
   proc `testImpl_proposer_slashing _ identifier`() =
 
@@ -66,15 +66,5 @@ template runTest(identifier: untyped) =
   `testImpl_proposer_slashing _ identifier`()
 
 suite "Official - Operations - Proposer slashing " & preset():
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/minimal/phase0/operations/proposer_slashing/pyspec_tests
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/mainnet/phase0/operations/proposer_slashing/pyspec_tests
-  runTest(epochs_are_different)
-  runTest(headers_are_same)
-  runTest(invalid_proposer_index)
-  runTest(invalid_sig_1)
-  runTest(invalid_sig_1_and_2)
-  runTest(invalid_sig_2)
-  runTest(proposer_is_not_activated)
-  runTest(proposer_is_slashed)
-  runTest(proposer_is_withdrawn)
-  runTest(success)
+  for kind, path in walkDir(OpProposerSlashingDir, true):
+    runTest(path)


### PR DESCRIPTION
This ensures that as the EF test vectors gain and lose tests, and in particular when they gain them, those new tests get picked up automatically and used.

This was a failure mode where `bad_merkle_proof`, for example, was ignored for months after its existence, when it would have highlighted a genuine issue which required fixing. By automatically incorporating all available tests in these categories where all tests pass, such regressions cannot re-occur.

The better way to do this is to use `nbench`, but this is an intermediate step, a minimal change which doesn't hinder adopting `nbench` (which uses a similar technique).