### PR TITLE
Fix sync issues.

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -550,8 +550,12 @@ proc runSyncLoop(node: BeaconNode) {.async.} =
   var syncman = newSyncManager[Peer, PeerID](
     node.network.peerPool, getLocalHeadSlot, getLocalWallSlot,
     updateLocalBlocks,
-    # TODO increase when block processing perf improves
-    chunkSize = 16
+    # 4 blocks per chunk is the optimal value right now, because our current
+    # syncing speed is around 4 blocks per second. So there no need to request
+    # more then 4 blocks right now. As soon as `store_speed` value become
+    # significantly more then 4 blocks per second you can increase this
+    # value appropriately.
+    chunkSize = 4
   )
 
   await syncman.sync()

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard library
-  os, tables, random, strutils, times,
+  os, tables, random, strutils, times, math,
 
   # Nimble packages
   stew/[objects, bitseqs, byteutils], stew/shims/macros,
@@ -516,12 +516,22 @@ proc runSyncLoop(node: BeaconNode) {.async.} =
   proc updateLocalBlocks(list: openarray[SignedBeaconBlock]): bool =
     debug "Forward sync imported blocks", count = len(list),
           local_head_slot = getLocalHeadSlot()
+    let sm = now(chronos.Moment)
     for blk in list:
       if not(node.storeBlock(blk)):
         return false
     discard node.updateHead()
+
+    let dur = now(chronos.Moment) - sm
+    let secs = float(chronos.seconds(1).nanoseconds)
+    var storeSpeed = 0.0
+    if not(dur.isZero()):
+      let v = float(len(list)) * (secs / float(dur.nanoseconds))
+      # We doing round manually because stdlib.round is deprecated
+      storeSpeed = round(v * 10000) / 10000
+
     info "Forward sync blocks got imported sucessfully", count = len(list),
-         local_head_slot = getLocalHeadSlot()
+         local_head_slot = getLocalHeadSlot(), store_speed = storeSpeed
     result = true
 
   proc scoreCheck(peer: Peer): bool =

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -4,6 +4,15 @@ import unittest
 import chronos
 import ../beacon_chain/sync_manager
 
+type
+  SomeTPeer = ref object
+
+proc `$`*(peer: SomeTPeer): string =
+  "SomeTPeer"
+
+proc updateScore(peer: SomeTPeer, score: int) =
+  discard
+
 suite "SyncManager test suite":
   proc createChain(start, finish: Slot): seq[SignedBeaconBlock] =
     doAssert(start <= finish)
@@ -14,48 +23,64 @@ suite "SyncManager test suite":
       item.message.slot = curslot
       curslot = curslot + 1'u64
 
+  proc syncUpdate(req: SyncRequest[SomeTPeer],
+                  data: openarray[SignedBeaconBlock]): bool {.gcsafe.} =
+    discard
+
   test "[SyncQueue] Start and finish slots equal":
