### PR TITLE
Remove three skipMerkleValidation usages

### DIFF
--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -647,7 +647,7 @@ proc updateStateData*(dag: CandidateChains, state: var StateData, bs: BlockSlot)
     let ok =
       dag.skipAndUpdateState(
         state, ancestors[i],
-        {skipBlsValidation, skipMerkleValidation, skipStateRootValidation},
+        {skipBlsValidation, skipStateRootValidation},
         false)
     doAssert ok, "Blocks in database should never fail to apply.."
 

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -104,8 +104,8 @@ template mockGenesisDepositsImpl(
       ) =
   # Genesis deposits with varying amounts
 
-  # NOTE: this could also apply for skipMerkleValidation, but prefer to er on the
-  # side of caution and generate a valid Deposit (it can still be skipped later).
+  # NOTE: prefer to er on the side of caution and generate a valid Deposit
+  # (it can still be skipped later).
   if skipBlsValidation in flags:
     # 1st loop - build deposit data
     for valIdx in 0 ..< validatorCount.int:

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -2,7 +2,7 @@
 
 import
   unittest, stint, ./testutil, stew/byteutils,
-  ../beacon_chain/[extras, interop, ssz],
+  ../beacon_chain/[interop, merkle_minimal, ssz],
   ../beacon_chain/spec/[beaconstate, crypto, datatypes]
 
 # Interop test yaml, found here:
@@ -146,13 +146,14 @@ suiteReport "Interop":
     for i in 0..<64:
       let privKey = makeInteropPrivKey(i)
       deposits.add makeDeposit(privKey.toPubKey(), privKey)
+    attachMerkleProofs(deposits)
 
     const genesis_time = 1570500000
     var
       # TODO this currently requires skipMerkleValidation to pass the test
       # makeDeposit doesn't appear to produce a proof?
       initialState = initialize_beacon_state_from_eth1(
-        eth1BlockHash, genesis_time, deposits, {skipMerkleValidation})
+        eth1BlockHash, genesis_time, deposits, {})
 
     # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state
     initialState.genesis_time = genesis_time

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -150,8 +150,6 @@ suiteReport "Interop":
 
     const genesis_time = 1570500000
     var
-      # TODO this currently requires skipMerkleValidation to pass the test
-      # makeDeposit doesn't appear to produce a proof?
       initialState = initialize_beacon_state_from_eth1(
         eth1BlockHash, genesis_time, deposits, {})
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -69,8 +69,7 @@ proc makeInitialDeposits*(
   # and ideally (but not yet) efficiently only once calculating a Merkle
   # tree utilizing as much of the shared substructure as feasible, means
   # attaching proofs all together, as a separate step.
-  if skipMerkleValidation notin flags:
-    attachMerkleProofs(result)
+  attachMerkleProofs(result)
 
 func signBlock*(
     fork: Fork, genesis_validators_root: Eth2Digest, blck: BeaconBlock,


### PR DESCRIPTION
Follow-up to https://github.com/status-im/nim-beacon-chain/pull/879

This is all tech debt that should be removed.

The three remaining references are:
```
beacon_chain/beacon_node.nim
1025:        eth1Hash, startTime, deposits, {skipBlsValidation, skipMerkleValidation})

beacon_chain/spec/beaconstate.nim
58:  if skipMerkleValidation notin flags and not is_valid_merkle_branch(

beacon_chain/extras.nim
23:    skipMerkleValidation ##\
```

Which `beacon_chain/beacon_node.nim` is causing. This leaves beacon_node for another PR.