### PR TITLE
Att pool fork choice refactor

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -140,9 +140,9 @@ proc isValidAttestation*(
   # as it supports aggregated attestations (which this can't be)
   var cache = get_empty_per_epoch_cache()
   if not is_valid_indexed_attestation(
-      pool.blockPool.headState.data.data[],
+      pool.blockPool.headState.data.data,
       get_indexed_attestation(
-        pool.blockPool.headState.data.data[], attestation, cache), {}):
+        pool.blockPool.headState.data.data, attestation, cache), {}):
     debug "isValidAttestation: signature verification failed"
     return false
 

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -295,7 +295,7 @@ proc add*(pool: var AttestationPool, blck: BlockRef) =
   pool.forkChoice.process_block(
     slot = blck.slot,
     block_root = blck.root,
-    parent_root = blck.parent.root,
+    parent_root = if not blck.parent.isNil: blck.parent.root else: default(Eth2Digest),
     state_root = default(Eth2Digest), # This is unnecessary for fork choice but may help external components
     justified_epoch = pool.blockPool.tmpState.data.data.current_justified_checkpoint.epoch,
     finalized_epoch = pool.blockPool.tmpState.data.data.finalized_checkpoint.epoch,

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -188,7 +188,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
   let
     attestationSlot = attestation.data.slot
     idx = pool.slotIndex(state, attestationSlot)
-    AttestationsSeen = addr pool.mapSlotsToAttestations[idx]
+    attestationsSeen = addr pool.mapSlotsToAttestations[idx]
     validation = Validation(
       aggregation_bits: attestation.aggregation_bits,
       aggregate_signature: attestation.signature)
@@ -196,7 +196,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
       state, attestation.data, validation.aggregation_bits)
 
   var found = false
-  for a in AttestationsSeen.attestations.mitems():
+  for a in attestationsSeen.attestations.mitems():
     if a.data == attestation.data:
       for v in a.validations:
         if validation.aggregation_bits.isSubsetOf(v.aggregation_bits):
@@ -244,7 +244,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
       break
 
   if not found:
