### PR TITLE
Bump discv5

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -177,7 +177,7 @@ for NUM_NODE in $(seq 0 $(( ${NUM_NODES} - 1 ))); do
 	fi
 
 	stdbuf -o0 build/beacon_node \
-		--nat=none \
+		--nat:extip:127.0.0.1 \
 		--log-level="${LOG_LEVEL}" \
 		--tcp-port=$(( ${BOOTSTRAP_PORT} + ${NUM_NODE} )) \
 		--udp-port=$(( ${BOOTSTRAP_PORT} + ${NUM_NODE} )) \


### PR DESCRIPTION
and set extip to lo for local testnet (not necessary but cleaner).

With this version of discv5 I manage to interop with go-ethereum discv5 fork.