### PR TITLE
avoid state copy in state transition

### DIFF
--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -149,7 +149,8 @@ proc runFullTransition*(dir, preState, blocksPrefix: string, blocksQty: int, ski
     let signedBlock = parseSSZ(blockPath, SignedBeaconBlock)
     let flags = if skipBLS: {skipBlsValidation}
                 else: {}
-    let success = state_transition(state[], signedBlock.message, flags)
+    let success = state_transition(
+      state[], signedBlock, flags, noRollback)
     echo "State transition status: ", if success: "SUCCESS ✓" else: "FAILURE ⚠️"
 
 proc runProcessSlots*(dir, preState: string, numSlots: uint64) =

--- a/ncli/ncli_transition.nim
+++ b/ncli/ncli_transition.nim
@@ -10,7 +10,7 @@ cli do(pre: string, blck: string, post: string, verifyStateRoot = false):
     flags = if verifyStateRoot: {skipStateRootValidation} else: {}
 
   var stateY = HashedBeaconState(data: stateX, root: hash_tree_root(stateX))
-  if not state_transition(stateY, blckX, flags):
+  if not state_transition(stateY, blckX, flags, noRollback):
     error "State transition failed"
-
-  SSZ.saveFile(post, stateY.data)
+  else:
+    SSZ.saveFile(post, stateY.data)

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -106,7 +106,7 @@ proc nfuzz_attester_slashing(input: openArray[byte], output: ptr byte,
 proc nfuzz_block(input: openArray[byte], output: ptr byte,
     output_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(BlockInput):
-    state_transition(data.state[], data.beaconBlock, flags)
+    state_transition(data.state[], data.beaconBlock, flags, noRollback)
 
 proc nfuzz_block_header(input: openArray[byte], output: ptr byte,
     output_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -78,15 +78,13 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   echo "Generating Genesis..."
 
   let
-    genesisState =
-      initialize_beacon_state_from_eth1(Eth2Digest(), 0, deposits, flags)
-    genesisBlock = get_initial_beacon_block(genesisState[])
+    state = initialize_beacon_state_from_eth1(Eth2Digest(), 0, deposits, flags)
+  let genesisBlock = get_initial_beacon_block(state[])
 
   echo "Starting simulation..."
 
   var
     attestations = initTable[Slot, seq[Attestation]]()
-    state = genesisState
     latest_block_root = hash_tree_root(genesisBlock.message)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
@@ -102,10 +100,10 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         write(stdout, ".")
 
       if last:
-        writeJson("state.json", state)
+        writeJson("state.json", state[])
     else:
-      if state.slot mod json_interval.uint64 == 0:
-        writeJson(jsonName(prefix, state.slot), state)
+      if state[].slot mod json_interval.uint64 == 0:
+        writeJson(jsonName(prefix, state.slot), state[])
         write(stdout, ":")
       else:
         write(stdout, ".")

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -131,4 +131,4 @@ proc add*(state: var BeaconState, attestation: Attestation, slot: Slot) =
   signMockBlock(state, signedBlock)
 
   doAssert state_transition(
-    state, signedBlock, flags = {skipStateRootValidation})
+    state, signedBlock, flags = {skipStateRootValidation}, noRollback)

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -65,4 +65,5 @@ proc applyEmptyBlock*(state: var BeaconState) =
   ## Do a state transition with an empty signed block
   ## on the current slot
   let signedBlock = mockBlock(state, state.slot, flags = {})
-  doAssert state_transition(state, signedBlock, {skipStateRootValidation})
+  doAssert state_transition(
+    state, signedBlock, {skipStateRootValidation}, noRollback)

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -44,10 +44,12 @@ proc runTest(identifier: string) =
 
         if hasPostState:
           # TODO: The EF is using invalid BLS keys so we can't verify them
-          let success = state_transition(preState[], blck, flags = {skipBlsValidation})
+          let success = state_transition(
+            preState[], blck, flags = {skipBlsValidation}, noRollback)
           doAssert success, "Failure when applying block " & $i
         else:
-          let success = state_transition(preState[], blck, flags = {})
+          let success = state_transition(
+            preState[], blck, flags = {}, noRollback)
           doAssert not success, "We didn't expect this invalid block to be processed"
 
       # check: preState.hash_tree_root() == postState.hash_tree_root()

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -38,7 +38,7 @@ suiteReport "Block processing" & preset():
       previous_block_root = hash_tree_root(genesisBlock.message)
       new_block = makeTestBlock(state[], previous_block_root)
 
-    let block_ok = state_transition(state[], new_block, {})
+    let block_ok = state_transition(state[], new_block, {}, noRollback)
 
     check:
       block_ok
@@ -58,7 +58,7 @@ suiteReport "Block processing" & preset():
     for i in 1..SLOTS_PER_EPOCH.int:
       let new_block = makeTestBlock(state[], previous_block_root)
 
-      let block_ok = state_transition(state[], new_block, {})
+      let block_ok = state_transition(state[], new_block, {}, noRollback)
 
       check:
         block_ok
@@ -91,7 +91,7 @@ suiteReport "Block processing" & preset():
       new_block = makeTestBlock(state[], previous_block_root,
         attestations = @[attestation]
       )
-    discard state_transition(state[], new_block, {})
+    check state_transition(state[], new_block, {}, noRollback)
 
     check:
       # TODO epoch attestations can get multiplied now; clean up paths to


### PR DESCRIPTION
In BlockPool, we keep the head state around, so it's trivial to restore
the temporary state there and keep going as if nothing happened.

This solves 3 problems:
* stack space - the state copy on mainnet is huge
* GC scanning - using stack space for state slows down the GC
significantly
* reckless copying - the copy itself takes a long time

In state_sim, we'll do the same and allocate on heap - this helps a
little with GC - without it, the collection of the temporary strings
created with `toHex` while printing the json dominates the trace.