### PR TITLE
use shuffled validator cache in more places; cleanups

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -490,6 +490,7 @@ proc `[]=`*[T](a: var seq[T], b: ValidatorIndex, c: T) =
 
 # `ValidatorIndex` Nim integration
 proc `==`*(x, y: ValidatorIndex) : bool {.borrow.}
+proc `<`*(x, y: ValidatorIndex) : bool {.borrow.}
 proc hash*(x: ValidatorIndex): Hash {.borrow.}
 proc `$`*(x: ValidatorIndex): auto = $(x.int64)
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -303,7 +303,9 @@ proc process_voluntary_exit*(
     validator_withdrawable_epoch = validator.withdrawable_epoch,
     validator_exit_epoch = validator.exit_epoch,
     validator_effective_balance = validator.effective_balance
-  initiate_validator_exit(state, voluntary_exit.validator_index.ValidatorIndex)
+  var cache = get_empty_per_epoch_cache()
+  initiate_validator_exit(
+    state, voluntary_exit.validator_index.ValidatorIndex, cache)
 
   true
 

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2020 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,11 +7,11 @@
 
 import
   # Standard library
-  os,
+  os, tables,
   # Status libraries
   confutils/defs, serialization,
   # Beacon-chain
-  ../beacon_chain/spec/[datatypes, crypto, beaconstate, validator, state_transition_block, state_transition_epoch],
+  ../beacon_chain/spec/[datatypes, crypto, helpers, beaconstate, validator, state_transition_block, state_transition_epoch],
   ../beacon_chain/[ssz, state_transition, extras]
 
 # Nimbus Bench - Scenario configuration
@@ -185,6 +185,9 @@ template processEpochScenarioImpl(
 
   when needCache:
     var cache = get_empty_per_epoch_cache()
+    let epoch = state.data.slot.compute_epoch_at_slot
+    cache.shuffled_active_validator_indices[epoch] =
+      get_shuffled_active_validator_indices(state.data, epoch)
 
   # Epoch transitions can't fail (TODO is this true?)
   when needCache:
@@ -251,11 +254,11 @@ genProcessEpochScenario(runProcessJustificationFinalization,
 
 genProcessEpochScenario(runProcessRegistryUpdates,
                         process_registry_updates,
-                        needCache = false)
+                        needCache = true)
 
 genProcessEpochScenario(runProcessSlashings,
                         process_slashings,
-                        needCache = false)
+                        needCache = true)
 
 genProcessEpochScenario(runProcessFinalUpdates,
                         process_final_updates,

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -66,13 +66,13 @@ runSuite(JustificationFinalizationDir, "Justification & Finalization",  process_
 # ---------------------------------------------------------------
 
 const RegistryUpdatesDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"registry_updates"/"pyspec_tests"
-runSuite(RegistryUpdatesDir, "Registry updates",  process_registry_updates, useCache = false)
+runSuite(RegistryUpdatesDir, "Registry updates",  process_registry_updates, useCache = true)
 
 # Slashings
 # ---------------------------------------------------------------
 
 const SlashingsDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"slashings"/"pyspec_tests"
-runSuite(SlashingsDir, "Slashings",  process_slashings, useCache = false)
+runSuite(SlashingsDir, "Slashings",  process_slashings, useCache = true)
 
 # Final updates
 # ---------------------------------------------------------------

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard library
-  strformat,
+  strformat, tables,
   # Specs
   ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator, helpers],
   # Test helpers
@@ -34,7 +34,10 @@ proc addMockAttestations*(
     raise newException(ValueError, &"Cannot include attestations from epoch {state.get_current_epoch()} in epoch {epoch}")
 
   # TODO: Working with an unsigned Gwei balance is a recipe for underflows to happen
-  var remaining_balance = state.get_total_active_balance().int64 * 2 div 3
+  var cache = get_empty_per_epoch_cache()
+  cache.shuffled_active_validator_indices[epoch] =
+    get_shuffled_active_validator_indices(state, epoch)
+  var remaining_balance = state.get_total_active_balance(cache).int64 * 2 div 3
 
   let start_slot = compute_start_slot_at_epoch(epoch)
 


### PR DESCRIPTION
https://github.com/status-im/nim-beacon-chain/issues/980

There's some ugliness around redundant-looking initialization of epoch caches -- that's all going to be refactored because initializing empty caches proved a bad idea to begin with. So a future PR will sweep through all the `get_empty_per_epoch_cache()` calls and replace them with an API which specifies an epoch to seed.