### PR TITLE
halve memory usage from state caches

### DIFF
--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -356,11 +356,14 @@ func putStateCache(
   # with the concomitant memory allocator and GC load. Instead, use a
   # more memory-intensive (but more conceptually straightforward, and
   # faster) strategy to just store, for the most recent slots.
+  if state.data.slot mod 2 != 0:
+    return
+
   let stateCacheIndex = dag.getStateCacheIndex(blck.root, state.data.slot)
   if stateCacheIndex == -1:
     # Could use a deque or similar, but want simpler structure, and the data
     # items are small and few.
-    const MAX_CACHE_SIZE = 32
+    const MAX_CACHE_SIZE = 16
 
     let cacheLen = dag.cachedStates.len
     doAssert cacheLen <= MAX_CACHE_SIZE

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -174,12 +174,12 @@ proc slash_validator*(state: var BeaconState, slashed_index: ValidatorIndex,
     validator.effective_balance div MIN_SLASHING_PENALTY_QUOTIENT)
 
   # The rest doesn't make sense without there being any proposer index, so skip
-  # Apply proposer and whistleblower rewards
   let proposer_index = get_beacon_proposer_index(state, cache)
   if proposer_index.isNone:
     debug "No beacon proposer index and probably no active validators"
     return
 
+  # Apply proposer and whistleblower rewards
   let
     # Spec has whistleblower_index as optional param, but it's never used.
     whistleblower_index = proposer_index.get


### PR DESCRIPTION
This shouldn't be merged until it's checked whether it finalizes in CI.

Much of the memory usage of mainnet beacon chain is due to these state caches, which were implemented as a quick stop-gap when state transitions were much more expensive due to both slow copying of ~2MB states and `hash_tree_root()` bottlenecking state changes, resulting in rewinding being excessively expensive. That's since been mostly mitigated, while emphasis on memory usage has increased.

This is a relatively low-risk, conservative change which keeps local testnets working reliably even without turbo boost enabled (so, 1.8GHz). Under the same conditions, it also keeps `finalizedEpoch + 2 == justifiedEpoch + 1 == headEpoch` ideal constraint.