### PR TITLE
12x state sim speedup with 100k validators by caching get_beacon_proposer_index()

### DIFF
--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -399,11 +399,11 @@ type
     data*: BeaconState
     root*: Eth2Digest # hash_tree_root(data)
 
-  # TODO remove some of these, or otherwise coordinate with EpochRef
   StateCache* = object
     shuffled_active_validator_indices*:
       Table[Epoch, seq[ValidatorIndex]]
     committee_count_cache*: Table[Epoch, uint64]
+    beacon_proposer_indices*: Table[Slot, Option[ValidatorIndex]]
 
 func shortValidatorKey*(state: BeaconState, validatorIdx: int): string =
     ($state.validators[validatorIdx].pubkey)[0..7]

--- a/beacon_chain/state_transition.nim
+++ b/beacon_chain/state_transition.nim
@@ -273,11 +273,11 @@ proc makeBeaconBlock*(
     graffiti: Eth2Digest,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    rollback: RollbackHashedProc): Option[BeaconBlock] =
+    rollback: RollbackHashedProc,
+    cache: var StateCache): Option[BeaconBlock] =
   ## Create a block for the given state. The last block applied to it must be
   ## the one identified by parent_root and process_slots must be called up to
   ## the slot for which a block is to be created.
-  var cache = get_empty_per_epoch_cache()
 
   # To create a block, we'll first apply a partial block to the state, skipping
   # some validations.

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -176,6 +176,7 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       doAssert v.addr == addr poolPtr.tmpState.data
       poolPtr.tmpState = poolPtr.headState
 
+    var cache = get_empty_per_epoch_cache()
     let message = makeBeaconBlock(
       hashedState,
       validator_index,
@@ -185,7 +186,8 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       graffiti,
       node.attestationPool.getAttestationsForBlock(state),
       deposits,
-      restore)
+      restore,
+      cache)
 
     if message.isSome():
       # TODO this restore is needed because otherwise tmpState will be internally

--- a/ncli/ncli_query.nim
+++ b/ncli/ncli_query.nim
@@ -1,8 +1,7 @@
 import
   confutils, os, strutils, json_serialization,
   stew/byteutils,
-  ../beacon_chain/spec/[crypto, datatypes],
-  ../beacon_chain/ssz/dynamic_navigator
+  ../beacon_chain/spec/[crypto, datatypes]
 
 type
   QueryCmd* = enum

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -117,7 +117,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
           Eth2Digest(),
           attPool.getAttestationsForBlock(state),
           @[],
-          noRollback)
+          noRollback,
+          cache)
 
       var
         newBlock = SignedBeaconBlock(

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -95,7 +95,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
     withTimer(timers[t]):
       signedBlock = addTestBlock(
-        state[], latest_block_root, attestations = blockAttestations, flags = flags)
+        state[], latest_block_root, cache, attestations = blockAttestations,
+        flags = flags)
     latest_block_root = withTimerRet(timers[tHashBlock]):
       hash_tree_root(signedBlock.message)
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -149,8 +149,9 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Fork choice returns latest block with no attestations":
+    var cache = get_empty_per_epoch_cache()
     let
-      b1 = addTestBlock(state.data, blockPool.tail.root)
+      b1 = addTestBlock(state.data, blockPool.tail.root, cache)
       b1Root = hash_tree_root(b1.message)
       b1Add = blockPool.add(b1Root, b1)[]
       head = pool.selectHead()
@@ -159,7 +160,7 @@ suiteReport "Attestation pool processing" & preset():
       head == b1Add
 
     let
-      b2 = addTestBlock(state.data, b1Root)
+      b2 = addTestBlock(state.data, b1Root, cache)
       b2Root = hash_tree_root(b2.message)
       b2Add = blockPool.add(b2Root, b2)[]
       head2 = pool.selectHead()
@@ -170,7 +171,7 @@ suiteReport "Attestation pool processing" & preset():
   timedTest "Fork choice returns block with attestation":
     var cache = get_empty_per_epoch_cache()
     let
-      b10 = makeTestBlock(state.data, blockPool.tail.root)
+      b10 = makeTestBlock(state.data, blockPool.tail.root, cache)
       b10Root = hash_tree_root(b10.message)
       b10Add = blockPool.add(b10Root, b10)[]
       head = pool.selectHead()
@@ -179,7 +180,7 @@ suiteReport "Attestation pool processing" & preset():
       head == b10Add
 
     let
