### PR TITLE
default to v0.12.1 beacon chain spec, keeping witti working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,10 +166,10 @@ clean-witti:
 	rm -rf build/data/shared_witti*
 
 witti: | build deps
-	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="$(LOG_LEVEL)" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
+	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="$(LOG_LEVEL)" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims --spec=v0.11.3 $(SCRIPT_PARAMS) shared/witti
 
 witti-dev: | build deps
-	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims $(SCRIPT_PARAMS) shared/witti
+	NIM_PARAMS="$(subst ",\",$(NIM_PARAMS))" LOG_LEVEL="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" $(ENV_SCRIPT) nim $(NIM_PARAMS) scripts/connect_to_testnet.nims --spec=v0.11.3 $(SCRIPT_PARAMS) shared/witti
 
 ctail: | build deps
 	mkdir -p vendor/.nimble/bin/

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -59,7 +59,7 @@ task test, "Run all tests":
   # price we pay for that.
 
   # Just the part of minimal config which explicitly differs from mainnet
-  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", "-d:const_preset=minimal -d:ETH2_SPEC=\"v0.11.3\""
+  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", "-d:const_preset=minimal -d:ETH2_SPEC=\"v0.11.3\" -d:BLS_ETH2_SPEC=\"v0.11.x\""
   buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", "-d:const_preset=minimal -d:ETH2_SPEC=\"v0.12.1\" -d:BLS_ETH2_SPEC=\"v0.12.x\""
 
   # Mainnet config
@@ -72,13 +72,13 @@ task test, "Run all tests":
 
   # Consensus object SSZ tests
   # 0.11.3
-  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.11.3\""
+  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.11.3\" -d:BLS_ETH2_SPEC=\"v0.11.x\""
 
   # 0.12.1
   buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.1\" -d:BLS_ETH2_SPEC=\"v0.12.x\""
 
   # 0.11.3
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.11.3\""
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.11.3\" -d:BLS_ETH2_SPEC=\"v0.11.x\""
 
   # 0.12.1
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:ETH2_SPEC=\"v0.12.1\" -d:BLS_ETH2_SPEC=\"v0.12.x\""

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -18,7 +18,7 @@ import
   eth/p2p/enode, eth/[keys, async_utils], eth/p2p/discoveryv5/[protocol, enr],
 
   # Local modules
-  spec/[datatypes, digest, crypto, beaconstate, helpers, network, signatures],
+  spec/[datatypes, digest, crypto, beaconstate, helpers, network],
   spec/state_transition, spec/presets/custom,
   conf, time, beacon_chain_db, validator_pool, extras,
   attestation_pool, block_pool, eth2_network, eth2_discovery,

