### PR TITLE
Should fix https://github.com/status-im/nim-beacon-chain/issues/1230

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -133,7 +133,7 @@ proc isValidAttestation*(
     pool.blockPool.addMissing(attestation.data.beacon_block_root)
     return false
 
-  pool.blockPool.withEpochState(
+  pool.blockPool.withState(
       pool.blockPool.tmpState,
       BlockSlot(blck: attestationBlck, slot: attestation.data.slot)):
     when ETH2_SPEC == "v0.12.1":


### PR DESCRIPTION
It seems fast enough.

```
$ N=0; while ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --disable-htop -- --verify-finalization --stop-at-epoch=8; do N=$((N+1)); echo "That was run #${N}"; sleep 71; done
Building: build/beacon_node
beacon_chain/beacon_node.nim(1117, 1) template/generic instantiation of `programMain` from here
beacon_chain/beacon_node.nim(1118, 35) template/generic instantiation of `makeBannerAndConfig` from here
beacon_chain/nimbus_binary_common.nim(59, 11) template/generic instantiation of `load` from here
vendor/nim-confutils/confutils.nim(749, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
{"lvl":"INF","ts":"2020-06-25 13:22:27+02:00","msg":"Generating deposits","tid":1729095,"file":"keystore_management.nim:109","secretsDir":"local_testnet_data/secrets","totalValidators":128,"validatorsDir":"local_testnet_data/deposits_dir"}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #1
Building: build/beacon_node
beacon_chain/beacon_node.nim(1117, 1) template/generic instantiation of `programMain` from here
beacon_chain/beacon_node.nim(1118, 35) template/generic instantiation of `makeBannerAndConfig` from here
beacon_chain/nimbus_binary_common.nim(59, 11) template/generic instantiation of `load` from here
vendor/nim-confutils/confutils.nim(749, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
{"lvl":"INF","ts":"2020-06-25 13:31:47+02:00","msg":"Generating deposits","tid":1731036,"file":"keystore_management.nim:109","secretsDir":"local_testnet_data/secrets","totalValidators":128,"validatorsDir":"local_testnet_data/deposits_dir"}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #2
```