### PR TITLE
SSZ cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ TOOLS := \
 	deposit_contract \
 	ncli_hash_tree_root \
 	ncli_pretty \
+	ncli_query \
 	ncli_transition \
 	process_dashboard \
 	stack_sizes \

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -24,7 +24,7 @@ import
   attestation_pool, block_pool, eth2_network, eth2_discovery,
   beacon_node_common, beacon_node_types,
   nimbus_binary_common,
-  mainchain_monitor, version, ssz, ssz/dynamic_navigator,
+  mainchain_monitor, version, ssz,
   sync_protocol, request_manager, validator_keygen, interop, statusbar,
   sync_manager, state_transition,
   validator_duties, validator_api
@@ -961,25 +961,3 @@ programMain:
         config.depositContractAddress,
         config.depositPrivateKey,
         delayGenerator)
-
-  of query:
-    case config.queryCmd
-    of QueryCmd.nimQuery:
-      # TODO: This will handle a simple subset of Nim using
-      #       dot syntax and `[]` indexing.
-      echo "nim query: ", config.nimQueryExpression
-
-    of QueryCmd.get:
-      let pathFragments = config.getQueryPath.split('/', maxsplit = 1)
-      let bytes =
-        case pathFragments[0]
-        of "genesis_state":
-          readFile(config.dataDir/genesisFile).string.toBytes()
-        else:
-          stderr.write config.getQueryPath & " is not a valid path"
-          quit 1
-
-      let navigator = DynamicSszNavigator.init(bytes, BeaconState)
-
-      echo navigator.navigatePath(pathFragments[1 .. ^1]).toJson
-

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -18,14 +18,9 @@ type
     importValidator
     createTestnet
     makeDeposits
-    query
 
   VCStartUpCmd* = enum
     VCNoCommand
-
-  QueryCmd* = enum
-    nimQuery
-    get
 
   Eth1Network* = enum
     custom
@@ -269,22 +264,6 @@ type
         defaultValue: 0.0
         desc: "Maximum possible delay between making two deposits (in seconds)"
         name: "max-delay" }: float
-
-    of query:
-      case queryCmd* {.
-        defaultValue: nimQuery
-        command
-        desc: "Query the beacon node database and print the result" }: QueryCmd
-
-      of nimQuery:
-        nimQueryExpression* {.
-          argument
-          desc: "Nim expression to evaluate (using limited syntax)" }: string
-
-      of get:
-        getQueryPath* {.
-          argument
-          desc: "REST API path to evaluate" }: string
 
   ValidatorClientConf* = object
     logLevel* {.

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -59,7 +59,8 @@ proc getStateFromSnapshot*(conf: BeaconNodeConf|ValidatorClientConf): NilableBea
       quit 1
 
   result = try:
-    newClone(SSZ.decode(snapshotContents, BeaconState))
+    newClone(SSZ.decode(
+      toOpenArrayByte(snapshotContents, 0, snapshotContents.high), BeaconState))
   except SerializationError:
     error "Failed to import genesis file", path = genesisPath
     quit 1

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -384,7 +384,7 @@ func process_final_updates*(state: var BeaconState) {.nbench.}=
 
   # Reset eth1 data votes
   if next_epoch mod EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
-    state.eth1_data_votes = type(state.eth1_data_votes) @[]
+    state.eth1_data_votes = default(type state.eth1_data_votes)
 
   # Update effective balances with hysteresis
   for index, validator in state.validators:
@@ -420,7 +420,7 @@ func process_final_updates*(state: var BeaconState) {.nbench.}=
 
   # Rotate current/previous epoch attestations
   state.previous_epoch_attestations = state.current_epoch_attestations
-  state.current_epoch_attestations = typeof(state.current_epoch_attestations) @[]
+  state.current_epoch_attestations = default(type state.current_epoch_attestations)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#epoch-processing
 proc process_epoch*(state: var BeaconState, updateFlags: UpdateFlags)

--- a/beacon_chain/ssz/navigator.nim
+++ b/beacon_chain/ssz/navigator.nim
@@ -121,7 +121,7 @@ func `[]`*[T](n: SszNavigator[T]): T {.raisesssz.} =
   mixin toSszType, fromSszBytes
   type SszRepr = type toSszType(declval T)
   when type(SszRepr) is type(T) or T is List:
-    readSszValue(toOpenArray(n.m), T)
+    readSszValue(toOpenArray(n.m), result)
   else:
     fromSszBytes(T, toOpenArray(n.m))
 

--- a/ncli/ncli_query.nim
+++ b/ncli/ncli_query.nim
@@ -1,0 +1,56 @@
+import
+  confutils, os, strutils, chronicles, json_serialization,
+  stew/byteutils,
+  ../beacon_chain/spec/[crypto, datatypes, digest],
+  ../beacon_chain/[ssz],
+  ../beacon_chain/ssz/dynamic_navigator
+
+type
+  QueryCmd* = enum
+    nimQuery
+    get
+
+  QueryConf = object
+    file* {.
+        defaultValue: ""
+        desc: "BeaconState ssz file"
+        name: "file" }: InputFile
+
+    case queryCmd* {.
+      defaultValue: nimQuery
+      command
+      desc: "Query the beacon node database and print the result" }: QueryCmd
+
+    of nimQuery:
+      nimQueryExpression* {.
+        argument
+        desc: "Nim expression to evaluate (using limited syntax)" }: string
+
+    of get:
+      getQueryPath* {.
+        argument
+        desc: "REST API path to evaluate" }: string
+
+
+let
+  config = QueryConf.load()
+
+case config.queryCmd
+of QueryCmd.nimQuery:
+  # TODO: This will handle a simple subset of Nim using
+  #       dot syntax and `[]` indexing.
+  echo "nim query: ", config.nimQueryExpression
+
+of QueryCmd.get:
+  let pathFragments = config.getQueryPath.split('/', maxsplit = 1)
+  let bytes =
+    case pathFragments[0]
+    of "genesis_state":
+      readFile(config.file.string).string.toBytes()
+    else:
+      stderr.write config.getQueryPath & " is not a valid path"
+      quit 1
+
+  let navigator = DynamicSszNavigator.init(bytes, BeaconState)
+
+  echo navigator.navigatePath(pathFragments[1 .. ^1]).toJson

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -58,7 +58,7 @@ template readFileBytes*(path: string): seq[byte] =
 proc sszDecodeEntireInput*(input: openarray[byte], Decoded: type): Decoded =
   var stream = unsafeMemoryInput(input)
   var reader = init(SszReader, stream, input.len)
-  result = reader.readValue(Decoded)
+  reader.readValue(result)
 
   if stream.readable:
     raise newException(UnconsumedInput, "Remaining bytes in the input")

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -57,9 +57,8 @@ template readFileBytes*(path: string): seq[byte] =
 
 proc sszDecodeEntireInput*(input: openarray[byte], Decoded: type): Decoded =
   var stream = unsafeMemoryInput(input)
-  var reader = init(SszReader, stream)
+  var reader = init(SszReader, stream, input.len)
   result = reader.readValue(Decoded)
 
   if stream.readable:
     raise newException(UnconsumedInput, "Remaining bytes in the input")
-


### PR DESCRIPTION
* be stricter about SSZ length prefix
* compute zeroHash list at compile time
* remove SSZ schema stuff
* move SSZ navigation to ncli
* cleanup a few leftover openArray uses