### PR TITLE
remove potentially GC leak-inducing acyclicity tag

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -154,7 +154,7 @@ type
     slots*: uint64 # number of slots that are suspected missing
     tries*: int
 
-  BlockRef* {.acyclic.} = ref object
+  BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to tail block, and to have
     ## a corresponding entry in database.
     ## Block graph should form a tree - in particular, there are no cycles.


### PR DESCRIPTION
https://github.com/status-im/nim-beacon-chain/issues/1010

https://nim-lang.org/docs/manual.html#pragmas-acyclic-pragma notes:
> Note that the type definition is recursive and the GC has to assume that objects of this type may form a cyclic graph. The `acyclic` pragma passes the information that this cannot happen to the GC. If the programmer uses the `acyclic` pragma for data types that are in reality cyclic, the memory leaks can be the result, but memory safety is preserved.