### PR TITLE
initial refactoring of block sanity test runner, with several new tests

### DIFF
--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -83,7 +83,11 @@ func get_epoch_validator_count(state: BeaconState): int64 =
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc process_slots*(state: var BeaconState, slot: Slot) {.nbench.}=
-  doAssert state.slot <= slot
+  if not (state.slot <= slot):
+    warn("Trying to apply old block",
+      state_slot = state.slot,
+      slot = slot)
+    return
 
   # Catch up to the target slot
   while state.slot < slot:

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -29,10 +29,10 @@ template runTest(identifier: string, num_blocks: int): untyped =
   const testDir = SanityBlocksDir / identifier
 
   proc `testImpl _ blck _ identifier`() =
-    let prefix = if existsFile(testDir/"post.ssz"):                             
+    let prefix = if existsFile(testDir/"post.ssz"):
       "[Valid]   "
-    else:              
-      "[Invalid] "                                       
+    else:
+      "[Invalid] "
 
     timedTest prefix & identifier:
       var stateRef, postRef: ref BeaconState

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -20,90 +20,77 @@ import
 
 const SanityBlocksDir = SszTestsDir/const_preset/"phase0"/"sanity"/"blocks"/"pyspec_tests"
 
-template runValidTest(testName: string, identifier: untyped, num_blocks: int): untyped =
+template runTest(identifier: string, num_blocks: int): untyped =
   # We wrap the tests in a proc to avoid running out of globals
   # in the future: Nim supports up to 3500 globals
   # but unittest with the macro/templates put everything as globals
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
 
-  const testDir = SanityBlocksDir / astToStr(identifier)
+  const testDir = SanityBlocksDir / identifier
 
   proc `testImpl _ blck _ identifier`() =
-    timedTest "[Valid]   " & testName & " (" & astToStr(identifier) & ")":
+    let prefix = if existsFile(testDir/"post.ssz"):                             
+      "[Valid]   "
+    else:              
+      "[Invalid] "                                       
+
+    timedTest prefix & identifier:
       var stateRef, postRef: ref BeaconState
       new stateRef
-      new postRef
       stateRef[] = parseTest(testDir/"pre.ssz", SSZ, BeaconState)
-      postRef[] = parseTest(testDir/"post.ssz", SSZ, BeaconState)
+
+      if existsFile(testDir/"post.ssz"):
+        new postRef
+        postRef[] = parseTest(testDir/"post.ssz", SSZ, BeaconState)
 
       for i in 0 ..< num_blocks:
         let blck = parseTest(testDir/"blocks_" & $i & ".ssz", SSZ, SignedBeaconBlock)
 
-        # TODO: The EF is using invalid BLS keys so we can't verify them
-        let success = state_transition(stateRef[], blck.message, flags = {skipValidation})
-        doAssert success, "Failure when applying block " & $i
+        if postRef.isNil:
+          let success = state_transition(stateRef[], blck.message, flags = {})
+          doAssert not success, "We didn't expect this invalid block to be processed"
+        else:
+          # TODO: The EF is using invalid BLS keys so we can't verify them
+          let success = state_transition(stateRef[], blck.message, flags = {skipValidation})
+          doAssert success, "Failure when applying block " & $i
 
-      # Checks:
-      # check: stateRef.hash_tree_root() == postRef.hash_tree_root()
-      reportDiff(stateRef, postRef)
+          # Checks:
+          # check: stateRef.hash_tree_root() == postRef.hash_tree_root()
+          if i == num_blocks - 1: reportDiff(stateRef, postRef)
 
   `testImpl _ blck _ identifier`()
 
 suite "Official - Sanity - Blocks " & preset():
