### PR TITLE
fix/restore 0.11.1 BeaconState genesis interop

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -80,7 +80,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + EPOCHS_PER_SLASHINGS_VECTOR                       8192                 [Preset: mainnet]   OK
 + ETH1_FOLLOW_DISTANCE                              1024                 [Preset: mainnet]   OK
 + GASPRICE_ADJUSTMENT_COEFFICIENT                   8                    [Preset: mainnet]   OK
-+ GENESIS_FORK_VERSION                              "0x00000000"         [Preset: mainnet]   OK
+- GENESIS_FORK_VERSION                              "0x00000000"         [Preset: mainnet]   Fail
 + HISTORICAL_ROOTS_LIMIT                            16777216             [Preset: mainnet]   OK
 + HYSTERESIS_DOWNWARD_MULTIPLIER                    1                    [Preset: mainnet]   OK
 + HYSTERESIS_QUOTIENT                               4                    [Preset: mainnet]   OK
@@ -141,7 +141,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + VALIDATOR_REGISTRY_LIMIT                          1099511627776        [Preset: mainnet]   OK
 + WHISTLEBLOWER_REWARD_QUOTIENT                     512                  [Preset: mainnet]   OK
 ```
-OK: 85/87 Fail: 2/87 Skip: 0/87
+OK: 84/87 Fail: 3/87 Skip: 0/87
 ## PeerPool testing suite
 ```diff
 + Access peers by key test                                                                   OK
@@ -222,4 +222,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 142/144 Fail: 2/144 Skip: 0/144
+OK: 141/144 Fail: 3/144 Skip: 0/144

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -51,6 +51,13 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## Interop
+```diff
++ Interop genesis                                                                            OK
++ Interop signatures                                                                         OK
++ Mocked start private key                                                                   OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Official - 0.11.1 - constants & config  [Preset: mainnet]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: mainnet]   OK
@@ -222,4 +229,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 141/144 Fail: 3/144 Skip: 0/144
+OK: 144/147 Fail: 3/147 Skip: 0/147

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -78,6 +78,13 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Attestation topics                                                                         OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## Interop
+```diff
++ Interop genesis                                                                            OK
++ Interop signatures                                                                         OK
++ Mocked start private key                                                                   OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Official - 0.11.1 - constants & config  [Preset: minimal]
 ```diff
 + BASE_REWARD_FACTOR                                64                   [Preset: minimal]   OK
@@ -249,4 +256,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 156/159 Fail: 3/159 Skip: 0/159
+OK: 159/162 Fail: 3/162 Skip: 0/162

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -107,7 +107,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + EPOCHS_PER_SLASHINGS_VECTOR                       64                   [Preset: minimal]   OK
 + ETH1_FOLLOW_DISTANCE                              16                   [Preset: minimal]   OK
 + GASPRICE_ADJUSTMENT_COEFFICIENT                   8                    [Preset: minimal]   OK
-+ GENESIS_FORK_VERSION                              "0x00000001"         [Preset: minimal]   OK
+- GENESIS_FORK_VERSION                              "0x00000001"         [Preset: minimal]   Fail
 + HISTORICAL_ROOTS_LIMIT                            16777216             [Preset: minimal]   OK
 + HYSTERESIS_DOWNWARD_MULTIPLIER                    1                    [Preset: minimal]   OK
 + HYSTERESIS_QUOTIENT                               4                    [Preset: minimal]   OK
@@ -168,7 +168,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + VALIDATOR_REGISTRY_LIMIT                          1099511627776        [Preset: minimal]   OK
 + WHISTLEBLOWER_REWARD_QUOTIENT                     512                  [Preset: minimal]   OK
 ```
