### PR TITLE
cache block hash

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -135,16 +135,14 @@ proc slotIndex(
     # to start counting at the last finalized epoch start slot - anything
     # earlier than that is thrown out by the above check
     info "First attestation!",
-      attestationSlot =  $shortLog(attestationSlot),
-      cat = "init"
+      attestationSlot =  shortLog(attestationSlot)
     pool.startingSlot =
       state.finalized_checkpoint.epoch.compute_start_slot_at_epoch()
 
   if pool.startingSlot + pool.mapSlotsToAttestations.len.uint64 <= attestationSlot:
     trace "Growing attestation pool",
-      attestationSlot =  $shortLog(attestationSlot),
-      startingSlot = $shortLog(pool.startingSlot),
-      cat = "caching"
+      attestationSlot =  shortLog(attestationSlot),
+      startingSlot = shortLog(pool.startingSlot)
 
     # Make sure there's a pool entry for every slot, even when there's a gap
     while pool.startingSlot + pool.mapSlotsToAttestations.len.uint64 <= attestationSlot:
@@ -153,11 +151,10 @@ proc slotIndex(
   if pool.startingSlot <
       state.finalized_checkpoint.epoch.compute_start_slot_at_epoch():
     debug "Pruning attestation pool",
-      startingSlot = $shortLog(pool.startingSlot),
-      finalizedSlot = $shortLog(
+      startingSlot = shortLog(pool.startingSlot),
+      finalizedSlot = shortLog(
         state.finalized_checkpoint
-             .epoch.compute_start_slot_at_epoch()),
-      cat = "pruning"
+             .epoch.compute_start_slot_at_epoch())
 
     # TODO there should be a better way to remove a whole epoch of stuff..
     while pool.startingSlot <
@@ -245,8 +242,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
   if not isValidAttestationTargetEpoch(state, attestation.data):
     notice "Invalid attestation",
       attestation = shortLog(attestation),
-      current_epoch = get_current_epoch(state),
-      cat = "filtering"
+      current_epoch = get_current_epoch(state)
     return
 
   # TODO inefficient data structures..
@@ -274,8 +270,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
           #      sets by virtue of not overlapping with some other attestation
           #      and therefore being useful after all?
           trace "Ignoring subset attestation",
-            newParticipants = participants,
-            cat = "filtering"
+            newParticipants = participants
           found = true
           break
 
@@ -284,8 +279,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
         # can now be removed per same logic as above
 
         trace "Removing subset attestations",
-          newParticipants = participants,
-          cat = "pruning"
+          newParticipants = participants
 
         a.validations.keepItIf(
           not it.aggregation_bits.isSubsetOf(validation.aggregation_bits))
@@ -297,8 +291,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
           attestation = shortLog(attestation),
           validations = a.validations.len(),
           current_epoch = get_current_epoch(state),
-          blockSlot = shortLog(blck.slot),
-          cat = "filtering"
+          blockSlot = shortLog(blck.slot)
 
         found = true
 
@@ -316,8 +309,7 @@ proc addResolved(pool: var AttestationPool, blck: BlockRef, attestation: Attesta
       attestation = shortLog(attestation),
       current_epoch = get_current_epoch(state),
       validations = 1,
-      blockSlot = shortLog(blck.slot),
-      cat = "filtering"
+      blockSlot = shortLog(blck.slot)
 
 proc addAttestation*(pool: var AttestationPool, attestation: Attestation) =
   ## Add a verified attestation to the fork choice context
@@ -400,14 +392,12 @@ proc getAttestationsForSlot*(pool: AttestationPool, newBlockSlot: Slot):
     Option[AttestationsSeen] =
   if newBlockSlot < (GENESIS_SLOT + MIN_ATTESTATION_INCLUSION_DELAY):
     debug "Too early for attestations",
-      newBlockSlot = shortLog(newBlockSlot),
-      cat = "query"
+      newBlockSlot = shortLog(newBlockSlot)
     return none(AttestationsSeen)
 
   if pool.mapSlotsToAttestations.len == 0: # startingSlot not set yet!
     info "No attestations found (pool empty)",
-      newBlockSlot = shortLog(newBlockSlot),
-      cat = "query"
+      newBlockSlot = shortLog(newBlockSlot)
     return none(AttestationsSeen)
 
   let
@@ -423,8 +413,7 @@ proc getAttestationsForSlot*(pool: AttestationPool, newBlockSlot: Slot):
     info "No attestations matching the slot range",
       attestationSlot = shortLog(attestationSlot),
       startingSlot = shortLog(pool.startingSlot),
-      endingSlot = shortLog(pool.startingSlot + pool.mapSlotsToAttestations.len.uint64),
-      cat = "query"
+      endingSlot = shortLog(pool.startingSlot + pool.mapSlotsToAttestations.len.uint64)
     return none(AttestationsSeen)
 
   let slotDequeIdx = int(attestationSlot - pool.startingSlot)
@@ -484,7 +473,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
     #      to include a broken attestation
     if not check_attestation(state, attestation, {}, cache):
       warn "Attestation no longer validates...",
-        cat = "query"
+        attestation = shortLog(attestation)
       continue
 
     for v in a.validations[1..^1]:
@@ -637,7 +626,7 @@ proc pruneBefore*(pool: var AttestationPool, finalizedhead: BlockSlot) =
 proc selectHead*(pool: var AttestationPool): BlockRef =
   let head_v1 = pool.selectHead_v1()
   # let head_v2 = pool.selectHead_v2()
-  # 
+  #
   # if head_v1 != head_v2:
   #   error "Fork choice engines in disagreement, using block from v1.",
   #     v1_block = shortlog(head_v1),

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -290,31 +290,29 @@ proc onAttestation(node: BeaconNode, attestation: Attestation) =
   # We received an attestation from the network but don't know much about it
   # yet - in particular, we haven't verified that it belongs to particular chain
   # we're on, or that it follows the rules of the protocol
-  logScope: pcs = "on_attestation"
+  logScope:
+    attestation = shortLog(attestation)
+    pcs = "on_attestation"
 
   let
     wallSlot = node.beaconClock.now().toSlot()
     head = node.blockPool.head
 
   debug "Attestation received",
-    attestation = shortLog(attestation),
-    headRoot = shortLog(head.blck.root),
-    headSlot = shortLog(head.blck.slot),
-    wallSlot = shortLog(wallSlot.slot),
-    cat = "consensus" # Tag "consensus|attestation"?
+    head = shortLog(head.blck),
+    wallSlot = shortLog(wallSlot.slot)
 
   if not wallSlot.afterGenesis or wallSlot.slot < head.blck.slot:
     warn "Received attestation before genesis or head - clock is wrong?",
       afterGenesis = wallSlot.afterGenesis,
       wallSlot = shortLog(wallSlot.slot),
-      headSlot = shortLog(head.blck.slot),
-      cat = "clock_drift" # Tag "attestation|clock_drift"?
+      head = shortLog(head.blck)
     return
 
   if attestation.data.slot > head.blck.slot and
       (attestation.data.slot - head.blck.slot) > MaxEmptySlotCount:
     warn "Ignoring attestation, head block too old (out of sync?)",
-      attestationSlot = attestation.data.slot, headSlot = head.blck.slot
+      head = head.blck
     return
 
   node.attestationPool.addAttestation(attestation)
@@ -326,28 +324,24 @@ proc dumpBlock[T](
     case res.error
     of Invalid:
       dump(
-        node.config.dumpDirInvalid, signedBlock,
-        hash_tree_root(signedBlock.message))
+        node.config.dumpDirInvalid, signedBlock)
     of MissingParent:
       dump(
-        node.config.dumpDirIncoming, signedBlock,
-        hash_tree_root(signedBlock.message))
+        node.config.dumpDirIncoming, signedBlock)
     else:
       discard
 
 proc storeBlock(
     node: BeaconNode, signedBlock: SignedBeaconBlock): Result[void, BlockError] =
-  let blockRoot = hash_tree_root(signedBlock.message)
   debug "Block received",
     signedBlock = shortLog(signedBlock.message),
-    blockRoot = shortLog(blockRoot),
-    cat = "block_listener",
+    blockRoot = shortLog(signedBlock.root),
     pcs = "receive_block"
 
   beacon_blocks_received.inc()
 
   {.gcsafe.}: # TODO: fork choice and blockpool should sync via messages instead of callbacks
-    let blck = node.blockPool.addRawBlock(blockRoot, signedBlock) do (validBlock: BlockRef):
+    let blck = node.blockPool.addRawBlock(signedBlock) do (validBlock: BlockRef):
       # Callback add to fork choice if valid
       # node.attestationPool.addForkChoice_v2(validBlock)
       discard "TODO: Deactivated"
@@ -364,8 +358,7 @@ proc storeBlock(
   # all of them. Let's add them to the attestation pool.
   for attestation in signedBlock.message.body.attestations:
     debug "Attestation from block",
-      attestation = shortLog(attestation),
-      cat = "consensus" # Tag "consensus|attestation"?
+      attestation = shortLog(attestation)
 
     node.attestationPool.addAttestation(attestation)
   ok()
@@ -418,8 +411,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     headRoot = shortLog(node.blockPool.head.blck.root),
     finalizedSlot = shortLog(node.blockPool.finalizedHead.blck.slot),
     finalizedRoot = shortLog(node.blockPool.finalizedHead.blck.root),
-    finalizedEpoch = shortLog(node.blockPool.finalizedHead.blck.slot.compute_epoch_at_slot()),
-    cat = "scheduling"
+    finalizedEpoch = shortLog(node.blockPool.finalizedHead.blck.slot.compute_epoch_at_slot())
 
   # Check before any re-scheduling of onSlotStart()
   # Offset backwards slightly to allow this epoch's finalization check to occur
@@ -447,8 +439,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
       beaconTime = shortLog(beaconTime),
       lastSlot = shortLog(lastSlot),
       scheduledSlot = shortLog(scheduledSlot),
-      nextSlot = shortLog(nextSlot),
-      cat = "clock_drift" # tag "scheduling|clock_drift"?
+      nextSlot = shortLog(nextSlot)
 
     addTimer(saturate(node.beaconClock.fromNow(nextSlot))) do (p: pointer):
       asyncCheck node.onSlotStart(slot, nextSlot)
@@ -474,8 +465,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
       lastSlot = shortLog(lastSlot),
       slot = shortLog(slot),
       nextSlot = shortLog(nextSlot),
-      scheduledSlot = shortLog(scheduledSlot),
-      cat = "overload"
+      scheduledSlot = shortLog(scheduledSlot)
 
     addTimer(saturate(node.beaconClock.fromNow(nextSlot))) do (p: pointer):
       # We pass the current slot here to indicate that work should be skipped!
@@ -522,8 +512,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
     headRoot = shortLog(node.blockPool.head.blck.root),
     finalizedSlot = shortLog(node.blockPool.finalizedHead.blck.slot),
     finalizedEpoch = shortLog(node.blockPool.finalizedHead.blck.slot.compute_epoch_at_slot()),
-    finalizedRoot = shortLog(node.blockPool.finalizedHead.blck.root),
-    cat = "scheduling"
+    finalizedRoot = shortLog(node.blockPool.finalizedHead.blck.root)
 
   when declared(GC_fullCollect):
     # The slots in the beacon node work as frames in a game: we want to make
@@ -844,8 +833,7 @@ proc run*(node: BeaconNode) =
     info "Scheduling first slot action",
       beaconTime = shortLog(node.beaconClock.now()),
       nextSlot = shortLog(nextSlot),
-      fromNow = shortLog(fromNow),
-      cat = "scheduling"
+      fromNow = shortLog(fromNow)
 
     addTimer(fromNow) do (p: pointer):
       asyncCheck node.onSlotStart(curSlot, nextSlot)
@@ -896,15 +884,12 @@ proc start(node: BeaconNode) =
     timeSinceFinalization =
       int64(finalizedHead.slot.toBeaconTime()) -
       int64(node.beaconClock.now()),
-    headSlot = shortLog(head.blck.slot),
-    headRoot = shortLog(head.blck.root),
-    finalizedSlot = shortLog(finalizedHead.blck.slot),
-    finalizedRoot = shortLog(finalizedHead.blck.root),
+    head = shortLog(head.blck),
+    finalizedHead = shortLog(finalizedHead),
     SLOTS_PER_EPOCH,
     SECONDS_PER_SLOT,
     SPEC_VERSION,
     dataDir = node.config.dataDir.string,
-    cat = "init",
     pcs = "start_beacon_node"
 
   if genesisTime.inFuture:

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -53,8 +53,7 @@ template head*(pool: BlockPool): Head =
 template finalizedHead*(pool: BlockPool): BlockSlot =
   pool.dag.finalizedHead
 
-proc addRawBlock*(pool: var BlockPool, blockRoot: Eth2Digest,
-          signedBlock: SignedBeaconBlock,
+proc addRawBlock*(pool: var BlockPool, signedBlock: SignedBeaconBlock,
           callback: proc(blck: BlockRef)
         ): Result[BlockRef, BlockError] =
   ## Add a raw block to the blockpool
@@ -65,7 +64,7 @@ proc addRawBlock*(pool: var BlockPool, blockRoot: Eth2Digest,
   # - the ugly `inAdd` field
   # - the callback
   # - callback may be problematic as it's called in async validator duties
-  result = addRawBlock(pool.dag, pool.quarantine, blockRoot, signedBlock, callback)
+  result = addRawBlock(pool.dag, pool.quarantine, signedBlock, callback)
 
 export parent        # func parent*(bs: BlockSlot): BlockSlot
 export isAncestorOf  # func isAncestorOf*(a, b: BlockRef): bool

--- a/beacon_chain/block_pools/quarantine.nim
+++ b/beacon_chain/block_pools/quarantine.nim
@@ -10,12 +10,13 @@ import
   stew/bitops2,
   metrics,
   ../spec/[datatypes, digest],
-  ../ssz/merkleization,
   block_pools_types
 
 export options
 
-logScope: topics = "quarant"
+logScope:
+  topics = "quarant"
+
 {.push raises: [Defect].}
 
 func checkMissing*(quarantine: var Quarantine): seq[FetchRecord] =
@@ -43,15 +44,9 @@ func addMissing*(quarantine: var Quarantine, broot: Eth2Digest) {.inline.} =
   discard quarantine.missing.hasKeyOrPut(broot, MissingBlock())
 
 func add*(quarantine: var Quarantine, dag: CandidateChains,
-          sblck: SignedBeaconBlock,
-          broot: Option[Eth2Digest] = none[Eth2Digest]()) =
+          sblck: SignedBeaconBlock) =
   ## Adds block to quarantine's `orphans` and `missing` lists.
-  let blockRoot = if broot.isSome():
-      broot.get()
-    else:
-      hash_tree_root(sblck.message)
-
-  quarantine.orphans[blockRoot] = sblck
+  quarantine.orphans[sblck.root] = sblck
 
   let parentRoot = sblck.message.parent_root
   quarantine.addMissing(parentRoot)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -45,7 +45,6 @@ func compute_deltas(
 
 logScope:
   topics = "fork_choice"
-  cat = "fork_choice"
 
 # API:
 # - The private procs uses the ForkChoiceError error code

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -19,7 +19,6 @@ import
 
 logScope:
   topics = "fork_choice"
-  cat = "fork_choice"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/fork-choice.md
 # This is a port of https://github.com/sigp/lighthouse/pull/804

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -80,8 +80,7 @@ proc sleepToSlotOffset*(clock: BeaconClock, extra: chronos.Duration,
   if fromNow.inFuture:
     trace msg,
       slot = shortLog(slot),
-      fromNow = shortLog(fromNow.offset),
-      cat = "scheduling"
+      fromNow = shortLog(fromNow.offset)
 
     await sleepAsync(fromNow.offset)
     return true

--- a/beacon_chain/request_manager.nim
+++ b/beacon_chain/request_manager.nim
@@ -41,8 +41,7 @@ proc checkResponse(roots: openArray[Eth2Digest],
   if len(blocks) > len(roots):
     return false
   for blk in blocks:
-    let blockRoot = hash_tree_root(blk.message)
-    let res = checks.find(blockRoot)
+    let res = checks.find(blk.root)
     if res == -1:
       return false
     else:

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -416,9 +416,13 @@ type
     message*: BeaconBlock
     signature*: ValidatorSig
 
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
   TrustedSignedBeaconBlock* = object
     message*: TrustedBeaconBlock
     signature*: TrustedSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
 
   # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#signedbeaconblockheader
   SignedBeaconBlockHeader* = object

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -235,9 +235,9 @@ proc state_transition*(
       verify_block_signature(state.data, signedBlock):
 
     # TODO after checking scaffolding, remove this
-    trace "in state_transition: processing block, signature passed",
-      signature = signedBlock.signature,
-      blockRoot = hash_tree_root(signedBlock.message)
+    trace "state_transition: processing block, signature passed",
+      signature = shortLog(signedBlock.signature),
+      blockRoot = shortLog(signedBlock.root)
     if process_block(preset, state.data, signedBlock.message, flags, stateCache):
       if skipStateRootValidation in flags or verifyStateRoot(state.data, signedBlock.message):
         # State root is what it should be - we're done!

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -173,8 +173,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Justified with previous epoch",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.current_justified_checkpoint),
-      cat = "justification"
+      checkpoint = shortLog(state.current_justified_checkpoint)
 
   let matching_target_attestations_current =
     get_matching_target_attestations(state, current_epoch)  # Current epoch
@@ -187,8 +186,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Justified with current epoch",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.current_justified_checkpoint),
-      cat = "justification"
+      checkpoint = shortLog(state.current_justified_checkpoint)
 
   # Process finalizations
   let bitfield = state.justification_bits
@@ -201,8 +199,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Finalized with rule 234",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.finalized_checkpoint),
-      cat = "finalization"
+      checkpoint = shortLog(state.finalized_checkpoint)
 
   ## The 2nd/3rd most recent epochs are justified, the 2nd using the 3rd as
   ## source
@@ -212,8 +209,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Finalized with rule 23",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.finalized_checkpoint),
-      cat = "finalization"
+      checkpoint = shortLog(state.finalized_checkpoint)
 
   ## The 1st/2nd/3rd most recent epochs are justified, the 1st using the 3rd as
   ## source
@@ -223,8 +219,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Finalized with rule 123",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.finalized_checkpoint),
-      cat = "finalization"
+      checkpoint = shortLog(state.finalized_checkpoint)
 
   ## The 1st/2nd most recent epochs are justified, the 1st using the 2nd as
   ## source
@@ -234,8 +229,7 @@ proc process_justification_and_finalization*(state: var BeaconState,
 
     debug "Finalized with rule 12",
       current_epoch = current_epoch,
-      checkpoint = shortLog(state.finalized_checkpoint),
-      cat = "finalization"
+      checkpoint = shortLog(state.finalized_checkpoint)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helpers
 func get_base_reward(state: BeaconState, index: ValidatorIndex,

--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -4,7 +4,7 @@
 import
   typetraits, options,
   stew/[bitops2, endians2, objects], serialization/testing/tracing,
-  ../spec/[digest, datatypes], ./types, ./spec_types
+  ../spec/[digest, datatypes], ./types, ./spec_types, ./merkleization
 
 template raiseIncorrectSize(T: type) =
   const typeName = name(T)
@@ -267,5 +267,7 @@ func readSszValue*[T](input: openarray[byte], val: var T) {.raisesssz.} =
           type(field),
           input.toOpenArray(int(startOffset), int(endOffset - 1)))
 
+    when val is SignedBeaconBlock | TrustedSignedBeaconBlock:
+      val.root = hash_tree_root(val.message)
   else:
     unsupported T

--- a/beacon_chain/sszdump.nim
+++ b/beacon_chain/sszdump.nim
@@ -18,16 +18,13 @@ proc dump*(dir: string, v: AttestationData, validator: ValidatorPubKey) =
   logErrors:
     SSZ.saveFile(dir / &"att-{v.slot}-{v.index}-{shortLog(validator)}.ssz", v)
 
-proc dump*(dir: string, v: SignedBeaconBlock, root: Eth2Digest) =
+proc dump*(dir: string, v: SignedBeaconBlock) =
   logErrors:
-    SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(root)}.ssz", v)
+    SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
 
-proc dump*(dir: string, v: TrustedSignedBeaconBlock, root: Eth2Digest) =
+proc dump*(dir: string, v: TrustedSignedBeaconBlock) =
   logErrors:
-    SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(root)}.ssz", v)
-
-proc dump*(dir: string, v: SomeSignedBeaconBlock, blck: BlockRef) =
-  dump(dir, v, blck.root)
+    SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
 
 proc dump*(dir: string, v: HashedBeaconState, blck: BlockRef) =
   logErrors:

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -195,7 +195,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.rpc("get_v1_beacon_states_fork") do (stateId: string) -> Fork:
     withStateForStateId(stateId):
       return state.fork
-  
+
   rpcServer.rpc("get_v1_beacon_states_finality_checkpoints") do (
       stateId: string) -> BeaconStatesFinalityCheckpointsTuple:
     withStateForStateId(stateId):
@@ -229,11 +229,11 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       seq[BeaconStatesCommitteesTuple]:
     withStateForStateId(stateId):
       var cache = StateCache() # TODO is this OK?
-      
+
       proc getCommittee(slot: Slot, index: CommitteeIndex): BeaconStatesCommitteesTuple =
         let vals = get_beacon_committee(state, slot, index, cache).mapIt(it.uint64)
         return (index: index.uint64, slot: slot.uint64, validators: vals)
-      
+
       proc forSlot(slot: Slot, res: var seq[BeaconStatesCommitteesTuple]) =
         if index == 0: # TODO this means if the parameter is missing (its optional)
           let committees_per_slot = get_committee_count_at_slot(state, slot)
@@ -323,8 +323,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     if head.slot >= body.message.slot:
       raise newException(CatchableError,
         "Proposal is for a past slot: " & $body.message.slot)
-    if head == await proposeSignedBlock(node, head, AttachedValidator(),
-                                        body, hash_tree_root(body.message)):
+    if head == await proposeSignedBlock(node, head, AttachedValidator(), body):
       raise newException(CatchableError, "Could not propose block")
     return true
 

--- a/beacon_chain/validator_client.nim
+++ b/beacon_chain/validator_client.nim
@@ -115,8 +115,7 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
     lastSlot = shortLog(lastSlot),
     scheduledSlot = shortLog(scheduledSlot),
     beaconTime = shortLog(beaconTime),
-    portBN = vc.config.rpcPort,
-    cat = "scheduling"
+    portBN = vc.config.rpcPort
 
   try:
     # at the start of each epoch - request all validator duties
@@ -141,9 +140,9 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
           message: await vc.client.get_v1_validator_block(slot, vc.graffitiBytes, randao_reveal)
         )
 
-      let blockRoot = hash_tree_root(newBlock.message)
+      newBlock.root = hash_tree_root(newBlock.message)
       newBlock.signature = await validator.signBlockProposal(
-        vc.fork, vc.beaconGenesis.genesis_validators_root, slot, blockRoot)
+        vc.fork, vc.beaconGenesis.genesis_validators_root, slot, newBlock.root)
 
       discard await vc.client.post_v1_validator_block(newBlock)
 
@@ -181,8 +180,7 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
   info "Slot end",
     slot = shortLog(slot),
     nextSlot = shortLog(nextSlot),
-    portBN = vc.config.rpcPort,
-    cat = "scheduling"
+    portBN = vc.config.rpcPort
 
   when declared(GC_fullCollect):
     # The slots in the validator client work as frames in a game: we want to make
@@ -240,8 +238,7 @@ programMain:
     info "Scheduling first slot action",
       beaconTime = shortLog(vc.beaconClock.now()),
       nextSlot = shortLog(nextSlot),
-      fromNow = shortLog(fromNow),
-      cat = "scheduling"
+      fromNow = shortLog(fromNow)
 
     addTimer(fromNow) do (p: pointer) {.gcsafe.}:
       asyncCheck vc.onSlotStart(curSlot, nextSlot)

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -106,7 +106,7 @@ proc cmdBench(conf: DbConf) =
         b.message.slot.compute_epoch_at_slot
     withTimer(timers[if isEpoch: tApplyEpochBlock else: tApplyBlock]):
       if not state_transition(defaultRuntimePreset, state[], b, {}, noRollback):
-        dump("./", b, hash_tree_root(b.message))
+        dump("./", b)
         echo "State transition failed (!)"
         quit 1
 
@@ -137,7 +137,7 @@ proc cmdDumpBlock(conf: DbConf) =
     try:
       let root = Eth2Digest(data: hexToByteArray[32](blockRoot))
       if (let blck = db.getBlock(root); blck.isSome):
-        dump("./", blck.get(), root)
+        dump("./", blck.get())
       else:
         echo "Couldn't load ", root
     except CatchableError as e:

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -127,14 +127,14 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
       let blockRoot = withTimerRet(timers[tHashBlock]):
         hash_tree_root(newBlock.message)
-
+      newBlock.root = blockRoot
       # Careful, state no longer valid after here because of the await..
       newBlock.signature = withTimerRet(timers[tSignBlock]):
         get_block_signature(
           state.fork, state.genesis_validators_root, newBlock.message.slot,
           blockRoot, privKey)
 
-      let added = blockPool.addRawBlock(blockRoot, newBlock) do (validBlock: BlockRef):
+      let added = blockPool.addRawBlock(newBlock) do (validBlock: BlockRef):
         # Callback Add to fork choice
         attPool.addForkChoice_v2(validBlock)
       blck() = added[]

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -99,6 +99,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         flags = flags)
     latest_block_root = withTimerRet(timers[tHashBlock]):
       hash_tree_root(signedBlock.message)
+    signedBlock.root = latest_block_root
 
     if attesterRatio > 0.0:
       # attesterRatio is the fraction of attesters that actually do their

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -29,9 +29,10 @@ proc signMockBlockImpl(
   signedBlock.message.body.randao_reveal = get_epoch_signature(
     state.fork, state.genesis_validators_root, block_slot.compute_epoch_at_slot,
     privkey)
+  signedBlock.root = hash_tree_root(signedBlock.message)
   signedBlock.signature = get_block_signature(
     state.fork, state.genesis_validators_root, block_slot,
-    hash_tree_root(signedBlock.message), privkey)
+    signedBlock.root, privkey)
 
 proc signMockBlock*(state: BeaconState, signedBlock: var SignedBeaconBlock) =
   signMockBlockImpl(state, signedBlock)

--- a/tests/official/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/test_fixture_ssz_consensus_objects.nim
@@ -50,6 +50,7 @@ proc checkSSZ(T: type SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeR
     [hash_tree_root(deserialized.message),
     hash_tree_root(deserialized.signature)]))
 
+  check deserialized.root == hash_tree_root(deserialized.message)
   check SSZ.encode(deserialized[]) == encoded
   check sszSize(deserialized[]) == encoded.len
 

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -36,7 +36,7 @@ suiteReport "Block processing" & preset():
 
   timedTest "Passes from genesis state, empty block" & preset():
     var
-      previous_block_root = hash_tree_root(genesisBlock.message)
+      previous_block_root = genesisBlock.root
       cache = StateCache()
       new_block = makeTestBlock(state[], previous_block_root, cache)
 
@@ -65,7 +65,7 @@ suiteReport "Block processing" & preset():
       check:
         block_ok
 
-      previous_block_root = hash_tree_root(new_block.message)
+      previous_block_root = new_block.root
 
     check:
       state.data.slot == genesisState.data.slot + SLOTS_PER_EPOCH

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -73,13 +73,14 @@ proc makeInitialDeposits*(
 func signBlock*(
     fork: Fork, genesis_validators_root: Eth2Digest, blck: BeaconBlock,
     privKey: ValidatorPrivKey, flags: UpdateFlags = {}): SignedBeaconBlock =
+  var root = hash_tree_root(blck)
   SignedBeaconBlock(
     message: blck,
+    root: root,
     signature:
       if skipBlsValidation notin flags:
         get_block_signature(
-          fork, genesis_validators_root, blck.slot,
-          hash_tree_root(blck), privKey)
+          fork, genesis_validators_root, blck.slot, root, privKey)
       else:
         ValidatorSig()
   )


### PR DESCRIPTION
hash_tree_root was turning up when running beacon_node, turns out to be
repeated hash_tree_root invocations - this pr brings them back down to
normal.

this PR caches the root of a block in the SignedBeaconBlock object -
this has the potential downside that even invalid blocks will be hashed
(as part of deserialization) - later, one could imagine delaying this
until checks have passed

there's also some cleanup of the `cat=` logs which were applied randomly
and haphazardly, and to a large degree are duplicated by other
information in the log statements - in particular, topics fulfill the
same role