### PR TITLE
ssz: move ref support outside

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -121,8 +121,8 @@ proc getStateFromSnapshot(conf: BeaconNodeConf): NilableBeaconStateRef =
       error "Failed to read genesis file", err = err.msg
       quit 1
 
-  try:
-    result = SSZ.decode(snapshotContents, BeaconStateRef)
+  result = try:
+    newClone(SSZ.decode(snapshotContents, BeaconState))
   except SerializationError:
     error "Failed to import genesis file", path = genesisPath
     quit 1

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -186,7 +186,7 @@ proc init*(T: type BeaconNode, conf: BeaconNodeConf): Future[BeaconNode] {.async
         # TODO how to get a block from a non-genesis state?
         error "Starting from non-genesis state not supported",
           stateSlot = genesisState.slot,
-          stateRoot = hash_tree_root(genesisState)
+          stateRoot = hash_tree_root(genesisState[])
         quit 1
 
       let tailBlock = get_initial_beacon_block(genesisState[])
@@ -1380,7 +1380,7 @@ programMain:
       echo "Wrote ", outGenesis
 
     let outSszGenesis = outGenesis.changeFileExt "ssz"
-    SSZ.saveFile(outSszGenesis, initialState)
+    SSZ.saveFile(outSszGenesis, initialState[])
     echo "Wrote ", outSszGenesis
 
     let bootstrapFile = config.outputBootstrapFile.string

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -492,7 +492,7 @@ proc makeBeaconBlock*(
     warn "Unable to apply new block to state", blck = shortLog(blck)
     return
 
-  blck.state_root = hash_tree_root(tmpState)
+  blck.state_root = hash_tree_root(tmpState[])
 
   some(blck)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -35,7 +35,7 @@
 {.push raises: [Defect].}
 
 import
-  math, options, sequtils, tables,
+  math, sequtils, tables,
   stew/[bitseqs, bitops2], chronicles, json_serialization/std/sets,
   metrics, ../ssz,
   beaconstate, crypto, datatypes, digest, helpers, validator,

--- a/beacon_chain/ssz.nim
+++ b/beacon_chain/ssz.nim
@@ -109,8 +109,6 @@ template toSszType*(x: auto): auto =
   elif x is Eth2Digest: x.data
   elif x is BlsCurveType: toRaw(x)
   elif x is BitSeq|BitList: ByteList(x)
-  elif x is ref|ptr: toSszType x[]
-  elif x is Option: toSszType x.get
   elif x is TypeWithMaxLen: toSszType valueOf(x)
   elif useListType and x is List: seq[x.T](x)
   else: x
@@ -217,10 +215,6 @@ proc writeVarSizeType(w: var SszWriter, value: auto) {.raises: [Defect, IOError]
       var cursor = w.stream.delayFixedSizeWrite offset
       for elem in value:
         cursor.writeFixedSized uint32(offset)
-        when elem is Option:
-          if not isSome(elem): continue
-        elif elem is ptr|ref:
-          if isNil(elem): continue
         let initPos = w.stream.pos
         w.writeVarSizeType toSszType(elem)
         offset += w.stream.pos - initPos

--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -168,7 +168,7 @@ func readSszValue*(input: openarray[byte], T: type): T {.raisesssz.} =
       const boundingOffsets = T.getFieldBoundingOffsets(fieldName)
       trs "BOUNDING OFFSET FOR FIELD ", fieldName, " = ", boundingOffsets
 
-      type FieldType = type maybeDeref(field)
+      type FieldType = type field
       type SszType = type toSszType(declval FieldType)
 
       when isFixedSize(SszType):
@@ -192,19 +192,19 @@ func readSszValue*(input: openarray[byte], T: type): T {.raisesssz.} =
       # TODO The extra type escaping here is a work-around for a Nim issue:
       when type(FieldType) is type(SszType):
         trs "READING NATIVE ", fieldName, ": ", name(SszType)
-        maybeDeref(field) = readSszValue(
+        field = readSszValue(
           input.toOpenArray(startOffset, endOffset - 1),
           SszType)
         trs "READING COMPLETE ", fieldName
 
       elif useListType and FieldType is List:
-        maybeDeref(field) = readSszValue(
+        field = readSszValue(
           input.toOpenArray(startOffset, endOffset - 1),
           FieldType)
 
       else:
         trs "READING FOREIGN ", fieldName, ": ", name(SszType)
-        maybeDeref(field) = fromSszBytes(
+        field = fromSszBytes(
           FieldType,
           input.toOpenArray(startOffset, endOffset - 1))
 

--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -91,14 +91,6 @@ func readSszValue*(input: openarray[byte], T: type): T {.raisesssz.} =
     type ElemType = type result[0]
     result = T readSszValue(input, seq[ElemType])
 
-  elif result is ptr|ref:
-    new result
-    result[] = readSszValue(input, type(result[]))
-
-  elif result is Option:
-    if input.len > 0:
-      result = some readSszValue(input, result.T)
-
   elif result is string|seq|openarray|array:
     type ElemType = type result[0]
     when ElemType is byte|char:

--- a/beacon_chain/ssz/navigator.nim
+++ b/beacon_chain/ssz/navigator.nim
@@ -119,16 +119,11 @@ template `[]`*[R, T](n: SszNavigator[array[R, T]], idx: int): SszNavigator[T] =
 
 func `[]`*[T](n: SszNavigator[T]): T {.raisesssz.} =
   mixin toSszType, fromSszBytes
-  when T is ref:
-    type ObjectType = type(result[])
-    new result
-    result[] = SszNavigator[ObjectType](n)[]
+  type SszRepr = type toSszType(declval T)
+  when type(SszRepr) is type(T):
+    readSszValue(toOpenArray(n.m), T)
   else:
-    type SszRepr = type toSszType(declval T)
-    when type(SszRepr) is type(T):
-      readSszValue(toOpenArray(n.m), T)
-    else:
-      fromSszBytes(T, toOpenArray(n.m))
+    fromSszBytes(T, toOpenArray(n.m))
 
 converter derefNavigator*[T](n: SszNavigator[T]): T {.raisesssz.} =
   n[]

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -87,7 +87,7 @@ template ElemType*(T: type[seq|string|List]): untyped =
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields
 
-  when T0 is openarray
+  when T0 is openarray:
     return false
   else:
     type T = type toSszType(declval T0)

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -87,7 +87,7 @@ template ElemType*(T: type[seq|string|List]): untyped =
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields
 
-  when T0 is openarray|Option|ref|ptr:
+  when T0 is openarray
     return false
   else:
     type T = type toSszType(declval T0)
@@ -111,7 +111,7 @@ func fixedPortionSize*(T0: type): int {.compileTime.} =
     type E = ElemType(T)
     when isFixedSize(E): len(T) * fixedPortionSize(E)
     else: len(T) * offsetSize
-  elif T is seq|string|openarray|ref|ptr|Option: offsetSize
+  elif T is seq|string|openarray: offsetSize
   elif T is object|tuple:
     enumAllSerializedFields(T):
       when isFixedSize(FieldType):

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -84,12 +84,6 @@ template ElemType*[T](A: type[openarray[T]]): untyped =
 template ElemType*(T: type[seq|string|List]): untyped =
   type(default(T)[0])
 
-template maybeDeref*(x: auto): auto =
-  when type(x) is ref|ptr:
-    x[]
-  else:
-    x
-
 func isFixedSize*(T0: type): bool {.compileTime.} =
   mixin toSszType, enumAllSerializedFields
 

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -140,7 +140,7 @@ proc runFullTransition*(dir, preState, blocksPrefix: string, blocksQty: int, ski
   let prePath = dir / preState & ".ssz"
 
   echo "Running: ", prePath
-  var state = parseSSZ(prePath, BeaconStateRef)
+  var state = newClone(parseSSZ(prePath, BeaconState))
 
   for i in 0 ..< blocksQty:
     let blockPath = dir / blocksPrefix & $i & ".ssz"
@@ -157,7 +157,7 @@ proc runProcessSlots*(dir, preState: string, numSlots: uint64) =
   let prePath = dir / preState & ".ssz"
 
   echo "Running: ", prePath
-  var state = parseSSZ(prePath, BeaconStateRef)
+  var state = newClone(parseSSZ(prePath, BeaconState))
 
   process_slots(state[], state.slot + numSlots)
 
@@ -168,7 +168,7 @@ template processEpochScenarioImpl(
   let prePath = dir/preState & ".ssz"
 
   echo "Running: ", prePath
-  var state = parseSSZ(prePath, BeaconStateRef)
+  var state = newClone(parseSSZ(prePath, BeaconState))
 
   when needCache:
     var cache = get_empty_per_epoch_cache()
@@ -193,7 +193,7 @@ template processBlockScenarioImpl(
   let prePath = dir/preState & ".ssz"
 
   echo "Running: ", prePath
-  var state = parseSSZ(prePath, BeaconStateRef)
+  var state = newClone(parseSSZ(prePath, BeaconState))
 
   when needCache:
     var cache = get_empty_per_epoch_cache()

--- a/ncli/ncli_hash_tree_root.nim
+++ b/ncli/ncli_hash_tree_root.nim
@@ -1,6 +1,6 @@
 import
   confutils, os, strutils, chronicles, json_serialization,
-  nimcrypto/utils,
+  stew/byteutils,
   ../beacon_chain/spec/[crypto, datatypes, digest],
   ../beacon_chain/ssz
 
@@ -8,16 +8,16 @@ import
 cli do(kind: string, file: string):
 
   template printit(t: untyped) {.dirty.} =
-      let v =
-        if cmpIgnoreCase(ext, ".ssz") == 0:
-          SSZ.loadFile(file, t)
-        elif cmpIgnoreCase(ext, ".json") == 0:
-          JSON.loadFile(file, t)
-        else:
-          echo "Unknown file type: ", ext
-          quit 1
-
-      echo hash_tree_root(v).data.toHex(true)
+    let v = newClone(
+      if cmpIgnoreCase(ext, ".ssz") == 0:
+        SSZ.loadFile(file, t)
+      elif cmpIgnoreCase(ext, ".json") == 0:
+        JSON.loadFile(file, t)
+      else:
+        echo "Unknown file type: ", ext
+        quit 1
+    )
+    echo hash_tree_root(v).data.toHex()
 
   let ext = splitFile(file).ext
 
@@ -30,6 +30,6 @@ cli do(kind: string, file: string):
   of "deposit": printit(Deposit)
   of "deposit_data": printit(DepositData)
   of "eth1_data": printit(Eth1Data)
-  of "state": printit(BeaconStateRef)
+  of "state": printit(BeaconState)
   of "proposer_slashing": printit(ProposerSlashing)
   of "voluntary_exit": printit(VoluntaryExit)

--- a/ncli/ncli_hash_tree_root.nim
+++ b/ncli/ncli_hash_tree_root.nim
@@ -17,7 +17,7 @@ cli do(kind: string, file: string):
         echo "Unknown file type: ", ext
         quit 1
     )
-    echo hash_tree_root(v).data.toHex()
+    echo hash_tree_root(v[]).data.toHex()
 
   let ext = splitFile(file).ext
 

--- a/ncli/ncli_pretty.nim
+++ b/ncli/ncli_pretty.nim
@@ -5,18 +5,17 @@ import
 
 # TODO turn into arguments
 cli do(kind: string, file: string):
-
   template printit(t: untyped) {.dirty.} =
-      let v =
-        if cmpIgnoreCase(ext, ".ssz") == 0:
-          SSZ.loadFile(file, t)
-        elif cmpIgnoreCase(ext, ".json") == 0:
-          JSON.loadFile(file, t)
-        else:
-          echo "Unknown file type: ", ext
-          quit 1
-
-      echo JSON.encode(v, pretty = true)
+    let v = newClone(
+      if cmpIgnoreCase(ext, ".ssz") == 0:
+        SSZ.loadFile(file, t)
+      elif cmpIgnoreCase(ext, ".json") == 0:
+        JSON.loadFile(file, t)
+      else:
+        echo "Unknown file type: ", ext
+        quit 1
+    )
+    echo JSON.encode(v[], pretty = true)
 
   let ext = splitFile(file).ext
 
@@ -29,7 +28,7 @@ cli do(kind: string, file: string):
   of "deposit": printit(Deposit)
   of "deposit_data": printit(DepositData)
   of "eth1_data": printit(Eth1Data)
-  of "state": printit(BeaconStateRef)
+  of "state": printit(BeaconState)
   of "proposer_slashing": printit(ProposerSlashing)
   of "voluntary_exit": printit(VoluntaryExit)
   else: echo "Unknown kind"

--- a/ncli/ncli_transition.nim
+++ b/ncli/ncli_transition.nim
@@ -5,12 +5,15 @@ import
 
 cli do(pre: string, blck: string, post: string, verifyStateRoot = false):
   let
-    stateX = SSZ.loadFile(pre, BeaconStateRef)
+    stateY = (ref HashedBeaconState)(
+      data: SSZ.loadFile(pre, BeaconState),
+    )
     blckX = SSZ.loadFile(blck, SignedBeaconBlock)
     flags = if verifyStateRoot: {skipStateRootValidation} else: {}
 
-  var stateY = HashedBeaconState(data: stateX[], root: hash_tree_root(stateX[]))
-  if not state_transition(stateY, blckX, flags, noRollback):
+  stateY.root = hash_tree_root(stateY.data)
+
+  if not state_transition(stateY[], blckX, flags, noRollback):
     error "State transition failed"
   else:
     SSZ.saveFile(post, stateY.data)

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -40,14 +40,14 @@ proc runTest(identifier: string) =
       var cache = get_empty_per_epoch_cache()
 
       let attestation = parseTest(testDir/"attestation.ssz", SSZ, Attestation)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconState)
         let done = process_attestation(preState[], attestation, {}, cache)
         doAssert done, "Valid attestation not processed"
         check: preState.hash_tree_root() == postState.hash_tree_root()
-        reportDiff(preState, postState)
+        reportDiff(preState[], postState[])
       else:
         let done = process_attestation(preState[], attestation, {}, cache)
         doAssert done == false, "We didn't expect this invalid attestation to be processed."

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -40,10 +40,10 @@ proc runTest(identifier: string) =
       var cache = get_empty_per_epoch_cache()
 
       let attesterSlashing = parseTest(testDir/"attester_slashing.ssz", SSZ, AttesterSlashing)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         let done = process_attester_slashing(preState[], attesterSlashing,
                                              {}, cache)
         doAssert done, "Valid attestater slashing not processed"

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -40,10 +40,10 @@ proc runTest(identifier: string) =
       var cache = get_empty_per_epoch_cache()
 
       let blck = parseTest(testDir/"block.ssz", SSZ, BeaconBlock)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         let done = process_block_header(preState[], blck, {}, cache)
         doAssert done, "Valid block header not processed"
         check: preState.hash_tree_root() == postState.hash_tree_root()

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -41,10 +41,10 @@ proc runTest(identifier: string) =
 
     timedTest prefix & " " & identifier:
       let deposit = parseTest(testDir/"deposit.ssz", SSZ, Deposit)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         discard process_deposit(preState[], deposit, flags)
         reportDiff(preState, postState)
       else:

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -38,12 +38,12 @@ proc runTest(identifier: string) =
 
     timedTest prefix & astToStr(identifier):
       let proposerSlashing = parseTest(testDir/"proposer_slashing.ssz", SSZ, ProposerSlashing)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       var cache = get_empty_per_epoch_cache()
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         let done = process_proposer_slashing(preState[], proposerSlashing, {}, cache)
         doAssert done, "Valid proposer slashing not processed"
         check: preState.hash_tree_root() == postState.hash_tree_root()

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -38,10 +38,10 @@ proc runTest(identifier: string) =
 
     timedTest prefix & identifier:
       let voluntaryExit = parseTest(testDir/"voluntary_exit.ssz", SSZ, SignedVoluntaryExit)
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
       if existsFile(testDir/"post.ssz"):
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         let done = process_voluntary_exit(preState[], voluntaryExit, {})
         doAssert done, "Valid voluntary exit not processed"
         check: preState.hash_tree_root() == postState.hash_tree_root()

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -34,7 +34,7 @@ proc runTest(identifier: string) =
       "[Invalid] "
 
     timedTest prefix & identifier:
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
       var hasPostState = existsFile(testDir/"post.ssz")
 
       # In test cases with more than 10 blocks the first 10 aren't 0-prefixed,
@@ -54,7 +54,7 @@ proc runTest(identifier: string) =
 
       # check: preState.hash_tree_root() == postState.hash_tree_root()
       if hasPostState:
-        let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+        let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         when false:
           reportDiff(preState, postState)
         doAssert preState.hash_tree_root() == postState.hash_tree_root()

--- a/tests/official/test_fixture_sanity_slots.nim
+++ b/tests/official/test_fixture_sanity_slots.nim
@@ -31,8 +31,8 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ slots _ identifier`() =
     timedTest "Slots - " & identifier:
-      var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
-      let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+      var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
+      let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
 
       process_slots(preState[], preState.slot + num_slots)
 

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -38,8 +38,8 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
 
         let unitTestName = testDir.rsplit(DirSep, 1)[1]
         timedTest testName & " - " & unitTestName & preset():
-          var preState = parseTest(testDir/"pre.ssz", SSZ, BeaconStateRef)
-          let postState = parseTest(testDir/"post.ssz", SSZ, BeaconStateRef)
+          var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
+          let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
 
           when useCache:
             var cache = get_empty_per_epoch_cache()
@@ -47,7 +47,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
           else:
             transitionProc(preState[])
 
-          reportDiff(preState, postState)
+          reportDiff(preState[], postState[])
 
   `suiteImpl _ transitionProc`()
 

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -47,7 +47,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
           else:
             transitionProc(preState[])
 
-          reportDiff(preState[], postState[])
+          reportDiff(preState, postState)
 
   `suiteImpl _ transitionProc`()
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -52,7 +52,7 @@ suiteReport "Beacon chain DB" & preset():
 
     let
       state = BeaconStateRef()
-      root = hash_tree_root(state)
+      root = hash_tree_root(state[])
 
     db.putState(state[])
 
@@ -103,7 +103,7 @@ suiteReport "Beacon chain DB" & preset():
     let
       state = initialize_beacon_state_from_eth1(
         eth1BlockHash, 0, makeInitialDeposits(SLOTS_PER_EPOCH), {skipBlsValidation})
-      root = hash_tree_root(state)
+      root = hash_tree_root(state[])
 
     db.putState(state[])
 

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -165,4 +165,4 @@ suiteReport "Interop":
       else:
         "unimplemented"
     check:
-      hash_tree_root(initialState).data.toHex() == expected
+      hash_tree_root(initialState[]).data.toHex() == expected


### PR DESCRIPTION
Instead of allocating ref's inside SSZ, move it to separate helper:

* makes `ref` allocations explicit
* less magic inside SSZ
* `ref` in nim generally means reference whereas SSZ was loading as
value - if a type indeed used references it would get copies instead of
references to a single value on roundtrip which is unexpected

`ref` has risks/costs: memory allocation, no `var/let` distinction, additional indirection, more garbage to collect etc
`not nil` has risks/costs: untested/experimental feature with the usual bugs - should be harmless / limited to spurious compiler errors/warnings and hopefully not bad codegen

TODO: EF tests would benefit from some refactoring since they all do the
same thing practically..

TODO: when/if refs become necessary for some useful functionality (ie potential RVO), we can re-evaluate ref support in SSZ

Continued discussion from #937