### PR TITLE
refactor --verify-finalization

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -180,7 +180,6 @@ for NUM_NODE in $(seq 0 $(( ${NUM_NODES} - 1 ))); do
 		--data-dir="${NODE_DATA_DIR}" \
 		${BOOTSTRAP_ARG} \
 		--state-snapshot="${NETWORK_DIR}/genesis.ssz" \
-		--verify-finalization \
 		${EXTRA_ARGS} \
 		> "${DATA_DIR}/log${NUM_NODE}.txt" 2>&1 &
 	if [[ "${PIDS}" == "" ]]; then

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -180,6 +180,7 @@ for NUM_NODE in $(seq 0 $(( ${NUM_NODES} - 1 ))); do
 		--data-dir="${NODE_DATA_DIR}" \
 		${BOOTSTRAP_ARG} \
 		--state-snapshot="${NETWORK_DIR}/genesis.ssz" \
+		--verify-finalization \
 		${EXTRA_ARGS} \
 		> "${DATA_DIR}/log${NUM_NODE}.txt" 2>&1 &
 	if [[ "${PIDS}" == "" ]]; then

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -10,8 +10,15 @@ shift
 source "$(dirname "$0")/vars.sh"
 
 if [[ ! -z "$1" ]]; then
+  ADDITIONAL_BEACON_NODE_ARGS=$1
+  shift
+else
+  ADDITIONAL_BEACON_NODE_ARGS=""
+fi
+
+if [[ ! -z "$1" ]]; then
   BOOTSTRAP_NODE_ID=$1
-  BOOTSTRAP_ADDRESS_FILE="${SIMULATION_DIR}/node-${BOOTSTRAP_NODE_ID}/beacon_node.address"
+  BOOTSTRAP_ADDRESS_FILE="${SIMULATION_DIR}/beacon_node.address"
   shift
 else
   BOOTSTRAP_NODE_ID=$MASTER_NODE
@@ -59,12 +66,11 @@ cd "$DATA_DIR" && $BEACON_NODE_BIN \
   --state-snapshot=$SNAPSHOT_FILE \
   $DEPOSIT_WEB3_URL_ARG \
   --deposit-contract=$DEPOSIT_CONTRACT_ADDRESS \
-  --verify-finalization \
   --rpc \
   --rpc-address="127.0.0.1" \
   --rpc-port="$(( $BASE_RPC_PORT + $NODE_ID ))" \
   --metrics \
   --metrics-address="127.0.0.1" \
   --metrics-port="$(( $BASE_METRICS_PORT + $NODE_ID ))" \
+  ${ADDITIONAL_BEACON_NODE_ARGS} \
   "$@"
-

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -18,7 +18,7 @@ fi
 
 if [[ ! -z "$1" ]]; then
   BOOTSTRAP_NODE_ID=$1
-  BOOTSTRAP_ADDRESS_FILE="${SIMULATION_DIR}/beacon_node.address"
+  BOOTSTRAP_ADDRESS_FILE="${SIMULATION_DIR}/node-${BOOTSTRAP_NODE_ID}/beacon_node.address"
   shift
 else
   BOOTSTRAP_NODE_ID=$MASTER_NODE

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -42,7 +42,7 @@ build_beacon_node () {
 build_beacon_node $BEACON_NODE_BIN
 
 if [ ! -f "${LAST_VALIDATOR}" ]; then
-  echo Building $DEPLOY_DEPOSIT_CONTRACT_BIN
+  echo Building "${DEPLOY_DEPOSIT_CONTRACT_BIN}"
   $MAKE NIMFLAGS="-o:\"$DEPLOY_DEPOSIT_CONTRACT_BIN\" $CUSTOM_NIMFLAGS $DEFS" deposit_contract
 
   if [ "$DEPOSIT_WEB3_URL_ARG" != "" ]; then
@@ -84,10 +84,10 @@ TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-nbc-network-sim}"
 
 # Using tmux or multitail is an opt-in
 USE_MULTITAIL="${USE_MULTITAIL:-no}"
