### PR TITLE
ncli_db: database tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ TOOLS := \
 	ncli_hash_tree_root \
 	ncli_pretty \
 	ncli_transition \
+	ncli_db \
 	process_dashboard \
 	stack_sizes \
 	state_sim \

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -14,7 +14,7 @@ import
 import
   block_pools/[block_pools_types, clearance, candidate_chains, quarantine]
 
-export results
+export results, block_pools_types
 
 # Block_Pools
 # --------------------------------------------

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -1,0 +1,58 @@
+import
+  confutils, stats, chronicles, strformat, tables,
+  ../beacon_chain/block_pool,
+  ../beacon_chain/spec/[crypto, datatypes],
+  ../beacon_chain/[beacon_chain_db, extras, state_transition, ssz],
+  ../research/simutils,
+  eth/db/[kvstore, kvstore_sqlite3]
+
+type Timers = enum
+  tInit = "Initialize DB"
+  tLoadBlock = "Load block from database"
+  tLoadState = "Load state from database"
+  tApplyBlock = "Apply block"
+
+cli do(databaseDir: string, cmd: string):
+  var timers: array[Timers, RunningStat]
+
+  echo "Opening database..."
+  let
+    db = BeaconChainDB.init(kvStore SqStoreRef.init(databaseDir, "nbc").tryGet())
+
+  if not BlockPool.isInitialized(db):
+    echo "Database not initialized"
+    quit 1
+
+  echo "Initializing block pool..."
+  let pool = withTimerRet(timers[tInit]):
+    CandidateChains.init(db, {})
+
+  echo &"Loaded {pool.blocks.len} blocks, head slot {pool.head.blck.slot}"
+
+  case cmd
+  of "bench":
+    var
+      blockRefs: seq[BlockRef]
+      blocks: seq[SignedBeaconBlock]
+      cur = pool.head.blck
+
+    while cur != nil:
+      blockRefs.add cur
+      cur = cur.parent
+
+    for b in 1..<blockRefs.len: # Skip genesis block
+      withTimer(timers[tLoadBlock]):
+        blocks.add db.getBlock(blockRefs[blockRefs.len - b - 1].root).get()
+
+    let state = (ref HashedBeaconState)(
+      root: db.getBlock(blockRefs[^1].root).get().message.state_root
+    )
+
+    withTimer(timers[tLoadState]):
+      discard db.getState(state[].root, state[].data, noRollback)
+
+    for b in blocks:
+      withTimer(timers[tApplyBlock]):
+        discard state_transition(state[], b, {}, noRollback)
+
+  printTimers(true, timers)

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -1,5 +1,5 @@
 import
-  stats, os, strformat,
+  stats, os, strformat, times,
   ../tests/[testblockutil],
   ../beacon_chain/[extras, ssz],
   ../beacon_chain/spec/[beaconstate, datatypes, digest, helpers]
@@ -74,11 +74,9 @@ proc loadGenesis*(validators: int, validate: bool): ref HashedBeaconState =
     res
 
 proc printTimers*[Timers: enum](
-    state: BeaconState, attesters: RunningStat, validate: bool,
-    timers: array[Timers, RunningStat]) =
-  echo "Validators: ", state.validators.len, ", epoch length: ", SLOTS_PER_EPOCH
-  echo "Validators per attestation (mean): ", attesters.mean
-
+  validate: bool,
+  timers: array[Timers, RunningStat]
+) =
   proc fmtTime(t: float): string = &"{t * 1000 :>12.3f}, "
 
   echo "All time are ms"
@@ -92,3 +90,10 @@ proc printTimers*[Timers: enum](
     echo fmtTime(timers[t].mean), fmtTime(timers[t].standardDeviationS),
       fmtTime(timers[t].min), fmtTime(timers[t].max), &"{timers[t].n :>12}, ",
       $t
+
+proc printTimers*[Timers: enum](
+    state: BeaconState, attesters: RunningStat, validate: bool,
+    timers: array[Timers, RunningStat]) =
+  echo "Validators: ", state.validators.len, ", epoch length: ", SLOTS_PER_EPOCH
+  echo "Validators per attestation (mean): ", attesters.mean
+  printTimers(validate, timers)


### PR DESCRIPTION
includes a benchmark tool for now

here's a test I've been running with the first 620 blocks from witti:
```
[arnetheduck@tempus ncli]$ ./ncli_db --databaseDir:../build/data/shared_witti/db/ --cmd=bench
```

devel:

```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    1787.845,        0.000,     1787.845,     1787.845,            1, Initialize DB
       0.505,        0.364,        0.308,        8.513,          619, Load block from database
      34.672,        0.000,       34.672,       34.672,            1, Load state from database
     131.484,       71.980,      106.325,     1698.509,          619, Apply block
```

After https://github.com/status-im/nim-beacon-chain/pull/1073 (before @zah copy fixes)

```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    1795.354,        0.000,     1795.354,     1795.354,            1, Initialize DB
       0.514,        0.380,        0.312,        8.951,          619, Load block from database
      21.858,        0.000,       21.858,       21.858,            1, Load state from database
     126.029,       74.113,      106.231,     1747.426,          619, Apply block
```


https://github.com/status-im/nim-beacon-chain/pull/1082 

```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    1865.264,        0.000,     1865.264,     1865.264,            1, Initialize DB
       0.532,        0.387,        0.322,        9.053,          619, Load block from database
      22.856,        0.000,       22.856,       22.856,            1, Load state from database
     127.804,       77.397,      102.216,     1836.070,          619, Apply block
```
