### PR TITLE
adopt Result[void, string] in place of some bool return signatures

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -83,7 +83,7 @@ func process_deposit*(
         # TODO spec test?
         # TODO: This is temporary set to trace level in order to deal with the
         #       large number of invalid deposits on Altona
-        return err("process_deposit: skipping deposit with invalid signature")
+        return ok()
 
     # Add validator and balance entries
     state.validators.add(Validator(

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -52,7 +52,7 @@ func decrease_balance*(
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#deposits
 func process_deposit*(
     state: var BeaconState, deposit: Deposit, flags: UpdateFlags = {}):
-    Result[void, string] {.nbench.} =
+    Result[void, cstring] {.nbench.} =
   # Process an Eth1 deposit, registering a validator or increasing its balance.
 
   # Verify the Merkle branch
@@ -632,7 +632,7 @@ proc check_attestation*(
 
 proc process_attestation*(
     state: var BeaconState, attestation: SomeAttestation, flags: UpdateFlags,
-    stateCache: var StateCache): Result[void, string] {.nbench.} =
+    stateCache: var StateCache): Result[void, cstring] {.nbench.} =
   # In the spec, attestation validation is mixed with state mutation, so here
   # we've split it into two functions so that the validation logic can be
   # reused when looking for suitable blocks to include in attestations.

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -63,7 +63,7 @@ func process_deposit*(
     state.eth1_deposit_index,
     state.eth1_data.deposit_root,
   ):
-    return err("Deposit Merkle validation failed")
+    return err("process_deposit: deposit Merkle validation failed")
 
   # Deposits must be processed in order
   state.eth1_deposit_index += 1
@@ -83,7 +83,7 @@ func process_deposit*(
         # TODO spec test?
         # TODO: This is temporary set to trace level in order to deal with the
         #       large number of invalid deposits on Altona
-        return err("Skipping deposit with invalid signature")
+        return err("process_deposit: skipping deposit with invalid signature")
 
     # Add validator and balance entries
     state.validators.add(Validator(
@@ -641,7 +641,7 @@ proc process_attestation*(
 
   let proposer_index = get_beacon_proposer_index(state, stateCache)
   if proposer_index.isNone:
-    return err("No beacon proposer index and probably no active validators")
+    return err("process_attestation: no beacon proposer index and probably no active validators")
 
   if check_attestation(state, attestation, flags, stateCache):
     let

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -83,6 +83,8 @@ func process_deposit*(
         # TODO spec test?
         # TODO: This is temporary set to trace level in order to deal with the
         #       large number of invalid deposits on Altona
+        trace "Skipping deposit with invalid signature",
+          deposit = shortLog(deposit.data)
         return ok()
 
     # Add validator and balance entries

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -46,23 +46,23 @@ func process_block_header*(
     stateCache: var StateCache): Result[void, cstring] {.nbench.} =
   # Verify that the slots match
   if not (blck.slot == state.slot):
-    return err("Block header: slot mismatch")
+    return err("process_block_header: slot mismatch")
 
   # Verify that the block is newer than latest block header
   if not (blck.slot > state.latest_block_header.slot):
-    return err("Block header: block not newer than latest block header")
+    return err("process_block_header: block not newer than latest block header")
 
   # Verify that proposer index is the correct index
   let proposer_index = get_beacon_proposer_index(state, stateCache)
   if proposer_index.isNone:
-    return err("Block header: proposer missing")
+    return err("process_block_header: proposer missing")
 
   if not (blck.proposer_index.ValidatorIndex == proposer_index.get):
-    return err("Block header: proposer index incorrect")
+    return err("process_block_header: proposer index incorrect")
 
   # Verify that the parent matches
   if not (blck.parent_root == hash_tree_root(state.latest_block_header)):
-    return err("Block header: previous block root mismatch")
+    return err("process_block_header: previous block root mismatch")
 
   # Cache current block as the new latest block
   state.latest_block_header = BeaconBlockHeader(
@@ -76,7 +76,7 @@ func process_block_header*(
   # Verify proposer is not slashed
   let proposer = state.validators[proposer_index.get]
   if proposer.slashed:
-    return err("Block header: proposer slashed")
+    return err("process_block_header: proposer slashed")
 
   ok()
 
@@ -147,24 +147,24 @@ proc process_proposer_slashing*(
 
   # Not from spec
   if header_1.proposer_index.int >= state.validators.len:
-    return err("Proposer slashing: invalid proposer index")
+    return err("process_proposer_slashing: invalid proposer index")
 
   # Verify header slots match
   if not (header_1.slot == header_2.slot):
-    return err("Proposer slashing: slot mismatch")
+    return err("process_proposer_slashing: slot mismatch")
 
   # Verify header proposer indices match
   if not (header_1.proposer_index == header_2.proposer_index):
-    return err("Proposer slashing: proposer indices mismatch")
+    return err("process_proposer_slashing: proposer indices mismatch")
 
   # Verify the headers are different
   if not (header_1 != header_2):
-    return err("Proposer slashing: headers not different")
+    return err("process_proposer_slashing: headers not different")
 
   # Verify the proposer is slashable
   let proposer = state.validators[header_1.proposer_index]
   if not is_slashable_validator(proposer, get_current_epoch(state)):
-    return err("Proposer slashing: slashed proposer")
+    return err("process_proposer_slashing: slashed proposer")
 
   # Verify signatures
   if skipBlsValidation notin flags:
@@ -173,7 +173,7 @@ proc process_proposer_slashing*(
       if not verify_block_signature(
           state.fork, state.genesis_validators_root, signed_header.message.slot,
           signed_header.message, proposer.pubkey, signed_header.signature):
-        return err("Proposer slashing: invalid signature")
+        return err("process_proposer_slashing: invalid signature")
 
   slashValidator(state, header_1.proposer_index.ValidatorIndex, stateCache)
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -44,8 +44,6 @@ declareGauge beacon_processed_deposits_total, "Number of total deposits included
 func process_block_header*(
     state: var BeaconState, blck: SomeBeaconBlock, flags: UpdateFlags,
     stateCache: var StateCache): Result[void, cstring] {.nbench.} =
-  logScope:
-    blck = shortLog(blck)
   # Verify that the slots match
   if not (blck.slot == state.slot):
     return err("Block header: slot mismatch")
@@ -339,11 +337,12 @@ proc process_block*(
   beacon_previous_live_validators.set(toHashSet(
     mapIt(state.previous_epoch_attestations, it.proposerIndex)).len.int64)
 
+  logScope:
+    blck = shortLog(blck)
   let res_block = process_block_header(state, blck, flags, stateCache)
   if res_block.isErr:
     debug "Block header not valid",
       block_header_error = $res_block,
-      blck = shortLog(blck),
       slot = state.slot
     return false
 
@@ -357,7 +356,6 @@ proc process_block*(
   if res_ops.isErr:
     debug "process_operations encountered error",
       operation_error = $res_ops,
-      blck = shortLog(blck),
       slot = state.slot,
       eth1_deposit_index = state.eth1_deposit_index,
       deposit_root = shortLog(state.eth1_data.deposit_root)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -342,7 +342,7 @@ proc process_block*(
   let res_block = process_block_header(state, blck, flags, stateCache)
   if res_block.isErr:
     debug "Block header not valid",
-      block_header_error = $res_block,
+      block_header_error = $(res_block.error),
       slot = state.slot
     return false
 
@@ -355,7 +355,7 @@ proc process_block*(
   let res_ops = process_operations(state, blck.body, flags, stateCache)
   if res_ops.isErr:
     debug "process_operations encountered error",
-      operation_error = $res_ops,
+      operation_error = $(res_ops.error),
       slot = state.slot,
       eth1_deposit_index = state.eth1_deposit_index,
       deposit_root = shortLog(state.eth1_data.deposit_root)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -21,8 +21,6 @@
 #   spec does so also.
 # * For indices, we get a mix of uint64, ValidatorIndex and int - this is currently
 #   swept under the rug with casts
-# * Sane error handling is missing in most cases (yay, we'll get the chance to
-#   debate exceptions again!)
 # When updating the code, add TODO sections to mark where there are clear
 # improvements to be made - other than that, keep things similar to spec for
 # now.
@@ -43,39 +41,33 @@ declareGauge beacon_pending_deposits, "Number of pending deposits (state.eth1_da
 declareGauge beacon_processed_deposits_total, "Number of total deposits included on chain" # On block
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#block-header
-proc process_block_header*(
+func process_block_header*(
     state: var BeaconState, blck: SomeBeaconBlock, flags: UpdateFlags,
-    stateCache: var StateCache): bool {.nbench.} =
+    stateCache: var StateCache): Result[void, string] {.nbench.} =
   logScope:
     blck = shortLog(blck)
   # Verify that the slots match
   if not (blck.slot == state.slot):
-    notice "Block header: slot mismatch",
-      state_slot = shortLog(state.slot)
-    return false
+    return err("Block header: slot mismatch; state.slot = " & $state.slot)
 
   # Verify that the block is newer than latest block header
   if not (blck.slot > state.latest_block_header.slot):
-    debug "Block header: block not newer than latest block header"
-    return false
+    return err("Block header: block not newer than latest block header")
 
   # Verify that proposer index is the correct index
   let proposer_index = get_beacon_proposer_index(state, stateCache)
   if proposer_index.isNone:
-    debug "Block header: proposer missing"
-    return false
+    return err("Block header: proposer missing")
 
   if not (blck.proposer_index.ValidatorIndex == proposer_index.get):
-    notice "Block header: proposer index incorrect",
-      proposer_index = proposer_index.get
-    return false
+    return err("Block header: proposer index incorrect; proposer_index = " &
+      $proposer_index.get)
 
   # Verify that the parent matches
   if not (blck.parent_root == hash_tree_root(state.latest_block_header)):
-    notice "Block header: previous block root mismatch",
-      latest_block_header = state.latest_block_header,
-      latest_block_header_root = shortLog(hash_tree_root(state.latest_block_header))
-    return false
+    return err("Block header: previous block root mismatch; expecting " &
+      shortLog(hash_tree_root(state.latest_block_header)) & " but got " &
+      $state.latest_block_header)
 
   # Cache current block as the new latest block
   state.latest_block_header = BeaconBlockHeader(
@@ -89,12 +81,11 @@ proc process_block_header*(
   # Verify proposer is not slashed
   let proposer = state.validators[proposer_index.get]
   if proposer.slashed:
-    notice "Block header: proposer slashed"
-    return false
+    return err("Block header: proposer slashed")
 
-  true
+  ok()
 
-proc `xor`[T: array](a, b: T): T =
+func `xor`[T: array](a, b: T): T =
   for i in 0..<result.len:
     result[i] = a[i] xor b[i]
 
@@ -152,7 +143,8 @@ func is_slashable_validator(validator: Validator, epoch: Epoch): bool =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#proposer-slashings
 proc process_proposer_slashing*(
     state: var BeaconState, proposer_slashing: ProposerSlashing,
-    flags: UpdateFlags, stateCache: var StateCache): bool {.nbench.}=
+    flags: UpdateFlags, stateCache: var StateCache):
+    Result[void, string] {.nbench.} =
 
   let
     header_1 = proposer_slashing.signed_header_1.message
@@ -160,29 +152,24 @@ proc process_proposer_slashing*(
 
   # Not from spec
   if header_1.proposer_index.int >= state.validators.len:
-    notice "Proposer slashing: invalid proposer index"
-    return false
+    return err("Proposer slashing: invalid proposer index")
 
   # Verify header slots match
   if not (header_1.slot == header_2.slot):
-    notice "Proposer slashing: slot mismatch"
-    return false
+    return err("Proposer slashing: slot mismatch")
 
   # Verify header proposer indices match
   if not (header_1.proposer_index == header_2.proposer_index):
-    notice "Proposer slashing: proposer indices mismatch"
-    return false
+    return err("Proposer slashing: proposer indices mismatch")
 
   # Verify the headers are different
   if not (header_1 != header_2):
-    notice "Proposer slashing: headers not different"
-    return false
+    return err("Proposer slashing: headers not different")
 
   # Verify the proposer is slashable
   let proposer = state.validators[header_1.proposer_index]
   if not is_slashable_validator(proposer, get_current_epoch(state)):
-    notice "Proposer slashing: slashed proposer"
-    return false
+    return err("Proposer slashing: slashed proposer")
 
   # Verify signatures
   if skipBlsValidation notin flags:
@@ -191,13 +178,11 @@ proc process_proposer_slashing*(
       if not verify_block_signature(
           state.fork, state.genesis_validators_root, signed_header.message.slot,
           signed_header.message, proposer.pubkey, signed_header.signature):
-        notice "Proposer slashing: invalid signature",
-          signature_index = i
-        return false
+        return err("Proposer slashing: invalid signature " & $i)
 
   slashValidator(state, header_1.proposer_index.ValidatorIndex, stateCache)
 
-  true
+  ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#is_slashable_attestation_data
 func is_slashable_attestation_data(
@@ -217,84 +202,73 @@ proc process_attester_slashing*(
        attester_slashing: AttesterSlashing,
        flags: UpdateFlags,
        stateCache: var StateCache
-     ): bool {.nbench.}=
-    let
-      attestation_1 = attester_slashing.attestation_1
-      attestation_2 = attester_slashing.attestation_2
+     ): Result[void, string] {.nbench.}=
+  let
+    attestation_1 = attester_slashing.attestation_1
+    attestation_2 = attester_slashing.attestation_2
 
-    if not is_slashable_attestation_data(
-        attestation_1.data, attestation_2.data):
-      notice "Attester slashing: surround or double vote check failed"
-      return false
+  if not is_slashable_attestation_data(
+      attestation_1.data, attestation_2.data):
+    return err("Attester slashing: surround or double vote check failed")
 
-    if not is_valid_indexed_attestation(state, attestation_1, flags):
-      notice "Attester slashing: invalid attestation 1"
-      return false
+  if not is_valid_indexed_attestation(state, attestation_1, flags):
+    return err("Attester slashing: invalid attestation 1")
 
-    if not is_valid_indexed_attestation(state, attestation_2, flags):
-      notice "Attester slashing: invalid attestation 2"
-      return false
+  if not is_valid_indexed_attestation(state, attestation_2, flags):
+    return err("Attester slashing: invalid attestation 2")
 
-    var slashed_any = false
+  var slashed_any = false
 
-    for index in sorted(toSeq(intersection(
-        toHashSet(attestation_1.attesting_indices.asSeq),
-        toHashSet(attestation_2.attesting_indices.asSeq)).items), system.cmp):
-      if is_slashable_validator(
-          state.validators[index.int], get_current_epoch(state)):
-        slash_validator(state, index.ValidatorIndex, stateCache)
-        slashed_any = true
-    if not slashed_any:
-      notice "Attester slashing: Trying to slash participant(s) twice"
-      return false
-    return true
+  for index in sorted(toSeq(intersection(
+      toHashSet(attestation_1.attesting_indices.asSeq),
+      toHashSet(attestation_2.attesting_indices.asSeq)).items), system.cmp):
+    if is_slashable_validator(
+        state.validators[index.int], get_current_epoch(state)):
+      slash_validator(state, index.ValidatorIndex, stateCache)
+      slashed_any = true
+  if not slashed_any:
+    return err("Attester slashing: Trying to slash participant(s) twice")
+  ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#voluntary-exits
 proc process_voluntary_exit*(
     state: var BeaconState,
     signed_voluntary_exit: SignedVoluntaryExit,
-    flags: UpdateFlags): bool {.nbench.}=
+    flags: UpdateFlags): Result[void, string] {.nbench.} =
 
   let voluntary_exit = signed_voluntary_exit.message
 
   # Not in spec. Check that validator_index is in range
   if voluntary_exit.validator_index >= state.validators.len.uint64:
-    notice "Exit: invalid validator index",
-      index = voluntary_exit.validator_index,
-      num_validators = state.validators.len
-    return false
+    return err("Exit: invalid validator index; " &
+      $voluntary_exit.validator_index & " >= " & $state.validators.len)
 
   let validator = state.validators[voluntary_exit.validator_index.int]
 
   # Verify the validator is active
   if not is_active_validator(validator, get_current_epoch(state)):
-    notice "Exit: validator not active"
-    return false
+    return err("Exit: validator not active")
 
   # Verify the validator has not yet exited
   if validator.exit_epoch != FAR_FUTURE_EPOCH:
-    notice "Exit: validator has exited"
-    return false
+    return err("Exit: validator has exited")
 
-  ## Exits must specify an epoch when they become valid; they are not valid
-  ## before then
+  # Exits must specify an epoch when they become valid; they are not valid
+  # before then
   if not (get_current_epoch(state) >= voluntary_exit.epoch):
-    notice "Exit: exit epoch not passed"
-    return false
+    return err("Exit: exit epoch not passed")
 
   # Verify the validator has been active long enough
   if not (get_current_epoch(state) >= validator.activation_epoch +
       SHARD_COMMITTEE_PERIOD):
-    notice "Exit: not in validator set long enough"
-    return false
+    return err("Exit: not in validator set long enough")
 
   # Verify signature
   if skipBlsValidation notin flags:
     if not verify_voluntary_exit_signature(
         state.fork, state.genesis_validators_root, voluntary_exit,
         validator.pubkey, signed_voluntary_exit.signature):
-      notice "Exit: invalid signature"
-      return false
+      return err("Exit: invalid signature")
 
   # Initiate exit
   debug "Exit: processing voluntary exit (validator_leaving)",
@@ -310,11 +284,12 @@ proc process_voluntary_exit*(
   initiate_validator_exit(
     state, voluntary_exit.validator_index.ValidatorIndex, cache)
 
-  true
+  ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#operations
 proc process_operations(state: var BeaconState, body: SomeBeaconBlockBody,
-    flags: UpdateFlags, stateCache: var StateCache): bool {.nbench.} =
+    flags: UpdateFlags, stateCache: var StateCache):
+    Result[void, string] {.nbench.} =
   # Verify that outstanding deposits are processed up to the maximum number of
   # deposits
   let
@@ -322,22 +297,20 @@ proc process_operations(state: var BeaconState, body: SomeBeaconBlockBody,
     req_deposits = min(MAX_DEPOSITS,
       state.eth1_data.deposit_count.int64 - state.eth1_deposit_index.int64)
   if not (num_deposits == req_deposits):
-    notice "processOperations: incorrect number of deposits",
-      num_deposits = num_deposits,
-      req_deposits = req_deposits,
-      deposit_count = state.eth1_data.deposit_count,
-      deposit_index = state.eth1_deposit_index
-    return false
+    return err("incorrect number of deposits; expected " & $req_deposits &
+      " and got " & $num_deposits)
 
   template for_ops_cached(operations: auto, fn: auto) =
     for operation in operations:
-      if not fn(state, operation, flags, stateCache):
-        return false
+      let res = fn(state, operation, flags, stateCache)
+      if res.isErr:
+        return res
 
   template for_ops(operations: auto, fn: auto) =
     for operation in operations:
-      if not fn(state, operation, flags):
-        return false
+      let res = fn(state, operation, flags)
+      if res.isErr:
+        return res
 
   for_ops_cached(body.proposer_slashings, process_proposer_slashing)
   for_ops_cached(body.attester_slashings, process_attester_slashing)
@@ -345,7 +318,7 @@ proc process_operations(state: var BeaconState, body: SomeBeaconBlockBody,
   for_ops(body.deposits, process_deposit)
   for_ops(body.voluntary_exits, process_voluntary_exit)
 
-  true
+  ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#block-processing
 proc process_block*(
@@ -371,8 +344,10 @@ proc process_block*(
   beacon_previous_live_validators.set(toHashSet(
     mapIt(state.previous_epoch_attestations, it.proposerIndex)).len.int64)
 
-  if not process_block_header(state, blck, flags, stateCache):
-    notice "Block header not valid", slot = shortLog(state.slot)
+  let res_block = process_block_header(state, blck, flags, stateCache)
+  if res_block.isErr:
+    debug "Block header not valid",
+      block_header_error = $res_block
     return false
 
   if not process_randao(state, blck.body, flags, stateCache):
@@ -380,8 +355,11 @@ proc process_block*(
     return false
 
   process_eth1_data(state, blck.body)
-  if not process_operations(state, blck.body, flags, stateCache):
-    # One could combine this and the default-true, but that's a bit implicit
+
+  let res_ops = process_operations(state, blck.body, flags, stateCache)
+  if res_ops.isErr:
+    debug "process_operations encountered error",
+      operation_error = $res_ops
     return false
 
   true

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -343,8 +343,8 @@ proc process_block*(
   if res_block.isErr:
     debug "Block header not valid",
       block_header_error = $res_block,
-      state = shortLog(state),
-      blck = shortLog(blck)
+      blck = shortLog(blck),
+      slot = state.slot
     return false
 
   if not process_randao(state, blck.body, flags, stateCache):
@@ -357,8 +357,10 @@ proc process_block*(
   if res_ops.isErr:
     debug "process_operations encountered error",
       operation_error = $res_ops,
-      state = shortLog(state),
-      blck = shortLog(blck)
+      blck = shortLog(blck),
+      slot = state.slot,
+      eth1_deposit_index = state.eth1_deposit_index,
+      deposit_root = shortLog(state.eth1_data.deposit_root)
     return false
 
   true

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -228,13 +228,13 @@ template processBlockScenarioImpl(
   var consObj = parseSSZ(consObjPath, ConsensusObjectRefType)
 
   when needFlags and needCache:
-    let success = transitionFn(state.data, consObj[], flags, cache)
+    let success = transitionFn(state.data, consObj[], flags, cache).isOk
   elif needFlags:
-    let success = transitionFn(state.data, consObj[], flags)
+    let success = transitionFn(state.data, consObj[], flags).isOk
   elif needCache:
-    let success = transitionFn(state, consObj[], flags, cache)
+    let success = transitionFn(state, consObj[], flags, cache).isOk
   else:
-    let success = transitionFn(state, consObj[])
+    let success = transitionFn(state, consObj[]).isOk
 
   echo astToStr(transitionFn) & " status: ", if success: "SUCCESS ✓" else: "FAILURE ⚠️"
 

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -97,12 +97,12 @@ template decodeAndProcess(typ, process: untyped): bool =
 proc nfuzz_attestation(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(AttestationInput):
-    process_attestation(data.state, data.attestation, flags, cache)
+    process_attestation(data.state, data.attestation, flags, cache).isOk
 
 proc nfuzz_attester_slashing(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(AttesterSlashingInput):
-    process_attester_slashing(data.state, data.attesterSlashing, flags, cache)
+    process_attester_slashing(data.state, data.attesterSlashing, flags, cache).isOk
 
 proc nfuzz_block(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
@@ -123,22 +123,22 @@ proc nfuzz_block(input: openArray[byte], xoutput: ptr byte,
 proc nfuzz_block_header(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(BlockHeaderInput):
-    process_block_header(data.state, data.beaconBlock.message, flags, cache)
+    process_block_header(data.state, data.beaconBlock.message, flags, cache).isOk
 
 proc nfuzz_deposit(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(DepositInput):
-    process_deposit(data.state, data.deposit, flags)
+    process_deposit(data.state, data.deposit, flags).isOk
 
 proc nfuzz_proposer_slashing(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(ProposerSlashingInput):
-    process_proposer_slashing(data.state, data.proposerSlashing, flags, cache)
+    process_proposer_slashing(data.state, data.proposerSlashing, flags, cache).isOk
 
 proc nfuzz_voluntary_exit(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(VoluntaryExitInput):
-    process_voluntary_exit(data.state, data.exit, flags)
+    process_voluntary_exit(data.state, data.exit, flags).isOk
 
 # Note: Could also accept raw input pointer and access list_size + seed here.
 # However, list_size needs to be known also outside this proc to allocate xoutput.

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, beaconstate, validator],
   ../../beacon_chain/ssz,
@@ -44,12 +46,12 @@ proc runTest(identifier: string) =
 
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
-        let done = process_attestation(preState[], attestation, {}, cache)
+        let done = process_attestation(preState[], attestation, {}, cache).isOk
         doAssert done, "Valid attestation not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_attestation(preState[], attestation, {}, cache)
+        let done = process_attestation(preState[], attestation, {}, cache).isOk
         doAssert done == false, "We didn't expect this invalid attestation to be processed."
 
   `testImpl _ operations_attestations _ identifier`()

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
   ../../beacon_chain/ssz,
@@ -45,13 +47,13 @@ proc runTest(identifier: string) =
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
         let done = process_attester_slashing(preState[], attesterSlashing,
-                                             {}, cache)
+                                             {}, cache).isOk
         doAssert done, "Valid attestater slashing not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
         let done = process_attester_slashing(preState[], attesterSlashing,
-                                             {}, cache)
+                                             {}, cache).isOk
         doAssert done == false, "We didn't expect this invalid attester slashing to be processed."
 
   `testImpl _ operations_attester_slashing _ identifier`()

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
   ../../beacon_chain/ssz,
@@ -44,12 +46,12 @@ proc runTest(identifier: string) =
 
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
-        let done = process_block_header(preState[], blck, {}, cache)
+        let done = process_block_header(preState[], blck, {}, cache).isOk
         doAssert done, "Valid block header not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_block_header(preState[], blck, {}, cache)
+        let done = process_block_header(preState[], blck, {}, cache).isOk
         doAssert done == false, "We didn't expect this invalid block header to be processed."
 
   `testImpl _ blockheader _ identifier`()

--- a/tests/official/test_fixture_operations_deposits.nim
+++ b/tests/official/test_fixture_operations_deposits.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, beaconstate],
   ../../beacon_chain/[ssz, extras],
@@ -48,7 +50,7 @@ proc runTest(identifier: string) =
         discard process_deposit(preState[], deposit, flags)
         reportDiff(preState, postState)
       else:
-        check not process_deposit(preState[], deposit, flags)
+        check process_deposit(preState[], deposit, flags).isErr
 
   `testImpl _ operations_deposits _ identifier`()
 

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
   ../../beacon_chain/ssz,
@@ -44,12 +46,12 @@ proc runTest(identifier: string) =
 
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
-        let done = process_proposer_slashing(preState[], proposerSlashing, {}, cache)
+        let done = process_proposer_slashing(preState[], proposerSlashing, {}, cache).isOk
         doAssert done, "Valid proposer slashing not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_proposer_slashing(preState[], proposerSlashing, {}, cache)
+        let done = process_proposer_slashing(preState[], proposerSlashing, {}, cache).isOk
         doAssert done == false, "We didn't expect this invalid proposer slashing to be processed."
 
   `testImpl_proposer_slashing _ identifier`()

--- a/tests/official/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/test_fixture_operations_voluntary_exit.nim
@@ -10,6 +10,8 @@
 import
   # Standard library
   os, unittest,
+  # Utilities
+  stew/results,
   # Beacon chain internals
   ../../beacon_chain/spec/[datatypes, state_transition_block],
   ../../beacon_chain/ssz,
@@ -42,12 +44,12 @@ proc runTest(identifier: string) =
 
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
-        let done = process_voluntary_exit(preState[], voluntaryExit, {})
+        let done = process_voluntary_exit(preState[], voluntaryExit, {}).isOk
         doAssert done, "Valid voluntary exit not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_voluntary_exit(preState[], voluntaryExit, {})
+        let done = process_voluntary_exit(preState[], voluntaryExit, {}).isOk
         doAssert done == false, "We didn't expect this invalid voluntary exit to be processed."
 
   `testImpl _ voluntary_exit _ identifier`()

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -14,6 +14,7 @@
 import
   # Standard library
   unittest,
+  stew/results,
   # Specs
   ../../beacon_chain/spec/[beaconstate, datatypes, helpers, validator],
   # Mock helpers
@@ -50,7 +51,7 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
       var cache = get_empty_per_epoch_cache()
       check process_attestation(
         state.data, attestation, flags = {}, cache
-      )
+      ).isOk
 
       # Check that the attestation was processed
       if attestation.data.target.epoch == get_current_epoch(state.data):

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -55,7 +55,7 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
       # State transition
       # ----------------------------------------
-      check: process_deposit(state.data, deposit, {skipBlsValidation})
+      check: process_deposit(state.data, deposit, {skipBlsValidation}).isOk
 
       # Check invariants
       # ----------------------------------------
@@ -97,7 +97,7 @@ suiteReport "[Unit - Spec - Block processing] Deposits " & preset():
 
     # State transition
     # ----------------------------------------
-    check: process_deposit(state.data, deposit, {skipBlsValidation})
+    check: process_deposit(state.data, deposit, {skipBlsValidation}).isOk
 
     # Check invariants
     # ----------------------------------------


### PR DESCRIPTION
This enables a purer functional core of eth2 beacon chain processing, which had been hindered from achieving that by chronicles logging. There's still some left, but this is an initial PR to show what it looks like. There will be more PRs like this one.

It also rationalizes the sort of pointlessly disparate chronicles logging levels used -- `trace` could be left alone for now, leaving basically `debug`-level ones. Probably the eth2 beacon chain code itself should be mostly quiet at the info/notice levels, so this was an opportunity to switch out some of the more-visible-chronicles-level messages which hadn't been noticed because they weren't showing up much.

```
$ N=0; while ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --disable-htop -- --verify-finalizon --stop-at-epoch=8; do N=$((N+1)); echo "That was run #${N}"; sleep 71; done
Building: build/beacon_node
beacon_chain/beacon_node.nim(1116, 1) template/generic instantiation of `programMain` from here
beacon_chain/beacon_node.nim(1117, 35) template/generic instantiation of `makeBannerAndConfig` from here
beacon_chain/nimbus_binary_common.nim(63, 11) template/generic instantiation of `load` from here
vendor/nim-confutils/confutils.nim(749, 23) Warning: Cannot prove that 'result' is initialized. This will ome a compile time error in the future. [ProveInit]
{"lvl":"INF","ts":"2020-07-02 18:38:14+02:00","msg":"Generating deposits","tid":552949,"file":"keystore_management.nim:109","secretsDi"local_testnet_data/secrets","totalValidators":128,"validatorsDir":"local_testnet_data/deposits_dir"}
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #1
Building: build/beacon_node
beacon_chain/beacon_node.nim(1116, 1) template/generic instantiation of `programMain` from here
beacon_chain/beacon_node.nim(1117, 35) template/generic instantiation of `makeBannerAndConfig` from here
beacon_chain/nimbus_binary_common.nim(63, 11) template/generic instantiation of `load` from here
vendor/nim-confutils/confutils.nim(749, 23) Warning: Cannot prove that 'result' is initialized. This will 
{"lvl":"INF","ts":"2020-07-02 18:47:38+02:00","msg":"Generating deposits","tid":555906,"file":"keystore_management.nim:109","secretsDi
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
That was run #2
```