-type "$MULTITAIL" &>/dev/null || { echo $MULTITAIL is missing; USE_MULTITAIL="no"; }
+type "$MULTITAIL" &>/dev/null || { echo "${MULTITAIL}" is missing; USE_MULTITAIL="no"; }
 
 USE_TMUX="${USE_TMUX:-no}"
-type "$TMUX" &>/dev/null || { echo $TMUX is missing; USE_TMUX="no"; }
+type "$TMUX" &>/dev/null || { echo "${TMUX}" is missing; USE_TMUX="no"; }
 
 # Prometheus config (continued inside the loop)
 mkdir -p "${METRICS_DIR}"
@@ -123,12 +123,12 @@ fi
 COMMANDS=()
 
 if [[ "$USE_TMUX" != "no" ]]; then
-  $TMUX new-session -s $TMUX_SESSION_NAME -d
+  $TMUX new-session -s "${TMUX_SESSION_NAME}" -d
 
   # maybe these should be moved to a user config file
-  $TMUX set-option -t $TMUX_SESSION_NAME history-limit 999999
-  $TMUX set-option -t $TMUX_SESSION_NAME remain-on-exit on
-  $TMUX set -t $TMUX_SESSION_NAME mouse on
+  $TMUX set-option -t "${TMUX_SESSION_NAME}" history-limit 999999
+  $TMUX set-option -t "${TMUX_SESSION_NAME}" remain-on-exit on
+  $TMUX set -t "${TMUX_SESSION_NAME}" mouse on
 fi
 
 for i in $(seq $MASTER_NODE -1 $TOTAL_USER_NODES); do
@@ -139,11 +139,11 @@ for i in $(seq $MASTER_NODE -1 $TOTAL_USER_NODES); do
     done
   fi
 
-  CMD="${SIM_ROOT}/run_node.sh $i"
+  CMD="${SIM_ROOT}/run_node.sh ${i} --verify-finalization"
 
   if [[ "$USE_TMUX" != "no" ]]; then
-    $TMUX split-window -t $TMUX_SESSION_NAME "$CMD"
-    $TMUX select-layout -t $TMUX_SESSION_NAME tiled
+    $TMUX split-window -t "${TMUX_SESSION_NAME}" "$CMD"
+    $TMUX select-layout -t "${TMUX_SESSION_NAME}" tiled
   elif [[ "$USE_MULTITAIL" != "no" ]]; then
     if [[ "$i" == "$MASTER_NODE" ]]; then
       SLEEP="0"
@@ -158,7 +158,7 @@ for i in $(seq $MASTER_NODE -1 $TOTAL_USER_NODES); do
 
   # Prometheus config
   cat >> "${METRICS_DIR}/prometheus.yml" <<EOF
-      - targets: ['127.0.0.1:$(( $BASE_METRICS_PORT + $i ))']
+      - targets: ['127.0.0.1:$(( BASE_METRICS_PORT + i ))']
         labels:
           node: '$i'
 EOF
@@ -166,8 +166,8 @@ done
 
 if [[ "$USE_TMUX" != "no" ]]; then
   $TMUX kill-pane -t $TMUX_SESSION_NAME:0.0
-  $TMUX select-layout -t $TMUX_SESSION_NAME tiled
-  $TMUX attach-session -t $TMUX_SESSION_NAME -d
+  $TMUX select-layout -t "${TMUX_SESSION_NAME}" tiled
+  $TMUX attach-session -t "${TMUX_SESSION_NAME}" -d
 elif [[ "$USE_MULTITAIL" != "no" ]]; then
   eval $MULTITAIL -s 3 -M 0 -x \"Nimbus beacon chain\" "${COMMANDS[@]}"
 else


### PR DESCRIPTION
This is a little clumsy because:

1) `env.sh` requires basically an empty set of arguments by the time it's invoked in that sort of inception/control-flow-inversion thing it does, which alone wouldn't be so bad, but

2) there are two different types of bootstrap node filename formats, depending on where it comes from, and the one that `run_node.sh` assumes is incorrect for `eth2_network_simulation` (where it's used).