### PR TITLE
ambiguous calls between toHex from byteutils and nimcrypto

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -1,8 +1,7 @@
 import
   deques, tables, options,
-  stew/[endians2], chronicles,
+  stew/[endians2, byteutils], chronicles,
   spec/[datatypes, crypto, digest],
-  nimcrypto/utils,
   beacon_chain_db
 
 type
@@ -223,8 +222,8 @@ proc shortLog*(v: AttachedValidator): string = shortLog(v.pubKey)
 
 chronicles.formatIt BlockSlot:
   mixin toHex
-  it.blck.root.data[0..3].toHex(true) & ":" & $it.slot
+  it.blck.root.data[0..3].toHex() & ":" & $it.slot
 
 chronicles.formatIt BlockRef:
   mixin toHex
-  it.root.data[0..3].toHex(true) & ":" & $it.slot
+  it.root.data[0..3].toHex() & ":" & $it.slot

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -221,9 +221,7 @@ type
 proc shortLog*(v: AttachedValidator): string = shortLog(v.pubKey)
 
 chronicles.formatIt BlockSlot:
-  mixin toHex
   it.blck.root.data[0..3].toHex() & ":" & $it.slot
 
 chronicles.formatIt BlockRef:
-  mixin toHex
   it.root.data[0..3].toHex() & ":" & $it.slot


### PR DESCRIPTION
Nimcrypto toHex was supposed to stay private for its own test suite.

Furthermore for unknown reason in my terminal I get ambiguous call but from VSCode terminal the code compiles.

I suspect there are some mixin trickeries at play:
![image](https://user-images.githubusercontent.com/22738317/79578923-2b359300-80c7-11ea-9725-edd34c0eb8aa.png)
