### PR TITLE
Increase finalization and finalization checking robustness

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -15,7 +15,7 @@ import
   chronicles, chronicles/helpers as chroniclesHelpers,
   json_serialization/std/[options, sets, net], serialization/errors,
   eth/db/kvstore, eth/db/kvstore_sqlite3,
-  eth/p2p/enode, eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
+  eth/p2p/enode, eth/keys, eth/p2p/discoveryv5/[protocol, enr],
 
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, network],
@@ -168,8 +168,12 @@ proc init*(T: type BeaconNode, conf: BeaconNodeConf): Future[BeaconNode] {.async
         quit 1
 
   # TODO check that genesis given on command line (if any) matches database
-  let
-    blockPool = BlockPool.init(db)
+  let blockPool = BlockPool.init(
+    db,
+    if conf.verifyFinalization:
+      {verifyFinalization}
+    else:
+      {})
 
   if mainchainMonitor.isNil and
      conf.web3Url.len > 0 and
@@ -305,21 +309,6 @@ proc onBeaconBlock(node: BeaconNode, signedBlock: SignedBeaconBlock) =
   # don't know if it's part of the chain we're currently building.
   discard node.storeBlock(signedBlock)
 
-proc verifyFinalization(node: BeaconNode, slot: Slot) =
-  # Epoch must be >= 4 to check finalization
-  const SETTLING_TIME_OFFSET = 1'u64
-  let epoch = slot.compute_epoch_at_slot()
-
-  # Don't static-assert this -- if this isn't called, don't require it
-  doAssert SLOTS_PER_EPOCH > SETTLING_TIME_OFFSET
-
-  # Intentionally, loudly assert. Point is to fail visibly and unignorably
-  # during testing.
-  if epoch >= 4 and slot mod SLOTS_PER_EPOCH > SETTLING_TIME_OFFSET:
-    let finalizedEpoch =
-      node.blockPool.finalizedHead.blck.slot.compute_epoch_at_slot()
-    doAssert finalizedEpoch + 2 == epoch
-
 proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, async.} =
   ## Called at the beginning of a slot - usually every slot, but sometimes might
   ## skip a few in case we're running late.
@@ -385,9 +374,6 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     nextSlot = slot + 1
 
   beacon_slot.set slot.int64
-
-  if node.config.verifyFinalization:
-    verifyFinalization(node, scheduledSlot)
 
   if slot > lastSlot + SLOTS_PER_EPOCH:
     # We've fallen behind more than an epoch - there's nothing clever we can

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -15,7 +15,7 @@ import
   chronicles, chronicles/helpers as chroniclesHelpers,
   json_serialization/std/[options, sets, net], serialization/errors,
   eth/db/kvstore, eth/db/kvstore_sqlite3,
-  eth/p2p/enode, eth/keys, eth/p2p/discoveryv5/[protocol, enr],
+  eth/p2p/enode, eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
 
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, network],

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -13,10 +13,9 @@ import
 
   # Local modules
   spec/[datatypes, crypto],
-  conf, time, beacon_chain_db, validator_pool,
+  conf, time, beacon_chain_db,
   attestation_pool, block_pool, eth2_network,
-  beacon_node_types, mainchain_monitor,
-  sync_protocol, request_manager
+  beacon_node_types, mainchain_monitor, request_manager
 
 type
   RpcServer* = RpcHttpServer

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -4,7 +4,7 @@ import
   deques, tables,
   stew/[endians2, byteutils], chronicles,
   spec/[datatypes, crypto, digest],
-  beacon_chain_db
+  beacon_chain_db, extras
 
 type
   # #############################################
@@ -143,13 +143,15 @@ type
 
     inAdd*: bool
 
-    headState*: StateData ## \
+    headState*: StateData ##\
     ## State given by the head block; only update in `updateHead`, not anywhere
     ## else via `withState`
 
     justifiedState*: StateData ## Latest justified state, as seen from the head
 
     tmpState*: StateData ## Scratchpad - may be any state
+
+    updateFlags*: UpdateFlags
 
   MissingBlock* = object
     slots*: uint64 # number of slots that are suspected missing

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -675,7 +675,8 @@ proc skipAndUpdateState(
     doAssert (addr(statePtr.data) == addr v)
     statePtr[] = pool.headState
 
-  let ok = state_transition(state.data, blck.data, pool.updateFlags, rollback)
+  let ok = state_transition(
+    state.data, blck.data, flags + pool.updateFlags, rollback)
   if ok and save:
     pool.putState(state.data, blck.refs)
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -139,7 +139,8 @@ func init*(T: type BlockRef, root: Eth2Digest, slot: Slot): BlockRef =
 func init*(T: type BlockRef, root: Eth2Digest, blck: BeaconBlock): BlockRef =
   BlockRef.init(root, blck.slot)
 
-proc init*(T: type BlockPool, db: BeaconChainDB): BlockPool =
+proc init*(T: type BlockPool, db: BeaconChainDB,
+    updateFlags: UpdateFlags = {}): BlockPool =
   # TODO we require that the db contains both a head and a tail block -
   #      asserting here doesn't seem like the right way to go about it however..
 
@@ -243,7 +244,8 @@ proc init*(T: type BlockPool, db: BeaconChainDB): BlockPool =
     heads: @[head],
     headState: tmpState[],
     justifiedState: tmpState[], # This is wrong but we'll update it below
-    tmpState: tmpState[]
+    tmpState: tmpState[],
+    updateFlags: updateFlags
   )
 
   res.updateStateData(res.justifiedState, justifiedHead)
