### PR TITLE
state_transition implements the spec fairly directly

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -4,8 +4,8 @@ import
   typetraits, stew/[results, objects, endians2],
   serialization, chronicles, snappy,
   eth/db/kvstore,
-  ./spec/[datatypes, digest, crypto],
-  ./ssz/[ssz_serialization, merkleization], ./state_transition
+  ./spec/[datatypes, digest, crypto, state_transition],
+  ./ssz/[ssz_serialization, merkleization]
 
 type
   BeaconChainDB* = ref object

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -19,15 +19,14 @@ import
 
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, network, signatures],
-  spec/presets/custom,
+  spec/state_transition, spec/presets/custom,
   conf, time, beacon_chain_db, validator_pool, extras,
   attestation_pool, block_pool, eth2_network, eth2_discovery,
   beacon_node_common, beacon_node_types, block_pools/block_pools_types,
   nimbus_binary_common,
   mainchain_monitor, version, ssz/[merkleization], sszdump,
   sync_protocol, request_manager, keystore_management, interop, statusbar,
-  sync_manager, state_transition,
-  validator_duties, validator_api, attestation_aggregation
+  sync_manager, validator_duties, validator_api, attestation_aggregation
 
 const
   genesisFile* = "genesis.ssz"

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -10,8 +10,8 @@
 import
   chronicles, options, sequtils, tables,
   metrics,
-  ../ssz/merkleization, ../beacon_chain_db, ../state_transition, ../extras,
-  ../spec/[crypto, datatypes, digest, helpers, validator],
+  ../ssz/merkleization, ../beacon_chain_db, ../extras,
+  ../spec/[crypto, datatypes, digest, helpers, validator, state_transition],
   block_pools_types
 
 declareCounter beacon_reorgs_total, "Total occurrences of reorganizations of the chain" # On fork choice

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -10,8 +10,8 @@
 import
   chronicles, sequtils, tables,
   metrics, stew/results,
-  ../ssz/merkleization, ../state_transition, ../extras,
-  ../spec/[crypto, datatypes, digest, helpers, signatures],
+  ../ssz/merkleization, ../extras,
+  ../spec/[crypto, datatypes, digest, helpers, signatures, state_transition],
   block_pools_types, candidate_chains, quarantine
 
 export results

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -31,10 +31,10 @@ import
   tables,
   chronicles,
   stew/results,
-  ./extras, ./ssz/merkleization, metrics,
-  ./spec/[datatypes, crypto, digest, helpers, signatures, validator],
-  ./spec/[state_transition_block, state_transition_epoch],
-  ../nbench/bench_lab
+  ../extras, ../ssz/merkleization, metrics,
+  datatypes, crypto, digest, helpers, signatures, validator,
+  state_transition_block, state_transition_epoch,
+  ../../nbench/bench_lab
 
 # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
 declareGauge beacon_current_validators, """Number of status="pending|active|exited|withdrawable" validators in current epoch""" # On epoch transition

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -19,7 +19,8 @@ import
 
   # Local modules
   spec/[datatypes, digest, crypto, beaconstate, helpers, validator, network],
-  conf, time, validator_pool, state_transition,
+  spec/state_transition,
+  conf, time, validator_pool,
   attestation_pool, block_pool, block_pools/candidate_chains, eth2_network,
   keystore_management, beacon_node_common, beacon_node_types,
   nimbus_binary_common, mainchain_monitor, version, ssz/merkleization, interop,

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -13,8 +13,8 @@ import
   # Beacon-chain
   ../beacon_chain/spec/[
       datatypes, crypto, helpers, beaconstate, validator,
-      state_transition_block, state_transition_epoch],
-  ../beacon_chain/[state_transition, extras],
+      state_transition_block, state_transition_epoch, state_transition],
+  ../beacon_chain/extras,
   ../beacon_chain/ssz/[merkleization, ssz_serialization]
 
 # Nimbus Bench - Scenario configuration

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -1,8 +1,8 @@
   import
   confutils, stats, chronicles, strformat, tables,
   stew/byteutils,
-  ../beacon_chain/[beacon_chain_db, block_pool, extras, state_transition],
-  ../beacon_chain/spec/[crypto, datatypes, digest, helpers],
+  ../beacon_chain/[beacon_chain_db, block_pool, extras],
+  ../beacon_chain/spec/[crypto, datatypes, digest, helpers, state_transition],
   ../beacon_chain/sszdump,
   ../research/simutils,
   eth/db/[kvstore, kvstore_sqlite3]

--- a/ncli/ncli_transition.nim
+++ b/ncli/ncli_transition.nim
@@ -1,7 +1,7 @@
 import
   confutils, chronicles,
-  ../beacon_chain/spec/[crypto, datatypes],
-  ../beacon_chain/[extras, state_transition],
+  ../beacon_chain/spec/[crypto, datatypes, state_transition],
+  ../beacon_chain/extras,
   ../beacon_chain/ssz/[merkleization, ssz_serialization]
 
 cli do(pre: string, blck: string, post: string, verifyStateRoot = false):

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -3,9 +3,9 @@
 
 import
   stew/ptrops, stew/ranges/ptr_arith,
