### PR TITLE
0.11.1 beacon chain spec update

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -51,7 +51,7 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Official - 0.11.0 - constants & config  [Preset: mainnet]
+## Official - 0.11.1 - constants & config  [Preset: mainnet]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: mainnet]   OK
 + BLS_WITHDRAWAL_PREFIX                             "0x00"               [Preset: mainnet]   OK

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -78,7 +78,7 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Official - 0.11.0 - constants & config  [Preset: minimal]
+## Official - 0.11.1 - constants & config  [Preset: minimal]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: minimal]   OK
 + BLS_WITHDRAWAL_PREFIX                             "0x00"               [Preset: minimal]   OK

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -45,6 +45,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + [Invalid] after_epoch_slots                                                                OK
 + [Invalid] bad_source_root                                                                  OK
 + [Invalid] before_inclusion_delay                                                           OK
++ [Invalid] empty_aggregation_bits                                                           OK
 + [Invalid] future_target_epoch                                                              OK
 + [Invalid] invalid_attestation_signature                                                    OK
 + [Invalid] invalid_current_source_root                                                      OK
@@ -58,7 +59,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + [Invalid] too_many_aggregation_bits                                                        OK
 + [Invalid] wrong_index_for_committee_signature                                              OK
 + [Invalid] wrong_index_for_slot                                                             OK
-+ [Valid]   empty_aggregation_bits                                                           OK
 + [Valid]   success                                                                          OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -45,6 +45,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + [Invalid] after_epoch_slots                                                                OK
 + [Invalid] bad_source_root                                                                  OK
 + [Invalid] before_inclusion_delay                                                           OK
++ [Invalid] empty_aggregation_bits                                                           OK
 + [Invalid] future_target_epoch                                                              OK
 + [Invalid] invalid_attestation_signature                                                    OK
 + [Invalid] invalid_current_source_root                                                      OK
@@ -58,7 +59,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + [Invalid] too_many_aggregation_bits                                                        OK
 + [Invalid] wrong_index_for_committee_signature                                              OK
 + [Invalid] wrong_index_for_slot                                                             OK
-+ [Valid]   empty_aggregation_bits                                                           OK
 + [Valid]   success                                                                          OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK

--- a/FixtureSSZConsensus-mainnet.md
+++ b/FixtureSSZConsensus-mainnet.md
@@ -1,6 +1,6 @@
 FixtureSSZConsensus-mainnet
 ===
-## Official - 0.11.0 - SSZ consensus objects  [Preset: mainnet]
+## Official - 0.11.1 - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK

--- a/FixtureSSZConsensus-minimal.md
+++ b/FixtureSSZConsensus-minimal.md
@@ -1,6 +1,6 @@
 FixtureSSZConsensus-minimal
 ===
-## Official - 0.11.0 - SSZ consensus objects  [Preset: minimal]
+## Official - 0.11.1 - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -308,7 +308,7 @@ proc getAttestationsForBlock*(
 
   for a in slotData.attestations:
     var