--- a/beacon_chain/eth2_discovery.nim
+++ b/beacon_chain/eth2_discovery.nim
@@ -64,7 +64,7 @@ proc loadBootstrapFile*(bootstrapFile: string,
     # removal of YAML metadata.
     try:
       for ln in lines(bootstrapFile):
-        addBootstrapNode(string(ln[3..^2]), bootstrapEnrs, localPubKey)
+        addBootstrapNode(string(ln.strip()[3..^2]), bootstrapEnrs, localPubKey)
     except IOError as e:
       error "Could not read bootstrap file", msg = e.msg
       quit 1

--- a/beacon_chain/mainchain_monitor.nim
+++ b/beacon_chain/mainchain_monitor.nim
@@ -1,7 +1,7 @@
 import
   deques, tables, hashes, options, strformat,
   chronos, web3, web3/ethtypes, json, chronicles, eth/async_utils,
-  spec/[datatypes, digest, crypto, beaconstate, helpers, signatures],
+  spec/[datatypes, digest, crypto, beaconstate, helpers],
   merkle_minimal
 
 export

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -47,7 +47,7 @@ export
 # internal state that's gone through sanity checks already.
 
 
-const ETH2_SPEC* {.strdefine.} = "v0.11.3"
+const ETH2_SPEC* {.strdefine.} = "v0.12.1"
 static: doAssert: ETH2_SPEC == "v0.11.3" or ETH2_SPEC == "v0.12.1"
 
 # Constant presets
@@ -132,7 +132,7 @@ type
 
   # https://github.com/nim-lang/Nim/issues/574 and be consistent across
   # 32-bit and 64-bit word platforms.
-  # TODO VALIDATOR_REGISTRY_LIMIT is 1 shl 40 in 0.8.3, and
+  # TODO VALIDATOR_REGISTRY_LIMIT is 1 shl 40 in 0.12.1, and
   # proc newSeq(typ: PNimType, len: int): pointer {.compilerRtl.}
   # in Nim/lib/system/gc.nim quite tightly ties seq addressibility
   # to the system wordsize. This lifts smaller, and now incorrect,
@@ -514,23 +514,23 @@ proc readValue*(reader: var JsonReader, value: var ForkDigest)
     raiseUnexpectedValue(reader, "Hex string of 4 bytes expected")
 
 # `ValidatorIndex` seq handling.
-proc max*(a: ValidatorIndex, b: int) : auto =
+func max*(a: ValidatorIndex, b: int) : auto =
   max(a.int, b)
 
-proc `[]`*[T](a: var seq[T], b: ValidatorIndex): var T =
+func `[]`*[T](a: var seq[T], b: ValidatorIndex): var T =
   a[b.int]
 
-proc `[]`*[T](a: seq[T], b: ValidatorIndex): auto =
+func `[]`*[T](a: seq[T], b: ValidatorIndex): auto =
   a[b.int]
 
-proc `[]=`*[T](a: var seq[T], b: ValidatorIndex, c: T) =
+func `[]=`*[T](a: var seq[T], b: ValidatorIndex, c: T) =
   a[b.int] = c
 
 # `ValidatorIndex` Nim integration
 proc `==`*(x, y: ValidatorIndex) : bool {.borrow.}
 proc `<`*(x, y: ValidatorIndex) : bool {.borrow.}
 proc hash*(x: ValidatorIndex): Hash {.borrow.}
-proc `$`*(x: ValidatorIndex): auto = $(x.int64)
+func `$`*(x: ValidatorIndex): auto = $(x.int64)
 
 ethTimeUnit Slot
 ethTimeUnit Epoch

--- a/scripts/connect_to_testnet.nims
+++ b/scripts/connect_to_testnet.nims
@@ -93,6 +93,8 @@ cli do (skipGoerliKey {.
     preset = constPreset
     if preset.len == 0: preset = "minimal"
 
+  doAssert specVersion in ["v0.11.3", "v0.12.1"]
+
   let
     dataDirName = testnetName.replace("/", "_")
                              .replace("(", "_")
@@ -101,8 +103,13 @@ cli do (skipGoerliKey {.
     validatorsDir = dataDir / "validators"
     secretsDir = dataDir / "secrets"
     beaconNodeBinary = buildDir / "beacon_node_" & dataDirName
+    specDefines =
+      if specVersion == "v0.12.1":
+        &"-d:ETH2_SPEC=\"v0.12.1\" -d:BLS_ETH2_SPEC=\"v0.12.x\""
+      else:
+        &"-d:ETH2_SPEC=\"v0.11.3\" -d:BLS_ETH2_SPEC=\"v0.11.x\""
   var
-    nimFlags = &"-d:chronicles_log_level=TRACE -d:ETH2_SPEC={specVersion} " & getEnv("NIM_PARAMS")
+    nimFlags = &"-d:chronicles_log_level=TRACE {specDefines} " & getEnv("NIM_PARAMS")
 
   # write the logs to a file
   nimFlags.add """ -d:"chronicles_sinks=textlines,json[file(nbc""" & staticExec("date +\"%Y%m%d%H%M%S\"") & """.log)]" """

--- a/scripts/connect_to_testnet.nims
+++ b/scripts/connect_to_testnet.nims
@@ -84,7 +84,7 @@ cli do (skipGoerliKey {.
   else:
     let bootstrapYamlFile = testnetDir / bootstrapYamlFileName
     if system.fileExists(bootstrapYamlFile):
-      bootstrapFileOpt = &"--enr-bootstrap-file=\"{bootstrapYamlFile}\""
+      bootstrapFileOpt = &"--bootstrap-file=\"{bootstrapYamlFile}\""
     else:
       echo "Warning: the network metadata doesn't include a bootstrap file"
 


### PR DESCRIPTION
It also converts a few `proc`s to `func`s and removes a couple of unused imports.