### PR TITLE
Compute state root instead of loading from database

### DIFF
--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -502,12 +502,8 @@ proc skipAndUpdateState(
     state: var HashedBeaconState, blck: BlockRef, slot: Slot, save: bool) =
   while state.data.slot < slot:
     # Process slots one at a time in case afterUpdate needs to see empty states
-    # TODO when replaying, we already do this query when loading the ancestors -
-    #      save and reuse
-    # TODO possibly we should keep this in memory for the hot blocks
-    let nextStateRoot = dag.db.getStateRoot(blck.root, state.data.slot + 1)
     var stateCache = getEpochCache(blck, state.data)
-    advance_slot(state, nextStateRoot, dag.updateFlags, stateCache)
+    advance_slot(state, dag.updateFlags, stateCache)
 
     if save:
       dag.putState(state, blck)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -125,8 +125,8 @@ func process_slot*(state: var HashedBeaconState) {.nbench.} =
     hash_tree_root(state.data.latest_block_header)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc advance_slot*(state: var HashedBeaconState,
-    nextStateRoot: Opt[Eth2Digest], updateFlags: UpdateFlags,
+proc advance_slot*(
+    state: var HashedBeaconState, updateFlags: UpdateFlags,
     epochCache: var StateCache) {.nbench.} =
   # Special case version of process_slots that moves one slot at a time - can
   # run faster if the state root is known already (for example when replaying
@@ -141,10 +141,7 @@ proc advance_slot*(state: var HashedBeaconState,
   if is_epoch_transition:
     beacon_current_validators.set(get_epoch_validator_count(state.data))
 
-  if nextStateRoot.isSome:
-    state.root = nextStateRoot.get()
-  else:
-    state.root = hash_tree_root(state.data)
+  state.root = hash_tree_root(state.data)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc process_slots*(state: var HashedBeaconState, slot: Slot,
@@ -166,7 +163,7 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot,
   # Catch up to the target slot
   var cache = get_empty_per_epoch_cache()
   while state.data.slot < slot:
-    advance_slot(state, err(Opt[Eth2Digest]), updateFlags, cache)
+    advance_slot(state, updateFlags, cache)
 
   true
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -92,7 +92,7 @@ proc addTestBlock*(
     graffiti = Eth2Digest(),
     flags: set[UpdateFlag] = {}): SignedBeaconBlock =
   # Create and add a block to state - state will advance by one slot!
-  advance_slot(state, err(Opt[Eth2Digest]), flags, cache)
+  advance_slot(state, flags, cache)
 
   let
     proposer_index = get_beacon_proposer_index(state.data, cache)


### PR DESCRIPTION
htr is fast now, so hitting the database to load the state root is no
longer motivated - the more simple code is less vulnerable to database
corruption.