### PR TITLE
fix and refactor merkle_minimal sanity checks and during CI

### DIFF
--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -19,6 +19,7 @@ import # Unit test
   ./test_discovery_helpers,
   ./test_helpers,
   ./test_kvstore,
+  ./test_mocking,
   ./test_kvstore_sqlite3,
   ./test_ssz,
   ./test_state_transition,

--- a/tests/test_mocking.nim
+++ b/tests/test_mocking.nim
@@ -1,0 +1,16 @@
+# beacon_chain
+# Copyright (c) 2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  unittest, ./testutil, ./mocking/merkle_minimal
+
+suiteReport "Mocking utilities":
+  timedTest "merkle_minimal":
+    check:
+      testMerkleMinimal()


### PR DESCRIPTION
As @mratsim pointed out, this was/is a pretty literal port of https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/tests/core/pyspec/eth2spec/utils/merkle_minimal.py. I changed it from checking against `hash_tree_root(...)`, because that's not an especially non-coincidental check to begin with, to checking that `merkleTreeFromLeaves(...)/getMerkleProof(...)` are consistent with `is_valid_merkle_branch(...)`. These are useful tests, so it also runs them during CI.

As far as `is_valid_merkle_branch(...)` itself, it's checked in a basic way by https://github.com/status-im/nim-beacon-chain/blob/master/tests/official/test_fixture_operations_deposits.nim.

Next steps for Merkle fixing are to continue on to other `mocking` modules and extending their use, but https://github.com/status-im/nim-beacon-chain/pull/875 currently modifies some relevant code concurrently, so keeping this PR as-is for now, pending that being merged.