### PR TITLE
reduce stack space usage in process_final_updates(...)

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -410,6 +410,10 @@ func process_final_updates*(state: var BeaconState) {.nbench.}=
 
   # Set historical root accumulator
   if next_epoch mod (SLOTS_PER_HISTORICAL_ROOT div SLOTS_PER_EPOCH).uint64 == 0:
+    # Equivalent to hash_tree_root(foo: HistoricalBatch), but without using
+    # significant additional stack or heap.
+    # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#historicalbatch
+    # In response to https://github.com/status-im/nim-beacon-chain/issues/921
     state.historical_roots.add hash_tree_root(
       [hash_tree_root(state.block_roots), hash_tree_root(state.state_roots)])
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -410,11 +410,8 @@ func process_final_updates*(state: var BeaconState) {.nbench.}=
 
   # Set historical root accumulator
   if next_epoch mod (SLOTS_PER_HISTORICAL_ROOT div SLOTS_PER_EPOCH).uint64 == 0:
-    let historical_batch = HistoricalBatch(
-      block_roots: state.block_roots,
-      state_roots: state.state_roots,
-    )
-    state.historical_roots.add (hash_tree_root(historical_batch))
+    state.historical_roots.add hash_tree_root(
+      [hash_tree_root(state.block_roots), hash_tree_root(state.state_roots)])
 
   # Rotate current/previous epoch attestations
   state.previous_epoch_attestations = state.current_epoch_attestations


### PR DESCRIPTION
It avoids a stack-usage-based segfault in https://github.com/status-im/nim-beacon-chain/issues/921 and, also, the pointless construction (and copying, and then GC reaping) of a `HistoricalBatch` object.