### PR TITLE
bump libp2p and increase bootstrap timeout

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -228,7 +228,7 @@ when networkBackend in [libp2p, libp2pDaemon]:
       await node.start()
 
       proc checkIfConnectedToBootstrapNode {.async.} =
-        await sleepAsync(10.seconds)
+        await sleepAsync(30.seconds)
         if bootstrapEnrs.len > 0 and libp2p_successful_dials.value == 0:
           fatal "Failed to connect to any bootstrap node. Quitting", bootstrapEnrs
           quit 1

--- a/beacon_chain/libp2p_backend.nim
+++ b/beacon_chain/libp2p_backend.nim
@@ -192,10 +192,6 @@ proc dialPeer*(node: Eth2Node, peerInfo: PeerInfo) {.async.} =
   debug "Initializing connection"
   await initializeConnection(peer)
 
-  # TODO: This should happen automatically in the future in nim-libp2p
-  debug "Subscribing to pubsub"
-  await peer.network.switch.subscribeToPeer(peer.info)
-
   inc libp2p_successful_dials
   debug "Network handshakes completed"
 


### PR DESCRIPTION
Bumping libp2p to latest master and removing the deprecated `subscribeToPeer` call. Also, increase timeout on bootstrap connect to prevent premature exits.