### PR TITLE
Improve block_sim speed with 50k+ validators

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -76,5 +76,5 @@ task test, "Run all tests":
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
 
   # State and block sims; getting to 4th epoch triggers consensus checks
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=2000 --slots=128"
-  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=2000 --slots=128"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
+  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard libraries
-  deques, sequtils, tables, options, algorithm,
+  deques, sequtils, tables, options,
   # Status libraries
   chronicles, stew/[byteutils], json_serialization/std/sets,
   # Internal
@@ -274,8 +274,6 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
           #      sets by virtue of not overlapping with some other attestation
           #      and therefore being useful after all?
           trace "Ignoring subset attestation",
-            existingParticipants = get_attesting_indices_seq(
-              state, a.data, v.aggregation_bits, cache),
             newParticipants = participants,
             cat = "filtering"
           found = true
@@ -286,10 +284,6 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
         # can now be removed per same logic as above
 
         trace "Removing subset attestations",
-          existingParticipants = a.validations.filterIt(
-            it.aggregation_bits.isSubsetOf(validation.aggregation_bits)
-          ).mapIt(get_attesting_indices_seq(
-            state, a.data, it.aggregation_bits, cache)),
           newParticipants = participants,
           cat = "pruning"
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -417,7 +417,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
       epoch = scheduledSlot.compute_epoch_at_slot(),
       slot = scheduledSlot
 
-    # Brute-force, but ensure it's reliably enough to run in CI.
+    # Brute-force, but ensure it's reliable enough to run in CI.
     quit(0)
 
   if not wallSlot.afterGenesis or (wallSlot.slot < lastSlot):

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -460,7 +460,6 @@ type
   StateCache* = object
     shuffled_active_validator_indices*:
       Table[Epoch, seq[ValidatorIndex]]
-    committee_count_cache*: Table[Epoch, uint64]
     beacon_proposer_indices*: Table[Slot, Option[ValidatorIndex]]
 
 func shortValidatorKey*(state: BeaconState, validatorIdx: int): string =

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -9,7 +9,7 @@
 {.push raises: [Defect].}
 
 import
