### PR TITLE
[Ready 1/2] Fork choice rewrite

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -46,6 +46,14 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Multiaddress to ENode                                                                      OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## Fork Choice + Finality  [Preset: mainnet]
+```diff
++ fork_choice - testing finality #01                                                         OK
++ fork_choice - testing finality #02                                                         OK
++ fork_choice - testing no votes                                                             OK
++ fork_choice - testing with votes                                                           OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Honest validator
 ```diff
 + Attestation topics                                                                         OK
@@ -234,4 +242,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 145/148 Fail: 3/148 Skip: 0/148
+OK: 149/152 Fail: 3/152 Skip: 0/152

--- a/AllTests-minimal.md
+++ b/AllTests-minimal.md
@@ -73,6 +73,14 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Multiaddress to ENode                                                                      OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## Fork Choice + Finality  [Preset: minimal]
+```diff
++ fork_choice - testing finality #01                                                         OK
++ fork_choice - testing finality #02                                                         OK
++ fork_choice - testing no votes                                                             OK
++ fork_choice - testing with votes                                                           OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Honest validator
 ```diff
 + Attestation topics                                                                         OK
@@ -261,4 +269,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 160/163 Fail: 3/163 Skip: 0/163
+OK: 164/167 Fail: 3/167 Skip: 0/167

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -52,8 +52,12 @@ task test, "Run all tests":
   # price we pay for that.
 
   # Minimal config
+  buildBinary "proto_array", "beacon_chain/fork_choice/", "-d:const_preset=minimal"
+  buildBinary "fork_choice", "beacon_chain/fork_choice/", "-d:const_preset=minimal"
   buildBinary "all_tests", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=minimal"
   # Mainnet config
+  buildBinary "proto_array", "beacon_chain/fork_choice/", "-d:const_preset=mainnet"
+  buildBinary "fork_choice", "beacon_chain/fork_choice/", "-d:const_preset=mainnet"
   buildBinary "all_tests", "tests/", "-d:const_preset=mainnet"
 
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
@@ -69,4 +73,3 @@ task test, "Run all tests":
   # State sim; getting into 4th epoch useful to trigger consensus checks
   buildBinary "state_sim", "research/", "", "--validators=1024 --slots=32"
   buildBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=1024 --slots=128"
-

--- a/beacon_chain/fork_choice/README.md
+++ b/beacon_chain/fork_choice/README.md
@@ -1,0 +1,5 @@
+# Fork choice implementations
+
+References:
+- https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md
+- https://github.com/protolambda/lmd-ghost

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -1,0 +1,576 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/tables, std/options, std/typetraits,
+  # Status libraries
+  nimcrypto/hash, stew/result,
+  # Internal
+  ../spec/[datatypes, digest],
+  # Fork choice
+  ./fork_choice_types, ./proto_array
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md
+# This is a port of https://github.com/sigp/lighthouse/pull/804
+# which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost
+#
+# See also the port of the port: https://github.com/protolambda/eth2-py-hacks/blob/ec9395d371903d855e1488d04b8fe89fd5be0ad9/proto_array.py
+
+const DefaultPruneThreshold = 256
+
+# Forward declarations
+# ----------------------------------------------------------------------
+
+func compute_deltas(
+       deltas: var openarray[Delta],
+       indices: Table[Eth2Digest, Index],
+       votes: var openArray[VoteTracker],
+       old_balances: openarray[Gwei],
+       new_balances: openarray[Gwei]
+     ): ForkChoiceError {.raises: [KeyError].}
+
+# Fork choice routines
+# ----------------------------------------------------------------------
+
+func initForkChoice(
+       finalized_block_slot: Slot,
+       finalized_block_state_root: Eth2Digest,
+       justified_epoch: Epoch,
+       finalized_epoch: Epoch,
+       finalized_root: Eth2Digest
+     ): Result[ForkChoice, string] {.raises: [KeyError].} =
+  ## Initialize a fork choice context
+  var proto_array = ProtoArray(
+    prune_threshold: DefaultPruneThreshold,
+    justified_epoch: justified_epoch,
+    finalized_epoch: finalized_epoch
+  )
+
+  let err = proto_array.on_block(
+    finalized_block_slot,
+    finalized_root,
+    none(Eth2Digest),
+    finalized_block_state_root,
+    justified_epoch,
+    finalized_epoch
+  )
+  if err.kind != fcSuccess:
+    result.err("Failed to add finalized block to proto_array: " & $err)
+    return
+  result.ok(ForkChoice(proto_array: proto_array))
+
+
+func extend[T](s: var seq[T], minLen: int) =
+  ## Extend a sequence so that it can contains at least `minLen` elements.
+  ## If it's already bigger, the sequence is unmodified.
+  ## The extension is zero-initialized
+  let curLen = s.len
+  let diff = minLen - curLen
+  if diff > 0:
+    # Note: seq has a length and a capacity.
+    #       If the new length is less than the original capacity
+    #         => setLen will not zeroMem
+    #       If the capacity was too small
+    #         => reallocation occurs
+    #         => the fresh buffer is zeroMem-ed
+    #       In the second case our own zeroMem is redundant
+    #       but this should happen rarely as we reuse the buffer
+    #       most of the time
+    s.setLen(minLen)
+    zeroMem(s[minLen].addr, diff * sizeof(T))
+
+
+func process_attestation*(
+       self: var ForkChoice,
+       validator_index: ValidatorIndex,
+       block_root: Eth2Digest,
+       target_epoch: Epoch
+     ): Result[void, string] {.raises: [].} =
+  ## Add an attestation to the fork choice context
+  self.votes.extend(validator_index.int)
+
+  template vote: untyped {.dirty.} = self.votes[validator_index.int]
+    # alias
+
+  if target_epoch > vote.next_epoch or vote == default(VoteTracker):
+    # TODO: the "default" condition is probably unneeded
+    vote.next_root = block_root
+    vote.next_epoch = target_epoch
+
+
+func process_block*(
+       self: var ForkChoice,
+       slot: Slot,
+       block_root: Eth2Digest,
+       parent_root: Eth2Digest,
+       state_root: Eth2Digest,
+       justified_epoch: Epoch,
+       finalized_epoch: Epoch
+     ): Result[void, string] {.raises: [KeyError].} =
+  ## Add a block to the fork choice context
+  let err = self.proto_array.on_block(
+    slot, block_root, some(parent_root), state_root, justified_epoch, finalized_epoch
+  )
+  if err.kind != fcSuccess:
+    result.err("process_block_error: " & $err)
+    return
+  result.ok()
+
+
+func find_head*(
+       self: var ForkChoice,
+       justified_epoch: Epoch,
+       justified_root: Eth2Digest,
+       finalized_epoch: Epoch,
+       justified_state_balances: seq[Gwei]
+     ): Result[Eth2Digest, string] {.raises: [UnpackError, KeyError].} =
+  ## Returns the new blockchain head
+
+  # Compute deltas with previous call
+  #   we might want to reuse the `deltas` buffer across calls
+  var deltas = newSeq[Delta](self.proto_array.indices.len)
+  let delta_err = deltas.compute_deltas(
+    indices = self.proto_array.indices,
+    votes = self.votes,
+    old_balances = self.balances,
+    new_balances = justified_state_balances
+  )
+  if delta_err.kind != fcSuccess:
+    result.err("find_head compute_deltas failed: " & $delta_err)
+    return
+
+  # Apply score changes
+  let score_err = self.proto_array.apply_score_changes(
+    deltas, justified_epoch, finalized_epoch
+  )
+  if score_err.kind != fcSuccess:
+    result.err("find_head apply_score_changes failed: " & $score_err)
+
+  # Find the best block
+  self.balances = justified_state_balances
+  var new_head{.noInit.}: Eth2Digest
+  let ghost_err = self.proto_array.find_head(new_head, justified_root)
+  if ghost_err.kind != fcSuccess:
+    result.err("find_head failed: " & $ghost_err)
+    return
+
+  result.ok(new_head)
+
+
+func maybe_prune*(
+       self: var ForkChoice, finalized_root: Eth2Digest
+     ): Result[void, string] {.raises: [KeyError].} =
+  ## Prune blocks preceding the finalized root as they are now unneeded.
+  let err = self.proto_array.maybe_prune(finalized_root)
+  if err.kind != fcSuccess:
+    result.err("find_head maybe_pruned failed: " & $err)
+
+
+func compute_deltas(
+       deltas: var openarray[Delta],
+       indices: Table[Eth2Digest, Index],
+       votes: var openArray[VoteTracker],
+       old_balances: openarray[Gwei],
+       new_balances: openarray[Gwei]
+     ): ForkChoiceError {.raises: [KeyError].} =
+  ## Update `deltas`
+  ##   between old and new balances
+  ##   between votes
+  ##
+  ## `deltas.len` must match `indices.len` (lenght match)
+  ##
+  ## Error:
+  ## - If a value in indices is greater than `indices.len`
+  ## - If a `Eth2Digest` in `votes` does not exist in `indices`
+  ##   except for the `default(Eth2Digest)` (i.e. zero hash)
+
+  for val_index, vote in votes.mpairs():
+    # No need to create a score change if the validator has never voted
+    # or if votes are for the zero hash (alias to the genesis block)
+    if vote.current_root == default(Eth2Digest) and vote.next_root == default(Eth2Digest):
+      continue
+
+    # If the validator was not included in `old_balances` (i.e. did not exist)
+    # its balance is zero
+    let old_balance = if val_index < old_balances.len: old_balances[val_index]
+                      else: 0
+
+    # If the validator is not known in the `new_balances` then use balance of zero
+    #
+    # It is possible that there is a vote for an unknown validator if we change our
+    # justified state to a new state with a higher epoch on a different fork
+    # because that fork may have on-boarded less validators than the previous fork.
+    #
+    # Note that attesters are not different as they are activated only under finality
+    let new_balance = if val_index < new_balances.len: new_balances[val_index]
+                      else: 0
+
+    if vote.current_root != vote.next_root or old_balance != new_balance:
+      # Ignore the current or next vote if it is not known in `indices`.
+      # We assume that it is outside of our tree (i.e., pre-finalization) and therefore not interesting.
+      if vote.current_root in indices:
+        let index = indices[vote.current_root]
+        if index >= deltas.len:
+          return ForkChoiceError(
+            kind: fcErrInvalidNodeDelta,
+            index: index
+          )
+        deltas[index] -= Delta old_balance
+          # Note that delta can be negative
+          # TODO: is int64 big enough?
+
+      if vote.next_root in indices:
+        let index = indices[vote.next_root]
+        if index >= deltas.len:
+          return ForkChoiceError(
+            kind: fcErrInvalidNodeDelta,
+            index: index
+          )
+        deltas[index] += Delta new_balance
+          # Note that delta can be negative
+          # TODO: is int64 big enough?
+
+      vote.current_root = vote.next_root
+
+    # debugEcho "deltas(", vote.next_root, ") = ", if vote.next_root in indices: $deltas[indices[vote.next_root]]
+    #                                              else: "nil"
+
+  return ForkChoiceSuccess
+
+# Sanity checks
+# ----------------------------------------------------------------------
+# Sanity checks on internal private procedures
+
+when isMainModule:
+  import nimcrypto/[sha2, utils]
+
+  func eth2hash(index: int): Eth2Digest =
+    sha256.digest(cast[array[sizeof(int), byte]](index))
+
+  proc tZeroHash() =
+    echo "    fork_choice compute_deltas - test zero votes"
+
+    const validator_count = 16
+    var deltas = newSeqUninitialized[Delta](validator_count)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+    var old_balances: seq[Gwei]
+    var new_balances: seq[Gwei]
+
+    for i in 0 ..< validator_count:
+      indices.add eth2hash(i), i
+      votes.add default(VoteTracker)
+      old_balances.add 0
+      new_balances.add 0
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    doAssert deltas == newSeq[Delta](validator_count), "deltas should be zeros"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tAll_voted_the_same() =
+    echo "    fork_choice compute_deltas - test all same votes"
+
+    const
+      Balance = Gwei(42)
+      validator_count = 16
+    var deltas = newSeqUninitialized[Delta](validator_count)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+    var old_balances: seq[Gwei]
+    var new_balances: seq[Gwei]
+
+    for i in 0 ..< validator_count:
+      indices.add eth2hash(i), i
+      votes.add VoteTracker(
+        current_root: default(Eth2Digest),
+        next_root: eth2hash(0), # Get a non-zero hash
+        next_epoch: Epoch(0)
+      )
+      old_balances.add Balance
+      new_balances.add Balance
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    for i, delta in deltas.pairs:
+      if i == 0:
+        doAssert delta == Delta(Balance * validator_count), "The 0th root should have a delta"
+      else:
+        doAssert delta == 0, "The non-0 indexes should have a zero delta"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tDifferent_votes() =
+    echo "    fork_choice compute_deltas - test all different votes"
+
+    const
+      Balance = Gwei(42)
+      validator_count = 16
+    var deltas = newSeqUninitialized[Delta](validator_count)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+    var old_balances: seq[Gwei]
+    var new_balances: seq[Gwei]
+
+    for i in 0 ..< validator_count:
+      indices.add eth2hash(i), i
+      votes.add VoteTracker(
+        current_root: default(Eth2Digest),
+        next_root: eth2hash(i), # Each vote for a different root
+        next_epoch: Epoch(0)
+      )
+      old_balances.add Balance
+      new_balances.add Balance
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    for i, delta in deltas.pairs:
+      doAssert delta == Delta(Balance), "Each root should have a delta"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tMoving_votes() =
+    echo "    fork_choice compute_deltas - test moving votes"
+
+    const
+      Balance = Gwei(42)
+      validator_count = 16
+      TotalDeltas = Delta(Balance * validator_count)
+    var deltas = newSeqUninitialized[Delta](validator_count)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+    var old_balances: seq[Gwei]
+    var new_balances: seq[Gwei]
+
+    for i in 0 ..< validator_count:
+      indices.add eth2hash(i), i
+      votes.add VoteTracker(
+        # Move vote from root 0 to root 1
+        current_root: eth2hash(0),
+        next_root: eth2hash(1),
+        next_epoch: Epoch(0)
+      )
+      old_balances.add Balance
+      new_balances.add Balance
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    for i, delta in deltas.pairs:
+      if i == 0:
+        doAssert delta == -TotalDeltas, "0th root should have a negative delta"
+      elif i == 1:
+        doAssert delta == TotalDeltas, "1st root should have a positive delta"
+      else:
+        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tMove_out_of_tree() =
+    echo "    fork_choice compute_deltas - test votes for unknown subtree"
+
+    const Balance = Gwei(42)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+
+    # Add a block
+    indices.add eth2hash(1), 0
+
+    # 2 validators
+    var deltas = newSeqUninitialized[Delta](2)
+    let old_balances = @[Balance, Balance]
+    let new_balances = @[Balance, Balance]
+
+    # One validator moves their vote from the block to the zero hash
+    votes.add VoteTracker(
+      current_root: eth2hash(1),
+      next_root: default(Eth2Digest),
+      next_epoch: Epoch(0)
+    )
+
+    # One validator moves their vote from the block to something outside of the tree
+    votes.add VoteTracker(
+      current_root: eth2hash(1),
+      next_root: eth2hash(1337),
+      next_epoch: Epoch(0)
+    )
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    doAssert deltas[0] == -Delta(Balance)*2, "The 0th block should have lost both balances."
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tChanging_balances() =
+    echo "    fork_choice compute_deltas - test changing balances"
+
+    const
+      OldBalance = Gwei(42)
+      NewBalance = OldBalance * 2
+      validator_count = 16
+      TotalOldDeltas = Delta(OldBalance * validator_count)
+      TotalNewDeltas = Delta(NewBalance * validator_count)
+    var deltas = newSeqUninitialized[Delta](validator_count)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+    var old_balances: seq[Gwei]
+    var new_balances: seq[Gwei]
+
+    for i in 0 ..< validator_count:
+      indices.add eth2hash(i), i
+      votes.add VoteTracker(
+        # Move vote from root 0 to root 1
+        current_root: eth2hash(0),
+        next_root: eth2hash(1),
+        next_epoch: Epoch(0)
+      )
+      old_balances.add OldBalance
+      new_balances.add NewBalance
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    for i, delta in deltas.pairs:
+      if i == 0:
+        doAssert delta == -TotalOldDeltas, "0th root should have a negative delta"
+      elif i == 1:
+        doAssert delta == TotalNewDeltas, "1st root should have a positive delta"
+      else:
+        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tValidator_appears() =
+    echo "    fork_choice compute_deltas - test validator appears"
+
+    const Balance = Gwei(42)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+
+    # Add 2 blocks
+    indices.add eth2hash(1), 0
+    indices.add eth2hash(2), 1
+
+    # 1 validator at the start, 2 at the end
+    var deltas = newSeqUninitialized[Delta](2)
+    let old_balances = @[Balance]
+    let new_balances = @[Balance, Balance]
+
+    # Both moves vote from Block 1 to 2
+    for _ in 0 ..< 2:
+      votes.add VoteTracker(
+        current_root: eth2hash(1),
+        next_root: eth2hash(2),
+        next_epoch: Epoch(0)
+      )
+
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    doAssert deltas[0] == -Delta(Balance), "Block 1 should have lost only 1 balance"
+    doAssert deltas[1] == Delta(Balance)*2, "Block 2 should have gained 2 balances"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  proc tValidator_disappears() =
+    echo "    fork_choice compute_deltas - test validator disappears"
+
+    const Balance = Gwei(42)
+
+    var indices: Table[Eth2Digest, Index]
+    var votes: seq[VoteTracker]
+
+    # Add 2 blocks
+    indices.add eth2hash(1), 0
+    indices.add eth2hash(2), 1
+
+    # 1 validator at the start, 2 at the end
+    var deltas = newSeqUninitialized[Delta](2)
+    let old_balances = @[Balance, Balance]
+    let new_balances = @[Balance]
+
+    # Both moves vote from Block 1 to 2
+    for _ in 0 ..< 2:
+      votes.add VoteTracker(
+        current_root: eth2hash(1),
+        next_root: eth2hash(2),
+        next_epoch: Epoch(0)
+      )
+
+
+    let err = deltas.compute_deltas(
+      indices, votes, old_balances, new_balances
+    )
+
+    doAssert err.kind == fcSuccess, "compute_deltas finished with error: " & $err
+
+    doAssert deltas[0] == -Delta(Balance)*2, "Block 1 should have lost 2 balances"
+    doAssert deltas[1] == Delta(Balance), "Block 2 should have gained 1 balance"
+
+    for vote in votes:
+      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
+
+
+  # ----------------------------------------------------------------------
+
+  echo "fork_choice internal tests for compute_deltas"
+  tZeroHash()
+  tAll_voted_the_same()
+  tDifferent_votes()
+  tMoving_votes()
+  tChanging_balances()
+  tValidator_appears()
+  tValidator_disappears()

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -9,7 +9,7 @@ import
   # Standard library
   std/tables, std/options, std/typetraits,
   # Status libraries
