### PR TITLE
metric names

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -604,7 +604,7 @@ proc currentSlot(node: BeaconNode): Slot =
   node.beaconClock.now.slotOrZero
 
 proc connectedPeersCount(node: BeaconNode): int =
-  libp2p_peers.value.int
+  nbc_peers.value.int
 
 proc fromJson(n: JsonNode; argName: string; result: var Slot) =
   var i: int

--- a/scripts/connect_to_testnet.nims
+++ b/scripts/connect_to_testnet.nims
@@ -43,6 +43,9 @@ cli do (skipGoerliKey {.
         baseMetricsPort {.
           desc: "Base metrics port (nodeID will be added to it)" .} = 8008.int,
 
+        baseRpcPort {.
+          desc: "Base rpc port (nodeID will be added to it)" .} = 9090.int,
+
         testnetName {.argument .}: string):
   let
     nameParts = testnetName.split "/"
@@ -172,6 +175,8 @@ cli do (skipGoerliKey {.
     --udp-port=""" & $(basePort + nodeID) & &"""
     --metrics
     --metrics-port=""" & $(baseMetricsPort + nodeID) & &"""
+    --rpc
+    --rpc-port=""" & $(baseRpcPort + nodeID) & &"""
     {bootstrapFileOpt}
     {logLevelOpt}
     {depositContractOpt}


### PR DESCRIPTION
* fix metric names to not clash with native libp2p metrics
* run testnet node with rpc enabled by default