### PR TITLE
Wrap tests in proc

### DIFF
--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -73,8 +73,11 @@ proc summarizeLongTests*(name: string) =
 template suiteReport*(name, body) =
   last = name
   status[last] = initOrderedTable[string, Status]()
-  suite name:
-    body
+  block: # namespacing
+    proc runSuite() =
+      suite name:
+        body
+    runSuite()
 
 template timedTest*(name, body) =
   var f: float


### PR DESCRIPTION
This wrap all suite in a proc to avoid polluting the test binary with so many globals and having a test overflow or ref objects that are never freed.

It might help #969.

Ideally I want to do the same for `timedTest` but you wouldn't be able to use `continue` here:

https://github.com/status-im/nim-beacon-chain/blob/9636ca3e17628d4bfbdc2a29006e5385fc398e66/tests/official/test_fixture_const_sanity_check.nim#L101-L126