-  stew/result,
+  stew/results,
   # Internal
   ../spec/[datatypes, digest],
   # Fork choice

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -251,7 +251,6 @@ func compute_deltas(
 when isMainModule:
   import stew/endians2
 
-  # TODO: Note - we don't want to import nimcrypto/hash as the `==` is buggy at the moment.
   func fakeHash*(index: SomeInteger): Eth2Digest =
     ## Create fake hashes
     ## Those are just the value serialized in big-endian

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -35,6 +35,8 @@ func compute_deltas(
        old_balances: openarray[Gwei],
        new_balances: openarray[Gwei]
      ): ForkChoiceError {.raises: [].}
+# TODO: raises [Defect] - once https://github.com/nim-lang/Nim/issues/12862 is fixed
+#       https://github.com/status-im/nim-beacon-chain/pull/865#pullrequestreview-389117232
 
 # Fork choice routines
 # ----------------------------------------------------------------------
@@ -95,7 +97,7 @@ func process_attestation*(
        validator_index: ValidatorIndex,
        block_root: Eth2Digest,
        target_epoch: Epoch
-     ): Result[void, string] {.raises: [].} =
+     ) =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 
@@ -106,7 +108,7 @@ func process_attestation*(
     # TODO: the "default" condition is probably unneeded
     vote.next_root = block_root
     vote.next_epoch = target_epoch
-  ok()
+
 
 func process_block*(
        self: var ForkChoice,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -82,7 +82,7 @@ func extend[T](s: var seq[T], minLen: int) =
     #       but this should happen rarely as we reuse the buffer
     #       most of the time
     s.setLen(minLen)
-    zeroMem(s[minLen].addr, diff * sizeof(T))
+    zeroMem(s[curLen].addr, diff * sizeof(T))
 
 
 func process_attestation*(
@@ -92,7 +92,7 @@ func process_attestation*(
        target_epoch: Epoch
      ): Result[void, string] {.raises: [].} =
   ## Add an attestation to the fork choice context
-  self.votes.extend(validator_index.int)
+  self.votes.extend(validator_index.int + 1)
 
   template vote: untyped {.dirty.} = self.votes[validator_index.int]
     # alias
@@ -102,6 +102,7 @@ func process_attestation*(
     vote.next_root = block_root
     vote.next_epoch = target_epoch
 
+  result.ok()
 
 func process_block*(
        self: var ForkChoice,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -97,7 +97,7 @@ func process_attestation*(
        validator_index: ValidatorIndex,
        block_root: Eth2Digest,
        target_epoch: Epoch
-     ) =
+     ) {.raises: [].} =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -244,10 +244,16 @@ func compute_deltas(
 # Sanity checks on internal private procedures
 
 when isMainModule:
-  import nimcrypto/[sha2, utils]
+  import stew/endians2
 
-  func fakeHash(index: int): Eth2Digest =
-    sha256.digest(cast[array[sizeof(int), byte]](index))
+  # TODO: if the value added is 1 or 16, we error out. Why? Nim table bug with not enough spaced hashes?
+  func fakeHash*(index: SomeInteger): Eth2Digest =
+    ## Create fake hashes
+    ## Those are just the value serialized in big-endian
+    ## We add 16x16 to avoid having a zero hash are those are special cased
+    ## We store them in the first 8 bytes
+    ## as those are the one used in hash tables Table[Eth2Digest, T]
+    result.data[0 ..< 8] = (16*16+index).uint64.toBytesBE()
 
   proc tZeroHash() =
     echo "    fork_choice compute_deltas - test zero votes"

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -573,10 +573,10 @@ when isMainModule:
   # ----------------------------------------------------------------------
 
   echo "fork_choice internal tests for compute_deltas"
-  # tZeroHash()
+  tZeroHash()
   tAll_voted_the_same()
   tDifferent_votes()
   tMoving_votes()
   tChanging_balances()
-  # tValidator_appears()
-  # tValidator_disappears()
+  tValidator_appears()
+  tValidator_disappears()

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -9,7 +9,7 @@ import
   # Standard library
   std/tables, std/options, std/typetraits,
   # Status libraries
-  nimcrypto/hash, stew/result,
+  stew/result,
   # Internal
   ../spec/[datatypes, digest],
   # Fork choice
@@ -145,6 +145,8 @@ func find_head*(
     result.err("find_head compute_deltas failed: " & $delta_err)
     return
 
+  # debugEcho "find_head deltas: ", deltas
+
   # Apply score changes
   let score_err = self.proto_array.apply_score_changes(
     deltas, justified_epoch, finalized_epoch
@@ -189,6 +191,16 @@ func compute_deltas(
   ## - If a value in indices is greater than `indices.len`
   ## - If a `Eth2Digest` in `votes` does not exist in `indices`
   ##   except for the `default(Eth2Digest)` (i.e. zero hash)
+
+  # TODO: Displaying the votes for debugging will cause the tests to fail!!!
+  #       if we do the precise sequence
+  #       - tAll_voted_the_same()
+  #       - tDifferent_votes()
+  #       - tMoving_votes()
+  #       - tChanging_balances()
+  # var openarray bug?
+  #
+  # debugEcho "compute_deltas votes: ", votes
 
   for val_index, vote in votes.mpairs():
     # No need to create a score change if the validator has never voted
@@ -246,7 +258,7 @@ func compute_deltas(
 when isMainModule:
   import stew/endians2
 
-  # TODO: if the value added is 1 or 16, we error out. Why? Nim table bug with not enough spaced hashes?
+  # TODO: Note - we don't want to import nimcrypto/hash as the `==` is buggy at the moment.
   func fakeHash*(index: SomeInteger): Eth2Digest =
     ## Create fake hashes
     ## Those are just the value serialized in big-endian
@@ -570,10 +582,10 @@ when isMainModule:
   # ----------------------------------------------------------------------
 
   echo "fork_choice internal tests for compute_deltas"
-  tZeroHash()
+  # tZeroHash()
   tAll_voted_the_same()
   tDifferent_votes()
   tMoving_votes()
   tChanging_balances()
-  tValidator_appears()
-  tValidator_disappears()
+  # tValidator_appears()
+  # tValidator_disappears()

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -34,7 +34,7 @@ func compute_deltas(
        votes: var openArray[VoteTracker],
        old_balances: openarray[Gwei],
        new_balances: openarray[Gwei]
-     ): ForkChoiceError {.raises: [].}
+     ): ForkChoiceError {.raises: [Defect].}
 # TODO: raises [Defect] - once https://github.com/nim-lang/Nim/issues/12862 is fixed
 #       https://github.com/status-im/nim-beacon-chain/pull/865#pullrequestreview-389117232
 
@@ -51,7 +51,7 @@ func initForkChoice*(
        justified_epoch: Epoch,
        finalized_epoch: Epoch,
        finalized_root: Eth2Digest
-     ): Result[ForkChoice, string] {.raises: [].} =
+     ): Result[ForkChoice, string] {.raises: [Defect].} =
   ## Initialize a fork choice context
   var proto_array = ProtoArray(
     prune_threshold: DefaultPruneThreshold,
@@ -72,7 +72,7 @@ func initForkChoice*(
     return err("Failed to add finalized block to proto_array: " & $err)
   return ok(ForkChoice(proto_array: proto_array))
 
-func extend[T](s: var seq[T], minLen: int) {.raises: [].} =
+func extend[T](s: var seq[T], minLen: int) {.raises: [Defect].} =
   ## Extend a sequence so that it can contains at least `minLen` elements.
   ## If it's already bigger, the sequence is unmodified.
   ## The extension is zero-initialized
@@ -97,7 +97,7 @@ func process_attestation*(
        validator_index: ValidatorIndex,
        block_root: Eth2Digest,
        target_epoch: Epoch
-     ) {.raises: [].} =
+     ) {.raises: [Defect].} =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 
@@ -118,7 +118,7 @@ func process_block*(
        state_root: Eth2Digest,
        justified_epoch: Epoch,
        finalized_epoch: Epoch
-     ): Result[void, string] {.raises: [].} =
+     ): Result[void, string] {.raises: [Defect].} =
   ## Add a block to the fork choice context
   let err = self.proto_array.on_block(
     slot, block_root, some(parent_root), state_root, justified_epoch, finalized_epoch
@@ -134,7 +134,7 @@ func find_head*(
        justified_root: Eth2Digest,
        finalized_epoch: Epoch,
        justified_state_balances: seq[Gwei]
-     ): Result[Eth2Digest, string] {.raises: [].} =
+     ): Result[Eth2Digest, string] {.raises: [Defect].} =
   ## Returns the new blockchain head
 
   # Compute deltas with previous call
@@ -169,7 +169,7 @@ func find_head*(
 
 func maybe_prune*(
        self: var ForkChoice, finalized_root: Eth2Digest
-     ): Result[void, string] {.raises: [].} =
+     ): Result[void, string] {.raises: [Defect].} =
   ## Prune blocks preceding the finalized root as they are now unneeded.
   let err = self.proto_array.maybe_prune(finalized_root)
   if err.kind != fcSuccess:
@@ -182,7 +182,7 @@ func compute_deltas(
        votes: var openArray[VoteTracker],
        old_balances: openarray[Gwei],
        new_balances: openarray[Gwei]
-     ): ForkChoiceError {.raises: [].} =
+     ): ForkChoiceError {.raises: [Defect].} =
   ## Update `deltas`
   ##   between old and new balances
   ##   between votes

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -39,6 +39,10 @@ func compute_deltas(
 # Fork choice routines
 # ----------------------------------------------------------------------
 
+# API:
+# - The private procs uses the ForkChoiceError error code
+# - The public procs use Result
+
 func initForkChoice*(
        finalized_block_slot: Slot,
        finalized_block_state_root: Eth2Digest,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -131,6 +131,8 @@ func find_head*(
        justified_state_balances: seq[Gwei]
      ): Result[Eth2Digest, string] {.raises: [UnpackError, KeyError].} =
   ## Returns the new blockchain head
+  # debugEcho "proto_array: ", self.proto_array
+  # debugEcho "-----------------------\n"
 
   # Compute deltas with previous call
   #   we might want to reuse the `deltas` buffer across calls
@@ -154,8 +156,11 @@ func find_head*(
   if score_err.kind != fcSuccess:
     result.err("find_head apply_score_changes failed: " & $score_err)
 
-  # Find the best block
   self.balances = justified_state_balances
+  # debugEcho "proto_array: ", self.proto_array
+  # debugEcho "-----------------------\n"
+
+  # Find the best block
   var new_head{.noInit.}: Eth2Digest
   let ghost_err = self.proto_array.find_head(new_head, justified_root)
   if ghost_err.kind != fcSuccess:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -172,7 +172,7 @@ func maybe_prune*(
   let err = self.proto_array.maybe_prune(finalized_root)
   if err.kind != fcSuccess:
     result.err("find_head maybe_pruned failed: " & $err)
-
+  result.ok()
 
 func compute_deltas(
        deltas: var openarray[Delta],

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -237,10 +237,6 @@ func compute_deltas(
           # TODO: is int64 big enough?
 
       vote.current_root = vote.next_root
-
-    # debugEcho "deltas(", vote.next_root, ") = ", if vote.next_root in indices: $deltas[indices[vote.next_root]]
-    #                                              else: "nil"
-
   return ForkChoiceSuccess
 
 # Sanity checks

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -197,7 +197,7 @@ func compute_deltas(
   ## - If a `Eth2Digest` in `votes` does not exist in `indices`
   ##   except for the `default(Eth2Digest)` (i.e. zero hash)
 
-  # TODO: Displaying the votes for debugging will cause the tests to fail!!!
+  # TODO: Displaying the votes for debugging will cause the tests in that very file to fail!!!
   #       if we do the precise sequence
   #       - tAll_voted_the_same()
   #       - tDifferent_votes()

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -37,7 +37,7 @@ func compute_deltas(
 # Fork choice routines
 # ----------------------------------------------------------------------
 
-func initForkChoice(
+func initForkChoice*(
        finalized_block_slot: Slot,
        finalized_block_state_root: Eth2Digest,
        justified_epoch: Epoch,
@@ -249,7 +249,7 @@ func compute_deltas(
 when isMainModule:
   import nimcrypto/[sha2, utils]
 
-  func eth2hash(index: int): Eth2Digest =
+  func fakeHash(index: int): Eth2Digest =
     sha256.digest(cast[array[sizeof(int), byte]](index))
 
   proc tZeroHash() =
@@ -264,7 +264,7 @@ when isMainModule:
     var new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
-      indices.add eth2hash(i), i
+      indices.add fakeHash(i), i
       votes.add default(VoteTracker)
       old_balances.add 0
       new_balances.add 0
@@ -295,10 +295,10 @@ when isMainModule:
     var new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
-      indices.add eth2hash(i), i
+      indices.add fakeHash(i), i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
-        next_root: eth2hash(0), # Get a non-zero hash
+        next_root: fakeHash(0), # Get a non-zero hash
         next_epoch: Epoch(0)
       )
       old_balances.add Balance
@@ -334,10 +334,10 @@ when isMainModule:
     var new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
-      indices.add eth2hash(i), i
+      indices.add fakeHash(i), i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
-        next_root: eth2hash(i), # Each vote for a different root
+        next_root: fakeHash(i), # Each vote for a different root
         next_epoch: Epoch(0)
       )
       old_balances.add Balance
@@ -371,11 +371,11 @@ when isMainModule:
     var new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
-      indices.add eth2hash(i), i
+      indices.add fakeHash(i), i
       votes.add VoteTracker(
         # Move vote from root 0 to root 1
-        current_root: eth2hash(0),
-        next_root: eth2hash(1),
+        current_root: fakeHash(0),
+        next_root: fakeHash(1),
         next_epoch: Epoch(0)
       )
       old_balances.add Balance
@@ -408,7 +408,7 @@ when isMainModule:
     var votes: seq[VoteTracker]
 
     # Add a block
-    indices.add eth2hash(1), 0
+    indices.add fakeHash(1), 0
 
     # 2 validators
     var deltas = newSeqUninitialized[Delta](2)
@@ -417,15 +417,15 @@ when isMainModule:
 
     # One validator moves their vote from the block to the zero hash
     votes.add VoteTracker(
-      current_root: eth2hash(1),
+      current_root: fakeHash(1),
       next_root: default(Eth2Digest),
       next_epoch: Epoch(0)
     )
 
     # One validator moves their vote from the block to something outside of the tree
     votes.add VoteTracker(
-      current_root: eth2hash(1),
-      next_root: eth2hash(1337),
+      current_root: fakeHash(1),
+      next_root: fakeHash(1337),
       next_epoch: Epoch(0)
     )
 
@@ -458,11 +458,11 @@ when isMainModule:
     var new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
-      indices.add eth2hash(i), i
+      indices.add fakeHash(i), i
       votes.add VoteTracker(
         # Move vote from root 0 to root 1
-        current_root: eth2hash(0),
-        next_root: eth2hash(1),
+        current_root: fakeHash(0),
+        next_root: fakeHash(1),
         next_epoch: Epoch(0)
       )
       old_balances.add OldBalance
@@ -495,8 +495,8 @@ when isMainModule:
     var votes: seq[VoteTracker]
 
     # Add 2 blocks
-    indices.add eth2hash(1), 0
-    indices.add eth2hash(2), 1
+    indices.add fakeHash(1), 0
+    indices.add fakeHash(2), 1
 
     # 1 validator at the start, 2 at the end
     var deltas = newSeqUninitialized[Delta](2)
@@ -506,8 +506,8 @@ when isMainModule:
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
-        current_root: eth2hash(1),
-        next_root: eth2hash(2),
+        current_root: fakeHash(1),
+        next_root: fakeHash(2),
         next_epoch: Epoch(0)
       )
 
@@ -534,8 +534,8 @@ when isMainModule:
     var votes: seq[VoteTracker]
 
     # Add 2 blocks
-    indices.add eth2hash(1), 0
-    indices.add eth2hash(2), 1
+    indices.add fakeHash(1), 0
+    indices.add fakeHash(2), 1
 
     # 1 validator at the start, 2 at the end
     var deltas = newSeqUninitialized[Delta](2)
@@ -545,8 +545,8 @@ when isMainModule:
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
-        current_root: eth2hash(1),
-        next_root: eth2hash(2),
+        current_root: fakeHash(1),
+        next_root: fakeHash(2),
         next_epoch: Epoch(0)
       )
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -34,7 +34,7 @@ func compute_deltas(
        votes: var openArray[VoteTracker],
        old_balances: openarray[Gwei],
        new_balances: openarray[Gwei]
-     ): ForkChoiceError {.raises: [KeyError].}
+     ): ForkChoiceError {.raises: [].}
 
 # Fork choice routines
 # ----------------------------------------------------------------------
@@ -45,7 +45,7 @@ func initForkChoice*(
        justified_epoch: Epoch,
        finalized_epoch: Epoch,
        finalized_root: Eth2Digest
-     ): Result[ForkChoice, string] {.raises: [KeyError].} =
+     ): Result[ForkChoice, string] {.raises: [].} =
   ## Initialize a fork choice context
   var proto_array = ProtoArray(
     prune_threshold: DefaultPruneThreshold,
@@ -67,7 +67,7 @@ func initForkChoice*(
   result.ok(ForkChoice(proto_array: proto_array))
 
 
-func extend[T](s: var seq[T], minLen: int) =
+func extend[T](s: var seq[T], minLen: int) {.raises: [].} =
   ## Extend a sequence so that it can contains at least `minLen` elements.
   ## If it's already bigger, the sequence is unmodified.
   ## The extension is zero-initialized
@@ -115,7 +115,7 @@ func process_block*(
        state_root: Eth2Digest,
        justified_epoch: Epoch,
        finalized_epoch: Epoch
-     ): Result[void, string] {.raises: [KeyError].} =
+     ): Result[void, string] {.raises: [].} =
   ## Add a block to the fork choice context
   let err = self.proto_array.on_block(
     slot, block_root, some(parent_root), state_root, justified_epoch, finalized_epoch
@@ -132,7 +132,7 @@ func find_head*(
        justified_root: Eth2Digest,
        finalized_epoch: Epoch,
        justified_state_balances: seq[Gwei]
-     ): Result[Eth2Digest, string] {.raises: [UnpackError, KeyError].} =
+     ): Result[Eth2Digest, string] {.raises: [].} =
   ## Returns the new blockchain head
 
   # Compute deltas with previous call
@@ -169,7 +169,7 @@ func find_head*(
 
 func maybe_prune*(
        self: var ForkChoice, finalized_root: Eth2Digest
-     ): Result[void, string] {.raises: [KeyError].} =
+     ): Result[void, string] {.raises: [].} =
   ## Prune blocks preceding the finalized root as they are now unneeded.
   let err = self.proto_array.maybe_prune(finalized_root)
   if err.kind != fcSuccess:
@@ -183,7 +183,7 @@ func compute_deltas(
        votes: var openArray[VoteTracker],
        old_balances: openarray[Gwei],
        new_balances: openarray[Gwei]
-     ): ForkChoiceError {.raises: [KeyError].} =
+     ): ForkChoiceError {.raises: [].} =
   ## Update `deltas`
   ##   between old and new balances
   ##   between votes
@@ -220,7 +220,7 @@ func compute_deltas(
       # Ignore the current or next vote if it is not known in `indices`.
       # We assume that it is outside of our tree (i.e., pre-finalization) and therefore not interesting.
       if vote.current_root in indices:
-        let index = indices[vote.current_root]
+        let index = indices.unsafeGet(vote.current_root)
         if index >= deltas.len:
           return ForkChoiceError(
             kind: fcErrInvalidNodeDelta,
@@ -231,7 +231,7 @@ func compute_deltas(
           # TODO: is int64 big enough?
 
       if vote.next_root in indices:
-        let index = indices[vote.next_root]
+        let index = indices.unsafeGet(vote.next_root)
         if index >= deltas.len:
           return ForkChoiceError(
             kind: fcErrInvalidNodeDelta,

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -94,7 +94,7 @@ type
     slot*: Slot
     state_root*: Eth2Digest
     root*: Eth2Digest
-    parent_delta*: Option[Delta]
+    parent*: Option[Index]
     justified_epoch*: Epoch
     finalized_epoch*: Epoch
     weight*: int64

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -12,9 +12,13 @@ import
   # Internal
   ../spec/[datatypes, digest]
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/fork-choice.md
 # This is a port of https://github.com/sigp/lighthouse/pull/804
 # which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost
+# See also:
+# - Protolambda port of Lighthouse: https://github.com/protolambda/eth2-py-hacks/blob/ae286567/proto_array.py
+# - Prysmatic writeup: https://hackmd.io/bABJiht3Q9SyV3Ga4FT9lQ#High-level-concept
+# - Gasper Whitepaper: https://arxiv.org/abs/2003.03052
 
 # ProtoArray low-level types
 # ----------------------------------------------------------------------
@@ -94,6 +98,7 @@ type
     # TODO: generic "Metadata" field for slot/state_root
     slot*: Slot              # This is unnecessary for fork choice but helps external components
     state_root*: Eth2Digest  # This is unnecessary for fork choice but helps external components
+    # Fields used in fork choice
     root*: Eth2Digest
     parent*: Option[Index]
     justified_epoch*: Epoch

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -1,0 +1,121 @@
+
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/tables, std/options,
+  # Internal
+  ../spec/[datatypes, digest]
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md
+# This is a port of https://github.com/sigp/lighthouse/pull/804
+# which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost
+
+# ProtoArray low-level types
+# ----------------------------------------------------------------------
+
+type
+  FcErrKind* = enum
+    ## Fork Choice Error Kinds
+    fcSuccess
+    fcErrFinalizedNodeUnknown
+    fcErrJustifiedNodeUnknown
+    fcErrInvalidFinalizedRootCHange
+    fcErrInvalidNodeIndex
+    fcErrInvalidParentIndex
+    fcErrInvalidBestChildIndex
+    fcErrInvalidJustifiedIndex
+    fcErrInvalidBestDescendant
+    fcErrInvalidParentDelta
+    fcErrInvalidNodeDelta
+    fcErrDeltaUnderflow
+    fcErrIndexUnderflow
+    fcErrInvalidDeltaLen
+    fcErrRevertedFinalizedEpoch
+    fcErrInvalidBestNode
+
+  FcUnderflowKind* = enum
+    ## Fork Choice Overflow Kinds
+     fcUnderflowIndices = "Indices Overflow"
+     fcUnderflowBestChild = "Best Child Overflow"
+     fcUnderflowBestDescendant = "Best Descendant Overflow"
+
+  Index* = int
+  Delta* = int
+    ## Delta indices
+
+  ForkChoiceError* = object
+    case kind*: FcErrKind
+    of fcSuccess:
+      discard
+    of fcErrFinalizedNodeUnknown,
+       fcErrJustifiedNodeUnknown:
+         block_root*: Eth2Digest
+    of fcErrInvalidFinalizedRootChange:
+      discard
+    of fcErrInvalidNodeIndex,
+       fcErrInvalidParentIndex,
+       fcErrInvalidBestChildIndex,
+       fcErrInvalidJustifiedIndex,
+       fcErrInvalidBestDescendant,
+       fcErrInvalidParentDelta,
+       fcErrInvalidNodeDelta,
+       fcErrDeltaUnderflow:
+         index*: Index
+    of fcErrIndexUnderflow:
+      underflowKind*: FcUnderflowKind
+    of fcErrInvalidDeltaLen:
+      deltasLen*: int
+      indicesLen*: int
+    of fcErrRevertedFinalizedEpoch:
+      current_finalized_epoch*: Epoch
+      new_finalized_epoch*: Epoch
+    of fcErrInvalidBestNode:
+      start_root*: Eth2Digest
+      justified_epoch*: Epoch
+      finalized_epoch*: Epoch
+      head_root*: Eth2Digest
+      head_justified_epoch*: Epoch
+      head_finalized_epoch*: Epoch
+
+  ProtoArray* = object
+    prune_threshold*: int
+    justified_epoch*: Epoch
+    finalized_epoch*: Epoch
+    nodes*: seq[ProtoNode]
+    indices*: Table[Eth2Digest, Index]
+
+  ProtoNode* = object
+    slot*: Slot
+    state_root*: Eth2Digest
+    root*: Eth2Digest
+    parent_delta*: Option[Delta]
+    justified_epoch*: Epoch
+    finalized_epoch*: Epoch
+    weight*: int64
+    best_child*: Option[Index]
+    best_descendant*: Option[Index]
+
+const ForkChoiceSuccess* = ForkChoiceError(kind: fcSuccess)
+
+# Fork choice high-level types
+# ----------------------------------------------------------------------
+
+type
+  VoteTracker* = object
+    current_root*: Eth2Digest
+    next_root*: Eth2Digest
+    next_epoch*: Epoch
+
+  ForkChoice* = object
+    # Note: Lighthouse is protecting all fields with Reader-Writer locks.
+    #       However, given the nature of the fields, I suspect sharing those fields
+    #       will lead to thread contention. For now, stay single-threaded. - Mamy
+    proto_array*: ProtoArray
+    votes*: seq[VoteTracker]
+    balances*: seq[Gwei]

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -91,8 +91,9 @@ type
     indices*: Table[Eth2Digest, Index]
 
   ProtoNode* = object
-    slot*: Slot
-    state_root*: Eth2Digest
+    # TODO: generic "Metadata" field for slot/state_root
+    slot*: Slot              # This is unnecessary for fork choice but helps external components
+    state_root*: Eth2Digest  # This is unnecessary for fork choice but helps external components
     root*: Eth2Digest
     parent*: Option[Index]
     justified_epoch*: Epoch

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -30,8 +30,11 @@ func tiebreak(a, b: Eth2Digest): bool =
   ## on the binary representation
   for i in 0 ..< a.data.len:
     if a.data[i] < b.data[i]:
+      return false
+    elif a.data[i] > b.data[i]:
       return true
-  return false
+    # else we have equality so far
+  return true
 
 # Forward declarations
 # ----------------------------------------------------------------------
@@ -467,7 +470,25 @@ when isMainModule:
 
   import nimcrypto/[hash, utils]
 
-  let a = Eth2Digest.fromHex("0xD86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4") # sha256(2)
-  let b = Eth2Digest.fromHex("0x7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8") # sha256(1)
+  block:
+    let a = Eth2Digest.fromHex("0x0000000000000001000000000000000000000000000000000000000000000000")
+    let b = Eth2Digest.fromHex("0x0000000000000000000000000000000000000000000000000000000000000000") # sha256(1)
 
-  doAssert tiebreak(a, b)
+    doAssert tiebreak(a, b)
+
+
+  block:
+    let a = Eth2Digest.fromHex("0x0000000000000002000000000000000000000000000000000000000000000000")
+    let b = Eth2Digest.fromHex("0x0000000000000001000000000000000000000000000000000000000000000000") # sha256(1)
+
+    doAssert tiebreak(a, b)
+
+
+  block:
+    let a = Eth2Digest.fromHex("0xD86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4") # sha256(2)
+    let b = Eth2Digest.fromHex("0x7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8") # sha256(1)
+
+    echo a.data
+    echo b.data
+
+    doAssert tiebreak(a, b)

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -40,10 +40,12 @@ template getOrFailcase*[K, V](table: Table[K, V], key: K, failcase: untyped): V 
   ## Get a value from a Nim Table, turning KeyError into
   ## the "failcase"
   block:
+    # TODO: try/except expression with Nim v1.2.0:
+    #       https://github.com/status-im/nim-beacon-chain/pull/865#discussion_r404856551
     var value: V
     try:
       value = table[key]
-    except:
+    except KeyError:
       failcase
     value
 
@@ -82,8 +84,6 @@ func apply_score_changes*(
   ## 3. Compare the current node with the parent's best-child,
   ##    updating if the current node should become the best-child
   ## 4. If required, update the parent's best-descendant with the current node or its best-descendant
-  # TODO: remove spurious raised exceptions
-
   if deltas.len != self.indices.len:
     return ForkChoiceError(
              kind: fcErrInvalidDeltaLen,
@@ -158,7 +158,6 @@ func on_block*(
      ): ForkChoiceError {.raises: [].} =
   ## Register a block with the fork choice
   ## A `none` parent is only valid for Genesis
-  # TODO: fix exceptions raised
 
   # If the block is already known, ignore it
   if root in self.indices:
@@ -172,7 +171,7 @@ func on_block*(
     elif parent.unsafeGet() notin self.indices:
       # Is this possible?
       none(int)
-    else: # TODO: How to tell the compiler not to raise KeyError
+    else:
       some(self.indices.unsafeGet(parent.unsafeGet()))
 
   let node = ProtoNode(

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -515,8 +515,9 @@ func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: 
 # Sanity checks on internal private procedures
 
 when isMainModule:
-
   import nimcrypto/[hash, utils]
+
+  echo "Sanity checks on fork choice tiebreaks"
 
   block:
     let a = Eth2Digest.fromHex("0x0000000000000001000000000000000000000000000000000000000000000000")
@@ -535,8 +536,5 @@ when isMainModule:
   block:
     let a = Eth2Digest.fromHex("0xD86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4") # sha256(2)
     let b = Eth2Digest.fromHex("0x7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8") # sha256(1)
-
-    echo a.data
-    echo b.data
 
     doAssert tiebreak(a, b)

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -396,12 +396,12 @@ func maybe_update_best_child_and_descendant(
           if child.root.tiebreak(best_child.root):
             change_to_child
           else:
-            change_to_none
+            no_change
         else: # Choose winner by weight
           if child.weight >= best_child.weight:
             change_to_child
           else:
-            change_to_none
+            no_change
     else:
       if child_leads_to_viable_head:
         # There is no current best-child and the child is viable

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -30,8 +30,8 @@ func tiebreak(a, b: Eth2Digest): bool =
   ## on the binary representation
   for i in 0 ..< a.data.len:
     if a.data[i] < b.data[i]:
-      return false
-  return true
+      return true
+  return false
 
 # Forward declarations
 # ----------------------------------------------------------------------
@@ -410,10 +410,15 @@ func maybe_update_best_child_and_descendant(
           # The best child leads to a viable head, but the child doesn't
           no_change
         elif child.weight == best_child.weight:
+          debugEcho "Reached tiebreak"
+          debugEcho "  child.root      0x", child.root
+          debugEcho "  best_child.root 0x", best_child.root
+          debugEcho "  child.root.tiebreak(best_child.root): ", child.root.tiebreak(best_child.root)
           # Tie-breaker of equal weights by root
           if child.root.tiebreak(best_child.root):
             change_to_child
           else:
+            debugEcho "----> no change"
             no_change
         else: # Choose winner by weight
           if child.weight >= best_child.weight:
@@ -476,3 +481,16 @@ func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: 
     (node.finalized_epoch == self.finalized_epoch) or
     (node.finalized_epoch == Epoch(0))
   )
+
+# Sanity checks
+# ----------------------------------------------------------------------
+# Sanity checks on internal private procedures
+
+when isMainModule:
+
+  import nimcrypto/[hash, utils]
+
+  let a = Eth2Digest.fromHex("0xD86E8112F3C4C4442126F8E9F44F16867DA487F29052BF91B810457DB34209A4") # sha256(2)
+  let b = Eth2Digest.fromHex("0x7C9FA136D4413FA6173637E883B6998D32E1D675F88CDDFF9DCBCF331820F4B8") # sha256(1)
+
+  doAssert tiebreak(a, b)

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -58,9 +58,9 @@ template unsafeGet*[K, V](table: Table[K, V], key: K): V =
 # Forward declarations
 # ----------------------------------------------------------------------
 
-func maybe_update_best_child_and_descendant(self: var ProtoArray, parent_index: Index, child_index: Index): ForkChoiceError {.raises: [].}
-func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [].}
-func node_leads_to_viable_head(self: ProtoArray, node: ProtoNode): tuple[viable: bool, err: ForkChoiceError] {.raises: [].}
+func maybe_update_best_child_and_descendant(self: var ProtoArray, parent_index: Index, child_index: Index): ForkChoiceError {.raises: [Defect].}
+func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [Defect].}
+func node_leads_to_viable_head(self: ProtoArray, node: ProtoNode): tuple[viable: bool, err: ForkChoiceError] {.raises: [Defect].}
 
 # ProtoArray routines
 # ----------------------------------------------------------------------
@@ -70,7 +70,7 @@ func apply_score_changes*(
        deltas: var openarray[Delta],
        justified_epoch: Epoch,
        finalized_epoch: Epoch
-     ): ForkChoiceError {.raises: [].}=
+     ): ForkChoiceError {.raises: [Defect].}=
   ## Iterate backwards through the array, touching all nodes and their parents
   ## and potentially the best-child of each parent.
   ##
@@ -155,7 +155,7 @@ func on_block*(
        state_root: Eth2Digest,
        justified_epoch: Epoch,
        finalized_epoch: Epoch
-     ): ForkChoiceError {.raises: [].} =
+     ): ForkChoiceError {.raises: [Defect].} =
   ## Register a block with the fork choice
   ## A `none` parent is only valid for Genesis
 
@@ -200,7 +200,7 @@ func find_head*(
         self: var ProtoArray,
         head: var Eth2Digest,
         justified_root: Eth2Digest
-     ): ForkChoiceError {.raises: [].} =
+     ): ForkChoiceError {.raises: [Defect].} =
   ## Follows the best-descendant links to find the best-block (i.e. head-block)
   ##
   ## ⚠️ Warning
@@ -259,7 +259,7 @@ func find_head*(
 func maybe_prune*(
        self: var ProtoArray,
        finalized_root: Eth2Digest
-     ): ForkChoiceError {.raises: [].} =
+     ): ForkChoiceError {.raises: [Defect].} =
   ## Update the tree with new finalization information.
   ## The tree is pruned if and only if:
   ## - The `finalized_root` and finalized epoch are different from current
@@ -340,7 +340,7 @@ func maybe_prune*(
 func maybe_update_best_child_and_descendant(
        self: var ProtoArray,
        parent_index: Index,
-       child_index: Index): ForkChoiceError {.raises: [].} =
+       child_index: Index): ForkChoiceError {.raises: [Defect].} =
   ## Observe the parent at `parent_index` with respect to the child at `child_index` and
   ## potentiatlly modify the `parent.best_child` and `parent.best_descendant` values
   ##
@@ -438,7 +438,7 @@ func maybe_update_best_child_and_descendant(
 
 func node_leads_to_viable_head(
        self: ProtoArray, node: ProtoNode
-     ): tuple[viable: bool, err: ForkChoiceError] {.raises: [].} =
+     ): tuple[viable: bool, err: ForkChoiceError] {.raises: [Defect].} =
   ## Indicates if the node itself or its best-descendant are viable
   ## for blockchain head
   let best_descendant_is_viable_for_head = block:
@@ -463,7 +463,7 @@ func node_leads_to_viable_head(
     ForkChoiceSuccess
   )
 
-func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [].} =
+func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [Defect].} =
   ## This is the equivalent of `filter_block_tree` function in eth2 spec
   ## https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/fork-choice.md#filter_block_tree
   ##

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -1,0 +1,456 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/tables, std/options, std/typetraits,
+  # Status libraries
+  nimcrypto/hash,
+  # Internal
+  ../spec/[datatypes, digest],
+  # Fork choice
+  ./fork_choice_types
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md
+# This is a port of https://github.com/sigp/lighthouse/pull/804
+# which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost
+#
+# See also the port of the port: https://github.com/protolambda/eth2-py-hacks/blob/ec9395d371903d855e1488d04b8fe89fd5be0ad9/proto_array.py
+
+# Helper
+# ----------------------------------------------------------------------
+
+func tiebreak(a, b: Eth2Digest): bool =
+  ## Fork-Choice tie-break between 2 digests
+  ## Currently implemented as `>=` (greater or equal)
+  ## on the binary representation
+  for i in 0 ..< a.data.len:
+    if a.data[i] < b.data[i]:
+      return false
+  return true
+
+# Forward declarations
+# ----------------------------------------------------------------------
+
+func maybe_update_best_child_and_descendant(self: var ProtoArray, parent_index: Index, child_index: Index): ForkChoiceError {.raises: [].}
+func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [].}
+func node_leads_to_viable_head(self: ProtoArray, node: ProtoNode): tuple[viable: bool, err: ForkChoiceError] {.raises: [].}
+
+# ProtoArray routines
+# ----------------------------------------------------------------------
+
+func apply_score_changes*(
+       self: var ProtoArray,
+       deltas: var openarray[Delta],
+       justified_epoch: Epoch,
+       finalized_epoch: Epoch
+     ): ForkChoiceError {.raises: [UnpackError].}=
+  ## Iterate backwards through the array, touching all nodes and their parents
+  ## and potentially the best-child of each parent.
+  ##
+  ## The structure of `self.nodes` array ensures that the child of each node
+  ## is always touched before it's aprent.
+  ##
+  ## For each node the following is done:
+  ##
+  ## 1. Update the node's weight with the corresponding delta.
+  ## 2. Backpropagate each node's delta to its parent's delta.
+  ## 3. Compare the current node with the parent's best-child,
+  ##    updating if the current node should become the best-child
+  ## 4. If required, update the parent's best-descendant with the current node or its best-descendant
+  # TODO: remove spurious raised exceptions
+  if deltas.len != self.indices.len:
+    return ForkChoiceError(
+             kind: fcErrInvalidDeltaLen,
+             deltasLen: deltas.len,
+             indicesLen: self.indices.len
+           )
+
+  self.justified_epoch = justified_epoch
+  self.finalized_epoch = finalized_epoch
+
+  # Iterate backwards through all the indices in `self.nodes`
+  for node_index in countdown(self.nodes.len - 1, 0):
+    template node: untyped {.dirty.}= self.nodes[node_index]
+      ## Alias
+      # This cannot raise the IndexError exception, how to tell compiler?
+
+    if node.root == default(Eth2Digest):
+      continue
+
+    if node_index notin {0..deltas.len-1}:
+      # TODO: Here `deltas.len == self.indices.len` from the previous check
+      #       and we can probably assume that
+      #       `self.indices.len == self.nodes.len` by construction
+      #       and avoid this check in a loop or altogether
+      return ForkChoiceError(
+        kind: fcErrInvalidNodeDelta,
+        index: node_index
+      )
+    let node_delta = deltas[node_index]
+
+    # Apply the delta to the node
+    # We fail fast if underflow, which shouldn't happen.
+    # Note that delta can be negative.
+    let weight = node.weight - node_delta
+    if weight < 0:
+      return ForkChoiceError(
+        kind: fcErrDeltaUnderflow,
+        index: node_index
+      )
+    node.weight = weight
+
+    # If the node has a parent, try to update its best-child and best-descendant
+    if node.parent_delta.isSome():
+      # TODO: Nim `options` module could use some {.inline.}
+      #       and a mutable overload for unsafeGet
+      #       and a "no exceptions" (only panics) implementation.
+      let parent_index = node.parent_delta.unsafeGet()
+      if parent_index notin {0..deltas.len-1}:
+        return ForkChoiceError(
+          kind: fcErrInvalidParentDelta,
+          index: parent_index
+        )
+
+      # Back-propagate the nodes delta to its parent.
+      node.parent_delta.get() += node_delta
+
+      let err = self.maybe_update_best_child_and_descendant(parent_index, node_index)
+      if err.kind != fcSuccess:
+        return err
+
+  return ForkChoiceSuccess
+
+
+func on_block*(
+       self: var ProtoArray,
+       slot: Slot,
+       root: Eth2Digest,
+       parent: Option[Eth2Digest],
+       state_root: Eth2Digest,
+       justified_epoch: Epoch,
+       finalized_epoch: Epoch
+     ): ForkChoiceError {.raises: [KeyError].} =
+  ## Register a block with the fork choice
+  ## A `none` parent is only valid for Genesis
+  # TODO: fix exceptions raised
+
+  # If the block is already known, ignore it
+  if root in self.indices:
+    return ForkChoiceSuccess
+
+  let node_index = self.nodes.len
+
+  let parent_index = block:
+    if parent.isNone:
+      none(int)
+    elif parent.unsafeGet() notin self.indices:
+      # Is this possible?
+      none(int)
+    else: # TODO: How to tell the compiler not to raise KeyError
+      some(self.indices[parent.unsafeGet()])
+
+  let node = ProtoNode(
+    slot: slot,
+    state_root: state_root,
+    root: root,
+    parent_delta: parent_index,
+    justified_epoch: justified_epoch,
+    finalized_epoch: finalized_epoch,
+    weight: 0,
+    best_child: none(int),
+    best_descendant: none(int)
+  )
+
+  self.indices[node.root] = node_index
+  self.nodes.add node # TODO: if this is costly, we can setLen + construct the node in-place
+
+  if parent_index.isSome():
+    let err = self.maybe_update_best_child_and_descendant(parent_index.unsafeGet(), node_index)
+    if err.kind != fcSuccess:
+      return err
+
+  return ForkChoiceSuccess
+
+func find_head*(
+        self: var ProtoArray,
+        head: var Eth2Digest,
+        justified_root: Eth2Digest
+     ): ForkChoiceError {.raises: [KeyError].} =
+  ## Follows the best-descendant links to find the best-block (i.e. head-block)
+  ##
+  ## ⚠️ Warning
+  ## The result may not be accurate if `on_new_block`
+  ## is not followed by `apply_score_changes` as `on_new_block` does not
+  ## update the whole tree.
+  if justified_root notin self.indices:
+    return ForkChoiceError(
+      kind: fcErrJustifiedNodeUnknown,
+      block_root: justified_root
+    )
+  let justified_index = self.indices[justified_root] # TODO: this can't throw KeyError
+
+  if justified_index notin {0..self.nodes.len-1}:
+    return ForkChoiceError(
+      kind: fcErrInvalidJustifiedIndex,
+      index: justified_index
+    )
+  template justified_node: untyped {.dirty.} = self.nodes[justified_index]
+    # Alias, TODO: no exceptions
+
+  let best_descendant_index = block:
+    if justified_node.best_descendant.isSome():
+      justified_node.best_descendant.unsafeGet()
+    else:
+      justified_index
+
+  if best_descendant_index notin {0..self.nodes.len-1}:
+    return ForkChoiceError(
+      kind: fcErrInvalidBestDescendant,
+      index: best_descendant_index
+    )
+  template best_node: untyped {.dirty.} = self.nodes[best_descendant_index]
+    # Alias, TODO: no exceptions
+
+  # Perform a sanity check to ensure the node can be head
+  if not self.node_is_viable_for_head(best_node):
+    return ForkChoiceError(
+      kind: fcErrInvalidBestNode,
+      start_root: justified_root,
+      justified_epoch: self.justified_epoch,
+      finalized_epoch: self.finalized_epoch,
+      head_root: justified_node.root,
+      head_justified_epoch: justified_node.justified_epoch,
+      head_finalized_epoch: justified_node.finalized_epoch
+    )
+
+  head = best_node.root
+  return ForkChoiceSuccess
+
+
+func maybe_prune*(
+       self: var ProtoArray,
+       finalized_root: Eth2Digest
+     ): ForkChoiceError {.raises: [KeyError].} =
+  ## Update the tree with new finalization information.
+  ## The tree is pruned if and only if:
+  ## - The `finalized_root` and finalized epoch are different from current
+  ## - The number of nodes in `self` is at least `self.prune_threshold`
+  ##
+  ## Returns error if:
+  ## - The finalized epoch is less than the current one
+  ## - The finalized epoch matches the current one but the finalized root is different
+  ## - Internal error due to invalid indices in `self`
+  # TODO: Exceptions
+
+  if finalized_root notin self.indices:
+    return ForkChoiceError(
+      kind: fcErrFinalizedNodeUnknown,
+      block_root: finalized_root
+    )
+  let finalized_index = self.indices[finalized_root]
+
+  if finalized_index < self.prune_threshold:
+    # Pruning small numbers of nodes incurs more overhead than leaving them as is
+    return ForkChoiceSuccess
+
+  # Remove the `self.indices` key/values for the nodes slated for deletion
+  if finalized_index notin {0..self.nodes.len-1}:
+    return ForkChoiceError(
+      kind: fcErrInvalidNodeIndex,
+      index: finalized_index
+    )
+  for node_index in 0 ..< finalized_index:
+    self.indices.del(self.nodes[node_index].root)
+
+  # Drop all nodes prior to finalization.
+  # This is done in-place with `moveMem` to avoid costly reallocations.
+  static: doAssert ProtoNode.supportsCopyMem(), "ProtoNode must be a trivial type"
+  let tail = self.nodes.len - finalized_index
+  # TODO: can we have an unallocated `self.nodes`? i.e. self.nodes[0] is nil
+  moveMem(self.nodes[0].addr, self.nodes[finalized_index].addr, tail * sizeof(ProtoNode))
+  self.nodes.setLen(tail)
+
+  # Adjust the indices map
+  for index in self.indices.mvalues():
+    index -= finalized_index
+    if index < 0:
+      return ForkChoiceError(
+        kind: fcErrIndexUnderflow,
+        underflowKind: fcUnderflowIndices
+      )
+
+  # Iterate through all the existing nodes and adjust their indices to match
+  # the new layout of `self.nodes`
+  for node in self.nodes.mitems():
+    # If `node.parent` is less than `finalized_index`, set it to None
+    if node.parent_delta.isSome():
+      let new_parent_delta = node.parent_delta.unsafeGet() - finalized_index
+      if new_parent_delta < 0:
+        node.parent_delta = none(Delta)
+      else:
+        node.parent_delta = some(new_parent_delta)
+
+    if node.best_child.isSome():
+      let new_best_child = node.best_child.unsafeGet() - finalized_index
+      if new_best_child < 0:
+        return ForkChoiceError(
+          kind: fcErrIndexUnderflow,
+          underflowKind: fcUnderflowBestChild
+        )
+      node.best_child = some(new_best_child)
+
+    if node.best_descendant.isSome():
+      let new_best_descendant = node.best_descendant.unsafeGet() - finalized_index
+      if new_best_descendant < 0:
+        return ForkChoiceError(
+          kind: fcErrIndexUnderflow,
+          underflowKind: fcUnderflowBestDescendant
+        )
+      node.best_descendant = some(new_best_descendant)
+
+  return ForkChoiceSuccess
+
+
+func maybe_update_best_child_and_descendant(
+       self: var ProtoArray,
+       parent_index: Index,
+       child_index: Index): ForkChoiceError {.raises: [].} =
+  ## Observe the parent at `parent_index` with respect to the child at `child_index` and
+  ## potentiatlly modify the `parent.best_child` and `parent.best_descendant` values
+  ##
+  ## There are four scenarios:
+  ##
+  ## 1. The child is already the best child
+  ##    but it's now invalid due to a FFG change and should be removed.
+  ## 2. The child is already the best child
+  ##    and the parent is updated with the new best descendant
+  ## 3. The child is not the best child but becomes the best child
+  ## 4. The child is not the best child and does not become the best child
+  if child_index notin {0..self.nodes.len-1}:
+    return ForkChoiceError(
+      kind: fcErrInvalidNodeIndex,
+      index: child_index
+    )
+  if parent_index notin {0..self.nodes.len-1}:
+    return ForkChoiceError(
+      kind: fcErrInvalidNodeIndex,
+      index: parent_index
+    )
+
+  # Aliases
+  template child: untyped {.dirty.} = self.nodes[child_index]
+  template parent: untyped {.dirty.} = self.nodes[parent_index]
+
+  let (child_leads_to_viable_head, err) = self.node_leads_to_viable_head(child)
+  if err.kind != fcSuccess:
+    return err
+
+  let # Aliases to the 3 possible (best_child, best_descendant) tuples
+    change_to_none = (none(Index), none(Index))
+    change_to_child = (
+        some(child_index),
+        # Nim `options` module doesn't implement option `or`
+        if child.best_descendant.isSome(): child.best_descendant
+        else: some(child_index)
+      )
+    no_change = (parent.best_child, parent.best_descendant)
+
+  # TODO: state-machine? The control-flow is messy
+
+  let (new_best_child, new_best_descendant) = block:
+    if parent.best_child.isSome:
+      let best_child_index = parent.best_child.unsafeGet()
+      if best_child_index == child_index and not child_leads_to_viable_head:
+        # The child is already the best-child of the parent
+        # but it's not viable to be the head block => remove it
+        change_to_none
+      elif best_child_index == child_index:
+        # If the child is the best-child already, set it again to ensure
+        # that the best-descendant of the parent is up-to-date.
+        change_to_child
+      else:
+        if best_child_index notin {0..self.nodes.len-1}:
+          return ForkChoiceError(
+            kind: fcErrInvalidBestDescendant,
+            index: best_child_index
+          )
+        let best_child = self.nodes[best_child_index]
+
+        let (best_child_leads_to_viable_head, err) = self.node_leads_to_viable_head(best_child)
+        if err.kind != fcSuccess:
+          return err
+
+        if child_leads_to_viable_head and not best_child_leads_to_viable_head:
+          # The child leads to a viable head, but the current best-child doesn't
+          change_to_child
+        elif not child_leads_to_viable_head and best_child_leads_to_viable_head:
+          # The best child leads to a viable head, but the child doesn't
+          no_change
+        elif child.weight == best_child.weight:
+          # Tie-breaker of equal weights by root
+          if child.root.tiebreak(best_child.root):
+            change_to_child
+          else:
+            change_to_none
+        else: # Choose winner by weight
+          if child.weight >= best_child.weight:
+            change_to_child
+          else:
+            change_to_none
+    else:
+      if child_leads_to_viable_head:
+        # There is no current best-child and the child is viable
+        change_to_child
+      else:
+        # There is no current best-child but the child is not viable
+        no_change
+
+  self.nodes[parent_index].best_child = new_best_child
+  self.nodes[parent_index].best_descendant = new_best_descendant
+
+
+func node_leads_to_viable_head(
+       self: ProtoArray, node: ProtoNode
+     ): tuple[viable: bool, err: ForkChoiceError] {.raises: [].} =
+  ## Indicates if the node itself or its best-descendant are viable
+  ## for blockchain head
+  let best_descendant_is_viable_for_head = block:
+    if node.best_descendant.isSome():
+      let best_descendant_index = node.best_descendant.unsafeGet()
+      if best_descendant_index notin {0..self.nodes.len-1}:
+        return (
+          false,
+          ForkChoiceError(
+            kind: fcErrInvalidBestDescendant,
+            index: best_descendant_index
+          )
+        )
+      let best_descendant = self.nodes[best_descendant_index]
+      self.node_is_viable_for_head(best_descendant)
+    else:
+      false
+
+  return (
+    best_descendant_is_viable_for_head or
+      self.node_is_viable_for_head(node),
+    ForkChoiceSuccess
+  )
+
+func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: [].} =
+  ## This is the equivalent of `filter_block_tree` function in eth2 spec
+  ## https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/fork-choice.md#filter_block_tree
+  ##
+  ## Any node that has a different finalized or justified epoch
+  ## should not be viable for the head.
+  (
+    (node.justified_epoch == self.justified_epoch) or
+    (node.justified_epoch == Epoch(0))
+  ) and (
+    (node.finalized_epoch == self.finalized_epoch) or
+    (node.finalized_epoch == Epoch(0))
+  )

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -29,7 +29,8 @@ import # Unit test
   ./test_peer_pool,
   ./test_sync_manager,
   ./test_honest_validator,
-  ./test_interop
+  ./test_interop,
+  ./tests_fork_choice
 
 import # Refactor state transition unit tests
   # TODO re-enable when useful

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -30,7 +30,7 @@ import # Unit test
   ./test_sync_manager,
   ./test_honest_validator,
   ./test_interop,
-  ./tests_fork_choice
+  ./fork_choice/tests_fork_choice
 
 import # Refactor state transition unit tests
   # TODO re-enable when useful

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -49,7 +49,6 @@ type
       justified_state_balances*: seq[Gwei]
       expected_head*: Eth2Digest
     of ProcessBlock:
-      slot*: Slot
       root*: Eth2Digest
       parent_root*: Eth2Digest
       blk_justified_epoch*: Epoch
@@ -85,10 +84,10 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
       debugEcho "    Detected an expected invalid head"
   of ProcessBlock:
     let r = ctx.process_block(
-      slot = op.slot,
+      slot = default(Slot),             # unused in fork choice, only helpful for external components
       block_root = op.root,
       parent_root = op.parent_root,
-      state_root = default(Eth2Digest),
+      state_root = default(Eth2Digest), # unused in fork choice, only helpful for external components
       justified_epoch = op.blk_justified_epoch,
       finalized_epoch = op.blk_finalized_epoch
     )

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -92,12 +92,11 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
     doAssert r.isOk(), &"process_block (op #{id}) returned an error: {r.error}"
     debugEcho "    Processed block      0x", op.root, " with parent 0x", op.parent_root, " and justified epoch ", op.blk_justified_epoch
   of ProcessAttestation:
-    let r = ctx.process_attestation(
+    ctx.process_attestation(
       validator_index = op.validator_index,
       block_root = op.block_root,
       target_epoch = op.target_epoch
     )
-    doAssert r.isOk(), &"process_attestation (op #{id}) returned an error: {r.error}"
     debugEcho "    Processed att target 0x", op.block_root, " from validator ", op.validator_index, " for epoch ", op.target_epoch
   of Prune:
     ctx.proto_array.prune_threshold = op.prune_threshold

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -72,7 +72,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
     if op.kind == FindHead:
       doAssert r.isOk(), &"find_head (op #{id}) returned an error: {r.error}"
       doAssert r.get() == op.expected_head, &"find_head (op #{id}) returned an incorrect result: {r.get()} (expected: {op.expected_head})"
-      debugEcho "    Found expected head: 0x", op.expected_head
+      debugEcho "    Found expected head: 0x", op.expected_head, " from justified checkpoint(epoch: ", op.justified_epoch, ", root: 0x", op.justified_root, ")"
     else:
       doAssert r.isErr(), "find_head was unexpectedly successful"
       debugEcho "    Detected an expected invalid head"

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -16,7 +16,8 @@ import
 
 export result, datatypes, digest, fork_choice, fork_choice_types, tables, options
 
-# TODO: if the value added is 1 or 16, we error out. Why? Nim table bug with not enough spaced hashes?
+# TODO: nimcrypto.hash.`==` is returns incorrect result with those fakeHash
+#       Don't import nimcrypto, let Nim do the `==` in the mean-time
 func fakeHash*(index: SomeInteger): Eth2Digest =
   ## Create fake hashes
   ## Those are just the value serialized in big-endian
@@ -66,6 +67,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
   ## Apply the specified operation to a ForkChoice context
   ## ``id`` is additional debugging info. It is the
   ## operation index.
+  # debugEcho "    ========================================================================================="
   case op.kind
   of FindHead, InvalidFindHead:
     let r = ctx.find_head(

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -1,0 +1,105 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/strformat, std/tables, std/options,
+  # Status libraries
+  stew/result, nimcrypto/[sha2, utils],
+  # Internals
+  ../../beacon_chain/spec/[datatypes, digest],
+  ../../beacon_chain/fork_choice/[fork_choice, fork_choice_types]
+
+export result, datatypes, digest, fork_choice, fork_choice_types, tables, options
+
+func fakeHash*(index: int): Eth2Digest =
+  ## Create fake hashes
+  sha256.digest(cast[array[sizeof(int), byte]](index))
+
+# The fork choice tests are quite complex.
+# For flexibility in block arrival, timers, operations sequencing, ...
+# we create a small interpreter that will trigger events in proper order
+# before fork choice.
+
+type
+  OpKind* = enum
+    FindHead
+    InvalidFindHead
+    ProcessBlock
+    ProcessAttestation
+    Prune
+
+  Operation* = object
+    # variant specific fields
+    case kind*: OpKind
+    of FindHead, InvalidFindHead:
+      justified_epoch*: Epoch
+      justified_root*: Eth2Digest
+      finalized_epoch*: Epoch
+      justified_state_balances*: seq[Gwei]
+      expected_head*: Eth2Digest
+    of ProcessBlock:
+      slot*: Slot
+      root*: Eth2Digest
+      parent_root*: Eth2Digest
+      blk_justified_epoch*: Epoch
+      blk_finalized_epoch*: Epoch
+    of ProcessAttestation:
+      validator_index*: ValidatorIndex
+      block_root*: Eth2Digest
+      target_epoch*: Epoch
+    of Prune: # ProtoArray specific
+      finalized_root*: Eth2Digest
+      prune_threshold*: int
+      expected_len*: int
+
+func apply(ctx: var ForkChoice, id: int, op: Operation) =
+  ## Apply the specified operation to a ForkChoice context
+  ## ``id`` is additional debugging info. It is the
+  ## operation index.
+
+  case op.kind
+  of FindHead, InvalidFindHead:
+    let r = ctx.find_head(
+      op.justified_epoch,
+      op.justified_root,
+      op.finalized_epoch,
+      op.justified_state_balances
+    )
+    if op.kind == FindHead:
+      doAssert r.isOk(), &"find_head (op #{id}) returned an error: {r.error}"
+      doAssert r.get() == op.expected_head, &"find_head (op #{id}) returned an incorrect result: {r.get()} (expected: {op.expected_head})"
+    else:
+      doAssert r.isErr(), "find_head was unexpectedly suvvessful"
+  of ProcessBlock:
+    let r = ctx.process_block(
+      slot = op.slot,
+      block_root = op.root,
+      parent_root = op.parent_root,
+      state_root = default(Eth2Digest),
+      justified_epoch = op.blk_justified_epoch,
+      finalized_epoch = op.blk_finalized_epoch
+    )
+    doAssert r.isOk(), &"process_block (op #{id}) returned an error: {r.error}"
+  of ProcessAttestation:
+    let r = ctx.process_attestation(
+      validator_index = op.validator_index,
+      block_root = op.block_root,
+      target_epoch = op.target_epoch
+    )
+    doAssert r.isOk(), &"process_attestation (op #{id}) returned an error: {r.error}"
+  of Prune:
+    ctx.proto_array.prune_threshold = op.prune_threshold
+    let r = ctx.maybe_prune(op.finalized_root)
+    doAssert r.isOk(), &"prune (op #{id}) returned an error: {r.error}"
+    doAssert ctx.proto_array.nodes.len == op.expected_len,
+      &"prune (op #{id}): the resulting length ({ctx.proto_array.nodes.len}) was not expected ({op.expected_len})"
+
+func run*(ctx: var ForkChoice, ops: seq[Operation]) =
+  ## Apply a sequence of fork-choice operations on a store
+  for i, op in ops:
+    ctx.apply(i, op)

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -61,7 +61,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
   ## Apply the specified operation to a ForkChoice context
   ## ``id`` is additional debugging info. It is the
   ## operation index.
-
+  debugEcho "    ---------------------------------------------------------------------------------"
   case op.kind
   of FindHead, InvalidFindHead:
     let r = ctx.find_head(

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -9,16 +9,21 @@ import
   # Standard library
   std/strformat, std/tables, std/options,
   # Status libraries
-  stew/result, nimcrypto/[sha2, utils],
+  stew/[result, endians2],
   # Internals
   ../../beacon_chain/spec/[datatypes, digest],
   ../../beacon_chain/fork_choice/[fork_choice, fork_choice_types]
 
 export result, datatypes, digest, fork_choice, fork_choice_types, tables, options
 
-func fakeHash*(index: int): Eth2Digest =
+# TODO: if the value added is 1 or 16, we error out. Why? Nim table bug with not enough spaced hashes?
+func fakeHash*(index: SomeInteger): Eth2Digest =
   ## Create fake hashes
-  sha256.digest(cast[array[sizeof(int), byte]](index))
+  ## Those are just the value serialized in big-endian
+  ## We add 16x16 to avoid having a zero hash are those are special cased
+  ## We store them in the first 8 bytes
+  ## as those are the one used in hash tables Table[Eth2Digest, T]
+  result.data[0 ..< 8] = (16*16+index).uint64.toBytesBE()
 
 # The fork choice tests are quite complex.
 # For flexibility in block arrival, timers, operations sequencing, ...

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -61,7 +61,6 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
   ## Apply the specified operation to a ForkChoice context
   ## ``id`` is additional debugging info. It is the
   ## operation index.
-  debugEcho "    ---------------------------------------------------------------------------------"
   case op.kind
   of FindHead, InvalidFindHead:
     let r = ctx.find_head(
@@ -73,10 +72,10 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
     if op.kind == FindHead:
       doAssert r.isOk(), &"find_head (op #{id}) returned an error: {r.error}"
       doAssert r.get() == op.expected_head, &"find_head (op #{id}) returned an incorrect result: {r.get()} (expected: {op.expected_head})"
-      debugEcho "    Successfully found head: ", op.expected_head
+      debugEcho "    Found expected head: 0x", op.expected_head
     else:
       doAssert r.isErr(), "find_head was unexpectedly successful"
-      debugEcho "    Successfully detected an invalid head"
+      debugEcho "    Detected an expected invalid head"
   of ProcessBlock:
     let r = ctx.process_block(
       slot = op.slot,
@@ -87,7 +86,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
       finalized_epoch = op.blk_finalized_epoch
     )
     doAssert r.isOk(), &"process_block (op #{id}) returned an error: {r.error}"
-    debugEcho "    Processed block 0x", op.root, " with parent 0x", op.parent_root, " and justified epoch ", op.blk_justified_epoch
+    debugEcho "    Processed block      0x", op.root, " with parent 0x", op.parent_root, " and justified epoch ", op.blk_justified_epoch
   of ProcessAttestation:
     let r = ctx.process_attestation(
       validator_index = op.validator_index,
@@ -95,7 +94,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
       target_epoch = op.target_epoch
     )
     doAssert r.isOk(), &"process_attestation (op #{id}) returned an error: {r.error}"
-    debugEcho "    Processed attestation for validator ", op.validator_index, " targeting ", op.block_root, " at epoch ", op.target_epoch
+    debugEcho "    Processed att target 0x", op.block_root, " from validator ", op.validator_index, " for epoch ", op.target_epoch
   of Prune:
     ctx.proto_array.prune_threshold = op.prune_threshold
     let r = ctx.maybe_prune(op.finalized_root)

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -16,8 +16,6 @@ import
 
 export result, datatypes, digest, fork_choice, fork_choice_types, tables, options
 
-# TODO: nimcrypto.hash.`==` is returns incorrect result with those fakeHash
-#       Don't import nimcrypto, let Nim do the `==` in the mean-time
 func fakeHash*(index: SomeInteger): Eth2Digest =
   ## Create fake hashes
   ## Those are just the value serialized in big-endian

--- a/tests/fork_choice/scenarios/ffg_01.nim
+++ b/tests/fork_choice/scenarios/ffg_01.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../interpreter
+# import ../interpreter # included to be able to use "suiteReport"
 
 proc setup_finality_01(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
@@ -118,12 +118,12 @@ proc setup_finality_01(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
 
 proc test_ffg01() =
-  echo "  fork_choice - testing finality #01"
-  # for i in 0 ..< 4:
-  #   echo "    block (", i, ") hash: ", fakeHash(i)
-  # echo "    ------------------------------------------------------"
+  timedTest "fork_choice - testing finality #01":
+    # for i in 0 ..< 4:
+    #   echo "    block (", i, ") hash: ", fakeHash(i)
+    # echo "    ------------------------------------------------------"
 
-  var (ctx, ops) = setup_finality_01()
-  ctx.run(ops)
+    var (ctx, ops) = setup_finality_01()
+    ctx.run(ops)
 
 test_ffg01()

--- a/tests/fork_choice/scenarios/ffg_01.nim
+++ b/tests/fork_choice/scenarios/ffg_01.nim
@@ -1,0 +1,129 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../interpreter
+
+proc setup_finality_01(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+  var balances = @[Gwei(1), Gwei(1)]
+  let GenesisRoot = fakeHash(0)
+
+  # Initialize the fork choice context
+  result.fork_choice = initForkChoice(
+    finalized_block_slot = Slot(0),                   # Metadata unused in fork choice
+    finalized_block_state_root = default(Eth2Digest), # Metadata unused in fork choice
+    justified_epoch = Epoch(1),
+    finalized_epoch = Epoch(1),
+    finalized_root = GenesisRoot
+  ).get()
+
+  # ----------------------------------
+
+  # Head should be genesis
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: GenesisRoot
+  )
+
+  # Build the following chain
+  #
+  #   0 <- just: 0, fin: 0
+  #   |
+  #   1 <- just: 0, fin: 0
+  #   |
+  #   2 <- just: 1, fin: 0
+  #   |
+  #   3 <- just: 2, fin: 1
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(1),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(0),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(2),
+    parent_root: fakeHash(1),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(3),
+    parent_root: fakeHash(2),
+    blk_justified_epoch: Epoch(2),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Ensure that with justified epoch 0 we find 3
+  #
+  #     0 <- start
+  #     |
+  #     1
+  #     |
+  #     2
+  #     |
+  #     3 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(3)
+  )
+
+  # Ensure that with justified epoch 1 we find 2
+  #
+  #     0
+  #     |
+  #     1
+  #     |
+  #     2 <- start
+  #     |
+  #     3 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: fakeHash(2),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+  # Ensure that with justified epoch 2 we find 3
+  #
+  #     0
+  #     |
+  #     1
+  #     |
+  #     2
+  #     |
+  #     3 <- start + head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(3),
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(3)
+  )
+
+proc test_ffg01() =
+  echo "  fork_choice - testing finality #01"
+  # for i in 0 ..< 4:
+  #   echo "    block (", i, ") hash: ", fakeHash(i)
+  # echo "    ------------------------------------------------------"
+
+  var (ctx, ops) = setup_finality_01()
+  ctx.run(ops)
+
+test_ffg01()

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../interpreter
+# import ../interpreter # included to be able to use "suiteReport"
 
 proc setup_finality_02(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
@@ -380,12 +380,12 @@ proc setup_finality_02(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
 
 proc test_ffg02() =
-  echo "  fork_choice - testing finality #02"
-  # for i in 0 ..< 12:
-  #   echo "    block (", i, ") hash: ", fakeHash(i)
-  # echo "    ------------------------------------------------------"
+  timedTest "fork_choice - testing finality #02":
+    # for i in 0 ..< 12:
+    #   echo "    block (", i, ") hash: ", fakeHash(i)
+    # echo "    ------------------------------------------------------"
 
-  var (ctx, ops) = setup_finality_02()
-  ctx.run(ops)
+    var (ctx, ops) = setup_finality_02()
+    ctx.run(ops)
 
 test_ffg02()

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -1,0 +1,391 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../interpreter
+
+proc setup_finality_02(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+  var balances = @[Gwei(1), Gwei(1)]
+  let GenesisRoot = fakeHash(0)
+
+  # Initialize the fork choice context
+  result.fork_choice = initForkChoice(
+    finalized_block_slot = Slot(0),                   # Metadata unused in fork choice
+    finalized_block_state_root = default(Eth2Digest), # Metadata unused in fork choice
+    justified_epoch = Epoch(1),
+    finalized_epoch = Epoch(1),
+    finalized_root = GenesisRoot
+  ).get()
+
+  # ----------------------------------
+
+  # Head should be genesis
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: GenesisRoot
+  )
+
+  # Build the following tree.
+  #
+  #                       0
+  #                      / \
+  #  just: 0, fin: 0 -> 1   2 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 3   4 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 5   6 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 7   8 <- just: 1, fin: 0
+  #                     |   |
+  #  just: 2, fin: 0 -> 9  10 <- just: 2, fin: 0
+
+  #  Left branch
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(1),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(0),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(3),
+    parent_root: fakeHash(1),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(5),
+    parent_root: fakeHash(3),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(7),
+    parent_root: fakeHash(5),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(9),
+    parent_root: fakeHash(7),
+    blk_justified_epoch: Epoch(2),
+    blk_finalized_epoch: Epoch(0)
+  )
+
+  # Build the following tree.
+  #
+  #                       0
+  #                      / \
+  #  just: 0, fin: 0 -> 1   2 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 3   4 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 5   6 <- just: 0, fin: 0
+  #                     |   |
+  #  just: 1, fin: 0 -> 7   8 <- just: 1, fin: 0
+  #                     |   |
+  #  just: 2, fin: 0 -> 9  10 <- just: 2, fin: 0
+
+  #  Right branch
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(2),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(0),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(4),
+    parent_root: fakeHash(2),
+    blk_justified_epoch: Epoch(0),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(6),
+    parent_root: fakeHash(4),
+    blk_justified_epoch: Epoch(0),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(8),
+    parent_root: fakeHash(6),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(0)
+  )
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    root: fakeHash(10),
+    parent_root: fakeHash(8),
+    blk_justified_epoch: Epoch(2),
+    blk_finalized_epoch: Epoch(0)
+  )
+
+  # Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
+  #
+  #           0  <-- start
+  #          / \
+  #         1   2
+  #         |   |
+  #         3   4
+  #         |   |
+  #         5   6
+  #         |   |
+  #         7   8
+  #         |   |
+  #         9  10 <-- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Same with justified_epoch 2
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Justified epoch 3 is invalid
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(3), # <--- Wrong epoch
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances
+  )
+
+  # Add a vote to 1.
+  #
+  #                 0
+  #                / \
+  #    +1 vote -> 1   2
+  #               |   |
+  #               3   4
+  #               |   |
+  #               5   6
+  #               |   |
+  #               7   8
+  #               |   |
+  #               9  10
+  result.ops.add Operation(
+    kind: ProcessAttestation,
+    validator_index: ValidatorIndex(0),
+    block_root: fake_hash(1),
+    target_epoch: Epoch(0)
+  )
+
+  # Ensure that if we start at 0 we find 9 (just: 0, fin: 0).
+  #
+  #           0  <-- start
+  #          / \
+  #         1   2
+  #         |   |
+  #         3   4
+  #         |   |
+  #         5   6
+  #         |   |
+  #         7   8
+  #         |   |
+  # head -> 9  10
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(9)
+  )
+
+  # Same with justified_epoch 2
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(9)
+  )
+
+  # Justified epoch 3 is invalid
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(3), # <--- Wrong epoch
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances
+  )
+
+  # Add a vote to 2.
+  #
+  #                 0
+  #                / \
+  #               1   2 <- +1 vote
+  #               |   |
+  #               3   4
+  #               |   |
+  #               5   6
+  #               |   |
+  #               7   8
+  #               |   |
+  #               9  10
+  result.ops.add Operation(
+    kind: ProcessAttestation,
+    validator_index: ValidatorIndex(1),
+    block_root: fake_hash(2),
+    target_epoch: Epoch(0)
+  )
+
+  # Ensure that if we start at 0 we find 10 again (just: 0, fin: 0).
+  #
+  #           0  <-- start
+  #          / \
+  #         1   2
+  #         |   |
+  #         3   4
+  #         |   |
+  #         5   6
+  #         |   |
+  #         7   8
+  #         |   |
+  #         9  10 <-- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Same with justified_epoch 2
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Justified epoch 3 is invalid
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(3), # <--- Wrong epoch
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances
+  )
+
+  # Ensure that if we start at 1 (instead of 0) we find 9 (just: 0, fin: 0).
+  #
+  #           0
+  #          / \
+  # start-> 1   2
+  #         |   |
+  #         3   4
+  #         |   |
+  #         5   6
+  #         |   |
+  #         7   8
+  #         |   |
+  # head -> 9  10
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: fakeHash(1),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(9)
+  )
+
+  # Same with justified_epoch 2
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(1),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(9)
+  )
+
+  # Justified epoch 3 is invalid
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(3), # <--- Wrong epoch
+    justified_root: fakeHash(1),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances
+  )
+
+  # Ensure that if we start at 2 (instead of 0) we find 10 (just: 0, fin: 0).
+  #
+  #           0
+  #          / \
+  #         1   2 <- start
+  #         |   |
+  #         3   4
+  #         |   |
+  #         5   6
+  #         |   |
+  #         7   8
+  #         |   |
+  #         9  10 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(0),
+    justified_root: fakeHash(2),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Same with justified_epoch 2
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(2),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
+
+  # Justified epoch 3 is invalid
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(3), # <--- Wrong epoch
+    justified_root: fakeHash(2),
+    finalized_epoch: Epoch(0),
+    justified_state_balances: balances
+  )
+
+proc test_ffg02() =
+  echo "  fork_choice - testing finality #02"
+  # for i in 0 ..< 12:
+  #   echo "    block (", i, ") hash: ", fakeHash(i)
+  # echo "    ------------------------------------------------------"
+
+  var (ctx, ops) = setup_finality_02()
+  ctx.run(ops)
+
+test_ffg02()

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../interpreter
+# import ../interpreter # included to be able to use "suiteReport"
 
 proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   let balances = newSeq[Gwei](16)
@@ -255,12 +255,12 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
 
 proc test_no_votes() =
-  echo "  fork_choice - testing no votes"
-  # for i in 0 ..< 6:
-  #   echo "    block (", i, ") hash: ", fakeHash(i)
-  # echo "    ------------------------------------------------------"
+  timedTest "fork_choice - testing no votes":
+    # for i in 0 ..< 6:
+    #   echo "    block (", i, ") hash: ", fakeHash(i)
+    # echo "    ------------------------------------------------------"
 
-  var (ctx, ops) = setup_no_votes()
-  ctx.run(ops)
+    var (ctx, ops) = setup_no_votes()
+    ctx.run(ops)
 
 test_no_votes()

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -11,6 +11,17 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   let balances = newSeq[Gwei](16)
   let GenesisRoot = fakeHash(0)
 
+  # Initialize the fork choice context
+  result.fork_choice = initForkChoice(
+    finalized_block_slot = Slot(0),
+    finalized_block_state_root = default(Eth2Digest),
+    justified_epoch = Epoch(1),
+    finalized_epoch = Epoch(1),
+    finalized_root = GenesisRoot
+  ).get()
+
+  # ----------------------------------
+
   # Head should be genesis
   result.ops.add Operation(
     kind: FindHead,
@@ -49,7 +60,7 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
     expected_head: fakeHash(2)
   )
 
-  # Add block 1
+  # Add block 1 as a fork
   #
   #         0
   #        / \
@@ -249,20 +260,11 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
     expected_head: fakeHash(6)
   )
 
-  # ----------------------------------
-  # Initialize the fork choice context
-  result.fork_choice = initForkChoice(
-    finalized_block_slot = Slot(0),
-    finalized_block_state_root = default(Eth2Digest),
-    justified_epoch = Epoch(1),
-    finalized_epoch = Epoch(1),
-    finalized_root = GenesisRoot
-  ).get()
-
 proc test_no_votes() =
   echo "  fork_choice - testing no votes"
   # for i in 0 ..< 6:
   #   echo "    block (", i, ") hash: ", fakeHash(i)
+  # echo "    ------------------------------------------------------"
 
   var (ctx, ops) = setup_no_votes()
   ctx.run(ops)

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -13,8 +13,8 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
 
   # Initialize the fork choice context
   result.fork_choice = initForkChoice(
-    finalized_block_slot = Slot(0),
-    finalized_block_state_root = default(Eth2Digest),
+    finalized_block_slot = Slot(0),                   # Metadata unused in fork choice
+    finalized_block_state_root = default(Eth2Digest), # Metadata unused in fork choice
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot
@@ -39,7 +39,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       2
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(2),
     parent_root: GenesisRoot,
     blk_justified_epoch: Epoch(1),
@@ -67,7 +66,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       2  1
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(1),
     parent_root: GenesisRoot,
     blk_justified_epoch: Epoch(1),
@@ -97,7 +95,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #          3
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(3),
     parent_root: fakeHash(1),
     blk_justified_epoch: Epoch(1),
@@ -129,7 +126,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       4  3
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(4),
     parent_root: fakeHash(2),
     blk_justified_epoch: Epoch(1),
@@ -163,7 +159,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       5 <- justified epoch = 2
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(5),
     parent_root: fakeHash(4),
     blk_justified_epoch: Epoch(2),
@@ -234,7 +229,6 @@ proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #     6
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(6),
     parent_root: fakeHash(5),
     blk_justified_epoch: Epoch(2),

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -1,0 +1,270 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../interpreter
+
+proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+  let balances = newSeq[Gwei](16)
+  let GenesisRoot = fakeHash(0)
+
+  # Head should be genesis
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: GenesisRoot
+  )
+
+  # Add block 2
+  #
+  #         0
+  #        /
+  #       2
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(2),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Head should be 2
+  #
+  #         0
+  #        /
+  #       2 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+  # Add block 1
+  #
+  #         0
+  #        / \
+  #       2  1
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(1),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Head is still 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
+  #
+  #          0
+  #         / \
+  # head-> 2  1
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+  # Add block 3
+  #
+  #         0
+  #        / \
+  #       2  1
+  #          |
+  #          3
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(3),
+    parent_root: fakeHash(1),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Head is still 2
+  #
+  #          0
+  #         / \
+  # head-> 2  1
+  #           |
+  #           3
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+  # Add block 4
+  #
+  #         0
+  #        / \
+  #       2  1
+  #       |  |
+  #       4  3
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(4),
+    parent_root: fakeHash(2),
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Check that head is 4
+  #
+  #          0
+  #         / \
+  #        2  1
+  #        |  |
+  # head-> 4  3
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(4)
+  )
+
+  # Add block 5 with justified epoch of 2
+  #
+  #         0
+  #        / \
+  #       2  1
+  #       |  |
+  #       4  3
+  #       |
+  #       5 <- justified epoch = 2
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(5),
+    parent_root: fakeHash(4),
+    blk_justified_epoch: Epoch(2),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Ensure the head is still 4 whilst the justified epoch is 0.
+  #
+  #          0
+  #         / \
+  #        2  1
+  #        |  |
+  # head-> 4  3
+  #        |
+  #        5
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(4)
+  )
+
+  # Ensure that there is an error when starting from a block with the wrong justified epoch
+  #      0
+  #     / \
+  #    2  1
+  #    |  |
+  #    4  3
+  #    |
+  #    5 <- starting from 5 with justified epoch 1 should error.
+  result.ops.add Operation(
+    kind: InvalidFindHead,
+    justified_epoch: Epoch(1), # <--- Wrong epoch
+    justified_root: fakeHash(5),
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances
+  )
+
+  # Set the justified epoch to 2 and the start block to 5 and ensure 5 is the head.
+  #      0
+  #     / \
+  #    2  1
+  #    |  |
+  #    4  3
+  #    |
+  #    5 <- head + justified
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(5),
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(5)
+  )
+
+  # Add block 6
+  #
+  #      0
+  #     / \
+  #     2  1
+  #     |  |
+  #     4  3
+  #     |
+  #     5 <- justified root
+  #     |
+  #     6
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(6),
+    parent_root: fakeHash(5),
+    blk_justified_epoch: Epoch(2),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Ensure 6 is the head
+  #      0
+  #     / \
+  #    2  1
+  #    |  |
+  #    4  3
+  #    |
+  #    5 <- justified root
+  #    |
+  #    6 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(5),
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(6)
+  )
+
+  # ----------------------------------
+  # Initialize the fork choice context
+  result.fork_choice = initForkChoice(
+    finalized_block_slot = Slot(0),
+    finalized_block_state_root = default(Eth2Digest),
+    justified_epoch = Epoch(1),
+    finalized_epoch = Epoch(1),
+    finalized_root = GenesisRoot
+  ).get()
+
+proc test_no_votes() =
+  echo "  fork_choice - testing no votes"
+  # for i in 0 ..< 6:
+  #   echo "    block (", i, ") hash: ", fakeHash(i)
+
+  var (ctx, ops) = setup_no_votes()
+  ctx.run(ops)
+
+test_no_votes()

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -236,6 +236,8 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       2  1
   #          |
   #          3
