### PR TITLE
initial v0.12.1 attestation subnet transition

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -731,12 +731,20 @@ proc installAttestationHandlers(node: BeaconNode) =
   for it in 0'u64 ..< ATTESTATION_SUBNET_COUNT.uint64:
     closureScope:
       let ci = it
-      attestationSubscriptions.add(node.network.subscribe(
-        getMainnetAttestationTopic(node.forkDigest, ci), attestationHandler,
-        # This proc needs to be within closureScope; don't lift out of loop.
-        proc(attestation: Attestation): bool =
-          attestationValidator(attestation, ci)
-      ))
+      when ETH2_SPEC == "v0.12.1":
+        attestationSubscriptions.add(node.network.subscribe(
+          getAttestationTopic(node.forkDigest, ci), attestationHandler,
+          # This proc needs to be within closureScope; don't lift out of loop.
+          proc(attestation: Attestation): bool =
+            attestationValidator(attestation, ci)
+        ))
+      else:
+        attestationSubscriptions.add(node.network.subscribe(
+          getMainnetAttestationTopic(node.forkDigest, ci), attestationHandler,
+          # This proc needs to be within closureScope; don't lift out of loop.
+          proc(attestation: Attestation): bool =
+            attestationValidator(attestation, ci)
+        ))
 
   when ETH2_SPEC == "v0.11.3":
     # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#interop-3

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -145,7 +145,7 @@ func getEpochInfo*(blck: BlockRef, epoch: Epoch): EpochRef =
 
   if matching_epochinfo.len == 0:
     trace "candidate_chains.getEpochInfo: parent.epochInfo missing"
-    raiseAssert "TOOD remove this assert before committing"
+    raiseAssert "callers to non-BeaconState getEpochInfo should ensure it's seeded"
   elif matching_epochinfo.len == 1:
     matching_epochinfo[0]
   else:

