### PR TITLE
Dual headed fork choice [Reloaded]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,9 +32,9 @@ build/
 *.sqlite3
 
 /local_testnet_data*/
+/local_testnet*_data*/
 
 # Prometheus db
 /data
 # Grafana dashboards
 /docker/*.json
-

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -9,8 +9,10 @@ AllTests-mainnet
 + Can add and retrieve simple attestation [Preset: mainnet]                                  OK
 + Fork choice returns block with attestation                                                 OK
 + Fork choice returns latest block with no attestations                                      OK
++ Trying to add a block twice tags the second as an error                                    OK
++ Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -32,7 +34,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool processing [Preset: mainnet]
 ```diff
-+ Can add same block twice [Preset: mainnet]                                                 OK
++ Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
 + Reverse order block add & get [Preset: mainnet]                                            OK
 + Simple block add&get [Preset: mainnet]                                                     OK
 + getRef returns nil for missing blocks                                                      OK
@@ -259,4 +261,4 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 158/161 Fail: 0/161 Skip: 3/161
+OK: 160/163 Fail: 0/163 Skip: 3/163

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -537,7 +537,7 @@ proc selectHead_v2(pool: var AttestationPool): BlockRef =
   let newHead = pool.forkChoice_v2.find_head(
     justified_epoch = pool.blockPool.justifiedState.data.data.slot.compute_epoch_at_slot(),
     justified_root = pool.blockPool.head.justified.blck.root,
-    finalized_epoch = pool.blockPool.justifiedState.data.data.finalized_checkpoint.epoch,
+    finalized_epoch = pool.blockPool.headState.data.data.finalized_checkpoint.epoch,
     justified_state_balances = attesterBalances
   ).get()
 

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -27,10 +27,11 @@ func init*(T: type AttestationPool, blockPool: BlockPool): T =
   # TODO: In tests, on blockpool.init the finalized root
   #       from the `headState` and `justifiedState` is zero
   let forkChoice = initForkChoice(
-    finalized_block_slot = default(Slot),             # This is unnecessary for fork choice but may help external components
-    finalized_block_state_root = default(Eth2Digest), # This is unnecessary for fork choice but may help external components
+    finalized_block_slot = default(Slot),             # This is unnecessary for fork choice but may help external components for example logging/debugging
+    finalized_block_state_root = default(Eth2Digest), # This is unnecessary for fork choice but may help external components for example logging/debugging
     justified_epoch = blockPool.headState.data.data.current_justified_checkpoint.epoch,
     finalized_epoch = blockPool.headState.data.data.finalized_checkpoint.epoch,
+    # We should use the checkpoint, but at genesis the headState finalized checkpoint is 0x0000...0000
     # finalized_root = blockPool.headState.data.data.finalized_checkpoint.root
     finalized_root = blockPool.finalizedHead.blck.root
   ).get()

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -11,7 +11,8 @@ import
   deques, sequtils, tables, options,
   chronicles, stew/[byteutils], json_serialization/std/sets,
   ./spec/[beaconstate, datatypes, crypto, digest, helpers, validator],
-  ./extras, ./block_pool, ./block_pools/candidate_chains, ./beacon_node_types
+  ./extras, ./block_pool, ./block_pools/candidate_chains, ./beacon_node_types,
+  ./fork_choice/[fork_choice_types, fork_choice]
 
 logScope: topics = "attpool"
 
@@ -22,10 +23,23 @@ func init*(T: type AttestationPool, blockPool: BlockPool): T =
   # TODO blockPool is only used when resolving orphaned attestations - it should
   #      probably be removed as a dependency of AttestationPool (or some other
   #      smart refactoring)
+
+  # TODO: In tests, on blockpool.init the finalized root
+  #       from the `headState` and `justifiedState` is zero
+  let forkChoice = initForkChoice(
+    finalized_block_slot = default(Slot),             # This is unnecessary for fork choice but may help external components
+    finalized_block_state_root = default(Eth2Digest), # This is unnecessary for fork choice but may help external components
+    justified_epoch = blockPool.headState.data.data.current_justified_checkpoint.epoch,
+    finalized_epoch = blockPool.headState.data.data.finalized_checkpoint.epoch,
+    # finalized_root = blockPool.headState.data.data.finalized_checkpoint.root
+    finalized_root = blockPool.finalizedHead.blck.root
+  ).get()
+
   T(
     mapSlotsToAttestations: initDeque[AttestationsSeen](),
     blockPool: blockPool,
     unresolved: initTable[Eth2Digest, UnresolvedAttestation](),
+    forkChoice_v2: forkChoice
   )
 
 proc combine*(tgt: var Attestation, src: Attestation, flags: UpdateFlags) =
@@ -107,12 +121,20 @@ proc slotIndex(
 func updateLatestVotes(
     pool: var AttestationPool, state: BeaconState, attestationSlot: Slot,
     participants: seq[ValidatorIndex], blck: BlockRef) =
+
+  # ForkChoice v2
+  let target_epoch = compute_epoch_at_slot(attestationSlot)
+
   for validator in participants:
+    # ForkChoice v1
     let
       pubKey = state.validators[validator].pubkey
       current = pool.latestAttestations.getOrDefault(pubKey)
     if current.isNil or current.slot < attestationSlot:
       pool.latestAttestations[pubKey] = blck
+
+    # ForkChoice v2
+    pool.forkChoice_v2.process_attestation(validator, blck.root, target_epoch)
 
 func get_attesting_indices_seq(state: BeaconState,
                                attestation_data: AttestationData,
@@ -261,6 +283,34 @@ proc add*(pool: var AttestationPool, attestation: Attestation) =
 
   pool.addResolved(blck, attestation)
 
+proc addForkChoice_v2*(pool: var AttestationPool, blck: BlockRef) =
+  ## Add a verified block to the fork choice context
+  ## The current justifiedState of the block pool is used as reference
+
+  # TODO: add(BlockPool, blockRoot: Eth2Digest, SignedBeaconBlock): BlockRef
+  # should ideally return the justified_epoch and finalized_epoch
+  # so that we can pass them directly to this proc without having to
+  # redo "updateStateData"
+  #
+  # In any case, `updateStateData` should shortcut
+  # to `getStateDataCached`
+
+  updateStateData(
+    pool.blockPool,
+    pool.blockPool.tmpState,
+    BlockSlot(blck: blck, slot: blck.slot)
+  )
+
+  let blockData = pool.blockPool.get(blck)
+  pool.forkChoice_v2.process_block(
+    slot = blck.slot,
+    block_root = blck.root,
+    parent_root = if not blck.parent.isNil: blck.parent.root else: default(Eth2Digest),
+    state_root = default(Eth2Digest), # This is unnecessary for fork choice but may help external components
+    justified_epoch = pool.blockPool.tmpState.data.data.current_justified_checkpoint.epoch,
+    finalized_epoch = pool.blockPool.tmpState.data.data.finalized_checkpoint.epoch,
+  ).get()
+
 proc getAttestationsForSlot*(pool: AttestationPool, newBlockSlot: Slot):
     Option[AttestationsSeen] =
   if newBlockSlot < (GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY):
@@ -395,7 +445,10 @@ proc resolve*(pool: var AttestationPool) =
   for a in resolved:
     pool.addResolved(a.blck, a.attestation)
 
-func latestAttestation*(
+# Fork choice v1
+# ---------------------------------------------------------------
+
+func latestAttestation(
     pool: AttestationPool, pubKey: ValidatorPubKey): BlockRef =
   pool.latestAttestations.getOrDefault(pubKey)
 
@@ -403,7 +456,7 @@ func latestAttestation*(
 # The structure of this code differs from the spec since we use a different
 # strategy for storing states and justification points - it should nonetheless
 # be close in terms of functionality.
-func lmdGhost*(
+func lmdGhost(
     pool: AttestationPool, start_state: BeaconState,
     start_block: BlockRef): BlockRef =
   # TODO: a Fenwick Tree datastructure to keep track of cumulated votes
@@ -454,7 +507,7 @@ func lmdGhost*(
           winCount = candCount
       head = winner
 
-proc selectHead*(pool: AttestationPool): BlockRef =
+proc selectHead_v1(pool: AttestationPool): BlockRef =
   let
     justifiedHead = pool.blockPool.latestJustifiedBlock()
 
@@ -462,3 +515,47 @@ proc selectHead*(pool: AttestationPool): BlockRef =
     lmdGhost(pool, pool.blockPool.justifiedState.data.data, justifiedHead.blck)
 
   newHead
+
+# Fork choice v2
+# ---------------------------------------------------------------
+
+func getAttesterBalances(state: StateData): seq[Gwei] {.noInit.}=
+  ## Get the balances from a state
+  result.newSeq(state.data.data.validators.len) # zero-init
+
+  let epoch = state.data.data.slot.compute_epoch_at_slot()
+
+  for i in 0 ..< result.len:
+    # All non-active validators have a 0 balance
+    template validator: Validator = state.data.data.validators[i]
+    if validator.is_active_validator(epoch):
+      result[i] = validator.effective_balance
+
+proc selectHead_v2(pool: var AttestationPool): BlockRef =
+  let attesterBalances = pool.blockPool.justifiedState.getAttesterBalances()
+
+  let newHead = pool.forkChoice_v2.find_head(
+    justified_epoch = pool.blockPool.justifiedState.data.data.slot.compute_epoch_at_slot(),
+    justified_root = pool.blockPool.head.justified.blck.root,
+    finalized_epoch = pool.blockPool.justifiedState.data.data.finalized_checkpoint.epoch,
+    justified_state_balances = attesterBalances
+  ).get()
+
+  pool.blockPool.getRef(newHead)
+
+proc pruneBefore*(pool: var AttestationPool, finalizedhead: BlockSlot) =
+  pool.forkChoice_v2.maybe_prune(finalizedHead.blck.root).get()
+
+# Dual-Headed Fork choice
+# ---------------------------------------------------------------
+
+proc selectHead*(pool: var AttestationPool): BlockRef =
+  let head_v1 = pool.selectHead_v1()
+  let head_v2 = pool.selectHead_v2()
+
+  if head_v1 != head_v2:
+    error "Fork choice engines in disagreement, using block from v1.",
+      v1_block = shortlog(head_v1),
+      v2_block = shortlog(head_v2)
+
+  return head_v1

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -556,7 +556,10 @@ proc runForwardSyncLoop(node: BeaconNode) {.async.} =
       # We going to ignore `BlockError.Old` errors because we have working
       # backward sync and it can happens that we can perform overlapping
       # requests.
-      if res.isErr and res.error != BlockError.Old:
+      # For the same reason we ignore Duplicate blocks as if they are duplicate
+      # from before the current finalized epoch, we can drop them
+      # (and they may have no parents anymore in the fork choice if it was pruned)
+      if res.isErr and res.error notin {BlockError.Old, BLockError.Duplicate}:
         return res
     discard node.updateHead()
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -322,6 +322,9 @@ proc storeBlock(
 
   node.dumpBlock(signedBlock, blck)
 
+  # There can be a scenario where we receive a block we already received.
+  # However this block was before the last finalized epoch and so its parent
+  # was pruned from the ForkChoice.
   if blck.isErr:
     return err(blck.error)
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -325,6 +325,10 @@ proc storeBlock(
   if blck.isErr:
     return err(blck.error)
 
+  # Still here? This means we received a valid block and we need to add it
+  # to the fork choice
+  node.attestationPool.addForkChoice_v2(blck.get())
+
   # The block we received contains attestations, and we might not yet know about
   # all of them. Let's add them to the attestation pool.
   let currentSlot = node.beaconClock.now.toSlot

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -20,7 +20,8 @@ import
   conf, time, beacon_chain_db,
   attestation_pool, block_pool, eth2_network,
   beacon_node_types, mainchain_monitor, request_manager,
-  sync_manager
+  sync_manager,
+  fork_choice/fork_choice
 
 # This removes an invalid Nim warning that the digest module is unused here
 # It's currently used for `shortLog(head.blck.root)`
@@ -67,6 +68,9 @@ proc updateHead*(node: BeaconNode): BlockRef =
   # justified and finalized
   node.blockPool.updateHead(newHead)
   beacon_head_root.set newHead.root.toGaugeValue
+
+  # Cleanup the fork choice v2 if we have a finalized head
+  node.attestationPool.pruneBefore(node.blockPool.finalizedHead)
 
   newHead
 

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -5,7 +5,8 @@ import
   stew/endians2,
   spec/[datatypes, crypto, digest],
   block_pools/block_pools_types,
-  block_pool # TODO: refactoring compat shim
+  block_pool, # TODO: refactoring compat shim
+  fork_choice/fork_choice_types
 
 export block_pools_types
 
@@ -74,6 +75,9 @@ type
     latestAttestations*: Table[ValidatorPubKey, BlockRef] ##\
     ## Map that keeps track of the most recent vote of each attester - see
     ## fork_choice
+    forkChoice_v2*: ForkChoice ##\
+    ## The alternative fork choice "proto_array" that will ultimately
+    ## replace the original one
 
   # #############################################
   #

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -68,7 +68,13 @@ proc init*(T: type BlockPools, db: BeaconChainDB,
     updateFlags: UpdateFlags = {}): BlockPools =
   result.dag = init(CandidateChains, db, updateFlags)
 
+func addFlags*(pool: BlockPool, flags: UpdateFlags) =
+  ## Add a flag to the block processing
+  ## This is destined for testing to add skipBLSValidation flag
+  pool.dag.updateFlags.incl flags
+
 export init          # func init*(T: type BlockRef, root: Eth2Digest, blck: BeaconBlock): BlockRef
+export addFlags
 
 func getRef*(pool: BlockPool, root: Eth2Digest): BlockRef =
   ## Retrieve a resolved block reference, if available

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -27,6 +27,7 @@ type
     MissingParent
     Old
     Invalid
+    Duplicate
 
   Quarantine* = object
     ## Keeps track of unsafe blocks coming from the network

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -135,14 +135,11 @@ proc add*(
       blockRoot = shortLog(blockRoot),
       cat = "filtering"
 
-    # # There can be a scenario where we receive a block we already received.
-    # # However this block was before the last finalized epoch and so its parent
-    # # was pruned from the ForkChoice. Trying to add it again, even if the fork choice
-    # # supports duplicate will lead to a crash.
-    # result.err(Duplicate)
-    # return
-
-    return ok blockRef[]
+    # There can be a scenario where we receive a block we already received.
+    # However this block was before the last finalized epoch and so its parent
+    # was pruned from the ForkChoice. Trying to add it again, even if the fork choice
+    # supports duplicate will lead to a crash.
+    return err Duplicate
 
   quarantine.missing.del(blockRoot)
 

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -135,6 +135,13 @@ proc add*(
       blockRoot = shortLog(blockRoot),
       cat = "filtering"
 
+    # # There can be a scenario where we receive a block we already received.
+    # # However this block was before the last finalized epoch and so its parent
+    # # was pruned from the ForkChoice. Trying to add it again, even if the fork choice
+    # # supports duplicate will lead to a crash.
+    # result.err(Duplicate)
+    # return
+
     return ok blockRef[]
 
   quarantine.missing.del(blockRoot)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -117,7 +117,7 @@ func process_attestation*(
     vote.next_epoch = target_epoch
 
     {.noSideEffect.}:
-      info "Integrating vote in fork choice",
+      trace "Integrating vote in fork choice",
         validator_index = $validator_index,
         new_vote = shortlog(vote)
   else:
@@ -129,7 +129,7 @@ func process_attestation*(
           ignored_block_root = shortlog(block_root),
           ignored_target_epoch = $target_epoch
       else:
-        info "Ignoring double-vote for fork choice",
+        trace "Ignoring double-vote for fork choice",
           validator_index = $validator_index,
           current_vote = shortlog(vote),
           ignored_block_root = shortlog(block_root),
@@ -159,7 +159,7 @@ func process_block*(
     return err("process_block_error: " & $err)
 
   {.noSideEffect.}:
-    info "Integrating block in fork choice",
+    trace "Integrating block in fork choice",
       block_root = $shortlog(block_root),
       parent_root = $shortlog(parent_root),
       justified_epoch = $justified_epoch,
@@ -205,7 +205,7 @@ func find_head*(
     return err("find_head failed: " & $ghost_err)
 
   {.noSideEffect.}:
-    info "Fork choice requested",
+    debug "Fork choice requested",
       justified_epoch = $justified_epoch,
       justified_root = shortlog(justified_root),
       finalized_epoch = $finalized_epoch,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -671,7 +671,9 @@ func makeAttestationData*(
       if start_slot == state.slot: beacon_block_root
       else: get_block_root_at_slot(state, start_slot)
 
-  doAssert slot.compute_epoch_at_slot == current_epoch
+  doAssert slot.compute_epoch_at_slot == current_epoch,
+    "Computed epoch was " & $slot.compute_epoch_at_slot &
+    "  while the state current_epoch was " & $current_epoch
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.11.2/specs/phase0/validator.md#attestation-data
   AttestationData(

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -33,7 +33,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       process_slots(state.data, state.data.data.slot + 1)
 
-    # pool[].add(blockPool[].tail) # Make the tail known to fork choice
+    pool[].addForkChoice_v2(blockPool[].tail) # Make the tail known to fork choice
 
   timedTest "Can add and retrieve simple attestation" & preset():
     var cache = get_empty_per_epoch_cache()
@@ -161,7 +161,7 @@ suiteReport "Attestation pool processing" & preset():
       b1Root = hash_tree_root(b1.message)
       b1Add = blockpool[].add(b1Root, b1)[]
 
-    # pool[].add(b1Add) - make a block known to the future fork choice
+    pool[].addForkChoice_v2(b1Add)
     let head = pool[].selectHead()
 
     check:
@@ -172,7 +172,7 @@ suiteReport "Attestation pool processing" & preset():
       b2Root = hash_tree_root(b2.message)
       b2Add = blockpool[].add(b2Root, b2)[]
 
-    # pool[].add(b2Add) - make a block known to the future fork choice
+    pool[].addForkChoice_v2(b2Add)
     let head2 = pool[].selectHead()
 
     check:
@@ -185,7 +185,7 @@ suiteReport "Attestation pool processing" & preset():
       b10Root = hash_tree_root(b10.message)
       b10Add = blockpool[].add(b10Root, b10)[]
 
-    # pool[].add(b10Add) - make a block known to the future fork choice
+    pool[].addForkChoice_v2(b10Add)
     let head = pool[].selectHead()
 
     check:
@@ -202,7 +202,7 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
       attestation0 = makeAttestation(state.data.data, b10Root, bc1[0], cache)
 
-    # pool[].add(b11Add) - make a block known to the future fork choice
+    pool[].addForkChoice_v2(b11Add)
     pool[].add(attestation0)
 
     let head2 = pool[].selectHead()

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -16,8 +16,9 @@ import
   chronicles,
   stew/byteutils,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[digest, validator, state_transition],
-  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool]
+  ../beacon_chain/spec/[digest, validator, state_transition, helpers, beaconstate],
+  ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, extras],
+  ../beacon_chain/fork_choice/[fork_choice_types, fork_choice]
 
 suiteReport "Attestation pool processing" & preset():
   ## For now just test that we can compile and execute block processing with
@@ -234,3 +235,110 @@ suiteReport "Attestation pool processing" & preset():
     check:
       # Two votes for b11
       head4 == b11Add
+
+  timedTest "Adding a block twice doesn't crash":
+    var cache = get_empty_per_epoch_cache()
+    let
+      b10 = makeTestBlock(state.data, blockPool[].tail.root, cache)
+      b10Root = hash_tree_root(b10.message)
+      b10Add = blockpool[].add(b10Root, b10)[]
+
+    pool[].addForkChoice_v2(b10Add)
+    let head = pool[].selectHead()
+
+    check:
+      head == b10Add
+
+    # -------------------------------------------------------------
+    let b10_clone = b10 # Assumes deep copy
+    let b10Add_clone = blockpool[].add(b10Root, b10_clone)[]
+
+    pool[].addForkChoice_v2(b10Add_clone)
+    let head2 = pool[].selectHead()
+
+    check:
+      head2 == b10Add
+
+  timedTest "Adding a duplicate block from an old epoch after it was pruned away doesn't crash":
+    var cache = get_empty_per_epoch_cache()
+
+    blockpool[].addFlags {skipBLSValidation}
+    pool.forkChoice_v2.proto_array.prune_threshold = 1
+
+    let
+      b10 = makeTestBlock(state.data, blockPool[].tail.root, cache)
+      b10Root = hash_tree_root(b10.message)
+      b10Add = blockpool[].add(b10Root, b10)[]
+
+    pool[].addForkChoice_v2(b10Add)
+    let head = pool[].selectHead()
+
+    check:
+      head == b10Add
+
+    let block_ok = state_transition(state.data, b10, {}, noRollback)
+    check:
+      block_ok
+
+    # -------------------------------------------------------------
+    let b10_clone = b10 # Assumes deep copy
+
+    # -------------------------------------------------------------
+    # Pass an epoch
+    var block_root = b10Root
+
+    var attestations: seq[Attestation]
+
+    for epoch in 0 ..< 5:
+      let start_slot = compute_start_slot_at_epoch(Epoch epoch)
+      for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+
+        let new_block = makeTestBlock(state.data, block_root, cache, attestations = attestations)
+        let block_ok = state_transition(state.data, new_block, {skipBLSValidation}, noRollback)
+        check:
+          block_ok
+
+        block_root = hash_tree_root(new_block.message)
+        let blockRef = blockpool[].add(block_root, new_block)[]
+
+        pool[].addForkChoice_v2(blockRef)
+
+        let head = pool[].selectHead()
+        check:
+          head == blockRef
+        blockPool[].updateHead(head)
+
+        attestations.setlen(0)
+        for index in 0 ..< get_committee_count_at_slot(state.data.data, slot.Slot):
+          let committee = get_beacon_committee(
+              state.data.data, state.data.data.slot, index.CommitteeIndex, cache)
+
+          # Create a bitfield filled with the given count per attestation,
+          # exactly on the right-most part of the committee field.
+          var aggregation_bits = init(CommitteeValidatorsBits, committee.len)
+          for v in 0 ..< committee.len * 2 div 3 + 1:
+            aggregation_bits[v] = true
+
+          attestations.add Attestation(
+            aggregation_bits: aggregation_bits,
+            data: makeAttestationData(
+              state.data.data, state.data.data.slot,
+              index, blockroot
+            )
+            # signature: ValidatorSig()
+          )
+
+      cache = get_empty_per_epoch_cache()
+
+    # -------------------------------------------------------------
+    # Prune
+
+    echo "\nPruning all blocks before: ", shortlog(blockPool[].finalizedHead), '\n'
+    doAssert blockPool[].finalizedHead.slot != 0
+
+    pool[].pruneBefore(blockPool[].finalizedHead)
+    doAssert: b10Root notin pool.forkChoice_v2
+
+    # Add back the old block to ensure we don't crash the fork choice
+    let b10Add_clone = blockpool[].add(b10Root, b10_clone)[]
+    pool[].addForkChoice_v2(b10Add_clone)

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -213,13 +213,13 @@ suiteReport "Block pool processing" & preset():
       pool2.heads.len == 1
       pool2.heads[0].blck.root == b2Root
 
-  timedTest "Can add same block twice" & preset():
+  timedTest "Adding the same block twice returns a Duplicate error" & preset():
     let
       b10 = pool.add(b1Root, b1)[]
-      b11 = pool.add(b1Root, b1)[]
+      b11 = pool.add(b1Root, b1)
 
     check:
-      b10 == b11
+      b11.error == Duplicate
       not b10.isNil
 
   timedTest "updateHead updates head and headState" & preset():
@@ -370,4 +370,3 @@ when const_preset == "minimal":  # These require some minutes in mainnet
           hash_tree_root(pool.headState.data.data)
         hash_tree_root(pool2.justifiedState.data.data) ==
           hash_tree_root(pool.justifiedState.data.data)
-


### PR DESCRIPTION
Reboot of #1163 after we had to revert in #1181

The issue has been reproduced and transformed into a test case:

1. We sync
2. We go pass a finalization point, and so prune the fork choice
3. We receive an old block from before the finalization point
4. The fork choice crashes because the block's parent doesn't exist anymore in its history

The solution is like "Old" blocks, to also drops duplicates here:
https://github.com/status-im/nim-beacon-chain/blob/206ff7f9d6085d9e192644513626feed9d28f3d8/beacon_chain/block_pools/clearance.nim#L110-L142
https://github.com/status-im/nim-beacon-chain/blob/206ff7f9d6085d9e192644513626feed9d28f3d8/beacon_chain/beacon_node.nim#L550-L576

The stacktrace of the test after 9af7e06 is
![image](https://user-images.githubusercontent.com/22738317/85447443-eaaa3800-b595-11ea-96cc-63bb26067d27.png)

which is the same as the one reported in https://github.com/status-im/nim-beacon-chain/pull/1163#issuecomment-644531631

```
_slot=143436 request_step=1 wall_clock_slot=145504
DBG 2020-06-16 06:54:41+02:00 Requesting blocks from peer                topics="syncman" tid=1901944 file=sync_manager.nim:611 peer=16Uiu2HAkucMAVckq8yyLU51pbnzjTZ6JptPLKdpH5USBGuuvinHP peer_score=200 slot=143436 slot_count=4 step=1
DBG 2020-06-16 06:54:41+02:00 Synchronization loop waiting for new peer  topics="syncman" tid=1901944 file=sync_manager.nim:935 local_head_slot=143432 sleep_time=6m24s0ns wall_head_slot=145504 workers_count=2
DBG 2020-06-16 06:54:41+02:00 Received blocks on request                 topics="syncman" tid=1901944 file=sync_manager.nim:762 blocks_count=4 blocks_map=xxxx peer=16Uiu2HAkvfDTKtFoSU5CHoA47BRwcJhN2zfvmr1kZXAwbweV3pq2 peer_score=200 request_count=4 request_slot=143432 request_step=1
DBG 2020-06-16 06:54:41+02:00 Forward sync imported blocks               topics="beacnde" tid=1901944 file=beacon_node.nim:552 count=4 local_head_slot=143432
DBG 2020-06-16 06:54:41+02:00 Block received                             topics="beacnde" tid=1901944 file=beacon_node.nim:293 blockRoot=1beab7a4 cat=block_listener pcs=receive_block signedBlock="(slot: 143432, proposer_index: 734, parent_root: \"c276ba51\", state_root: \"9c33444b\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 7, deposits_len: 0, voluntary_exits_len: 0)"
DBG 2020-06-16 06:54:41+02:00 Block already exists                       topics="clearance" tid=1901944 file=clearance.nim:133 blck="(slot: 143432, proposer_index: 734, parent_root: \"c276ba51\", state_root: \"9c33444b\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 7, deposits_len: 0, voluntary_exits_len: 0)" blockRoot=1beab7a4 cat=filtering pcs=block_addition
 peers: 0 ❯ finalized: abfa25a6:4034 ❯ head: 1beab7a4:4482:8 ❯ time: 4546:1 (145473)                                                                                                                                                                           ETH: 31.47697782 Traceback (most recent call last, using override)
../csu/libc-start.c(308) 
/home/arnetheduck/status/nim-beacon-chain/beacon_chain/mainchain_monitor.nim(526) main
/home/arnetheduck/status/nim-beacon-chain/beacon_chain/mainchain_monitor.nim(519) NimMain
/home/arnetheduck/status/nim-beacon-chain/beacon_chain/beacon_node.nim(1109) main
/home/arnetheduck/status/nim-beacon-chain/beacon_chain/beacon_node.nim(851) start
/home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronicles/chronicles.nim(331) run
/home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(407) reportUnhandledError
/home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(358) reportUnhandledErrorAux
Error: unhandled exception: Trying to acces value with err Result: process_block_error: (kind: fcErrUnknownParent, child_root: 1BEAB7A4C29A864B05F3D8E5AAC8727F34D06D28280BD89D5BDE969B436D54DE, parent_root: C276BA5155F19C72D73932FE75D8291DD4FC3630A5FDF82D3A3484319BFA04CD) [ResultDefect]
```