-OK: 85/87 Fail: 2/87 Skip: 0/87
+OK: 84/87 Fail: 3/87 Skip: 0/87
 ## PeerPool testing suite
 ```diff
 + Access peers by key test                                                                   OK
@@ -249,4 +249,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 157/159 Fail: 2/159 Skip: 0/159
+OK: 156/159 Fail: 3/159 Skip: 0/159

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -943,7 +943,7 @@ proc getProposer*(pool: BlockPool, head: BlockRef, slot: Slot): Option[Validator
   pool.withState(pool.tmpState, head.atSlot(slot)):
     var cache = get_empty_per_epoch_cache()
 
-    # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md#validator-assignments
+    # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#validator-assignments
     let proposerIdx = get_beacon_proposer_index(state, cache)
     if proposerIdx.isNone:
       warn "Missing proposer index",

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -51,7 +51,7 @@ func makeDeposit*(
         withdrawal_credentials: makeWithdrawalCredentials(pubkey)))
 
   if skipBLSValidation notin flags:
-    let domain = compute_domain(DOMAIN_DEPOSIT)
+    let domain = compute_domain(DOMAIN_DEPOSIT, GENESIS_FORK_VERSION)
     let signing_root = compute_signing_root(ret.getDepositMessage, domain)
 
     ret.data.signature = bls_sign(privkey, signing_root.data)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -193,7 +193,7 @@ proc slash_validator*(state: var BeaconState, slashed_index: ValidatorIndex,
   increase_balance(
     state, whistleblower_index, whistleblowing_reward - proposer_reward)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#genesis
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#genesis
 proc initialize_beacon_state_from_eth1*(
     eth1_block_hash: Eth2Digest,
     eth1_timestamp: uint64,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -47,7 +47,7 @@ func decrease_balance*(
     else:
       state.balances[index] - delta
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#deposits
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#deposits
 proc process_deposit*(
     state: var BeaconState, deposit: Deposit, flags: UpdateFlags = {}): bool {.nbench.}=
   # Process an Eth1 deposit, registering a validator or increasing its balance.
@@ -56,7 +56,7 @@ proc process_deposit*(
   if skipMerkleValidation notin flags and not is_valid_merkle_branch(
     hash_tree_root(deposit.data),
     deposit.proof,
-    DEPOSIT_CONTRACT_TREE_DEPTH + 1,
+    DEPOSIT_CONTRACT_TREE_DEPTH + 1,  # Add 1 for the `List` length mix-in
     state.eth1_deposit_index,
     state.eth1_data.deposit_root,
   ):
@@ -72,8 +72,17 @@ proc process_deposit*(
     index = validator_pubkeys.find(pubkey)
 
   if index == -1:
-    # Verify the deposit signature (proof of possession)
-    let domain = compute_domain(DOMAIN_DEPOSIT)
+    # Verify the deposit signature (proof of possession) which is not checked
+    # by the deposit contract
+
+    # Fork-agnostic domain since deposits are valid across forks
+    #
+    # TODO zcli/zrnt does use the GENESIS_FORK_VERSION which can
+    # vary between minimal/mainnet, though, despite the comment,
+    # which is copied verbatim from the eth2 beacon chain spec.
+    # https://github.com/protolambda/zrnt/blob/v0.11.0/eth2/phase0/kickstart.go#L58
+    let domain = compute_domain(DOMAIN_DEPOSIT, GENESIS_FORK_VERSION)
+
     let signing_root = compute_signing_root(deposit.getDepositMessage, domain)
     if skipBLSValidation notin flags and not bls_verify(
         pubkey, signing_root.data,
@@ -98,7 +107,7 @@ proc process_deposit*(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#compute_activation_exit_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#compute_activation_exit_epoch
 func compute_activation_exit_epoch(epoch: Epoch): Epoch =
   ## Return the epoch during which validator activations and exits initiated in
   ## ``epoch`` take effect.
@@ -185,7 +194,7 @@ proc slash_validator*(state: var BeaconState, slashed_index: ValidatorIndex,
     state, whistleblower_index, whistleblowing_reward - proposer_reward)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#genesis
-func initialize_beacon_state_from_eth1*(
+proc initialize_beacon_state_from_eth1*(
     eth1_block_hash: Eth2Digest,
     eth1_timestamp: uint64,
     deposits: openArray[Deposit],
@@ -208,6 +217,10 @@ func initialize_beacon_state_from_eth1*(
 
   const SECONDS_PER_DAY = uint64(60*60*24)
   var state = BeaconState(
+    fork: Fork(
+      previous_version: GENESIS_FORK_VERSION,
+      current_version: GENESIS_FORK_VERSION,
+      epoch: GENESIS_EPOCH),
     genesis_time:
       eth1_timestamp + 2'u64 * SECONDS_PER_DAY -
         (eth1_timestamp mod SECONDS_PER_DAY),
@@ -248,7 +261,8 @@ func initialize_beacon_state_from_eth1*(
       validator.activation_epoch = GENESIS_EPOCH
 
   # Set genesis validators root for domain separation and chain versioning
-  state.genesis_validators_root = hash_tree_root(state.validators)
+  state.genesis_validators_root =
+    hash_tree_root(sszList(state.validators, VALIDATOR_REGISTRY_LIMIT))
 
   state
 

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -260,6 +260,10 @@ func initFromBytes*(val: var ValidatorPrivKey, bytes: openarray[byte]) {.inline.
 func fromBytes[T](R: type BlsValue[T], bytes: openarray[byte]): R {.inline.}=
   result.initFromBytes(bytes)
 
+func fromBytes[T](R: var BlsValue[T], bytes: openarray[byte]) {.inline.}=
+  # This version is only to support tests/test_interop.nim
+  R.initFromBytes(bytes)
+
 func fromHex*[T](R: var BlsValue[T], hexStr: string) {.inline.} =
   ## Initialize a BLSValue from its hex representation
   R.fromBytes(hexStr.hexToSeqByte())

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -257,8 +257,7 @@ type
     eth1_deposit_index*: uint64
 
     # Registry
-    # TODO List[] won't construct due to VALIDATOR_REGISTRY_LIMIT > high(int)
-    validators*: seq[Validator]
+    validators*: List[Validator, VALIDATOR_REGISTRY_LIMIT]
     balances*: seq[uint64]
 
     # Randomness

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -20,7 +20,7 @@ type
 const
   # Misc
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/mainnet.yaml#L6
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L6
 
   MAX_COMMITTEES_PER_SLOT* {.intdefine.} = 64
 
@@ -49,7 +49,7 @@ const
   HYSTERESIS_UPWARD_MULTIPLIER* = 5
 
   # Constants (TODO: not actually configurable)
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#constants
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#constants
   BASE_REWARDS_PER_EPOCH* = 4
 
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -75,7 +75,7 @@ const
   # ---------------------------------------------------------------
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L70
   GENESIS_SLOT* = 0.Slot
-  GENESIS_FORK_VERSION* = 0x00000000
+  GENESIS_FORK_VERSION* = [0'u8, 0'u8, 0'u8, 0'u8]
   BLS_WITHDRAWAL_PREFIX* = 0'u8
 
   # Time parameters

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -66,7 +66,7 @@ const
 
   # Unchanged
   GENESIS_SLOT* = 0.Slot
-  GENESIS_FORK_VERSION* = 0x01000000
+  GENESIS_FORK_VERSION* = [0'u8, 0'u8, 0'u8, 1'u8]
   BLS_WITHDRAWAL_PREFIX* = 0'u8
 
   # Time parameters

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -20,7 +20,7 @@ type
 const
   # Misc
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L4
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L4
 
   # Changed
   MAX_COMMITTEES_PER_SLOT* = 4

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -62,9 +62,9 @@ type
       discard
 
 when useListType:
-  type List*[T; maxLen: static int] = distinct seq[T]
+  type List*[T; maxLen: static int64] = distinct seq[T]
 else:
-  type List*[T; maxLen: static int] = seq[T]
+  type List*[T; maxLen: static int64] = seq[T]
 
 macro unsupported*(T: typed): untyped =
   # TODO: {.fatal.} breaks compilation even in `compiles()` context,

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -27,12 +27,8 @@ import # Unit test
   ./test_zero_signature,
   ./test_peer_pool,
   ./test_sync_manager,
-  ./test_honest_validator
-
-  # ./test_interop
-  # TODO: BLS changes in v0.10.1 will generate different interop signatures
-  #       Requires an update of the interop mocked start: https://github.com/ethereum/eth2.0-pm/tree/master/interop/mocked_start
-  #       or of ZRNT / ZCLI to v0.10.1
+  ./test_honest_validator,
+  ./test_interop
 
 import # Refactor state transition unit tests
   # TODO re-enable when useful

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -88,6 +88,7 @@ const
 const IgnoreKeys = [
   # Ignore all non-numeric types
   "DEPOSIT_CONTRACT_ADDRESS",
+  "GENESIS_FORK_VERSION",
   "SHARD_BLOCK_OFFSETS"
 ]
 

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -3,11 +3,7 @@
 import
   unittest, stint, blscurve, ./testutil, stew/byteutils,
   ../beacon_chain/[extras, interop, ssz],
-  ../beacon_chain/spec/[beaconstate, crypto, helpers, datatypes]
-
-# TODO: BLS changes in v0.10.1 will generate different interop signatures
-#       Requires an update of the interop mocked start
-#       or of ZRNT / ZCLI to v0.10.1
+  ../beacon_chain/spec/[beaconstate, crypto, datatypes]
 
 # Interop test yaml, found here:
 # https://github.com/ethereum/eth2.0-pm/blob/a0b9d22fad424574b1307828f867b30237758468/interop/mocked_start/keygen_10_validators.yaml
@@ -35,87 +31,89 @@ type DepositConfig = object
 #   - https://github.com/status-im/eth2.0-specs/blob/c58096754b62389b0ea75dbdd717d362691b7c34/test_libs/pyspec/mockup_genesis.py
 #   - "zcli genesis mock" https://github.com/protolambda/zcli
 
+func fromHex(T: type[ValidatorSig], hex: string): T = result.fromhex(hex)
+
 let depositsConfig = [
   DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866"),
+    privkey: ValidatorPrivKey.init("0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866"),
     signing_root: hexToByteArray[32]("139b510ea7f2788ab82da1f427d6cbe1db147c15a053db738ad5500cd83754a6"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"8684b7f46d25cdd6f937acdaa54bdd2fb34c78d687dca93884ba79e60ebb0df964faa4c49f3469fb882a50c7726985ff0b20c9584cc1ded7c90467422674a05177b2019661f78a5c5c56f67d586f04fd37f555b4876a910bedff830c2bece0aa"
+    sig: ValidatorSig.fromHex"b796b670fa7eb04b4422bb0872b016895a6adffb1ebd1023db41452701ad65d6fa53d84f3b62e8753bf55230364c6aa318620b574528506ad78517f70c688b82d1c9ad0b12633e0fa5792cf58c21cee9ad25f74156eebd0b6dcd548b91db860f"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x51d0b65185db6989ab0b560d6deed19c7ead0e24b9b6372cbecb1f26bdfad000"),
+    privkey: ValidatorPrivKey.init("0x51d0b65185db6989ab0b560d6deed19c7ead0e24b9b6372cbecb1f26bdfad000"),
     signing_root: hexToByteArray[32]("bb4b6184b25873cdf430df3838c8d3e3d16cf3dc3b214e2f3ab7df9e6d5a9b52"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"a2c86c4f654a2a229a287aabc8c63f224d9fb8e1d77d4a13276a87a80c8b75aa7c55826febe4bae6c826aeeccaa82f370517db4f0d5eed5fbc06a3846088871696b3c32ff3fdebdb52355d1eede85bcd71aaa2c00d6cf088a647332edc21e4f3"
+    sig: ValidatorSig.fromHex"98c4c6a7e12a2b4aeaa23a7d6ae4d2acabc8193d1c1cb53fabcb107ebcbd9c04189c4278995c62883507926712133d941677bd15407eefa49ea6c1cb97f4f7ee4efc3fe0bfa80e3efc3c6b48646b06e6bb845c4e0e7f21df58ef67147f0da7ea"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x315ed405fafe339603932eebe8dbfd650ce5dafa561f6928664c75db85f97857"),
+    privkey: ValidatorPrivKey.init("0x315ed405fafe339603932eebe8dbfd650ce5dafa561f6928664c75db85f97857"),
     signing_root: hexToByteArray[32]("c6ddd74b1b45db17a864c87dd941cb6c6e16540c534cdbe1cc0d43e9a5d87f7c"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"a5a463d036e9ccb19757b2ddb1e6564a00463aed1ef51bf69264a14b6bfcff93eb6f63664e0df0b5c9e6760c560cb58d135265cecbf360a23641af627bcb17cf6c0541768d3f3b61e27f7c44f21b02cd09b52443405b12fb541f5762cd615d6e"
+    sig: ValidatorSig.fromHex"8e6163059668ff2db1c8d430a1b0f9aeb330e8eaf680ed9709aaff5d437a54fb0144f2703cbb1e2a4a67c505b534718d0450d99203cccaf18e442bddd27e93ebfa289e6ce30a92e7befb656f12a01cb0204ffd14eed39ae457b7fad22faf8eab"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x25b1166a43c109cb330af8945d364722757c65ed2bfed5444b5a2f057f82d391"),
+    privkey: ValidatorPrivKey.init("0x25b1166a43c109cb330af8945d364722757c65ed2bfed5444b5a2f057f82d391"),
     signing_root: hexToByteArray[32]("9397cd33d4e8883dbdc1a1d7df410aa2b627740d11c5574697a2d483a50ab7bb"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"8731c258353c8aa46a8e38509eecfdc32018429239d9acad9b634a4d010ca51395828c0c056808c6e6df373fef7e9a570b3d648ec455d90f497e12fc3011148eded7265b0f995de72e5982db1dbb6eca8275fc99cdd10704b8cf19ec0bb9c350"
+    sig: ValidatorSig.fromHex"b389e7b4db5caccad6b0b32394b1e77a814e519f4d0789a1e4bb20e2f7f68d7787fe5f065181eeab72d31d847ae96abc0512466689eafbee0439ab7229fb14272654815f535759467e012d9ab7db6e3b3e86d9f73742c46993c755d1f2893684"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x3f5615898238c4c4f906b507ee917e9ea1bb69b93f1dbd11a34d229c3b06784b"),
+    privkey: ValidatorPrivKey.init("0x3f5615898238c4c4f906b507ee917e9ea1bb69b93f1dbd11a34d229c3b06784b"),
     signing_root: hexToByteArray[32]("27340cc0f3b76bcc89c78e67166c13a58c97c232889391d1387fc404c4f5255e"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"90b20f054f6a2823d66e159050915335e7a4f64bf7ac449ef83bb1d1ba9a6b2385da977b5ba295ea2d019ee3a8140607079d671352ab233b3bf6be45c61dce5b443f23716d64382e34d7676ae64eedd01babeeb8bfd26386371f6bc01f1d4539"
+    sig: ValidatorSig.fromHex"aeb410612b19c3176fa087fab3e56e278a01cf5ba5379aa7f4e7344dbfa9e3b3f91b6f39af463ce2e448787b0a77ee1a05f22c0d9afd2f0f6137232c432f83c26389c07a8348364ab8a745eda59ecf2aa65fa8eb3f18eacd10e5a8a2e71b1e06"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x055794614bc85ed5436c1f5cab586aab6ca84835788621091f4f3b813761e7a8"),
+    privkey: ValidatorPrivKey.init("0x055794614bc85ed5436c1f5cab586aab6ca84835788621091f4f3b813761e7a8"),
     signing_root: hexToByteArray[32]("b8cf48542d8531ae59b56e175228e7fcb82415649b5e992e132d3234b31dda2f"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"99df72b850141c67fc956a5ba91abb5a091538d963aa6c082e1ea30b7f7e5a54ec0ff79c749342d4635e4901e8dfc9b90604d5466ff2a7b028c53d4dac01ffb3ac0555abd3f52d35aa1ece7e8e9cce273416b3cf582a5f2190e87a3b15641f0c"
+    sig: ValidatorSig.fromHex"b501a41ca61665dddbe248d2fa15e5498cb2b38dcf2093acd5768efeda1b0ac963e600d8e38c2c91964d8bf72fd197c71824c1d493272caf6140828f7f6b266281f044b4811bbd7ef0f57953b15399b4ef17af5b9c80df5c142600cf17bfee64"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x1023c68852075965e0f7352dee3f76a84a83e7582c181c10179936c6d6348893"),
+    privkey: ValidatorPrivKey.init("0x1023c68852075965e0f7352dee3f76a84a83e7582c181c10179936c6d6348893"),
     signing_root: hexToByteArray[32]("5f919d91faecece67422edf573a507fc5f9720f4e37063cceb40aa3b371f1aa9"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"a4023f36f4f354f69b615b3651596d4b479f005b04f80ef878aaeb342e94ad6f9acddf237309a79247d560b05f4f7139048b5eee0f08da3a11f3ee148ca76e3e1351a733250515a61e12027468cff2de193ab8ee5cd90bdd1c50e529edda512b"
+    sig: ValidatorSig.fromHex"8f2e2de3c0504cc4d424de1593d508d7488bfc54f61882922b754e97e4faeebe4f24f19184f0630dc51327bc9ab26dd2073d55687f7284ab3395b770d7c4d35bb6e719e6881739e2f4f61e29e11c3b9e61529c202e30f5f5957544eeb0a9626e"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x3a941600dc41e5d20e818473b817a28507c23cdfdb4b659c15461ee5c71e41f5"),
+    privkey: ValidatorPrivKey.init("0x3a941600dc41e5d20e818473b817a28507c23cdfdb4b659c15461ee5c71e41f5"),
     signing_root: hexToByteArray[32]("d2ff8bfda7e7bcc64c636a4855d2a1eccb7f47379f526a753fd934ae37ba9ec7"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"81c52ada6d975a5b968509ab16fa58d617dd36a6c333e6ed86a7977030e4c5d37a488596c6776c2cdf4831ea7337ad7902020092f60e547714449253a947277681ff80b7bf641ca782214fc9ec9b58c66ab43c0a554c133073c96ad35edff101"
+    sig: ValidatorSig.fromHex"90a83842b6d215f1da3ebf3eeea6c4bff0682ee3f7aa9d06bb818c716cfdb5cd577f997ddd606c908f7a68157f36ff660a0e73265f17cccbd23be5ed053b3812672ba52bce6ec034fadea3b78f46a9c6da88db6327a18a9bb3a7f2747185fc6f"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x066e3bdc0415530e5c7fed6382d5c822c192b620203cf669903e1810a8c67d06"),
+    privkey: ValidatorPrivKey.init("0x066e3bdc0415530e5c7fed6382d5c822c192b620203cf669903e1810a8c67d06"),
     signing_root: hexToByteArray[32]("1e19687d32785632ddc9b6b319690ea45c0ea20d7bc8aacbd33f6ebbe30816e1"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"b4aab8f6624f61f4f5eb6d75839919a3ef6b4e1b19cae6ef063d6281b60ff1d5efe02bcbfc4b9eb1038c42e0a3325d8a0fcf7b64ff3cd9df5c629b864dfdc5b763283254ccd6cfa28cff53e477fb1743440a18d76a776ec4d66c5f50d695ca85"
+    sig: ValidatorSig.fromHex"a232a8bb03ecd356cf0e18644077880afe7ecfc565c8627841797deb4dfce8366cc0d0f6e151b51c0acc05a66f1363d204e8133e772dfb4878c11f7bf14b8293ce734c37adca9c32cc2987f0bc34242cc30f139d86c44f8d4383af743be3d1ae"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x2b3b88a041168a1c4cd04bdd8de7964fd35238f95442dc678514f9dadb81ec34"),
+    privkey: ValidatorPrivKey.init("0x2b3b88a041168a1c4cd04bdd8de7964fd35238f95442dc678514f9dadb81ec34"),
     signing_root: hexToByteArray[32]("64a910a0a3e7da9a7a29ee2c92859314a160040ffb2042641fc56cba75b78012"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"9603f7dcab6822edb92eb588f1e15fcc685ceb8bcc7257adb0e4a5995820b8ef77215650792120aff871f30a52475ea31212aa741a3f0e6b2dbcb3a63181571306a411c772a7fd08826ddeab98d1c47b5ead82f8e063b9d7f1f217808ee4fb50"
+    sig: ValidatorSig.fromHex"8e0ccf7dd9dd00820a695161ea865220489ca48504012b7c36c85b3effb896a02ee9714a5e383f7105357a24f791562c1353e331d2cfa048cb94fd4fe42a008b18c5bdec6fcf7c8b75c5f5e582cd9571b308e8b1757d672fbb9092725985a716"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x2e62dbea7fe3127c3b236a92795dd633be51ee7cdfe5424882a2f355df497117"),
+    privkey: ValidatorPrivKey.init("0x2e62dbea7fe3127c3b236a92795dd633be51ee7cdfe5424882a2f355df497117"),
     signing_root: hexToByteArray[32]("5bf0c7a39df536b3c8a5dc550f0163af0b33a56b9454b5240cea9ad8356c4117"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"92b04a4128e84b827b46fd91611acc46f97826d13fbdcbf000b6b3585edd8629e38d4c13f7f3fde5a1170f4f3f55bef21883498602396c875275cb2c795d4488383b1e931fefe813296beea823c228af9e0d97e65742d380a0bbd6f370a89b23"
+    sig: ValidatorSig.fromHex"a07adeeb639a974fe3ae78a0a28785b195bffeaa2ec558c6baa63458daaf5b7a245940a2d9b91a993515295075eba4e115c6777eda1e7933cb53f64ab36619e49faadf289a8cc1521ca3ae5f9a3f2b88e355ef0b75dd8a9949c9d2a43c5589e0"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x2042dc809c130e91906c9cb0be2fec0d6afaa8f22635efc7a3c2dbf833c1851a"),
+    privkey: ValidatorPrivKey.init("0x2042dc809c130e91906c9cb0be2fec0d6afaa8f22635efc7a3c2dbf833c1851a"),
     signing_root: hexToByteArray[32]("e8a45fa71addd854d8d78e0b2cdc8f9100c8a5e03d894c1c382068e8aa4b71e2"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"89ac6297195e768b5e88cbbb047d8b81c77550c9462df5750f4b899fc0de985fa9e16fccc6c6bd71124eb7806064b7110d534fb8f6ccaf118074cd4f4fac8a22442e8facc2cd380ddc4ebf6b9c2f7e956f418279dc04a6737ede6d7763396ed9"
+    sig: ValidatorSig.fromHex"95719c0c4dae737aac602aeadf9faeb9ad3492450af249c43a1147a6e471ddb3f2b5979b6587e843d20c9caa8ecd83e8001b57a4f7c302927725966acc959eb6668357831b7a0692f2396a18939d9fa974e611beed4a7a59ffe892e77d2680bd"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x15283c540041cd85c4533ee47517c8bb101c6207e9acbba2935287405a78502c"),
+    privkey: ValidatorPrivKey.init("0x15283c540041cd85c4533ee47517c8bb101c6207e9acbba2935287405a78502c"),
     signing_root: hexToByteArray[32]("3dfab0daa3be9c72c5dd3b383e756d6048bb76cd3d09abb4dc991211ae8a547b"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"8adee09a19ca26d5753b9aa447b0af188a769f061d11bf40b32937ad3fa142ca9bc164323631a4bb78f0a5d4fd1262010134adc723ab377a2e6e362d3e2130a46b0a2088517aee519a424147f043cc5007a13f2d2d5311c18ee2f694ca3f19fc"
+    sig: ValidatorSig.fromHex"b8221ad674d7c23378b488555eb6e06ce56a342dad84ba6e3a57e108c1c426161b568a9366d82fd0059a23621922a1fc0e59d8eaa66dbb4611a173be167731367edf8daad3b07b64207faf3ea457a335228def3ca61571c4edc15dc392bf4e56"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x03c85e538e1bb30235a87a3758c5571753ca1308b7dee321b74c19f78423999b"),
+    privkey: ValidatorPrivKey.init("0x03c85e538e1bb30235a87a3758c5571753ca1308b7dee321b74c19f78423999b"),
     signing_root: hexToByteArray[32]("8905ae60c419e38f263eb818a5536e4144df3c0a800132e07594d457c62b5825"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"90dc90a295644da5c6d441cd0b33e34b8f1f77230755fd78b9ecbd86fd6e845e554c0579ab88c76ca14b56d9f0749f310cd884c193ec69623ccd724469268574c985ee614e80f00331c24f78a3638576d304c67c2aa6ce8949652257581c18a5"
+    sig: ValidatorSig.fromHex"a5e61349958745c80862af84e06924748832cae379b02a50909468fef9f07f21d35a98e1287b6219528a1ad566567d0619e049efa9fa6e81410bb3a247cf53b0f6787f747f8229fb9f851290b140f14f14a2adcb23b7cafaf90b301d14169324"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x45a577d5cab31ac5cfff381500e09655f0799f29b130e6ad61c1eec4b15bf8dd"),
+    privkey: ValidatorPrivKey.init("0x45a577d5cab31ac5cfff381500e09655f0799f29b130e6ad61c1eec4b15bf8dd"),
     signing_root: hexToByteArray[32]("702d1bd9c27c999923149f6c6578c835943b58b90845086bbf5be3b94aa4663d"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"9338c8b0050cdb464efae738d6d89ac48d5839ce750e3f1f20acd52a0b61e5c033fa186d3ed0ddf5856af6c4815971b00a68002b1eba45f5af27f91cad04831e32157fecf5fb091a8087829e2d3dd3438e0b86ff8d036be4a3876fa0dfa60e6c"
+    sig: ValidatorSig.fromHex"893d8e70f2cdb6f7acc3d9828e72d7b20e512956588d8c068b3ef4aa649db369cf962506b7c9107246246d9b20361cd80250109da513809415314af3ef1f220c171dbc2d9c2b62056739703ae4eb1be13fa289ea8472920b2393041f69198dc5"
   ), DepositConfig(
-    privkey: ValidatorPrivKey.init(hexToSeqByte"0x03cffafa1cbaa7e585eaee07a9d35ae57f6dfe19a9ea53af9c37e9f3dfac617c"),
+    privkey: ValidatorPrivKey.init("0x03cffafa1cbaa7e585eaee07a9d35ae57f6dfe19a9ea53af9c37e9f3dfac617c"),
     signing_root: hexToByteArray[32]("77f3da02c410e9ccba39d89983c52e6e77ca5dec3ae423311a578ee28b2ec0cd"),
     domain: DOMAIN_DEPOSIT,
-    sig: ValidatorSig.fromHex"8819f719f7af378f27fe65c699b5206f1f7bbfd62200cab09e7ffe3d8fce0346eaa84b274d66d700cd1a0c0c7b46f62100afb2601270292ddf6a2bddff0248bb8ed6085d10c8c9e691a24b15d74bc7a9fcf931d953300d133f8c0e772704b9ba"
+    sig: ValidatorSig.fromHex"87ae1567999d3ceefce04c1a48aa189c3d368efbeda53c01962783941c03d3a26e08e5e9d287a927decf4e77755b97e80856e339c3af41dc5ffd373c6e4768de62718ce76cfd8c2062e7673c9eedd2fec235467967f932e59e0b3a32040c0038"
   )
 ]
 
@@ -128,14 +126,13 @@ suiteReport "Interop":
 
       check:
         # getBytes is bigendian and returns full 48 bytes of key..
-        Uint256.fromBytesBE(key.getBytes()[48-32..<48]) == v
+        Uint256.fromBytesBE(key.exportRaw()[48-32..<48]) == v
 
   timedTest "Interop signatures":
     for dep in depositsConfig:
       let computed_sig = bls_sign(
-        key = dep.privkey,
-        msg = dep.signing_root,
-        domain = compute_domain(dep.domain)
+        privkey = dep.privkey,
+        message = dep.signing_root
       )
 
       check:
@@ -152,20 +149,21 @@ suiteReport "Interop":
         privKey = makeInteropPrivKey(i)
       deposits.add(makeDeposit(privKey.pubKey(), privKey))
 
+    const genesis_time = 1570500000
     var
       # TODO this currently requires skipMerkleValidation to pass the test
       # makeDeposit doesn't appear to produce a proof?
       initialState = initialize_beacon_state_from_eth1(
-        eth1BlockHash, 1570500000, deposits, {skipMerkleValidation})
+        eth1BlockHash, genesis_time, deposits, {skipMerkleValidation})
 
     # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state
-    initialState.genesis_time = 1570500000
+    initialState.genesis_time = genesis_time
 
     let expected =
       when const_preset == "minimal":
-        "5a3bbcae4ab2b4eafded947689fd7bd8214a616ffffd2521befdfe2a3b2f74c0"
+        "410c8758710155b49208d52c9e4bd2f11aa16a7c7521e560a2d05dcd69a023b3"
       elif const_preset == "mainnet":
-        "db0a887acd5e201ac579d6cdc0c4932f2a0adf342d84dc5cd11ce959fbce3760"
+        "95a0b1e7b0b77d0cbe2bcd12c90469e68edb141424b1a6126f1d55498afe3ae6"
       else:
         "unimplemented"
     check:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -43,7 +43,7 @@ func makeDeposit(i: int, flags: UpdateFlags): Deposit =
     privkey = makeFakeValidatorPrivKey(i)
     pubkey = privkey.pubKey()
     withdrawal_credentials = makeFakeHash(i)
-    domain = compute_domain(DOMAIN_DEPOSIT)
+    domain = compute_domain(DOMAIN_DEPOSIT, GENESIS_FORK_VERSION)
 
   result = Deposit(
     data: DepositData(


### PR DESCRIPTION
There were basically three distinct tasks involved here, along with the basic restoration of `test_interop`.

- use `GENESIS_FORK_VERSION` properly in BeaconState init
- use `GENESIS_FORK_VERSION` to be compatible with zcli/zrnt initial eth1 deposits
- let `List[foo]` work with 64-bit ints, so `BeaconState.validators` SSZ-serializes properly; this doesn't actually fix the `int` limitation on `seq`, just ensures that the correct number of Merkle tree merges with zero hashes on the right-branch occurs
- update `test_interop` to use new spec/crypto API

`GENESIS_FORK_VERSION` showing up as failing in the constants sanity check is fine -- it's an artifact of:
```
const IgnoreKeys = [
  # Ignore all non-numeric types
  "DEPOSIT_CONTRACT_ADDRESS",
  "GENESIS_FORK_VERSION",
  "SHARD_BLOCK_OFFSETS"
]
```
As it's specified as an array, not a number (also better for endianness-portability). The `.md` files record that as a failure, but it's more correctly thought of as skipped.