### PR TITLE
Cache roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ build/
 
 # State sim # TODO - move in another folder
 0000-*.json
+*.ssz
+*.log
+*.sqlite3
 
 /local_testnet_data
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -247,7 +247,7 @@ proc init*(T: type BeaconNode, conf: BeaconNodeConf): Future[BeaconNode] {.async
   #      time to do so?
   network.initBeaconSync(blockPool, enrForkId.forkDigest,
     proc(signedBlock: SignedBeaconBlock) =
-      if signedBlock.message.slot mod SLOTS_PER_EPOCH == 0:
+      if signedBlock.message.slot.isEpoch:
         # TODO this is a hack to make sure that lmd ghost is run regularly
         #      while syncing blocks - it's poor form to keep it here though -
         #      the logic should be moved elsewhere

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -38,6 +38,9 @@ func compute_epoch_at_slot*(slot: Slot|uint64): Epoch =
 template epoch*(slot: Slot): Epoch =
   compute_epoch_at_slot(slot)
 
+template isEpoch*(slot: Slot): bool =
+  (slot mod SLOTS_PER_EPOCH) == 0
+
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
 func compute_start_slot_at_epoch*(epoch: Epoch): Slot =
   # Return the start slot of ``epoch``.

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -40,7 +40,7 @@ func verifyConsensus*(state: BeaconState, attesterRatio: auto) =
     doAssert state.finalized_checkpoint.epoch + 2 >= current_epoch
 
 proc loadGenesis*(validators: int, validate: bool): ref BeaconState =
-  let fn = &"genesim_{const_preset}_{validators}"
+  let fn = &"genesim_{const_preset}_{validators}.ssz"
   if fileExists(fn):
     let res = newClone(SSZ.loadFile(fn, BeaconState))
     if res.slot != GENESIS_SLOT:

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -51,7 +51,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     latest_block_root = hash_tree_root(genesisBlock.message)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
-    r: Rand
+    r = initRand(1)
     signedBlock: SignedBeaconBlock
     cache = get_empty_per_epoch_cache()
 
@@ -89,7 +89,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
     let t =
       if (state.slot > GENESIS_SLOT and
-        (state.slot + 1) mod SLOTS_PER_EPOCH == 0): tEpoch
+        (state.slot + 1).isEpoch): tEpoch
       else: tBlock
 
     withTimer(timers[t]):


### PR DESCRIPTION
When replaying state transitions, for the slots that have a block, the
state root is taken from the block. For slots that lack a block, it's
currently calculated using hash_tree_root which is expensive.

Caching the empty slot state roots helps us avoid recalculating this
hash, meaning that for replay, hashes are never calculated. This turns
blocks into fairly lightweight "state-diffs"!

* avoid re-saving state when replaying blocks
* advance empty slots slot-by-slot and save root
* fix sim randomness
* fix sim genesis filename
* introduce `isEpoch` to check if a slot is an epoch slot
