### PR TITLE
2 changes getting us closer to interop

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1367,13 +1367,15 @@ when isMainModule:
     if bootstrapFile.len > 0:
       let
         networkKeys = getPersistentNetKeys(config)
+        metadata = getPersistentNetMetadata(config)
         bootstrapEnr = enr.Record.init(
           1, # sequence number
           networkKeys.seckey.asEthKey,
           some(config.bootstrapAddress),
           config.bootstrapPort,
           config.bootstrapPort,
-          [toFieldPair("eth2", SSZ.encode(enrForkIdFromState initialState))])
+          [toFieldPair("eth2", SSZ.encode(enrForkIdFromState initialState)),
+           toFieldPair("attnets", SSZ.encode(metadata.attnets))])
 
       writeFile(bootstrapFile, bootstrapEnr.toURI)
       echo "Wrote ", bootstrapFile

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -25,10 +25,11 @@ import
   chronicles,
   nimcrypto/[sha2, hash],
   stew/byteutils,
-  hashes
+  hashes,
+  eth/common/eth_types_json_serialization
 
 export
-  hash.`$`, sha2
+  hash.`$`, sha2, readValue, writeValue
 
 type
   Eth2Digest* = MDigest[32 * 8] ## `hash32` from spec

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -25,11 +25,10 @@ import
   chronicles,
   nimcrypto/[sha2, hash],
   stew/byteutils,
-  hashes,
-  eth/common/eth_types_json_serialization
+  hashes
 
 export
-  hash.`$`, sha2, writeValue, readValue
+  hash.`$`, sha2
 
 type
   Eth2Digest* = MDigest[32 * 8] ## `hash32` from spec

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -25,10 +25,11 @@ import
   chronicles,
   nimcrypto/[sha2, hash],
   stew/byteutils,
-  hashes
+  hashes,
+  eth/common/eth_types_json_serialization
 
 export
-  hash.`$`, sha2
+  hash.`$`, sha2, writeValue, readValue
 
 type
   Eth2Digest* = MDigest[32 * 8] ## `hash32` from spec


### PR DESCRIPTION
- exported the right overloads for serializing hashes properly to json (and not as byte arrays)
- added the attestation bitfield to the bootstrap enr - before that lighthouse was reporting `WARN Peer has invalid ENR bitfield           error: "ENR bitfield non-existent", peer_id: 16Uiu2HAm14a594UPQJau2BsQQLb3VzrG5WHb5F75rSog9UZqE8ZL, service: network`

