### PR TITLE
restore EpochRef and flush statecaches on epoch transitions

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -48,7 +48,7 @@ proc aggregate_attestations*(
   # TODO for testing purposes, refactor this into the condition check
   # and just calculation
   # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#aggregation-selection
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   if not is_aggregator(state, slot, index, slot_signature, cache):
     return none(AggregateAndProof)
 

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -13,7 +13,7 @@ import
   # Status libraries
   chronicles, stew/[byteutils], json_serialization/std/sets,
   # Internal
-  ./spec/[beaconstate, datatypes, crypto, digest, helpers, validator],
+  ./spec/[beaconstate, datatypes, crypto, digest, helpers],
   ./extras, ./block_pool, ./block_pools/candidate_chains, ./beacon_node_types,
   ./fork_choice/fork_choice
 
@@ -464,7 +464,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
   if attestations.len == 0:
     return
 
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   for a in attestations:
     var
       # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#construct-attestation

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -172,7 +172,7 @@ func getEpochInfo*(blck: BlockRef, state: BeaconState): EpochRef =
 
     # Don't use BlockRef caching as far as the epoch where the active
     # validator indices can diverge.
-    if (compute_activation_exit_epoch(blck.slot.compute_epoch_at_slot) <
+    if (compute_activation_exit_epoch(blck.slot.compute_epoch_at_slot) >
         state_epoch):
       blck.epochsInfo.add(cache)
     trace "candidate_chains.getEpochInfo: back-filling parent.epochInfo",
@@ -185,7 +185,7 @@ func getEpochInfo*(blck: BlockRef, state: BeaconState): EpochRef =
 
 func getEpochCache*(blck: BlockRef, state: BeaconState): StateCache =
   let epochInfo = getEpochInfo(blck, state)
-  result = get_empty_per_epoch_cache()
+  result = StateCache()
   result.shuffled_active_validator_indices[
     state.slot.compute_epoch_at_slot] =
       epochInfo.shuffled_active_validator_indices
@@ -925,7 +925,7 @@ proc getProposer*(
     dag: CandidateChains, head: BlockRef, slot: Slot):
     Option[(ValidatorIndex, ValidatorPubKey)] =
   dag.withState(dag.tmpState, head.atSlot(slot)):
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
 
     let proposerIdx = get_beacon_proposer_index(state, cache)
     if proposerIdx.isNone:

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -592,10 +592,13 @@ proc check_attestation*(
   trace "process_attestation: beginning",
     attestation=attestation
 
-  if not (data.index < get_committee_count_at_slot(state, data.slot)):
+  let committee_count_at_slot =
+    get_committee_count_at_slot(get_shuffled_active_validator_indices(
+      state, stateSlot.compute_epoch_at_slot, stateCache).len.uint64).uint64
+  if not (data.index < committee_count_at_slot):
     warn("Data index exceeds committee count",
       data_index = data.index,
-      committee_count = get_committee_count_at_slot(state, data.slot))
+      committee_count = committee_count_at_slot)
     return
 
   if not isValidAttestationTargetEpoch(state, data):

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -107,7 +107,7 @@ proc process_deposit*(preset: RuntimePreset,
   ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_activation_exit_epoch
-func compute_activation_exit_epoch(epoch: Epoch): Epoch =
+func compute_activation_exit_epoch*(epoch: Epoch): Epoch =
   ## Return the epoch during which validator activations and exits initiated in
   ## ``epoch`` take effect.
   epoch + 1 + MAX_SEED_LOOKAHEAD

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -65,7 +65,7 @@ func get_active_validator_indices*(state: BeaconState, epoch: Epoch):
       result.add idx.ValidatorIndex
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_committee_count_at_slot
-func get_committee_count_at_slot*(num_active_validators: Slot): uint64 =
+func get_committee_count_at_slot*(num_active_validators: uint64): uint64 =
   clamp(
     num_active_validators div SLOTS_PER_EPOCH div TARGET_COMMITTEE_SIZE,
     1, MAX_COMMITTEES_PER_SLOT).uint64
@@ -77,9 +77,10 @@ func get_committee_count_at_slot*(state: BeaconState, slot: Slot): uint64 =
   # be converted to CommitteeIndex types for get_beacon_committee(...); replace
   # with better and more type-safe use pattern, probably beginning with using a
   # CommitteeIndex return type here.
-  let epoch = compute_epoch_at_slot(slot)
-  let active_validator_indices = get_active_validator_indices(state, epoch)
-  result = get_committee_count_at_slot(len(active_validator_indices).uint64.Slot)
+  let
+    epoch = compute_epoch_at_slot(slot)
+    active_validator_indices = get_active_validator_indices(state, epoch)
+  result = get_committee_count_at_slot(len(active_validator_indices).uint64)
 
   # Otherwise, get_beacon_committee(...) cannot access some committees.
   doAssert (SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT).uint64 >= result

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -70,7 +70,7 @@ func compute_subnet_for_attestation*(
   let
     slots_since_epoch_start = attestation.data.slot mod SLOTS_PER_EPOCH
     committees_since_epoch_start =
-      get_committee_count_at_slot(num_active_validators.Slot) * slots_since_epoch_start
+      get_committee_count_at_slot(num_active_validators) * slots_since_epoch_start
 
   (committees_since_epoch_start + attestation.data.index) mod ATTESTATION_SUBNET_COUNT
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -172,7 +172,7 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot,
     return false
 
   # Catch up to the target slot
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   while state.data.slot < slot:
     advance_slot(state, updateFlags, cache)
 
@@ -264,7 +264,7 @@ proc state_transition*(
   # TODO consider moving this to testutils or similar, since non-testing
   # and fuzzing code should always be coming from blockpool which should
   # always be providing cache or equivalent
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   cache.shuffled_active_validator_indices[state.data.slot.compute_epoch_at_slot] =
     get_shuffled_active_validator_indices(
       state.data, state.data.slot.compute_epoch_at_slot)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -137,6 +137,7 @@ proc advance_slot*(
     # Note: Genesis epoch = 0, no need to test if before Genesis
     beacon_previous_validators.set(get_epoch_validator_count(state.data))
     process_epoch(state.data, updateFlags, epochCache)
+    epochCache = get_empty_per_epoch_cache()
   state.data.slot += 1
   if is_epoch_transition:
     beacon_current_validators.set(get_epoch_validator_count(state.data))
@@ -207,10 +208,8 @@ proc state_transition*(
   #      the changes in case of failure (look out for `var BeaconState` and
   #      bool return values...)
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
-  when false:
-    # TODO readd this assetion when epochref cache is back
-    doAssert stateCache.shuffled_active_validator_indices.hasKey(
-      state.data.slot.compute_epoch_at_slot)
+  doAssert stateCache.shuffled_active_validator_indices.hasKey(
+    state.data.slot.compute_epoch_at_slot)
 
   if not process_slots(state, signedBlock.message.slot, flags):
     rollback(state)
@@ -256,8 +255,6 @@ proc state_transition*(
   # and fuzzing code should always be coming from blockpool which should
   # always be providing cache or equivalent
   var cache = get_empty_per_epoch_cache()
-  # TODO not here, but in blockpool, should fill in as far ahead towards
-  # block's slot as protocol allows to be known already
   cache.shuffled_active_validator_indices[state.data.slot.compute_epoch_at_slot] =
     get_shuffled_active_validator_indices(
       state.data, state.data.slot.compute_epoch_at_slot)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -274,7 +274,7 @@ proc process_voluntary_exit*(
     validator_withdrawable_epoch = validator.withdrawable_epoch,
     validator_exit_epoch = validator.exit_epoch,
     validator_effective_balance = validator.effective_balance
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   initiate_validator_exit(
     state, voluntary_exit.validator_index.ValidatorIndex, cache)
 

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -211,18 +211,17 @@ func compute_proposer_index(state: BeaconState, indices: seq[ValidatorIndex],
   if len(indices) == 0:
     return none(ValidatorIndex)
 
-  let seq_len = indices.len
+  let seq_len = indices.len.uint64
 
   var
-    i = 0
+    i = 0'u64
     buffer: array[32+8, byte]
   buffer[0..31] = seed.data
   while true:
     buffer[32..39] = int_to_bytes8(i.uint64 div 32)
     let
       candidate_index =
-        indices[
-          compute_shuffled_index((i mod seq_len).uint64, seq_len.uint64, seed)]
+        indices[compute_shuffled_index((i mod seq_len).uint64, seq_len, seed)]
       random_byte = (eth2digest(buffer).data)[i mod 32]
       effective_balance =
         state.validators[candidate_index].effective_balance

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -218,13 +218,12 @@ func compute_proposer_index(state: BeaconState, indices: seq[ValidatorIndex],
     buffer: array[32+8, byte]
   buffer[0..31] = seed.data
   while true:
-    buffer[32..39] = int_to_bytes8(i.uint64 div 32)
+    buffer[32..39] = int_to_bytes8(i div 32)
     let
       candidate_index =
-        indices[compute_shuffled_index((i mod seq_len).uint64, seq_len, seed)]
+        indices[compute_shuffled_index(i mod seq_len, seq_len, seed)]
       random_byte = (eth2digest(buffer).data)[i mod 32]
-      effective_balance =
-        state.validators[candidate_index].effective_balance
+      effective_balance = state.validators[candidate_index].effective_balance
     if effective_balance * MAX_RANDOM_BYTE >=
         MAX_EFFECTIVE_BALANCE * random_byte:
       return some(candidate_index)

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -228,7 +228,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       stateId: string, epoch: uint64, index: uint64, slot: uint64) ->
       seq[BeaconStatesCommitteesTuple]:
     withStateForStateId(stateId):
-      var cache = get_empty_per_epoch_cache() # TODO is this OK?
+      var cache = StateCache() # TODO is this OK?
       
       proc getCommittee(slot: Slot, index: CommitteeIndex): BeaconStatesCommitteesTuple =
         let vals = get_beacon_committee(state, slot, index, cache).mapIt(it.uint64)

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -341,13 +341,7 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
           cache.shuffled_active_validator_indices[
             slot.compute_epoch_at_slot].len.uint64
         except KeyError:
-          when false:
-            # TODO re-enable when getEpochCache() works
-            raiseAssert "getEpochCache(...) didn't fill cache"
-          let epoch = slot.compute_epoch_at_slot
-          cache.shuffled_active_validator_indices[epoch] =
-            get_shuffled_active_validator_indices(state, epoch)
-          cache.shuffled_active_validator_indices[epoch].len.uint64
+          raiseAssert "getEpochCache(...) didn't fill cache"
 
     for committee_index in 0'u64..<committees_per_slot:
       let committee = get_beacon_committee(

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -196,7 +196,7 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       doAssert v.addr == addr poolPtr.tmpState.data
       assign(poolPtr.tmpState, poolPtr.headState)
 
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let message = makeBeaconBlock(
       node.config.runtimePreset,
       hashedState,
@@ -401,7 +401,7 @@ proc broadcastAggregatedAttestations(
   node.blockPool.withState(node.blockPool.tmpState, bs):
     let
       committees_per_slot = get_committee_count_at_slot(state, aggregationSlot)
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     for committee_index in 0'u64..<committees_per_slot:
       let committee = get_beacon_committee(
         state, aggregationSlot, committee_index.CommitteeIndex, cache)

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -187,7 +187,7 @@ template processEpochScenarioImpl(
   state.root = hash_tree_root(state.data)
 
   when needCache:
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let epoch = state.data.slot.compute_epoch_at_slot
     cache.shuffled_active_validator_indices[epoch] =
       get_shuffled_active_validator_indices(state.data, epoch)
@@ -223,7 +223,7 @@ template processBlockScenarioImpl(
   state.root = hash_tree_root(state.data)
 
   when needCache:
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
   when needFlags:
     let flags = if skipBLS: {skipBlsValidation}
                 else: {}

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -60,7 +60,7 @@ template decodeAndProcess(typ, process: untyped): bool =
   let flags {.inject.} = if disable_bls: {skipBlsValidation} else: {}
 
   var
-    cache {.used, inject.} = get_empty_per_epoch_cache()
+    cache {.used, inject.} = StateCache()
     data {.inject.} = newClone(
       try:
         SSZ.decode(input, typ)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -67,7 +67,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       attestationHead = blockPool.head.blck.atSlot(slot)
 
     blockPool.withState(blockPool.tmpState, attestationHead):
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
       let committees_per_slot = get_committee_count_at_slot(state, slot)
 
       for committee_index in 0'u64..<committees_per_slot:
@@ -100,7 +100,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       head = blockPool.head.blck
 
     blockPool.withState(blockPool.tmpState, head.atSlot(slot)):
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       let
         proposerIdx = get_beacon_proposer_index(state, cache).get()

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -54,7 +54,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     attesters: RunningStat
     r = initRand(1)
     signedBlock: SignedBeaconBlock
-    cache = get_empty_per_epoch_cache()
+    cache = StateCache()
 
   proc maybeWrite(last: bool) =
     if write_last_json:

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -55,7 +55,7 @@ proc mockAttestationData(
   )
 
 proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   let participants = get_attesting_indices(
     state,
     attestation.data,
@@ -80,7 +80,7 @@ proc mockAttestationImpl(
        slot: Slot,
        flags: UpdateFlags): Attestation =
 
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
 
   let
     beacon_committee = get_beacon_committee(
@@ -113,7 +113,7 @@ proc mockAttestation*(
   mockAttestationImpl(state, slot, flags)
 
 func fillAggregateAttestation*(state: BeaconState, attestation: var Attestation) =
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   let beacon_committee = get_beacon_committee(
     state,
     attestation.data.slot,

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -44,7 +44,7 @@ proc mockBlock(
   ## Mock a BeaconBlock for the specific slot
   ## Skip signature creation if block should not be signed (skipBlsValidation present)
 
-  var emptyCache = get_empty_per_epoch_cache()
+  var emptyCache = StateCache()
   let proposer_index = get_beacon_proposer_index(state, emptyCache)
   result.message.slot = slot
   result.message.proposer_index = proposer_index.get.uint64

--- a/tests/official/test_fixture_operations_attestations.nim
+++ b/tests/official/test_fixture_operations_attestations.nim
@@ -13,7 +13,7 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, beaconstate, validator],
+  ../../beacon_chain/spec/[datatypes, beaconstate],
   ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
@@ -39,7 +39,7 @@ proc runTest(identifier: string) =
       prefix = "[Invalid] "
 
     timedTest prefix & identifier:
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       let attestation = parseTest(testDir/"attestation.ssz", SSZ, Attestation)
       var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))

--- a/tests/official/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/test_fixture_operations_attester_slashings.nim
@@ -13,7 +13,7 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
+  ../../beacon_chain/spec/[datatypes, state_transition_block],
   ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
@@ -39,7 +39,7 @@ proc runTest(identifier: string) =
       prefix = "[Invalid] "
 
     timedTest prefix & identifier:
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       let attesterSlashing = parseTest(testDir/"attester_slashing.ssz", SSZ, AttesterSlashing)
       var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -13,7 +13,7 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
+  ../../beacon_chain/spec/[datatypes, state_transition_block],
   ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
@@ -39,7 +39,7 @@ proc runTest(identifier: string) =
       prefix = "[Invalid] "
 
     timedTest prefix & identifier:
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       let blck = parseTest(testDir/"block.ssz", SSZ, BeaconBlock)
       var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))

--- a/tests/official/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/test_fixture_operations_proposer_slashings.nim
@@ -13,7 +13,7 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, state_transition_block, validator],
+  ../../beacon_chain/spec/[datatypes, state_transition_block],
   ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,
@@ -42,7 +42,7 @@ proc runTest(identifier: string) =
       let proposerSlashing = parseTest(testDir/"proposer_slashing.ssz", SSZ, ProposerSlashing)
       var preState = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
 
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       if existsFile(testDir/"post.ssz"):
         let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))

--- a/tests/official/test_fixture_state_transition_epoch.nim
+++ b/tests/official/test_fixture_state_transition_epoch.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   os, unittest, strutils,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, validator, state_transition_epoch],
+  ../../beacon_chain/spec/[datatypes, state_transition_epoch],
   # Test utilities
   ../testutil,
   ./fixtures_utils,
@@ -42,7 +42,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
           let postState = newClone(parseTest(testDir/"post.ssz", SSZ, BeaconState))
 
           when useCache:
-            var cache = get_empty_per_epoch_cache()
+            var cache = StateCache()
             transitionProc(preState[], cache)
           else:
             transitionProc(preState[])

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -16,7 +16,7 @@ import
   unittest,
   stew/results,
   # Specs
-  ../../beacon_chain/spec/[beaconstate, datatypes, helpers, validator],
+  ../../beacon_chain/spec/[beaconstate, datatypes, helpers],
   # Mock helpers
   ../mocking/[mock_genesis, mock_attestations, mock_state],
   ../testutil
@@ -48,7 +48,7 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
 
       # State transition
       # ----------------------------------------
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
       check process_attestation(
         state.data, attestation, flags = {}, cache
       ).isOk

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -8,7 +8,7 @@
 import
   # Specs
   ../../beacon_chain/spec/[
-    datatypes, state_transition_epoch, validator, state_transition]
+    datatypes, state_transition_epoch, state_transition]
 
 proc processSlotsUntilEndCurrentEpoch(state: var HashedBeaconState) =
   # Process all slots until the end of the last slot of the current epoch
@@ -28,6 +28,6 @@ proc transitionEpochUntilJustificationFinalization*(state: var HashedBeaconState
   processSlotsUntilEndCurrentEpoch(state)
 
   # From process_epoch()
-  var per_epoch_cache = get_empty_per_epoch_cache()
+  var per_epoch_cache = StateCache()
 
   process_justification_and_finalization(state.data, per_epoch_cache, {})

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -34,7 +34,7 @@ proc addMockAttestations*(
     raise newException(ValueError, &"Cannot include attestations from epoch {state.get_current_epoch()} in epoch {epoch}")
 
   # TODO: Working with an unsigned Gwei balance is a recipe for underflows to happen
-  var cache = get_empty_per_epoch_cache()
+  var cache = StateCache()
   cache.shuffled_active_validator_indices[epoch] =
     get_shuffled_active_validator_indices(state, epoch)
   var remaining_balance = state.get_total_active_balance(cache).int64 * 2 div 3
@@ -45,7 +45,7 @@ proc addMockAttestations*(
   for slot in start_slot.uint64 ..< start_slot.uint64 + SLOTS_PER_EPOCH:
     for index in 0 ..< get_committee_count_at_slot(state, slot.Slot):
       # TODO: can we move cache out of the loops
-      var cache = get_empty_per_epoch_cache()
+      var cache = StateCache()
 
       let committee = get_beacon_committee(
                         state, slot.Slot, index.CommitteeIndex, cache)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -44,7 +44,7 @@ suiteReport "Attestation pool processing" & preset():
       process_slots(state.data, state.data.data.slot + 1)
 
   timedTest "Can add and retrieve simple attestation" & preset():
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       # Create an attestation for slot 1!
       beacon_committee = get_beacon_committee(
@@ -63,7 +63,7 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Attestations may arrive in any order" & preset():
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
@@ -92,7 +92,7 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Attestations should be combined" & preset():
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
@@ -114,7 +114,7 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Attestations may overlap, bigger first" & preset():
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
 
     var
       # Create an attestation for slot 1!
@@ -139,7 +139,7 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Attestations may overlap, smaller first" & preset():
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     var
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(state.data.data,
@@ -163,7 +163,7 @@ suiteReport "Attestation pool processing" & preset():
       attestations.len == 1
 
   timedTest "Fork choice returns latest block with no attestations":
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       b1 = addTestBlock(state.data, blockPool[].tail.root, cache)
       b1Root = hash_tree_root(b1.message)
@@ -189,7 +189,7 @@ suiteReport "Attestation pool processing" & preset():
       head2 == b2Add[]
 
   timedTest "Fork choice returns block with attestation":
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, blockPool[].tail.root, cache)
       b10Root = hash_tree_root(b10.message)
@@ -248,7 +248,7 @@ suiteReport "Attestation pool processing" & preset():
       head4 == b11Add[]
 
   timedTest "Trying to add a block twice tags the second as an error":
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, blockPool[].tail.root, cache)
       b10Root = hash_tree_root(b10.message)
@@ -270,7 +270,7 @@ suiteReport "Attestation pool processing" & preset():
     doAssert: b10Add_clone.error == Duplicate
 
   wrappedTimedTest "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
-    var cache = get_empty_per_epoch_cache()
+    var cache = StateCache()
 
     blockpool[].addFlags {skipBLSValidation}
     pool.forkChoice_v2.proto_array.prune_threshold = 1
@@ -335,7 +335,7 @@ suiteReport "Attestation pool processing" & preset():
             # signature: ValidatorSig()
           )
 
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
 
     # -------------------------------------------------------------
     # Prune

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -324,10 +324,6 @@ suiteReport "BlockPool finalization tests" & preset():
           pool.tail.children.len == 2
           pool.heads.len == 2
 
-      if i mod SLOTS_PER_EPOCH == 0:
-        # Reset cache at epoch boundaries
-        cache = get_empty_per_epoch_cache()
-
       blck = makeTestBlock(
         pool.headState.data, pool.head.blck.root, cache,
         attestations = makeFullAttestations(

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -10,8 +10,7 @@
 import
   options, sequtils, unittest,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[datatypes, digest, helpers, validator,
-                        state_transition, presets],
+  ../beacon_chain/spec/[datatypes, digest, helpers, state_transition, presets],
   ../beacon_chain/[beacon_node_types, block_pool, ssz]
 
 when isMainModule:
@@ -92,7 +91,7 @@ suiteReport "Block pool processing" & preset():
       db = makeTestDB(SLOTS_PER_EPOCH)
       pool = BlockPool.init(defaultRuntimePreset, db)
       stateData = newClone(pool.loadTailState())
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
       b1 = addTestBlock(stateData.data, pool.tail.root, cache)
       b1Root = hash_tree_root(b1.message)
       b2 = addTestBlock(stateData.data, b1Root, cache)
@@ -299,7 +298,7 @@ suiteReport "BlockPool finalization tests" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       pool = BlockPool.init(defaultRuntimePreset, db)
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
 
   timedTest "prune heads on finalization" & preset():
     # Create a fork that will not be taken
@@ -361,7 +360,7 @@ suiteReport "BlockPool finalization tests" & preset():
         hash_tree_root(pool.justifiedState.data.data)
 
   # timedTest "init with gaps" & preset():
-  #   var cache = get_empty_per_epoch_cache()
+  #   var cache = StateCache()
   #   for i in 0 ..< (SLOTS_PER_EPOCH * 6 - 2):
   #     var
   #       blck = makeTestBlock(

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -37,7 +37,7 @@ suiteReport "Block processing" & preset():
   timedTest "Passes from genesis state, empty block" & preset():
     var
       previous_block_root = hash_tree_root(genesisBlock.message)
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
       new_block = makeTestBlock(state[], previous_block_root, cache)
 
     let block_ok = state_transition(defaultRuntimePreset, state[], new_block, {}, noRollback)
@@ -55,7 +55,7 @@ suiteReport "Block processing" & preset():
   timedTest "Passes through epoch update, empty block" & preset():
     var
       previous_block_root = genesisRoot
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
 
     for i in 1..SLOTS_PER_EPOCH.int:
       let new_block = makeTestBlock(state[], previous_block_root, cache)
@@ -73,7 +73,7 @@ suiteReport "Block processing" & preset():
   timedTest "Attestation gets processed at epoch" & preset():
     var
       previous_block_root = genesisRoot
-      cache = get_empty_per_epoch_cache()
+      cache = StateCache()
 
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:


### PR DESCRIPTION
It's unclear https://github.com/status-im/nim-beacon-chain/pull/1296 was helpful.

After having been able to reproduce at least one aspect of the reported cache invalidation issue, it was a result of `StateCache`s being followed down multiple forks/branches, because by design, they they only track a single chain. It's `BlockRef`s which know about the tree structure.

I saw no evidence so far it was related to `EpochRef`.

Therefore, this PR restores `EpochRef`, with an additional guard not to store an `EpochRef` more than `MAX_SEED_LOOKAHEAD` epochs ahead, for similar reasons as above, and flushes the `StateCache`s when they cross epoch boundaries.

It also

- removes `get_empty_per_epoch_cache()` in favor of directly using `StateCache()`, which avoids pulling in `spec/validator` as a dependency of several modules;

- switches `check_attestion()`'s `get_committee_count_at_slot()` call to rely on the already-extant active validator cache, since it's just an arithmetic function of the number of active validators, cutting out a few percent of runtime at 100k validators;

- implements an abstraction layer to begin to stop having random parts of the codebase directly access the `StateCache` tables and implement their own refill logic; and

- implements a more direct version of the `get_beacon_proposer_index()`/`compute_proposer_index()`/`compute_shuffled_index()` from the spec, which becomes quite faster, because when the first validator has; from https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_proposer_index one has:
```
    MAX_RANDOM_BYTE = 2**8 - 1
    i = 0
    while True:
        candidate_index = indices[compute_shuffled_index(i % len(indices), len(indices), seed)]
        random_byte = hash(seed + int_to_bytes(i // 32, length=8))[i % 32]
        effective_balance = state.validators[candidate_index].effective_balance
        if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
            return candidate_index
```
Where `random_byte` is a uniform rv across [0, 256) and effective balance in Gwei ranges from 16 to 32 (because `EJECTION_BALANCE` is 16 Gwei and `MAX_EFFECTIVE_BALANCE` is 32 Gwei). So even pessimistically, at `EJECTION_BALANCE` (a transient condition, but could occur for a while, or even slightly less, but slashing doesn't happen that fast within an epoch), that amounts to a probability of around 0.5 that each loop iteration will exit, creating a geometric distribution with an expected value of 2 attempts, and exponentially decreasingly likely to require 3, 4, probes. So in this case, the naïve approach is better than the per-index more efficient approach with nontrivial numbers of validators (50k, 100k+ for example) because while it's not strictly bounded, its average case is much better.

A future improvement could be to do this in small batches, to still amortize part of the work, but "almost always" (say, with an initial probe of the first 20 or 30 indices) succeed on the first probe. This would have be balanced against avoiding memory allocations, though, as any approach which operations on sequences might require, versus just one index at a time, with some static `array` buffers.

On net, this restores and improves `block_sim` performance at 100k validators from (using commit just before https://github.com/status-im/nim-beacon-chain/pull/1296 as otherwise, it's far too slow; `EpochRef` caching is crucial for `block_sim` at 100k validators):
```
$ time build/block_sim --validators=100000 --slots=96
Loaded genesim_mainnet_100000_0.12.1.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
................................ slot: 96 epoch: 3
Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    3921.207,     1833.534,     2317.112,    15342.748,           93, Process non-epoch slot with block
   16265.877,     7532.276,     9845.094,    24557.149,            3, Process epoch slot with block
       6.808,        0.990,        0.015,        7.313,           96, Tree-hash block
       2.120,        0.201,        1.428,        2.478,           96, Sign block
    4482.599,      247.826,     3998.950,     5205.104,           96, Have committee attest to block
       3.723,        0.000,        3.723,        3.723,            1, Replay all produced blocks

real	14m26.752s
user	14m11.620s
sys	0m4.020s
```

to:
```
$ time build/block_sim --validators=100000 --slots=96
Loaded genesim_mainnet_100000_0.12.1.ssz...
Starting simulation...
................................ slot: 32 epoch: 1
................................ slot: 64 epoch: 2
................................ slot: 96 epoch: 3
Done!
Validators: 100000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    2448.128,     1898.213,     1227.159,    14483.485,           93, Process non-epoch slot with block
   15094.988,     7247.443,     8480.230,    22841.866,            3, Process epoch slot with block
       5.492,        0.814,        0.017,        6.382,           96, Tree-hash block
       1.786,        0.135,        1.483,        2.055,           96, Sign block
    4519.973,      187.028,     4013.158,     4921.316,           96, Have committee attest to block
       4.013,        0.000,        4.013,        4.013,            1, Replay all produced blocks

real	12m11.320s
user	11m54.967s
sys	0m3.960s
```
For a 15% `block_sim` speedup at 100k validators from a couple days ago.

Overall, the remaining `perf` profile for 100k validators in `block_sim` starting at `CLI`/`nimMain`/`main` has `handleAttestations()` at 62.5% and `proposeBlock()` at 11.8%. In `handleAttestations()`, (55.5% / 62.5%) ~ 89% of its time is spent in `get_attestation_signature()`, which is basically 100% `blsSign()`.

`is_valid_indexed_attestation()` consumes 10% of the time, but that's 100% `verify_attestation_signature()`, so that's more BLS cryptography.

`proposeBlock()` isn't quite optimal yet -- it ends up doing maybe more shuffling that it needs to.

`get_shuffled_active_validator_indices()` gets called for no really good reason from `get_beacon_proposer_index()` -- it's because the cache is set up that way, and it wasn't an obvious win one way or the other how to approach that. Generally, everything but `get_beacon_proposer_index()` which wants active validator indices wants them shuffled by the per-epoch seed, so if it didn't do the shuffling, something else would. It might be quicker for it to never shuffle, to always either get the shuffled cache or run `get_active_validator_indices()`, or etc, but that's a more nuanced tradeoff, which I didn't pursue for this PR.

Around 25% of the time doesn't show up in `perf` at all.

So, an overall breakdown of time spent, oriented by cryptography-or-not:
- 26% just not accounted for by the `perf` settings used
- 55.2% in `blsSign()`/`sign()`/`coreSign()`
- 9.9% in `verify_attestation_signature()`/`fastAggregateVerify()`/`coreVerify()`

Which leaves ~8.9% total used by everything else. The visible algorithms themselves aren't the bottleneck anymore, but the per-dark-matter (26% vs 8.9%) before being straightforwardly bottlenecked by BLS signing and verification, for the non-epoch slots, which are `prof`-profiled above.