### PR TITLE
Makefile: "publish-book" target combines both books

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,30 +224,21 @@ book:
 	cd docs/the_nimbus_book && \
 	mdbook build
 
-publish-book: | book
-	git worktree add tmp-book gh-pages && \
-	rm -rf tmp-book/* && \
-	cp -a docs/the_nimbus_book/book/* tmp-book/ && \
-	cd tmp-book && \
-	git add . && { \
-		git commit -m "make publish-book" && \
-		git push origin gh-pages || true; } && \
-	cd .. && \
-	git worktree remove -f tmp-book && \
-	rm -rf tmp-book
-
 auditors-book:
 	cd docs/the_auditors_handbook && \
 	mdbook build
 
-publish-auditors-book: | auditors-book
+publish-book: | book auditors-book
+	git branch -D gh-pages && \
+	git branch --track gh-pages origin/gh-pages && \
 	git worktree add tmp-book gh-pages && \
+	rm -rf tmp-book/* && \
 	mkdir -p tmp-book/auditors-book && \
-	rm -rf tmp-book/auditors-book/* && \
+	cp -a docs/the_nimbus_book/book/* tmp-book/ && \
 	cp -a docs/the_auditors_handbook/book/* tmp-book/auditors-book/ && \
 	cd tmp-book && \
 	git add . && { \
-		git commit -m "make publish-auditors-book" && \
+		git commit -m "make publish-book" && \
 		git push origin gh-pages || true; } && \
 	cd .. && \
 	git worktree remove -f tmp-book && \


### PR DESCRIPTION
Since both books share the same Git branch and the same base URL, it
makes sense to combine them when publishing.

Fixes #1281 