### PR TITLE
update most remaining non-fork-choice spec refs, updating code where necessary

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -243,9 +243,10 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                          OK
 + Deposit over MAX_EFFECTIVE_BALANCE balance (32 ETH)                                        OK
 + Deposit under MAX_EFFECTIVE_BALANCE balance (32 ETH)                                       OK
++ Invalid deposit at MAX_EFFECTIVE_BALANCE balance (32 ETH)                                  OK
 + Validator top-up                                                                           OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
+OK: 5/5 Fail: 0/5 Skip: 0/5
 ## [Unit - Spec - Epoch processing] Justification and Finalization  [Preset: mainnet]
 ```diff
 +  Rule I - 234 finalization with enough support                                             OK
@@ -265,4 +266,4 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 160/163 Fail: 0/163 Skip: 3/163
+OK: 161/164 Fail: 0/164 Skip: 3/164

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -52,7 +52,7 @@ proc aggregate_attestations*(
   if not is_aggregator(state, slot, index, slot_signature, cache):
     return none(AggregateAndProof)
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#attestation-data
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#attestation-data
   # describes how to construct an attestation, which applies for makeAttestationData(...)
   # TODO this won't actually match anything
   let attestation_data = AttestationData(

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -340,7 +340,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
   var cache = get_empty_per_epoch_cache()
   for a in attestations:
     var
-      # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#construct-attestation
+      # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#construct-attestation
       attestation = Attestation(
         aggregation_bits: a.validations[0].aggregation_bits,
         data: a.data,

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -898,7 +898,6 @@ proc getProposer*(
   dag.withState(dag.tmpState, head.atSlot(slot)):
     var cache = get_empty_per_epoch_cache()
 
-    # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/validator.md#validator-assignments
     let proposerIdx = get_beacon_proposer_index(state, cache)
     if proposerIdx.isNone:
       warn "Missing proposer index",

--- a/beacon_chain/inspector.nim
+++ b/beacon_chain/inspector.nim
@@ -509,7 +509,7 @@ proc pubsubLogger(conf: InspectorConf, switch: Switch,
     try:
       if topic.endsWith(topicBeaconBlocksSuffix & "_snappy"):
         info "SignedBeaconBlock", msg = SSZ.decode(buffer, SignedBeaconBlock)
-      elif topic.endsWith(topicMainnetAttestationsSuffix & "_snappy"):
+      elif topic.endsWith("_snappy") and topic.contains("/beacon_attestation_"):
         info "Attestation", msg = SSZ.decode(buffer, Attestation)
       elif topic.endsWith(topicVoluntaryExitsSuffix & "_snappy"):
         info "SignedVoluntaryExit", msg = SSZ.decode(buffer,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -453,7 +453,7 @@ func get_attesting_indices*(state: BeaconState,
   # This shouldn't happen if one begins with a valid BeaconState and applies
   # valid updates, but one can construct a BeaconState where it does. Do not
   # do anything here since the PendingAttestation wouldn't have made it past
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#attestations
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#attestations
   # which checks len(attestation.aggregation_bits) == len(committee) that in
   # nim-beacon-chain lives in check_attestation(...).
   # Addresses https://github.com/status-im/nim-beacon-chain/issues/922
@@ -568,7 +568,7 @@ proc isValidAttestationTargetEpoch*(
 
   true
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.2/specs/phase0/beacon-chain.md#attestations
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
     state: BeaconState, attestation: SomeAttestation, flags: UpdateFlags,
     stateCache: var StateCache): bool =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -184,13 +184,15 @@ func get_domain*(
   ## of a message.
   get_domain(state.fork, domain_type, epoch, state.genesis_validators_root)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_signing_root
+# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#compute_signing_root
 func compute_signing_root*(ssz_object: auto, domain: Domain): Eth2Digest =
-  # Return the signing root for the corresponding signing data.
-  hash_tree_root(SigningData(
+  # Return the signing root of an object by calculating the root of the
+  # object-domain tree.
+  let domain_wrapped_object = SigningData(
     object_root: hash_tree_root(ssz_object),
     domain: domain
-  ))
+  )
+  hash_tree_root(domain_wrapped_object)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_seed
 func get_seed*(state: BeaconState, epoch: Epoch, domain_type: DomainType): Eth2Digest =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -184,15 +184,13 @@ func get_domain*(
   ## of a message.
   get_domain(state.fork, domain_type, epoch, state.genesis_validators_root)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#compute_signing_root
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_signing_root
 func compute_signing_root*(ssz_object: auto, domain: Domain): Eth2Digest =
-  # Return the signing root of an object by calculating the root of the
-  # object-domain tree.
-  let domain_wrapped_object = SigningData(
+  # Return the signing root for the corresponding signing data.
+  hash_tree_root(SigningData(
     object_root: hash_tree_root(ssz_object),
     domain: domain
-  )
-  hash_tree_root(domain_wrapped_object)
+  ))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_seed
 func get_seed*(state: BeaconState, epoch: Epoch, domain_type: DomainType): Eth2Digest =

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -19,9 +19,6 @@ const
   topicAttesterSlashingsSuffix* = "attester_slashing/ssz"
   topicAggregateAndProofsSuffix* = "beacon_aggregate_and_proof/ssz"
 
-  # https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/p2p-interface.md#topics-and-messages
-  topicMainnetAttestationsSuffix* = "_beacon_attestation/ssz"
-
   # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#misc
   ATTESTATION_SUBNET_COUNT* = 64
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -262,7 +262,7 @@ proc state_transition*(
       state.data, state.data.slot.compute_epoch_at_slot)
   state_transition(state, signedBlock, cache, flags, rollback)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#preparing-for-a-beaconblock
 # TODO There's more to do here - the spec has helpers that deal set up some of
 #      the fields in here!
 proc makeBeaconBlock*(

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -70,7 +70,7 @@ func get_total_active_balance*(state: BeaconState, cache: var StateCache): Gwei 
   except KeyError:
     raiseAssert("get_total_active_balance(): cache always filled before usage")
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#helper-functions-1
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_matching_source_attestations(state: BeaconState,
                                       epoch: Epoch): seq[PendingAttestation] =
   doAssert epoch in [get_current_epoch(state), get_previous_epoch(state)]
@@ -104,7 +104,7 @@ func get_attesting_balance(
   get_total_balance(state, get_unslashed_attesting_indices(
     state, attestations, stateCache))
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#justification-and-finalization
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#justification-and-finalization
 proc process_justification_and_finalization*(state: var BeaconState,
     stateCache: var StateCache, updateFlags: UpdateFlags = {}) {.nbench.} =
 
@@ -437,7 +437,7 @@ func process_rewards_and_penalties(
     increase_balance(state, i.ValidatorIndex, rewards[i])
     decrease_balance(state, i.ValidatorIndex, penalties[i])
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.9.4/specs/core/0_beacon-chain.md#slashings
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#slashings
 func process_slashings*(state: var BeaconState, cache: var StateCache) {.nbench.}=
   let
     epoch = get_current_epoch(state)

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -24,7 +24,7 @@ func shortLog*(x: Checkpoint): string =
 # Helpers used in epoch transition and trace-level block transition
 # --------------------------------------------------------
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#helper-functions-1
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_attesting_indices*(
     state: BeaconState, attestations: openarray[PendingAttestation],
     stateCache: var StateCache): HashSet[ValidatorIndex] =

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -12,7 +12,7 @@ import
   # Specs
   ../../beacon_chain/spec/[datatypes, beaconstate],
   # Internals
-  ../../beacon_chain/[extras, interop],
+  ../../beacon_chain/interop,
   # Mocking procs
   ./mock_deposits
 


### PR DESCRIPTION
No semantic/functional changes outside inspector.

What's left:
```
$ grep -Frin "https://github.com/ethereum/eth2.0-specs/" . | grep -Ev "issues|v0.12|/vendor/|fork-choice.md|/pull/|/dev/|/master/"
./beacon_chain/attestation_aggregation.nim:77:# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#attestation-subnets
./beacon_chain/block_pools/clearance.nim:265:# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/p2p-interface.md#global-topics
./beacon_chain/spec/beaconstate.nim:503:# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#attestations
./beacon_chain/mainchain_monitor.nim:423:# https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#get_eth1_data
```

`beacon_chain/attestation_aggregation.nim:77` is `isValidAttestation()`, which needs rechecking for v0.12.1.

`beacon_chain/spec/beaconstate.nim:503` is sort of part of that, a half-done refactoring of attestation validation, which has the same issue.

`beacon_chain/block_pools/clearance.nim:265` is `isValidBlock()`, which similarly needs rechecking for v0.12.1.

`beacon_chain/mainchain_monitor.nim:423` I need to look more closely at -- it's `getBlockProposalData()`.

The test result summary change just catches up to a previous PR which should have done that already, but didn't.

Initially:
`compute_signing_root()` is the same, but rephrased as v0.12.1 does in the spec. I don't have much strong preference for either form, but they're about equally natural in Nim, so no reason not to.

Now:
I reverted `compute_signing_root()` because, though it's by appearances harmless, it ensures it's mergeable independently of debugging the PeerPool issue that appeared in https://dev.azure.com/nimbus-dev/nim-beacon-chain/_build/results?buildId=5972&view=logs&jobId=2e1ef983-081d-5c63-b72a-d9f329364ee0&j=2e1ef983-081d-5c63-b72a-d9f329364ee0&t=69fb04d4-8d32-57d9-fbcf-c139b9f5d9e0 in 64-bit Azure.