### PR TITLE
update test results summary after BLS 0.10.1 update

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -51,13 +51,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Interop
-```diff
-+ Interop genesis                                                                            OK
-+ Interop signatures                                                                         OK
-+ Mocked start private key                                                                   OK
-```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Official - 0.10.1 - constants & config  [Preset: mainnet]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: mainnet]   OK
@@ -172,11 +165,10 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## [Unit - Spec - Block processing] Attestations  [Preset: mainnet]
 ```diff
-+ Empty aggregation bit                                                                      OK
 + Valid attestation                                                                          OK
 + Valid attestation from previous epoch                                                      OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## [Unit - Spec - Block processing] Deposits  [Preset: mainnet]
 ```diff
 + Deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                          OK
@@ -199,4 +191,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 116/117 Fail: 1/117 Skip: 0/117
+OK: 112/113 Fail: 1/113 Skip: 0/113

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -78,13 +78,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Interop
-```diff
-+ Interop genesis                                                                            OK
-+ Interop signatures                                                                         OK
-+ Mocked start private key                                                                   OK
-```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Official - 0.10.1 - constants & config  [Preset: minimal]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: minimal]   OK
@@ -205,11 +198,10 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## [Unit - Spec - Block processing] Attestations  [Preset: minimal]
 ```diff
-+ Empty aggregation bit                                                                      OK
 + Valid attestation                                                                          OK
 + Valid attestation from previous epoch                                                      OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## [Unit - Spec - Block processing] Deposits  [Preset: minimal]
 ```diff
 + Deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                          OK
@@ -232,4 +224,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 137/138 Fail: 1/138 Skip: 0/138
+OK: 133/134 Fail: 1/134 Skip: 0/134

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -68,11 +68,9 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 ```diff
 + [Invalid] att1_bad_extra_index                                                             OK
 + [Invalid] att1_bad_replaced_index                                                          OK
-+ [Invalid] att1_duplicate_index_double_signed                                               OK
 + [Invalid] att1_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_bad_extra_index                                                             OK
 + [Invalid] att2_bad_replaced_index                                                          OK
-+ [Invalid] att2_duplicate_index_double_signed                                               OK
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] invalid_sig_1                                                                    OK
 + [Invalid] invalid_sig_1_and_2                                                              OK
@@ -85,7 +83,7 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 16/16 Fail: 0/16 Skip: 0/16
 ## Official - Operations - Block header  [Preset: mainnet]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -129,7 +127,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Official - Sanity - Blocks  [Preset: mainnet]
 ```diff
-+ [Invalid] expected_deposit_in_block                                                        OK
 + [Invalid] invalid_block_sig                                                                OK
 + [Invalid] invalid_state_root                                                               OK
 + [Invalid] prev_slot_block_transition                                                       OK
@@ -148,7 +145,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Valid]   skipped_slots                                                                    OK
 + [Valid]   voluntary_exit                                                                   OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 17/17 Fail: 0/17 Skip: 0/17
 ## Official - Sanity - Slots  [Preset: mainnet]
 ```diff
 + Slots - double_empty_epoch                                                                 OK
@@ -160,4 +157,4 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 110/110 Fail: 0/110 Skip: 0/110
+OK: 107/107 Fail: 0/107 Skip: 0/107

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -68,11 +68,9 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 ```diff
 + [Invalid] att1_bad_extra_index                                                             OK
 + [Invalid] att1_bad_replaced_index                                                          OK
-+ [Invalid] att1_duplicate_index_double_signed                                               OK
 + [Invalid] att1_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_bad_extra_index                                                             OK
 + [Invalid] att2_bad_replaced_index                                                          OK
-+ [Invalid] att2_duplicate_index_double_signed                                               OK
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] invalid_sig_1                                                                    OK
 + [Invalid] invalid_sig_1_and_2                                                              OK
@@ -85,7 +83,7 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 16/16 Fail: 0/16 Skip: 0/16
 ## Official - Operations - Block header  [Preset: minimal]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -129,7 +127,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Official - Sanity - Blocks  [Preset: minimal]
 ```diff
-+ [Invalid] expected_deposit_in_block                                                        OK
 + [Invalid] invalid_block_sig                                                                OK
 + [Invalid] invalid_state_root                                                               OK
 + [Invalid] prev_slot_block_transition                                                       OK
@@ -151,7 +148,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Valid]   skipped_slots                                                                    OK
 + [Valid]   voluntary_exit                                                                   OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
+OK: 20/20 Fail: 0/20 Skip: 0/20
 ## Official - Sanity - Slots  [Preset: minimal]
 ```diff
 + Slots - double_empty_epoch                                                                 OK
@@ -163,4 +160,4 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 113/113 Fail: 0/113 Skip: 0/113
+OK: 110/110 Fail: 0/110 Skip: 0/110


### PR DESCRIPTION
Intentionally isolating this in its own PR.

The removed tests are legitimately removed/skipped for now, but random PRs ideally shouldn't have to be updating this -- so, this way, make the awareness/consciousness clear.