-      b11 = makeTestBlock(state.data, blockPool.tail.root,
+      b11 = makeTestBlock(state.data, blockPool.tail.root, cache,
         graffiti = Eth2Digest(data: [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
       )
       b11Root = hash_tree_root(b11.message)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -36,7 +36,8 @@ suiteReport "Block processing" & preset():
   timedTest "Passes from genesis state, empty block" & preset():
     var
       previous_block_root = hash_tree_root(genesisBlock.message)
-      new_block = makeTestBlock(state[], previous_block_root)
+      cache = get_empty_per_epoch_cache()
+      new_block = makeTestBlock(state[], previous_block_root, cache)
 
     let block_ok = state_transition(state[], new_block, {}, noRollback)
 
@@ -53,9 +54,10 @@ suiteReport "Block processing" & preset():
   timedTest "Passes through epoch update, empty block" & preset():
     var
       previous_block_root = genesisRoot
+      cache = get_empty_per_epoch_cache()
 
     for i in 1..SLOTS_PER_EPOCH.int:
-      let new_block = makeTestBlock(state[], previous_block_root)
+      let new_block = makeTestBlock(state[], previous_block_root, cache)
 
       let block_ok = state_transition(state[], new_block, {}, noRollback)
 
@@ -90,7 +92,7 @@ suiteReport "Block processing" & preset():
         state[], GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY + 1)
 
     let
-      new_block = makeTestBlock(state[], previous_block_root,
+      new_block = makeTestBlock(state[], previous_block_root, cache,
         attestations = @[attestation]
       )
     check state_transition(state[], new_block, {}, noRollback)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -89,13 +89,13 @@ func signBlock*(
 proc addTestBlock*(
     state: var HashedBeaconState,
     parent_root: Eth2Digest,
+    cache: var StateCache,
     eth1_data = Eth1Data(),
     attestations = newSeq[Attestation](),
     deposits = newSeq[Deposit](),
     graffiti = Eth2Digest(),
     flags: set[UpdateFlag] = {}): SignedBeaconBlock =
   # Create and add a block to state - state will advance by one slot!
-  var cache = get_empty_per_epoch_cache()
   advance_slot(state, err(Opt[Eth2Digest]), flags, cache)
 
   let
@@ -122,7 +122,8 @@ proc addTestBlock*(
       graffiti,
       attestations,
       deposits,
-      noRollback)
+      noRollback,
+      cache)
 
   doAssert message.isSome(), "Should have created a valid block!"
 
@@ -136,6 +137,7 @@ proc addTestBlock*(
 proc makeTestBlock*(
     state: HashedBeaconState,
     parent_root: Eth2Digest,
+    cache: var StateCache,
     eth1_data = Eth1Data(),
     attestations = newSeq[Attestation](),
     deposits = newSeq[Deposit](),
@@ -147,7 +149,8 @@ proc makeTestBlock*(
   # because the block includes the state root.
   var tmpState = newClone(state)
   addTestBlock(
-    tmpState[], parent_root, eth1_data, attestations, deposits, graffiti, flags)
+    tmpState[], parent_root, cache, eth1_data, attestations, deposits,
+    graffiti, flags)
 
 proc makeAttestation*(
     state: BeaconState, beacon_block_root: Eth2Digest,


### PR DESCRIPTION
Before:
```
$ time research/state_sim --slots=64 --validate=off --validators=100000
Loaded genesim_mainnet_100000.ssz...
Starting simulation...
:............................... slot: 32 epoch: 1
:............................... slot: 64 epoch: 2
:Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 130.2083333333333
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    5430.698,      594.887,      864.675,     5743.549,           62, Process non-epoch slot with block
    7739.411,     2533.209,     5948.162,     9530.660,            2, Process epoch slot with block
       0.291,        0.043,        0.015,        0.362,           64, Tree-hash block
       9.471,       37.097,        1.194,      183.688,           64, Retrieve committee once using get_beacon_committee
       0.181,        0.012,        0.153,        0.244,         1536, Combine committee attestations

real	6m2.964s
user	6m1.050s
sys	0m0.648s
```

After:
```
$ time research/state_sim --slots=64 --validate=off --validators=100000
Loaded genesim_mainnet_100000.ssz...
Starting simulation...
:............................... slot: 32 epoch: 1
:............................... slot: 64 epoch: 2
:Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 130.2083333333333
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
     213.807,       15.996,      208.000,      337.122,           62, Process non-epoch slot with block
    1929.787,     2066.848,      468.305,     3391.269,            2, Process epoch slot with block
       0.351,        0.047,        0.014,        0.398,           64, Tree-hash block
       1.450,        0.299,        1.303,        2.880,           64, Retrieve committee once using get_beacon_committee
       0.213,        0.014,        0.148,        0.328,         1536, Combine committee attestations

real	0m25.838s
user	0m25.513s
sys	0m0.184s
```

In `state_sim` at least, this achieves the optimal exactly one shuffling per slot.