### PR TITLE
Markdown test reports

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1,0 +1,202 @@
+AllTests-mainnet
+===
+## Beacon chain DB [Preset: mainnet]
+```diff
++ empty database [Preset: mainnet]                                                           OK
++ find ancestors [Preset: mainnet]                                                           OK
++ sanity check blocks [Preset: mainnet]                                                      OK
++ sanity check genesis roundtrip [Preset: mainnet]                                           OK
++ sanity check states [Preset: mainnet]                                                      OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## Beacon node
+```diff
++ Compile                                                                                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Beacon state [Preset: mainnet]
+```diff
++ Smoke test initialize_beacon_state_from_eth1 [Preset: mainnet]                             OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Block processing [Preset: mainnet]
+```diff
++ Attestation gets processed at epoch [Preset: mainnet]                                      OK
++ Passes from genesis state, empty block [Preset: mainnet]                                   OK
++ Passes from genesis state, no block [Preset: mainnet]                                      OK
++ Passes through epoch update, empty block [Preset: mainnet]                                 OK
++ Passes through epoch update, no block [Preset: mainnet]                                    OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## BlockRef and helpers [Preset: mainnet]
+```diff
++ getAncestorAt sanity [Preset: mainnet]                                                     OK
++ isAncestorOf sanity [Preset: mainnet]                                                      OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## BlockSlot and helpers [Preset: mainnet]
+```diff
++ atSlot sanity [Preset: mainnet]                                                            OK
++ parent sanity [Preset: mainnet]                                                            OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Discovery v5 utilities
+```diff
++ ENR to ENode                                                                               OK
++ Multiaddress to ENode                                                                      OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Honest validator
+```diff
++ Attestation topics                                                                         OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Interop
+```diff
++ Interop genesis                                                                            OK
++ Interop signatures                                                                         OK
++ Mocked start private key                                                                   OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## Official - 0.10.1 - constants & config  [Preset: mainnet]
+```diff
++ BASE_REWARD_FACTOR                                64                   [Preset: mainnet]   OK
++ BLS_WITHDRAWAL_PREFIX                             "0x00"               [Preset: mainnet]   OK
++ CHURN_LIMIT_QUOTIENT                              65536                [Preset: mainnet]   OK
+- DEPOSIT_CONTRACT_ADDRESS                          "0x1234567890123456789012345678901234567 Fail
++ DOMAIN_BEACON_ATTESTER                            "0x01000000"         [Preset: mainnet]   OK
++ DOMAIN_BEACON_PROPOSER                            "0x00000000"         [Preset: mainnet]   OK
++ DOMAIN_CUSTODY_BIT_CHALLENGE                      "0x06000000"         [Preset: mainnet]   OK
++ DOMAIN_DEPOSIT                                    "0x03000000"         [Preset: mainnet]   OK
++ DOMAIN_RANDAO                                     "0x02000000"         [Preset: mainnet]   OK
++ DOMAIN_SHARD_ATTESTER                             "0x81000000"         [Preset: mainnet]   OK
++ DOMAIN_SHARD_PROPOSER                             "0x80000000"         [Preset: mainnet]   OK
++ DOMAIN_VOLUNTARY_EXIT                             "0x04000000"         [Preset: mainnet]   OK
++ EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS    16384                [Preset: mainnet]   OK
++ EFFECTIVE_BALANCE_INCREMENT                       1000000000           [Preset: mainnet]   OK
++ EJECTION_BALANCE                                  16000000000          [Preset: mainnet]   OK
++ EPOCHS_PER_HISTORICAL_VECTOR                      65536                [Preset: mainnet]   OK
++ EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION             256                  [Preset: mainnet]   OK
++ EPOCHS_PER_SLASHINGS_VECTOR                       8192                 [Preset: mainnet]   OK
++ ETH1_FOLLOW_DISTANCE                              1024                 [Preset: mainnet]   OK
++ GENESIS_FORK_VERSION                              "0x00000000"         [Preset: mainnet]   OK
++ HISTORICAL_ROOTS_LIMIT                            16777216             [Preset: mainnet]   OK
++ INACTIVITY_PENALTY_QUOTIENT                       33554432             [Preset: mainnet]   OK
++ MAX_ATTESTATIONS                                  128                  [Preset: mainnet]   OK
++ MAX_ATTESTER_SLASHINGS                            1                    [Preset: mainnet]   OK
++ MAX_COMMITTEES_PER_SLOT                           64                   [Preset: mainnet]   OK
++ MAX_DEPOSITS                                      16                   [Preset: mainnet]   OK
++ MAX_EFFECTIVE_BALANCE                             32000000000          [Preset: mainnet]   OK
++ MAX_EPOCHS_PER_CROSSLINK                          64                   [Preset: mainnet]   OK
++ MAX_PROPOSER_SLASHINGS                            16                   [Preset: mainnet]   OK
++ MAX_SEED_LOOKAHEAD                                4                    [Preset: mainnet]   OK
++ MAX_VALIDATORS_PER_COMMITTEE                      2048                 [Preset: mainnet]   OK
++ MAX_VOLUNTARY_EXITS                               16                   [Preset: mainnet]   OK
++ MIN_ATTESTATION_INCLUSION_DELAY                   1                    [Preset: mainnet]   OK
++ MIN_DEPOSIT_AMOUNT                                1000000000           [Preset: mainnet]   OK
++ MIN_EPOCHS_TO_INACTIVITY_PENALTY                  4                    [Preset: mainnet]   OK
++ MIN_GENESIS_ACTIVE_VALIDATOR_COUNT                16384                [Preset: mainnet]   OK
++ MIN_GENESIS_DELAY                                 86400                [Preset: mainnet]   OK
++ MIN_GENESIS_TIME                                  1578009600           [Preset: mainnet]   OK
++ MIN_PER_EPOCH_CHURN_LIMIT                         4                    [Preset: mainnet]   OK
++ MIN_SEED_LOOKAHEAD                                1                    [Preset: mainnet]   OK
++ MIN_SLASHING_PENALTY_QUOTIENT                     32                   [Preset: mainnet]   OK
++ MIN_VALIDATOR_WITHDRAWABILITY_DELAY               256                  [Preset: mainnet]   OK
++ PERSISTENT_COMMITTEE_PERIOD                       2048                 [Preset: mainnet]   OK
++ PROPOSER_REWARD_QUOTIENT                          8                    [Preset: mainnet]   OK
++ RANDOM_SUBNETS_PER_VALIDATOR                      1                    [Preset: mainnet]   OK
++ SAFE_SLOTS_TO_UPDATE_JUSTIFIED                    8                    [Preset: mainnet]   OK
++ SECONDS_PER_ETH1_BLOCK                            14                   [Preset: mainnet]   OK
++ SECONDS_PER_SLOT                                  12                   [Preset: mainnet]   OK
++ SHUFFLE_ROUND_COUNT                               90                   [Preset: mainnet]   OK
++ SLOTS_PER_EPOCH                                   32                   [Preset: mainnet]   OK
++ SLOTS_PER_ETH1_VOTING_PERIOD                      1024                 [Preset: mainnet]   OK
++ SLOTS_PER_HISTORICAL_ROOT                         8192                 [Preset: mainnet]   OK
++ TARGET_AGGREGATORS_PER_COMMITTEE                  16                   [Preset: mainnet]   OK
++ TARGET_COMMITTEE_SIZE                             128                  [Preset: mainnet]   OK
++ VALIDATOR_REGISTRY_LIMIT                          1099511627776        [Preset: mainnet]   OK
++ WHISTLEBLOWER_REWARD_QUOTIENT                     512                  [Preset: mainnet]   OK
+```
+OK: 55/56 Fail: 1/56 Skip: 0/56
+## PeerPool testing suite
+```diff
++ Access peers by key test                                                                   OK
++ Acquire from empty pool                                                                    OK
++ Acquire/Sorting and consistency test                                                       OK
++ Iterators test                                                                             OK
++ Peer lifetime test                                                                         OK
++ Safe/Clear test                                                                            OK
++ addPeer() test                                                                             OK
++ addPeerNoWait() test                                                                       OK
++ deletePeer() test                                                                          OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## SSZ dynamic navigator
+```diff
++ navigating fields                                                                          OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## SSZ navigator
+```diff
++ lists with max size                                                                        OK
++ simple object fields                                                                       OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Spec helpers
+```diff
++ integer_squareroot                                                                         OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Sync protocol
+```diff
++ Compile                                                                                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## SyncManager test suite
+```diff
++ PeerGroup tests                                                                            OK
++ PeerSlot tests                                                                             OK
++ SyncManager failure test                                                                   OK
++ SyncManager group-recovery test                                                            OK
++ SyncManager one-peer test                                                                  OK
++ SyncManager one-peer-group test                                                            OK
++ SyncManager one-peer-slot test                                                             OK
++ SyncQueue async tests                                                                      OK
++ SyncQueue non-async tests                                                                  OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Zero signature sanity checks
+```diff
++ SSZ serialization roundtrip of SignedBeaconBlockHeader                                     OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## [Unit - Spec - Block processing] Attestations  [Preset: mainnet]
+```diff
++ Empty aggregation bit                                                                      OK
++ Valid attestation                                                                          OK
++ Valid attestation from previous epoch                                                      OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## [Unit - Spec - Block processing] Deposits  [Preset: mainnet]
+```diff
++ Deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                          OK
++ Deposit over MAX_EFFECTIVE_BALANCE balance (32 ETH)                                        OK
++ Deposit under MAX_EFFECTIVE_BALANCE balance (32 ETH)                                       OK
++ Validator top-up                                                                           OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## [Unit - Spec - Epoch processing] Justification and Finalization  [Preset: mainnet]
+```diff
++  Rule I - 234 finalization with enough support                                             OK
++  Rule I - 234 finalization without support                                                 OK
++  Rule II - 23 finalization with enough support                                             OK
++  Rule II - 23 finalization without support                                                 OK
++  Rule III - 123 finalization with enough support                                           OK
++  Rule III - 123 finalization without support                                               OK
++  Rule IV - 12 finalization with enough support                                             OK
++  Rule IV - 12 finalization without support                                                 OK
+```
+OK: 8/8 Fail: 0/8 Skip: 0/8
+
+---TOTAL---
+OK: 116/117 Fail: 1/117 Skip: 0/117

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -1,0 +1,235 @@
+AllTests-minimal
+===
+## Attestation pool processing [Preset: minimal]
+```diff
++ Attestations may arrive in any order [Preset: minimal]                                     OK
++ Attestations may overlap, bigger first [Preset: minimal]                                   OK
++ Attestations may overlap, smaller first [Preset: minimal]                                  OK
++ Attestations should be combined [Preset: minimal]                                          OK
++ Can add and retrieve simple attestation [Preset: minimal]                                  OK
++ Fork choice returns block with attestation                                                 OK
++ Fork choice returns latest block with no attestations                                      OK
+```
+OK: 7/7 Fail: 0/7 Skip: 0/7
+## Beacon chain DB [Preset: minimal]
+```diff
++ empty database [Preset: minimal]                                                           OK
++ find ancestors [Preset: minimal]                                                           OK
++ sanity check blocks [Preset: minimal]                                                      OK
++ sanity check genesis roundtrip [Preset: minimal]                                           OK
++ sanity check states [Preset: minimal]                                                      OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## Beacon node
+```diff
++ Compile                                                                                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Beacon state [Preset: minimal]
+```diff
++ Smoke test initialize_beacon_state_from_eth1 [Preset: minimal]                             OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Block pool processing [Preset: minimal]
+```diff
++ Can add same block twice [Preset: minimal]                                                 OK
++ Reverse order block add & get [Preset: minimal]                                            OK
++ Simple block add&get [Preset: minimal]                                                     OK
++ getRef returns nil for missing blocks                                                      OK
++ loadTailState gets genesis block on first load [Preset: minimal]                           OK
++ updateHead updates head and headState [Preset: minimal]                                    OK
++ updateStateData sanity [Preset: minimal]                                                   OK
+```
+OK: 7/7 Fail: 0/7 Skip: 0/7
+## Block processing [Preset: minimal]
+```diff
++ Attestation gets processed at epoch [Preset: minimal]                                      OK
++ Passes from genesis state, empty block [Preset: minimal]                                   OK
++ Passes from genesis state, no block [Preset: minimal]                                      OK
++ Passes through epoch update, empty block [Preset: minimal]                                 OK
++ Passes through epoch update, no block [Preset: minimal]                                    OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## BlockPool finalization tests [Preset: minimal]
+```diff
++ prune heads on finalization [Preset: minimal]                                              OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## BlockRef and helpers [Preset: minimal]
+```diff
++ getAncestorAt sanity [Preset: minimal]                                                     OK
++ isAncestorOf sanity [Preset: minimal]                                                      OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## BlockSlot and helpers [Preset: minimal]
+```diff
++ atSlot sanity [Preset: minimal]                                                            OK
++ parent sanity [Preset: minimal]                                                            OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Discovery v5 utilities
+```diff
++ ENR to ENode                                                                               OK
++ Multiaddress to ENode                                                                      OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Honest validator
+```diff
++ Attestation topics                                                                         OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Interop
+```diff
++ Interop genesis                                                                            OK
++ Interop signatures                                                                         OK
++ Mocked start private key                                                                   OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## Official - 0.10.1 - constants & config  [Preset: minimal]
+```diff
++ BASE_REWARD_FACTOR                                64                   [Preset: minimal]   OK
++ BLS_WITHDRAWAL_PREFIX                             "0x00"               [Preset: minimal]   OK
++ CHURN_LIMIT_QUOTIENT                              65536                [Preset: minimal]   OK
++ CUSTODY_PERIOD_TO_RANDAO_PADDING                  4                    [Preset: minimal]   OK
+- DEPOSIT_CONTRACT_ADDRESS                          "0x1234567890123456789012345678901234567 Fail
++ DOMAIN_BEACON_ATTESTER                            "0x01000000"         [Preset: minimal]   OK
++ DOMAIN_BEACON_PROPOSER                            "0x00000000"         [Preset: minimal]   OK
++ DOMAIN_CUSTODY_BIT_CHALLENGE                      "0x06000000"         [Preset: minimal]   OK
++ DOMAIN_DEPOSIT                                    "0x03000000"         [Preset: minimal]   OK
++ DOMAIN_RANDAO                                     "0x02000000"         [Preset: minimal]   OK
++ DOMAIN_SHARD_ATTESTER                             "0x81000000"         [Preset: minimal]   OK
++ DOMAIN_SHARD_PROPOSER                             "0x80000000"         [Preset: minimal]   OK
++ DOMAIN_VOLUNTARY_EXIT                             "0x04000000"         [Preset: minimal]   OK
++ EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS    4096                 [Preset: minimal]   OK
++ EFFECTIVE_BALANCE_INCREMENT                       1000000000           [Preset: minimal]   OK
++ EJECTION_BALANCE                                  16000000000          [Preset: minimal]   OK
++ EPOCHS_PER_CUSTODY_PERIOD                         4                    [Preset: minimal]   OK
++ EPOCHS_PER_HISTORICAL_VECTOR                      64                   [Preset: minimal]   OK
++ EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION             256                  [Preset: minimal]   OK
++ EPOCHS_PER_SHARD_PERIOD                           4                    [Preset: minimal]   OK
++ EPOCHS_PER_SLASHINGS_VECTOR                       64                   [Preset: minimal]   OK
++ ETH1_FOLLOW_DISTANCE                              16                   [Preset: minimal]   OK
++ GENESIS_FORK_VERSION                              "0x00000001"         [Preset: minimal]   OK
++ HISTORICAL_ROOTS_LIMIT                            16777216             [Preset: minimal]   OK
++ INACTIVITY_PENALTY_QUOTIENT                       33554432             [Preset: minimal]   OK
++ MAX_ATTESTATIONS                                  128                  [Preset: minimal]   OK
++ MAX_ATTESTER_SLASHINGS                            1                    [Preset: minimal]   OK
++ MAX_COMMITTEES_PER_SLOT                           4                    [Preset: minimal]   OK
++ MAX_DEPOSITS                                      16                   [Preset: minimal]   OK
++ MAX_EFFECTIVE_BALANCE                             32000000000          [Preset: minimal]   OK
++ MAX_EPOCHS_PER_CROSSLINK                          4                    [Preset: minimal]   OK
++ MAX_PROPOSER_SLASHINGS                            16                   [Preset: minimal]   OK
++ MAX_SEED_LOOKAHEAD                                4                    [Preset: minimal]   OK
++ MAX_VALIDATORS_PER_COMMITTEE                      2048                 [Preset: minimal]   OK
++ MAX_VOLUNTARY_EXITS                               16                   [Preset: minimal]   OK
++ MIN_ATTESTATION_INCLUSION_DELAY                   1                    [Preset: minimal]   OK
++ MIN_DEPOSIT_AMOUNT                                1000000000           [Preset: minimal]   OK
++ MIN_EPOCHS_TO_INACTIVITY_PENALTY                  4                    [Preset: minimal]   OK
++ MIN_GENESIS_ACTIVE_VALIDATOR_COUNT                64                   [Preset: minimal]   OK
++ MIN_GENESIS_DELAY                                 300                  [Preset: minimal]   OK
++ MIN_GENESIS_TIME                                  1578009600           [Preset: minimal]   OK
++ MIN_PER_EPOCH_CHURN_LIMIT                         4                    [Preset: minimal]   OK
++ MIN_SEED_LOOKAHEAD                                1                    [Preset: minimal]   OK
++ MIN_SLASHING_PENALTY_QUOTIENT                     32                   [Preset: minimal]   OK
++ MIN_VALIDATOR_WITHDRAWABILITY_DELAY               256                  [Preset: minimal]   OK
++ PERSISTENT_COMMITTEE_PERIOD                       2048                 [Preset: minimal]   OK
++ PHASE_1_FORK_EPOCH                                8                    [Preset: minimal]   OK
++ PHASE_1_FORK_SLOT                                 64                   [Preset: minimal]   OK
++ PROPOSER_REWARD_QUOTIENT                          8                    [Preset: minimal]   OK
++ RANDOM_SUBNETS_PER_VALIDATOR                      1                    [Preset: minimal]   OK
++ SAFE_SLOTS_TO_UPDATE_JUSTIFIED                    2                    [Preset: minimal]   OK
++ SECONDS_PER_ETH1_BLOCK                            14                   [Preset: minimal]   OK
++ SECONDS_PER_SLOT                                  6                    [Preset: minimal]   OK
++ SHARD_SLOTS_PER_BEACON_SLOT                       2                    [Preset: minimal]   OK
++ SHUFFLE_ROUND_COUNT                               10                   [Preset: minimal]   OK
++ SLOTS_PER_EPOCH                                   8                    [Preset: minimal]   OK
++ SLOTS_PER_ETH1_VOTING_PERIOD                      16                   [Preset: minimal]   OK
++ SLOTS_PER_HISTORICAL_ROOT                         64                   [Preset: minimal]   OK
++ TARGET_AGGREGATORS_PER_COMMITTEE                  16                   [Preset: minimal]   OK
++ TARGET_COMMITTEE_SIZE                             4                    [Preset: minimal]   OK
++ VALIDATOR_REGISTRY_LIMIT                          1099511627776        [Preset: minimal]   OK
++ WHISTLEBLOWER_REWARD_QUOTIENT                     512                  [Preset: minimal]   OK
+```
+OK: 61/62 Fail: 1/62 Skip: 0/62
+## PeerPool testing suite
+```diff
++ Access peers by key test                                                                   OK
++ Acquire from empty pool                                                                    OK
++ Acquire/Sorting and consistency test                                                       OK
++ Iterators test                                                                             OK
++ Peer lifetime test                                                                         OK
++ Safe/Clear test                                                                            OK
++ addPeer() test                                                                             OK
++ addPeerNoWait() test                                                                       OK
++ deletePeer() test                                                                          OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## SSZ dynamic navigator
+```diff
++ navigating fields                                                                          OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## SSZ navigator
+```diff
++ lists with max size                                                                        OK
++ simple object fields                                                                       OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Spec helpers
+```diff
++ integer_squareroot                                                                         OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Sync protocol
+```diff
++ Compile                                                                                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## SyncManager test suite
+```diff
++ PeerGroup tests                                                                            OK
++ PeerSlot tests                                                                             OK
++ SyncManager failure test                                                                   OK
++ SyncManager group-recovery test                                                            OK
++ SyncManager one-peer test                                                                  OK
++ SyncManager one-peer-group test                                                            OK
++ SyncManager one-peer-slot test                                                             OK
++ SyncQueue async tests                                                                      OK
++ SyncQueue non-async tests                                                                  OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Zero signature sanity checks
+```diff
++ SSZ serialization roundtrip of SignedBeaconBlockHeader                                     OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## [Unit - Spec - Block processing] Attestations  [Preset: minimal]
+```diff
++ Empty aggregation bit                                                                      OK
++ Valid attestation                                                                          OK
++ Valid attestation from previous epoch                                                      OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## [Unit - Spec - Block processing] Deposits  [Preset: minimal]
+```diff
++ Deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                          OK
++ Deposit over MAX_EFFECTIVE_BALANCE balance (32 ETH)                                        OK
++ Deposit under MAX_EFFECTIVE_BALANCE balance (32 ETH)                                       OK
++ Validator top-up                                                                           OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## [Unit - Spec - Epoch processing] Justification and Finalization  [Preset: minimal]
+```diff
++  Rule I - 234 finalization with enough support                                             OK
++  Rule I - 234 finalization without support                                                 OK
++  Rule II - 23 finalization with enough support                                             OK
++  Rule II - 23 finalization without support                                                 OK
++  Rule III - 123 finalization with enough support                                           OK
++  Rule III - 123 finalization without support                                               OK
++  Rule IV - 12 finalization with enough support                                             OK
++  Rule IV - 12 finalization without support                                                 OK
+```
+OK: 8/8 Fail: 0/8 Skip: 0/8
+
+---TOTAL---
+OK: 137/138 Fail: 1/138 Skip: 0/138

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -1,0 +1,163 @@
+FixtureAll-mainnet
+===
+## Official - Epoch Processing - Final updates [Preset: mainnet]
+```diff
++ Final updates - effective_balance_hysteresis [Preset: mainnet]                             OK
++ Final updates - eth1_vote_no_reset [Preset: mainnet]                                       OK
++ Final updates - eth1_vote_reset [Preset: mainnet]                                          OK
++ Final updates - historical_root_accumulator [Preset: mainnet]                              OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## Official - Epoch Processing - Justification & Finalization [Preset: mainnet]
+```diff
++ Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
++ Justification & Finalization - 123_poor_support [Preset: mainnet]                          OK
++ Justification & Finalization - 12_ok_support [Preset: mainnet]                             OK
++ Justification & Finalization - 12_ok_support_messed_target [Preset: mainnet]               OK
++ Justification & Finalization - 12_poor_support [Preset: mainnet]                           OK
++ Justification & Finalization - 234_ok_support [Preset: mainnet]                            OK
++ Justification & Finalization - 234_poor_support [Preset: mainnet]                          OK
++ Justification & Finalization - 23_ok_support [Preset: mainnet]                             OK
++ Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Official - Epoch Processing - Registry updates [Preset: mainnet]
+```diff
++ Registry updates - activation_queue_activation_and_ejection [Preset: mainnet]              OK
++ Registry updates - activation_queue_efficiency [Preset: mainnet]                           OK
++ Registry updates - activation_queue_no_activation_no_finality [Preset: mainnet]            OK
++ Registry updates - activation_queue_sorting [Preset: mainnet]                              OK
++ Registry updates - activation_queue_to_activated_if_finalized [Preset: mainnet]            OK
++ Registry updates - add_to_activation_queue [Preset: mainnet]                               OK
++ Registry updates - ejection [Preset: mainnet]                                              OK
++ Registry updates - ejection_past_churn_limit [Preset: mainnet]                             OK
+```
+OK: 8/8 Fail: 0/8 Skip: 0/8
+## Official - Epoch Processing - Slashings [Preset: mainnet]
+```diff
++ Slashings - max_penalties [Preset: mainnet]                                                OK
++ Slashings - scaled_penalties [Preset: mainnet]                                             OK
++ Slashings - small_penalty [Preset: mainnet]                                                OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## Official - Operations - Attestations  [Preset: mainnet]
+```diff
++ [Invalid] after_epoch_slots                                                                OK
++ [Invalid] bad_source_root                                                                  OK
++ [Invalid] before_inclusion_delay                                                           OK
++ [Invalid] future_target_epoch                                                              OK
++ [Invalid] invalid_attestation_signature                                                    OK
++ [Invalid] invalid_current_source_root                                                      OK
++ [Invalid] invalid_index                                                                    OK
++ [Invalid] mismatched_target_and_slot                                                       OK
++ [Invalid] new_source_epoch                                                                 OK
++ [Invalid] old_source_epoch                                                                 OK
++ [Invalid] old_target_epoch                                                                 OK
++ [Invalid] source_root_is_target_root                                                       OK
++ [Invalid] too_few_aggregation_bits                                                         OK
++ [Invalid] too_many_aggregation_bits                                                        OK
++ [Invalid] wrong_index_for_committee_signature                                              OK
++ [Invalid] wrong_index_for_slot                                                             OK
++ [Valid]   empty_aggregation_bits                                                           OK
++ [Valid]   success                                                                          OK
++ [Valid]   success_multi_proposer_index_iterations                                          OK
++ [Valid]   success_previous_epoch                                                           OK
+```
+OK: 20/20 Fail: 0/20 Skip: 0/20
+## Official - Operations - Attester slashing  [Preset: mainnet]
+```diff
++ [Invalid] att1_bad_extra_index                                                             OK
++ [Invalid] att1_bad_replaced_index                                                          OK
++ [Invalid] att1_duplicate_index_double_signed                                               OK
++ [Invalid] att1_duplicate_index_normal_signed                                               OK
++ [Invalid] att2_bad_extra_index                                                             OK
++ [Invalid] att2_bad_replaced_index                                                          OK
++ [Invalid] att2_duplicate_index_double_signed                                               OK
++ [Invalid] att2_duplicate_index_normal_signed                                               OK
++ [Invalid] invalid_sig_1                                                                    OK
++ [Invalid] invalid_sig_1_and_2                                                              OK
++ [Invalid] invalid_sig_2                                                                    OK
++ [Invalid] no_double_or_surround                                                            OK
++ [Invalid] participants_already_slashed                                                     OK
++ [Invalid] same_data                                                                        OK
++ [Invalid] unsorted_att_1                                                                   OK
++ [Invalid] unsorted_att_2                                                                   OK
++ [Valid]   success_double                                                                   OK
++ [Valid]   success_surround                                                                 OK
+```
+OK: 18/18 Fail: 0/18 Skip: 0/18
+## Official - Operations - Block header  [Preset: mainnet]
+```diff
++ [Invalid] invalid_parent_root                                                              OK
++ [Invalid] invalid_slot_block_header                                                        OK
++ [Invalid] proposer_slashed                                                                 OK
++ [Valid]   success_block_header                                                             OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## Official - Operations - Deposits  [Preset: mainnet]
+```diff
++ [Invalid]  bad_merkle_proof                                                                OK
++ [Invalid]  wrong_deposit_for_deposit_count                                                 OK
++ [Valid]    invalid_sig_new_deposit                                                         OK
++ [Valid]    invalid_sig_other_version                                                       OK
++ [Valid]    invalid_sig_top_up                                                              OK
++ [Valid]    invalid_withdrawal_credentials_top_up                                           OK
++ [Valid]    new_deposit_max                                                                 OK
++ [Valid]    new_deposit_over_max                                                            OK
++ [Valid]    new_deposit_under_max                                                           OK
++ [Valid]    success_top_up                                                                  OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Official - Operations - Proposer slashing  [Preset: mainnet]
+```diff
++ [Invalid] identifier                                                                       OK
++ [Valid]   identifier                                                                       OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Official - Operations - Voluntary exit  [Preset: mainnet]
+```diff
++ [Invalid] invalid_signature                                                                OK
++ [Invalid] validator_already_exited                                                         OK
++ [Invalid] validator_exit_in_future                                                         OK
++ [Invalid] validator_invalid_validator_index                                                OK
++ [Invalid] validator_not_active                                                             OK
++ [Invalid] validator_not_active_long_enough                                                 OK
++ [Valid]   default_exit_epoch_subsequent_exit                                               OK
++ [Valid]   success                                                                          OK
++ [Valid]   success_exit_queue                                                               OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Official - Sanity - Blocks  [Preset: mainnet]
+```diff
++ [Invalid] expected_deposit_in_block                                                        OK
++ [Invalid] invalid_block_sig                                                                OK
++ [Invalid] invalid_state_root                                                               OK
++ [Invalid] prev_slot_block_transition                                                       OK
++ [Invalid] zero_block_sig                                                                   OK
++ [Valid]   attestation                                                                      OK
++ [Valid]   balance_driven_status_transitions                                                OK
++ [Valid]   deposit_in_block                                                                 OK
++ [Valid]   deposit_top_up                                                                   OK
++ [Valid]   empty_block_transition                                                           OK
++ [Valid]   empty_epoch_transition                                                           OK
++ [Valid]   high_proposer_index                                                              OK
++ [Valid]   historical_batch                                                                 OK
++ [Valid]   proposer_after_inactive_index                                                    OK
++ [Valid]   proposer_slashing                                                                OK
++ [Valid]   same_slot_block_transition                                                       OK
++ [Valid]   skipped_slots                                                                    OK
++ [Valid]   voluntary_exit                                                                   OK
+```
+OK: 18/18 Fail: 0/18 Skip: 0/18
+## Official - Sanity - Slots  [Preset: mainnet]
+```diff
++ Slots - double_empty_epoch                                                                 OK
++ Slots - empty_epoch                                                                        OK
++ Slots - over_epoch_boundary                                                                OK
++ Slots - slots_1                                                                            OK
++ Slots - slots_2                                                                            OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+
+---TOTAL---
+OK: 110/110 Fail: 0/110 Skip: 0/110

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -1,0 +1,166 @@
+FixtureAll-minimal
+===
+## Official - Epoch Processing - Final updates [Preset: minimal]
+```diff
++ Final updates - effective_balance_hysteresis [Preset: minimal]                             OK
++ Final updates - eth1_vote_no_reset [Preset: minimal]                                       OK
++ Final updates - eth1_vote_reset [Preset: minimal]                                          OK
++ Final updates - historical_root_accumulator [Preset: minimal]                              OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## Official - Epoch Processing - Justification & Finalization [Preset: minimal]
+```diff
++ Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
++ Justification & Finalization - 123_poor_support [Preset: minimal]                          OK
++ Justification & Finalization - 12_ok_support [Preset: minimal]                             OK
++ Justification & Finalization - 12_ok_support_messed_target [Preset: minimal]               OK
++ Justification & Finalization - 12_poor_support [Preset: minimal]                           OK
++ Justification & Finalization - 234_ok_support [Preset: minimal]                            OK
++ Justification & Finalization - 234_poor_support [Preset: minimal]                          OK
++ Justification & Finalization - 23_ok_support [Preset: minimal]                             OK
++ Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Official - Epoch Processing - Registry updates [Preset: minimal]
+```diff
++ Registry updates - activation_queue_activation_and_ejection [Preset: minimal]              OK
++ Registry updates - activation_queue_efficiency [Preset: minimal]                           OK
++ Registry updates - activation_queue_no_activation_no_finality [Preset: minimal]            OK
++ Registry updates - activation_queue_sorting [Preset: minimal]                              OK
++ Registry updates - activation_queue_to_activated_if_finalized [Preset: minimal]            OK
++ Registry updates - add_to_activation_queue [Preset: minimal]                               OK
++ Registry updates - ejection [Preset: minimal]                                              OK
++ Registry updates - ejection_past_churn_limit [Preset: minimal]                             OK
+```
+OK: 8/8 Fail: 0/8 Skip: 0/8
+## Official - Epoch Processing - Slashings [Preset: minimal]
+```diff
++ Slashings - max_penalties [Preset: minimal]                                                OK
++ Slashings - scaled_penalties [Preset: minimal]                                             OK
++ Slashings - small_penalty [Preset: minimal]                                                OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
+## Official - Operations - Attestations  [Preset: minimal]
+```diff
++ [Invalid] after_epoch_slots                                                                OK
++ [Invalid] bad_source_root                                                                  OK
++ [Invalid] before_inclusion_delay                                                           OK
++ [Invalid] future_target_epoch                                                              OK
++ [Invalid] invalid_attestation_signature                                                    OK
++ [Invalid] invalid_current_source_root                                                      OK
++ [Invalid] invalid_index                                                                    OK
++ [Invalid] mismatched_target_and_slot                                                       OK
++ [Invalid] new_source_epoch                                                                 OK
++ [Invalid] old_source_epoch                                                                 OK
++ [Invalid] old_target_epoch                                                                 OK
++ [Invalid] source_root_is_target_root                                                       OK
++ [Invalid] too_few_aggregation_bits                                                         OK
++ [Invalid] too_many_aggregation_bits                                                        OK
++ [Invalid] wrong_index_for_committee_signature                                              OK
++ [Invalid] wrong_index_for_slot                                                             OK
++ [Valid]   empty_aggregation_bits                                                           OK
++ [Valid]   success                                                                          OK
++ [Valid]   success_multi_proposer_index_iterations                                          OK
++ [Valid]   success_previous_epoch                                                           OK
+```
+OK: 20/20 Fail: 0/20 Skip: 0/20
+## Official - Operations - Attester slashing  [Preset: minimal]
+```diff
++ [Invalid] att1_bad_extra_index                                                             OK
++ [Invalid] att1_bad_replaced_index                                                          OK
++ [Invalid] att1_duplicate_index_double_signed                                               OK
++ [Invalid] att1_duplicate_index_normal_signed                                               OK
++ [Invalid] att2_bad_extra_index                                                             OK
++ [Invalid] att2_bad_replaced_index                                                          OK
++ [Invalid] att2_duplicate_index_double_signed                                               OK
++ [Invalid] att2_duplicate_index_normal_signed                                               OK
++ [Invalid] invalid_sig_1                                                                    OK
++ [Invalid] invalid_sig_1_and_2                                                              OK
++ [Invalid] invalid_sig_2                                                                    OK
++ [Invalid] no_double_or_surround                                                            OK
++ [Invalid] participants_already_slashed                                                     OK
++ [Invalid] same_data                                                                        OK
++ [Invalid] unsorted_att_1                                                                   OK
++ [Invalid] unsorted_att_2                                                                   OK
++ [Valid]   success_double                                                                   OK
++ [Valid]   success_surround                                                                 OK
+```
+OK: 18/18 Fail: 0/18 Skip: 0/18
+## Official - Operations - Block header  [Preset: minimal]
+```diff
++ [Invalid] invalid_parent_root                                                              OK
++ [Invalid] invalid_slot_block_header                                                        OK
++ [Invalid] proposer_slashed                                                                 OK
++ [Valid]   success_block_header                                                             OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
+## Official - Operations - Deposits  [Preset: minimal]
+```diff
++ [Invalid]  bad_merkle_proof                                                                OK
++ [Invalid]  wrong_deposit_for_deposit_count                                                 OK
++ [Valid]    invalid_sig_new_deposit                                                         OK
++ [Valid]    invalid_sig_other_version                                                       OK
++ [Valid]    invalid_sig_top_up                                                              OK
++ [Valid]    invalid_withdrawal_credentials_top_up                                           OK
++ [Valid]    new_deposit_max                                                                 OK
++ [Valid]    new_deposit_over_max                                                            OK
++ [Valid]    new_deposit_under_max                                                           OK
++ [Valid]    success_top_up                                                                  OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Official - Operations - Proposer slashing  [Preset: minimal]
+```diff
++ [Invalid] identifier                                                                       OK
++ [Valid]   identifier                                                                       OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Official - Operations - Voluntary exit  [Preset: minimal]
+```diff
++ [Invalid] invalid_signature                                                                OK
++ [Invalid] validator_already_exited                                                         OK
++ [Invalid] validator_exit_in_future                                                         OK
++ [Invalid] validator_invalid_validator_index                                                OK
++ [Invalid] validator_not_active                                                             OK
++ [Invalid] validator_not_active_long_enough                                                 OK
++ [Valid]   default_exit_epoch_subsequent_exit                                               OK
++ [Valid]   success                                                                          OK
++ [Valid]   success_exit_queue                                                               OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
+## Official - Sanity - Blocks  [Preset: minimal]
+```diff
++ [Invalid] expected_deposit_in_block                                                        OK
++ [Invalid] invalid_block_sig                                                                OK
++ [Invalid] invalid_state_root                                                               OK
++ [Invalid] prev_slot_block_transition                                                       OK
++ [Invalid] zero_block_sig                                                                   OK
++ [Valid]   attestation                                                                      OK
++ [Valid]   balance_driven_status_transitions                                                OK
++ [Valid]   deposit_in_block                                                                 OK
++ [Valid]   deposit_top_up                                                                   OK
++ [Valid]   empty_block_transition                                                           OK
++ [Valid]   empty_epoch_transition                                                           OK
++ [Valid]   empty_epoch_transition_not_finalizing                                            OK
++ [Valid]   eth1_data_votes_consensus                                                        OK
++ [Valid]   eth1_data_votes_no_consensus                                                     OK
++ [Valid]   high_proposer_index                                                              OK
++ [Valid]   historical_batch                                                                 OK
++ [Valid]   proposer_after_inactive_index                                                    OK
++ [Valid]   proposer_slashing                                                                OK
++ [Valid]   same_slot_block_transition                                                       OK
++ [Valid]   skipped_slots                                                                    OK
++ [Valid]   voluntary_exit                                                                   OK
+```
+OK: 21/21 Fail: 0/21 Skip: 0/21
+## Official - Sanity - Slots  [Preset: minimal]
+```diff
++ Slots - double_empty_epoch                                                                 OK
++ Slots - empty_epoch                                                                        OK
++ Slots - over_epoch_boundary                                                                OK
++ Slots - slots_1                                                                            OK
++ Slots - slots_2                                                                            OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+
+---TOTAL---
+OK: 113/113 Fail: 0/113 Skip: 0/113

--- a/FixtureSSZConsensus-mainnet.md
+++ b/FixtureSSZConsensus-mainnet.md
@@ -1,0 +1,34 @@
+FixtureSSZConsensus-mainnet
+===
+## Official - 0.10.1 - SSZ consensus objects  [Preset: mainnet]
+```diff
++   Testing    AggregateAndProof                                                             OK
++   Testing    Attestation                                                                   OK
++   Testing    AttestationData                                                               OK
++   Testing    AttesterSlashing                                                              OK
++   Testing    BeaconBlock                                                                   OK
++   Testing    BeaconBlockBody                                                               OK
++   Testing    BeaconBlockHeader                                                             OK
++   Testing    BeaconState                                                                   OK
++   Testing    Checkpoint                                                                    OK
++   Testing    Deposit                                                                       OK
++   Testing    DepositData                                                                   OK
++   Testing    DepositMessage                                                                OK
++   Testing    Eth1Block                                                                     OK
++   Testing    Eth1Data                                                                      OK
++   Testing    Fork                                                                          OK
++   Testing    HistoricalBatch                                                               OK
++   Testing    IndexedAttestation                                                            OK
++   Testing    PendingAttestation                                                            OK
++   Testing    ProposerSlashing                                                              OK
++   Testing    SignedBeaconBlock                                                             OK
++   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedVoluntaryExit                                                           OK
++   Testing    SigningRoot                                                                   OK
++   Testing    Validator                                                                     OK
++   Testing    VoluntaryExit                                                                 OK
+```
+OK: 25/25 Fail: 0/25 Skip: 0/25
+
+---TOTAL---
+OK: 25/25 Fail: 0/25 Skip: 0/25

--- a/FixtureSSZConsensus-minimal.md
+++ b/FixtureSSZConsensus-minimal.md
@@ -1,0 +1,34 @@
+FixtureSSZConsensus-minimal
+===
+## Official - 0.10.1 - SSZ consensus objects  [Preset: minimal]
+```diff
++   Testing    AggregateAndProof                                                             OK
++   Testing    Attestation                                                                   OK
++   Testing    AttestationData                                                               OK
++   Testing    AttesterSlashing                                                              OK
++   Testing    BeaconBlock                                                                   OK
++   Testing    BeaconBlockBody                                                               OK
++   Testing    BeaconBlockHeader                                                             OK
++   Testing    BeaconState                                                                   OK
++   Testing    Checkpoint                                                                    OK
++   Testing    Deposit                                                                       OK
++   Testing    DepositData                                                                   OK
++   Testing    DepositMessage                                                                OK
++   Testing    Eth1Block                                                                     OK
++   Testing    Eth1Data                                                                      OK
++   Testing    Fork                                                                          OK
++   Testing    HistoricalBatch                                                               OK
++   Testing    IndexedAttestation                                                            OK
++   Testing    PendingAttestation                                                            OK
++   Testing    ProposerSlashing                                                              OK
++   Testing    SignedBeaconBlock                                                             OK
++   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedVoluntaryExit                                                           OK
++   Testing    SigningRoot                                                                   OK
++   Testing    Validator                                                                     OK
++   Testing    VoluntaryExit                                                                 OK
+```
+OK: 25/25 Fail: 0/25 Skip: 0/25
+
+---TOTAL---
+OK: 25/25 Fail: 0/25 Skip: 0/25

--- a/FixtureSSZGeneric-minimal.md
+++ b/FixtureSSZGeneric-minimal.md
@@ -1,0 +1,20 @@
+FixtureSSZGeneric-minimal
+===
+## Official - SSZ generic types
+```diff
++ **Skipping** bitlist inputs - valid - skipped altogether                                   OK
+  Testing basic_vector inputs - invalid - skipping Vector[uint128, N] and Vector[uint256, N] Skip
++ Testing basic_vector inputs - valid - skipping Vector[uint128, N] and Vector[uint256, N]   OK
+  Testing bitvector    inputs - invalid                                                      Skip
++ Testing bitvector    inputs - valid                                                        OK
++ Testing boolean      inputs - invalid                                                      OK
++ Testing boolean      inputs - valid                                                        OK
++ Testing containers   inputs - invalid - skipping VarTestStruct, ComplexTestStruct, BitsStr OK
++ Testing containers   inputs - valid - skipping VarTestStruct, ComplexTestStruct, BitsStruc OK
++ Testing uints        inputs - invalid - skipping uint128 and uint256                       OK
++ Testing uints        inputs - valid - skipping uint128 and uint256                         OK
+```
+OK: 9/11 Fail: 0/11 Skip: 2/11
+
+---TOTAL---
+OK: 9/11 Fail: 0/11 Skip: 2/11

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -46,4 +46,4 @@ import # Refactor state transition unit tests
 #   ./official/test_fixture_shuffling,
 #   ./official/test_fixture_bls
 
-summarizeLongTests()
+summarizeLongTests("AllTests")

--- a/tests/official/all_fixtures_require_ssz.nim
+++ b/tests/official/all_fixtures_require_ssz.nim
@@ -22,4 +22,4 @@ import
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit
 
-summarizeLongTests()
+summarizeLongTests("FixtureAll")

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -49,7 +49,7 @@ proc readValue*(r: var JsonReader, a: var Domain) {.inline.} =
 # TODO: json tests were removed
 const BLSDir = JsonTestsDir/"general"/"phase0"/"bls"
 
-suite "Official - BLS tests":
+suiteReport "Official - BLS tests":
   timedTest "Private to public key conversion":
     for file in walkDirRec(BLSDir/"priv_to_pub"):
       let t = parseTest(file, Json, BLSPrivToPub)

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -121,5 +121,5 @@ proc checkConfig() =
       else:
         check: ConstsToCheck[constant] == value.getBiggestInt().uint64()
 
-suite "Official - 0.10.1 - constants & config " & preset():
+suiteReport "Official - 0.10.1 - constants & config " & preset():
   checkConfig()

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -65,6 +65,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ operations_attestations _ identifier`()
 
