### PR TITLE
temporary workaround for witti attestation dropping

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -532,6 +532,14 @@ proc isValidAttestation*(
             attestation_pool_validation = validation.aggregation_bits
           return false
 
+  # Temporary: on Witti testnet, attestations and blocks routinely come in out
+  # of order. TODO we need to support this case but to enable participation in
+  # Witti, before https://github.com/status-im/nim-beacon-chain/issues/1106 is
+  # fixed, just disable these validations for now.
+  const kludge = true
+  if kludge:
+    return true
+
   # The block being voted for (attestation.data.beacon_block_root) passes
   # validation.
   # We rely on the block pool to have been validated, so check for the


### PR DESCRIPTION
This PR can be merged if people think it's worth the tradeoff -- it temporarily disables two of the attestation validation checks which are causing Witti issues related to beacon blocks/blockpool. https://github.com/status-im/nim-beacon-chain/issues/1106 tracks the actual fix.

Or, it can be used standalone, for people to see if it fixes the attestation stability issues people are experiencing in Witti.

@dryajov has suggested also increasing the log levels to all `TRACE`:
```
diff --git a/Makefile b/Makefile
index 85c2b87..1c562ac 100644
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ witti: | build deps
 	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="$(LOG_LEVEL)" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
 
 witti-dev: | build deps
-	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
+	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="TRACE; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
 
 clean: | clean-common
 	rm -rf build/{$(TOOLS_CSV),all_tests,*_node,*ssz*,beacon_node_testnet*,block_sim,state_sim,transition*}
```

With also verifying that it's not disconnecting any more than usual:
```
$ grep "Received Goodbye message" nbc.log | wc -l
87
$ grep "Received Goodbye message" truncated_nbc9.txt | wc -l
88
```

The logging can be filtered as @dryajov suggested as well, by, e.g.,:
> tail -f nbc.log| grep -i "processing message with id\|forwarding message to\|message already processed, skipping\|dropping message due to failed signature verification\|dropping message due to failed validation\|eof\|finalized\|decoded msg from peer\|Received Goodbye message\|connected"