### PR TITLE
Start discovery after starting libp2p switch

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -838,8 +838,8 @@ proc start*(node: Eth2Node) {.async.} =
   for i in 0 ..< ConcurrentConnections:
     node.connWorkers.add connectWorker(node)
 
-  node.discovery.start()
   node.libp2pTransportLoops = await node.switch.start()
+  node.discovery.start()
   node.discoveryLoop = node.runDiscoveryLoop()
   traceAsyncErrors node.discoveryLoop
 


### PR DESCRIPTION
This should improve possible failures in `eth2_network_simulation`, failures due to lack of connections with the 3 other peers. Specifically when a node is connecting to another one that was discovered, but that didn't actually start the libp2p transport listener yet.

That being said, I did notice it fail connecting to all 3 peers with this applied still, TBI.