@@ -324,7 +326,7 @@ proc getState(
     pool: BlockPool, db: BeaconChainDB, stateRoot: Eth2Digest, blck: BlockRef,
     output: var StateData): bool =
   let outputAddr = unsafeAddr output # local scope
-  proc rollback(v: var BeaconState) =
+  func rollback(v: var BeaconState) =
     if outputAddr == (unsafeAddr pool.headState):
       # TODO seeing the headState in the rollback shouldn't happen - we load
       #      head states only when updating the head position, and by that time
@@ -470,14 +472,15 @@ proc add*(
 
     let
       poolPtr = unsafeAddr pool # safe because restore is short-lived
-    proc restore(v: var HashedBeaconState) =
+    func restore(v: var HashedBeaconState) =
       # TODO address this ugly workaround - there should probably be a
       #      `state_transition` that takes a `StateData` instead and updates
       #      the block as well
       doAssert v.addr == addr poolPtr.tmpState.data
       poolPtr.tmpState = poolPtr.headState
 
-    if not state_transition(pool.tmpState.data, signedBlock, {}, restore):
+    if not state_transition(
+        pool.tmpState.data, signedBlock, pool.updateFlags, restore):
       # TODO find a better way to log all this block data
       notice "Invalid block",
         blck = shortLog(blck),
@@ -545,7 +548,7 @@ func getRef*(pool: BlockPool, root: Eth2Digest): BlockRef =
   ## Retrieve a resolved block reference, if available
   pool.blocks.getOrDefault(root, nil)
 
-proc getBlockRange*(
+func getBlockRange*(
     pool: BlockPool, startSlot: Slot, skipStep: Natural,
     output: var openArray[BlockRef]): Natural =
   ## This function populates an `output` buffer of blocks
@@ -650,7 +653,7 @@ proc skipAndUpdateState(
     #      save and reuse
     # TODO possibly we should keep this in memory for the hot blocks
     let nextStateRoot = pool.db.getStateRoot(blck.root, state.data.slot + 1)
-    advance_slot(state, nextStateRoot)
+    advance_slot(state, nextStateRoot, pool.updateFlags)
 
     if save:
       pool.putState(state, blck)
@@ -663,11 +666,11 @@ proc skipAndUpdateState(
     state.data, blck.refs, blck.data.message.slot - 1, save)
 
   var statePtr = unsafeAddr state # safe because `rollback` is locally scoped
-  proc rollback(v: var HashedBeaconState) =
+  func rollback(v: var HashedBeaconState) =
     doAssert (addr(statePtr.data) == addr v)
     statePtr[] = pool.headState
 
-  let ok  = state_transition(state.data, blck.data, flags, rollback)
+  let ok = state_transition(state.data, blck.data, pool.updateFlags, rollback)
   if ok and save:
     pool.putState(state.data, blck.refs)
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -333,10 +333,10 @@ proc getState(
   let outputAddr = unsafeAddr output # local scope
   func restore(v: var BeaconState) =
     if outputAddr == (unsafeAddr pool.headState):
-      # TODO seeing the headState in the rollback shouldn't happen - we load
+      # TODO seeing the headState in the restore shouldn't happen - we load
       #      head states only when updating the head position, and by that time
       #      the database will have gone through enough sanity checks that
-      #      SSZ exceptions shouldn't happen, which is when rollback happens.
+      #      SSZ exceptions shouldn't happen, which is when restore happens.
       #      Nonetheless, this is an ugly workaround that needs to go away
       doAssert false, "Cannot alias headState"
 
@@ -670,13 +670,13 @@ proc skipAndUpdateState(
   pool.skipAndUpdateState(
     state.data, blck.refs, blck.data.message.slot - 1, save)
 
-  var statePtr = unsafeAddr state # safe because `rollback` is locally scoped
-  func rollback(v: var HashedBeaconState) =
+  var statePtr = unsafeAddr state # safe because `restore` is locally scoped
+  func restore(v: var HashedBeaconState) =
     doAssert (addr(statePtr.data) == addr v)
     statePtr[] = pool.headState
 
   let ok = state_transition(
-    state.data, blck.data, flags + pool.updateFlags, rollback)
+    state.data, blck.data, flags + pool.updateFlags, restore)
   if ok and save:
     pool.putState(state.data, blck.refs)
 

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -31,5 +31,6 @@ type
     ## Skip verification of block state root.
     skipBlockParentRootValidation ##\
     ## Skip verification that the block's parent root matches the previous block header.
+    verifyFinalization
 
   UpdateFlags* = set[UpdateFlag]

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -564,12 +564,14 @@ proc process_attestation*(
 
     if attestation.data.target.epoch == get_current_epoch(state):
       trace "process_attestation: current_epoch_attestations.add",
+        attestation = shortLog(attestation),
         pending_attestation = pending_attestation,
         indices = get_attesting_indices(
           state, attestation.data, attestation.aggregation_bits, stateCache).len
       state.current_epoch_attestations.add(pending_attestation)
     else:
       trace "process_attestation: previous_epoch_attestations.add",
+        attestation = shortLog(attestation),
         pending_attestation = pending_attestation,
         indices = get_attesting_indices(
           state, attestation.data, attestation.aggregation_bits, stateCache).len
@@ -577,6 +579,10 @@ proc process_attestation*(
 
     true
   else:
+    trace "process_attestation: check_attestation failed",
+      attestation = shortLog(attestation),
+      indices = get_attesting_indices(
+        state, attestation.data, attestation.aggregation_bits, stateCache).len
     false
 
 func makeAttestationData*(

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -123,7 +123,8 @@ func process_slot*(state: var HashedBeaconState) {.nbench.} =
     hash_tree_root(state.data.latest_block_header)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc advance_slot*(state: var HashedBeaconState, nextStateRoot: Opt[Eth2Digest]) =
+proc advance_slot*(state: var HashedBeaconState,
+    nextStateRoot: Opt[Eth2Digest], updateFlags: UpdateFlags) =
   # Special case version of process_slots that moves one slot at a time - can
   # run faster if the state root is known already (for example when replaying
   # existing slots)
@@ -135,7 +136,7 @@ proc advance_slot*(state: var HashedBeaconState, nextStateRoot: Opt[Eth2Digest])
       beacon_previous_validators.set(get_epoch_validator_count(state.data))
     except Exception as e: # TODO https://github.com/status-im/nim-metrics/pull/22
       trace "Couldn't update metrics", msg = e.msg
-    process_epoch(state.data)
+    process_epoch(state.data, updateFlags)
   state.data.slot += 1
   if is_epoch_transition:
     try:
@@ -149,7 +150,8 @@ proc advance_slot*(state: var HashedBeaconState, nextStateRoot: Opt[Eth2Digest])
     state.root = hash_tree_root(state.data)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.10.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc process_slots*(state: var HashedBeaconState, slot: Slot) {.nbench.} =
+proc process_slots*(state: var HashedBeaconState, slot: Slot,
+    updateFlags: UpdateFlags = {}) {.nbench.} =
   # TODO: Eth specs strongly assert that state.data.slot <= slot
   #       This prevents receiving attestation in any order
   #       (see tests/test_attestation_pool)
@@ -171,7 +173,7 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot) {.nbench.} =
 
   # Catch up to the target slot
   while state.data.slot < slot:
-    advance_slot(state, err(Opt[Eth2Digest]))
+    advance_slot(state, err(Opt[Eth2Digest]), updateFlags)
 
 proc noRollback*(state: var HashedBeaconState) =
   trace "Skipping rollback of broken state"
@@ -211,7 +213,7 @@ proc state_transition*(
   #      bool return values...)
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
   # These should never fail.
-  process_slots(state, signedBlock.message.slot)
+  process_slots(state, signedBlock.message.slot, flags)
 
   # Block updates - these happen when there's a new block being suggested
   # by the block proposer. Every actor in the network will update its state
@@ -223,6 +225,9 @@ proc state_transition*(
       verify_block_signature(state.data, signedBlock):
 
     var per_epoch_cache = get_empty_per_epoch_cache()
+    trace "in state_transition: processing block, signature passed",
+      signature = signedBlock.signature,
+      blockRoot = hash_tree_root(signedBlock.message)
     if processBlock(state.data, signedBlock.message, flags, per_epoch_cache):
       if skipStateRootValidation in flags or verifyStateRoot(state.data, signedBlock.message):
         # State root is what it should be - we're done!

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -7,25 +7,25 @@
 
 import
   # Standard library
-  os, tables, random, strutils, times,
+  os, tables, strutils, times,
 
   # Nimble packages
-  stew/[objects, bitseqs, byteutils], stew/shims/macros,
-  chronos, confutils, metrics, json_rpc/[rpcserver, jsonmarshal],
-  chronicles, chronicles/helpers as chroniclesHelpers,
+  stew/[objects, bitseqs], stew/shims/macros,
+  chronos, metrics, json_rpc/[rpcserver, jsonmarshal],
+  chronicles,
   json_serialization/std/[options, sets, net], serialization/errors,
   eth/db/kvstore, eth/db/kvstore_sqlite3,
-  eth/p2p/enode, eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
+  eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
 
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, validator, network,
-    state_transition_block], spec/presets/custom,
-  conf, time, beacon_chain_db, validator_pool, extras,
-  attestation_pool, block_pool, eth2_network, eth2_discovery,
+    state_transition_block],
+  conf, time, beacon_chain_db, validator_pool,
+  attestation_pool, block_pool, eth2_network,
   beacon_node_common, beacon_node_types,
   mainchain_monitor, version, ssz, ssz/dynamic_navigator,
-  sync_protocol, request_manager, validator_keygen, interop, statusbar,
-  attestation_aggregation, sync_manager, state_transition, sszdump
+  request_manager, interop, statusbar,
+  attestation_aggregation, sync_manager, sszdump
 
 # Metrics for tracking attestation and beacon block loss
 declareCounter beacon_attestations_sent,

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -31,4 +31,4 @@ proc transitionEpochUntilJustificationFinalization*(state: var HashedBeaconState
   # From process_epoch()
   var per_epoch_cache = get_empty_per_epoch_cache()
 
-  process_justification_and_finalization(state.data, per_epoch_cache)
+  process_justification_and_finalization(state.data, per_epoch_cache, {})


### PR DESCRIPTION
- fix some warnings related to beacon_node splitting;
- re-implement finalization verification more robustly; and
- improve attestation pool block selection logic

I've been running this in a loop of:
`N=0; while ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level TRACE --disable-htop -- --verify-finalization --stop-at-epoch=9; do N=$((N+1)); echo "That was run #${N}"; sleep 79; done` for a while, and it's now at:
```Building: build/beacon_node
beacon_chain/mainchain_monitor.nim(435, 65) template/generic instantiation of `async` from here
vendor/nim-chronos/chronos/asyncmacro2.nim(222, 37) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
beacon_chain/beacon_node.nim(18, 21) Warning: imported and not used: 'async_utils' [UnusedImport]
{"lvl":"INF","ts":"2020-05-07 15:30:29+02:00","msg":"Generating deposits","tid":2170474,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":false,"totalValidators":8}
{"lvl":"INF","ts":"2020-05-07 15:30:29+02:00","msg":"Generating deposits","tid":2170474,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":true,"totalValidators":120}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #7
Building: build/beacon_node
beacon_chain/mainchain_monitor.nim(435, 65) template/generic instantiation of `async` from here
vendor/nim-chronos/chronos/asyncmacro2.nim(222, 37) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
beacon_chain/beacon_node.nim(18, 21) Warning: imported and not used: 'async_utils' [UnusedImport]
{"lvl":"INF","ts":"2020-05-07 15:39:39+02:00","msg":"Generating deposits","tid":2173379,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":false,"totalValidators":8}
{"lvl":"INF","ts":"2020-05-07 15:39:39+02:00","msg":"Generating deposits","tid":2173379,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":true,"totalValidators":120}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #8
Building: build/beacon_node
beacon_chain/mainchain_monitor.nim(435, 65) template/generic instantiation of `async` from here
vendor/nim-chronos/chronos/asyncmacro2.nim(222, 37) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
beacon_chain/beacon_node.nim(18, 21) Warning: imported and not used: 'async_utils' [UnusedImport]
{"lvl":"INF","ts":"2020-05-07 15:48:49+02:00","msg":"Generating deposits","tid":2176042,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":false,"totalValidators":8}
{"lvl":"INF","ts":"2020-05-07 15:48:49+02:00","msg":"Generating deposits","tid":2176042,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":true,"totalValidators":120}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #9
Building: build/beacon_node
beacon_chain/mainchain_monitor.nim(435, 65) template/generic instantiation of `async` from here
vendor/nim-chronos/chronos/asyncmacro2.nim(222, 37) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
beacon_chain/beacon_node.nim(18, 21) Warning: imported and not used: 'async_utils' [UnusedImport]
{"lvl":"INF","ts":"2020-05-07 15:57:59+02:00","msg":"Generating deposits","tid":2179558,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":false,"totalValidators":8}
{"lvl":"INF","ts":"2020-05-07 15:57:59+02:00","msg":"Generating deposits","tid":2179558,"file":"validator_keygen.nim:28","outputDir":"local_testnet_data/deposits_dir","randomKeys":true,"totalValidators":120}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #10
```
Without any failures so far.

It's similarly completed 3 sets of 8 full epochs, finalizing when appropriate, and never not finalizing when appropriate, on `mainnet` via `testnet1`.