### PR TITLE
collect signature production and verificaiton in one place

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -9,9 +9,12 @@
 
 import
   options, chronicles,
-  ./spec/[beaconstate, datatypes, crypto, digest, helpers, validator,
-    state_transition_block],
+  ./spec/[
+    beaconstate, datatypes, crypto, digest, helpers, validator, signatures],
   ./block_pool, ./attestation_pool, ./beacon_node_types, ./ssz
+
+logScope:
+  topics = "att_aggr"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#aggregation-selection
 func is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex,
@@ -75,17 +78,20 @@ proc aggregate_attestations*(
 proc isValidAttestation*(
     pool: AttestationPool, attestation: Attestation, current_slot: Slot,
     topicCommitteeIndex: uint64): bool =
+  logScope:
+    topics = "att_aggr valid_att"
+    received_attestation = shortLog(attestation)
+
   # The attestation's committee index (attestation.data.index) is for the
   # correct subnet.
   if attestation.data.index != topicCommitteeIndex:
-    debug "isValidAttestation: attestation's committee index not for the correct subnet",
-      topicCommitteeIndex = topicCommitteeIndex,
-      attestation_data_index = attestation.data.index
+    debug "attestation's committee index not for the correct subnet",
+      topicCommitteeIndex = topicCommitteeIndex
     return false
 
   if not (attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >=
       current_slot and current_slot >= attestation.data.slot):
-    debug "isValidAttestation: attestation.data.slot not within ATTESTATION_PROPAGATION_SLOT_RANGE"
+    debug "attestation.data.slot not within ATTESTATION_PROPAGATION_SLOT_RANGE"
     return false
 
   # The attestation is unaggregated -- that is, it has exactly one
@@ -100,11 +106,10 @@ proc isValidAttestation*(
       continue
     onesCount += 1
     if onesCount > 1:
-      debug "isValidAttestation: attestation has too many aggregation bits",
-        aggregation_bits = attestation.aggregation_bits
+      debug "attestation has too many aggregation bits"
       return false
   if onesCount != 1:
-    debug "isValidAttestation: attestation has too few aggregation bits"
+    debug "attestation has too few aggregation bits"
     return false
 
   # The attestation is the first valid attestation received for the
@@ -117,9 +122,7 @@ proc isValidAttestation*(
       # Attestations might be aggregated eagerly or lazily; allow for both.
       for validation in attestationEntry.validations:
         if attestation.aggregation_bits.isSubsetOf(validation.aggregation_bits):
-          debug "isValidAttestation: attestation already exists at slot",
-            attestation_data_slot = attestation.data.slot,
-            attestation_aggregation_bits = attestation.aggregation_bits,
+          debug "attestation already exists at slot",
             attestation_pool_validation = validation.aggregation_bits
           return false
 
@@ -131,8 +134,7 @@ proc isValidAttestation*(
   # propagated - i.e. imagine that attestations are smaller than blocks and
   # therefore propagate faster, thus reordering their arrival in some nodes
   if pool.blockPool.get(attestation.data.beacon_block_root).isNone():
-    debug "isValidAttestation: block doesn't exist in block pool",
-      attestation_data_beacon_block_root = attestation.data.beacon_block_root
+    debug "block doesn't exist in block pool"
     return false
 
   # The signature of attestation is valid.
@@ -143,7 +145,7 @@ proc isValidAttestation*(
       pool.blockPool.headState.data.data,
       get_indexed_attestation(
         pool.blockPool.headState.data.data, attestation, cache), {}):
-    debug "isValidAttestation: signature verification failed"
+    debug "signature verification failed"
     return false
 
   true

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -3,7 +3,7 @@
 import
   stew/endians2, stint,
   ./extras, ./ssz/merkleization,
-  spec/[crypto, datatypes, digest, helpers, keystore]
+  spec/[crypto, datatypes, digest, keystore, signatures]
 
 func get_eth1data_stub*(deposit_count: uint64, current_epoch: Epoch): Eth1Data =
   # https://github.com/ethereum/eth2.0-pm/blob/e596c70a19e22c7def4fd3519e20ae4022349390/interop/mocked_eth1data/README.md
@@ -47,9 +47,6 @@ func makeDeposit*(
         withdrawal_credentials: makeWithdrawalCredentials(pubkey)))
 
   if skipBLSValidation notin flags:
-    let domain = compute_domain(DOMAIN_DEPOSIT)
-    let signing_root = compute_signing_root(ret.getDepositMessage, domain)
-
-    ret.data.signature = bls_sign(privkey, signing_root.data)
+    ret.data.signature = get_deposit_signature(ret.data, privkey)
 
   ret

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -99,16 +99,6 @@ func toPubKey*(privkey: ValidatorPrivKey): ValidatorPubKey =
   else:
     privkey.getKey
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#bls-signatures
-func aggregate*[T](values: openarray[ValidatorSig]): ValidatorSig =
-  ## Aggregate arrays of sequences of Validator Signatures
-  ## This assumes that they are real signatures
-
-  result = BlsValue[T](kind: Real, blsValue: values[0].BlsValue)
-
-  for i in 1 ..< values.len:
-    result.blsValue.aggregate(values[i].blsValue)
-
 func aggregate*(x: var ValidatorSig, other: ValidatorSig) =
   ## Aggregate 2 Validator Signatures
   ## This assumes that they are real signatures
@@ -143,13 +133,13 @@ func blsVerify*(
   #   return true
   pubkey.blsValue.verify(message, signature.blsValue)
 
-func blsSign*(privkey: ValidatorPrivKey, message: openarray[byte]): ValidatorSig =
+func blsSign*(privkey: ValidatorPrivKey, message: openArray[byte]): ValidatorSig =
   ## Computes a signature from a secret key and a message
   ValidatorSig(kind: Real, blsValue: SecretKey(privkey).sign(message))
 
-func blsFastAggregateVerify*[T: byte|char](
-       publicKeys: openarray[ValidatorPubKey],
-       message: openarray[T],
+func blsFastAggregateVerify*(
+       publicKeys: openArray[ValidatorPubKey],
+       message: openArray[byte],
        signature: ValidatorSig
      ): bool =
   ## Verify the aggregate of multiple signatures on the same message
@@ -177,7 +167,8 @@ func blsFastAggregateVerify*[T: byte|char](
     if pubkey.kind != Real:
       return false
     unwrapped.add pubkey.blsValue
-  return fastAggregateVerify(unwrapped, message, signature.blsValue)
+
+  fastAggregateVerify(unwrapped, message, signature.blsValue)
 
 proc newKeyPair*(): BlsResult[tuple[pub: ValidatorPubKey, priv: ValidatorPrivKey]] =
   ## Generates a new public-private keypair
@@ -230,14 +221,14 @@ func toRaw*(x: BlsValue): auto =
 func toHex*(x: BlsCurveType): string =
   toHex(toRaw(x))
 
-func fromRaw*(T: type ValidatorPrivKey, bytes: openarray[byte]): BlsResult[T] =
+func fromRaw*(T: type ValidatorPrivKey, bytes: openArray[byte]): BlsResult[T] =
   var val: SecretKey
   if val.fromBytes(bytes):
     ok ValidatorPrivKey(val)
   else:
     err "bls: invalid private key"
 
-func fromRaw*[N, T](BT: type BlsValue[N, T], bytes: openarray[byte]): BlsResult[BT] =
+func fromRaw*[N, T](BT: type BlsValue[N, T], bytes: openArray[byte]): BlsResult[BT] =
   # This is a workaround, so that we can deserialize the serialization of a
   # default-initialized BlsValue without raising an exception
   when defined(ssz_testing):
@@ -294,7 +285,7 @@ proc readValue*(reader: var JsonReader, value: var ValidatorPrivKey) {.
     inline, raises: [Exception].} =
   value = ValidatorPrivKey.fromHex(reader.readValue(string)).tryGet()
 
-template fromSszBytes*(T: type BlsValue, bytes: openarray[byte]): auto =
+template fromSszBytes*(T: type BlsValue, bytes: openArray[byte]): auto =
   let v = fromRaw(T, bytes)
   if v.isErr:
     raise newException(MalformedSszError, $v.error)
@@ -350,10 +341,9 @@ proc getRandomBytes*(n: Natural): seq[byte]
   if randomBytes(result) != result.len:
     raise newException(RandomSourceDepleted, "Failed to generate random bytes")
 
-proc getRandomBytesOrPanic*(output: var openarray[byte]) =
+proc getRandomBytesOrPanic*(output: var openArray[byte]) =
   doAssert randomBytes(output) == output.len
 
 proc getRandomBytesOrPanic*(n: Natural): seq[byte] =
   result = newSeq[byte](n)
   getRandomBytesOrPanic(result)
-

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -213,7 +213,7 @@ type
   DepositData* = object
     pubkey*: ValidatorPubKey
     withdrawal_credentials*: Eth2Digest
-    amount*: uint64
+    amount*: Gwei
     signature*: ValidatorSig  # Signing over DepositMessage
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#voluntaryexit
@@ -619,6 +619,14 @@ func shortLog*(v: BeaconBlock): auto =
 func shortLog*(v: SignedBeaconBlock): auto =
   (
     blck: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )
+
+func shortLog*(v: DepositData): auto =
+  (
+    pubkey: shortLog(v.pubkey),
+    withdrawal_credentials: shortlog(v.withdrawal_credentials),
+    amount: v.amount,
     signature: shortLog(v.signature)
   )
 

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -10,7 +10,7 @@ import
   stew/[results, byteutils, bitseqs, bitops2], stew/shims/macros,
   eth/keyfile/uuid, blscurve,
   nimcrypto/[sha2, rijndael, pbkdf2, bcmode, hash, sysrand],
-  datatypes, crypto, digest, helpers
+  ./datatypes, ./crypto, ./digest, ./signatures
 
 export
   results
@@ -396,9 +396,6 @@ proc prepareDeposit*(credentials: Credentials,
         pubkey: signingPubKey,
         withdrawal_credentials: makeWithdrawalCredentials(withdrawalPubKey)))
 
-  let domain = compute_domain(DOMAIN_DEPOSIT)
-  let signing_root = compute_signing_root(ret.getDepositMessage, domain)
+  ret.data.signature = get_deposit_signature(ret.data, credentials.signingKey)
 
-  ret.data.signature = bls_sign(credentials.signingKey, signing_root.data)
   ret
-

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
 import
   ./crypto, ./digest, ./datatypes, ./helpers, ../ssz/merkleization
 

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -1,0 +1,128 @@
+import
+  ./crypto, ./digest, ./datatypes, ./helpers, ../ssz/merkleization
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#aggregation-selection
+func get_slot_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    privkey: ValidatorPrivKey): ValidatorSig =
+  let
+    epoch = compute_epoch_at_slot(slot)
+    domain = get_domain(
+      fork, DOMAIN_SELECTION_PROOF, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(slot, domain)
+
+  blsSign(privKey, signing_root.data)
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#randao-reveal
+func get_epoch_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
+    privkey: ValidatorPrivKey): ValidatorSig =
+  let
+    domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(epoch, domain)
+
+  blsSign(privKey, signing_root.data)
+
+func verify_epoch_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
+    pubkey: ValidatorPubKey, signature: ValidatorSig): bool =
+  let
+    domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(epoch, domain)
+
+  blsVerify(pubkey, signing_root.data, signature)
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#signature
+func get_block_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    root: Eth2Digest, privkey: ValidatorPrivKey): ValidatorSig =
+  let
+    epoch = compute_epoch_at_slot(slot)
+    domain = get_domain(
+      fork, DOMAIN_BEACON_PROPOSER, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(root, domain)
+
+  blsSign(privKey, signing_root.data)
+
+func verify_block_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
+    blck: Eth2Digest | BeaconBlock | BeaconBlockHeader, pubkey: ValidatorPubKey,
+    signature: ValidatorSig): bool =
+  let
+    epoch = compute_epoch_at_slot(slot)
+    domain = get_domain(
+      fork, DOMAIN_BEACON_PROPOSER, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(blck, domain)
+
+  blsVerify(pubKey, signing_root.data, signature)
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-aggregate
+func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
+                                        aggregate_and_proof: AggregateAndProof,
+                                        privKey: ValidatorPrivKey): ValidatorSig =
+  let
+    epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
+    domain = get_domain(
+      fork, DOMAIN_AGGREGATE_AND_PROOF, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(aggregate_and_proof, domain)
+
+  blsSign(privKey, signing_root.data)
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#aggregate-signature
+func get_attestation_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    attestation_data: AttestationData,
+    privkey: ValidatorPrivKey): ValidatorSig =
+  let
+    epoch = attestation_data.target.epoch
+    domain = get_domain(
+      fork, DOMAIN_BEACON_ATTESTER, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(attestation_data, domain)
+
+  blsSign(privKey, signing_root.data)
+
+func verify_attestation_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    attestation_data: AttestationData,
+    pubkeys: openArray[ValidatorPubKey],
+    signature: ValidatorSig): bool =
+  let
+    epoch = attestation_data.target.epoch
+    domain = get_domain(
+      fork, DOMAIN_BEACON_ATTESTER, epoch, genesis_validators_root)
+    signing_root = compute_signing_root(attestation_data, domain)
+
+  blsFastAggregateVerify(pubkeys, signing_root.data, signature)
+
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#deposits
+func get_deposit_signature*(
+    deposit: DepositData,
+    privkey: ValidatorPrivKey): ValidatorSig =
+
+  let
+    deposit_message = deposit.getDepositMessage()
+    # Fork-agnostic domain since deposits are valid across forks
+    domain = compute_domain(DOMAIN_DEPOSIT)
+    signing_root = compute_signing_root(deposit_message, domain)
+
+  blsSign(privKey, signing_root.data)
+
+func verify_deposit_signature*(deposit: DepositData): bool =
+  let
+    deposit_message = deposit.getDepositMessage()
+    # Fork-agnostic domain since deposits are valid across forks
+    domain = compute_domain(DOMAIN_DEPOSIT)
+    signing_root = compute_signing_root(deposit_message, domain)
+
+  blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
+
+func verify_voluntary_exit_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    voluntary_exit: VoluntaryExit,
+    pubkey: ValidatorPubKey, signature: ValidatorSig): bool =
+  let
+    domain = get_domain(
+      fork, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch, genesis_validators_root)
+    signing_root = compute_signing_root(voluntary_exit, domain)
+
+  blsVerify(pubkey, signing_root.data, signature)

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -1,7 +1,7 @@
 import
   tables,
   chronos, chronicles,
-  spec/[datatypes, crypto, digest, state_transition_block],
+  spec/[datatypes, crypto, digest, signatures, helpers],
   beacon_node_types
 
 func init*(T: type ValidatorPool): T =
@@ -83,7 +83,8 @@ proc signAggregateAndProof*(v: AttachedValidator,
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#randao-reveal
 func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork,
     genesis_validators_root: Eth2Digest, slot: Slot): ValidatorSig =
-  get_epoch_signature(fork, genesis_validators_root, slot, k)
+  get_epoch_signature(
+    fork, genesis_validators_root, slot.compute_epoch_at_slot, k)
 
 func genRandaoReveal*(v: AttachedValidator, fork: Fork,
     genesis_validators_root: Eth2Digest, slot: Slot): ValidatorSig =

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -20,8 +20,7 @@ import
   options, random, tables,
   ../tests/[testblockutil],
   ../beacon_chain/spec/[
-    beaconstate, crypto, datatypes, digest, helpers, validator,
-    state_transition_block],
+    beaconstate, crypto, datatypes, digest, helpers, validator, signatures],
   ../beacon_chain/[
     attestation_pool, block_pool, beacon_node_types, beacon_chain_db,
     interop, state_transition, validator_pool],

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -13,7 +13,7 @@ import
   sets,
   # Specs
   ../../beacon_chain/spec/[datatypes, beaconstate, helpers, validator, crypto,
-     state_transition_block],
+    signatures],
   # Internals
   ../../beacon_chain/[ssz, extras, state_transition],
   # Mocking procs

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -8,7 +8,7 @@
 import
   options,
   # Specs
