### PR TITLE
Discv5: Don't pass ip address when external ip is not known

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1196,15 +1196,12 @@ when isMainModule:
     if bootstrapFile.len > 0:
       let
         networkKeys = getPersistentNetKeys(config)
-        bootstrapAddress = enode.Address(
-          ip: config.bootstrapAddress,
-          tcpPort: config.bootstrapPort,
-          udpPort: config.bootstrapPort)
-
         bootstrapEnr = enr.Record.init(
           1, # sequence number
           networkKeys.seckey.asEthKey,
-          some(bootstrapAddress))
+          some(config.bootstrapAddress),
+          config.bootstrapPort,
+          config.bootstrapPort)
 
       writeFile(bootstrapFile, bootstrapEnr.toURI)
       echo "Wrote ", bootstrapFile

--- a/beacon_chain/eth2_discovery.nim
+++ b/beacon_chain/eth2_discovery.nim
@@ -154,7 +154,8 @@ proc loadBootstrapFile*(bootstrapFile: string,
 
 proc new*(T: type Eth2DiscoveryProtocol,
           conf: BeaconNodeConf,
-          ip: IpAddress, rawPrivKeyBytes: openarray[byte]): T =
+          ip: Option[IpAddress], tcpPort, udpPort: Port,
+          rawPrivKeyBytes: openarray[byte]): T =
   # TODO
   # Implement more configuration options:
   # * for setting up a specific key
@@ -174,4 +175,4 @@ proc new*(T: type Eth2DiscoveryProtocol,
   if fileExists(persistentBootstrapFile):
     loadBootstrapFile(persistentBootstrapFile, bootNodes, bootEnrs, ourPubKey)
 
-  newProtocol(pk, db, ip, conf.tcpPort, conf.udpPort, bootEnrs)
+  newProtocol(pk, db, ip, tcpPort, udpPort, bootEnrs)


### PR DESCRIPTION
nim-eth has updates:
- Will create ENR without IP address if none is passed
- Some additional IP validation checks on ENRs received from Nodes packet.