-  timedTest "[Invalid] Previous slot block transition (prev_slot_block_transition)":
-    const testDir = SanityBlocksDir/"prev_slot_block_transition"
-    var stateRef: ref BeaconState
-    new stateRef
-    stateRef[] = parseTest(testDir/"pre.ssz", SSZ, BeaconState)
-
-    let blck = parseTest(testDir/"blocks_0.ssz", SSZ, SignedBeaconBlock)
-
-    # Check that a block build for an old slot cannot be used for state transition
-    expect(AssertionError):
-      # assert in process_slots. This should not be triggered
-      #                          for blocks from block_pool/network
-      discard state_transition(stateRef[], blck.message, flags = {skipValidation})
-
-  runValidTest("Same slot block transition", same_slot_block_transition, 1)
-  runValidTest("Empty block transition", empty_block_transition, 1)
-
-  when false: # TODO: we need more granular skipValidation
-    timedTest "[Invalid] Invalid state root":
-      const testDir = SanityBlocksDir/"invalid_state_root"
-      var stateRef: ref BeaconState
-      new stateRef
-      stateRef[] = parseTest(testDir/"pre.ssz", SSZ, BeaconState)
-
-      let blck = parseTest(testDir/"blocks_0.ssz", SSZ, BeaconBlock)
-
-      expect(AssertionError):
-        discard state_transition(stateRef[], blck, flags = {skipValidation})
-
-  runValidTest("Skipped Slots", skipped_slots, 1)
-  runValidTest("Empty epoch transition", empty_epoch_transition, 1)
-  when const_preset=="minimal":
-    runValidTest("Empty epoch transition not finalizing", empty_epoch_transition_not_finalizing, 1)
+  const expected_failures = ["attester_slashing"]
+  runTest("attestation", 2)
 
   when false:
-    # TODO investigate/fix after 0.9.0 transition broke this in mainnet and
-    # in 0.9.1 even minimal broke. For the latter at least, it differs only
-    # in latest_block_header.body_root, which is just a hash_tree_root() of
-    # the one block read by this test case. All balances agree. It's an SSZ
-    # or hashing issue.
-    runValidTest("Attester slashing", attester_slashing, 1)
-  runValidTest("Proposer slashing", proposer_slashing, 1)
+    # Failing due to signature checking in indexed validation checking pending
+    # 0.10 BLS verification API with new domain handling.
+    runTest("attester_slashing", 1)
+  echo "Skipping test: attester_slashing"
 
-  # TODO: Expected deposit in block
-
-  runValidTest("Deposit in block", deposit_in_block, 1)
-  runValidTest("Deposit top up", deposit_top_up, 1)
+  runTest("balance_driven_status_transitions", 1)
+  runTest("deposit_in_block", 1)
+  runTest("deposit_top_up", 1)
+  runTest("empty_block_transition", 1)
+  runTest("empty_epoch_transition", 1)
 
   when const_preset=="minimal":
-    # TODO this doesn't work on mainnet
-    runValidTest("Attestation", attestation, 2)
-  runValidTest("Voluntary exit", voluntary_exit, 2)
-  runValidTest("Balance-driven status transitions", balance_driven_status_transitions, 1)
-  runValidTest("Historical batch", historical_batch, 1)
+    runTest("empty_epoch_transition_not_finalizing", 1)
+    runTest("eth1_data_votes_consensus", 17)
+    runTest("eth1_data_votes_no_consensus", 16)
+
+  runTest("expected_deposit_in_block", 1)
+  runTest("high_proposer_index", 1)
+  runTest("historical_batch", 1)
+  runTest("invalid_block_sig", 1)
+  runTest("invalid_state_root", 1)
+  runTest("prev_slot_block_transition", 1)
+  runTest("proposer_after_inactive_index", 1)
+  runTest("proposer_slashing", 1)
+  runTest("same_slot_block_transition", 1)
+  runTest("skipped_slots", 1)
+  runTest("voluntary_exit", 2)
   when const_preset=="minimal":
-    runValidTest("ETH1 data votes consensus", eth1_data_votes_consensus, 17)
-    runValidTest("ETH1 data votes no consensus", eth1_data_votes_no_consensus, 16)
+    runTest("zero_block_sig", 1)


### PR DESCRIPTION
This is partway to the full enumeration of all block sanity tests, which needs a bit more intelligence on the part of the test runner than currently exists. It does this by first making sure all tests are run in a more uniform way. What remains is to detect (either by just scanning the filesystem or reading `meta.yaml`) how many blocks to apply, rather than manually specifying that in each case.

All tests except `attester_slashing` are now enabled -- about a half dozen new tests, with all previously enabled tests remaining enabled.