-  ../../beacon_chain/spec/[datatypes, validator, state_transition_block],
+  ../../beacon_chain/spec/[datatypes, helpers, signatures, validator],
   # Internals
   ../../beacon_chain/[ssz, extras],
   # Mock helpers
@@ -27,7 +27,8 @@ proc signMockBlockImpl(
   let privkey = MockPrivKeys[signedBlock.message.proposer_index]
 
   signedBlock.message.body.randao_reveal = get_epoch_signature(
-    state.fork, state.genesis_validators_root, block_slot, privkey)
+    state.fork, state.genesis_validators_root, block_slot.compute_epoch_at_slot,
+    privkey)
   signedBlock.signature = get_block_signature(
     state.fork, state.genesis_validators_root, block_slot,
     hash_tree_root(signedBlock.message), privkey)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -12,7 +12,7 @@ import
   ../beacon_chain/ssz/merkleization,
     state_transition, validator_pool],
   ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest,
-    helpers, validator, state_transition_block]
+    helpers, validator, signatures]
 
 func makeFakeValidatorPrivKey(i: int): ValidatorPrivKey =
   # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
@@ -44,7 +44,6 @@ func makeDeposit(i: int, flags: UpdateFlags): Deposit =
     privkey = makeFakeValidatorPrivKey(i)
     pubkey = privkey.toPubKey()
     withdrawal_credentials = makeFakeHash(i)
-    domain = compute_domain(DOMAIN_DEPOSIT, Version(GENESIS_FORK_VERSION))
 
   result = Deposit(
     data: DepositData(
@@ -55,8 +54,7 @@ func makeDeposit(i: int, flags: UpdateFlags): Deposit =
   )
 
   if skipBLSValidation notin flags:
-    let signing_root = compute_signing_root(result.getDepositMessage, domain)
-    result.data.signature = bls_sign(privkey, signing_root.data)
+    result.data.signature = get_deposit_signature(result.data, privkey)
 
 proc makeInitialDeposits*(
     n = SLOTS_PER_EPOCH, flags: UpdateFlags = {}): seq[Deposit] =


### PR DESCRIPTION
Signatures are made over data and domain - here we collect all such
activities in one place.

Also:
* security: fix cast-before-range-check
* log block/attestation verification consistently
* run block verification based on `getProposer` in its own history
* clean up some unused stuff