### PR TITLE
A new experimental way to write unit tests

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -30,6 +30,7 @@ requires "nim >= 0.19.0",
   "nimcrypto",
   "serialization",
   "stew",
+  "testutils",
   "prompt",
   "web3",
   "yaml"
@@ -43,6 +44,12 @@ proc buildBinary(name: string, srcDir = "./", params = "", cmdParams = "", lang 
   for i in 2..<paramCount():
     extra_params &= " " & paramStr(i)
   exec "nim " & lang & " --out:./build/" & name & " -r " & extra_params & " " & srcDir & name & ".nim" & " " & cmdParams
+
+task moduleTests, "Run all module tests":
+  buildBinary "beacon_node", "beacon_chain/",
+              "-d:chronicles_log_level=TRACE " &
+              "-d:const_preset=minimal " &
+              "-d:testutils_test_build"
 
 ### tasks
 task test, "Run all tests":

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1054,7 +1054,7 @@ when hasPrompt:
       # var t: Thread[ptr Prompt]
       # createThread(t, processPromptCommands, addr p)
 
-when isMainModule:
+programMain:
   let config = BeaconNodeConf.load(
     version = clientId,
     copyrightBanner = clientId & "\p" & copyrights)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -28,6 +28,16 @@ func integer_squareroot*(n: SomeInteger): SomeInteger =
     y = (x + n div x) div 2
   x
 
+tests:
+  test "integer_squareroot":
+    check:
+      integer_squareroot(0'u64) == 0'u64
+      integer_squareroot(1'u64) == 1'u64
+      integer_squareroot(2'u64) == 1'u64
+      integer_squareroot(3'u64) == 1'u64
+      integer_squareroot(4'u64) == 2'u64
+      integer_squareroot(5'u64) == 2'u64
+
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#compute_epoch_at_slot
 func compute_epoch_at_slot*(slot: Slot|uint64): Epoch =
   # Return the epoch number at ``slot``.
@@ -113,6 +123,15 @@ func int_to_bytes4*(x: uint64): array[4, byte] =
   result[1] = ((x shr  8) and 0xff).byte
   result[2] = ((x shr 16) and 0xff).byte
   result[3] = ((x shr 24) and 0xff).byte
+
+tests:
+  test "int_to_bytes4":
+    let bytes = int_to_bytes4(1024)
+    check:
+      bytes[0] == 0
+      bytes[1] == 4
+      bytes[2] == 0
+      bytes[3] == 0
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#compute_domain
 func compute_domain*(

--- a/config.nims
+++ b/config.nims
@@ -39,6 +39,8 @@ else:
 --define:metrics
 --define:chronicles_line_numbers
 
+switch("import", "testutils/moduletests")
+
 # the default open files limit is too low on macOS (512), breaking the
 # "--debugger:native" build. It can be increased with `ulimit -n 1024`.
 if not defined(macosx):


### PR DESCRIPTION
I'd like to propose a new experimental way for writing unit tests.

Instead of putting the tests into separate modules in the "tests" folder, we place them in the same module where the tested functionality is defined (similar to the `isMainModule` practice).

The whole program has two compilation modes:

1) Normal compilation where all testing code is removed.
2) Testing compilation where the `main` program entry is removed and only the top-level code in every module is executed along with all tests.

There are few advantages to doing this:

1) It's possible to test private helpers.
2) You don't have to spend time hunting the correct import in the test module, setting up separate test tasks and so on. It's easy to bind a key in your text editor that executes all tests in the current file.
3) The tests can serve as a form of a documentation.

This PR implement this proposal (with a small example) through a new helper facility added to [`nim-testutils`](https://github.com/status-im/nim-testutils/blob/master/testutils/moduletests.nim)