### PR TITLE
fix spec/beaconstate compile error given other PRs' SSZ tightening

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -275,7 +275,7 @@ proc initialize_hashed_beacon_state_from_eth1*(
     flags: UpdateFlags = {}): HashedBeaconState =
   let genesisState = initialize_beacon_state_from_eth1(
     eth1_block_hash, eth1_timestamp, deposits, flags)
-  HashedBeaconState(data: genesisState[], root: hash_tree_root(genesisState))
+  HashedBeaconState(data: genesisState[], root: hash_tree_root(genesisState[]))
 
 func is_valid_genesis_state*(state: BeaconState): bool =
   if state.genesis_time < MIN_GENESIS_TIME:


### PR DESCRIPTION
https://github.com/status-im/nim-beacon-chain/pull/951 added:
```
proc initialize_hashed_beacon_state_from_eth1*(      
    eth1_block_hash: Eth2Digest,
    eth1_timestamp: uint64,                                                                                
    deposits: openArray[Deposit],                       
    flags: UpdateFlags = {}): HashedBeaconState =                                                   
  let genesisState = initialize_beacon_state_from_eth1(                     
    eth1_block_hash, eth1_timestamp, deposits, flags)                          
  HashedBeaconState(data: genesisState[], root: hash_tree_root(genesisState))
```

Which worked prior to another PR (there have been a couple recent SSZ PRs). But now `hash_tree_root(genesisState: beaconStateRef)` isn't valid, so fix that in a minimal way to keep `devel` going.