### PR TITLE
fork choice fixes, round 3

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -176,7 +176,7 @@ proc isValidAttestation*(
           attestation.data.slot, attestation.data.index.CommitteeIndex)
 
     if requiredSubnetIndex != topicCommitteeIndex:
-      debug "isValidAttestation: attestation's committee index not for the correct subnet",
+      debug "attestation's committee index not for the correct subnet",
         topicCommitteeIndex = topicCommitteeIndex,
         attestation_data_index = attestation.data.index,
         requiredSubnetIndex = requiredSubnetIndex
@@ -200,6 +200,9 @@ proc isValidAggregatedAttestation*(
     aggregate_and_proof = signedAggregateAndProof.message
     aggregate = aggregate_and_proof.aggregate
 
+  logScope:
+    aggregate = shortLog(aggregate)
+
   # There's some overlap between this and isValidAttestation(), but unclear if
   # saving a few lines of code would balance well with losing straightforward,
   # spec-based synchronization.
@@ -210,7 +213,7 @@ proc isValidAggregatedAttestation*(
   # ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= aggregate.data.slot
   if not (aggregate.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >=
       current_slot and current_slot >= aggregate.data.slot):
-    debug "isValidAggregatedAttestation: aggregation.data.slot not within ATTESTATION_PROPAGATION_SLOT_RANGE"
+    debug "aggregation.data.slot not within ATTESTATION_PROPAGATION_SLOT_RANGE"
     return false
 
   # [IGNORE] The valid aggregate attestation defined by
@@ -232,7 +235,7 @@ proc isValidAggregatedAttestation*(
   # passes validation.
   let attestationBlck = pool.blockPool.getRef(aggregate.data.beacon_block_root)
   if attestationBlck.isNil:
-    debug "isValidAggregatedAttestation: block doesn't exist in block pool"
+    debug "Block not found"
     pool.blockPool.addMissing(aggregate.data.beacon_block_root)
     return false
 
@@ -250,7 +253,7 @@ proc isValidAggregatedAttestation*(
   # But (2) would reflect an invalid aggregation in other ways, so reject it
   # either way.
   if isZeros(aggregate.aggregation_bits):
-    debug "isValidAggregatedAttestation: attestation has no or invalid aggregation bits"
+    debug "Attestation has no or invalid aggregation bits"
     return false
 
   if not isValidAttestationSlot(pool, aggregate.data.slot, attestationBlck):
@@ -268,7 +271,7 @@ proc isValidAggregatedAttestation*(
     if not is_aggregator(
         state, aggregate.data.slot, aggregate.data.index.CommitteeIndex,
         aggregate_and_proof.selection_proof, cache):
-      debug "isValidAggregatedAttestation: incorrect aggregator"
+      debug "Incorrect aggregator"
       return false
 
     # [REJECT] The aggregator's validator index is within the committee -- i.e.
@@ -277,7 +280,7 @@ proc isValidAggregatedAttestation*(
     if aggregate_and_proof.aggregator_index.ValidatorIndex notin
         get_beacon_committee(
           state, aggregate.data.slot, aggregate.data.index.CommitteeIndex, cache):
-      debug "isValidAggregatedAttestation: aggregator's validator index not in committee"
+      debug "Aggregator's validator index not in committee"
       return false
 
     # [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the
@@ -285,14 +288,14 @@ proc isValidAggregatedAttestation*(
     # aggregate_and_proof.aggregator_index.
     # get_slot_signature(state, aggregate.data.slot, privkey)
     if aggregate_and_proof.aggregator_index >= state.validators.len.uint64:
-      debug "isValidAggregatedAttestation: invalid aggregator_index"
+      debug "Invalid aggregator_index"
       return false
 
     if not verify_slot_signature(
         state.fork, state.genesis_validators_root, aggregate.data.slot,
         state.validators[aggregate_and_proof.aggregator_index].pubkey,
         aggregate_and_proof.selection_proof):
-      debug "isValidAggregatedAttestation: selection_proof signature verification failed"
+      debug "Selection_proof signature verification failed"
       return false
 
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
@@ -300,14 +303,13 @@ proc isValidAggregatedAttestation*(
         state.fork, state.genesis_validators_root, aggregate_and_proof,
         state.validators[aggregate_and_proof.aggregator_index].pubkey,
         signed_aggregate_and_proof.signature):
-      debug "isValidAggregatedAttestation: signed_aggregate_and_proof signature verification failed"
+      debug "Signed_aggregate_and_proof signature verification failed"
       return false
 
     # [REJECT] The signature of aggregate is valid.
     if not is_valid_indexed_attestation(
         state, get_indexed_attestation(state, aggregate, cache), {}):
-      debug "isValidAggregatedAttestation: aggregate signature verification failed"
+      debug "Aggregate signature verification failed"
       return false
 
-  debug "isValidAggregatedAttestation: succeeded"
   true

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -326,8 +326,9 @@ proc storeBlock(
         state: HashedBeaconState):
       # Callback add to fork choice if valid
       node.attestationPool.addForkChoice_v2(
-        blckRef, state.data.current_justified_checkpoint.epoch,
-        state.data.finalized_checkpoint.epoch)
+        state.data, blckRef, signedBlock.message,
+        node.beaconClock.now().slotOrZero())
+
 
   node.dumpBlock(signedBlock, blck)
 

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -64,7 +64,7 @@ proc updateHead*(node: BeaconNode): BlockRef =
   node.attestationPool.resolve()
 
   # Grab the new head according to our latest attestation data
-  let newHead = node.attestationPool.selectHead()
+  let newHead = node.attestationPool.selectHead(node.beaconClock.now().slotOrZero())
 
   # Store the new head in the block pool - this may cause epochs to be
   # justified and finalized
@@ -75,7 +75,7 @@ proc updateHead*(node: BeaconNode): BlockRef =
 
   # Cleanup the fork choice v2 if we have a finalized head
   if oldFinalized != node.blockPool.finalizedHead.blck:
-    node.attestationPool.pruneBefore(node.blockPool.finalizedHead.blck)
+    node.attestationPool.prune()
 
   newHead
 

--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -168,6 +168,9 @@ template headState*(pool: BlockPool): StateData =
 template tmpState*(pool: BlockPool): StateData =
   pool.dag.tmpState
 
+template balanceState*(pool: BlockPool): StateData =
+  pool.dag.balanceState
+
 template justifiedState*(pool: BlockPool): StateData =
   pool.dag.justifiedState
 

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -130,6 +130,10 @@ type
       ## Cached state used during block clearance - should only be used in the
       ## clearance module to avoid the risk of modifying it in a callback
 
+    balanceState*: StateData ##\
+      ## Cached state for fork choice balance processing - should be replaced
+      ## with a light-weight cache of balances only
+
     updateFlags*: UpdateFlags
 
     runtimePreset*: RuntimePreset

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -135,7 +135,9 @@ proc createAndSendAttestation(node: BeaconNode,
                               num_active_validators: uint64) {.async.} =
   logScope: pcs = "send_attestation"
 
-  var attestation = await validator.produceAndSignAttestation(attestationData, committeeLen, indexInCommittee, fork, genesis_validators_root)
+  var attestation = await validator.produceAndSignAttestation(
+    attestationData, committeeLen, indexInCommittee, fork,
+    genesis_validators_root)
 
   node.sendAttestation(attestation, num_active_validators)
 
@@ -229,8 +231,8 @@ proc proposeSignedBlock*(node: BeaconNode,
         state: HashedBeaconState):
       # Callback add to fork choice if valid
       node.attestationPool.addForkChoice_v2(
-        blckRef, state.data.current_justified_checkpoint.epoch,
-        state.data.finalized_checkpoint.epoch)
+        state.data, blckRef, signedBlock.message,
+        node.beaconClock.now().slotOrZero())
 
   if newBlockRef.isErr:
     warn "Unable to add proposed block to block pool",

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -138,9 +138,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        attPool.addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        attPool.addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
       blck() = added[]
       blockPool.updateHead(added[])

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -60,7 +60,7 @@ type
       prune_threshold*: int
       expected_len*: int
 
-func apply(ctx: var ForkChoice, id: int, op: Operation) =
+func apply(ctx: var ForkChoiceBackend, id: int, op: Operation) =
   ## Apply the specified operation to a ForkChoice context
   ## ``id`` is additional debugging info. It is the
   ## operation index.
@@ -104,7 +104,7 @@ func apply(ctx: var ForkChoice, id: int, op: Operation) =
       &"prune (op #{id}): the resulting length ({ctx.proto_array.nodes.len}) was not expected ({op.expected_len})"
     debugEcho "    Maybe_pruned block preceding finalized block 0x", op.finalized_root
 
-func run*(ctx: var ForkChoice, ops: seq[Operation]) =
+func run*(ctx: var ForkChoiceBackend, ops: seq[Operation]) =
   ## Apply a sequence of fork-choice operations on a store
   for i, op in ops:
     ctx.apply(i, op)

--- a/tests/fork_choice/scenarios/ffg_01.nim
+++ b/tests/fork_choice/scenarios/ffg_01.nim
@@ -7,12 +7,12 @@
 
 # import ../interpreter # included to be able to use "suiteReport"
 
-proc setup_finality_01(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+proc setup_finality_01(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
   let GenesisRoot = fakeHash(0)
 
   # Initialize the fork choice context
-  result.fork_choice = initForkChoice(
+  result.fork_choice = initForkChoiceBackend(
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -7,12 +7,12 @@
 
 # import ../interpreter # included to be able to use "suiteReport"
 
-proc setup_finality_02(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+proc setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
   let GenesisRoot = fakeHash(0)
 
   # Initialize the fork choice context
-  result.fork_choice = initForkChoice(
+  result.fork_choice = initForkChoiceBackend(
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -7,12 +7,12 @@
 
 # import ../interpreter # included to be able to use "suiteReport"
 
-proc setup_no_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+proc setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   let balances = newSeq[Gwei](16)
   let GenesisRoot = fakeHash(0)
 
   # Initialize the fork choice context
-  result.fork_choice = initForkChoice(
+  result.fork_choice = initForkChoiceBackend(
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -7,12 +7,12 @@
 
 # import ../interpreter # included to be able to use "suiteReport"
 
-proc setup_votes(): tuple[fork_choice: ForkChoice, ops: seq[Operation]] =
+proc setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   var balances = @[Gwei(1), Gwei(1)]
   let GenesisRoot = fakeHash(0)
 
   # Initialize the fork choice context
-  result.fork_choice = initForkChoice(
+  result.fork_choice = initForkChoiceBackend(
     justified_epoch = Epoch(1),
     finalized_epoch = Epoch(1),
     finalized_root = GenesisRoot

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -170,12 +170,10 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
 
-    let head = pool[].selectHead()
+    let head = pool[].selectHead(b1Add[].slot)
 
     check:
       head == b1Add[]
@@ -186,11 +184,9 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
-    let head2 = pool[].selectHead()
+    let head2 = pool[].selectHead(b2Add[].slot)
 
     check:
       head2 == b2Add[]
@@ -203,11 +199,9 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
-    let head = pool[].selectHead()
+    let head = pool[].selectHead(b10Add[].slot)
 
     check:
       head == b10Add[]
@@ -220,9 +214,7 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
       bc1 = get_beacon_committee(
         state.data.data, state.data.data.slot, 1.CommitteeIndex, cache)
@@ -230,7 +222,7 @@ suiteReport "Attestation pool processing" & preset():
 
     pool[].addAttestation(attestation0)
 
-    let head2 = pool[].selectHead()
+    let head2 = pool[].selectHead(b10Add[].slot)
 
     check:
       # Single vote for b10 and no votes for b11
@@ -241,7 +233,7 @@ suiteReport "Attestation pool processing" & preset():
       attestation2 = makeAttestation(state.data.data, b11.root, bc1[2], cache)
     pool[].addAttestation(attestation1)
 
-    let head3 = pool[].selectHead()
+    let head3 = pool[].selectHead(b10Add[].slot)
     # Warning - the tiebreak are incorrect and guaranteed consensus fork, it should be bigger
     let smaller = if b10.root.data < b11.root.data: b10Add else: b11Add
 
@@ -254,7 +246,7 @@ suiteReport "Attestation pool processing" & preset():
 
     pool[].addAttestation(attestation2)
 
-    let head4 = pool[].selectHead()
+    let head4 = pool[].selectHead(b11Add[].slot)
 
     check:
       # Two votes for b11
@@ -268,11 +260,9 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
-    let head = pool[].selectHead()
+    let head = pool[].selectHead(b10Add[].slot)
 
     check:
       head == b10Add[]
@@ -284,9 +274,7 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
     doAssert: b10Add_clone.error == Duplicate
 
@@ -294,7 +282,7 @@ suiteReport "Attestation pool processing" & preset():
     var cache = StateCache()
 
     blockpool[].addFlags {skipBLSValidation}
-    pool.forkChoice_v2.proto_array.prune_threshold = 1
+    pool.forkChoice_v2.backend.proto_array.prune_threshold = 1
 
     let
       b10 = makeTestBlock(state.data, blockPool[].tail.root, cache)
@@ -302,11 +290,9 @@ suiteReport "Attestation pool processing" & preset():
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
-    let head = pool[].selectHead()
+    let head = pool[].selectHead(b10Add[].slot)
 
     doAssert: head == b10Add[]
 
@@ -335,11 +321,9 @@ suiteReport "Attestation pool processing" & preset():
             blckRef: BlockRef, signedBlock: SignedBeaconBlock,
             state: HashedBeaconState):
           # Callback add to fork choice if valid
-          pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+          pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
-        let head = pool[].selectHead()
+        let head = pool[].selectHead(blockRef[].slot)
         doassert: head == blockRef[]
         blockPool[].updateHead(head)
 
@@ -370,16 +354,14 @@ suiteReport "Attestation pool processing" & preset():
 
     doAssert: blockPool[].finalizedHead.slot != 0
 
-    pool[].pruneBefore(blockPool[].finalizedHead.blck)
-    doAssert: b10.root notin pool.forkChoice_v2
+    pool[].prune()
+    doAssert: b10.root notin pool.forkChoice_v2.backend
 
     # Add back the old block to ensure we have a duplicate error
     let b10Add_clone = blockpool[].addRawBlock(b10_clone) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
           state: HashedBeaconState):
         # Callback add to fork choice if valid
-        pool[].addForkChoice_v2(
-          blckRef, state.data.current_justified_checkpoint.epoch,
-          state.data.finalized_checkpoint.epoch)
+        pool[].addForkChoice_v2(state.data, blckRef, signedBlock.message, blckRef.slot)
 
     doAssert: b10Add_clone.error == Duplicate


### PR DESCRIPTION
* introduce checkpoint tracker
* split out fork choice backend that is independent of dag
* correctly update best checkpoint to use for head selection
* correctly consider wall clock when processing attestations
* preload head history only (only one history is loaded from database
anyway)
* love the DAG