-  ../beacon_chain/[extras, state_transition],
+  ../beacon_chain/extras,
   ../beacon_chain/spec/[crypto, datatypes, digest, validator, beaconstate,
-      state_transition_block],
+      state_transition_block, state_transition],
   ../beacon_chain/ssz/[merkleization, ssz_serialization]
 
 type

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -20,10 +20,11 @@ import
   options, random, tables,
   ../tests/[testblockutil],
   ../beacon_chain/spec/[
-    beaconstate, crypto, datatypes, digest, helpers, validator, signatures],
+    beaconstate, crypto, datatypes, digest, helpers, validator, signatures,
+    state_transition],
   ../beacon_chain/[
     attestation_pool, block_pool, beacon_node_types, beacon_chain_db,
-    interop, state_transition, validator_pool],
+    interop, validator_pool],
   eth/db/[kvstore, kvstore_sqlite3],
   ../beacon_chain/ssz/[merkleization, ssz_serialization],
   ./simutils

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -13,9 +13,9 @@ import
   sets,
   # Specs
   ../../beacon_chain/spec/[datatypes, beaconstate, helpers, validator, crypto,
-    signatures],
+    signatures, state_transition],
   # Internals
-  ../../beacon_chain/[ssz, extras, state_transition],
+  ../../beacon_chain/[ssz, extras],
   # Mocking procs
   ./mock_blocks,
   ./mock_validator_keys

--- a/tests/mocking/mock_state.nim
+++ b/tests/mocking/mock_state.nim
@@ -10,9 +10,7 @@
 
 import
   # Specs
-  ../../beacon_chain/spec/[datatypes],
-  # Internals
-  ../../beacon_chain/state_transition
+  ../../beacon_chain/spec/[datatypes, state_transition]
 
 proc nextEpoch*(state: var HashedBeaconState) =
   ## Transition to the start of the next epoch

--- a/tests/official/test_fixture_sanity_blocks.nim
+++ b/tests/official/test_fixture_sanity_blocks.nim
@@ -11,8 +11,8 @@ import
   # Standard library
   os, sequtils, unittest,
   # Beacon chain internals
-  ../../beacon_chain/spec/[crypto, datatypes],
-  ../../beacon_chain/[ssz, state_transition],
+  ../../beacon_chain/spec/[crypto, datatypes, state_transition],
+  ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
   ./fixtures_utils

--- a/tests/official/test_fixture_sanity_slots.nim
+++ b/tests/official/test_fixture_sanity_slots.nim
@@ -11,8 +11,7 @@ import
   # Standard library
   os, strutils, unittest,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes,
-  ../../beacon_chain/state_transition,
+  ../../beacon_chain/spec/[datatypes, state_transition],
   # Test utilities
   ../testutil,
   ./fixtures_utils,

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -7,9 +7,8 @@
 
 import
   # Specs
-  ../../beacon_chain/spec/[datatypes, state_transition_epoch, validator],
-  # Internals
-  ../../beacon_chain/[state_transition]
+  ../../beacon_chain/spec/[
+    datatypes, state_transition_epoch, validator, state_transition]
 
 proc processSlotsUntilEndCurrentEpoch(state: var HashedBeaconState) =
   # Process all slots until the end of the last slot of the current epoch

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -16,8 +16,8 @@ import
   chronicles,
   stew/byteutils,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[digest, validator],
-  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, state_transition]
+  ../beacon_chain/spec/[digest, validator, state_transition],
+  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool]
 
 suiteReport "Attestation pool processing" & preset():
   ## For now just test that we can compile and execute block processing with

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -8,8 +8,9 @@
 {.used.}
 
 import  options, unittest, sequtils,
-  ../beacon_chain/[beacon_chain_db, extras, interop, ssz, state_transition],
-  ../beacon_chain/spec/[beaconstate, datatypes, digest, crypto],
+  ../beacon_chain/[beacon_chain_db, extras, interop, ssz],
+  ../beacon_chain/spec/[
+    beaconstate, datatypes, digest, crypto, state_transition],
   eth/db/kvstore,
   # test utilies
   ./testutil, ./testblockutil

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -10,8 +10,8 @@
 import
   options, sequtils, unittest,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[datatypes, digest, validator],
-  ../beacon_chain/[beacon_node_types, block_pool, state_transition, ssz]
+  ../beacon_chain/spec/[datatypes, digest, validator, state_transition],
+  ../beacon_chain/[beacon_node_types, block_pool, ssz]
 
 when isMainModule:
   import chronicles # or some random compile error happens...

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -10,8 +10,9 @@
 import
   unittest,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[beaconstate, datatypes, digest, validator],
-  ../beacon_chain/[state_transition, ssz]
+  ../beacon_chain/spec/[
+    beaconstate, datatypes, digest, validator, state_transition],
+  ../beacon_chain/ssz
 
 suiteReport "Block processing" & preset():
   ## For now just test that we can compile and execute block processing with

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -9,10 +9,9 @@ import
   options, stew/endians2,
   chronicles, eth/trie/[db],
   ../beacon_chain/[beacon_chain_db, block_pool, extras, merkle_minimal,
-  ../beacon_chain/ssz/merkleization,
-    state_transition, validator_pool],
+  ../beacon_chain/ssz/merkleization, validator_pool],
   ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest,
-    helpers, validator, signatures]
+    helpers, validator, signatures, state_transition]
 
 func makeFakeValidatorPrivKey(i: int): ValidatorPrivKey =
   # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,


### PR DESCRIPTION
No semantic change, just adjusting how `state_transition` is imported, what it imports, and moving it in the repo.