### PR TITLE
Bump nim-metrics

### DIFF
--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -117,7 +117,7 @@ fi
 # Trap and ignore SIGTERM, so we don't kill this process along with its children.
 if [ "$USE_MULTITAIL" = "no" ]; then
   trap '' SIGTERM
-  trap 'kill -- -$$' SIGINT EXIT
+  trap 'pkill -P $$ beacon_node' SIGINT EXIT
 fi
 
 COMMANDS=()


### PR DESCRIPTION
Bumping nim-metrics and fix for start.sh to properly kill all child processes on mac os.

To clarify, the fix around `kill`  is due to the lack of support for the `kill -<ppid>` syntax on macos (bsd). This is used to kill the process group of the calling process, instead `pkill` seems to be a more portable way to accomplish that with the `pkill -P<ppid> beacon_node` syntax.