### PR TITLE
3x blocksim speedup by using EpochRef in attestation pool addResolved

### DIFF
--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  chronicles, tables,
+  chronicles, sequtils, tables,
   metrics, stew/results,
   ../ssz/merkleization, ../state_transition, ../extras,
   ../spec/[crypto, datatypes, digest, helpers],
@@ -46,8 +46,8 @@ proc addResolvedBlock(
   doAssert state.slot == signedBlock.message.slot, "state must match block"
 
   let blockRef = BlockRef.init(blockRoot, signedBlock.message)
-  parent.epochsInfo =
-    @[populateEpochCache(state, state.slot.compute_epoch_at_slot)]
+  blockRef.epochsInfo = filterIt(parent.epochsInfo,
+    it.epoch + 1 >= state.slot.compute_epoch_at_slot)
   link(parent, blockRef)
 
   dag.blocks[blockRoot] = blockRef

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -39,7 +39,7 @@ type Timers = enum
 
 # TODO confutils is an impenetrable black box. how can a help text be added here?
 cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 100, # One per shard is minimum
+       validators = SLOTS_PER_EPOCH * 130, # One per shard is minimum
        attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.73,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -10,7 +10,7 @@
 import
   options, sequtils, unittest,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[datatypes, digest, helpers, validator],
+  ../beacon_chain/spec/[datatypes, digest, validator],
   ../beacon_chain/[beacon_node_types, block_pool, state_transition, ssz]
 
 suiteReport "BlockRef and helpers" & preset():
@@ -278,7 +278,7 @@ suiteReport "Block pool processing" & preset():
       tmpState.data.data.slot == bs1.parent.slot
 
 when const_preset == "minimal":  # These require some minutes in mainnet
-  import ../beacon_chain/spec/validator
+  import ../beacon_chain/spec/helpers
 
   suiteReport "BlockPool finalization tests" & preset():
     setup:


### PR DESCRIPTION
Before:
```
Loaded genesim_mainnet_4160.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
................................ slot: 96 epoch: 3
................................ slot: 128 epoch: 4
................................ slot: 160 epoch: 5
................................ slot: 192 epoch: 6
Done!
Validators: 4160, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
     258.414,       28.096,      187.628,      533.518,          186, Process non-epoch slot with block
     572.866,      156.315,      338.179,      688.885,            6, Process epoch slot with block
       0.243,        0.027,        0.020,        0.286,          192, Tree-hash block
       1.660,        0.126,        1.347,        2.006,          192, Sign block
     855.564,       57.341,      697.230,      990.150,          192, Have committee attest to block
      31.057,        0.000,       31.057,       31.057,            1, Replay all produced blocks

real	3m50.531s
user	3m36.070s
```

After:
```
Loaded genesim_mainnet_4160.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
................................ slot: 96 epoch: 3
................................ slot: 128 epoch: 4
................................ slot: 160 epoch: 5
................................ slot: 192 epoch: 6
Done!
Validators: 4160, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
     224.460,       25.196,      171.755,      519.183,          186, Process non-epoch slot with block
     551.169,      196.656,      266.442,      703.590,            6, Process epoch slot with block
       0.238,        0.026,        0.017,        0.271,          192, Tree-hash block
       1.628,        0.118,        1.364,        1.902,          192, Sign block
     170.123,       15.204,      137.368,      222.527,          192, Have committee attest to block
      34.789,        0.000,       34.789,       34.789,            1, Replay all produced blocks

real	1m19.671s
user	1m18.089s
```

Before, the bottleneck was related to calculating committees, `get_attesting_indices_seq` from attestation pool `addResolved` in particular, which eventually resolves to the usual `get_beacon_committee()` set of functions. `Have committee attest to block` in particular is a quarter of what it was, almost entirely driving this improvement.

With this PR, the bottlenecks are
- `handleAttestations()` (39%) calling `get_attestation_signature()` (35.2%) calling `blsSign()` calling `sign()`/`coreSign()` (35%) calling `hashToG2()` (32%);
- `proposeBlock()` (36.6%) mainly through a diffuse network of copying `HashedBeaconState`s between local `StateData`s and the in-memory cache via `updateStateData()`, `getStateDataCached()`, and `putState()`;
- `hashToG2()` as a whole, which is `handleAttestations()` plus another 3% somewhere, for 35% total.
- and `genericAssignAux` (28.4%), which mostly is within the transitive closure of `proposeBlock()`.

`get_shuffled_seq()` is about 10% total, which can/should be driven down further, but t's not the main problem at this point. A couple days ago, it was 70-85%.

One obvious question is whether caching whole `HashedBeaconState`s every slot (`putState()`) is too slow to be worthwhile now, which is readily enough tested, and fortunately, if so, that would save both CPU and memory.