-    var queue = SyncQueue.init(Slot(0), Slot(0), 1'u64, nil)
+    let p1 = SomeTPeer()
+    var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(0), 1'u64, syncUpdate)
     check len(queue) == 1
-    var r11 = queue.pop(Slot(0))
+    var r11 = queue.pop(Slot(0), p1)
     check len(queue) == 0
     queue.push(r11)
     check len(queue) == 1
-    var r11e = queue.pop(Slot(0))
+    var r11e = queue.pop(Slot(0), p1)
     check:
       len(queue) == 0
       r11e == r11
+      r11.item == p1
+      r11e.item == r11.item
       r11.slot == Slot(0) and r11.count == 1'u64 and r11.step == 1'u64
 
   test "[SyncQueue] Two full requests success/fail":
-    var queue = SyncQueue.init(Slot(0), Slot(1), 1'u64, nil)
+    var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(1), 1'u64, syncUpdate)
+    let p1 = SomeTPeer()
+    let p2 = SomeTPeer()
     check len(queue) == 2
-    var r21 = queue.pop(Slot(1))
+    var r21 = queue.pop(Slot(1), p1)
     check len(queue) == 1
-    var r22 = queue.pop(Slot(1))
+    var r22 = queue.pop(Slot(1), p2)
     check len(queue) == 0
     queue.push(r22)
     check len(queue) == 1
     queue.push(r21)
     check len(queue) == 2
-    var r21e = queue.pop(Slot(1))
+    var r21e = queue.pop(Slot(1), p1)
     check len(queue) == 1
-    var r22e = queue.pop(Slot(1))
+    var r22e = queue.pop(Slot(1), p2)
     check:
       len(queue) == 0
       r21 == r21e
       r22 == r22e
+      r21.item == p1
+      r22.item == p2
+      r21.item == r21e.item
+      r22.item == r22e.item
       r21.slot == Slot(0) and r21.count == 1'u64 and r21.step == 1'u64
       r22.slot == Slot(1) and r22.count == 1'u64 and r22.step == 1'u64
 
   test "[SyncQueue] Full and incomplete success/fail start from zero":
-    var queue = SyncQueue.init(Slot(0), Slot(4), 2'u64, nil)
+    var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(4), 2'u64, syncUpdate)
+    let p1 = SomeTPeer()
+    let p2 = SomeTPeer()
+    let p3 = SomeTPeer()
     check len(queue) == 5
-    var r31 = queue.pop(Slot(4))
+    var r31 = queue.pop(Slot(4), p1)
     check len(queue) == 3
-    var r32 = queue.pop(Slot(4))
+    var r32 = queue.pop(Slot(4), p2)
     check len(queue) == 1
-    var r33 = queue.pop(Slot(4))
+    var r33 = queue.pop(Slot(4), p3)
     check len(queue) == 0
     queue.push(r33)
     check len(queue) == 1
@@ -63,76 +88,98 @@ suite "SyncManager test suite":
     check len(queue) == 3
     queue.push(r31)
     check len(queue) == 5
-    var r31e = queue.pop(Slot(4))
+    var r31e = queue.pop(Slot(4), p1)
     check len(queue) == 3
-    var r32e = queue.pop(Slot(4))
+    var r32e = queue.pop(Slot(4), p2)
     check len(queue) == 1
-    var r33e = queue.pop(Slot(4))
+    var r33e = queue.pop(Slot(4), p3)
     check:
       len(queue) == 0
       r31 == r31e
       r32 == r32e
       r33 == r33e
+      r31.item == r31e.item
+      r32.item == r32e.item
+      r33.item == r33e.item
+      r31.item == p1
+      r32.item == p2
+      r33.item == p3
       r31.slot == Slot(0) and r31.count == 2'u64 and r31.step == 1'u64
       r32.slot == Slot(2) and r32.count == 2'u64 and r32.step == 1'u64
       r33.slot == Slot(4) and r33.count == 1'u64 and r33.step == 1'u64
 
   test "[SyncQueue] Full and incomplete success/fail start from non-zero":
-    var queue = SyncQueue.init(Slot(1), Slot(5), 3'u64, nil)
+    var queue = SyncQueue.init(SomeTPeer, Slot(1), Slot(5), 3'u64, syncUpdate)
+    let p1 = SomeTPeer()
+    let p2 = SomeTPeer()
     check len(queue) == 5
-    var r41 = queue.pop(Slot(5))
+    var r41 = queue.pop(Slot(5), p1)
     check len(queue) == 2
-    var r42 = queue.pop(Slot(5))
+    var r42 = queue.pop(Slot(5), p2)
     check len(queue) == 0
     queue.push(r42)
     check len(queue) == 2
     queue.push(r41)
     check len(queue) == 5
-    var r41e = queue.pop(Slot(5))
+    var r41e = queue.pop(Slot(5), p1)
     check len(queue) == 2
-    var r42e = queue.pop(Slot(5))
+    var r42e = queue.pop(Slot(5), p2)
     check:
       len(queue) == 0
       r41 == r41e
       r42 == r42e
+      r41.item == r41e.item
+      r42.item == r42e.item
+      r41.item == p1
+      r42.item == p2
       r41.slot == Slot(1) and r41.count == 3'u64 and r41.step == 1'u64
       r42.slot == Slot(4) and r42.count == 2'u64 and r42.step == 1'u64
 
   test "[SyncQueue] Smart and stupid success/fail":
-    var queue = SyncQueue.init(Slot(0), Slot(4), 5'u64, nil)
+    var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(4), 5'u64, syncUpdate)
+    let p1 = SomeTPeer()
+    let p2 = SomeTPeer()
     check len(queue) == 5
-    var r51 = queue.pop(Slot(3))
+    var r51 = queue.pop(Slot(3), p1)
     check len(queue) == 1
-    var r52 = queue.pop(Slot(4))
+    var r52 = queue.pop(Slot(4), p2)
     check len(queue) == 0
     queue.push(r52)
     check len(queue) == 1
     queue.push(r51)
     check len(queue) == 5
-    var r51e = queue.pop(Slot(3))
+    var r51e = queue.pop(Slot(3), p1)
     check len(queue) == 1
-    var r52e = queue.pop(Slot(4))
+    var r52e = queue.pop(Slot(4), p2)
     check:
       len(queue) == 0
       r51 == r51e
       r52 == r52e
+      r51.item == r51e.item
+      r52.item == r52e.item
+      r51.item == p1
+      r52.item == p2
       r51.slot == Slot(0) and r51.count == 4'u64 and r51.step == 1'u64
       r52.slot == Slot(4) and r52.count == 1'u64 and r52.step == 1'u64
 
   test "[SyncQueue] One smart and one stupid + debt split + empty":
-    var queue = SyncQueue.init(Slot(0), Slot(4), 5'u64, nil)
+    var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(4), 5'u64, syncUpdate)
+    let p1 = SomeTPeer()
+    let p2 = SomeTPeer()
+    let p3 = SomeTPeer()
+    let p4 = SomeTPeer()
     check len(queue) == 5
-    var r61 = queue.pop(Slot(4))
+    var r61 = queue.pop(Slot(4), p1)
     check len(queue) == 0
     queue.push(r61)
-    var r61e = queue.pop(Slot(2))
+    var r61e = queue.pop(Slot(2), p1)
     check len(queue) == 2
-    var r62e = queue.pop(Slot(2))
+    var r62e = queue.pop(Slot(2), p2)
     check len(queue) == 2
     check r62e.isEmpty()
-    var r63e = queue.pop(Slot(3))
+    var r63e = queue.pop(Slot(3), p3)
     check len(queue) == 1
-    var r64e = queue.pop(Slot(4))
+    var r64e = queue.pop(Slot(4), p4)
     check:
       len(queue) == 0
       r61.slot == Slot(0) and r61.count == 5'u64 and r61.step == 1'u64
@@ -140,12 +187,18 @@ suite "SyncManager test suite":
       r62e.isEmpty()
       r63e.slot == Slot(3) and r63e.count == 1'u64 and r63e.step == 1'u64
       r64e.slot == Slot(4) and r64e.count == 1'u64 and r64e.step == 1'u64
+      r61.item == p1
+      r61e.item == p1
+      isNil(r62e.item) == true
+      r63e.item == p3
+      r64e.item == p4
 
   test "[SyncQueue] Async unordered push start from zero":
     proc test(): Future[bool] {.async.} =
       var counter = 0
 
-      proc receiver(list: openarray[SignedBeaconBlock]): bool =
+      proc syncReceiver(req: SyncRequest[SomeTPeer],
+                        list: openarray[SignedBeaconBlock]): bool {.gcsafe.} =
         result = true
         for item in list:
           if item.message.slot == Slot(counter):
@@ -155,10 +208,14 @@ suite "SyncManager test suite":
             break
 
       var chain = createChain(Slot(0), Slot(2))
-      var queue = SyncQueue.init(Slot(0), Slot(2), 1'u64, receiver, 1)
-      var r11 = queue.pop(Slot(2))
-      var r12 = queue.pop(Slot(2))
-      var r13 = queue.pop(Slot(2))
+      var queue = SyncQueue.init(SomeTPeer, Slot(0), Slot(2), 1'u64,
+                                 syncReceiver, 1)
+      let p1 = SomeTPeer()
+      let p2 = SomeTPeer()
+      let p3 = SomeTPeer()
+      var r11 = queue.pop(Slot(2), p1)
+      var r12 = queue.pop(Slot(2), p2)
+      var r13 = queue.pop(Slot(2), p3)
       var f13 = queue.push(r13, @[chain[2]])
       var f12 = queue.push(r12, @[chain[1]])
       await sleepAsync(100.milliseconds)
@@ -172,6 +229,9 @@ suite "SyncManager test suite":
       doAssert(f12.finished == true and f12.failed == false)
       doAssert(f13.finished == true and f13.failed == false)
       doAssert(counter == 3)
+      doAssert(r11.item == p1)
+      doAssert(r12.item == p2)
+      doAssert(r13.item == p3)
       result = true
 
     check waitFor(test())
@@ -180,7 +240,8 @@ suite "SyncManager test suite":
     proc test(): Future[bool] {.async.} =
       var counter = 5
 
-      proc receiver(list: openarray[SignedBeaconBlock]): bool =
+      proc syncReceiver(req: SyncRequest[SomeTPeer],
+                        list: openarray[SignedBeaconBlock]): bool {.gcsafe.} =
         result = true
         for item in list:
           if item.message.slot == Slot(counter):
@@ -188,12 +249,19 @@ suite "SyncManager test suite":
           else:
             result = false
             break
+
       var chain = createChain(Slot(5), Slot(11))
-      var queue = SyncQueue.init(Slot(5), Slot(11), 2'u64, receiver, 2)
-      var r21 = queue.pop(Slot(11))
-      var r22 = queue.pop(Slot(11))
-      var r23 = queue.pop(Slot(11))
-      var r24 = queue.pop(Slot(11))
+      var queue = SyncQueue.init(SomeTPeer, Slot(5), Slot(11), 2'u64,
+                                 syncReceiver, 2)
+      let p1 = SomeTPeer()
+      let p2 = SomeTPeer()
+      let p3 = SomeTPeer()
+      let p4 = SomeTPeer()
+
+      var r21 = queue.pop(Slot(11), p1)
+      var r22 = queue.pop(Slot(11), p2)
+      var r23 = queue.pop(Slot(11), p3)
+      var r24 = queue.pop(Slot(11), p4)
 
       var f24 = queue.push(r24, @[chain[6]])
       var f22 = queue.push(r22, @[chain[2], chain[3]])
@@ -210,6 +278,41 @@ suite "SyncManager test suite":
       doAssert(counter == 12)
       await sleepAsync(100.milliseconds)
       doAssert(counter == 12)
+      doAssert(r21.item == p1)
+      doAssert(r22.item == p2)
+      doAssert(r23.item == p3)
+      doAssert(r24.item == p4)
       result = true
 
     check waitFor(test())
+
+  test "[SyncQueue] hasEndGap() test":
+    let chain1 = createChain(Slot(1), Slot(1))
+    let chain2 = newSeq[SignedBeaconBlock]()
+
+    for counter in countdown(32'u64, 2'u64):
+      let req = SyncRequest[SomeTPeer](slot: Slot(1), count: counter,
+                                      step: 1'u64)
+      let sr = SyncResult[SomeTPeer](request: req, data: chain1)
+      check sr.hasEndGap() == true
+
+    let req = SyncRequest[SomeTPeer](slot: Slot(1), count: 1'u64, step: 1'u64)
+    let sr1 = SyncResult[SomeTPeer](request: req, data: chain1)
+    let sr2 = SyncResult[SomeTPeer](request: req, data: chain2)
+    check:
+      sr1.hasEndGap() == false
+      sr2.hasEndGap() == true
+
+  test "[SyncQueue] getLastNonEmptySlot() test":
+    let chain1 = createChain(Slot(10), Slot(10))
+    let chain2 = newSeq[SignedBeaconBlock]()
+
+    for counter in countdown(32'u64, 2'u64):
+      let req = SyncRequest[SomeTPeer](slot: Slot(10), count: counter,
+                                      step: 1'u64)
+      let sr = SyncResult[SomeTPeer](request: req, data: chain1)
+      check sr.getLastNonEmptySlot() == Slot(10)
+
+    let req = SyncRequest[SomeTPeer](slot: Slot(100), count: 1'u64, step: 1'u64)
+    let sr = SyncResult[SomeTPeer](request: req, data: chain2)
+    check sr.getLastNonEmptySlot() == Slot(100)


### PR DESCRIPTION
According to current Ethereum2 network specification
> Clients MUST respond with at least one block, if they have it and it exists in the range. Clients MAY limit the number of blocks in the response.

Such rule can lead to very uncertain responses, for example let slots from 10 to 13 will be not empty. Client which follows specification can answer with any response from this list (X - block, `-` empty space):
```
1.   X X X
2.   - - X
3.   - X -
4.   - X X
5.   X - -
6.   X - X
7.   X X -
```

If peer answers with `1` everything will be fine and we will be able to process all 3 blocks. In case of `2`, `3`, `4`, `6` block_pool will find a problem immediately in our list and report "parent is missing error". But in case of `5` and `7` blocks will be processed by `block_pool` without any problems, however it will start producing problems right from this uncertain last slot. Sync manager will start query next blocks from the peers and will be unable to add this blocks anymore because slot is missed and it even do not knows about it. Lets call such peers "jokers", because they are joking with responses.

To fix "joker" problem i'm going to introduce "zero-point" which represents first slot in gap at the end of requested chunk. If sync manager receives chunk of blocks with gap at the end and this chunk will be successfully processed by `block_pool` it will set `zero_point` to the first uncertain slot. For example:

```
Case 1

X  X  X  X  X  -
3  4  5  6  7  8

Case2
X  X  -  -  -  -
3  4  5  6  7  8
```
In Case 1 `zero-point` will be equal to 8, in Case 2 `zero-point` will be equal to 5.

When `zero-point` is set and the next received chunk of blocks will be empty, then peer produced this chunk of blocks will be added to suspect list.

If the next chunk of blocks has at least one non-empty block and this chunk will
be successfully processed by `block_pool`, then `zero-point` will be reset and suspect list will be cleared.

If the block_pool failed to process next chunk of blocks, sync manager will perform
rollback to `zero-point` and penalize all the peers in suspect list.