+  #          |
+  #          4
   result.ops.add Operation(
     kind: ProcessBlock,
     slot: Slot(0),
@@ -473,6 +475,16 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(9),
     target_epoch: Epoch(5)
+  )
+
+  # Head should still be 9
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(5),
+    finalized_epoch: Epoch(2),
+    justified_state_balances: balances,
+    expected_head: fakeHash(9)
   )
 
   # Add block 10

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -1,0 +1,152 @@
+# beacon_chain
+# Copyright (c) 2018 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ../interpreter
+
+proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+  let balances = @[Gwei(1), Gwei(1)]
+  let GenesisRoot = fakeHash(0)
+
+  # Initialize the fork choice context
+  result.fork_choice = initForkChoice(
+    finalized_block_slot = Slot(0),
+    finalized_block_state_root = default(Eth2Digest),
+    justified_epoch = Epoch(1),
+    finalized_epoch = Epoch(1),
+    finalized_root = GenesisRoot
+  ).get()
+
+  # ----------------------------------
+
+  # Head should be genesis
+  # result.ops.add Operation(
+  #   kind: FindHead,
+  #   justified_epoch: Epoch(1),
+  #   justified_root: GenesisRoot,
+  #   finalized_epoch: Epoch(1),
+  #   justified_state_balances: balances,
+  #   expected_head: GenesisRoot
+  # )
+
+  # Add block 2
+  #
+  #         0
+  #        /
+  #       2
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(2),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Head should be 2
+  #
+  #         0
+  #        /
+  #       2 <- head
+  # result.ops.add Operation(
+  #   kind: FindHead,
+  #   justified_epoch: Epoch(1),
+  #   justified_root: GenesisRoot,
+  #   finalized_epoch: Epoch(1),
+  #   justified_state_balances: balances,
+  #   expected_head: fakeHash(2)
+  # )
+
+  # Add block 1 as a fork
+  #
+  #         0
+  #        / \
+  #       2  1
+  result.ops.add Operation(
+    kind: ProcessBlock,
+    slot: Slot(0),
+    root: fakeHash(1),
+    parent_root: GenesisRoot,
+    blk_justified_epoch: Epoch(1),
+    blk_finalized_epoch: Epoch(1)
+  )
+
+  # Head is still 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
+  #
+  #          0
+  #         / \
+  # head-> 2  1
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+  # Add a vote to block 1
+  #
+  #          0
+  #         / \
+  #        2  1 <- +vote
+  result.ops.add Operation(
+    kind: ProcessAttestation,
+    validator_index: ValidatorIndex(0),
+    block_root: fakeHash(1),
+    target_epoch: Epoch(2)
+  )
+
+  # Head is now 1 as 1 has an extra vote
+  #
+  #          0
+  #         / \
+  #        2  1 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(1)
+  )
+
+  # Add a vote to block 2
+  #
+  #           0
+  #          / \
+  # +vote-> 2   1
+  result.ops.add Operation(
+    kind: ProcessAttestation,
+    validator_index: ValidatorIndex(1),
+    block_root: fakeHash(2),
+    target_epoch: Epoch(2)
+  )
+
+  # Head is back to 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
+  #
+  #          0
+  #         / \
+  # head-> 2  1
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(1),
+    justified_root: GenesisRoot,
+    finalized_epoch: Epoch(1),
+    justified_state_balances: balances,
+    expected_head: fakeHash(2)
+  )
+
+proc test_votes() =
+  echo "  fork_choice - testing with votes"
+  for i in 0 ..< 11:
+    echo "    block (", i, ") hash: ", fakeHash(i)
+  echo "    ------------------------------------------------------"
+
+  var (ctx, ops) = setup_votes()
+  ctx.run(ops)
+
+test_votes()

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import ../interpreter
+# import ../interpreter # included to be able to use "suiteReport"
 
 proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
