### PR TITLE
Remove more warnings, both deprecations and unused imports

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -882,14 +882,14 @@ proc handleMissingBlocks(node: BeaconNode) =
       #      work with while the sync problem is dealt with more systematically
       dec left
       if left == 0:
-        addTimer(Moment.now()) do (p: pointer):
+        discard setTimer(Moment.now()) do (p: pointer):
           handleMissingBlocks(node)
 
 proc onSecond(node: BeaconNode, moment: Moment) {.async.} =
   node.handleMissingBlocks()
 
   let nextSecond = max(Moment.now(), moment + chronos.seconds(1))
-  addTimer(nextSecond) do (p: pointer):
+  discard setTimer(nextSecond) do (p: pointer):
     asyncCheck node.onSecond(nextSecond)
 
 # TODO: Should we move these to other modules?
@@ -1037,7 +1037,7 @@ proc run*(node: BeaconNode) =
     asyncCheck node.onSlotStart(curSlot, nextSlot)
 
   let second = Moment.now() + chronos.seconds(1)
-  addTimer(second) do (p: pointer):
+  discard setTimer(second) do (p: pointer):
     asyncCheck node.onSecond(second)
 
   runForever()

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -89,7 +89,7 @@ func getAncestorAt*(blck: BlockRef, slot: Slot): BlockRef =
     blck = blck.parent
 
 func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
-  ## https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/fork-choice.md#get_ancestor
+  ## https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/fork-choice.md#get_ancestor
   ## Return ancestor at slot, or nil if queried block is older
   var blck = blck
 

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -181,7 +181,7 @@ const
 
   # Phase 1 - Custody game
   # ---------------------------------------------------------------
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase1/custody-game.md#constants
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/configs/minimal.yaml#L201
   # TODO those are included in minimal.yaml but not mainnet.yaml
   #      Why?
   RANDAO_PENALTY_EPOCHS* = 2

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -31,7 +31,7 @@
 # now.
 
 import
-  chronicles, options,
+  chronicles,
   ./extras, ./ssz, metrics,
   ./spec/[datatypes, crypto, digest, helpers, validator],
   ./spec/[state_transition_block, state_transition_epoch],

--- a/beacon_chain/time.nim
+++ b/beacon_chain/time.nim
@@ -79,7 +79,7 @@ func saturate*(d: tuple[inFuture: bool, offset: Duration]): Duration =
   if d.inFuture: d.offset else: seconds(0)
 
 proc addTimer*(fromNow: Duration, cb: CallbackFunc, udata: pointer = nil) =
-  addTimer(Moment.now() + fromNow, cb, udata)
+  discard setTimer(Moment.now() + fromNow, cb, udata)
 
 func shortLog*(d: Duration): string =
   let dd = int64(d.milliseconds())

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -10,8 +10,7 @@
 import
   times, unittest,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[beaconstate, datatypes, digest],
-  ../beacon_chain/extras
+  ../beacon_chain/spec/[beaconstate, datatypes, digest]
 
 suiteReport "Beacon state" & preset():
   timedTest "Smoke test initialize_beacon_state_from_eth1" & preset():

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -8,7 +8,7 @@
 {.used.}
 
 import
-  unittest, chronicles,
+  unittest,
   ./testutil,
   ../beacon_chain/spec/datatypes,
   ../beacon_chain/[beacon_node_types, block_pool, ssz]

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -11,7 +11,7 @@ import
   unittest,
   ./testutil, ./testblockutil,
   ../beacon_chain/spec/[beaconstate, datatypes, digest, validator],
-  ../beacon_chain/[extras, state_transition, ssz]
+  ../beacon_chain/[state_transition, ssz]
 
 suiteReport "Block processing" & preset():
   ## For now just test that we can compile and execute block processing with


### PR DESCRIPTION
`addTimer(...)` translates mechanically into `discard setTimer(...)` according to https://github.com/status-im/nim-chronos/blob/9ea1017a06e9b09996075c2b385fa8ea8aefa0b7/chronos/asyncloop.nim#L748-L752:
```
proc addTimer*(at: Moment, cb: CallbackFunc, udata: pointer = nil) {.
     inline, deprecated: "Use setTimer/clearTimer instead".} =
  ## Arrange for the callback ``cb`` to be called at the given absolute
  ## timestamp ``at``. You can also pass ``udata`` to callback.
  discard setTimer(at, cb, udata)
```

Secondarily, removing unused imports in general helps with https://github.com/status-im/nim-beacon-chain/issues/364, besides removing warnings.