### PR TITLE
check that parent of added block is sufficiently recent

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -560,10 +560,10 @@ proc runForwardSyncLoop(node: BeaconNode) {.async.} =
     let sm = now(chronos.Moment)
     for blk in list:
       let res = node.storeBlock(blk)
-      # We going to ignore `BlockError.Old` errors because we have working
+      # We going to ignore `BlockError.Unviable` errors because we have working
       # backward sync and it can happens that we can perform overlapping
       # requests.
-      if res.isErr and res.error != BlockError.Old:
+      if res.isErr and res.error != BlockError.Unviable:
         return res
     discard node.updateHead()
 

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -24,9 +24,18 @@ import
 
 type
   BlockError* = enum
-    MissingParent
-    Old
-    Invalid
+    MissingParent ##\
+      ## We don't know the parent of this block so we can't tell if it's valid
+      ## or not - it'll go into the quarantine and be reexamined when the parent
+      ## appears or be discarded if finality obsoletes it
+
+    Unviable ##\
+      ## Block is from a different history / fork than the one we're interested
+      ## in (based on our finalized checkpoint)
+
+    Invalid ##\
+      ## Block is broken / doesn't apply cleanly - whoever sent it is fishy (or
+      ## we're buggy)
 
   Quarantine* = object
     ## Keeps track of unsafe blocks coming from the network


### PR DESCRIPTION
Otherwise, we might introduce a fork into the DAG that is no longer
viable, creating trouble for both sync and fork choice