### PR TITLE
Work around sync not dealing with gaps

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -541,7 +541,7 @@ proc runSyncLoop(node: BeaconNode) {.async.} =
     node.network.peerPool, getLocalHeadSlot, getLocalWallSlot,
     updateLocalBlocks,
     # TODO increase when block processing perf improves
-    chunkSize = 16
+    chunkSize = 8
   )
 
   await syncman.sync()


### PR DESCRIPTION
Currently, when a peer returns fewer slots than we expected, the next
"chunk" of blocks will nonetheless be requested as if the full request
was satisfied. This results in an infinite loop where blocks without
parent are passed to be block pool and rejected.

The workaround here is to request one range at a time, extending the
range every time - this way, we'll request the same range as the
previous request, in addition to what should have been requested.

This branch fixes one issue and introduces several others - it's useful mostly as a reference point