### PR TITLE
Add separate state for clearance

### DIFF
--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -126,6 +126,10 @@ type
 
     tmpState*: StateData ## Scratchpad - may be any state
 
+    clearanceState*: StateData ##\
+      ## Cached state used during block clearance - should only be used in the
+      ## clearance module to avoid the risk of modifying it in a callback
+
     updateFlags*: UpdateFlags
 
     runtimePreset*: RuntimePreset

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -300,6 +300,7 @@ proc init*(T: type CandidateChains,
     headState: tmpState[],
     justifiedState: tmpState[], # This is wrong but we'll update it below
     tmpState: tmpState[],
+    clearanceState: tmpState[],
 
     # The only allowed flag right now is verifyFinalization, as the others all
     # allow skipping some validation.
@@ -311,6 +312,7 @@ proc init*(T: type CandidateChains,
 
   res.updateStateData(res.justifiedState, justifiedHead)
   res.updateStateData(res.headState, headRef.atSlot(headRef.slot))
+  res.clearanceState = res.headState
 
   info "Block dag initialized",
     head = head.blck, justifiedHead, finalizedHead, tail = tailRef,


### PR DESCRIPTION
When clearing blocks, a callback is called - this callback, if it uses
`tmpState`, will be corrupted because it's not fully up to date when the
callback is called - we thus introduce a specific state cache for this
purpose - ideally, it can be removed later when epoch caching is
improved.

Incidentally, this helps block sync speed a lot - without this state,
the block sync would ping-pong between attestation state and block state
which is costly.