-suite "Official - Operations - Attestations " & preset():
+suiteReport "Official - Operations - Attestations " & preset():
   for kind, path in walkDir(OperationsAttestationsDir, true):
     runTest(path)

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -67,7 +67,7 @@ proc runTest(identifier: string) =
 
   `testImpl _ operations_attester_slashing _ identifier`()
 
-suite "Official - Operations - Attester slashing " & preset():
+suiteReport "Official - Operations - Attester slashing " & preset():
   # TODO these are both valid and check BLS signatures, which isn't working
   # since 0.10.x introduces new BLS signing/verifying interface with domain
   # in particular handled differently through compute_signing_root() rather

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -62,6 +62,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ blockheader _ identifier`()
 
-suite "Official - Operations - Block header " & preset():
+suiteReport "Official - Operations - Block header " & preset():
   for kind, path in walkDir(OpBlockHeaderDir, true):
     runTest(path)

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -60,7 +60,7 @@ proc runTest(identifier: string) =
 
   `testImpl _ operations_deposits _ identifier`()
 
-suite "Official - Operations - Deposits " & preset():
+suiteReport "Official - Operations - Deposits " & preset():
   # TODO
   const expected_failures = ["valid_sig_but_forked_state"]
 

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -65,6 +65,6 @@ proc runTest(identifier: string) =
 
   `testImpl_proposer_slashing _ identifier`()
 
-suite "Official - Operations - Proposer slashing " & preset():
+suiteReport "Official - Operations - Proposer slashing " & preset():
   for kind, path in walkDir(OpProposerSlashingDir, true):
     runTest(path)

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -63,6 +63,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ voluntary_exit _ identifier`()
 
