### PR TITLE
Witti tryout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,13 @@ schlesi-dev: | build deps
 	LOG_LEVEL="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" NIM_PARAMS="$(NIM_PARAMS)" \
 		$(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) --dev-build shared/schlesi
 
+witti: | build deps
+	LOG_LEVEL="DEBUG" NIM_PARAMS="$(NIM_PARAMS)" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
+
+witti-dev: | build deps
+	LOG_LEVEL="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" NIM_PARAMS="$(NIM_PARAMS)" \
+		$(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) --dev-build shared/witti
+
 clean: | clean-common
 	rm -rf build/{$(TOOLS_CSV),all_tests,*_node,*ssz*,beacon_node_testnet*,block_sim,state_sim,transition*}
 ifneq ($(USE_LIBBACKTRACE), 0)

--- a/beacon_chain/eth2_discovery.nim
+++ b/beacon_chain/eth2_discovery.nim
@@ -135,10 +135,7 @@ proc addBootstrapNode*(bootstrapAddr: string,
                        localPubKey: PublicKey) =
   let enrRes = parseBootstrapAddress(bootstrapAddr)
   if enrRes.isOk:
-    let enodeRes = enrRes.value.toENode
-    if enodeRes.isOk:
-      if enodeRes.value.pubKey != localPubKey:
-        bootEnrs.add enrRes.value
+    bootEnrs.add enrRes.value
   else:
     warn "Ignoring invalid bootstrap address",
           bootstrapAddr, reason = enrRes.error


### PR DESCRIPTION
So, had to remove some code as `toEnode` was failing because the bootstrap nodes don't have the tcp field in their ENR. This makes sense as it looks like they are discovery only nodes.

Anyhow, that check which required `toEnode` is not even needed as the same check is already done inside discovery when adding a node. Also, a whole lot of this code will be refactored/deleted after some upcoming changes in discoveryv5.