### PR TITLE
add --compatibility to accept cpu/mem limits

### DIFF
--- a/docker/manage_testnet_hosts.nims
+++ b/docker/manage_testnet_hosts.nims
@@ -103,7 +103,7 @@ of restart_nodes:
       echo &"ssh {n.server} docker pull -q statusteam/nimbus_beacon_node:{conf.network}"
     # docker-compose will rebuild the container if it detects a newer image.
     # Prints: "Recreating beacon-node-testnet1-1 ... done".
-    echo &"ssh {n.server} 'cd /docker/{n.container} && docker-compose up -d'"
+    echo &"ssh {n.server} 'cd /docker/{n.container} && docker-compose --compatibility up -d'"
 
 of reset_network:
   for n, firstValidator, lastValidator in validatorAssignments():


### PR DESCRIPTION
Otherwise you'll get a warning like this:
```
WARNING: Some services (beacon_node) use the 'deploy' key, which will be ignored.
Compose does not support 'deploy' configuration - use `docker stack deploy` to deploy to a swarm.
```
Same change in the Ansible role: https://github.com/status-im/infra-role-beacon-node/commit/4ab78731
For more details see: https://github.com/status-im/infra-nimbus/issues/12