### PR TITLE
re-enable mainnet attestation pool tests

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1,5 +1,16 @@
 AllTests-mainnet
 ===
+## Attestation pool processing [Preset: mainnet]
+```diff
++ Attestations may arrive in any order [Preset: mainnet]                                     OK
++ Attestations may overlap, bigger first [Preset: mainnet]                                   OK
++ Attestations may overlap, smaller first [Preset: mainnet]                                  OK
++ Attestations should be combined [Preset: mainnet]                                          OK
++ Can add and retrieve simple attestation [Preset: mainnet]                                  OK
++ Fork choice returns block with attestation                                                 OK
++ Fork choice returns latest block with no attestations                                      OK
+```
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -230,4 +241,4 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 OK: 8/8 Fail: 0/8 Skip: 0/8
 
 ---TOTAL---
-OK: 141/144 Fail: 3/144 Skip: 0/144
+OK: 148/151 Fail: 3/151 Skip: 0/151

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -78,5 +78,5 @@ task test, "Run all tests":
   buildBinary "all_fixtures_require_ssz", "tests/official/", "-d:const_preset=mainnet"
 
   # State sim; getting into 4th epoch useful to trigger consensus checks
-  buildBinary "state_sim", "research/", "", "--validators=1024 --slots=32"
-  buildBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=1024 --slots=128"
+  buildBinary "state_sim", "research/", "-d:const_preset=minimal", "--validators=2000 --slots=32"
+  buildBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=2000 --slots=128"

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -63,7 +63,7 @@ func verifyConsensus(state: BeaconState, attesterRatio: auto) =
     doAssert state.finalized_checkpoint.epoch + 2 >= current_epoch
 
 cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 30, # One per shard is minimum
+       validators = SLOTS_PER_EPOCH * 100, # One per shard is minimum
        json_interval = SLOTS_PER_EPOCH,
        write_last_json = false,
        prefix = 0,

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -7,7 +7,7 @@
 
 
 # process_deposit (beaconstate.nim)
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#deposits
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#deposits
 # ---------------------------------------------------------------
 
 {.used.}

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,210 +8,205 @@
 {.used.}
 
 import
-  ../beacon_chain/spec/datatypes,
-  ../beacon_chain/ssz
+  unittest,
+  chronicles,
+  stew/byteutils,
+  ./testutil, ./testblockutil,
+  ../beacon_chain/spec/[datatypes, digest, validator],
+  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition, ssz]
 
-when const_preset == "minimal": # Too much stack space used on mainnet
-  import
-    unittest,
-    chronicles,
-    stew/byteutils,
-    ./testutil, ./testblockutil,
-    ../beacon_chain/spec/[digest, validator],
-    ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition]
+suiteReport "Attestation pool processing" & preset():
+  ## For now just test that we can compile and execute block processing with
+  ## mock data.
 
-  suiteReport "Attestation pool processing" & preset():
-    ## For now just test that we can compile and execute block processing with
-    ## mock data.
+  setup:
+    # Genesis state that results in 3 members per committee
+    var
+      blockPool = BlockPool.init(makeTestDB(SLOTS_PER_EPOCH * 3))
+      pool = AttestationPool.init(blockPool)
+      state = newClone(loadTailState(blockPool))
+    # Slot 0 is a finalized slot - won't be making attestations for it..
+    process_slots(state.data, state.data.data.slot + 1)
 
-    setup:
-      # Genesis state that results in 3 members per committee
-      var
-        blockPool = BlockPool.init(makeTestDB(SLOTS_PER_EPOCH * 3))
-        pool = AttestationPool.init(blockPool)
-        state = newClone(loadTailState(blockPool))
-      # Slot 0 is a finalized slot - won't be making attestations for it..
-      process_slots(state.data, state.data.data.slot + 1)
+  timedTest "Can add and retrieve simple attestation" & preset():
+    var cache = get_empty_per_epoch_cache()
+    let
+      # Create an attestation for slot 1!
+      beacon_committee = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation = makeAttestation(
+        state.data.data, state.blck.root, beacon_committee[0], cache)
 
-    timedTest "Can add and retrieve simple attestation" & preset():
-      var cache = get_empty_per_epoch_cache()
-      let
-        # Create an attestation for slot 1!
-        beacon_committee = get_beacon_committee(
-          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation = makeAttestation(
-          state.data.data, state.blck.root, beacon_committee[0], cache)
+    pool.add(attestation)
 
-      pool.add(attestation)
+    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    let attestations = pool.getAttestationsForBlock(state.data.data)
 
-      let attestations = pool.getAttestationsForBlock(state.data.data)
+    check:
+      attestations.len == 1
 
-      check:
-        attestations.len == 1
+  timedTest "Attestations may arrive in any order" & preset():
+    var cache = get_empty_per_epoch_cache()
+    let
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state.data.data, state.blck.root, bc0[0], cache)
 
