### PR TITLE
quick/minimal mitigation of beacon_node memory usage

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -233,8 +233,8 @@ proc init*(T: type BlockPool, db: BeaconChainDB,
     pending: initTable[Eth2Digest, SignedBeaconBlock](),
     missing: initTable[Eth2Digest, MissingBlock](),
     cachedStates: [
-      newTable[tuple[a: Eth2Digest, b: Slot], StateData](),
-      newTable[tuple[a: Eth2Digest, b: Slot], StateData]()
+      newTable[tuple[a: Eth2Digest, b: Slot], StateData](initialSize = 2),
+      newTable[tuple[a: Eth2Digest, b: Slot], StateData](initialSize = 2)
     ],
     blocks: blocks,
     tail: tailRef,
@@ -383,7 +383,7 @@ proc putState(pool: BlockPool, state: HashedBeaconState, blck: BlockRef) =
     # resulting lookback window is thus >= SLOTS_PER_EPOCH in size, while
     # bounded from above by 2*SLOTS_PER_EPOCH.
     pool.cachedStates[epochParity] =
-      newTable[tuple[a: Eth2Digest, b: Slot], StateData]()
+      newTable[tuple[a: Eth2Digest, b: Slot], StateData](initialSize = 2)
   else:
     # Need to be able to efficiently access states for both attestation
     # aggregation and to process block proposals going back to the last


### PR DESCRIPTION
It results from 2*`Table.defaultInitialSize` pointless `BeaconState` objects in block pool state cache, but the time advantage is more than offset by the memory waste.

This isn't a real fix, and more to come, just not today, and not in this PR. This is intentionally low-risk, changing only `newTable(..)` calls.

https://github.com/nim-lang/Nim/blob/version-1-2/lib/pure/collections/tables.nim#L780 says:
```
proc newTable*[A, B](initialSize = defaultInitialSize): <//>TableRef[A, B] =
  ## Creates a new ref hash table that is empty.
  ##
  ## ``initialSize`` must be a power of two (default: 64).
  ## If you need to accept runtime values for this you could use the
  ## `nextPowerOfTwo proc<math.html#nextPowerOfTwo,int>`_ from the
  ## `math module<math.html>`_ or the `rightSize proc<#rightSize,Natural>`_
  ## from this module.
```

Even in `mainnet`, `SLOTS_PER_EPOCH` is only 32, so half those aren't generally used in the current benign, linear-chain case.