### PR TITLE
Travis: disable the ARM64 job (too unreliable)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ build_script:
 
 test_script:
   - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% LOG_LEVEL=TRACE
-  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+  - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" beacon_node
   - mingw32-make -j2 ARCH_OVERRIDE=%PLATFORM% DISABLE_TEST_FIXTURES_SCRIPT=1 test
 
 deploy: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,25 +22,24 @@ matrix:
         - NPROC=2
       before_install:
         - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-        - sudo apt-get -q update
-    - os: linux
-      arch: arm64
-      sudo: required
-      env:
-        - NPROC=6 # Worth trying more than 2 parallel jobs: https://travis-ci.community/t/no-cache-support-on-arm64/5416/8
-        # (also used to get a different cache key than the amd64 one)
-      before_install:
-        - export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
-        - sudo apt-get -q update
-        - sudo apt-get install -y libpcre3-dev
+    #- os: linux
+      #arch: arm64
+      #sudo: required
+      #env:
+        #- NPROC=6 # Worth trying more than 2 parallel jobs: https://travis-ci.community/t/no-cache-support-on-arm64/5416/8
+        ## (also used to get a different cache key than the amd64 one)
+      #before_install:
+        #- export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+        #- sudo apt-get -q update
+        #- sudo apt-get install -y libpcre3-dev
     - os: osx
       before_install:
         - HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install ccache
       env:
         - NPROC=2
-  allow_failures:
-    # ARM64 is a bit buggy: https://travis-ci.community/t/no-output-has-been-received-and-then-build-terminated-on-arm64/8834
-    - arch: arm64
+  #allow_failures:
+    ## ARM64 is a bit buggy: https://travis-ci.community/t/no-output-has-been-received-and-then-build-terminated-on-arm64/8834
+    #- arch: arm64
 
 
 install:
@@ -52,7 +51,6 @@ script:
   # Building Nim-1.0.4 takes up to 10 minutes on Travis - the time limit after which jobs are cancelled for having no output
   - make -j${NPROC} NIMFLAGS="--parallelBuild:2" V=1 update # to allow a newer Nim version to be detected
   - make -j${NPROC} NIMFLAGS="--parallelBuild:2" LOG_LEVEL=TRACE
-  - make -j${NPROC} NIMFLAGS="--parallelBuild:2 -d:testnet_servers_image" LOG_LEVEL=TRACE
-  # Compiling "test_all" on ARM64 can take longer than 10 minutes, so make it verbose.
-  - make -j${NPROC} NIMFLAGS="--parallelBuild:2" DISABLE_TEST_FIXTURES_SCRIPT=1 V=1 test
+  - make -j${NPROC} NIMFLAGS="--parallelBuild:2 -d:testnet_servers_image" LOG_LEVEL=TRACE beacon_node
+  - make -j${NPROC} NIMFLAGS="--parallelBuild:2" DISABLE_TEST_FIXTURES_SCRIPT=1 test
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ def runStages() {
 						sh """#!/bin/bash
 						set -e
 						make -j${env.NPROC}
-						make -j${env.NPROC} LOG_LEVEL=TRACE NIMFLAGS='-d:testnet_servers_image'
+						make -j${env.NPROC} LOG_LEVEL=TRACE NIMFLAGS='-d:testnet_servers_image' beacon_node
 						"""
 					}
 				},

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       - task: CacheBeta@1
         displayName: 'cache official test fixtures'
         inputs:
-          key: jsonTestsCache
+          key: jsonTestsCacheV1
           path: jsonTestsCache
 
       - task: CacheBeta@1
@@ -67,7 +67,7 @@ jobs:
           mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE
           if [[ $PLATFORM == "x64" ]]; then
             # everything builds more slowly on 32-bit, since there's no libbacktrace support
-            mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image"
+            mingw32-make -j2 ARCH_OVERRIDE=${PLATFORM} LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" beacon_node
           fi
           file build/beacon_node
           # fail fast


### PR DESCRIPTION
Azure: the jsonTestsCache key needs updating
all: lighten the load a little, since only beacon_node is built with that flag in production