### PR TITLE
Add timeout to switch.connect

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -652,20 +652,22 @@ proc dialPeer*(node: Eth2Node, peerInfo: PeerInfo) {.async.} =
   logScope: peer = $peerInfo
 
   debug "Connecting to peer"
-  await node.switch.connect(peerInfo)
-  var peer = node.getPeer(peerInfo)
-  peer.wasDialed = true
+  if await withTimeout(node.switch.connect(peerInfo), 10.seconds):
+    var peer = node.getPeer(peerInfo)
+    peer.wasDialed = true
 
-  #let msDial = newMultistream()
-  #let conn = node.switch.connections.getOrDefault(peerInfo.id)
-  #let ls = await msDial.list(conn)
-  #debug "Supported protocols", ls
+    #let msDial = newMultistream()
+    #let conn = node.switch.connections.getOrDefault(peerInfo.id)
+    #let ls = await msDial.list(conn)
+    #debug "Supported protocols", ls
 
-  debug "Initializing connection"
-  await initializeConnection(peer)
+    debug "Initializing connection"
+    await initializeConnection(peer)
 
-  inc libp2p_successful_dials
-  debug "Network handshakes completed"
+    inc libp2p_successful_dials
+    debug "Network handshakes completed"
+  else:
+    debug "Connection timed out"
 
 proc runDiscoveryLoop*(node: Eth2Node) {.async.} =
   debug "Starting discovery loop"


### PR DESCRIPTION
Adding a timeout to `switch.connect`, as libp2p does not handle the timeouts itself.
If we don't do this the `runDiscoveryLoop` will block forever after a timeout and no new connections will be made.

This is rather temporary and will be improved by @cheatfate in an upcoming PR but at least get things going again. (Mind you that a lot of timeouts will occur, as discovery needs to get more selective on the nodes it passes, or perhaps there are other problems also at hand in libp2p layer, TBI).

