### PR TITLE
drop get_attesting_indices() from 15% to 1% of block_sim at 100k validators

### DIFF
--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -875,7 +875,7 @@ proc isInitialized*(T: type CandidateChains, db: BeaconChainDB): bool =
   if not db.containsState(tailBlock.get().message.state_root):
     return false
 
-  return true
+  true
 
 proc preInit*(
     T: type CandidateChains, db: BeaconChainDB, state: BeaconState,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -290,7 +290,7 @@ func is_valid_genesis_state*(preset: RuntimePreset,
   # This is an okay get_active_validator_indices(...) for the time being.
   if active_validator_indices.len.uint64 < preset.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:
     return false
-  return true
+  true
 
 # TODO this is now a non-spec helper function, and it's not really accurate
 # so only usable/used in research/ and tests/
@@ -527,7 +527,7 @@ proc isValidAttestationSlot*(attestationSlot, stateSlot: Slot): bool =
       state_slot = shortLog(stateSlot))
     return false
 
-  return true
+  true
 
 # TODO remove/merge with p2p-interface validation
 proc isValidAttestationTargetEpoch*(

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -326,7 +326,7 @@ func init*(T: typedesc[ValidatorPrivKey], hex: string): T {.noInit, raises: [Val
   let v = T.fromHex(hex)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
-  return v[]
+  v[]
 
 
 # For mainchain monitor
@@ -334,11 +334,11 @@ func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte]): T {.
   let v = T.fromRaw(data)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
-  return v[]
+  v[]
 
 # For mainchain monitor
 func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte]): T {.noInit, raises: [ValueError, Defect].} =
   let v = T.fromRaw(data)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
-  return v[]
+  v[]

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -32,8 +32,8 @@ func get_attesting_indices*(
   # Exported bceause of external trace-level chronicles logging.
   result = initHashSet[ValidatorIndex]()
   for a in attestations:
-    result = result.union(get_attesting_indices(
-      state, a.data, a.aggregation_bits, stateCache))
+    result.incl get_attesting_indices(
+      state, a.data, a.aggregation_bits, stateCache)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_unslashed_attesting_indices*(


### PR DESCRIPTION
This showed up as part of the epoch transition, not so much part of the non-epoch state transition. Presumably, it also eases GC load quite a bit.

There are other ways of improving it, but this was quick, low-risk, and high-return.