@@ -707,12 +707,12 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
 
 proc test_votes() =
-  echo "  fork_choice - testing with votes"
-  # for i in 0 ..< 12:
-  #   echo "    block (", i, ") hash: ", fakeHash(i)
-  # echo "    ------------------------------------------------------"
+  timedTest "fork_choice - testing with votes":
+    # for i in 0 ..< 12:
+    #   echo "    block (", i, ") hash: ", fakeHash(i)
+    # echo "    ------------------------------------------------------"
 
-  var (ctx, ops) = setup_votes()
-  ctx.run(ops)
+    var (ctx, ops) = setup_votes()
+    ctx.run(ops)
 
 test_votes()

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -532,41 +532,41 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   result.ops.add Operation(
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(2),
-    block_root: fakeHash(9),
+    block_root: fakeHash(10),
     target_epoch: Epoch(5)
   )
   result.ops.add Operation(
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(3),
-    block_root: fakeHash(9),
+    block_root: fakeHash(10),
     target_epoch: Epoch(5)
   )
 
-  # # Check that the head is now 10.
-  # #
-  # #          0
-  # #         / \
-  # #        2   1
-  # #            |
-  # #            3
-  # #            |
-  # #            4
-  # #           / \
-  # #          5   6
-  # #          |
-  # #          7
-  # #          |
-  # #          8
-  # #         / \
-  # #        9  10 <- head
-  # result.ops.add Operation(
-  #   kind: FindHead,
-  #   justified_epoch: Epoch(2),
-  #   justified_root: fakeHash(5),
-  #   finalized_epoch: Epoch(2),
-  #   justified_state_balances: balances,
-  #   expected_head: fakeHash(10)
-  # )
+  # Check that the head is now 10.
+  #
+  #          0
+  #         / \
+  #        2   1
+  #            |
+  #            3
+  #            |
+  #            4
+  #           / \
+  #          5   6
+  #          |
+  #          7
+  #          |
+  #          8
+  #         / \
+  #        9  10 <- head
+  result.ops.add Operation(
+    kind: FindHead,
+    justified_epoch: Epoch(2),
+    justified_root: fakeHash(5),
+    finalized_epoch: Epoch(2),
+    justified_state_balances: balances,
+    expected_head: fakeHash(10)
+  )
 
 proc test_votes() =
   echo "  fork_choice - testing with votes"

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -13,8 +13,8 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
 
   # Initialize the fork choice context
   result.fork_choice = initForkChoice(
-    finalized_block_slot = Slot(0),
-    finalized_block_state_root = default(Eth2Digest),
+    finalized_block_slot = Slot(0),                   # Metadata unused in fork choice
+    finalized_block_state_root = default(Eth2Digest), # Metadata unused in fork choice
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot
@@ -39,7 +39,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       2
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(2),
     parent_root: GenesisRoot,
     blk_justified_epoch: Epoch(1),
@@ -67,7 +66,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #       2  1
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(1),
     parent_root: GenesisRoot,
     blk_justified_epoch: Epoch(1),
@@ -149,7 +147,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #          3
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(3),
     parent_root: fakeHash(1),
     blk_justified_epoch: Epoch(1),
@@ -240,7 +237,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #          4
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(4),
     parent_root: fakeHash(3),
     blk_justified_epoch: Epoch(1),
@@ -278,7 +274,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #          5 <- justified epoch = 2
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(5),
     parent_root: fakeHash(4),
     blk_justified_epoch: Epoch(2),
@@ -318,7 +313,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #          5   6 <- justified epoch = 0
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(6),
     parent_root: fakeHash(4),
     blk_justified_epoch: Epoch(1),
@@ -369,7 +363,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #        9
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(7),
     parent_root: fakeHash(5),
     blk_justified_epoch: Epoch(2),
@@ -377,7 +370,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(8),
     parent_root: fakeHash(7),
     blk_justified_epoch: Epoch(2),
@@ -385,7 +377,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   )
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(9),
     parent_root: fakeHash(8),
     blk_justified_epoch: Epoch(2),