-    timedTest "Attestations may arrive in any order" & preset():
-      var cache = get_empty_per_epoch_cache()
-      let
-        # Create an attestation for slot 1!
-        bc0 = get_beacon_committee(
-          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0], cache)
+    process_slots(state.data, state.data.data.slot + 1)
 
-      process_slots(state.data, state.data.data.slot + 1)
+    let
+      bc1 = get_beacon_committee(state.data.data,
+        state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation1 = makeAttestation(
+        state.data.data, state.blck.root, bc1[0], cache)
 
-      let
-        bc1 = get_beacon_committee(state.data.data,
-          state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc1[0], cache)
+    # test reverse order
+    pool.add(attestation1)
+    pool.add(attestation0)
 
-      # test reverse order
-      pool.add(attestation1)
-      pool.add(attestation0)
+    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    let attestations = pool.getAttestationsForBlock(state.data.data)
 
-      let attestations = pool.getAttestationsForBlock(state.data.data)
+    check:
+      attestations.len == 1
 
-      check:
-        attestations.len == 1
+  timedTest "Attestations should be combined" & preset():
+    var cache = get_empty_per_epoch_cache()
+    let
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state.data.data, state.blck.root, bc0[0], cache)
+      attestation1 = makeAttestation(
+        state.data.data, state.blck.root, bc0[1], cache)
 
-    timedTest "Attestations should be combined" & preset():
-      var cache = get_empty_per_epoch_cache()
-      let
-        # Create an attestation for slot 1!
-        bc0 = get_beacon_committee(
-          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0], cache)
-        attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1], cache)
+    pool.add(attestation0)
+    pool.add(attestation1)
 
-      pool.add(attestation0)
-      pool.add(attestation1)
+    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    let attestations = pool.getAttestationsForBlock(state.data.data)
 
-      let attestations = pool.getAttestationsForBlock(state.data.data)
+    check:
+      attestations.len == 1
 
-      check:
-        attestations.len == 1
+  timedTest "Attestations may overlap, bigger first" & preset():
+    var cache = get_empty_per_epoch_cache()
 
-    timedTest "Attestations may overlap, bigger first" & preset():
-      var cache = get_empty_per_epoch_cache()
+    var
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state.data.data, state.blck.root, bc0[0], cache)
+      attestation1 = makeAttestation(
+        state.data.data, state.blck.root, bc0[1], cache)
 
-      var
-        # Create an attestation for slot 1!
-        bc0 = get_beacon_committee(
-          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0], cache)
-        attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1], cache)
+    attestation0.combine(attestation1, {})
 
-      attestation0.combine(attestation1, {})
+    pool.add(attestation0)
+    pool.add(attestation1)
 
-      pool.add(attestation0)
-      pool.add(attestation1)
+    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    let attestations = pool.getAttestationsForBlock(state.data.data)
 
-      let attestations = pool.getAttestationsForBlock(state.data.data)
+    check:
+      attestations.len == 1
 
-      check:
-        attestations.len == 1
+  timedTest "Attestations may overlap, smaller first" & preset():
+    var cache = get_empty_per_epoch_cache()
+    var
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(state.data.data,
+        state.data.data.slot, 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state.data.data, state.blck.root, bc0[0], cache)
+      attestation1 = makeAttestation(
+        state.data.data, state.blck.root, bc0[1], cache)
 
-    timedTest "Attestations may overlap, smaller first" & preset():
-      var cache = get_empty_per_epoch_cache()
-      var
-        # Create an attestation for slot 1!
-        bc0 = get_beacon_committee(state.data.data,
-          state.data.data.slot, 0.CommitteeIndex, cache)
-        attestation0 = makeAttestation(
-          state.data.data, state.blck.root, bc0[0], cache)
-        attestation1 = makeAttestation(
-          state.data.data, state.blck.root, bc0[1], cache)
+    attestation0.combine(attestation1, {})
 
-      attestation0.combine(attestation1, {})
+    pool.add(attestation1)
+    pool.add(attestation0)
 
-      pool.add(attestation1)
-      pool.add(attestation0)
+    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    let attestations = pool.getAttestationsForBlock(state.data.data)
 