--- a/beacon_chain/inspector.nim
+++ b/beacon_chain/inspector.nim
@@ -207,8 +207,12 @@ func getTopics(forkDigest: ForkDigest,
     var topics = newSeq[string](ATTESTATION_SUBNET_COUNT * 2)
     var offset = 0
     for i in 0'u64 ..< ATTESTATION_SUBNET_COUNT.uint64:
-      topics[offset] = getMainnetAttestationTopic(forkDigest, i)
-      topics[offset + 1] = getMainnetAttestationTopic(forkDigest, i) & "_snappy"
+      when ETH2_SPEC == "v0.12.1":
+        topics[offset] = getAttestationTopic(forkDigest, i)
+        topics[offset + 1] = getAttestationTopic(forkDigest, i) & "_snappy"
+      else:
+        topics[offset] = getMainnetAttestationTopic(forkDigest, i)
+        topics[offset + 1] = getMainnetAttestationTopic(forkDigest, i) & "_snappy"
       offset += 2
     topics
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -64,7 +64,13 @@ func get_active_validator_indices*(state: BeaconState, epoch: Epoch):
     if is_active_validator(val, epoch):
       result.add idx.ValidatorIndex
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#get_committee_count_at_slot
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_committee_count_at_slot
+func get_committee_count_at_slot*(num_active_validators: auto):
+    uint64 =
+  clamp(
+    num_active_validators div SLOTS_PER_EPOCH div TARGET_COMMITTEE_SIZE,
+    1, MAX_COMMITTEES_PER_SLOT).uint64
+
 func get_committee_count_at_slot*(state: BeaconState, slot: Slot): uint64 =
   # Return the number of committees at ``slot``.
 
@@ -74,10 +80,7 @@ func get_committee_count_at_slot*(state: BeaconState, slot: Slot): uint64 =
   # CommitteeIndex return type here.
   let epoch = compute_epoch_at_slot(slot)
   let active_validator_indices = get_active_validator_indices(state, epoch)
-  let committees_per_slot = clamp(
-    len(active_validator_indices) div SLOTS_PER_EPOCH div TARGET_COMMITTEE_SIZE,
-    1, MAX_COMMITTEES_PER_SLOT).uint64
-  result = committees_per_slot
+  result = get_committee_count_at_slot(len(active_validator_indices))
 
   # Otherwise, get_beacon_committee(...) cannot access some committees.
   doAssert (SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT).uint64 >= result

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -108,5 +108,6 @@ when ETH2_SPEC == "v0.12.1":
       raiseAssert e.msg
 
   func getAttestationTopic*(forkDigest: ForkDigest, attestation: Attestation, num_active_validators: uint64): string =
-    let attestation_subnet = compute_subnet_for_attestation(num_active_validators, attestation)
-    getAttestationTopic(forkDigest, attestation_subnet)
+    getAttestationTopic(
+      forkDigest,
+      compute_subnet_for_attestation(num_active_validators, attestation))

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -12,14 +12,17 @@ import
   datatypes
 
 const
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#topics-and-messages
   topicBeaconBlocksSuffix* = "beacon_block/ssz"
-  topicMainnetAttestationsSuffix* = "_beacon_attestation/ssz"
   topicVoluntaryExitsSuffix* = "voluntary_exit/ssz"
   topicProposerSlashingsSuffix* = "proposer_slashing/ssz"
   topicAttesterSlashingsSuffix* = "attester_slashing/ssz"
   topicAggregateAndProofsSuffix* = "beacon_aggregate_and_proof/ssz"
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#configuration
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/p2p-interface.md#topics-and-messages
+  topicMainnetAttestationsSuffix* = "_beacon_attestation/ssz"
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#misc
   ATTESTATION_SUBNET_COUNT* = 64
 
   defaultEth2TcpPort* = 9000
@@ -30,35 +33,30 @@ const
 when ETH2_SPEC == "v0.11.3":
   const topicInteropAttestationSuffix* = "beacon_attestation/ssz"
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#topics-and-messages
 func getBeaconBlocksTopic*(forkDigest: ForkDigest): string =
   try:
     &"/eth2/{$forkDigest}/{topicBeaconBlocksSuffix}"
   except ValueError as e:
     raiseAssert e.msg
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#topics-and-messages
 func getVoluntaryExitsTopic*(forkDigest: ForkDigest): string =
   try:
     &"/eth2/{$forkDigest}/{topicVoluntaryExitsSuffix}"
   except ValueError as e:
     raiseAssert e.msg
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#topics-and-messages
 func getProposerSlashingsTopic*(forkDigest: ForkDigest): string =
   try:
     &"/eth2/{$forkDigest}/{topicProposerSlashingsSuffix}"
   except ValueError as e:
     raiseAssert e.msg
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#topics-and-messages
 func getAttesterSlashingsTopic*(forkDigest: ForkDigest): string =
   try:
     &"/eth2/{$forkDigest}/{topicAttesterSlashingsSuffix}"
   except ValueError as e:
     raiseAssert e.msg
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#topics-and-messages
 func getAggregateAndProofsTopic*(forkDigest: ForkDigest): string =
   try:
     &"/eth2/{$forkDigest}/{topicAggregateAndProofsSuffix}"
@@ -72,10 +70,43 @@ when ETH2_SPEC == "v0.11.3":
     except ValueError as e:
       raiseAssert e.msg
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#mainnet-3
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/p2p-interface.md#mainnet-3
 func getMainnetAttestationTopic*(forkDigest: ForkDigest, committeeIndex: uint64): string =
+  let topicIndex = committeeIndex mod ATTESTATION_SUBNET_COUNT
   try:
-    let topicIndex = committeeIndex mod ATTESTATION_SUBNET_COUNT
     &"/eth2/{$forkDigest}/committee_index{topicIndex}{topicMainnetAttestationsSuffix}"
   except ValueError as e:
     raiseAssert e.msg
+
+when ETH2_SPEC == "v0.12.1":
+  import helpers
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-attestation
+  func compute_subnet_for_attestation*(
+      num_active_validators: uint64, attestation: Attestation): uint64 =
+    # Compute the correct subnet for an attestation for Phase 0.
+    # Note, this mimics expected Phase 1 behavior where attestations will be
+    # mapped to their shard subnet.
+    #
+    # The spec version has params (state: BeaconState, attestation: Attestation),
+    # but it's only to call get_committee_count_at_slot(), which needs only epoch
+    # and the number of active validators.
+    let
+      slots_since_epoch_start = attestation.data.slot mod SLOTS_PER_EPOCH
+      committees_since_epoch_start =
+        get_committee_count_at_slot(num_active_validators) * slots_since_epoch_start
+
+    (committees_since_epoch_start + attestation.data.index) mod ATTESTATION_SUBNET_COUNT
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-attestation
+  func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
+      string =
+    # This is for subscribing or broadcasting manually to a known index.
+    try:
+      &"/eth2/{$forkDigest}/beacon_attestation_{subnetIndex}/ssz"
+    except ValueError as e:
+      raiseAssert e.msg
+
+  func getAttestationTopic*(forkDigest: ForkDigest, attestation: Attestation, num_active_validators: uint64): string =
+    let attestation_subnet = compute_subnet_for_attestation(num_active_validators, attestation)
+    getAttestationTopic(forkDigest, attestation_subnet)

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -24,7 +24,7 @@ const
 
   MAX_COMMITTEES_PER_SLOT* {.intdefine.} = 64
 
-  TARGET_COMMITTEE_SIZE* = 2^7 ##\
+  TARGET_COMMITTEE_SIZE* = 128 ##\
   ## Number of validators in the committee attesting to one shard
   ## Per spec:
   ## For the safety of crosslinks `TARGET_COMMITTEE_SIZE` exceeds

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -106,8 +106,7 @@ proc sendAttestation*(
   when ETH2_SPEC == "v0.12.1":
     # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestations-and-aggregation
     node.network.broadcast(
-      getAttestationTopic(node.forkDigest, attestation.data.index,
-        num_active_validators),
+      getAttestationTopic(node.forkDigest, attestation, num_active_validators),
       attestation)
   else:
     # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/validator.md#broadcast-attestation

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -20,7 +20,8 @@ import
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, validator, network],
   conf, time, validator_pool, state_transition,
-  attestation_pool, block_pool, eth2_network, keystore_management,
+  attestation_pool, block_pool, block_pools/candidate_chains,
+  eth2_network, keystore_management,
   beacon_node_common, beacon_node_types, nimbus_binary_common,
   mainchain_monitor, version, ssz/merkleization, interop,
   attestation_aggregation, sync_manager, sszdump
@@ -98,23 +99,15 @@ proc isSynced(node: BeaconNode, head: BlockRef): bool =
   else:
     true
 
-proc sendAttestation*(node: BeaconNode, attestation: Attestation) =
+proc sendAttestation*(
+    node: BeaconNode, attestation: Attestation, num_active_validators: uint64) =
   logScope: pcs = "send_attestation"
 
   when ETH2_SPEC == "v0.12.1":
     # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestations-and-aggregation
-    let blck = node.blockPool.getRef(attestation.data.beacon_block_root)
-
-    if blck.isNil:
-      debug "Attempt to send attestation without corresponding block"
-      return
-
-    let epochInfo =
-      node.blockPool.dag.getEpochInfo(
-        attestation.data.slot.compute_epoch_at_slot)
-
     node.network.broadcast(
-      getAttestationTopic(node.forkDigest, attestation.data.index, epochInfo.shuffled_active_validator_indices.len),
+      getAttestationTopic(node.forkDigest, attestation.data.index,
+        num_active_validators),
       attestation)
   else:
     # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/validator.md#broadcast-attestation
@@ -124,23 +117,34 @@ proc sendAttestation*(node: BeaconNode, attestation: Attestation) =
 
   beacon_attestations_sent.inc()
 
+proc sendAttestation*(node: BeaconNode, attestation: Attestation) =
+  # This version is for the validator API, which doesn't supply either
+  # num_active_validators or have direct access itself to it.
+  let blck = node.blockPool.getRef(attestation.data.beacon_block_root)
+
+  if blck.isNil:
+    debug "Attempt to send attestation without corresponding block"
+    return
+
+  let epochInfo =
+    blck.getEpochInfo(attestation.data.slot.compute_epoch_at_slot)
+
+  node.sendAttestation(
+    attestation, epochInfo.shuffled_active_validator_indices.len.uint64)
+
 proc createAndSendAttestation(node: BeaconNode,
                               fork: Fork,
                               genesis_validators_root: Eth2Digest,
                               validator: AttachedValidator,
                               attestationData: AttestationData,
                               committeeLen: int,
-                              indexInCommittee: int) {.async.} =
+                              indexInCommittee: int,
+                              num_active_validators: uint64) {.async.} =
   logScope: pcs = "send_attestation"
 
   var attestation = await validator.produceAndSignAttestation(attestationData, committeeLen, indexInCommittee, fork, genesis_validators_root)
 
