### PR TITLE
Enable 3 official EF spec tests

### DIFF
--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -80,10 +80,12 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Invalid] same_data                                                                        OK
 + [Invalid] unsorted_att_1                                                                   OK
 + [Invalid] unsorted_att_2                                                                   OK
++ [Valid]   success_already_exited_long_ago                                                  OK
++ [Valid]   success_already_exited_recent                                                    OK
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
+OK: 18/18 Fail: 0/18 Skip: 0/18
 ## Official - Operations - Block header  [Preset: mainnet]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -105,8 +107,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]    new_deposit_over_max                                                            OK
 + [Valid]    new_deposit_under_max                                                           OK
 + [Valid]    success_top_up                                                                  OK
++ [Valid]    valid_sig_but_forked_state                                                      OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## Official - Operations - Proposer slashing  [Preset: mainnet]
 ```diff
 + [Invalid] identifier                                                                       OK
@@ -160,4 +163,4 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 110/110 Fail: 0/110 Skip: 0/110
+OK: 113/113 Fail: 0/113 Skip: 0/113

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -80,10 +80,12 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Invalid] same_data                                                                        OK
 + [Invalid] unsorted_att_1                                                                   OK
 + [Invalid] unsorted_att_2                                                                   OK
++ [Valid]   success_already_exited_long_ago                                                  OK
++ [Valid]   success_already_exited_recent                                                    OK
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
+OK: 18/18 Fail: 0/18 Skip: 0/18
 ## Official - Operations - Block header  [Preset: minimal]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -105,8 +107,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]    new_deposit_over_max                                                            OK
 + [Valid]    new_deposit_under_max                                                           OK
 + [Valid]    success_top_up                                                                  OK
++ [Valid]    valid_sig_but_forked_state                                                      OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## Official - Operations - Proposer slashing  [Preset: minimal]
 ```diff
 + [Invalid] identifier                                                                       OK
@@ -163,4 +166,4 @@ OK: 22/22 Fail: 0/22 Skip: 0/22
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 113/113 Fail: 0/113 Skip: 0/113
+OK: 116/116 Fail: 0/116 Skip: 0/116

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -79,5 +79,6 @@ suiteReport "Official - Operations - Attester slashing " & preset():
     ]
   for kind, path in walkDir(OpAttSlashingDir, true):
     if path in expected_failures:
+      echo "Skipping test: ", path
       continue
     runTest(path)

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -74,12 +74,10 @@ suiteReport "Official - Operations - Attester slashing " & preset():
   # which cases signature checks had been incorrectly passing.
   const expected_failures =
     [
-      "success_already_exited_recent", "success_already_exited_long_ago",
       # TODO: Regressions introduced by BLS v0.10.1
       "att1_duplicate_index_double_signed", "att2_duplicate_index_double_signed"
     ]
   for kind, path in walkDir(OpAttSlashingDir, true):
     if path in expected_failures:
-      echo "Skipping test: ", path
       continue
     runTest(path)

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -61,11 +61,5 @@ proc runTest(identifier: string) =
   `testImpl _ operations_deposits _ identifier`()
 
 suiteReport "Official - Operations - Deposits " & preset():
-  # TODO
-  const expected_failures = ["valid_sig_but_forked_state"]
-
   for kind, path in walkDir(OperationsDepositsDir, true):
-    if path in expected_failures:
-      echo "Skipping test: ", path
-      continue
     runTest(path)


### PR DESCRIPTION
Notably, `test_fixture_operations_deposits.nim` doesn't exclude any official tests anymore; it's running everything the EF provides successfully.