### PR TITLE
fix remaining block sanity test vectors

### DIFF
--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -133,6 +133,7 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Official - Sanity - Blocks  [Preset: mainnet]
 ```diff
++ [Invalid] expected_deposit_in_block                                                        OK
 + [Invalid] invalid_block_sig                                                                OK
 + [Invalid] invalid_proposer_index_sig_from_expected_proposer                                OK
 + [Invalid] invalid_proposer_index_sig_from_proposer_index                                   OK
@@ -140,6 +141,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Invalid] prev_slot_block_transition                                                       OK
 + [Invalid] zero_block_sig                                                                   OK
 + [Valid]   attestation                                                                      OK
++ [Valid]   attester_slashing                                                                OK
 + [Valid]   balance_driven_status_transitions                                                OK
 + [Valid]   deposit_in_block                                                                 OK
 + [Valid]   deposit_top_up                                                                   OK
@@ -153,7 +155,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Valid]   skipped_slots                                                                    OK
 + [Valid]   voluntary_exit                                                                   OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
+OK: 21/21 Fail: 0/21 Skip: 0/21
 ## Official - Sanity - Slots  [Preset: mainnet]
 ```diff
 + Slots - double_empty_epoch                                                                 OK
@@ -165,4 +167,4 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 115/115 Fail: 0/115 Skip: 0/115
+OK: 117/117 Fail: 0/117 Skip: 0/117

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -133,6 +133,7 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Official - Sanity - Blocks  [Preset: minimal]
 ```diff
++ [Invalid] expected_deposit_in_block                                                        OK
 + [Invalid] invalid_block_sig                                                                OK
 + [Invalid] invalid_proposer_index_sig_from_expected_proposer                                OK
 + [Invalid] invalid_proposer_index_sig_from_proposer_index                                   OK
@@ -140,6 +141,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Invalid] prev_slot_block_transition                                                       OK
 + [Invalid] zero_block_sig                                                                   OK
 + [Valid]   attestation                                                                      OK
++ [Valid]   attester_slashing                                                                OK
 + [Valid]   balance_driven_status_transitions                                                OK
 + [Valid]   deposit_in_block                                                                 OK
 + [Valid]   deposit_top_up                                                                   OK
@@ -156,7 +158,7 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Valid]   skipped_slots                                                                    OK
 + [Valid]   voluntary_exit                                                                   OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
+OK: 24/24 Fail: 0/24 Skip: 0/24
 ## Official - Sanity - Slots  [Preset: minimal]
 ```diff
 + Slots - double_empty_epoch                                                                 OK
@@ -168,4 +170,4 @@ OK: 22/22 Fail: 0/22 Skip: 0/22
 OK: 5/5 Fail: 0/5 Skip: 0/5
 
 ---TOTAL---
-OK: 118/118 Fail: 0/118 Skip: 0/118
+OK: 120/120 Fail: 0/120 Skip: 0/120

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -395,7 +395,7 @@ proc is_valid_indexed_attestation*(
     return false
 
   # Verify indices are sorted and unique
-  if indices != sorted(toSet(indices).toSeq, system.cmp):
+  if indices != sorted(toHashSet(indices).toSeq, system.cmp):
     notice "indexed attestation: indices not sorted"
     return false
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -418,14 +418,14 @@ func process_final_updates*(state: var BeaconState) {.nbench.}=
   state.previous_epoch_attestations = state.current_epoch_attestations
   state.current_epoch_attestations = @[]
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#epoch-processing
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#epoch-processing
 proc process_epoch*(state: var BeaconState) {.nbench.}=
   trace "process_epoch",
     current_epoch = get_current_epoch(state)
 
   var per_epoch_cache = get_empty_per_epoch_cache()
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#justification-and-finalization
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#justification-and-finalization
   process_justification_and_finalization(state, per_epoch_cache)
 
   trace "ran process_justification_and_finalization",
@@ -434,7 +434,7 @@ proc process_epoch*(state: var BeaconState) {.nbench.}=
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#rewards-and-penalties-1
   process_rewards_and_penalties(state, per_epoch_cache)
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#registry-updates
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#registry-updates
   # Don't rely on caching here.
   process_registry_updates(state)
 
@@ -442,7 +442,7 @@ proc process_epoch*(state: var BeaconState) {.nbench.}=
   ## get_active_validator_indices(...) usually changes.
   clear(per_epoch_cache.beacon_committee_cache)
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#slashings
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#slashings
   process_slashings(state)
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#final-updates

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -58,22 +58,12 @@ proc runTest(identifier: string) =
 
       # check: stateRef.hash_tree_root() == postRef.hash_tree_root()
       if not postRef.isNil:
-        reportDiff(stateRef, postRef)
+        when false:
+          reportDiff(stateRef, postRef)
+        doAssert stateRef.hash_tree_root() == postRef.hash_tree_root()
 
   `testImpl _ blck _ identifier`()
 
 suiteReport "Official - Sanity - Blocks " & preset():
-  # Failing due to signature checking in indexed validation checking pending
-  # 0.10 BLS verification API with new domain handling.
-  const expected_failures =
-    [
-      "attester_slashing",
-      # TODO: regression BLS v0.10.1 to fix
-      "expected_deposit_in_block",
-    ]
-
   for kind, path in walkDir(SanityBlocksDir, true):
-    if path in expected_failures:
-      echo "Skipping test: ", path
-      continue
     runTest(path)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -117,7 +117,11 @@ proc addTestBlock*(
       state,
       parent_root,
       randao_reveal,
-      eth1_data,
+      # Keep deposit counts internally consistent.
+      Eth1Data(
+        deposit_root: eth1_data.deposit_root,
+        deposit_count: state.eth1_deposit_index + deposits.len.uint64,
+        block_hash: eth1_data.block_hash),
       graffiti,
       attestations,
       deposits)


### PR DESCRIPTION
These were the last of the `expected_failures` exceptions. All the EF spec tests of the sanity/operations variety now run. None are skipped.