-  # TODO the non-API caller here already has a state, etc, which has this
-  # this information without resorting to epochRef: split sendAttestation
-  # into the two-argument version for the validator_duty codepath, with a
-  # one-argument wrapper as one sees here to fill in from epochRef, which
-  # the validator API codepath uses.
-  node.sendAttestation(attestation)
+  node.sendAttestation(attestation, num_active_validators)
 
   if node.config.dumpEnabled:
     dump(node.config.dumpDir, attestation.data, validator.pubKey)
@@ -335,8 +339,15 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
   #      the complexity of handling forks correctly - instead, we use an adapted
   #      version here that calculates the committee for a single slot only
   node.blockPool.withState(node.blockPool.tmpState, attestationHead):
-    var cache = get_empty_per_epoch_cache()
-    let committees_per_slot = get_committee_count_at_slot(state, slot)
+    var cache = getEpochCache(attestationHead.blck, state)
+    let
+      committees_per_slot = get_committee_count_at_slot(state, slot)
+      num_active_validators =
+        try:
+          cache.shuffled_active_validator_indices[
+            slot.compute_epoch_at_slot].len.uint64
+        except KeyError:
+          raiseAssert "getEpochCache(...) didn't fill cache"
 
     for committee_index in 0'u64..<committees_per_slot:
       let committee = get_beacon_committee(
@@ -351,7 +362,7 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     for a in attestations:
       traceAsyncErrors createAndSendAttestation(
         node, state.fork, state.genesis_validators_root, a.validator, a.data,
-        a.committeeLen, a.indexInCommittee)
+        a.committeeLen, a.indexInCommittee, num_active_validators)
 
 proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
     Future[BlockRef] {.async.} =

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -19,45 +19,89 @@ suiteReport "Honest validator":
         true
       getAggregateAndProofsTopic(forkDigest) == "/eth2/00000000/beacon_aggregate_and_proof/ssz"
 