-  algorithm, options, sequtils, math, tables,
+  algorithm, options, sequtils, math, tables, sets,
   ./datatypes, ./digest, ./helpers
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_shuffled_index
@@ -140,18 +140,15 @@ func get_beacon_committee*(
     cache.shuffled_active_validator_indices[epoch] =
       get_shuffled_active_validator_indices(state, epoch)
 
-  # Constant throughout an epoch
-  if epoch notin cache.committee_count_cache:
-    cache.committee_count_cache[epoch] =
-      get_committee_count_at_slot(state, slot)
-
   try:
+    let committee_count = get_committee_count_at_slot(
+      cache.shuffled_active_validator_indices[epoch].len)
     compute_committee(
       cache.shuffled_active_validator_indices[epoch],
       get_seed(state, epoch, DOMAIN_BEACON_ATTESTER),
-      (slot mod SLOTS_PER_EPOCH) * cache.committee_count_cache[epoch] +
+      (slot mod SLOTS_PER_EPOCH) * committee_count +
         index.uint64,
-      cache.committee_count_cache[epoch] * SLOTS_PER_EPOCH
+      committee_count * SLOTS_PER_EPOCH
     )
   except KeyError:
     raiseAssert "values are added to cache before using them"
@@ -160,7 +157,6 @@ func get_beacon_committee*(
 func get_empty_per_epoch_cache*(): StateCache =
   result.shuffled_active_validator_indices =
     initTable[Epoch, seq[ValidatorIndex]]()
-  result.committee_count_cache = initTable[Epoch, uint64]()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_proposer_index
 func compute_proposer_index(state: BeaconState, indices: seq[ValidatorIndex],
@@ -234,7 +230,8 @@ func get_beacon_proposer_index*(state: BeaconState, cache: var StateCache):
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#validator-assignments
 func get_committee_assignment*(
-    state: BeaconState, epoch: Epoch, validator_index: ValidatorIndex):
+    state: BeaconState, epoch: Epoch,
+    validator_indices: HashSet[ValidatorIndex]):
     Option[tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot]] {.used.} =
   # Return the committee assignment in the ``epoch`` for ``validator_index``.
   # ``assignment`` returned is a tuple of the following form:
@@ -242,6 +239,9 @@ func get_committee_assignment*(
   #     * ``assignment[1]`` is the index to which the committee is assigned
   #     * ``assignment[2]`` is the slot at which the committee is assigned
   # Return None if no assignment.
+  #
+  # Slightly adapted from spec version to support multiple validator indices,
+  # since each beacon_node supports many validators.
   let next_epoch = get_current_epoch(state) + 1
   doAssert epoch <= next_epoch
 
@@ -251,9 +251,8 @@ func get_committee_assignment*(
   for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
     for index in 0 ..< get_committee_count_at_slot(state, slot):
       let idx = index.CommitteeIndex
-      let committee =
-        get_beacon_committee(state, slot, idx, cache)
-      if validator_index in committee:
+      let committee = get_beacon_committee(state, slot, idx, cache)
+      if not disjoint(validator_indices, toHashSet(committee)):
         return some((committee, idx, slot))
   none(tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot])
 

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard library
-  tables, strutils, parseutils, sequtils,
+  tables, strutils, parseutils, sequtils, sets,
 
   # Nimble packages
   stew/[byteutils, objects],
@@ -356,7 +356,8 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
         let idx = state.validators.asSeq.findIt(it.pubKey == pubkey)
         if idx == -1:
           continue
-        let ca = state.get_committee_assignment(epoch, idx.ValidatorIndex)
+        let ca = state.get_committee_assignment(
+          epoch, toHashSet([idx.ValidatorIndex]))
         if ca.isSome:
           result.add((public_key: pubkey,
                       committee_index: ca.get.b,


### PR DESCRIPTION
More progress towards running 50k or 100k validators smoothly on `block_sim`.

- `get_beacon_committee()` was pointlessly calling the full version of `get_committee_count_at_slot()`, when it's just a simple arithmetic function of the number of active validators, which `get_beacon_committee()` already has.

- `get_inclusion_delay_deltas()` is part of the epoch processing, which had a quadratically growing part.

- the `get_committee_assignment()` / `installValidatorApiHandlers()` changes prepare for dynamically subscribing and unsubscribing to attestation subnets.

Before:
```
$ time build/block_sim --validators=100000 --slots=64
Loaded genesim_mainnet_100000_0.12.1.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    4025.887,     2255.056,     2237.409,    15992.623,           62, Process non-epoch slot with block
   21661.675,    16770.872,     9802.878,    33520.473,            2, Process epoch slot with block
       4.948,        0.878,        0.018,        5.684,           64, Tree-hash block
       1.562,        0.103,        1.385,        1.842,           64, Sign block
    7754.820,      156.415,     7471.934,     8206.023,           64, Have committee attest to block
       3.745,        0.000,        3.745,        3.745,            1, Replay all produced blocks

real	13m29.612s
user	13m18.196s
sys	0m2.752s
```

After:
```
$ time build/block_sim --validators=100000 --slots=64
Loaded genesim_mainnet_100000_0.12.1.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    3859.758,     2263.392,     2142.557,    16094.623,           62, Process non-epoch slot with block
   11636.219,     3293.731,     9307.200,    13965.239,            2, Process epoch slot with block
       4.811,        0.852,        0.023,        5.823,           64, Tree-hash block
       1.521,        0.087,        1.355,        1.764,           64, Sign block
    4311.929,      142.398,     3978.022,     4696.124,           64, Have committee attest to block
       3.924,        0.000,        3.924,        3.924,            1, Replay all produced blocks

real	9m16.943s
user	9m9.943s
sys	0m1.356s
```

Non-epoch slot times only go down slightly -- that was worth fixing, but was coming up when reloading an `epochRef` into `StateCache`, where the latter was being incompletely repopulated due to `EpochRef` not containing all the same information. In particular, it was coming up in `onAttestation`, which doesn't have any other source for its cache.

Epoch slot times are reduced by 2 to 3 times.

The combination creates a ~40% increase in block sim speed overall at 100k validators. It doesn't seem to matter nearly as much up to, say, 20k validators.