### PR TITLE
Azure: reduce 32-bit Windows job runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,13 @@ all: | $(TOOLS) libnfuzz.so libnfuzz.a
 # must be included after the default target
 -include $(BUILD_SYSTEM_DIR)/makefiles/targets.mk
 
+ifeq ($(OS), Windows_NT)
+  ifeq ($(ARCH), x86)
+    # 32-bit Windows is not supported by libbacktrace/libunwind
+    USE_LIBBACKTRACE := 0
+  endif
+endif
+
 # "--define:release" implies "--stacktrace:off" and it cannot be added to config.nims
 ifeq ($(USE_LIBBACKTRACE), 0)
 NIM_PARAMS := $(NIM_PARAMS) -d:debug -d:disable_libbacktrace

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,13 +63,13 @@ jobs:
           git config --global core.longpaths true
           git config --global core.autocrlf false
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
-          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} fetch-dlls
-          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
-          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
-          #file build/beacon_node
-          ## fail fast
-          #export NIMTEST_ABORT_ON_ERROR=1
-          #scripts/setup_official_tests.sh jsonTestsCache
-          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} DISABLE_TEST_FIXTURES_SCRIPT=1 test
+          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} fetch-dlls
+          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
+          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+          file build/beacon_node
+          # fail fast
+          export NIMTEST_ABORT_ON_ERROR=1
+          scripts/setup_official_tests.sh jsonTestsCache
+          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} DISABLE_TEST_FIXTURES_SCRIPT=1 test
         displayName: 'build and test'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,10 @@ jobs:
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} fetch-dlls
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
-          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+          if [[ $PLATFORM == "x64" ]]; then
+            # everything builds more slowly on 32-bit, since there's no libbacktrace support
+            mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+          fi
           file build/beacon_node
           # fail fast
           export NIMTEST_ABORT_ON_ERROR=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,12 +63,13 @@ jobs:
           git config --global core.longpaths true
           git config --global core.autocrlf false
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} CI_CACHE=NimBinaries update
-          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} fetch-dlls
-          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
-          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
-          file build/beacon_node
-          # fail fast
-          export NIMTEST_ABORT_ON_ERROR=1
-          scripts/setup_official_tests.sh jsonTestsCache
-          mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} DISABLE_TEST_FIXTURES_SCRIPT=1 test
+          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} fetch-dlls
+          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
+          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+          #file build/beacon_node
+          ## fail fast
+          #export NIMTEST_ABORT_ON_ERROR=1
+          #scripts/setup_official_tests.sh jsonTestsCache
+          #mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} DISABLE_TEST_FIXTURES_SCRIPT=1 test
         displayName: 'build and test'
+


### PR DESCRIPTION
The 32-bit Windows build times out. Let's make sure the compiler is cached before taking other measures.