### PR TITLE
remove skipMerkleValidation and skipBlockParentRootValidation

### DIFF
--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -20,17 +20,12 @@
 
 type
   UpdateFlag* = enum
-    skipMerkleValidation ##\
-    ## When processing deposits, skip verifying the Merkle proof trees of each
-    ## deposit.
     skipBlsValidation ##\
     ## Skip verification of BLS signatures in block processing.
     ## Predominantly intended for use in testing, e.g. to allow extra coverage.
     ## Also useful to avoid unnecessary work when replaying known, good blocks.
     skipStateRootValidation ##\
     ## Skip verification of block state root.
-    skipBlockParentRootValidation ##\
-    ## Skip verification that the block's parent root matches the previous block header.
     verifyFinalization
 
   UpdateFlags* = set[UpdateFlag]

--- a/beacon_chain/keystore_management.nim
+++ b/beacon_chain/keystore_management.nim
@@ -109,7 +109,7 @@ proc generateDeposits*(totalValidators: int,
     let credentials = generateCredentials(password = password)
 
     let
-      keyName = $(credentials.signingKey.toPubKey)
+      keyName = intToStr(i, 6) & "_" & $(credentials.signingKey.toPubKey)
       validatorDir = validatorsDir / keyName
       passphraseFile = secretsDir / keyName
       depositFile = validatorDir / depositFileName

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -55,14 +55,14 @@ proc process_deposit*(
   # Process an Eth1 deposit, registering a validator or increasing its balance.
 
   # Verify the Merkle branch
-  if skipMerkleValidation notin flags and not is_valid_merkle_branch(
+  if not is_valid_merkle_branch(
     hash_tree_root(deposit.data),
     deposit.proof,
     DEPOSIT_CONTRACT_TREE_DEPTH + 1,  # Add 1 for the `List` length mix-in
     state.eth1_deposit_index,
     state.eth1_data.deposit_root,
   ):
-    notice "Deposit merkle validation failed",
+    notice "Deposit Merkle validation failed",
       proof = deposit.proof, deposit_root = state.eth1_data.deposit_root,
       deposit_index = state.eth1_deposit_index
     return false

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -71,8 +71,7 @@ proc process_block_header*(
     return false
 
   # Verify that the parent matches
-  if skipBlockParentRootValidation notin flags and not (blck.parent_root ==
-      hash_tree_root(state.latest_block_header)):
+  if not (blck.parent_root == hash_tree_root(state.latest_block_header)):
     notice "Block header: previous block root mismatch",
       latest_block_header = state.latest_block_header,
       blck = shortLog(blck),

--- a/tests/simulation/vars.sh
+++ b/tests/simulation/vars.sh
@@ -19,7 +19,7 @@ cd - &>/dev/null
 
 # When changing these, also update the readme section on running simulation
 # so that the run_node example is correct!
-NUM_VALIDATORS=${VALIDATORS:-192}
+NUM_VALIDATORS=${VALIDATORS:-128}
 TOTAL_NODES=${NODES:-4}
 TOTAL_USER_NODES=${USER_NODES:-0}
 TOTAL_SYSTEM_NODES=$(( TOTAL_NODES - TOTAL_USER_NODES ))


### PR DESCRIPTION
These are/were tech debt.

```
NUM_VALIDATORS=${VALIDATORS:-192}
NUM_VALIDATORS=${VALIDATORS:-128}
```
Is to keep `make eth2_network_simulation` working a little better, pending a real fix.