### PR TITLE
switch state cache to use ref statedata objects to limit memory usage

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -134,7 +134,7 @@ type
     db*: BeaconChainDB
 
     cachedStates*:
-      array[2, Table[tuple[a: Eth2Digest, b: Slot], ref StateData]] ##\
+      array[2, Table[tuple[a: Eth2Digest, b: Slot], ref HashedBeaconState]] ##\
     ## Dual BeaconChainDBs operates as a pool allocator which handles epoch
     ## boundaries which don't align with an ongoing latency of availability
     ## of precalculated BeaconStates from the recent past.

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -134,7 +134,7 @@ type
     db*: BeaconChainDB
 
     cachedStates*:
-      array[2, TableRef[tuple[a: Eth2Digest, b: Slot], StateData]] ##\
+      array[2, Table[tuple[a: Eth2Digest, b: Slot], ref StateData]] ##\
     ## Dual BeaconChainDBs operates as a pool allocator which handles epoch
     ## boundaries which don't align with an ongoing latency of availability
     ## of precalculated BeaconStates from the recent past.

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -133,11 +133,8 @@ type
 
     db*: BeaconChainDB
 
-    cachedStates*:
-      array[2, Table[tuple[a: Eth2Digest, b: Slot], ref HashedBeaconState]] ##\
-    ## Dual BeaconChainDBs operates as a pool allocator which handles epoch
-    ## boundaries which don't align with an ongoing latency of availability
-    ## of precalculated BeaconStates from the recent past.
+    cachedStates*: seq[tuple[blockRoot: Eth2Digest, slot: Slot,
+      state: ref HashedBeaconState]]
 
     heads*: seq[Head]
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -412,10 +412,8 @@ proc putState(pool: BlockPool, state: HashedBeaconState, blck: BlockRef) =
   let key = (a: blck.root, b: state.data.slot)
   if key notin pool.cachedStates[bucketParity]:
     # Avoid constructing StateData if not necessary
-    var stateData = new StateData
-    stateData.data = state
-    stateData.blck = blck
-    pool.cachedStates[bucketParity][key] = stateData
+    pool.cachedStates[bucketParity][key] =
+      (ref StateData)(data: state, blck: blck)
 
 proc add*(
     pool: var BlockPool, blockRoot: Eth2Digest,

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -1,7 +1,7 @@
 import
   options, tables, sets, macros,
   chronicles, chronos, stew/ranges/bitranges, libp2p/switch,
-  spec/[datatypes, crypto, digest, helpers],
+  spec/[datatypes, crypto, digest],
   beacon_node_types, eth2_network, block_pool, ssz
 
 logScope:


### PR DESCRIPTION
More progress towards https://github.com/status-im/nim-beacon-chain/issues/979

490MB RSS after 115 slots of mainnet.

700MB RSS after 200 slots of mainnet.

There's still some memory leak, but it's slower.