### PR TITLE
keep cache of per-epoch items in block pool

### DIFF
--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -118,6 +118,7 @@ type
 
   EpochRef* = ref object
     shuffled_active_validator_indices*: seq[ValidatorIndex]
+    epoch*: Epoch
 
   BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to tail block, and to have
@@ -135,7 +136,8 @@ type
 
     slot*: Slot # TODO could calculate this by walking to root, but..
 
-    epochInfo*: EpochRef
+    epochsInfo*: seq[EpochRef]
+    ## Could be multiple, since blocks could be skipped, but usually, not many
 
   BlockData* = object
     ## Body and graph in one

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -116,6 +116,9 @@ type
 
     updateFlags*: UpdateFlags
 
+  EpochRef* = ref object
+    shuffled_active_validator_indices*: seq[ValidatorIndex]
+
   BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to tail block, and to have
     ## a corresponding entry in database.
@@ -131,6 +134,8 @@ type
     # TODO do we strictly need this?
 
     slot*: Slot # TODO could calculate this by walking to root, but..
+
+    epochInfo*: EpochRef
 
   BlockData* = object
     ## Body and graph in one

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -137,7 +137,9 @@ type
     slot*: Slot # TODO could calculate this by walking to root, but..
 
     epochsInfo*: seq[EpochRef]
-    ## Could be multiple, since blocks could be skipped, but usually, not many
+    ## Could be multiple, since blocks could skip slots, but usually, not many
+    ## Even if competing forks happen later during this epoch, potential empty
+    ## slots beforehand must all be from this fork.
 
   BlockData* = object
     ## Body and graph in one

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -53,6 +53,11 @@ func parent*(bs: BlockSlot): BlockSlot =
       slot: bs.slot - 1
     )
 
+func populateEpochCache*(state: BeaconState, epoch: Epoch): EpochRef =
+  result = new EpochRef
+  result.shuffled_active_validator_indices =
+    get_shuffled_active_validator_indices(state, epoch)
+
 func link*(parent, child: BlockRef) =
   doAssert (not (parent.root == Eth2Digest() or child.root == Eth2Digest())),
     "blocks missing root!"
@@ -441,8 +446,26 @@ proc skipAndUpdateState(
     doAssert (addr(statePtr.data) == addr v)
     statePtr[] = dag.headState
 
+  # While addResolved(...)-created BlockRefs already have this, BlockRefs
+  # loaded from BeaconChainDB don't, necessarily, so there's be a startup
+  # period, during which this proc and clearance.add(...) might fill them
+  # in before their respective state_transition() calls. TODO, if can get
+  # this from same epoch in same part of tree, that'd be better.
+  if blck.refs.epochInfo.isNil:
+    blck.refs.epochInfo =
+      populateEpochCache(
+        state.data.data, state.data.data.slot.compute_epoch_at_slot)
+    trace "candidate_chains.skipAndUpdateState(): back-filling parent.epochInfo",
+      state_slot = state.data.data.slot
+
+  # TODO it's probably not the right way to convey this, but for now, avoids
+  # death-by-dozens-of-pointless-changes in developing this
+  var stateCache = get_empty_per_epoch_cache()
+  stateCache.shuffled_active_validator_indices[state.data.data.slot.compute_epoch_at_slot] =
+    blck.refs.epochInfo.shuffled_active_validator_indices
+
   let ok = state_transition(
-    state.data, blck.data, flags + dag.updateFlags, restore)
+    state.data, blck.data, stateCache, flags + dag.updateFlags, restore)
   if ok and save:
     dag.putState(state.data, blck.refs)
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -399,10 +399,13 @@ type
     data*: BeaconState
     root*: Eth2Digest # hash_tree_root(data)
 
+  # TODO remove some of these, or otherwise coordinate with EpochRef
   StateCache* = object
     beacon_committee_cache*:
       Table[tuple[a: int, b: Eth2Digest], seq[ValidatorIndex]]
     active_validator_indices_cache*:
+      Table[Epoch, seq[ValidatorIndex]]
+    shuffled_active_validator_indices*:
       Table[Epoch, seq[ValidatorIndex]]
     committee_count_cache*: Table[Epoch, uint64]
 


### PR DESCRIPTION
At this point, a fair amount of this is scaffolding to keep things working until complete. This is why it reuses `StateCache` in the beacon chain spec code side -- otherwise, it creates lots of changes which aren't especially helpful for development. The plan is to deprecate and remove `StateCache` as it exists, though something with a similar role more aligned with the block pool source of truth will probably continue to exist.

The per-epoch version here aims to track mutability more clearly and delineate where things are set and where they're read, so `var` params are a bit less littered around the beacon chain spec part of the codebase in the near future.

Coming PRs will hook this more firmly into the state transition machinery.