### PR TITLE
remove all but one UnusedImport warning

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -4,7 +4,7 @@ import
   options as stdOptions, net as stdNet,
 
   # Status libs
-  stew/[io, varints, base58], stew/shims/[macros, tables], stint,
+  stew/[varints, base58], stew/shims/[macros, tables], stint,
   faststreams/output_stream,
   json_serialization, json_serialization/std/[net, options],
   chronos, chronicles, metrics,

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -482,7 +482,7 @@ func node_is_viable_for_head(self: ProtoArray, node: ProtoNode): bool {.raises: 
 # Sanity checks on internal private procedures
 
 when isMainModule:
-  import nimcrypto/[hash, utils]
+  import nimcrypto/hash
 
   echo "Sanity checks on fork choice tiebreaks"
 

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -33,7 +33,7 @@ const eth1BlockHash* = block:
   for v in x.data.mitems: v = 0x42
   x
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/deposit-contract.md#withdrawal-credentials
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/deposit-contract.md#withdrawal-credentials
 func makeWithdrawalCredentials*(k: ValidatorPubKey): Eth2Digest =
   var bytes = eth2hash(k.getBytes())
   bytes.data[0] = BLS_WITHDRAWAL_PREFIX.uint8

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -7,7 +7,7 @@
 
 # Serenity hash function / digest
 #
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#hash
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#hash
 #
 # In Phase 0 the beacon chain is deployed with SHA256 (SHA2-256).
 # Note that is is different from Keccak256 (often mistakenly called SHA3-256)

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -80,7 +80,7 @@ const
 
   # Time parameters
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/mainnet.yaml#L71
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L77
   MIN_GENESIS_DELAY* = 86400 # 86400 seconds (1 day)
 
   SECONDS_PER_SLOT*{.intdefine.} = 12'u64 # Compile with -d:SECONDS_PER_SLOT=1 for 12x faster slots
@@ -154,7 +154,7 @@ const
 
   # Max operations per block
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/mainnet.yaml#L128
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L131
   MAX_PROPOSER_SLASHINGS* = 2^4
   MAX_ATTESTER_SLASHINGS* = 2^0
   MAX_ATTESTATIONS* = 2^7
@@ -168,7 +168,7 @@ const
 
   # Validators
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/mainnet.yaml#L32
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/mainnet.yaml#L38
   ETH1_FOLLOW_DISTANCE* = 1024 # blocks ~ 4 hours
   TARGET_AGGREGATORS_PER_COMMITTEE* = 16 # validators
   RANDOM_SUBNETS_PER_VALIDATOR* = 1 # subnet
@@ -218,14 +218,3 @@ const
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/configs/mainnet.yaml#L220
   EARLY_DERIVED_SECRET_REVEAL_SLOT_REWARD_MULTIPLE* = 2
   MINOR_REWARD_QUOTIENT* = 256
-
-  # Phase 1 - Sharding
-  # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase1/shard-data-chains.md#time-parameters
-  # TODO those are included in minimal.yaml but not mainnet.yaml
-  #      Why?
-  # SHARD_SLOTS_PER_BEACON_SLOT* = 2 # spec: SHARD_SLOTS_PER_EPOCH
-  # EPOCHS_PER_SHARD_PERIOD* = 4
-  # PHASE_1_FORK_EPOCH* = 8
-  # PHASE_1_FORK_SLOT* = 64
-

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -62,9 +62,8 @@ const
 
   # Initial values
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L64
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L70
 
-  # Unchanged
   GENESIS_SLOT* = 0.Slot
   GENESIS_FORK_VERSION* = [0'u8, 0'u8, 0'u8, 1'u8]
   BLS_WITHDRAWAL_PREFIX* = 0'u8
@@ -107,11 +106,13 @@ const
 
   # State vector lengths
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L105
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L105
 
   # Changed
   EPOCHS_PER_HISTORICAL_VECTOR* = 64
   EPOCHS_PER_SLASHINGS_VECTOR* = 64
+
+  # Unchanged
   HISTORICAL_ROOTS_LIMIT* = 16777216
   VALIDATOR_REGISTRY_LIMIT* = 1099511627776
 
@@ -137,7 +138,7 @@ const
 
   # Fork choice
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/configs/minimal.yaml#L26
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L32
 
   # Changed
   SAFE_SLOTS_TO_UPDATE_JUSTIFIED* = 2

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -33,7 +33,7 @@
 # now.
 
 import
-  algorithm, collections/sets, chronicles, options, sequtils, sets, tables,
+  algorithm, collections/sets, chronicles, options, sequtils, sets,
   ../extras, ../ssz, metrics,
   beaconstate, crypto, datatypes, digest, helpers, validator,
   ../../nbench/bench_lab

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -210,7 +210,7 @@ proc processProposerSlashings(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#is_slashable_attestation_data
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#is_slashable_attestation_data
 func is_slashable_attestation_data(
     data_1: AttestationData, data_2: AttestationData): bool =
   ## Check if ``data_1`` and ``data_2`` are slashable according to Casper FFG

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -77,7 +77,7 @@ func get_shuffled_seq*(seed: Eth2Digest,
 
   result = shuffled_active_validator_indices
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#get_previous_epoch
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#get_previous_epoch
 func get_previous_epoch*(state: BeaconState): Epoch =
   # Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
   let current_epoch = get_current_epoch(state)

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -31,7 +31,7 @@
 # now.
 
 import
-  collections/sets, chronicles, sets, options,
+  collections/sets, chronicles, sets,
   ./extras, ./ssz, metrics,
   ./spec/[datatypes, crypto, digest, helpers, validator],
   ./spec/[state_transition_block, state_transition_epoch],

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -24,7 +24,7 @@ func getValidator*(pool: ValidatorPool,
                    validatorKey: ValidatorPubKey): AttachedValidator =
   pool.validators.getOrDefault(validatorKey)
 
-# TODO: Honest validator - https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md
+# TODO: Honest validator - https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md
 proc signBlockProposal*(v: AttachedValidator, fork: Fork,
                         genesis_validators_root: Eth2Digest, slot: Slot,
                         blockRoot: Eth2Digest): Future[ValidatorSig] {.async.} =

--- a/nbench/README.md
+++ b/nbench/README.md
@@ -24,7 +24,7 @@ Features
 
 ```
 nim c -d:const_preset=mainnet -d:nbench -d:release -o:build/nbench nbench/nbench.nim
-export SCENARIOS=vendor/nim-eth2-scenarios/tests-v0.10.1/mainnet/phase0
+export SCENARIOS=vendor/nim-eth2-scenarios/tests-v0.11.1/mainnet/phase0
 
 # Full state transition
 build/nbench cmdFullStateTransition -d="${SCENARIOS}"/sanity/blocks/pyspec_tests/voluntary_exit/ -q=2
@@ -71,7 +71,7 @@ Furthermore benchmarks are run in parallel and might interfere which each other.
 ```
 nim c -d:const_preset=mainnet -d:nbench -d:release -o:build/nbench nbench/nbench.nim
 nim c -o:build/nbench_tests nbench/nbench_spec_scenarios.nim
-build/nbench_tests --nbench=build/nbench --tests=vendor/nim-eth2-scenarios/tests-v0.10.1/mainnet/
+build/nbench_tests --nbench=build/nbench --tests=vendor/nim-eth2-scenarios/tests-v0.11.1/mainnet/
 ```
 
 ## TODO Reporting

--- a/tests/fork_choice/tests_fork_choice.nim
+++ b/tests/fork_choice/tests_fork_choice.nim
@@ -2,6 +2,8 @@
 # - beacon_chain/fork_choice/proto_array.nim (sanity checks for tiebreak)
 # - beacon_chain/fork_choice/fork_choice.nim (sanity checks for compute_deltas)
 
+{.used.}
+
 import ../testutil, std/unittest
 
 # include to be able to use "suiteReport"

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -12,7 +12,7 @@ import
   os, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, beaconstate, validator],
-  ../../beacon_chain/[ssz, extras],
+  ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
   ./fixtures_utils,

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -12,7 +12,7 @@ import
   os, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
-  ../../beacon_chain/[extras, ssz],
+  ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
   ./fixtures_utils,

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -12,7 +12,7 @@ import
   os, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
-  ../../beacon_chain/[ssz, extras],
+  ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
   ./fixtures_utils,

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -12,7 +12,7 @@ import
   os, unittest,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block],
-  ../../beacon_chain/[ssz, extras],
+  ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
   ./fixtures_utils,

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,16 +8,18 @@
 {.used.}
 
 import
-  unittest,
-  chronicles,
-  stew/byteutils,
-  ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[digest, validator],
-  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition],
   ../beacon_chain/spec/datatypes,
   ../beacon_chain/ssz
 
 when const_preset == "minimal": # Too much stack space used on mainnet
+  import
+    unittest,
+    chronicles,
+    stew/byteutils,
+    ./testutil, ./testblockutil,
+    ../beacon_chain/spec/[digest, validator],
+    ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition]
+
   suiteReport "Attestation pool processing" & preset():
     ## For now just test that we can compile and execute block processing with
     ## mock data.

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2020 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,9 +8,9 @@
 {.used.}
 
 import
-  options, sequtils, unittest, chronicles,
-  ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[datatypes, digest, helpers, validator],
+  unittest,
+  ./testutil,
+  ../beacon_chain/spec/datatypes,
   ../beacon_chain/[beacon_node_types, block_pool, ssz]
 
 suiteReport "BlockRef and helpers" & preset():
@@ -83,6 +83,11 @@ suiteReport "BlockSlot and helpers" & preset():
       s24.parent.parent == s22
 
 when const_preset == "minimal": # Too much stack space used on mainnet
+  import
+    options, sequtils, chronicles,
+    ./testblockutil,
+    ../beacon_chain/spec/[digest, helpers, validator]
+
   suiteReport "Block pool processing" & preset():
     setup:
       var

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -84,7 +84,7 @@ suiteReport "BlockSlot and helpers" & preset():
 
 when const_preset == "minimal": # Too much stack space used on mainnet
   import
-    options, sequtils, chronicles,
+    options, sequtils,
     ./testblockutil,
     ../beacon_chain/spec/[digest, helpers, validator]
 


### PR DESCRIPTION
Per @zah's question in https://github.com/status-im/nim-beacon-chain/issues/880 I looked more closely at the remaining warnings. About half were real, and the other half or so were predominantly in `test_attestation_pool` and `test_block_pool`, which entirely or mostly get conditionally disabled in `mainnet` due to stack usage issues.

This PR addresses the quick first pass I did of the non-false-positives, and leaves only:
```
beacon_chain/eth2_network.nim(16, 26) Warning: imported and not used: 'messages' [UnusedImport]
```
Regarding which, if removed:
```
beacon_chain/eth2_network.nim(959, 80) template/generic instantiation of `async` from here
beacon_chain/eth2_network.nim(976, 59) Error: undeclared identifier: 'messages'
```