### PR TITLE
peers rpc call

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -705,6 +705,22 @@ proc installDebugApiHandlers(rpcServer: RpcServer, node: BeaconNode) =
 
     return res
 
+  rpcServer.rpc("peers") do () -> JsonNode:
+    var res = newJObject()
+    var peers = newJArray()
+    for id, peer in node.network.peerPool:
+      peers.add(
+        %(
+          info: shortLog(peer.info),
+          wasDialed: peer.wasDialed,
+          connectionState: $peer.connectionState,
+          score: peer.score,
+        )
+      )
+    res.add("peers", peers)
+
+    return res
+
 proc installRpcHandlers(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.installValidatorApiHandlers(node)
   rpcServer.installBeaconApiHandlers(node)

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -192,8 +192,6 @@ const
   TTFB_TIMEOUT* = 5.seconds
   RESP_TIMEOUT* = 10.seconds
 
-  readTimeoutErrorMsg = "Exceeded read timeout for a request"
-
   NewPeerScore* = 200
     ## Score which will be assigned to new connected Peer
   PeerScoreLowLimit* = 0
@@ -273,10 +271,6 @@ proc openStream(node: Eth2Node,
       return await openStream(node, peer, protocolId)
     else:
       raise
-
-func peerId(conn: Connection): PeerID =
-  # TODO: Can this be `nil`?
-  conn.peerInfo.peerId
 
 proc init*(T: type Peer, network: Eth2Node, info: PeerInfo): Peer {.gcsafe.}
 
@@ -571,6 +565,11 @@ proc handleIncomingStream(network: Eth2Node,
 
   try:
     let peer = peerFromStream(network, conn)
+
+    # TODO peer connection setup is broken, update info in some better place
+    #      whenever race is fix:
+    #      https://github.com/status-im/nim-beacon-chain/issues/1157
+    peer.info = conn.peerInfo
 
     template returnInvalidRequest(msg: ErrorMsg) =
       await sendErrorResponse(peer, conn, noSnappy, InvalidRequest, msg)


### PR DESCRIPTION
simple way to display nbc peer table

```
[arnetheduck@tempus lighthouse]$ curl -d '{"jsonrpc":"2.0","id":"id","method":"peers","params":[] }' -H 'Content-Type: application/json' localhost:9090 -s  | jq
{
  "jsonrpc": "2.0",
  "id": "id",
  "result": {
    "peers": [
      {
        "info": {
          "id": "16Uiu2HAmDPTSbDzkAPGwLTuGKH1vtcAPhE8iVEFkLWjJdz2NdkUQ",
          "addrs": [
            "/ip4/93.214.213.223/tcp/13000"
          ],
          "protocols": [],
          "protoVersion": "",
          "agentVersion": ""
        },
        "wasDialed": true,
        "connectionState": "Connected",
        "score": 200
      },
      {
        "info": {
          "id": "16Uiu2HAmNU5LnMBkM6xsXEnBBLiLqXefJoxmkbgNmFamDkJQeQ7m",
          "addrs": [
            "/ip4/51.210.9.77/tcp/9000",
            "/ip4/127.0.0.1/tcp/9000",
            "/ip4/51.210.9.77/tcp/9000",
            "/ip6/::1/tcp/9000",
            "/ip6/2001:41d0:404:200::5bf2/tcp/9000"
          ],
          "protocols": [
            "/meshsub/1.0.0",
            "/eth2/beacon_chain/req/status/1/ssz_snappy",
            "/eth2/beacon_chain/req/status/1/ssz",
            "/eth2/beacon_chain/req/goodbye/1/ssz_snappy",
            "/eth2/beacon_chain/req/goodbye/1/ssz",
            "/eth2/beacon_chain/req/beacon_blocks_by_range/1/ssz_snappy",
            "/eth2/beacon_chain/req/beacon_blocks_by_range/1/ssz",
            "/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz_snappy",
            "/eth2/beacon_chain/req/beacon_blocks_by_root/1/ssz",
            "/eth2/beacon_chain/req/ping/1/ssz_snappy",
            "/eth2/beacon_chain/req/ping/1/ssz",
            "/eth2/beacon_chain/req/metadata/1/ssz_snappy",
            "/eth2/beacon_chain/req/metadata/1/ssz",
            "/ipfs/id/1.0.0"
          ],
          "protoVersion": "lighthouse/libp2p",
          "agentVersion": "Lighthouse/v0.1.2-unstable/x86_64-linux"
        },
        "wasDialed": true,
        "connectionState": "Connected",
        "score": 300
      },
      {
        "info": {
          "id": "16Uiu2HAm3n7H1nmRg5ShhRsgV7mqu4KyRDGN7S59dCMzNWk8G38V",
          "addrs": [
```
