### PR TITLE
add another check for inconsistent aggregation and committee length

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -424,6 +424,18 @@ func get_attesting_indices*(state: BeaconState,
   result = initHashSet[ValidatorIndex]()
   let committee = get_beacon_committee(
     state, data.slot, data.index.CommitteeIndex, stateCache)
+
+  # This shouldn't happen if one begins with a valid BeaconState and applies
+  # valid updates, but one can construct a BeaconState where it does. Do not
+  # do anything here since the PendingAttestation wouldn't have made it past
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#attestations
+  # which checks len(attestation.aggregation_bits) == len(committee) that in
+  # nim-beacon-chain lives in check_attestation(...).
+  # Addresses https://github.com/status-im/nim-beacon-chain/issues/922
+  if bits.len != committee.len:
+    trace "get_attesting_indices: inconsistent aggregation and committee length"
+    return
+
   for i, index in committee:
     if bits[i]:
       result.incl index

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -20,7 +20,7 @@ const
   topicAttesterSlashingsSuffix* = "attester_slashing/ssz"
   topicAggregateAndProofsSuffix* = "beacon_aggregate_and_proof/ssz"
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/p2p-interface.md#configuration
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#configuration
   ATTESTATION_SUBNET_COUNT* = 64
 
   defaultEth2TcpPort* = 9000
@@ -59,7 +59,7 @@ func getAggregateAndProofsTopic*(forkDigest: ForkDigest): string =
     raiseAssert e.msg
 
 func getAttestationTopic*(forkDigest: ForkDigest, committeeIndex: uint64): string =
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/validator.md#broadcast-attestation
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#broadcast-attestation
   try:
     let topicIndex = committeeIndex mod ATTESTATION_SUBNET_COUNT
     &"/eth2/{toHex forkDigest}/committee_index{topicIndex}{topicAttestationsSuffix}"

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -451,7 +451,7 @@ proc process_block*(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/validator.md
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md
 # TODO There's more to do here - the spec has helpers that deal set up some of
 #      the fields in here!
 proc makeBeaconBlock*(

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -88,7 +88,7 @@ func get_previous_epoch*(state: BeaconState): Epoch =
   else:
     current_epoch - 1
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#compute_committee
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#compute_committee
 func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
     index: uint64, count: uint64, stateCache: var StateCache): seq[ValidatorIndex] =
   ## Return the committee corresponding to ``indices``, ``seed``, ``index``,
@@ -115,7 +115,7 @@ func compute_committee(indices: seq[ValidatorIndex], seed: Eth2Digest,
   except KeyError:
     raiseAssert("Cached entries are added before use")
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#get_beacon_committee
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee*(
     state: BeaconState, slot: Slot, index: CommitteeIndex,
     cache: var StateCache): seq[ValidatorIndex] =
@@ -204,7 +204,7 @@ func get_beacon_proposer_index*(state: BeaconState, stateCache: var StateCache):
 
   compute_proposer_index(state, indices, seed, stateCache)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md#validator-assignments
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#validator-assignments
 func get_committee_assignment(
     state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex):
     Option[tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot]] {.used.} =
@@ -229,7 +229,7 @@ func get_committee_assignment(
         return some((committee, idx, slot))
   none(tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot])
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/validator.md#validator-assignments
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#validator-assignments
 func is_proposer(
     state: BeaconState, validator_index: ValidatorIndex): bool {.used.} =
   var cache = get_empty_per_epoch_cache()


### PR DESCRIPTION
https://github.com/status-im/nim-beacon-chain/issues/922 occurs because  `ncli_transition` bypasses `process_attestation(...)`/`check_attestation(...)` and calls almost directly into `process_epoch(...)`, which calls `process_justification_and_finalization(...)`, which calls `get_unslashed_attesting_indices(...)`, and only in the modified function here itself, arguably, its caller, is there a single centralized place to put this check.

This happens because the `BeaconState` constructed was itself not valid. Inductively, this should/would be prevented during correct operation by  `check_attestation(...)` in https://github.com/status-im/nim-beacon-chain/blob/devel/beacon_chain/spec/beaconstate.nim#L447 but that entire ingestion phase gets skipped by `ncli`, so add a secondary check.