### PR TITLE
eth2_network_simulation: fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,8 +154,9 @@ GOERLI_TESTNETS_PARAMS := \
   --rpc \
   --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
-eth2_network_simulation: | build deps clean_eth2_network_simulation_data
+eth2_network_simulation: | build deps clean_eth2_network_simulation_all
 	+ GIT_ROOT="$$PWD" NIMFLAGS="$(NIMFLAGS)" LOG_LEVEL="$(LOG_LEVEL)" tests/simulation/start-in-tmux.sh
+	killall prometheus &>/dev/null
 
 clean-testnet0:
 	rm -rf build/data/testnet0*

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -226,7 +226,7 @@ type
 
       lastUserValidator* {.
         defaultValue: config.totalValidators - 1,
-        desc: "The last validator index that will free for taking from a testnet participant"
+        desc: "The last validator index that will be free for taking from a testnet participant"
         name: "last-user-validator" }: uint64
 
       bootstrapAddress* {.

--- a/tests/simulation/start-in-tmux.sh
+++ b/tests/simulation/start-in-tmux.sh
@@ -15,9 +15,12 @@ if [[ "$USE_TMUX" != "no" ]]; then
   type "$TMUX_CMD" &>/dev/null || { echo "${TMUX_CMD}" is missing; USE_TMUX="no"; }
 fi
 
+export TMUX_CMD USE_TMUX
+
 if [[ "$USE_TMUX" != "no" ]]; then
   TMUX_SESSION_NAME="${TMUX_SESSION_NAME:-nbc-sim}"
 
+  $TMUX_CMD kill-session -t "${TMUX_SESSION_NAME}" &>/dev/null || true
   $TMUX_CMD new-session -s "${TMUX_SESSION_NAME}" -d
   $TMUX_CMD setenv -t "${TMUX_SESSION_NAME}" USE_TMUX yes
 
@@ -32,7 +35,7 @@ if [[ "$USE_TMUX" != "no" ]]; then
   $TMUX_CMD new-window -d -t "${TMUX_SESSION_NAME}" -n "sim"
   $TMUX_CMD kill-pane -t "${TMUX_SESSION_NAME}:0"
 
-  $TMUX_CMD new-window -t "${TMUX_SESSION_NAME}" -n "start-script" "if ! $PWD/start.sh; then; read; tmux kill-session; fi"
+  $TMUX_CMD new-window -t "${TMUX_SESSION_NAME}" -n "start-script" "if ! $PWD/start.sh; then echo -en '\nPress any key to exit... '; read; tmux kill-session; fi"
   $TMUX_CMD select-window -t "${TMUX_SESSION_NAME}:start-script"
 
   $TMUX_CMD attach-session -t "${TMUX_SESSION_NAME}"

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -90,7 +90,7 @@ if [[ "$USE_PROMETHEUS" == "yes" ]]; then
     rm -rf "${METRICS_DIR}/data"
     mkdir -p "${METRICS_DIR}/data"
     # TODO: Prometheus is not shut down properly on tmux kill-session
-    killall prometheus > /dev/null || true
+    killall prometheus &>/dev/null || true
     PROMETHEUS_FLAGS="--config.file=./prometheus.yml --storage.tsdb.path=./data"
     $TMUX_CMD new-window -d -t $TMUX_SESSION_NAME -n "$PROMETHEUS_CMD" "cd '$METRICS_DIR' && $PROMETHEUS_CMD $PROMETHEUS_FLAGS"
   else
@@ -99,7 +99,7 @@ if [[ "$USE_PROMETHEUS" == "yes" ]]; then
   fi
 fi
 
-$MAKE -j3 --no-print-directory NIMFLAGS="$CUSTOM_NIMFLAGS $DEFS" LOG_LEVEL="${LOG_LEVEL:-DEBUG}" beacon_node validator_client
+$MAKE -j2 --no-print-directory NIMFLAGS="$CUSTOM_NIMFLAGS $DEFS" LOG_LEVEL="${LOG_LEVEL:-DEBUG}" beacon_node validator_client
 
 count_files () {
   { ls -1q $1 2> /dev/null || true ; } | wc -l
@@ -145,7 +145,7 @@ function run_cmd {
   if [[ "$USE_TMUX" == "yes" ]]; then
     echo "Starting node $i..."
     $TMUX_CMD select-window -t "${TMUX_SESSION_NAME}:sim"
-    $TMUX_CMD split-window -t "${TMUX_SESSION_NAME}" "if ! $CMD; then; read; fi"
+    $TMUX_CMD split-window -t "${TMUX_SESSION_NAME}" "if ! $CMD; then read; fi"
     $TMUX_CMD select-layout -t "${TMUX_SESSION_NAME}:sim" tiled
   elif [[ "$USE_MULTITAIL" != "no" ]]; then
     if [[ "$i" == "$BOOTSTRAP_NODE" ]]; then


### PR DESCRIPTION
- delete "tests/simulation/{data,validators}" by default, because old
  validator keys can lead to a crash with a cryptic error message
- actually start the Prometheus daemon on `make eth2_network_simulation`
- kill any running Prometheus daemon on exit
- fix some shell script syntax incompatible with Bash

Fixes https://github.com/status-im/nim-beacon-chain/issues/1353