### PR TITLE
[WIP] merge/combine redundant ancestor block access mechanisms

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -67,27 +67,6 @@ func isAncestorOf*(a, b: BlockRef): bool =
     doAssert b.slot > b.parent.slot
     b = b.parent
 
-func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
-  ## Return the most recent block as of the time at `slot` that not more recent
-  ## than `blck` itself
-
-  var blck = blck
-
-  var depth = 0
-  const maxDepth = (100'i64 * 365 * 24 * 60 * 60 div SECONDS_PER_SLOT.int)
-
-  while true:
-    if blck.slot <= slot:
-      return blck
-
-    if blck.parent.isNil:
-      return nil
-
-    doAssert depth < maxDepth
-    depth += 1
-
-    blck = blck.parent
-
 func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
   ## https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md#get_ancestor
   ## Return ancestor at slot, or nil if queried block is older
@@ -110,6 +89,29 @@ func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
     depth += 1
 
     blck = blck.parent
+
+func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
+  ## Return the most recent block as of the time at `slot` that not more recent
+  ## than `blck` itself
+
+  var blck = blck
+
+  var depth = 0
+  const maxDepth = (100'i64 * 365 * 24 * 60 * 60 div SECONDS_PER_SLOT.int)
+
+  while true:
+    if blck.slot <= slot:
+      return blck
+
+    if blck.parent.isNil:
+      return nil
+
+    doAssert depth < maxDepth
+    depth += 1
+
+    blck = blck.parent
+
+  doAssert result == get_ancestor(blck, slot)
 
 func atSlot*(blck: BlockRef, slot: Slot): BlockSlot =
   ## Return a BlockSlot at a given slot, with the block set to the closest block


### PR DESCRIPTION
The functions differ slightly, but mostly come up in the `tests/` directory, and the `beacon_node/` use cases don't appear to depend on their differences. `get_ancestor(...)` is the spec name, so that's the better name to keep. https://github.com/status-im/nim-beacon-chain/commit/ca892ae662b707a02cf71c506e8a97d69ddfa617 shows the identical behavior in our codebase in `make eth2_network_simulation` and `make test`.

Eliding some identical prologue code, they both handle the `if blck.parent.isNil:` and `depth < maxDepth`-bounded ancestor search identically, along with the `blck.slot == slot` case where one has found exactly the slot one wants in the block pool:
```
func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
  ...
  while true:
    if blck.slot == slot:
      return blck

    if blck.slot < slot:
      return nil

    if blck.parent.isNil:
      return nil

    doAssert depth < maxDepth
    depth += 1

    blck = blck.parent
```
and
```
func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
  ...
  while true:
    if blck.slot <= slot:
      return blck

    if blck.parent.isNil:
      return nil

    doAssert depth < maxDepth
    depth += 1

    blck = blck.parent
```

They differ only when the block pool skips slots, so, say, slot 4 appears as the ancestor of slot 6, but slot 5 doesn't exist. For this to happen, first, the sync would presumably have failed, and the caller would have to specifically prefer the looser constraint.

The `beacon_chain/` callers or definitions (including via a thin `BlockSlot` wrapper `atSlot`) are:
```
$ grep -Erin -C2 "getAncestorAt|atSlot" beacon_chain
beacon_chain/beacon_node.nim-385-  # block for - potentially we will be processing empty slots along the way.
beacon_chain/beacon_node.nim-386-  let (nroot, nblck) = node.blockPool.withState(
beacon_chain/beacon_node.nim:387:      node.blockPool.tmpState, head.atSlot(slot)):
beacon_chain/beacon_node.nim-388-    let (eth1data, deposits) =
beacon_chain/beacon_node.nim-389-      if node.mainchainMonitor.isNil:
--
beacon_chain/block_pool.nim-91-    blck = blck.parent
beacon_chain/block_pool.nim-92-
beacon_chain/block_pool.nim:93:func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
beacon_chain/block_pool.nim-94-  ## Return the most recent block as of the time at `slot` that not more recent
beacon_chain/block_pool.nim-95-  ## than `blck` itself
--
beacon_chain/block_pool.nim-114-  doAssert result == get_ancestor(blck, slot)
beacon_chain/block_pool.nim-115-
beacon_chain/block_pool.nim:116:func atSlot*(blck: BlockRef, slot: Slot): BlockSlot =
beacon_chain/block_pool.nim-117-  ## Return a BlockSlot at a given slot, with the block set to the closest block
beacon_chain/block_pool.nim-118-  ## available. If slot comes from before the block, a suitable block ancestor
--
beacon_chain/block_pool.nim-122-  ## near future if nothing happens (such as when looking ahead for the next
beacon_chain/block_pool.nim-123-  ## block proposal)
beacon_chain/block_pool.nim:124:  BlockSlot(blck: blck.getAncestorAt(slot), slot: slot)
beacon_chain/block_pool.nim-125-
beacon_chain/block_pool.nim-126-func init*(T: type BlockRef, root: Eth2Digest, slot: Slot): BlockRef =
--
beacon_chain/block_pool.nim-932-
beacon_chain/block_pool.nim-933-proc getProposer*(pool: BlockPool, head: BlockRef, slot: Slot): Option[ValidatorPubKey] =
beacon_chain/block_pool.nim:934:  pool.withState(pool.tmpState, head.atSlot(slot)):
beacon_chain/block_pool.nim-935-    var cache = get_empty_per_epoch_cache()
beacon_chain/block_pool.nim-936-
```

Of those five references/definitions, only the first and fifth aren't definitions:
```
beacon_chain/beacon_node.nim-385-  # block for - potentially we will be processing empty slots along the way.
beacon_chain/beacon_node.nim-386-  let (nroot, nblck) = node.blockPool.withState(
beacon_chain/beacon_node.nim:387:      node.blockPool.tmpState, head.atSlot(slot)):
beacon_chain/beacon_node.nim-388-    let (eth1data, deposits) =
beacon_chain/beacon_node.nim-389-      if node.mainchainMonitor.isNil:
```
and
```
beacon_chain/block_pool.nim-932-
beacon_chain/block_pool.nim-933-proc getProposer*(pool: BlockPool, head: BlockRef, slot: Slot): Option[ValidatorPubKey] =
beacon_chain/block_pool.nim:934:  pool.withState(pool.tmpState, head.atSlot(slot)):
beacon_chain/block_pool.nim-935-    var cache = get_empty_per_epoch_cache()
beacon_chain/block_pool.nim-936-
```

But nim-beacon-chain can't say anything meaningful/useful about the proposer of some random ancestor slot to the one it's actually interested in, regarding `getProposer(...)`, and
```
  # Advance state to the slot immediately preceding the one we're creating a
  # block for - potentially we will be processing empty slots along the way.
  let (nroot, nblck) = node.blockPool.withState(
      node.blockPool.tmpState, head.atSlot(slot)):
    let (eth1data, deposits) =
```
also needs to target slot-exactly.

So `getAncestorAt(...)` has an incorrect API and should be replaced in all use cases in `beacon_chain/` by `get_ancestor(...)` from the 0.10.1 spec as already implemented.