-  timedTest "Mainnet attestation topics":
-    check:
-      getMainnetAttestationTopic(forkDigest, 0) ==
-        "/eth2/00000000/committee_index0_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 9) ==
-        "/eth2/00000000/committee_index9_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 10) ==
-        "/eth2/00000000/committee_index10_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 11) ==
-        "/eth2/00000000/committee_index11_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 14) ==
-        "/eth2/00000000/committee_index14_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 22) ==
-        "/eth2/00000000/committee_index22_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 34) ==
-        "/eth2/00000000/committee_index34_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 46) ==
-        "/eth2/00000000/committee_index46_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 60) ==
-        "/eth2/00000000/committee_index60_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 63) ==
-        "/eth2/00000000/committee_index63_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 200) ==
-        "/eth2/00000000/committee_index8_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 400) ==
-        "/eth2/00000000/committee_index16_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 469) ==
-        "/eth2/00000000/committee_index21_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 550) ==
-        "/eth2/00000000/committee_index38_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 600) ==
-        "/eth2/00000000/committee_index24_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 613) ==
-        "/eth2/00000000/committee_index37_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 733) ==
-        "/eth2/00000000/committee_index29_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 775) ==
-        "/eth2/00000000/committee_index7_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 888) ==
-        "/eth2/00000000/committee_index56_beacon_attestation/ssz"
-      getMainnetAttestationTopic(forkDigest, 995) ==
-        "/eth2/00000000/committee_index35_beacon_attestation/ssz"
+  when ETH2_SPEC == "v0.11.3":
+    timedTest "Mainnet attestation topics":
+      check:
+        getMainnetAttestationTopic(forkDigest, 0) ==
+          "/eth2/00000000/committee_index0_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 9) ==
+          "/eth2/00000000/committee_index9_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 10) ==
+          "/eth2/00000000/committee_index10_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 11) ==
+          "/eth2/00000000/committee_index11_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 14) ==
+          "/eth2/00000000/committee_index14_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 22) ==
+          "/eth2/00000000/committee_index22_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 34) ==
+          "/eth2/00000000/committee_index34_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 46) ==
+          "/eth2/00000000/committee_index46_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 60) ==
+          "/eth2/00000000/committee_index60_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 63) ==
+          "/eth2/00000000/committee_index63_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 200) ==
+          "/eth2/00000000/committee_index8_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 400) ==
+          "/eth2/00000000/committee_index16_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 469) ==
+          "/eth2/00000000/committee_index21_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 550) ==
+          "/eth2/00000000/committee_index38_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 600) ==
+          "/eth2/00000000/committee_index24_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 613) ==
+          "/eth2/00000000/committee_index37_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 733) ==
+          "/eth2/00000000/committee_index29_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 775) ==
+          "/eth2/00000000/committee_index7_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 888) ==
+          "/eth2/00000000/committee_index56_beacon_attestation/ssz"
+        getMainnetAttestationTopic(forkDigest, 995) ==
+          "/eth2/00000000/committee_index35_beacon_attestation/ssz"
+  else:
+    timedTest "Mainnet attestation topics":
+      check:
+        getAttestationTopic(forkDigest, 0) ==
+          "/eth2/00000000/beacon_attestation_0/ssz"
+        getAttestationTopic(forkDigest, 5) ==
+          "/eth2/00000000/beacon_attestation_5/ssz"
+        getAttestationTopic(forkDigest, 7) ==
+          "/eth2/00000000/beacon_attestation_7/ssz"
+        getAttestationTopic(forkDigest, 9) ==
+          "/eth2/00000000/beacon_attestation_9/ssz"
+        getAttestationTopic(forkDigest, 13) ==
+          "/eth2/00000000/beacon_attestation_13/ssz"
+        getAttestationTopic(forkDigest, 19) ==
+          "/eth2/00000000/beacon_attestation_19/ssz"
+        getAttestationTopic(forkDigest, 20) ==
+          "/eth2/00000000/beacon_attestation_20/ssz"
+        getAttestationTopic(forkDigest, 22) ==
+          "/eth2/00000000/beacon_attestation_22/ssz"
+        getAttestationTopic(forkDigest, 25) ==
+          "/eth2/00000000/beacon_attestation_25/ssz"
+        getAttestationTopic(forkDigest, 27) ==
+          "/eth2/00000000/beacon_attestation_27/ssz"
+        getAttestationTopic(forkDigest, 31) ==
+          "/eth2/00000000/beacon_attestation_31/ssz"
+        getAttestationTopic(forkDigest, 39) ==
+          "/eth2/00000000/beacon_attestation_39/ssz"
+        getAttestationTopic(forkDigest, 45) ==
+          "/eth2/00000000/beacon_attestation_45/ssz"
+        getAttestationTopic(forkDigest, 47) ==
+          "/eth2/00000000/beacon_attestation_47/ssz"
+        getAttestationTopic(forkDigest, 48) ==
+          "/eth2/00000000/beacon_attestation_48/ssz"
+        getAttestationTopic(forkDigest, 50) ==
+          "/eth2/00000000/beacon_attestation_50/ssz"
+        getAttestationTopic(forkDigest, 53) ==
+          "/eth2/00000000/beacon_attestation_53/ssz"
+        getAttestationTopic(forkDigest, 54) ==
+          "/eth2/00000000/beacon_attestation_54/ssz"
+        getAttestationTopic(forkDigest, 62) ==
+          "/eth2/00000000/beacon_attestation_62/ssz"
+        getAttestationTopic(forkDigest, 63) ==
+          "/eth2/00000000/beacon_attestation_63/ssz"


### PR DESCRIPTION
This is part of https://github.com/status-im/nim-beacon-chain/issues/1103 and works towards implementing the first condition of:

- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestation-subnets
- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestations-and-aggregation
- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-attestation

It doesn't properly handle this for https://github.com/status-im/nim-beacon-chain/issues/1106 or https://github.com/status-im/nim-beacon-chain/issues/1141 but that's the same as with a couple other attestation validation fields.