### PR TITLE
allow beacon_node to verify finalization when appropriate

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -688,10 +688,10 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     cat = "scheduling"
 
   # Check before any re-scheduling of onSlotStart()
-  if node.config.checkEpochs > 0'u64 and
-      scheduledSlot.compute_epoch_at_slot() >= node.config.checkEpochs:
+  if node.config.stopAtEpoch > 0'u64 and
+      scheduledSlot.compute_epoch_at_slot() >= node.config.stopAtEpoch:
     info "Stopping at pre-chosen epoch",
-      chosenEpoch = node.config.checkEpochs,
+      chosenEpoch = node.config.stopAtEpoch,
       epoch = scheduledSlot.compute_epoch_at_slot(),
       slot = scheduledSlot
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -137,10 +137,10 @@ type
         desc: "Specify whether to verify finalization occurs on schedule, for testing."
         name: "verify-finalization" }: bool
 
-      checkEpochs* {.
+      stopAtEpoch* {.
         defaultValue: 0
-        desc: "A positive checkEpochs selects how many epochs to run."
-        name: "check-epochs" }: uint64
+        desc: "A positive epoch selects the epoch at which to stop."
+        name: "stop-at-epoch" }: uint64
 
       metricsServer* {.
         defaultValue: false

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -132,6 +132,16 @@ type
               "If you set this to 'auto', a persistent automatically generated ID will be seleceted for each --dataDir folder."
         name: "node-name" }: string
 
+      verifyFinalization* {.
+        defaultValue: false
+        desc: "Specify whether to verify finalization occurs on schedule, for testing."
+        name: "verify-finalization" }: bool
+
+      checkEpochs* {.
+        defaultValue: 0
+        desc: "A positive checkEpochs selects how many epochs to run."
+        name: "check-epochs" }: uint64
+
       metricsServer* {.
         defaultValue: false
         desc: "Enable the metrics server."

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -63,6 +63,7 @@ cd "$DATA_DIR" && $NODE_BIN \
   --state-snapshot=$SNAPSHOT_FILE \
   $DEPOSIT_WEB3_URL_ARG \
   --deposit-contract=$DEPOSIT_CONTRACT_ADDRESS \
+  --verify-finalization=on \
   --metrics-server=on \
   --metrics-server-address="127.0.0.1" \
   --metrics-server-port="$(( $BASE_METRICS_PORT + $NODE_ID ))" \


### PR DESCRIPTION
This is a building block for using this in CI, along with just allowing for `make eth2_network_simulation` more useful by default.

For CI use, one would also enable stopping at a specified epoch.