### PR TITLE
remove a pointless hash_tree_root(BeaconState) per node per proposed block

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -476,7 +476,7 @@ proc add*(
     # the BlockRef first!
     pool.tmpState.blck = pool.addResolvedBlock(
       pool.tmpState.data.data[], blockRoot, signedBlock, parent)
-    pool.putState(pool.tmpState.data[], pool.tmpState.blck)
+    pool.putState(pool.tmpState.data, pool.tmpState.blck)
 
     return pool.tmpState.blck
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -339,6 +339,62 @@ proc addResolvedBlock(
       keepGoing = pool.pending.len < retries.len
   blockRef
 
+proc putState(pool: BlockPool, state: HashedBeaconState, blck: BlockRef) =
+  # TODO we save state at every epoch start but never remove them - we also
+  #      potentially save multiple states per slot if reorgs happen, meaning
+  #      we could easily see a state explosion
+  logScope: pcs = "save_state_at_epoch_start"
+
+  var currentCache =
+    pool.cachedStates[state.data.slot.compute_epoch_at_slot.uint64 mod 2]
+  if state.data.slot mod SLOTS_PER_EPOCH == 0:
+    if not pool.db.containsState(state.root):
+      info "Storing state",
+        blockRoot = shortLog(blck.root),
+        blockSlot = shortLog(blck.slot),
+        stateSlot = shortLog(state.data.slot),
+        stateRoot = shortLog(state.root),
+        cat = "caching"
+      pool.db.putState(state.root, state.data)
+      # TODO this should be atomic with the above write..
+      pool.db.putStateRoot(blck.root, state.data.slot, state.root)
+
+      # Because state.data.slot mod SLOTS_PER_EPOCH == 0, wrap back to last
+      # time this was the case i.e. last currentCache. The opposite parity,
+      # by contrast, has just finished filling from the previous epoch. The
+      # resulting lookback window is thus >= SLOTS_PER_EPOCH in size, while
+      # bounded from above by 2*SLOTS_PER_EPOCH.
+      currentCache = init(BeaconChainDB, kvStore MemStoreRef.init())
+  else:
+    # Need to be able to efficiently access states for both attestation
+    # aggregation and to process block proposals going back to the last
+    # finalized slot. Ideally to avoid potential combinatiorial forking
+    # storage and/or memory constraints could CoW, up to and including,
+    # in particular, hash_tree_root() which is expensive to do 30 times
+    # since the previous epoch, to efficiently state_transition back to
+    # desired slot. However, none of that's in place, so there are both
+    # expensive, repeated BeaconState copies as well as computationally
+    # time-consuming-near-end-of-epoch hash tree roots. The latter are,
+    # effectively, naïvely O(n^2) in slot number otherwise, so when the
+    # slots become in the mid-to-high-20s it's spending all its time in
+    # pointlessly repeated calculations of prefix-state-transitions. An
+    # intermediate time/memory workaround involves storing only mapping
+    # between BlockRefs, or BlockSlots, and the BeaconState tree roots,
+    # but that still involves tens of megabytes worth of copying, along
+    # with the concomitant memory allocator and GC load. Instead, use a
+    # more memory-intensive (but more conceptually straightforward, and
+    # faster) strategy to just store, for the most recent slots. Keep a
+    # block's StateData of odd-numbered epoch in bucket 1, whilst evens
+    # land in bucket 0 (which is handed back to GC in if branch). There
+    # still is a possibility of combinatorial explosion, but this only,
+    # by a constant-factor, worsens things. TODO the actual solution's,
+    # eventually, to switch to CoW and/or ref objects for state and the
+    # hash_tree_root processing.
+    if not currentCache.containsState(state.root):
+      currentCache.putState(state.root, state.data)
+      # TODO this should be atomic with the above write..
+      currentCache.putStateRoot(blck.root, state.data.slot, state.root)
+
 proc add*(
     pool: var BlockPool, blockRoot: Eth2Digest,
     signedBlock: SignedBeaconBlock): BlockRef {.gcsafe.} =
@@ -420,6 +476,7 @@ proc add*(
     # the BlockRef first!
     pool.tmpState.blck = pool.addResolvedBlock(
       pool.tmpState.data.data[], blockRoot, signedBlock, parent)
+    pool.putState(pool.tmpState.data[], pool.tmpState.blck)
 
     return pool.tmpState.blck
 
@@ -570,61 +627,6 @@ func checkMissing*(pool: var BlockPool): seq[FetchRecord] =
   for k, v in pool.missing.pairs():
     if v.tries.popcount() == 1:
       result.add(FetchRecord(root: k, historySlots: v.slots))
-
-proc putState(pool: BlockPool, state: HashedBeaconState, blck: BlockRef) =
-  # TODO we save state at every epoch start but never remove them - we also
-  #      potentially save multiple states per slot if reorgs happen, meaning
-  #      we could easily see a state explosion
-  logScope: pcs = "save_state_at_epoch_start"
-
-  var currentCache =
-    pool.cachedStates[state.data.slot.compute_epoch_at_slot.uint64 mod 2]
-  if state.data.slot mod SLOTS_PER_EPOCH == 0:
-    if not pool.db.containsState(state.root):
-      info "Storing state",
-        blockRoot = shortLog(blck.root),
-        blockSlot = shortLog(blck.slot),
-        stateSlot = shortLog(state.data.slot),
-        stateRoot = shortLog(state.root),
-        cat = "caching"
-      pool.db.putState(state.root, state.data)
-      # TODO this should be atomic with the above write..
-      pool.db.putStateRoot(blck.root, state.data.slot, state.root)
-
-      # Because state.data.slot mod SLOTS_PER_EPOCH == 0, wrap back to last
-      # time this was the case i.e. last currentCache. The opposite parity,
-      # by contrast, has just finished filling from the previous epoch. The
-      # resulting lookback window is thus >= SLOTS_PER_EPOCH in size, while
-      # bounded from above by 2*SLOTS_PER_EPOCH.
-      currentCache = init(BeaconChainDB, kvStore MemStoreRef.init())
-  else:
-    # Need to be able to efficiently access states for both attestation
-    # aggregation and to process block proposals going back to the last
-    # finalized slot. Ideally to avoid potential combinatiorial forking
-    # storage and/or memory constraints could CoW, up to and including,
-    # in particular, hash_tree_root() which is expensive to do 30 times
-    # since the previous epoch, to efficiently state_transition back to
-    # desired slot. However, none of that's in place, so there are both
-    # expensive, repeated BeaconState copies as well as computationally
-    # time-consuming-near-end-of-epoch hash tree roots. The latter are,
-    # effectively, naïvely O(n^2) in slot number otherwise, so when the
-    # slots become in the mid-to-high-20s it's spending all its time in
-    # pointlessly repeated calculations of prefix-state-transitions. An
-    # intermediate time/memory workaround involves storing only mapping
-    # between BlockRefs, or BlockSlots, and the BeaconState tree roots,
-    # but that still involves tens of megabytes worth of copying, along
-    # with the concomitant memory allocator and GC load. Instead, use a
-    # more memory-intensive (but more conceptually straightforward, and
-    # faster) strategy to just store, for the most recent slots. Keep a
-    # block's StateData of odd-numbered epoch in bucket 1, whilst evens
-    # land in bucket 0 (which is handed back to GC in if branch). There
-    # still is a possibility of combinatorial explosion, but this only,
-    # by a constant-factor, worsens things. TODO the actual solution's,
-    # eventually, to switch to CoW and/or ref objects for state and the
-    # hash_tree_root processing.
-    currentCache.putState(state.root, state.data)
-    # TODO this should be atomic with the above write..
-    currentCache.putStateRoot(blck.root, state.data.slot, state.root)
 
 proc skipAndUpdateState(
     pool: BlockPool,


### PR DESCRIPTION
When I have Turbo boost enabled, this operation requires 0.05 seconds. Without it (capped to 1.8GHz), it requires 0.09 seconds.

This doesn't change the contents of `putState()` beyond adding a condition of whether the relevant cache already holds the (expensive to copy) `BeaconBlock`, just moves it up in the module so that it's available to `BlockPool.add()` without forward declarations or requiring code reordering pragmas.

This brings the total
```
$ strip_ansi < hm.txt | grep ^FOOBAR | sort | uniq -c | sort -n | tail -n30
      8 FOOBAR0: BF87B0E1EE02599DBC5A49091E2E53DB077B66677D3DA8383BC3F063A096EF8D
      8 FOOBAR0: C372F9D82F5B44CFCD110F7E82FB32885C43019BF549601572CFA7A12FE4E2F1
      8 FOOBAR0: CF66B919F62C80670F778F2E922C92462618982CAC514717CA3756DBCFCDC532
      8 FOOBAR0: D29C1A64EC5479B3A7E735E396A5161FBE8212543520325EF7F157BBB0694C12
      8 FOOBAR0: D7B7399B2E0F10BE0E93000904F0242A8C035F08EBCA6E9F1A6EA99E7A8BCF61
      8 FOOBAR0: EFD799E100E3F40A63E5A85CA8D80F8652B1DCBB56DFE164C85EBA6DB8BD1217
      8 FOOBAR0: F4F421B3066837C748263AAECDCDC3508787380C9DD3F696C3575C97D7DB5632
      8 FOOBAR2: 01EB3BA25B87532B43CB76AD333D08289CFC04BBF14A9C736D29F1DD82FCF93F
      8 FOOBAR2: 240233FC2A5AA8EE0CBC8176F4D1D33A9995418171E324A5564310039D28D6BF
      8 FOOBAR2: 3CA4153CDE8276314A72C0627D2B18C485459E7A4C78BF9BDE06092A332848C2
     11 FOOBAR2: 5CEC503F4B97EDDE13A115F2E67162CCBCDBA8DC85DF32E426228469081525A6
     12 FOOBAR2: 1065E45B2F5B66C08A9CB61235D4667474E691C768E21485A6768ADC5DB277E4
     12 FOOBAR2: 2F1CE104BCE6F37B01D815D979B6333996E76365297B280D28086E5B3E0509BD
     12 FOOBAR2: 3C9B5D9A392F7E99BDB35FBE25DABC5285A8DB522939114322E326FAD493E27B
     12 FOOBAR2: 426EA5296F114BFEF2FAD4CA951CFF4867D353C16CB74476EF0FC8823DEE7105
     12 FOOBAR2: 434FBE3F97EC1640C24F8A2489671B676C878B6FE5C4A949C8AAA9F43F5FE7D3
     12 FOOBAR2: 599745CA3CEC8BCACA9B71AD0C890458F4A5F7C44AF7F37F315CA8ADE61D5A1C
     12 FOOBAR2: 717216A0EE6385837CA0B78A0C6442F007D647BE22D3FE87785854139A30E624
     12 FOOBAR2: 93D13048D7520259B05C9D6C8C0F36E41E76E68C9F2DD96BB9BAC46CA739ED12
     12 FOOBAR2: A0FEFECE48856C1DE07D039561C4FAA655645E4EE2D36DD527B168B879CF94F0
     12 FOOBAR2: A3AE394A0CAA2FE3C36D214D828E847B3827B14878182ADC473064F63965C568
     12 FOOBAR2: A41F94B9F94240F61B7E4EA15A04D4DC5ADDABDAFE8935A11585381AB47AA5FA
     12 FOOBAR2: AA9C0373E4C572549466D40852454E1AABFE473CC16489C84BDB89825C1E9E84
     12 FOOBAR2: BF87B0E1EE02599DBC5A49091E2E53DB077B66677D3DA8383BC3F063A096EF8D
     12 FOOBAR2: C372F9D82F5B44CFCD110F7E82FB32885C43019BF549601572CFA7A12FE4E2F1
     12 FOOBAR2: CF66B919F62C80670F778F2E922C92462618982CAC514717CA3756DBCFCDC532
     12 FOOBAR2: D29C1A64EC5479B3A7E735E396A5161FBE8212543520325EF7F157BBB0694C12
     12 FOOBAR2: D7B7399B2E0F10BE0E93000904F0242A8C035F08EBCA6E9F1A6EA99E7A8BCF61
     12 FOOBAR2: EFD799E100E3F40A63E5A85CA8D80F8652B1DCBB56DFE164C85EBA6DB8BD1217
     12 FOOBAR2: F4F421B3066837C748263AAECDCDC3508787380C9DD3F696C3575C97D7DB5632
```

Down from 16 total (4/node) to 12 total (3/node) in the same location now.

As a result, per [perf_record_call_stacks.txt](https://github.com/status-im/nim-beacon-chain/files/4529871/perf_record_call_stacks.txt)
`hash_tree_root__YAhTlhenDEuYRasPu5CcEQ` is `hash_tree_root(foo: BeaconState)` mangled. It's now at 22%, behind `genericAssignAux__U5DxFPRpHCCZDKWQzM9adaw` (32%), and:
```
               |--29.05%--decode__HLyxqEyZBgpXzMNB9aOgTZg_3                                                                                              
               |          |                                                                                                                                         
               |          |--11.18%--readSszValue__qVyXyKDNMOaK0UYfRPPwfw                                                    
               |          |          |                                                                                                                              
               |          |          |--5.64%--readSszValue__09c0XqLSi9auKDAfxp9cQWfaA                                             
               |          |          |          |                                                                                       
               |          |          |           --5.64%--readSszValue__hurtFrQmCKEzHuwfF9avQRQ
               |          |          |                     |                                                                                  
               |          |          |                      --5.63%--fromRaw__FSHe2XS4euWLxPApEjE9cnQ        
               |          |          |                                |                                   
               |          |          |                                 --5.62%--fromBytes__Ca9cmQaf4ILV89a9a50RESS7Qbls_signature_scheme (inlined)
               |          |          |                                           fromBytes__UYUq8cyyvY0x9b9bF32Qd4Kg
               |          |          |                                           |                              
               |          |          |                                            --5.60%--setx__4sVLfbpI4UwKx4xRFfOVSA
               |          |          |                                                      |                         
               |          |          |                                                      |--4.23%--FP_BLS381_sqrt
```
regarding which https://github.com/status-im/nim-beacon-chain/issues/412 already elaborates.

The `genericAssignAux` probably would be helped by https://github.com/status-im/nim-beacon-chain/pull/930