### PR TITLE
allow 50k validators on block_sim

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -268,6 +268,7 @@ func get_eligible_validator_indices(state: BeaconState): seq[ValidatorIndex] =
 
 func get_attestation_component_deltas(state: BeaconState,
                                       attestations: seq[PendingAttestation],
+                                      total_balance: Gwei,
                                       cache: var StateCache,
                                       ): tuple[a: seq[Gwei], b: seq[Gwei]] =
   # Helper with shared logic for use by get source, target, and head deltas
@@ -276,7 +277,6 @@ func get_attestation_component_deltas(state: BeaconState,
     rewards = repeat(0'u64, len(state.validators))
     penalties = repeat(0'u64, len(state.validators))
   let
-    total_balance = get_total_active_balance(state, cache)
     unslashed_attesting_indices =
       get_unslashed_attesting_indices(state, attestations, cache)
     attesting_balance = get_total_balance(state, unslashed_attesting_indices)
@@ -298,28 +298,36 @@ func get_attestation_component_deltas(state: BeaconState,
   (rewards, penalties)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#components-of-attestation-deltas
-func get_source_deltas(state: BeaconState, cache: var StateCache):
+# These is slightly refactored to calculate total_balance once.
+func get_source_deltas(
+    state: BeaconState, total_balance: Gwei, cache: var StateCache):
     tuple[a: seq[Gwei], b: seq[Gwei]] =
   # Return attester micro-rewards/penalties for source-vote for each validator.
   let matching_source_attestations =
     get_matching_source_attestations(state, get_previous_epoch(state))
-  get_attestation_component_deltas(state, matching_source_attestations, cache)
+  get_attestation_component_deltas(
+    state, matching_source_attestations, total_balance, cache)
 
-func get_target_deltas(state: BeaconState, cache: var StateCache):
+func get_target_deltas(
+    state: BeaconState, total_balance: Gwei, cache: var StateCache):
     tuple[a: seq[Gwei], b: seq[Gwei]] =
   # Return attester micro-rewards/penalties for target-vote for each validator.
   let matching_target_attestations =
     get_matching_target_attestations(state, get_previous_epoch(state))
-  get_attestation_component_deltas(state, matching_target_attestations, cache)
+  get_attestation_component_deltas(
+    state, matching_target_attestations, total_balance, cache)
 
-func get_head_deltas(state: BeaconState, cache: var StateCache):
+func get_head_deltas(
+    state: BeaconState, total_balance: Gwei, cache: var StateCache):
     tuple[a: seq[Gwei], b: seq[Gwei]] =
   # Return attester micro-rewards/penalties for head-vote for each validator.
   let matching_head_attestations =
     get_matching_head_attestations(state, get_previous_epoch(state))
-  get_attestation_component_deltas(state, matching_head_attestations, cache)
+  get_attestation_component_deltas(
+    state, matching_head_attestations, total_balance, cache)
 
-func get_inclusion_delay_deltas(state: BeaconState, cache: var StateCache):
+func get_inclusion_delay_deltas(
+    state: BeaconState, total_balance: Gwei, cache: var StateCache):
     seq[Gwei] =
   # Return proposer and inclusion delay micro-rewards/penalties for each validator.
   var rewards = repeat(0'u64, len(state.validators))
@@ -330,7 +338,6 @@ func get_inclusion_delay_deltas(state: BeaconState, cache: var StateCache):
       matching_source_attestations,
       get_attesting_indices(state, it.data, it.aggregation_bits, cache))
 
-  let total_balance = get_total_active_balance(state, cache)
   for index in get_unslashed_attesting_indices(state, matching_source_attestations, cache):
     # Translation of attestation = min([...])
     # Start by filtering the right attestations
@@ -363,11 +370,11 @@ func get_inclusion_delay_deltas(state: BeaconState, cache: var StateCache):
   # Spec constructs both and returns both; this doesn't
   rewards
 
-func get_inactivity_penalty_deltas(state: BeaconState, cache: var StateCache):
+func get_inactivity_penalty_deltas(
+    state: BeaconState, total_balance: Gwei, cache: var StateCache):
     seq[Gwei] =
   # Return inactivity reward/penalty deltas for each validator.
   var penalties = repeat(0'u64, len(state.validators))
-  let total_balance = get_total_active_balance(state, cache)
   if is_in_inactivity_leak(state):
     let
       matching_target_attestations =
@@ -392,14 +399,21 @@ func get_inactivity_penalty_deltas(state: BeaconState, cache: var StateCache):
   penalties
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_attestation_deltas
-func get_attestation_deltas(state: BeaconState, cache: var StateCache): tuple[a: seq[Gwei], b: seq[Gwei]] =
+func get_attestation_deltas(state: BeaconState, cache: var StateCache):
+    tuple[a: seq[Gwei], b: seq[Gwei]] =
   # Return attestation reward/penalty deltas for each validator.
   let
-    (source_rewards, source_penalties) = get_source_deltas(state, cache)
-    (target_rewards, target_penalties) = get_target_deltas(state, cache)
-    (head_rewards, head_penalties) = get_head_deltas(state, cache)
-    inclusion_delay_rewards = get_inclusion_delay_deltas(state, cache)
-    inactivity_penalties = get_inactivity_penalty_deltas(state, cache)
+    total_balance = get_total_active_balance(state, cache)
+    (source_rewards, source_penalties) =
+      get_source_deltas(state, total_balance, cache)
+    (target_rewards, target_penalties) =
+      get_target_deltas(state, total_balance, cache)
+    (head_rewards, head_penalties) =
+      get_head_deltas(state, total_balance, cache)
+    inclusion_delay_rewards =
+      get_inclusion_delay_deltas(state, total_balance, cache)
+    inactivity_penalties =
+      get_inactivity_penalty_deltas(state, total_balance, cache)
 
   let rewards = mapIt(0 ..< len(state.validators),
     source_rewards[it] + target_rewards[it] + head_rewards[it] +


### PR DESCRIPTION
Before, this wouldn't ever finish:
```
Loaded genesim_mainnet_50000_0.12.1.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
................................ slot: 96 epoch: 3
................................ slot: 128 epoch: 4
Done!
Validators: 50000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    1174.637,      282.054,      618.135,     4067.196,          124, Process non-epoch slot with block
    6663.852,     3834.512,     1435.751,     9639.003,            4, Process epoch slot with block
       2.626,        0.344,        0.023,        2.936,          128, Tree-hash block
       1.622,        0.117,        1.357,        1.887,          128, Sign block
    2681.017,      128.942,     2389.148,     3032.249,          128, Have committee attest to block
       2.009,        0.000,        2.009,        2.009,            1, Replay all produced blocks
```