### PR TITLE
eth2hash -> eth2digest

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -24,7 +24,7 @@ func is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex,
   let
     committee = get_beacon_committee(state, slot, index, cache)
     modulo = max(1, len(committee) div TARGET_AGGREGATORS_PER_COMMITTEE).uint64
-  bytes_to_int(eth2hash(slot_signature.toRaw()).data[0..7]) mod modulo == 0
+  bytes_to_int(eth2digest(slot_signature.toRaw()).data[0..7]) mod modulo == 0
 
 proc aggregate_attestations*(
     pool: AttestationPool, state: BeaconState, index: CommitteeIndex,

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -25,7 +25,7 @@ func makeInteropPrivKey*(i: int): ValidatorPrivKey =
     curveOrder =
       "52435875175126190479447740508185965837690552500527637822603658699938581184513".parse(UInt256)
 
-    privkeyBytes = eth2hash(bytes)
+    privkeyBytes = eth2digest(bytes)
     key = (UInt256.fromBytesLE(privkeyBytes.data) mod curveOrder).toBytesBE()
 
   ValidatorPrivKey.fromRaw(key).get

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -29,7 +29,7 @@ func is_valid_merkle_branch*(leaf: Eth2Digest, branch: openarray[Eth2Digest], de
     else:
       buf[0..31] = value.data
       buf[32..63] = branch[i.int].data
-    value = eth2hash(buf)
+    value = eth2digest(buf)
   value == root
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#increase_balance

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -17,7 +17,7 @@
 #
 # In our code base, to enable a smooth transition
 # (already did Blake2b --> Keccak256 --> SHA2-256),
-# we call this function `eth2hash`, and it outputs a `Eth2Digest`. Easy to sed :)
+# we call this function `eth2digest`, and it outputs a `Eth2Digest`. Easy to sed :)
 
 {.push raises: [Defect].}
 
@@ -44,7 +44,7 @@ chronicles.formatIt Eth2Digest:
 # TODO: expose an in-place digest function
 #       when hashing in loop or into a buffer
 #       See: https://github.com/cheatfate/nimcrypto/blob/b90ba3abd/nimcrypto/sha2.nim#L570
-func eth2hash*(v: openArray[byte]): Eth2Digest {.inline.} =
+func eth2digest*(v: openArray[byte]): Eth2Digest {.inline.} =
   # We use the init-update-finish interface to avoid
   # the expensive burning/clearing memory (20~30% perf)
   # TODO: security implication?
@@ -63,8 +63,7 @@ template withEth2Hash*(body: untyped): Eth2Digest =
   var h  {.inject.}: sha256
   init(h)
   body
-  var res = finish(h)
-  res
+  finish(h)
 
 func hash*(x: Eth2Digest): Hash =
   ## Hash for digests for Nim hash tables

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -212,4 +212,4 @@ func get_seed*(state: BeaconState, epoch: Epoch, domain_type: DomainType): Eth2D
   seed_input[12..43] =
     get_randao_mix(state, # Avoid underflow
       epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1).data
-  eth2hash(seed_input)
+  eth2digest(seed_input)

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -379,7 +379,7 @@ proc generateCredentials*(entropy: openarray[byte] = @[],
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/deposit-contract.md#withdrawal-credentials
 proc makeWithdrawalCredentials*(k: ValidatorPubKey): Eth2Digest =
-  var bytes = eth2hash(k.toRaw())
+  var bytes = eth2digest(k.toRaw())
   bytes.data[0] = BLS_WITHDRAWAL_PREFIX.uint8
   bytes
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -130,7 +130,7 @@ proc process_randao(
   # Mix it in
   let
     mix = get_randao_mix(state, epoch)
-    rr = eth2hash(body.randao_reveal.toRaw()).data
+    rr = eth2digest(body.randao_reveal.toRaw()).data
 
   state.randao_mixes[epoch mod EPOCHS_PER_HISTORICAL_VECTOR].data =
     mix.data xor rr

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -52,14 +52,14 @@ func get_shuffled_seq*(seed: Eth2Digest,
     source_buffer[32] = round_bytes1
 
     # Only one pivot per round.
-    let pivot = bytes_to_int(eth2hash(pivot_buffer).data.toOpenArray(0, 7)) mod list_size
+    let pivot = bytes_to_int(eth2digest(pivot_buffer).data.toOpenArray(0, 7)) mod list_size
 
     ## Only need to run, per round, position div 256 hashes, so precalculate
     ## them. This consumes memory, but for low-memory devices, it's possible
     ## to mitigate by some light LRU caching and similar.
     for reduced_position in 0 ..< sources.len:
       source_buffer[33..36] = int_to_bytes4(reduced_position.uint64)
-      sources[reduced_position] = eth2hash(source_buffer)
+      sources[reduced_position] = eth2digest(source_buffer)
 
     ## Iterate over all the indices. This was in get_permuted_index, but large
     ## efficiency gains exist in caching and re-using data.
@@ -185,7 +185,7 @@ func compute_proposer_index(state: BeaconState, indices: seq[ValidatorIndex],
     buffer[32..39] = int_to_bytes8(i.uint64 div 32)
     let
       candidate_index = shuffled_seq[(i.uint64 mod seq_len).int]
-      random_byte = (eth2hash(buffer).data)[i mod 32]
+      random_byte = (eth2digest(buffer).data)[i mod 32]
       effective_balance =
         state.validators[candidate_index].effective_balance
     if effective_balance * MAX_RANDOM_BYTE >=
@@ -217,7 +217,7 @@ func get_beacon_proposer_index*(state: BeaconState, cache: var StateCache, slot:
 
   try:
     let
-      seed = eth2hash(buffer)
+      seed = eth2digest(buffer)
       indices =
         sorted(cache.shuffled_active_validator_indices[epoch], system.cmp)
 


### PR DESCRIPTION
hash in nim is the insecure hash-map helper - might as well use `digest`
consistently to mark the difference