-suite "Official - Operations - Voluntary exit " & preset():
+suiteReport "Official - Operations - Voluntary exit " & preset():
   for kind, path in walkDir(OpVoluntaryExitDir, true):
     runTest(path)

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -62,7 +62,7 @@ proc runTest(identifier: string) =
 
   `testImpl _ blck _ identifier`()
 
-suite "Official - Sanity - Blocks " & preset():
+suiteReport "Official - Sanity - Blocks " & preset():
   # Failing due to signature checking in indexed validation checking pending
   # 0.10 BLS verification API with new domain handling.
   const expected_failures = ["attester_slashing"]

--- a/tests/official/test_fixture_sanity_slots.nim
+++ b/tests/official/test_fixture_sanity_slots.nim
@@ -44,6 +44,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ slots _ identifier`()
 
-suite "Official - Sanity - Slots " & preset():
+suiteReport "Official - Sanity - Slots " & preset():
   for kind, path in walkDir(SanitySlotsDir, true):
     runTest(path)

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -103,5 +103,7 @@ proc runSSZtests() =
           else:
             raise newException(ValueError, "Unsupported test: " & sszType)
 
-suite "Official - 0.10.1 - SSZ consensus objects " & preset():
+suiteReport "Official - 0.10.1 - SSZ consensus objects " & preset():
   runSSZtests()
+
+summarizeLongTests("FixtureSSZConsensus")

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -302,5 +302,7 @@ proc runSSZtests() =
   # test "Testing " & name & " inputs (" & $T & ") - invalid":
   #   const path = SSZDir/name/"invalid"
 
-suite "Official - SSZ generic types":
+suiteReport "Official - SSZ generic types":
   runSSZtests()
+
+summarizeLongTests("FixtureSSZGeneric")

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -33,7 +33,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
 
   proc `suiteImpl _ transitionProc`() =
-    suite "Official - Epoch Processing - " & testName & preset():
+    suiteReport "Official - Epoch Processing - " & testName & preset():
       for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}):
 
         let unitTestName = testDir.rsplit(DirSep, 1)[1]

--- a/tests/spec_block_processing/test_genesis.nim
+++ b/tests/spec_block_processing/test_genesis.nim
@@ -27,7 +27,7 @@ import
 #   - MIN_GENESIS_TIME is not implemented
 #   - is_valid_genesis_state is not implemented
 
-suite "[Unit - Spec - Genesis] Genesis block checks " & preset():
+suiteReport "[Unit - Spec - Genesis] Genesis block checks " & preset():
   timedTest "is_valid_genesis_state for a valid state":
     discard initGenesisState(
       num_validators = MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -20,7 +20,7 @@ import
   ../mocking/[mock_genesis, mock_attestations, mock_state, mock_blocks],
   ../testutil
 
-suite "[Unit - Spec - Block processing] Attestations " & preset():
+suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
 
   const NumValidators = uint64(8) * SLOTS_PER_EPOCH
   let genesisState = initGenesisState(NumValidators)

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -23,7 +23,7 @@ import
   ../mocking/[mock_deposits, mock_genesis],
   ../testutil, ../helpers/math_helpers
 
-suite "[Unit - Spec - Block processing] Deposits " & preset():
+suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
   const NumValidators = uint64 5 * SLOTS_PER_EPOCH
   let genesisState = initGenesisState(NumValidators)

--- a/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
+++ b/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
@@ -212,7 +212,7 @@ proc finalizeOn12(state: var BeaconState, epoch: Epoch, sufficient_support: bool
     doAssert state.current_justified_checkpoint == c2    # still old current
     doAssert state.finalized_checkpoint == old_finalized # no new finalized checkpoint
 
-suite "[Unit - Spec - Epoch processing] Justification and Finalization " & preset():
+suiteReport "[Unit - Spec - Epoch processing] Justification and Finalization " & preset():
   echo "   Finalization rules are detailed at https://github.com/protolambda/eth2-docs#justification-and-finalization"
 
   const NumValidators = uint64(8) * SLOTS_PER_EPOCH

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -16,7 +16,7 @@ import
   ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, extras, state_transition, ssz]
 
 when const_preset == "minimal": # Too much stack space used on mainnet
-  suite "Attestation pool processing" & preset():
+  suiteReport "Attestation pool processing" & preset():
     ## For now just test that we can compile and execute block processing with
     ## mock data.
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -13,7 +13,7 @@ import  options, unittest, sequtils,
   # test utilies
   ./testutil, ./testblockutil
 
-suite "Beacon chain DB" & preset():
+suiteReport "Beacon chain DB" & preset():
   timedTest "empty database" & preset():
     var
       db = init(BeaconChainDB, kvStore MemoryStoreRef.init())

--- a/tests/test_beacon_node.nim
+++ b/tests/test_beacon_node.nim
@@ -12,7 +12,7 @@ import unittest, ./testutil
 when false:
   import ../beacon_chain/beacon_node
 
-suite "Beacon node":
+suiteReport "Beacon node":
   # Compile test
 
   timedTest "Compile":

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -13,7 +13,7 @@ import
   ../beacon_chain/spec/[beaconstate, datatypes, digest],
   ../beacon_chain/extras
 
-suite "Beacon state" & preset():
+suiteReport "Beacon state" & preset():
   timedTest "Smoke test initialize_beacon_state_from_eth1" & preset():
     let state = initialize_beacon_state_from_eth1(
       Eth2Digest(), 0,

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -13,7 +13,7 @@ import
   ../beacon_chain/spec/[datatypes, digest, helpers, validator],
   ../beacon_chain/[beacon_node_types, block_pool, beacon_chain_db, extras, ssz]
 
-suite "BlockRef and helpers" & preset():
+suiteReport "BlockRef and helpers" & preset():
   timedTest "isAncestorOf sanity" & preset():
     let
       s0 = BlockRef(slot: Slot(0))
@@ -51,7 +51,7 @@ suite "BlockRef and helpers" & preset():
       s4.getAncestorAt(Slot(3)) == s2
       s4.getAncestorAt(Slot(4)) == s4
 
-suite "BlockSlot and helpers" & preset():
+suiteReport "BlockSlot and helpers" & preset():
   timedTest "atSlot sanity" & preset():
     let
       s0 = BlockRef(slot: Slot(0))
@@ -83,7 +83,7 @@ suite "BlockSlot and helpers" & preset():
       s24.parent.parent == s22
 
 when const_preset == "minimal": # Too much stack space used on mainnet
-  suite "Block pool processing" & preset():
+  suiteReport "Block pool processing" & preset():
     setup:
       var
         db = makeTestDB(SLOTS_PER_EPOCH)
@@ -236,7 +236,7 @@ when const_preset == "minimal": # Too much stack space used on mainnet
         tmpState.blck == b1Add.parent
         tmpState.data.data.slot == bs1.parent.slot
 
-  suite "BlockPool finalization tests" & preset():
+  suiteReport "BlockPool finalization tests" & preset():
     setup:
       var
         db = makeTestDB(SLOTS_PER_EPOCH)

--- a/tests/test_discovery_helpers.nim
+++ b/tests/test_discovery_helpers.nim
@@ -3,7 +3,7 @@ import
   eth/keys, eth/p2p/enode, libp2p/multiaddress,
   ../beacon_chain/eth2_discovery
 
-suite "Discovery v5 utilities":
+suiteReport "Discovery v5 utilities":
   timedTest "Multiaddress to ENode":
     let addrStr = "/ip4/178.128.140.61/tcp/9000/p2p/16Uiu2HAmL5A5DAiiupFi6sUTF6Zq1TCKf6Pd5T8oFt9opQJqLqTQ"
     let ma = MultiAddress.init addrStr

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -11,7 +11,7 @@ import
   unittest, ./testutil,
   ../beacon_chain/spec/[helpers]
 
-suite "Spec helpers":
+suiteReport "Spec helpers":
   timedTest "integer_squareroot":
     check:
       integer_squareroot(0'u64) == 0'u64

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -4,7 +4,7 @@ import
   unittest, stint, ./testutil,
   ../beacon_chain/spec/network
 
-suite "Honest validator":
+suiteReport "Honest validator":
   timedTest "Attestation topics":
     check:
       getAttestationTopic(0) == "/eth2/index0_beacon_attestation/ssz"

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -115,7 +115,7 @@ let depositsConfig = [
   )
 ]
 
-suite "Interop":
+suiteReport "Interop":
   timedTest "Mocked start private key":
     for i, k in privateKeys:
       let

--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -36,7 +36,7 @@ proc init*(t: typedesc[PeerTest], id: string = "",
 proc close*(peer: PeerTest) =
   peer.future.complete()
 
-suite "PeerPool testing suite":
+suiteReport "PeerPool testing suite":
   timedTest "addPeerNoWait() test":
     const peersCount = [
       [10, 5, 5, 10, 5, 5],

--- a/tests/test_ssz.nim
+++ b/tests/test_ssz.nim
@@ -75,7 +75,7 @@ type
 proc toDigest[N: static int](x: array[N, byte]): Eth2Digest =
   result.data[0 .. N-1] = x
 
-suite "SSZ navigator":
+suiteReport "SSZ navigator":
   timedTest "simple object fields":
     var foo = Foo(bar: Bar(b: "bar", baz: Baz(i: 10'u64)))
     let encoded = SSZ.encode(foo)
@@ -101,7 +101,7 @@ suite "SSZ navigator":
     let root2 = hash_tree_root(leaves2)
     check $root2 == "9FB7D518368DC14E8CC588FB3FD2749BEEF9F493FEF70AE34AF5721543C67173"
 
-suite "SSZ dynamic navigator":
+suiteReport "SSZ dynamic navigator":
   timedTest "navigating fields":
     var fooOrig = Foo(bar: Bar(b: "bar", baz: Baz(i: 10'u64)))
     let fooEncoded = SSZ.encode(fooOrig)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -13,7 +13,7 @@ import
   ../beacon_chain/spec/[beaconstate, datatypes, digest, validator],
   ../beacon_chain/[extras, state_transition, ssz]
 
-suite "Block processing" & preset():
+suiteReport "Block processing" & preset():
   ## For now just test that we can compile and execute block processing with
   ## mock data.
 

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -885,7 +885,7 @@ proc syncManagerFailureTest(): Future[bool] {.async.} =
     doAssert(checkRequest(peer, i, 10000, 20, 1) == true)
   result = true
 
-suite "SyncManager test suite":
+suiteReport "SyncManager test suite":
   timedTest "PeerSlot tests":
     check waitFor(peerSlotTests()) == true
   timedTest "PeerGroup tests":

--- a/tests/test_sync_protocol.nim
+++ b/tests/test_sync_protocol.nim
@@ -12,7 +12,7 @@ import unittest, ./testutil
 when false:
   import ../beacon_chain/sync_protocol
 
-suite "Sync protocol":
+suiteReport "Sync protocol":
   # Compile test
 
   timedTest "Compile":

--- a/tests/test_validator.nim
+++ b/tests/test_validator.nim
@@ -9,6 +9,6 @@ import
   ../beacon_chain/spec/[helpers, datatypes, digest, validator, beaconstate],
   ../beacon_chain/extras
 
-suite "Validators":
+suiteReport "Validators":
   # TODO: Empty!
   discard

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -17,7 +17,7 @@ import
 # and https://github.com/ethereum/eth2.0-specs/issues/1396
 # don't blow up.
 
-suite "Zero signature sanity checks":
+suiteReport "Zero signature sanity checks":
   # Using signature directly triggers a bug
   # in object_serialization/stew: https://github.com/status-im/nim-beacon-chain/issues/396
 


### PR DESCRIPTION
It works pretty much the same way Nimbus's json test reporting does, except the suites are defined manually and the test cases use the `timedTest` template. All suites that are run get included in the report, and reports are created based the module that calls `summarizeLongTests` and the `const_preset` (minimal/mainnet). This was a very simple solution and given the TODOs in the code, refactoring is probably needed, so consider this more a proof of concept. 

Depends on https://github.com/status-im/nim-testutils/pull/15
Fixes #744 