-      # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md#construct-attestation
+      # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#construct-attestation
       attestation = Attestation(
         aggregation_bits: a.validations[0].aggregation_bits,
         data: a.data,

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -335,7 +335,7 @@ proc sendAttestation(node: BeaconNode,
     aggregation_bits: aggregationBits
   )
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md#broadcast-attestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#broadcast-attestation
   node.network.broadcast(
     getAttestationTopic(attestationData.index), attestation)
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -385,7 +385,7 @@ proc proposeBlock(node: BeaconNode,
     let message = makeBeaconBlock(
       state,
       head.root,
-      validator.genRandaoReveal(state.fork, slot, state.genesis_validators_root),
+      validator.genRandaoReveal(state.fork, state.genesis_validators_root, slot),
       eth1data,
       Eth2Digest(),
       node.attestationPool.getAttestationsForBlock(state),
@@ -401,8 +401,8 @@ proc proposeBlock(node: BeaconNode,
     let blockRoot = hash_tree_root(newBlock.message)
 
     # Careful, state no longer valid after here because of the await..
-    newBlock.signature =
-      await validator.signBlockProposal(state.fork, slot, blockRoot, state.genesis_validators_root)
+    newBlock.signature = await validator.signBlockProposal(
+      state.fork, state.genesis_validators_root, slot, blockRoot)
 
     (blockRoot, newBlock)
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -286,12 +286,12 @@ func get_block_root*(state: BeaconState, epoch: Epoch): Eth2Digest =
   # Return the block root at the start of a recent ``epoch``.
   get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch))
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/beacon-chain.md#get_total_balance
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#get_total_balance
 func get_total_balance*(state: BeaconState, validators: auto): Gwei =
-  ## Return the combined effective balance of the ``indices``. (1 Gwei minimum
-  ## to avoid divisions by zero.)
+  ## Return the combined effective balance of the ``indices``.
+  ## ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
   ## Math safe up to ~10B ETH, afterwhich this overflows uint64.
-  max(1'u64,
+  max(EFFECTIVE_BALANCE_INCREMENT,
     foldl(validators, a + state.validators[b].effective_balance, 0'u64)
   )
 
@@ -365,7 +365,7 @@ proc process_registry_updates*(state: var BeaconState) {.nbench.}=
     validator.activation_epoch =
       compute_activation_exit_epoch(get_current_epoch(state))
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#is_valid_indexed_attestation
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
     state: BeaconState, indexed_attestation: IndexedAttestation,
     flags: UpdateFlags): bool =
@@ -381,7 +381,6 @@ proc is_valid_indexed_attestation*(
     return false
 
   # Verify indices are sorted and unique
-  # TODO but why? this is a local artifact
   if indices != sorted(indices, system.cmp):
     notice "indexed attestation: indices not sorted"
     return false
@@ -436,7 +435,7 @@ func get_indexed_attestation(state: BeaconState, attestation: Attestation,
     signature: attestation.signature
   )
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#attestations
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
     state: BeaconState, attestation: Attestation, flags: UpdateFlags,
     stateCache: var StateCache): bool =

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -57,7 +57,7 @@ else:
   loadCustomPreset const_preset
 
 const
-  SPEC_VERSION* = "0.11.0" ## \
+  SPEC_VERSION* = "0.11.1" ## \
   ## Spec version we're aiming to be compatible with, right now
 
   GENESIS_EPOCH* = (GENESIS_SLOT.uint64 div SLOTS_PER_EPOCH).Epoch ##\

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -149,25 +149,21 @@ func compute_domain*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#get_domain
 func get_domain*(
-    fork: Fork, domain_type: DomainType, epoch: Epoch): Domain =
+    fork: Fork, domain_type: DomainType, epoch: Epoch, genesis_validators_root: Eth2Digest): Domain =
   ## Return the signature domain (fork version concatenated with domain type)
   ## of a message.
-  let
-    fork_version =
-      if epoch < fork.epoch:
-        fork.previous_version
-      else:
-        fork.current_version
-  compute_domain(domain_type, fork_version)
+  let fork_version =
+    if epoch < fork.epoch:
+      fork.previous_version
+    else:
+      fork.current_version
+  compute_domain(domain_type, fork_version, genesis_validators_root)
 
 func get_domain*(
-    state: BeaconState, domain_type: DomainType, message_epoch: Epoch): Domain =
+    state: BeaconState, domain_type: DomainType, epoch: Epoch): Domain =
   ## Return the signature domain (fork version concatenated with domain type)
   ## of a message.
-  get_domain(state.fork, domain_type, message_epoch)
-
-func get_domain*(state: BeaconState, domain_type: DomainType): Domain =
-  get_domain(state, domain_type, get_current_epoch(state))
+  get_domain(state.fork, domain_type, epoch, state. genesis_validators_root)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/beacon-chain.md#compute_signing_root
 func compute_signing_root*(ssz_object: auto, domain: Domain): Eth2Digest =

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -56,7 +56,7 @@ const
 
   # Gwei values
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/mainnet.yaml#L52
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L58
 
   MIN_DEPOSIT_AMOUNT* = 2'u64^0 * 10'u64^9 ##\
   ## Minimum amounth of ETH that can be deposited in one call - deposits can

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -71,7 +71,7 @@ const
 
   # Time parameters
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L71
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L77
   # Changed: Faster to spin up testnets, but does not give validator
   # reasonable warning time for genesis
   MIN_GENESIS_DELAY* = 300
@@ -177,16 +177,6 @@ const
   MAX_GASPRICE* = 16384 # Gwei
   MIN_GASPRICE* = 32 # Gwei
   GASPRICE_ADJUSTMENT_COEFFICIENT* = 8
-
-  # Phase 1 - Sharding
-  # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L157
-  # TODO those are included in minimal.yaml but not mainnet.yaml
-  #      Why?
-  SHARD_SLOTS_PER_BEACON_SLOT* = 2 # spec: SHARD_SLOTS_PER_EPOCH
-  EPOCHS_PER_SHARD_PERIOD* = 4
-  PHASE_1_FORK_EPOCH* = 8
-  PHASE_1_FORK_SLOT* = 64
 
   # Phase 1 - Custody game
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -484,8 +484,8 @@ proc makeBeaconBlock*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#aggregation-selection
 func get_slot_signature*(
-    fork: Fork, slot: Slot, privkey: ValidatorPrivKey,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    privkey: ValidatorPrivKey): ValidatorSig =
   let
     domain = get_domain(fork, DOMAIN_SELECTION_PROOF,
       compute_epoch_at_slot(slot), genesis_validators_root)
@@ -495,8 +495,8 @@ func get_slot_signature*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#randao-reveal
 func get_epoch_signature*(
-    fork: Fork, slot: Slot, privkey: ValidatorPrivKey,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    privkey: ValidatorPrivKey): ValidatorSig =
   let
     domain = get_domain(fork, DOMAIN_RANDAO, compute_epoch_at_slot(slot),
       genesis_validators_root)
@@ -506,8 +506,8 @@ func get_epoch_signature*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#signature
 func get_block_signature*(
-    fork: Fork, slot: Slot, root: Eth2Digest, privkey: ValidatorPrivKey,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    root: Eth2Digest, privkey: ValidatorPrivKey): ValidatorSig =
   let
     domain = get_domain(fork, DOMAIN_BEACON_PROPOSER,
       compute_epoch_at_slot(slot), genesis_validators_root)
@@ -517,8 +517,8 @@ func get_block_signature*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#aggregate-signature
 func get_attestation_signature*(
-    fork: Fork, attestation: AttestationData, privkey: ValidatorPrivKey,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
+    fork: Fork, genesis_validators_root: Eth2Digest, attestation: AttestationData,
+    privkey: ValidatorPrivKey): ValidatorSig =
   let
     attestationRoot = hash_tree_root(attestation)
     domain = get_domain(fork, DOMAIN_BEACON_ATTESTER,

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -242,7 +242,7 @@ func get_base_reward(state: BeaconState, index: ValidatorIndex,
   effective_balance * BASE_REWARD_FACTOR div
     integer_squareroot(total_balance) div BASE_REWARDS_PER_EPOCH
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/beacon-chain.md#rewards-and-penalties-1
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#rewards-and-penalties-1
 func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
     tuple[a: seq[Gwei], b: seq[Gwei]] {.nbench.}=
   let
@@ -280,7 +280,7 @@ func get_attestation_deltas(state: BeaconState, stateCache: var StateCache):
         const increment = EFFECTIVE_BALANCE_INCREMENT
         let reward_numerator = get_base_reward(state, index, total_balance) *
           (attesting_balance div increment)
-        rewards[index] = reward_numerator div (total_balance div increment)
+        rewards[index] += reward_numerator div (total_balance div increment)
       else:
         penalties[index] += get_base_reward(state, index, total_balance)
 

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -25,9 +25,9 @@ func getValidator*(pool: ValidatorPool,
   pool.validators.getOrDefault(validatorKey)
 
 # TODO: Honest validator - https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md
-proc signBlockProposal*(v: AttachedValidator, fork: Fork, slot: Slot,
-                        blockRoot: Eth2Digest,
-                        genesis_validators_root: Eth2Digest): Future[ValidatorSig] {.async.} =
+proc signBlockProposal*(v: AttachedValidator, fork: Fork,
+                        genesis_validators_root: Eth2Digest, slot: Slot,
+                        blockRoot: Eth2Digest): Future[ValidatorSig] {.async.} =
 
   if v.kind == inProcess:
     # TODO this is an ugly hack to fake a delay and subsequent async reordering
@@ -36,7 +36,7 @@ proc signBlockProposal*(v: AttachedValidator, fork: Fork, slot: Slot,
     await sleepAsync(chronos.milliseconds(1))
 
     result = get_block_signature(
-      fork, slot, blockRoot, v.privKey, genesis_validators_root)
+      fork, genesis_validators_root, slot, blockRoot, v.privKey)
   else:
     error "Unimplemented"
     quit 1
@@ -52,16 +52,16 @@ proc signAttestation*(v: AttachedValidator,
     await sleepAsync(chronos.milliseconds(1))
 
     result = get_attestation_signature(
-      fork, attestation, v.privKey, genesis_validators_root)
+      fork, genesis_validators_root, attestation, v.privKey)
   else:
     error "Unimplemented"
     quit 1
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#randao-reveal
-func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork, slot: Slot,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
-  get_epoch_signature(fork, slot, k, genesis_validators_root)
+func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork,
+    genesis_validators_root: Eth2Digest, slot: Slot): ValidatorSig =
+  get_epoch_signature(fork, genesis_validators_root, slot, k)
 
-func genRandaoReveal*(v: AttachedValidator, fork: Fork, slot: Slot,
-    genesis_validators_root: Eth2Digest): ValidatorSig =
-  genRandaoReveal(v.privKey, fork, slot, genesis_validators_root)
+func genRandaoReveal*(v: AttachedValidator, fork: Fork,
+    genesis_validators_root: Eth2Digest, slot: Slot): ValidatorSig =
+  genRandaoReveal(v.privKey, fork, genesis_validators_root, slot)

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -66,7 +66,8 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
   var first_iter = true # Can't do while loop on hashset
   for validator_index in participants:
     let sig = get_attestation_signature(
-      state.fork, attestation.data, MockPrivKeys[validator_index]
+      state.fork, attestation.data, MockPrivKeys[validator_index],
+      state.genesis_validators_root
     )
     if first_iter:
       attestation.signature = sig

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -66,8 +66,8 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
   var first_iter = true # Can't do while loop on hashset
   for validator_index in participants:
     let sig = get_attestation_signature(
-      state.fork, attestation.data, MockPrivKeys[validator_index],
-      state.genesis_validators_root
+      state.fork, state.genesis_validators_root, attestation.data,
+      MockPrivKeys[validator_index]
     )
     if first_iter:
       attestation.signature = sig

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -28,9 +28,10 @@ proc signMockBlockImpl(
   let privkey = MockPrivKeys[proposer_index]
 
   signedBlock.message.body.randao_reveal = get_epoch_signature(
-    state.fork, block_slot, privkey)
+    state.fork, block_slot, privkey, state.genesis_validators_root)
   signedBlock.signature = get_block_signature(
-    state.fork, block_slot, hash_tree_root(signedBlock.message), privkey)
+    state.fork, block_slot, hash_tree_root(signedBlock.message), privkey,
+    state.genesis_validators_root)
 
 proc signMockBlock*(
   state: BeaconState,

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -28,10 +28,10 @@ proc signMockBlockImpl(
   let privkey = MockPrivKeys[proposer_index]
 
   signedBlock.message.body.randao_reveal = get_epoch_signature(
-    state.fork, block_slot, privkey, state.genesis_validators_root)
+    state.fork, state.genesis_validators_root, block_slot, privkey)
   signedBlock.signature = get_block_signature(
-    state.fork, block_slot, hash_tree_root(signedBlock.message), privkey,
-    state.genesis_validators_root)
+    state.fork, state.genesis_validators_root, block_slot,
+    hash_tree_root(signedBlock.message), privkey)
 
 proc signMockBlock*(
   state: BeaconState,

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -36,7 +36,7 @@ proc readValue*(r: var JsonReader, a: var seq[byte]) {.inline.} =
 
 const
   FixturesDir* = currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / "vendor" / "nim-eth2-scenarios"
-  SszTestsDir* = FixturesDir/"tests-v0.11.0"
+  SszTestsDir* = FixturesDir/"tests-v0.11.1"
 
 proc parseTest*(path: string, Format: typedesc[Json or SSZ], T: typedesc): T =
   try:

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -19,7 +19,7 @@ import
 const
   SpecDir = currentSourcePath.rsplit(DirSep, 1)[0] /
                   ".."/".."/"beacon_chain"/"spec"
-  Config = FixturesDir/"tests-v0.11.0"/const_preset/"config.yaml"
+  Config = FixturesDir/"tests-v0.11.1"/const_preset/"config.yaml"
 
 type
   CheckedType = SomeInteger or Slot or Epoch
@@ -122,5 +122,5 @@ proc checkConfig() =
       else:
         check: ConstsToCheck[constant] == value.getBiggestInt().uint64()
 
-suiteReport "Official - 0.11.0 - constants & config " & preset():
+suiteReport "Official - 0.11.1 - constants & config " & preset():
   checkConfig()

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -32,8 +32,6 @@ proc runTest(identifier: string) =
 
     var flags: UpdateFlags
     var prefix: string
-    if not existsFile(testDir/"meta.yaml"):
-      flags.incl skipBlsValidation
     if existsFile(testDir/"post.ssz"):
       prefix = "[Valid]   "
     else:

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -32,8 +32,6 @@ proc runTest(identifier: string) =
 
     var flags: UpdateFlags
     var prefix: string
-    if not existsFile(testDir/"meta.yaml"):
-      flags.incl skipBlsValidation
     if existsFile(testDir/"post.ssz"):
       prefix = "[Valid]   "
     else:

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -32,8 +32,6 @@ proc runTest(identifier: string) =
 
     var flags: UpdateFlags
     var prefix: string
-    if not existsFile(testDir/"meta.yaml"):
-      flags.incl skipBlsValidation
     if existsFile(testDir/"post.ssz"):
       prefix = "[Valid]   "
     else:

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -32,8 +32,6 @@ proc runTest(identifier: string) =
 
     var flags: UpdateFlags
     var prefix: string
-    if not existsFile(testDir/"meta.yaml"):
-      flags.incl skipBlsValidation
     if existsFile(testDir/"post.ssz"):
       prefix = "[Valid]   "
     else:

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -25,7 +25,7 @@ import
 # ----------------------------------------------------------------
 
 const
-  SSZDir = FixturesDir/"tests-v0.11.0"/const_preset/"phase0"/"ssz_static"
+  SSZDir = FixturesDir/"tests-v0.11.1"/const_preset/"phase0"/"ssz_static"
 
 type
   SSZHashTreeRoot = object
@@ -106,7 +106,7 @@ proc runSSZtests() =
           else:
             raise newException(ValueError, "Unsupported test: " & sszType)
 
-suiteReport "Official - 0.11.0 - SSZ consensus objects " & preset():
+suiteReport "Official - 0.11.1 - SSZ consensus objects " & preset():
   runSSZtests()
 
 summarizeLongTests("FixtureSSZConsensus")

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -23,7 +23,7 @@ import
 # ------------------------------------------------------------------------
 
 const
-  SSZDir = FixturesDir/"tests-v0.11.0"/"general"/"phase0"/"ssz_generic"
+  SSZDir = FixturesDir/"tests-v0.11.1"/"general"/"phase0"/"ssz_generic"
 
 type
   SSZHashTreeRoot = object

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -84,7 +84,8 @@ proc addTestBlock*(
     privKey = hackPrivKey(proposer)
     randao_reveal =
       if skipBlsValidation notin flags:
-        privKey.genRandaoReveal(state.fork, state.slot)
+        privKey.genRandaoReveal(
+          state.fork, state.slot, state.genesis_validators_root)
       else:
         ValidatorSig()
 
@@ -149,7 +150,8 @@ proc makeAttestation*(
   let
     sig =
       if skipBLSValidation notin flags:
-        get_attestation_signature(state.fork, data, hackPrivKey(validator))
+        get_attestation_signature(state.fork, data, hackPrivKey(validator),
+          state.genesis_validators_root)
       else:
         ValidatorSig()
 
@@ -204,7 +206,8 @@ proc makeFullAttestations*(
       data: data,
       signature: get_attestation_signature(
         state.fork, data,
-        hackPrivKey(state.validators[committee[0]]))
+        hackPrivKey(state.validators[committee[0]]),
+        state.genesis_validators_root)
     )
     # Aggregate the remainder
     attestation.aggregation_bits.setBit 0
@@ -213,7 +216,8 @@ proc makeFullAttestations*(
       if skipBLSValidation notin flags:
         attestation.signature.aggregate(get_attestation_signature(
           state.fork, data,
-          hackPrivKey(state.validators[committee[j]])
+          hackPrivKey(state.validators[committee[j]]),
+          state.genesis_validators_root
         ))
 
     result.add attestation

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -85,7 +85,7 @@ proc addTestBlock*(
     randao_reveal =
       if skipBlsValidation notin flags:
         privKey.genRandaoReveal(
-          state.fork, state.slot, state.genesis_validators_root)
+          state.fork, state.genesis_validators_root, state.slot)
       else:
         ValidatorSig()
 
@@ -150,8 +150,8 @@ proc makeAttestation*(
   let
     sig =
       if skipBLSValidation notin flags:
-        get_attestation_signature(state.fork, data, hackPrivKey(validator),
-          state.genesis_validators_root)
+        get_attestation_signature(state.fork, state.genesis_validators_root,
+          data, hackPrivKey(validator))
       else:
         ValidatorSig()
 
@@ -205,9 +205,8 @@ proc makeFullAttestations*(
       aggregation_bits: CommitteeValidatorsBits.init(committee.len),
       data: data,
       signature: get_attestation_signature(
-        state.fork, data,
-        hackPrivKey(state.validators[committee[0]]),
-        state.genesis_validators_root)
+        state.fork, state.genesis_validators_root, data,
+        hackPrivKey(state.validators[committee[0]]))
     )
     # Aggregate the remainder
     attestation.aggregation_bits.setBit 0
@@ -215,9 +214,8 @@ proc makeFullAttestations*(
       attestation.aggregation_bits.setBit j
       if skipBLSValidation notin flags:
         attestation.signature.aggregate(get_attestation_signature(
-          state.fork, data,
-          hackPrivKey(state.validators[committee[j]]),
-          state.genesis_validators_root
+          state.fork, state.genesis_validators_root, data,
+          hackPrivKey(state.validators[committee[j]])
         ))
 
     result.add attestation


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/releases/tag/v0.11.1

Aside from just the spec update as such, this better integrates `get_domain(..)` from 0.10.x and 0.11.x so that attester, attester slashing, proposer slashing, and voluntary exit operations tests fixtures don't disable BLS verification. Before, BLS 0.10.x/0.11.x-compatible BLS, they had to, but now the full tests are effectively restored.