### PR TITLE
fix remaining attester slashing tests from EF spec tests

### DIFF
--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -68,9 +68,11 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 ```diff
 + [Invalid] att1_bad_extra_index                                                             OK
 + [Invalid] att1_bad_replaced_index                                                          OK
++ [Invalid] att1_duplicate_index_double_signed                                               OK
 + [Invalid] att1_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_bad_extra_index                                                             OK
 + [Invalid] att2_bad_replaced_index                                                          OK
++ [Invalid] att2_duplicate_index_double_signed                                               OK
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] invalid_sig_1                                                                    OK
 + [Invalid] invalid_sig_1_and_2                                                              OK
@@ -85,7 +87,7 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 20/20 Fail: 0/20 Skip: 0/20
 ## Official - Operations - Block header  [Preset: mainnet]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -163,4 +165,4 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 113/113 Fail: 0/113 Skip: 0/113
+OK: 115/115 Fail: 0/115 Skip: 0/115

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -68,9 +68,11 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 ```diff
 + [Invalid] att1_bad_extra_index                                                             OK
 + [Invalid] att1_bad_replaced_index                                                          OK
++ [Invalid] att1_duplicate_index_double_signed                                               OK
 + [Invalid] att1_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_bad_extra_index                                                             OK
 + [Invalid] att2_bad_replaced_index                                                          OK
++ [Invalid] att2_duplicate_index_double_signed                                               OK
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] invalid_sig_1                                                                    OK
 + [Invalid] invalid_sig_1_and_2                                                              OK
@@ -85,7 +87,7 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_surround                                                                 OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 20/20 Fail: 0/20 Skip: 0/20
 ## Official - Operations - Block header  [Preset: minimal]
 ```diff
 + [Invalid] invalid_parent_root                                                              OK
@@ -166,4 +168,4 @@ OK: 22/22 Fail: 0/22 Skip: 0/22
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 116/116 Fail: 0/116 Skip: 0/116
+OK: 118/118 Fail: 0/118 Skip: 0/118

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -395,7 +395,7 @@ proc is_valid_indexed_attestation*(
     return false
 
   # Verify indices are sorted and unique
-  if indices != sorted(indices, system.cmp):
+  if indices != sorted(toSet(indices).toSeq, system.cmp):
     notice "indexed attestation: indices not sorted"
     return false
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -222,7 +222,7 @@ func is_slashable_attestation_data(
     (data_1.source.epoch < data_2.source.epoch and
      data_2.target.epoch < data_1.target.epoch)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#attester-slashings
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#attester-slashings
 proc process_attester_slashing*(
        state: var BeaconState,
        attester_slashing: AttesterSlashing,

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -65,20 +65,5 @@ proc runTest(identifier: string) =
   `testImpl _ operations_attester_slashing _ identifier`()
 
 suiteReport "Official - Operations - Attester slashing " & preset():
-  # TODO these are both valid and check BLS signatures, which isn't working
-  # since 0.10.x introduces new BLS signing/verifying interface with domain
-  # in particular handled differently through compute_signing_root() rather
-  # than through the bls_verify(...) call directly. This did not become the
-  # visible issue it now is because another bug had been masking it wherein
-  # crypto.nim's bls_verify(...) call had been creating false positives, in
-  # which cases signature checks had been incorrectly passing.
-  const expected_failures =
-    [
-      # TODO: Regressions introduced by BLS v0.10.1
-      "att1_duplicate_index_double_signed", "att2_duplicate_index_double_signed"
-    ]
   for kind, path in walkDir(OpAttSlashingDir, true):
-    if path in expected_failures:
-      echo "Skipping test: ", path
-      continue
     runTest(path)


### PR DESCRIPTION
I'm 100% aware this is naive, inefficient code which does pointless memory allocations, multiple passes over the data, for a yes/no answer that could be obtained more readily. This is intentionally following https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#is_valid_indexed_attestation as closely as possible.

If/when this becomes a performance issue, I'll rewrite it with an eye towards that.