-      let attestations = pool.getAttestationsForBlock(state.data.data)
+    check:
+      attestations.len == 1
 
-      check:
-        attestations.len == 1
+  timedTest "Fork choice returns latest block with no attestations":
+    let
+      b1 = addTestBlock(state.data.data, blockPool.tail.root)
+      b1Root = hash_tree_root(b1.message)
+      b1Add = blockPool.add(b1Root, b1)
+      head = pool.selectHead()
 
-    timedTest "Fork choice returns latest block with no attestations":
-      let
-        b1 = addTestBlock(state.data.data, blockPool.tail.root)
-        b1Root = hash_tree_root(b1.message)
-        b1Add = blockPool.add(b1Root, b1)
-        head = pool.selectHead()
+    check:
+      head == b1Add
 
-      check:
-        head == b1Add
+    let
+      b2 = addTestBlock(state.data.data, b1Root)
+      b2Root = hash_tree_root(b2.message)
+      b2Add = blockPool.add(b2Root, b2)
+      head2 = pool.selectHead()
 
-      let
-        b2 = addTestBlock(state.data.data, b1Root)
-        b2Root = hash_tree_root(b2.message)
-        b2Add = blockPool.add(b2Root, b2)
-        head2 = pool.selectHead()
+    check:
+      head2 == b2Add
 
-      check:
-        head2 == b2Add
+  timedTest "Fork choice returns block with attestation":
+    var cache = get_empty_per_epoch_cache()
+    let
+      b10 = makeTestBlock(state.data.data, blockPool.tail.root)
+      b10Root = hash_tree_root(b10.message)
+      b10Add = blockPool.add(b10Root, b10)
+      head = pool.selectHead()
 
-    timedTest "Fork choice returns block with attestation":
-      var cache = get_empty_per_epoch_cache()
-      let
-        b10 = makeTestBlock(state.data.data, blockPool.tail.root)
-        b10Root = hash_tree_root(b10.message)
-        b10Add = blockPool.add(b10Root, b10)
-        head = pool.selectHead()
+    check:
+      head == b10Add
 
-      check:
-        head == b10Add
+    let
+      b11 = makeTestBlock(state.data.data, blockPool.tail.root,
+        graffiti = Eth2Digest(data: [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+      )
+      b11Root = hash_tree_root(b11.message)
+      b11Add = blockPool.add(b11Root, b11)
 
-      let
-        b11 = makeTestBlock(state.data.data, blockPool.tail.root,
-          graffiti = Eth2Digest(data: [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        )
-        b11Root = hash_tree_root(b11.message)
-        b11Add = blockPool.add(b11Root, b11)
+      bc1 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
+      attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
 
-        bc1 = get_beacon_committee(
-          state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
-        attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
+    pool.add(attestation0)
 
-      pool.add(attestation0)
+    let head2 = pool.selectHead()
 
-      let head2 = pool.selectHead()
+    check:
+      # Single vote for b10 and no votes for b11
+      head2 == b10Add
 
-      check:
-        # Single vote for b10 and no votes for b11
-        head2 == b10Add
+    let
+      attestation1 = makeAttestation(state.data.data, b11Root, bc1[1], cache)
+      attestation2 = makeAttestation(state.data.data, b11Root, bc1[2], cache)
+    pool.add(attestation1)
 
-      let
-        attestation1 = makeAttestation(state.data.data, b11Root, bc1[1], cache)
-        attestation2 = makeAttestation(state.data.data, b11Root, bc1[2], cache)
-      pool.add(attestation1)
+    let head3 = pool.selectHead()
+    let smaller = if b10Root.data < b11Root.data: b10Add else: b11Add
 
-      let head3 = pool.selectHead()
-      let smaller = if b10Root.data < b11Root.data: b10Add else: b11Add
+    check:
+      # Ties broken lexicographically
+      head3 == smaller
 
-      check:
-        # Ties broken lexicographically
-        head3 == smaller
+    pool.add(attestation2)
 
-      pool.add(attestation2)
+    let head4 = pool.selectHead()
 
-      let head4 = pool.selectHead()
-
-      check:
-        # Two votes for b11
-        head4 == b11Add
+    check:
+      # Two votes for b11
+      head4 == b11Add


### PR DESCRIPTION
- attestation pool tests now work in mainnet

- https://github.com/status-im/nim-beacon-chain/pull/930 allows `state_sim` to be efficient enough to double CI state sim validators, approaching more realistic eth2 network numbers as well as more quickly testing/rooting out remaining potential quadratic complexity