### PR TITLE
finish conversion to automatic iteration over EF test vectors

### DIFF
--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -66,5 +66,6 @@ suite "Official - Operations - Deposits " & preset():
 
   for kind, path in walkDir(OperationsDepositsDir, true):
     if path in expected_failures:
+      echo "Skipping test: ", path
       continue
     runTest(path)

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -20,13 +20,13 @@ import
 
 const OperationsDepositsDir = SszTestsDir/const_preset/"phase0"/"operations"/"deposit"/"pyspec_tests"
 
-template runTest(testName: string, identifier: untyped) =
+proc runTest(identifier: string) =
   # We wrap the tests in a proc to avoid running out of globals
   # in the future: Nim supports up to 3500 globals
   # but unittest with the macro/templates put everything as globals
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
 
-  const testDir = OperationsDepositsDir / astToStr(identifier)
+  let testDir = OperationsDepositsDir / identifier
 
   proc `testImpl _ operations_deposits _ identifier`() =
 
@@ -39,7 +39,7 @@ template runTest(testName: string, identifier: untyped) =
     else:
       prefix = "[Invalid] "
 
-    timedTest prefix & testName & " (" & astToStr(identifier) & ")":
+    timedTest prefix & " " & identifier:
       var stateRef, postRef: ref BeaconState
       var depositRef: ref Deposit
       new depositRef
@@ -61,19 +61,10 @@ template runTest(testName: string, identifier: untyped) =
   `testImpl _ operations_deposits _ identifier`()
 
 suite "Official - Operations - Deposits " & preset():
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/minimal/phase0/operations/deposit/pyspec_tests
-  # https://github.com/ethereum/eth2.0-spec-tests/tree/v0.10.1/tests/mainnet/phase0/operations/deposit/pyspec_tests
-  runTest("bad merkle proof", bad_merkle_proof)
-  runTest("invalid signature new deposit", invalid_sig_new_deposit)
-  runTest("invalid signature other version", invalid_sig_other_version)
-  runTest("invalid signature top-up", invalid_sig_top_up)
-  runTest("invalid withdrawal credentials top-up",
-    invalid_withdrawal_credentials_top_up)
-  runTest("new deposit max", new_deposit_max)
-  runTest("new deposit over max", new_deposit_over_max)
-  runTest("new deposit under max", new_deposit_under_max)
-  runTest("success top-up", success_top_up)
-  when false:
-    # TODO
-    runTest("valid signature but forked state", valid_sig_but_forked_state)
-  runTest("wrong deposit for deposit count", wrong_deposit_for_deposit_count)
+  # TODO
+  const expected_failures = ["valid_sig_but_forked_state"]
+
+  for kind, path in walkDir(OperationsDepositsDir, true):
+    if path in expected_failures:
+      continue
+    runTest(path)

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -69,5 +69,6 @@ suite "Official - Sanity - Blocks " & preset():
 
   for kind, path in walkDir(SanityBlocksDir, true):
     if path in expected_failures:
+      echo "Skipping test: ", path
       continue
     runTest(path)


### PR DESCRIPTION
- I didn't seriously investigate why `valid_sig_but_forked_state` is failing -- it was failing before and failing now. This just makes it more obvious.

- One advantage of automatic enumeration is that there's no question of whether some `when const_preset == "minimal"` or `"mainnet"` conditional block is a failure or just the presence or lack thereof. There are no test-case-failure-based conditions of that sort left for EF tests.

- It's now much easier to see all 4 failing EF test vectors, `valid_sig_but_forked_state`, `success_already_exited_recent`, `success_already_exited_long_ago`, and `attester_slashing`:
```
$ grep -r -A1 "expected_failures =" tests/official/
tests/official/test_fixture_operations_deposits.nim:  const expected_failures = ["valid_sig_but_forked_state"]
tests/official/test_fixture_operations_deposits.nim-
--
tests/official/test_fixture_operations_attester_slashings.nim:  const expected_failures =
tests/official/test_fixture_operations_attester_slashings.nim-    ["success_already_exited_recent", "success_already_exited_long_ago"]
--
tests/official/test_fixture_sanity_blocks.nim:  const expected_failures = ["attester_slashing"]
tests/official/test_fixture_sanity_blocks.nim-
```
where 3 of them are waiting on BLS verify call signature updates and the fourth, `valid_sig_but_forked_state`, might be too (I haven't looked at it).

- https://github.com/status-im/nim-beacon-chain/issues/407 seems less important than it was -- two of the cases where it came up turns out to have been unnecessary and the tests pass without it. It's still useful for fuzzing, but it's blocking less.

- Of course, the test of test vectors gets automatically updated now each version, so there won't be any missing added/removed test cases aside from if an entirely new section is added or a section is removed.

- It gets things ready to switch to the overall better approach used by https://github.com/status-im/nim-beacon-chain/tree/devel/nbench#running-the-whole-test-suite which also automatically enumerates test vectors, by defining clearly exactly which test vectors need to be skipped or fixed.