### PR TITLE
Attach all local validators before starting the networking

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -245,7 +245,7 @@ proc init*(T: type BeaconNode, conf: BeaconNodeConf): Future[BeaconNode] {.async
       onBeaconBlock(res, signedBlock)
   )
 
-  traceAsyncErrors res.addLocalValidators()
+  await res.addLocalValidators()
 
   # This merely configures the BeaconSync
   # The traffic will be started when we join the network.

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -137,7 +137,7 @@ if [ ! -f "${SNAPSHOT_FILE}" ]; then
       --output-bootstrap-file="${NETWORK_BOOTSTRAP_FILE}" \
       --bootstrap-address=127.0.0.1 \
       --bootstrap-port=$(( BASE_P2P_PORT + BOOTSTRAP_NODE )) \
-      --genesis-offset=15 # Delay in seconds
+      --genesis-offset=30 # Delay in seconds
   fi
 fi
 


### PR DESCRIPTION
This prevents some Discv5 connectivity problems during the initial search for network peers.