-    AttestationsSeen.attestations.add(AttestationEntry(
+    attestationsSeen.attestations.add(AttestationEntry(
       data: attestation.data,
       blck: blck,
       validations: @[validation]

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -30,6 +30,7 @@ proc combine*(tgt: var Attestation, src: Attestation, flags: UpdateFlags) =
   ## Combine the signature and participation bitfield, with the assumption that
   ## the same data is being signed - if the signatures overlap, they are not
   ## combined.
+  # TODO: Exported only for testing, all usage are internals
 
   doAssert tgt.data == src.data
 
@@ -44,43 +45,6 @@ proc combine*(tgt: var Attestation, src: Attestation, flags: UpdateFlags) =
   else:
     trace "Ignoring overlapping attestations"
 
-# TODO remove/merge with p2p-interface validation
-proc validate(
-    state: BeaconState, attestation: Attestation): bool =
-  # TODO what constitutes a valid attestation when it's about to be added to
-  #      the pool? we're interested in attestations that will become viable
-  #      for inclusion in blocks in the future and on any fork, so we need to
-  #      consider that validations might happen using the state of a different
-  #      fork.
-  #      Some things are always invalid (like out-of-bounds issues etc), but
-  #      others are more subtle - how do we validate the signature for example?
-  #      It might be valid on one fork but not another. One thing that helps
-  #      is that committees are stable per epoch and that it should be OK to
-  #      include an attestation in a block even if the corresponding validator
-  #      was slashed in the same epoch - there's no penalty for doing this and
-  #      the vote counting logic will take care of any ill effects (TODO verify)
-  let data = attestation.data
-  # TODO re-enable check
-  #if not (data.crosslink.shard < SHARD_COUNT):
-  #  notice "Attestation shard too high",
-  #    attestation_shard = data.crosslink.shard
-  #  return
-
-  # Without this check, we can't get a slot number for the attestation as
-  # certain helpers will assert
-  # TODO this could probably be avoided by being smart about the specific state
-  #      used to validate the attestation: most likely if we pick the state of
-  #      the beacon block being voted for and a slot in the target epoch
-  #      of the attestation, we'll be safe!
-  # TODO the above state selection logic should probably live here in the
-  #      attestation pool
-  if not (data.target.epoch == get_previous_epoch(state) or
-      data.target.epoch == get_current_epoch(state)):
-    notice "Target epoch not current or previous epoch"
-
-    return
-
-  true
 
 proc slotIndex(
     pool: var AttestationPool, state: BeaconState, attestationSlot: Slot): int =
@@ -168,21 +132,24 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
   #      reasonable to involve the head being voted for as well as the intended
   #      slot of the attestation - double-check this with spec
 
-  # A basic check is that the attestation is at least as new as the block being
-  # voted for..
-  if blck.slot > attestation.data.slot:
-    notice "Invalid attestation (too new!)",
-      attestation = shortLog(attestation),
-      blockSlot = shortLog(blck.slot)
-    return
+  # TODO: How fast is state rewind?
+  #       Can this be a DOS vector.
 
+  # Get a temporary state at the (block, slot) targeted by the attestation
   updateStateData(
     pool.blockPool, pool.blockPool.tmpState,
     BlockSlot(blck: blck, slot: attestation.data.slot))
 
   template state(): BeaconState = pool.blockPool.tmpState.data.data
 
-  if not validate(state, attestation):
+  # Check that the attestation is indeed valid
+  # TODO: we might want to split checks that depend
+  #       on the state and those that don't to cheaply
+  #       discard invalid attestations before rewinding state.
+
+  # TODO: stateCache usage
+  var stateCache = get_empty_per_epoch_cache()
+  if not check_attestation(state, attestation, flags = {}, stateCache):
     notice "Invalid attestation",
       attestation = shortLog(attestation),
       current_epoch = get_current_epoch(state),
@@ -267,15 +234,18 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
 proc add*(pool: var AttestationPool, attestation: Attestation) =
   logScope: pcs = "atp_add_attestation"
 
+  # Fetch the target block or notify the block pool that it's needed
   let blck = pool.blockPool.getOrResolve(attestation.data.beacon_block_root)
 
+  # If the block exist, add it to the fork choice context
+  # Otherwise delay until it resolves
   if blck.isNil:
     pool.addUnresolved(attestation)
     return
 
   pool.addResolved(blck, attestation)
 
-proc getAttestationsForSlot(pool: AttestationPool, newBlockSlot: Slot):
+proc getAttestationsForSlot*(pool: AttestationPool, newBlockSlot: Slot):
     Option[SlotData] =
   if newBlockSlot < (GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY):
     debug "Too early for attestations",
@@ -353,21 +323,17 @@ proc getAttestationsForBlock*(pool: AttestationPool,
         signature: a.validations[0].aggregate_signature
       )
 
-    if not validate(state, attestation):
-      warn "Attestation no longer validates...",
-        cat = "query"
-      continue
-
     # TODO what's going on here is that when producing a block, we need to
     #      include only such attestations that will not cause block validation
     #      to fail. How this interacts with voting and the acceptance of
     #      attestations into the pool in general is an open question that needs
     #      revisiting - for example, when attestations are added, against which
     #      state should they be validated, if at all?
-    # TODO we're checking signatures here every time which is very slow - this
-    #      is needed because validate does nothing for now and we don't want
+    # TODO we're checking signatures here every time which is very slow and we don't want
     #      to include a broken attestation
     if not check_attestation(state, attestation, {}, cache):
+      warn "Attestation no longer validates...",
+        cat = "query"
       continue
 
     for v in a.validations[1..^1]:
@@ -478,80 +444,3 @@ proc selectHead*(pool: AttestationPool): BlockRef =
     lmdGhost(pool, pool.blockPool.justifiedState.data.data, justifiedHead.blck)
 
   newHead
-
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#attestation-subnets
-proc isValidAttestation*(
-    pool: AttestationPool, attestation: Attestation, current_slot: Slot,
-    topicCommitteeIndex: uint64, flags: UpdateFlags): bool =
-  # The attestation's committee index (attestation.data.index) is for the
-  # correct subnet.
-  if attestation.data.index != topicCommitteeIndex:
-    debug "isValidAttestation: attestation's committee index not for the correct subnet",
-      topicCommitteeIndex = topicCommitteeIndex,
-      attestation_data_index = attestation.data.index
-    return false
-
-  if not (attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >=
-      current_slot and current_slot >= attestation.data.slot):
-    debug "isValidAttestation: attestation.data.slot not within ATTESTATION_PROPAGATION_SLOT_RANGE"
-    return false
-
-  # The attestation is unaggregated -- that is, it has exactly one
-  # participating validator (len([bit for bit in attestation.aggregation_bits
-  # if bit == 0b1]) == 1).
-  # TODO a cleverer algorithm, along the lines of countOnes() in nim-stew
-  # But that belongs in nim-stew, since it'd break abstraction layers, to
-  # use details of its representation from nim-beacon-chain.
-  var onesCount = 0
-  for aggregation_bit in attestation.aggregation_bits:
-    if not aggregation_bit:
-      continue
-    onesCount += 1
-    if onesCount > 1:
-      debug "isValidAttestation: attestation has too many aggregation bits",
-        aggregation_bits = attestation.aggregation_bits
-      return false
-  if onesCount != 1:
-    debug "isValidAttestation: attestation has too few aggregation bits"
-    return false
-
-  # The attestation is the first valid attestation received for the
-  # participating validator for the slot, attestation.data.slot.
-  let maybeSlotData = getAttestationsForSlot(pool, attestation.data.slot)
-  if maybeSlotData.isSome:
-    for attestationEntry in maybeSlotData.get.attestations:
-      if attestation.data != attestationEntry.data:
-        continue
-      # Attestations might be aggregated eagerly or lazily; allow for both.
-      for validation in attestationEntry.validations:
-        if attestation.aggregation_bits.isSubsetOf(validation.aggregation_bits):
-          debug "isValidAttestation: attestation already exists at slot",
-            attestation_data_slot = attestation.data.slot,
-            attestation_aggregation_bits = attestation.aggregation_bits,
-            attestation_pool_validation = validation.aggregation_bits
-          return false
-
-  # The block being voted for (attestation.data.beacon_block_root) passes
-  # validation.
-  # We rely on the block pool to have been validated, so check for the
-  # existence of the block in the pool.
-  # TODO: consider a "slush pool" of attestations whose blocks have not yet
-  # propagated - i.e. imagine that attestations are smaller than blocks and
-  # therefore propagate faster, thus reordering their arrival in some nodes
-  if pool.blockPool.get(attestation.data.beacon_block_root).isNone():
-    debug "isValidAttestation: block doesn't exist in block pool",
-      attestation_data_beacon_block_root = attestation.data.beacon_block_root
-    return false
-
-  # The signature of attestation is valid.
-  # TODO need to know above which validator anyway, and this is too general
-  # as it supports aggregated attestations (which this can't be)
-  var cache = get_empty_per_epoch_cache()
-  if not is_valid_indexed_attestation(
-      pool.blockPool.headState.data.data,
-      get_indexed_attestation(
-        pool.blockPool.headState.data.data, attestation, cache), {}):
-    debug "isValidAttestation: signature verification failed"
-    return false
-
-  true

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -17,7 +17,7 @@ import
 
 logScope: topics = "attpool"
 
-func init*(T: type AttestationPool, blockPool: BlockPool, finalizedHead: BlockSlot): T =
+func init*(T: type AttestationPool, blockPool: BlockPool): T =
   ## Initialize an AttestationPool from the blockPool `headState`
   ## The `finalized_root` works around the finalized_checkpoint of the genesis block
   ## holding a zero_root.
@@ -33,7 +33,7 @@ func init*(T: type AttestationPool, blockPool: BlockPool, finalizedHead: BlockSl
     justified_epoch = blockPool.headState.data.data.current_justified_checkpoint.epoch,
     finalized_epoch = blockPool.headState.data.data.finalized_checkpoint.epoch,
     # finalized_root = blockPool.headState.data.data.finalized_checkpoint.root
-    finalized_root = finalizedHead.blck.root
+    finalized_root = blockPool.finalizedHead.blck.root
   ).get()
 
   T(

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -26,7 +26,7 @@ import
   mainchain_monitor, version, ssz, ssz/dynamic_navigator,
   sync_protocol, request_manager, validator_keygen, interop, statusbar,
   sync_manager, state_transition,
-  validator_duties
+  validator_duties, attestation_aggregation
 
 const
   genesisFile = "genesis.ssz"

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -209,7 +209,7 @@ proc init*(T: type BeaconNode, conf: BeaconNodeConf): Future[BeaconNode] {.async
     config: conf,
     attachedValidators: ValidatorPool.init(),
     blockPool: blockPool,
-    attestationPool: AttestationPool.init(blockPool, blockPool.finalizedHead),
+    attestationPool: AttestationPool.init(blockPool),
     mainchainMonitor: mainchainMonitor,
     beaconClock: BeaconClock.init(blockPool.headState.data.data),
     rpcServer: rpcServer,

--- a/beacon_chain/beacon_node.nim.cfg
+++ b/beacon_chain/beacon_node.nim.cfg
@@ -5,4 +5,3 @@
   -d:"chronicles_sinks=json"
   -d:"withoutPrompt"
 @end
-

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -56,4 +56,7 @@ proc updateHead*(node: BeaconNode): BlockRef =
   node.blockPool.updateHead(newHead)
   beacon_head_root.set newHead.root.toGaugeValue
 
+  # Cleanup the fork choice if we have a finalized head
+  node.attestationPool.pruneBefore(node.blockPool.finalizedHead)
+
   newHead

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -4,7 +4,8 @@ import
   deques, tables,
   stew/[endians2, byteutils], chronicles,
   spec/[datatypes, crypto, digest],
-  beacon_chain_db, extras
+  beacon_chain_db, extras,
+  fork_choice/fork_choice_types
 
 type
   # #############################################
@@ -36,7 +37,7 @@ type
     ## this seq and aggregate only when needed
     ## TODO there are obvious caching opportunities here..
 
-  SlotData* = object
+  AttestationsSeen* = object
     attestations*: seq[AttestationEntry] ## \
     ## Depending on the world view of the various validators, they may have
     ## voted on different states - here we collect all the different
@@ -56,7 +57,7 @@ type
     ## contains both votes that have been included in the chain and those that
     ## have not.
 
-    slots*: Deque[SlotData] ## \
+    mapSlotsToAttestations*: Deque[AttestationsSeen] ## \
     ## We keep one item per slot such that indexing matches slot number
     ## together with startingSlot
 
@@ -68,9 +69,8 @@ type
 
     unresolved*: Table[Eth2Digest, UnresolvedAttestation]
 
-    latestAttestations*: Table[ValidatorPubKey, BlockRef] ##\
-    ## Map that keeps track of the most recent vote of each attester - see
-    ## fork_choice
+    forkChoice*: ForkChoice ##\
+    ## Tracks the most recent vote of each attester
 
   # #############################################
   #
@@ -158,6 +158,8 @@ type
     ## Node in object graph guaranteed to lead back to tail block, and to have
     ## a corresponding entry in database.
     ## Block graph should form a tree - in particular, there are no cycles.
+
+    # TODO: we probably want BlockRef to also keep track of justified and finalized epoch
 
     root*: Eth2Digest ##\
     ## Root that can be used to retrieve block data from database

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -418,6 +418,13 @@ proc add*(
   ## the state parameter may be updated to include the given block, if
   ## everything checks out
   # TODO reevaluate passing the state in like this
+
+  # TODO: to facilitate adding the block to the attestation pool
+  #       this should also return justified and finalized epoch corresponding
+  #       to each block.
+  #       This would be easy apart from the "Block already exists"
+  #       early return.
+
   let blck = signedBlock.message
   doAssert blockRoot == hash_tree_root(blck)
 
@@ -998,7 +1005,7 @@ func latestJustifiedBlock*(pool: BlockPool): BlockSlot =
   ## as the latest finalized block
 
   doAssert pool.heads.len > 0,
-    "We should have at least the genesis block in heaads"
+    "We should have at least the genesis block in heads"
   doAssert (not pool.head.blck.isNil()),
     "Genesis block will be head, if nothing else"
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -151,10 +151,11 @@ func process_block*(
   if err.kind != fcSuccess:
     return err("process_block_error: " & $err)
 
+
   {.noSideEffect.}:
     info "Integrating block in fork choice",
       block_root = $shortlog(block_root),
-      parent_root = $shortlog(parent_root),
+      # parent_root = $shortlog(parent_root), # TODO: For some reason this segfaults
       justified_epoch = $justified_epoch,
       finalized_epoch = $finalized_epoch
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -151,11 +151,10 @@ func process_block*(
   if err.kind != fcSuccess:
     return err("process_block_error: " & $err)
 
-
   {.noSideEffect.}:
     info "Integrating block in fork choice",
       block_root = $shortlog(block_root),
-      # parent_root = $shortlog(parent_root), # TODO: For some reason this segfaults
+      parent_root = $shortlog(parent_root),
       justified_epoch = $justified_epoch,
       finalized_epoch = $finalized_epoch
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/tables, std/options, std/typetraits,
+  std/tables, std/typetraits,
   # Status libraries
   stew/results,
   # Internal
@@ -48,8 +48,8 @@ func compute_deltas(
 # - The public procs use Result
 
 func initForkChoice*(
-       finalized_block_slot: Slot,
-       finalized_block_state_root: Eth2Digest,
+       finalized_block_slot: Slot,             # This is unnecessary for fork choice but helps external components
+       finalized_block_state_root: Eth2Digest, # This is unnecessary for fork choice but helps external components
        justified_epoch: Epoch,
        finalized_epoch: Epoch,
        finalized_root: Eth2Digest
@@ -64,7 +64,8 @@ func initForkChoice*(
   let err = proto_array.on_block(
     finalized_block_slot,
     finalized_root,
-    none(Eth2Digest),
+    hasParentInForkChoice = false,
+    default(Eth2Digest),
     finalized_block_state_root,
     justified_epoch,
     finalized_epoch
@@ -129,7 +130,7 @@ func process_block*(
      ): Result[void, string] =
   ## Add a block to the fork choice context
   let err = self.proto_array.on_block(
-    slot, block_root, some(parent_root), state_root, justified_epoch, finalized_epoch
+    slot, block_root, hasParentInForkChoice = true, parent_root, state_root, justified_epoch, finalized_epoch
   )
   if err.kind != fcSuccess:
     return err("process_block_error: " & $err)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -111,6 +111,12 @@ func process_attestation*(
     vote.next_root = block_root
     vote.next_epoch = target_epoch
 
+func contains*(self: ForkChoice, block_root: Eth2Digest): bool =
+  ## Returns `true` if a block is known to the fork choice
+  ## and `false` otherwise.
+  ##
+  ## In particular, before adding a block, its parent must be known to the fork choice
+  self.proto_array.indices.contains(block_root)
 
 func process_block*(
        self: var ForkChoice,
@@ -252,7 +258,7 @@ func compute_deltas(
 when isMainModule:
   import stew/endians2
 
-  func fakeHash*(index: SomeInteger): Eth2Digest =
+  func fakeHash(index: SomeInteger): Eth2Digest =
     ## Create fake hashes
     ## Those are just the value serialized in big-endian
     ## We add 16x16 to avoid having a zero hash are those are special cased

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -132,3 +132,9 @@ type
     proto_array*: ProtoArray
     votes*: seq[VoteTracker]
     balances*: seq[Gwei]
+
+func shortlog*(vote: VoteTracker): string =
+  result = "Vote("
+  result &= "current_root: " & shortlog(vote.current_root)
+  result &= ", next_root: " & shortlog(vote.next_root)
+  result &= ", next_epoch: " & $vote.next_epoch & ')'

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -1,4 +1,3 @@
-
 # beacon_chain
 # Copyright (c) 2018-2020 Status Research & Development GmbH
 # Licensed and distributed under either of
@@ -44,6 +43,9 @@ type
     fcErrInvalidDeltaLen
     fcErrRevertedFinalizedEpoch
     fcErrInvalidBestNode
+    # -------------------------
+    # TODO: Extra error modes beyond Proto/Lighthouse to be reviewed
+    fcErrUnknownParent
 
   FcUnderflowKind* = enum
     ## Fork Choice Overflow Kinds
@@ -88,6 +90,9 @@ type
       head_root*: Eth2Digest
       head_justified_epoch*: Epoch
       head_finalized_epoch*: Epoch
+    of fcErrUnknownParent:
+      child_root*: Eth2Digest
+      parent_root*: Eth2Digest
 
   ProtoArray* = object
     prune_threshold*: int

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -475,6 +475,12 @@ proc check_attestation*(
   ## at the current slot. When acting as a proposer, the same rules need to
   ## be followed!
 
+  # TODO: When checking attestation from the network, currently rewinding/advancing
+  #       a temporary state is needed.
+  #       If this is too costly we can be DOS-ed.
+  #       We might want to split this into "state-dependent" checks and "state-independent" checks
+  #       The latter one should be made prior to state-rewinding.
+
   let
     stateSlot = state.slot
     data = attestation.data

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -538,7 +538,7 @@ proc isValidAttestationTargetEpoch*(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#attestations
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.2/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
     state: BeaconState, attestation: Attestation, flags: UpdateFlags,
     stateCache: var StateCache): bool =

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -55,7 +55,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
   var
     blockPool = BlockPool.init(db)
-    attPool = AttestationPool.init(blockPool, blockPool.finalizedHead)
+    attPool = AttestationPool.init(blockPool)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
     r = initRand(1)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -55,7 +55,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
   var
     blockPool = BlockPool.init(db)
-    attPool = AttestationPool.init(blockPool)
+    attPool = AttestationPool.init(blockPool, blockPool.finalizedHead)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
     r = initRand(1)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,16 +8,120 @@
 {.used.}
 
 import
+  ../beacon_chain/spec/datatypes,
+  ../beacon_chain/ssz
+
+import
   unittest,
   chronicles,
   stew/byteutils,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[datatypes, digest, validator],
-  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition, ssz]
+  ../beacon_chain/spec/[digest, validator],
+  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition]
 
-suiteReport "Attestation pool processing" & preset():
-  ## For now just test that we can compile and execute block processing with
-  ## mock data.
+proc main() =
+  suiteReport "Attestation pool processing" & preset():
+    ## For now just test that we can compile and execute block processing with
+    ## mock data.
+    setup: # ref to avoid stack overflow
+      var pool: ref AttestationPool
+      new pool
+
+      var state: ref StateData
+      new state
+
+      # Genesis state that results in 3 members per committee
+      var blockPool = BlockPool.init(makeTestDB(SLOTS_PER_EPOCH * 3))
+      pool[] = AttestationPool.init(blockPool, blockPool.finalizedHead)
+      state[] = loadTailState(blockPool)
+      # Slot 0 is a finalized slot - won't be making attestations for it..
+      process_slots(state.data, state.data.data.slot + 1)
+
+      pool[].add(blockPool.tail) # Make the tail known to fork choice
+
+    timedTest "Can add and retrieve simple attestation" & preset():
+      var cache = get_empty_per_epoch_cache()
+      let
+        # Create an attestation for slot 1!
+        beacon_committee = get_beacon_committee(
+          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation = makeAttestation(
+          state.data.data[], state.blck.root, beacon_committee[0], cache)
+
+      pool[].add(attestation)
+
+      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+
+      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+
+      check:
+        attestations.len == 1
+
+    timedTest "Attestations may arrive in any order" & preset():
+      var cache = get_empty_per_epoch_cache()
+      let
+        # Create an attestation for slot 1!
+        bc0 = get_beacon_committee(
+          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation0 = makeAttestation(
+          state.data.data[], state.blck.root, bc0[0], cache)
+
+      process_slots(state.data, state.data.data.slot + 1)
+
+      let
+        bc1 = get_beacon_committee(state.data.data[],
+          state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation1 = makeAttestation(
+          state.data.data[], state.blck.root, bc1[0], cache)
+
+      # test reverse order
+      pool[].add(attestation1)
+      pool[].add(attestation0)
+
+      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+
+      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+
+      check:
+        attestations.len == 1
+
+    timedTest "Attestations should be combined" & preset():
+      var cache = get_empty_per_epoch_cache()
+      let
+        # Create an attestation for slot 1!
+        bc0 = get_beacon_committee(
+          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation0 = makeAttestation(
+          state.data.data[], state.blck.root, bc0[0], cache)
+        attestation1 = makeAttestation(
+          state.data.data[], state.blck.root, bc0[1], cache)
+
+      pool[].add(attestation0)
+      pool[].add(attestation1)
+
+      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+
+      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+
+      check:
+        attestations.len == 1
+
+    timedTest "Attestations may overlap, bigger first" & preset():
+      var cache = get_empty_per_epoch_cache()
+
+      var
+        # Create an attestation for slot 1!
+        bc0 = get_beacon_committee(
+          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation0 = makeAttestation(
+          state.data.data[], state.blck.root, bc0[0], cache)
+        attestation1 = makeAttestation(
+          state.data.data[], state.blck.root, bc0[1], cache)
+
+      attestation0.combine(attestation1, {})
+
+      pool[].add(attestation0)
+      pool[].add(attestation1)
 
   setup:
     # Genesis state that results in 3 members per committee
@@ -39,9 +143,13 @@ suiteReport "Attestation pool processing" & preset():
 
     pool.add(attestation)
 
+<<<<<<< HEAD
     process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
     let attestations = pool.getAttestationsForBlock(state.data.data)
+=======
+      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+>>>>>>> f045519... Use ProtoArray fork choice
 
     check:
       attestations.len == 1
@@ -114,11 +222,17 @@ suiteReport "Attestation pool processing" & preset():
 
     process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
+<<<<<<< HEAD
     let attestations = pool.getAttestationsForBlock(state.data.data)
+=======
+      pool[].add(attestation1)
+      pool[].add(attestation0)
+>>>>>>> f045519... Use ProtoArray fork choice
 
     check:
       attestations.len == 1
 
+<<<<<<< HEAD
   timedTest "Attestations may overlap, smaller first" & preset():
     var cache = get_empty_per_epoch_cache()
     var
@@ -129,25 +243,61 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, bc0[0], cache)
       attestation1 = makeAttestation(
         state.data.data, state.blck.root, bc0[1], cache)
+=======
+      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+>>>>>>> f045519... Use ProtoArray fork choice
 
     attestation0.combine(attestation1, {})
 
+<<<<<<< HEAD
     pool.add(attestation1)
     pool.add(attestation0)
+=======
+    timedTest "Fork choice returns latest block with no attestations":
+      let
+        b1 = addTestBlock(state.data.data[], blockPool.tail.root)
+        b1Root = hash_tree_root(b1.message)
+        b1Add = blockPool.add(b1Root, b1)
+
+      pool[].add(b1Add)
+      let head = pool[].selectHead()
+>>>>>>> f045519... Use ProtoArray fork choice
 
     process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
+<<<<<<< HEAD
     let attestations = pool.getAttestationsForBlock(state.data.data)
+=======
+      let
+        b2 = addTestBlock(state.data.data[], b1Root)
+        b2Root = hash_tree_root(b2.message)
+        b2Add = blockPool.add(b2Root, b2)
+
+      pool[].add(b2Add)
+      let head2 = pool[].selectHead()
+>>>>>>> f045519... Use ProtoArray fork choice
 
     check:
       attestations.len == 1
 
+<<<<<<< HEAD
   timedTest "Fork choice returns latest block with no attestations":
     let
       b1 = addTestBlock(state.data.data, blockPool.tail.root)
       b1Root = hash_tree_root(b1.message)
       b1Add = blockPool.add(b1Root, b1)
       head = pool.selectHead()
+=======
+    timedTest "Fork choice returns block with attestation":
+      var cache = get_empty_per_epoch_cache()
+      let
+        b10 = makeTestBlock(state.data.data[], blockPool.tail.root)
+        b10Root = hash_tree_root(b10.message)
+        b10Add = blockPool.add(b10Root, b10)
+
+      pool[].add(b10Add)
+      let head = pool[].selectHead()
+>>>>>>> f045519... Use ProtoArray fork choice
 
     check:
       head == b1Add
@@ -161,6 +311,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       head2 == b2Add
 
+<<<<<<< HEAD
   timedTest "Fork choice returns block with attestation":
     var cache = get_empty_per_epoch_cache()
     let
@@ -171,6 +322,12 @@ suiteReport "Attestation pool processing" & preset():
 
     check:
       head == b10Add
+=======
+      pool[].add(b11Add)
+      pool[].add(attestation0)
+
+      let head2 = pool[].selectHead()
+>>>>>>> f045519... Use ProtoArray fork choice
 
     let
       b11 = makeTestBlock(state.data.data, blockPool.tail.root,
@@ -179,6 +336,7 @@ suiteReport "Attestation pool processing" & preset():
       b11Root = hash_tree_root(b11.message)
       b11Add = blockPool.add(b11Root, b11)
 
+<<<<<<< HEAD
       bc1 = get_beacon_committee(
         state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
       attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
@@ -210,3 +368,27 @@ suiteReport "Attestation pool processing" & preset():
     check:
       # Two votes for b11
       head4 == b11Add
+=======
+      let
+        attestation1 = makeAttestation(state.data.data[], b11Root, bc1[1], cache)
+        attestation2 = makeAttestation(state.data.data[], b11Root, bc1[2], cache)
+      pool[].add(attestation1)
+
+      let head3 = pool[].selectHead()
+      let bigger = if b10Root.data > b11Root.data: b10Add else: b11Add
+
+      check:
+        # Ties broken lexicographically in spec -> ?
+        # all implementations favor the biggest root
+        head3 == bigger
+
+      pool[].add(attestation2)
+
+      let head4 = pool[].selectHead()
+
+      check:
+        # Two votes for b11
+        head4 == b11Add
+
+main()
+>>>>>>> f045519... Use ProtoArray fork choice

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -231,5 +231,3 @@ proc main() =
         head4 == b11Add
 
 main()
-
-main()

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -32,7 +32,7 @@ proc main() =
 
       # Genesis state that results in 3 members per committee
       var blockPool = BlockPool.init(makeTestDB(SLOTS_PER_EPOCH * 3))
-      pool[] = AttestationPool.init(blockPool, blockPool.finalizedHead)
+      pool[] = AttestationPool.init(blockPool)
       state[] = loadTailState(blockPool)
       # Slot 0 is a finalized slot - won't be making attestations for it..
       process_slots(state.data, state.data.data.slot + 1)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -44,15 +44,15 @@ proc main() =
       let
         # Create an attestation for slot 1!
         beacon_committee = get_beacon_committee(
-          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
         attestation = makeAttestation(
-          state.data.data[], state.blck.root, beacon_committee[0], cache)
+          state.data.data, state.blck.root, beacon_committee[0], cache)
 
       pool[].add(attestation)
 
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+      let attestations = pool[].getAttestationsForBlock(state.data.data)
 
       check:
         attestations.len == 1
@@ -62,17 +62,17 @@ proc main() =
       let
         # Create an attestation for slot 1!
         bc0 = get_beacon_committee(
-          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
         attestation0 = makeAttestation(
-          state.data.data[], state.blck.root, bc0[0], cache)
+          state.data.data, state.blck.root, bc0[0], cache)
 
       process_slots(state.data, state.data.data.slot + 1)
 
       let
-        bc1 = get_beacon_committee(state.data.data[],
+        bc1 = get_beacon_committee(state.data.data,
           state.data.data.slot, 0.CommitteeIndex, cache)
         attestation1 = makeAttestation(
-          state.data.data[], state.blck.root, bc1[0], cache)
+          state.data.data, state.blck.root, bc1[0], cache)
 
       # test reverse order
       pool[].add(attestation1)
@@ -80,7 +80,7 @@ proc main() =
 
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+      let attestations = pool[].getAttestationsForBlock(state.data.data)
 
       check:
         attestations.len == 1
@@ -90,18 +90,18 @@ proc main() =
       let
         # Create an attestation for slot 1!
         bc0 = get_beacon_committee(
-          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
         attestation0 = makeAttestation(
-          state.data.data[], state.blck.root, bc0[0], cache)
+          state.data.data, state.blck.root, bc0[0], cache)
         attestation1 = makeAttestation(
-          state.data.data[], state.blck.root, bc0[1], cache)
+          state.data.data, state.blck.root, bc0[1], cache)
 
       pool[].add(attestation0)
       pool[].add(attestation1)
 
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-      let attestations = pool[].getAttestationsForBlock(state.data.data[])
+      let attestations = pool[].getAttestationsForBlock(state.data.data)
 
       check:
         attestations.len == 1
@@ -112,266 +112,106 @@ proc main() =
       var
         # Create an attestation for slot 1!
         bc0 = get_beacon_committee(
-          state.data.data[], state.data.data.slot, 0.CommitteeIndex, cache)
+          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
         attestation0 = makeAttestation(
-          state.data.data[], state.blck.root, bc0[0], cache)
+          state.data.data, state.blck.root, bc0[0], cache)
         attestation1 = makeAttestation(
-          state.data.data[], state.blck.root, bc0[1], cache)
+          state.data.data, state.blck.root, bc0[1], cache)
 
       attestation0.combine(attestation1, {})
 
       pool[].add(attestation0)
       pool[].add(attestation1)
 
-  setup:
-    # Genesis state that results in 3 members per committee
-    var
-      blockPool = BlockPool.init(makeTestDB(SLOTS_PER_EPOCH * 3))
-      pool = AttestationPool.init(blockPool)
-      state = newClone(loadTailState(blockPool))
-    # Slot 0 is a finalized slot - won't be making attestations for it..
-    process_slots(state.data, state.data.data.slot + 1)
+      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-  timedTest "Can add and retrieve simple attestation" & preset():
-    var cache = get_empty_per_epoch_cache()
-    let
-      # Create an attestation for slot 1!
-      beacon_committee = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation = makeAttestation(
-        state.data.data, state.blck.root, beacon_committee[0], cache)
+      let attestations = pool[].getAttestationsForBlock(state.data.data)
 
-    pool.add(attestation)
+      check:
+        attestations.len == 1
 
-<<<<<<< HEAD
-    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+    timedTest "Attestations may overlap, smaller first" & preset():
+      var cache = get_empty_per_epoch_cache()
+      var
+        # Create an attestation for slot 1!
+        bc0 = get_beacon_committee(state.data.data,
+          state.data.data.slot, 0.CommitteeIndex, cache)
+        attestation0 = makeAttestation(
+          state.data.data, state.blck.root, bc0[0], cache)
+        attestation1 = makeAttestation(
+          state.data.data, state.blck.root, bc0[1], cache)
 
-    let attestations = pool.getAttestationsForBlock(state.data.data)
-=======
-      let attestations = pool[].getAttestationsForBlock(state.data.data[])
->>>>>>> f045519... Use ProtoArray fork choice
+      attestation0.combine(attestation1, {})
 
-    check:
-      attestations.len == 1
-
-  timedTest "Attestations may arrive in any order" & preset():
-    var cache = get_empty_per_epoch_cache()
-    let
-      # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
-
-    process_slots(state.data, state.data.data.slot + 1)
-
-    let
-      bc1 = get_beacon_committee(state.data.data,
-        state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc1[0], cache)
-
-    # test reverse order
-    pool.add(attestation1)
-    pool.add(attestation0)
-
-    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
-
-    let attestations = pool.getAttestationsForBlock(state.data.data)
-
-    check:
-      attestations.len == 1
-
-  timedTest "Attestations should be combined" & preset():
-    var cache = get_empty_per_epoch_cache()
-    let
-      # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
-      attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
-
-    pool.add(attestation0)
-    pool.add(attestation1)
-
-    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
-
-    let attestations = pool.getAttestationsForBlock(state.data.data)
-
-    check:
-      attestations.len == 1
-
-  timedTest "Attestations may overlap, bigger first" & preset():
-    var cache = get_empty_per_epoch_cache()
-
-    var
-      # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
-      attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
-
-    attestation0.combine(attestation1, {})
-
-    pool.add(attestation0)
-    pool.add(attestation1)
-
-    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
-
-<<<<<<< HEAD
-    let attestations = pool.getAttestationsForBlock(state.data.data)
-=======
       pool[].add(attestation1)
       pool[].add(attestation0)
->>>>>>> f045519... Use ProtoArray fork choice
 
-    check:
-      attestations.len == 1
+      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-<<<<<<< HEAD
-  timedTest "Attestations may overlap, smaller first" & preset():
-    var cache = get_empty_per_epoch_cache()
-    var
-      # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(state.data.data,
-        state.data.data.slot, 0.CommitteeIndex, cache)
-      attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
-      attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
-=======
-      let attestations = pool[].getAttestationsForBlock(state.data.data[])
->>>>>>> f045519... Use ProtoArray fork choice
+      let attestations = pool[].getAttestationsForBlock(state.data.data)
 
-    attestation0.combine(attestation1, {})
+      check:
+        attestations.len == 1
 
-<<<<<<< HEAD
-    pool.add(attestation1)
-    pool.add(attestation0)
-=======
     timedTest "Fork choice returns latest block with no attestations":
       let
-        b1 = addTestBlock(state.data.data[], blockPool.tail.root)
+        b1 = addTestBlock(state.data.data, blockPool.tail.root)
         b1Root = hash_tree_root(b1.message)
         b1Add = blockPool.add(b1Root, b1)
 
       pool[].add(b1Add)
       let head = pool[].selectHead()
->>>>>>> f045519... Use ProtoArray fork choice
 
-    process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
+      check:
+        head == b1Add
 
-<<<<<<< HEAD
-    let attestations = pool.getAttestationsForBlock(state.data.data)
-=======
       let
-        b2 = addTestBlock(state.data.data[], b1Root)
+        b2 = addTestBlock(state.data.data, b1Root)
         b2Root = hash_tree_root(b2.message)
         b2Add = blockPool.add(b2Root, b2)
 
       pool[].add(b2Add)
       let head2 = pool[].selectHead()
->>>>>>> f045519... Use ProtoArray fork choice
 
-    check:
-      attestations.len == 1
+      check:
+        head2 == b2Add
 
-<<<<<<< HEAD
-  timedTest "Fork choice returns latest block with no attestations":
-    let
-      b1 = addTestBlock(state.data.data, blockPool.tail.root)
-      b1Root = hash_tree_root(b1.message)
-      b1Add = blockPool.add(b1Root, b1)
-      head = pool.selectHead()
-=======
     timedTest "Fork choice returns block with attestation":
       var cache = get_empty_per_epoch_cache()
       let
-        b10 = makeTestBlock(state.data.data[], blockPool.tail.root)
+        b10 = makeTestBlock(state.data.data, blockPool.tail.root)
         b10Root = hash_tree_root(b10.message)
         b10Add = blockPool.add(b10Root, b10)
 
       pool[].add(b10Add)
       let head = pool[].selectHead()
->>>>>>> f045519... Use ProtoArray fork choice
 
-    check:
-      head == b1Add
+      check:
+        head == b10Add
 
-    let
-      b2 = addTestBlock(state.data.data, b1Root)
-      b2Root = hash_tree_root(b2.message)
-      b2Add = blockPool.add(b2Root, b2)
-      head2 = pool.selectHead()
+      let
+        b11 = makeTestBlock(state.data.data, blockPool.tail.root,
+          graffiti = Eth2Digest(data: [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        )
+        b11Root = hash_tree_root(b11.message)
+        b11Add = blockPool.add(b11Root, b11)
 
-    check:
-      head2 == b2Add
+        bc1 = get_beacon_committee(
+          state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
+        attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
 
-<<<<<<< HEAD
-  timedTest "Fork choice returns block with attestation":
-    var cache = get_empty_per_epoch_cache()
-    let
-      b10 = makeTestBlock(state.data.data, blockPool.tail.root)
-      b10Root = hash_tree_root(b10.message)
-      b10Add = blockPool.add(b10Root, b10)
-      head = pool.selectHead()
-
-    check:
-      head == b10Add
-=======
       pool[].add(b11Add)
       pool[].add(attestation0)
 
       let head2 = pool[].selectHead()
->>>>>>> f045519... Use ProtoArray fork choice
 
-    let
-      b11 = makeTestBlock(state.data.data, blockPool.tail.root,
-        graffiti = Eth2Digest(data: [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-      )
-      b11Root = hash_tree_root(b11.message)
-      b11Add = blockPool.add(b11Root, b11)
+      check:
+        # Single vote for b10 and no votes for b11
+        head2 == b10Add
 
-<<<<<<< HEAD
-      bc1 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
-      attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
-
-    pool.add(attestation0)
-
-    let head2 = pool.selectHead()
-
-    check:
-      # Single vote for b10 and no votes for b11
-      head2 == b10Add
-
-    let
-      attestation1 = makeAttestation(state.data.data, b11Root, bc1[1], cache)
-      attestation2 = makeAttestation(state.data.data, b11Root, bc1[2], cache)
-    pool.add(attestation1)
-
-    let head3 = pool.selectHead()
-    let smaller = if b10Root.data < b11Root.data: b10Add else: b11Add
-
-    check:
-      # Ties broken lexicographically
-      head3 == smaller
-
-    pool.add(attestation2)
-
-    let head4 = pool.selectHead()
-
-    check:
-      # Two votes for b11
-      head4 == b11Add
-=======
       let
-        attestation1 = makeAttestation(state.data.data[], b11Root, bc1[1], cache)
-        attestation2 = makeAttestation(state.data.data[], b11Root, bc1[2], cache)
+        attestation1 = makeAttestation(state.data.data, b11Root, bc1[1], cache)
+        attestation2 = makeAttestation(state.data.data, b11Root, bc1[2], cache)
       pool[].add(attestation1)
 
       let head3 = pool[].selectHead()
@@ -391,4 +231,5 @@ proc main() =
         head4 == b11Add
 
 main()
->>>>>>> f045519... Use ProtoArray fork choice
+
+main()


### PR DESCRIPTION
This replace the current fork choice with a new one that is proto-array based.

Note: the ProtoArray fork choice caches the state_root and the state_slot at the moment. Apparently this is helpful in Lighthouse, but it's unneeded in our case.

The attestation pool tests have been wrapped in a main and AttestationPool and StateData have been made ref to prevent stack overflow.
Regarding stack overflow, changing an Option[Eth2Digest] to `genesis: bool, root: Eth2Digest` was somehow necessary here:

https://github.com/status-im/nim-beacon-chain/pull/965/files#diff-c92015bb69b5f41ae03b31ac70452f48L156-L177

I've been trying to hunt a finalization issue on this branch, but I don't see what could cause it. Unfortunately it seems like it might be in the devel code in general.

This also moves the isValidAttestation used in attestation aggregation to the attestations_aggregation.nim file and create explicit `isValidAttestationSlot` and `isValidAttestationEpoch` proc in BeaconState next to "check_attestation" as we currently have 4 different kinds of implicits/explicits attestation checks.
The goal is to have `isValidAttestationQuick()` (without state rewind) and `isValidAttestationExp')` (with Expensive state rewind) so that we can discard as fast as possible invalid attestations but not have 4 different checks in the codebase.