### PR TITLE
send and validate with v0.12.1 attestations

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -136,7 +136,7 @@ proc isValidAttestation*(
       pool.blockPool.tmpState,
       BlockSlot(blck: attestationBlck, slot: attestation.data.slot)):
     when ETH2_SPEC == "v0.12.1":
-      # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md
+      # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestation-subnets
       # [REJECT] The attestation is for the correct subnet (i.e.
       # compute_subnet_for_attestation(state, attestation) == subnet_id).
       let

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -161,7 +161,7 @@ proc isValidAttestation*(
         return false
 
     # The signature of attestation is valid.
-    var cache = get_empty_per_epoch_cache()
+    var cache = getEpochCache(blck, state)
     if not is_valid_indexed_attestation(
         state, get_indexed_attestation(state, attestation, cache), {}):
       debug "signature verification failed"

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -10,8 +10,10 @@
 import
   options, chronicles,
   ./spec/[
-    beaconstate, datatypes, crypto, digest, helpers, validator, signatures],
-  ./block_pool, ./attestation_pool, ./beacon_node_types, ./ssz
+    beaconstate, datatypes, crypto, digest, helpers, network, validator,
+    signatures],
+  ./block_pool, ./block_pools/candidate_chains, ./attestation_pool,
+  ./beacon_node_types, ./ssz
 
 logScope:
   topics = "att_aggr"