@@ -505,7 +496,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #        9  10
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(10),
     parent_root: fakeHash(8),
     blk_justified_epoch: Epoch(2),
@@ -700,7 +690,6 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
   #        11
   result.ops.add Operation(
     kind: ProcessBlock,
-    slot: Slot(0),
     root: fakeHash(11),
     parent_root: fakeHash(9),
     blk_justified_epoch: Epoch(2),
@@ -719,9 +708,9 @@ proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
 
 proc test_votes() =
   echo "  fork_choice - testing with votes"
-  for i in 0 ..< 11:
-    echo "    block (", i, ") hash: ", fakeHash(i)
-  echo "    ------------------------------------------------------"
+  # for i in 0 ..< 12:
+  #   echo "    block (", i, ") hash: ", fakeHash(i)
+  # echo "    ------------------------------------------------------"
 
   var (ctx, ops) = setup_votes()
   ctx.run(ops)

--- a/tests/fork_choice/tests_fork_choice.nim
+++ b/tests/fork_choice/tests_fork_choice.nim
@@ -2,5 +2,9 @@
 # - beacon_chain/fork_choice/proto_array.nim (sanity checks for tiebreak)
 # - beacon_chain/fork_choice/fork_choice.nim (sanity checks for compute_deltas)
 
-import
-  scenarios/[no_votes, votes, ffg_01, ffg_02]
+import ../testutil, std/unittest
+
+# include to be able to use "suiteReport"
+import ./interpreter
+suiteReport "Fork Choice + Finality " & preset():
+  include scenarios/[no_votes, votes, ffg_01, ffg_02]

--- a/tests/fork_choice/tests_fork_choice.nim
+++ b/tests/fork_choice/tests_fork_choice.nim
@@ -1,0 +1,6 @@
+# Don't forgot to run the following files as main modules:
+# - beacon_chain/fork_choice/proto_array.nim (sanity checks for tiebreak)
+# - beacon_chain/fork_choice/fork_choice.nim (sanity checks for compute_deltas)
+
+import
+  scenarios/[no_votes, votes, ffg_01, ffg_02]


### PR DESCRIPTION
Fork choice complete refactor.

This closes https://github.com/status-im/nim-beacon-chain/issues/719 but no EF test vectors yet (https://github.com/status-im/nim-beacon-chain/issues/777) see https://github.com/ethereum/eth2.0-spec-tests/issues/17 for upstream discussion.

The implementation closely follows Lighthouse's at https://github.com/sigp/lighthouse/tree/869b0621d6f51e98473bb67cec0446d3623b8957/eth2/proto_array_fork_choice/src

Lighthouse implementation is derived from Protolambda's Array-based stateful DAG at https://github.com/protolambda/lmd-ghost

Fun fact, Protolambda's forked the fork at: https://github.com/protolambda/eth2-py-hacks/blob/ae2865670dcb0427f10b0725b897cd2d7b887c9c/proto_array.py

Other resources:
- Spec: https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/fork-choice.md
- Prysmatic write up: https://hackmd.io/bABJiht3Q9SyV3Ga4FT9lQ#High-level-concept
- Gasper White Paper from march 6: https://arxiv.org/abs/2003.03052

This highlighted 2 critical bugs

1. in Nimcrypto, fixed by https://github.com/status-im/nim-beacon-chain/pull/864. When nimcrypto.hash module was imported `==` was sometimes wrong causing mayhem in fork choice. This might be the final solution to the finality issues we have.
2. `var openarray` seems unstable, uncommenting the debugEcho in the following spot make the fork choice compute_deltas test give the wrong results, this is only for the "isMainModule" sanity checks, the unit tests are not affected: https://github.com/status-im/nim-beacon-chain/blob/65889784fc7b8a65451f1e3b7f7f56ba1c529d8c/beacon_chain/fork_choice/fork_choice.nim#L182-L208
  
## TODO:
- [x] - The current branch is littered with (commented out) debugEcho that have to be removed
- [ ] - in a second PR - Replacing the old fork choice in the attestation_pool with the new one

Note: The PR will be separated in 2 as this one is already 3000 lines of complex code.
This only add the fork choice and accompanying tests as a separate module.
It does not replace the current fork choice used in testnet.

This will be done in a second PR, that will update the attestation_pool https://github.com/status-im/nim-beacon-chain/blob/bd5400aea4f23a722c207826b21070db7966bee5/beacon_chain/attestation_pool.nim#L378-L440


## Postponed / Not in scope:
- Internally we are using Nim options and tables but those raise exceptions. Ideally we have a fork that doesn't except.
- The implementation has the slot and state_root as unused metadata, mirroring Lighthouse but this might be useless for us or we might need more metadata, in that case maybe we should have a generic "metadata" field here: https://github.com/status-im/nim-beacon-chain/blob/65889784fc7b8a65451f1e3b7f7f56ba1c529d8c/beacon_chain/fork_choice/fork_choice_types.nim#L93-L103
- The current implementation (and Lighthouse / Prysmatic) does not implement `should_update_justified_checkpoint` which protect against a class of attack called "bouncing attacks": https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/fork-choice.md#should_update_justified_checkpoint
- Implementing the 1-to-1 with spec might help generating test cases as internally the control flow is quite complex. However the interface and error model are very different and it is a significant effort: https://github.com/status-im/nim-beacon-chain/tree/fork-choice/beacon_chain/fork_choice 
- Protolambda has a variant that always prune at https://github.com/protolambda/eth2-py-hacks/blob/ae2865670dcb0427f10b0725b897cd2d7b887c9c/proto_array.py by making pruning cheaper. Instead of scanning the proto_array and substracting on a prune, it keeps the pruned index offset as a field and only substract on query.

## Tips for debugging in the future

The commit https://github.com/status-im/nim-beacon-chain/pull/865/commits/9146bcd69d454368495fd7c172cbf00a2c736a62 removed the `debugEcho` I found useful to debug fork choice. It can be locally reverted to restore them for debugging.