### PR TITLE
begin removing plain BeaconState versions of state transition functions

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -268,6 +268,15 @@ proc initialize_beacon_state_from_eth1*(
 
   state
 
+proc initialize_hashed_beacon_state_from_eth1*(
+    eth1_block_hash: Eth2Digest,
+    eth1_timestamp: uint64,
+    deposits: openArray[Deposit],
+    flags: UpdateFlags = {}): HashedBeaconState =
+  let genesisState = initialize_beacon_state_from_eth1(
+    eth1_block_hash, eth1_timestamp, deposits, flags)
+  HashedBeaconState(data: genesisState[], root: hash_tree_root(genesisState))
+
 func is_valid_genesis_state*(state: BeaconState): bool =
   if state.genesis_time < MIN_GENESIS_TIME:
     return false

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -121,12 +121,6 @@ func process_slot*(state: var HashedBeaconState) {.nbench.} =
   state.data.block_roots[state.data.slot mod SLOTS_PER_HISTORICAL_ROOT] =
     hash_tree_root(state.data.latest_block_header)
 
-# TODO remove this once callers gone
-func process_slot*(state: var BeaconState) =
-  var hashedState = HashedBeaconState(data: state, root: hash_tree_root(state))
-  process_slot(hashedState)
-  state = hashedState.data
-
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc process_slots*(state: var HashedBeaconState, slot: Slot) {.nbench.} =
   # TODO: Eth specs strongly assert that state.data.slot <= slot

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -123,12 +123,12 @@ proc fillAggregateAttestation*(state: BeaconState, attestation: var Attestation)
   for i in 0 ..< beacon_committee.len:
     attestation.aggregation_bits[i] = true
 
-proc add*(state: var BeaconState, attestation: Attestation, slot: Slot) =
-  var signedBlock = mockBlockForNextSlot(state)
+proc add*(state: var HashedBeaconState, attestation: Attestation, slot: Slot) =
+  var signedBlock = mockBlockForNextSlot(state.data)
   signedBlock.message.slot = slot
   signedBlock.message.body.attestations.add attestation
   process_slots(state, slot)
-  signMockBlock(state, signedBlock)
+  signMockBlock(state.data, signedBlock)
 
   doAssert state_transition(
     state, signedBlock, flags = {skipStateRootValidation}, noRollback)

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -61,9 +61,9 @@ proc mockBlockForNextSlot*(state: BeaconState, flags: UpdateFlags = {}):
     SignedBeaconBlock =
   mockBlock(state, state.slot + 1, flags)
 
-proc applyEmptyBlock*(state: var BeaconState) =
+proc applyEmptyBlock*(state: var HashedBeaconState) =
   ## Do a state transition with an empty signed block
   ## on the current slot
-  let signedBlock = mockBlock(state, state.slot, flags = {})
+  let signedBlock = mockBlock(state.data, state.data.slot, flags = {})
   doAssert state_transition(
     state, signedBlock, {skipStateRootValidation}, noRollback)

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -17,14 +17,14 @@ import
   ./mock_deposits
 
 
-proc initGenesisState*(num_validators: uint64, genesis_time: uint64 = 0): BeaconStateRef =
+proc initGenesisState*(num_validators: uint64, genesis_time: uint64 = 0): HashedBeaconState =
   let deposits = mockGenesisBalancedDeposits(
       validatorCount = num_validators,
       amountInEth = 32, # We create canonical validators with 32 Eth
       flags = {skipBlsValidation}
     )
 
-  initialize_beacon_state_from_eth1(
+  initialize_hashed_beacon_state_from_eth1(
     eth1BlockHash, 0, deposits, {skipBlsValidation})
 
 when isMainModule:

--- a/tests/mocking/mock_state.nim
+++ b/tests/mocking/mock_state.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2019 Status Research & Development GmbH
+# Copyright (c) 2018-2020 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -14,11 +14,12 @@ import
   # Internals
   ../../beacon_chain/state_transition
 
-proc nextEpoch*(state: var BeaconState) =
+proc nextEpoch*(state: var HashedBeaconState) =
   ## Transition to the start of the next epoch
-  let slot = state.slot + SLOTS_PER_EPOCH - (state.slot mod SLOTS_PER_EPOCH)
+  let slot =
+    state.data.slot + SLOTS_PER_EPOCH - (state.data.slot mod SLOTS_PER_EPOCH)
   process_slots(state, slot)
 
-proc nextSlot*(state: var BeaconState) =
+proc nextSlot*(state: var HashedBeaconState) =
   ## Transition to the next slot
-  process_slots(state, state.slot + 1)
+  process_slots(state, state.data.slot + 1)

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -24,7 +24,7 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
 
   const NumValidators = uint64(8) * SLOTS_PER_EPOCH
   let genesisState = initGenesisState(NumValidators)
-  doAssert genesisState.validators.len == int NumValidators
+  doAssert genesisState.data.validators.len == int NumValidators
 
   template valid_attestation(name: string, body: untyped): untyped {.dirty.}=
     # Process a valid attestation
@@ -42,29 +42,29 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
       # Params for sanity checks
       # ----------------------------------------
       let
-        current_epoch_count = state.current_epoch_attestations.len
-        previous_epoch_count = state.previous_epoch_attestations.len
+        current_epoch_count = state.data.current_epoch_attestations.len
+        previous_epoch_count = state.data.previous_epoch_attestations.len
 
       # State transition
       # ----------------------------------------
       var cache = get_empty_per_epoch_cache()
       check process_attestation(
-        state[], attestation, flags = {}, cache
+        state.data, attestation, flags = {}, cache
       )
 
       # Check that the attestation was processed
-      if attestation.data.target.epoch == get_current_epoch(state[]):
-        check(state.current_epoch_attestations.len == current_epoch_count + 1)
+      if attestation.data.target.epoch == get_current_epoch(state.data):
+        check(state.data.current_epoch_attestations.len == current_epoch_count + 1)
       else:
-        check(state.previous_epoch_attestations.len == previous_epoch_count + 1)
+        check(state.data.previous_epoch_attestations.len == previous_epoch_count + 1)
 
   valid_attestation("Valid attestation"):
-    let attestation = mockAttestation(state[])
-    state.slot += MIN_ATTESTATION_INCLUSION_DELAY
+    let attestation = mockAttestation(state.data)
+    state.data.slot += MIN_ATTESTATION_INCLUSION_DELAY
 
   valid_attestation("Valid attestation from previous epoch"):
-    let attestation = mockAttestation(state[])
-    state.slot = Slot(SLOTS_PER_EPOCH - 1)
+    let attestation = mockAttestation(state.data)
+    state.data.slot = Slot(SLOTS_PER_EPOCH - 1)
     nextEpoch(state[])
     applyEmptyBlock(state[])
 
@@ -90,7 +90,7 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
 
   # valid_attestation("Empty aggregation bit"):
   #   var attestation = mockAttestation(state)
-  #   state.slot += MIN_ATTESTATION_INCLUSION_DELAY
+  #   state.data.slot += MIN_ATTESTATION_INCLUSION_DELAY
 
   #   # Overwrite committee
   #   attestation.aggregation_bits = init(CommitteeValidatorsBits, attestation.aggregation_bits.len)

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -27,7 +27,7 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
   const NumValidators = uint64 5 * SLOTS_PER_EPOCH
   let genesisState = initGenesisState(NumValidators)
-  doAssert genesisState.validators.len == int NumValidators
+  doAssert genesisState.data.validators.len == int NumValidators
 
   template valid_deposit(deposit_amount: uint64, name: string): untyped =
     # TODO: BLS signature
@@ -37,9 +37,9 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
       # Test configuration
       # ----------------------------------------
-      let validator_index = state.validators.len
+      let validator_index = state.data.validators.len
       let deposit = mockUpdateStateForNewDeposit(
-                      state[],
+                      state.data,
                       uint64 validator_index,
                       deposit_amount,
                       flags = {skipBlsValidation}
@@ -47,25 +47,25 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
       # Params for sanity checks
       # ----------------------------------------
-      let pre_val_count = state.validators.len
+      let pre_val_count = state.data.validators.len
       let pre_balance = if validator_index < pre_val_count:
-                          state.balances[validator_index]
+                          state.data.balances[validator_index]
                         else:
                           0
 
       # State transition
       # ----------------------------------------
-      check: process_deposit(state[], deposit, {skipBlsValidation})
+      check: process_deposit(state.data, deposit, {skipBlsValidation})
 
       # Check invariants
       # ----------------------------------------
       check:
-        state.validators.len == pre_val_count + 1
-        state.balances.len == pre_val_count + 1
-        state.balances[validator_index] == pre_balance + deposit.data.amount
-        state.validators[validator_index].effective_balance ==
+        state.data.validators.len == pre_val_count + 1
+        state.data.balances.len == pre_val_count + 1
+        state.data.balances[validator_index] == pre_balance + deposit.data.amount
+        state.data.validators[validator_index].effective_balance ==
           round_multiple_down(
-            min(MAX_EFFECTIVE_BALANCE, state.balances[validator_index]),
+            min(MAX_EFFECTIVE_BALANCE, state.data.balances[validator_index]),
             EFFECTIVE_BALANCE_INCREMENT
           )
 
@@ -81,7 +81,7 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
     let validator_index = 0
     let deposit_amount = MAX_EFFECTIVE_BALANCE div 4
     let deposit = mockUpdateStateForNewDeposit(
-                    state[],
+                    state.data,
                     uint64 validator_index,
                     deposit_amount,
                     flags = {skipBlsValidation}
@@ -89,25 +89,25 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
     # Params for sanity checks
     # ----------------------------------------
-    let pre_val_count = state.validators.len
+    let pre_val_count = state.data.validators.len
     let pre_balance = if validator_index < pre_val_count:
-                        state.balances[validator_index]
+                        state.data.balances[validator_index]
                       else:
                         0
 
     # State transition
     # ----------------------------------------
-    check: process_deposit(state[], deposit, {skipBlsValidation})
+    check: process_deposit(state.data, deposit, {skipBlsValidation})
 
     # Check invariants
     # ----------------------------------------
     check:
-      state.validators.len == pre_val_count
-      state.balances.len == pre_val_count
-      state.balances[validator_index] == pre_balance + deposit.data.amount
-      state.validators[validator_index].effective_balance ==
+      state.data.validators.len == pre_val_count
+      state.data.balances.len == pre_val_count
+      state.data.balances[validator_index] == pre_balance + deposit.data.amount
+      state.data.validators[validator_index].effective_balance ==
         round_multiple_down(
-          min(MAX_EFFECTIVE_BALANCE, state.balances[validator_index]),
+          min(MAX_EFFECTIVE_BALANCE, state.data.balances[validator_index]),
           EFFECTIVE_BALANCE_INCREMENT
         )
 

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2020 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -11,9 +11,10 @@ import
   # Internals
   ../../beacon_chain/[state_transition]
 
-proc processSlotsUntilEndCurrentEpoch(state: var BeaconState) =
+proc processSlotsUntilEndCurrentEpoch(state: var HashedBeaconState) =
   # Process all slots until the end of the last slot of the current epoch
-  let slot = state.slot + SLOTS_PER_EPOCH - (state.slot mod SLOTS_PER_EPOCH)
+  let slot =
+    state.data.slot + SLOTS_PER_EPOCH - (state.data.slot mod SLOTS_PER_EPOCH)
 
   # Transition to slot before the epoch state transition
   process_slots(state, slot - 1)
@@ -23,11 +24,11 @@ proc processSlotsUntilEndCurrentEpoch(state: var BeaconState) =
   # (see process_slots())
   process_slot(state)
 
-proc transitionEpochUntilJustificationFinalization*(state: var BeaconState) =
+proc transitionEpochUntilJustificationFinalization*(state: var HashedBeaconState) =
   # Process slots and do the epoch transition until crosslinks
   processSlotsUntilEndCurrentEpoch(state)
 
   # From process_epoch()
   var per_epoch_cache = get_empty_per_epoch_cache()
 
-  process_justification_and_finalization(state, per_epoch_cache)
+  process_justification_and_finalization(state.data, per_epoch_cache)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -20,43 +20,43 @@ suiteReport "Block processing" & preset():
   let
     # Genesis state with minimal number of deposits
     # TODO bls verification is a bit of a bottleneck here
-    genesisState = initialize_beacon_state_from_eth1(
+    genesisState = initialize_hashed_beacon_state_from_eth1(
       Eth2Digest(), 0, makeInitialDeposits(), {})
-    genesisBlock = get_initial_beacon_block(genesisState[])
+    genesisBlock = get_initial_beacon_block(genesisState.data)
     genesisRoot = hash_tree_root(genesisBlock.message)
 
   setup:
     var state = newClone(genesisState)
 
   timedTest "Passes from genesis state, no block" & preset():
-    process_slots(state[], state.slot + 1)
+    process_slots(state[], state.data.slot + 1)
     check:
-      state.slot == genesisState.slot + 1
+      state.data.slot == genesisState.data.slot + 1
 
   timedTest "Passes from genesis state, empty block" & preset():
     var
       previous_block_root = hash_tree_root(genesisBlock.message)
-      new_block = makeTestBlock(state[], previous_block_root)
+      new_block = makeTestBlock(state.data, previous_block_root)
 
     let block_ok = state_transition(state[], new_block, {}, noRollback)
 
     check:
       block_ok
 
-      state.slot == genesisState.slot + 1
+      state.data.slot == genesisState.data.slot + 1
 
   timedTest "Passes through epoch update, no block" & preset():
     process_slots(state[], Slot(SLOTS_PER_EPOCH))
 
     check:
-      state.slot == genesisState.slot + SLOTS_PER_EPOCH
+      state.data.slot == genesisState.data.slot + SLOTS_PER_EPOCH
 
   timedTest "Passes through epoch update, empty block" & preset():
     var
       previous_block_root = genesisRoot
 
     for i in 1..SLOTS_PER_EPOCH.int:
-      let new_block = makeTestBlock(state[], previous_block_root)
+      let new_block = makeTestBlock(state.data, previous_block_root)
 
       let block_ok = state_transition(state[], new_block, {}, noRollback)
 
@@ -66,7 +66,7 @@ suiteReport "Block processing" & preset():
       previous_block_root = hash_tree_root(new_block.message)
 
     check:
-      state.slot == genesisState.slot + SLOTS_PER_EPOCH
+      state.data.slot == genesisState.data.slot + SLOTS_PER_EPOCH
 
   timedTest "Attestation gets processed at epoch" & preset():
     var
@@ -74,21 +74,21 @@ suiteReport "Block processing" & preset():
       cache = get_empty_per_epoch_cache()
 
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    process_slots(state[], state.slot + 1)
+    process_slots(state[], state.data.slot + 1)
 
     let
       # Create an attestation for slot 1 signed by the only attester we have!
       beacon_committee =
-        get_beacon_committee(state[], state.slot, 0.CommitteeIndex, cache)
+        get_beacon_committee(state.data, state.data.slot, 0.CommitteeIndex, cache)
       attestation = makeAttestation(
-        state[], previous_block_root, beacon_committee[0], cache)
+        state.data, previous_block_root, beacon_committee[0], cache)
 
     # Some time needs to pass before attestations are included - this is
     # to let the attestation propagate properly to interested participants
     process_slots(state[], GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY + 1)
 
     let
-      new_block = makeTestBlock(state[], previous_block_root,
+      new_block = makeTestBlock(state.data, previous_block_root,
         attestations = @[attestation]
       )
     check state_transition(state[], new_block, {}, noRollback)
@@ -96,7 +96,7 @@ suiteReport "Block processing" & preset():
     check:
       # TODO epoch attestations can get multiplied now; clean up paths to
       # enable exact 1-check again and keep finalization.
-      state.current_epoch_attestations.len >= 1
+      state.data.current_epoch_attestations.len >= 1
 
     when const_preset=="minimal":
       # Can take several minutes with mainnet settings


### PR DESCRIPTION
The `HashedBeaconState` versions are fundamentally better/necessary.

`beacon_chain/`, e.g., `beacon_node` already only uses the `HashedBeaconState` versions, so this doesn't affect them. It does affect `tests/`, `research/`, et cetera, by making them temporarily slower, but that'll get fixed by having the callers naturally work with `HashedBeaconState`.

This PR will be built upon as individual callers get switched to the `Hashed` versions without relying on the wrappers, but is also meant to be mergeable at any time.

Even from the first commit, it provides the advantage of increasing test coverage: right now in `devel`, the actual running `beacon_node` uses the `HashedBeaconState` functions, while virtually all the test functions use the `BeaconState` functions, so it's possible for one code path to behave differently than the other in a way the tests would create either false negatives or positives regarding. This PR unifies the state transition and slot processing code paths between testing and beacon node code.