@@ -73,7 +75,6 @@ proc aggregate_attestations*(
 
   none(AggregateAndProof)
 
-
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#attestation-subnets
 proc isValidAttestation*(
     pool: AttestationPool, attestation: Attestation, current_slot: Slot,
@@ -81,13 +82,6 @@ proc isValidAttestation*(
   logScope:
     topics = "att_aggr valid_att"
     received_attestation = shortLog(attestation)
-
-  # The attestation's committee index (attestation.data.index) is for the
-  # correct subnet.
-  if attestation.data.index != topicCommitteeIndex:
-    debug "attestation's committee index not for the correct subnet",
-      topicCommitteeIndex = topicCommitteeIndex
-    return false
 
   if not (attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >=
       current_slot and current_slot >= attestation.data.slot):
@@ -133,19 +127,44 @@ proc isValidAttestation*(
   # TODO: consider a "slush pool" of attestations whose blocks have not yet
   # propagated - i.e. imagine that attestations are smaller than blocks and
   # therefore propagate faster, thus reordering their arrival in some nodes
-  if pool.blockPool.get(attestation.data.beacon_block_root).isNone():
+  let attestationBlck = pool.blockPool.getRef(attestation.data.beacon_block_root)
+  if attestationBlck.isNil:
     debug "block doesn't exist in block pool"
     return false
 
-  # The signature of attestation is valid.
-  # TODO need to know above which validator anyway, and this is too general
-  # as it supports aggregated attestations (which this can't be)
-  var cache = get_empty_per_epoch_cache()
-  if not is_valid_indexed_attestation(
-      pool.blockPool.headState.data.data,
-      get_indexed_attestation(
-        pool.blockPool.headState.data.data, attestation, cache), {}):
-    debug "signature verification failed"
-    return false
+  pool.blockPool.withEpochState(
+      pool.blockPool.tmpState,
+      BlockSlot(blck: attestationBlck, slot: attestation.data.slot)):
+    when ETH2_SPEC == "v0.12.1":
+      # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md
+      # [REJECT] The attestation is for the correct subnet (i.e.
+      # compute_subnet_for_attestation(state, attestation) == subnet_id).
+      let
+        epochInfo = blck.getEpochInfo(state)
+        requiredSubnetIndex =
+          compute_subnet_for_attestation(
+            epochInfo.shuffled_active_validator_indices.len.uint64, attestation)
+
+      if requiredSubnetIndex != topicCommitteeIndex:
+        debug "isValidAttestation: attestation's committee index not for the correct subnet",
+          topicCommitteeIndex = topicCommitteeIndex,
+          attestation_data_index = attestation.data.index,
+          requiredSubnetIndex = requiredSubnetIndex
+        return false
+    else:
+      # The attestation's committee index (attestation.data.index) is for the
+      # correct subnet.
+      if attestation.data.index != topicCommitteeIndex:
+        debug "isValidAttestation: attestation's committee index not for the correct subnet",
+          topicCommitteeIndex = topicCommitteeIndex,
+          attestation_data_index = attestation.data.index
+        return false
+
+    # The signature of attestation is valid.
+    var cache = get_empty_per_epoch_cache()
+    if not is_valid_indexed_attestation(
+        state, get_indexed_attestation(state, attestation, cache), {}):
+      debug "signature verification failed"
+      return false
 
   true

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -166,8 +166,6 @@ template withEpochState*(
     untyped =
   ## Helper template that updates state to a particular BlockSlot - usage of
   ## cache is unsafe outside of block.
-  ## TODO async transformations will lead to a race where cache gets updated
-  ##      while waiting for future to complete - catch this here somehow?
 
   withEpochState(pool.dag, cache, blockSlot, body)
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -152,13 +152,24 @@ template justifiedState*(pool: BlockPool): StateData =
   pool.dag.justifiedState
 
 template withState*(
-    pool: BlockPool, cache: var StateData, blockSlot: BlockSlot, body: untyped): untyped =
+    pool: BlockPool, cache: var StateData, blockSlot: BlockSlot, body: untyped):
+    untyped =
   ## Helper template that updates state to a particular BlockSlot - usage of
   ## cache is unsafe outside of block.
   ## TODO async transformations will lead to a race where cache gets updated
   ##      while waiting for future to complete - catch this here somehow?
 
   withState(pool.dag, cache, blockSlot, body)
+
+template withEpochState*(
+    pool: BlockPool, cache: var StateData, blockSlot: BlockSlot, body: untyped):
+    untyped =
+  ## Helper template that updates state to a particular BlockSlot - usage of
+  ## cache is unsafe outside of block.
+  ## TODO async transformations will lead to a race where cache gets updated
+  ##      while waiting for future to complete - catch this here somehow?
+
+  withEpochState(pool.dag, cache, blockSlot, body)
 
 proc updateStateData*(pool: BlockPool, state: var StateData, bs: BlockSlot) =
   ## Rewind or advance state such that it matches the given block and slot -

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -164,7 +164,12 @@ template withState*(
 template withEpochState*(
     pool: BlockPool, cache: var StateData, blockSlot: BlockSlot, body: untyped):
     untyped =
-  ## Helper template that updates state to a particular BlockSlot - usage of
+  ## Helper template that updates state to a state with an epoch matching the
+  ## epoch of blockSlot. This aims to be at least as fast as withState, quick
+  ## enough to expose to unautheticated, remote use, but trades off that it's
+  ## possible for it to decide that finding a state from a matching epoch may
+  ## provide too expensive for such use cases.
+  ##
   ## cache is unsafe outside of block.
 
   withEpochState(pool.dag, cache, blockSlot, body)

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -129,7 +129,7 @@ func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
 
     blck = blck.parent
 
-iterator get_ancestors*(blockSlot: BlockSlot): BlockSlot =
+iterator get_ancestors_in_epoch(blockSlot: BlockSlot): BlockSlot =
   let min_slot =
     blockSlot.slot.compute_epoch_at_slot.compute_start_slot_at_epoch
   var blockSlot = blockSlot
@@ -641,7 +641,7 @@ template withEpochState*(
   ## TODO async transformations will lead to a race where cache gets updated
   ##      while waiting for future to complete - catch this here somehow?
 
-  for ancestor in get_ancestors(blockSlot):
+  for ancestor in get_ancestors_in_epoch(blockSlot):
     if getStateDataCached(dag, cache, ancestor):
       break
 

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -136,7 +136,7 @@ iterator get_ancestors*(blockSlot: BlockSlot): BlockSlot =
   while true:
     let parent_slot =
       if blockSlot.blck.parent.isNil:
-        min_epoch.compute_start_slot_at_epoch
+        min_epoch.compute_start_slot_at_epoch - 1
       else:
         blockSlot.blck.parent.slot
 

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -129,6 +129,26 @@ func get_ancestor*(blck: BlockRef, slot: Slot): BlockRef =
 
     blck = blck.parent
 
+iterator get_ancestors*(blockSlot: BlockSlot): BlockSlot =
+  let min_epoch = blockSlot.slot.compute_epoch_at_slot
+  var blockSlot = blockSlot
+
+  while true:
+    let parent_slot =
+      if blockSlot.blck.parent.isNil:
+        min_epoch.compute_start_slot_at_epoch
+      else:
+        blockSlot.blck.parent.slot
+
+    for slot in countdown(blockSlot.slot, parent_slot + 1):
+      yield BlockSlot(blck: blockSlot.blck, slot: slot)
+
+    if parent_slot.compute_epoch_at_slot < min_epoch or
+        blockSlot.blck.parent.isNil:
+      break
+
+    blockSlot = BlockSlot(blck: blockSlot.blck.parent, slot: parent_slot)
+
 func atSlot*(blck: BlockRef, slot: Slot): BlockSlot =
   ## Return a BlockSlot at a given slot, with the block set to the closest block
   ## available. If slot comes from before the block, a suitable block ancestor
@@ -617,6 +637,26 @@ proc getStateDataCached(dag: CandidateChains, state: var StateData, bs: BlockSlo
     return dag.getState(dag.db, tmp.get(), bs.blck, state)
 
   false
+
+template withEpochState*(
+    dag: CandidateChains, cache: var StateData, blockSlot: BlockSlot, body: untyped): untyped =
+  ## Helper template that updates state to a particular BlockSlot - usage of
+  ## cache is unsafe outside of block.
+  ## TODO async transformations will lead to a race where cache gets updated
+  ##      while waiting for future to complete - catch this here somehow?
+
+  var isStateValid {.inject, used.} = false
+  for ancestor in get_ancestors(blockSlot):
+    if getStateDataCached(dag, cache, ancestor):
+      isStateValid = true
+      break
+
+  template hashedState(): HashedBeaconState {.inject, used.} = cache.data
+  template state(): BeaconState {.inject, used.} = cache.data.data
+  template blck(): BlockRef {.inject, used.} = cache.blck
+  template root(): Eth2Digest {.inject, used.} = cache.data.root
+
+  body
 
 proc updateStateData*(dag: CandidateChains, state: var StateData, bs: BlockSlot) =
   ## Rewind or advance state such that it matches the given block and slot -

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -116,8 +116,7 @@ proc sendAttestation*(
   beacon_attestations_sent.inc()
 
 proc sendAttestation*(node: BeaconNode, attestation: Attestation) =
-  # This version is for the validator API, which doesn't supply either
-  # num_active_validators or have direct access itself to it.
+  # For the validator API, which doesn't supply num_active_validators.
   let attestationBlck =
     node.blockPool.getRef(attestation.data.beacon_block_root)
   if attestationBlck.isNil:

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -98,7 +98,8 @@ proc isSynced(node: BeaconNode, head: BlockRef): bool =
   else:
     true
 
-proc sendAttestation*(node: BeaconNode, attestation: Attestation, num_active_validators: uint64) =
+proc sendAttestation*(
+  node: BeaconNode, attestation: Attestation, num_active_validators: uint64) =
   logScope: pcs = "send_attestation"
 
   when ETH2_SPEC == "v0.12.1":


### PR DESCRIPTION
Obsoletes/replaces https://github.com/status-im/nim-beacon-chain/pull/1170

This is part of https://github.com/status-im/nim-beacon-chain/issues/1103 and works towards implementing:

- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestation-subnets
- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#attestations-and-aggregation
- https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-attestation

It doesn't properly handle this for https://github.com/status-im/nim-beacon-chain/issues/1106 or https://github.com/status-im/nim-beacon-chain/issues/1141 but that's the same as with a couple other attestation validation fields, so this gets things to the v0.11.3 status quo.