### PR TITLE
lazily initialize validator public keys, which were a 1/3 or more of sync CPU [alt design #1371]

### DIFF
--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -879,4 +879,6 @@ proc getProposer*(
         balances=state.balances
       return
 
-    return some((proposerIdx.get(), state.validators[proposerIdx.get()].pubkey))
+    return some((
+      proposerIdx.get(),
+      state.validators[proposerIdx.get()].pubkey.initPubKey))

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -413,7 +413,7 @@ proc process_registry_updates*(state: var BeaconState,
       compute_activation_exit_epoch(get_current_epoch(state))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
-func is_valid_indexed_attestation*(
+proc is_valid_indexed_attestation*(
     state: BeaconState, indexed_attestation: SomeIndexedAttestation,
     flags: UpdateFlags): bool =
   # Check if ``indexed_attestation`` is not empty, has sorted and unique

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -88,11 +88,12 @@ proc process_deposit*(preset: RuntimePreset,
 
   let
     pubkey = deposit.data.pubkey
+    pubkey_inited = pubkey.initPubKey # TODO replicate previous PR semantics, check later
     amount = deposit.data.amount
   var index = -1
 
   for i, validator in state.validators:
-    if pubkey == validator.pubkey:
+    if pubkey == validator.pubkey.initPubKey:
       index = i
       break
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -50,7 +50,7 @@ func decrease_balance*(
       state.balances[index] - delta
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#deposits
-func get_validator_from_deposit(state: BeaconState, deposit: Deposit):
+proc get_validator_from_deposit(state: BeaconState, deposit: Deposit):
     Validator =
   let
     amount = deposit.data.amount
@@ -58,7 +58,7 @@ func get_validator_from_deposit(state: BeaconState, deposit: Deposit):
       amount - amount mod EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
 
   Validator(
-    pubkey: deposit.data.pubkey,
+    pubkey: deposit.data.pubkey.initPubKey,
     withdrawal_credentials: deposit.data.withdrawal_credentials,
     activation_eligibility_epoch: FAR_FUTURE_EPOCH,
     activation_epoch: FAR_FUTURE_EPOCH,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -93,7 +93,7 @@ proc process_deposit*(preset: RuntimePreset,
   var index = -1
 
   for i, validator in state.validators:
-    if pubkey == validator.pubkey.initPubKey:
+    if pubkey_inited == validator.pubkey.initPubKey:
       index = i
       break
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -50,7 +50,7 @@ func decrease_balance*(
       state.balances[index] - delta
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#deposits
-proc get_validator_from_deposit(state: BeaconState, deposit: Deposit):
+func get_validator_from_deposit(state: BeaconState, deposit: Deposit):
     Validator =
   let
     amount = deposit.data.amount
@@ -58,7 +58,7 @@ proc get_validator_from_deposit(state: BeaconState, deposit: Deposit):
       amount - amount mod EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
 
   Validator(
-    pubkey: deposit.data.pubkey.initPubKey,
+    pubkey: deposit.data.pubkey,
     withdrawal_credentials: deposit.data.withdrawal_credentials,
     activation_eligibility_epoch: FAR_FUTURE_EPOCH,
     activation_epoch: FAR_FUTURE_EPOCH,

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -108,23 +108,22 @@ func toPubKey*(privkey: ValidatorPrivKey): ValidatorPubKey =
 proc toRealPubKey(pubkey: ValidatorPubKey): Option[ValidatorPubKey] =
   var validatorKeyCache {.threadvar.}: Table[Hash, Option[ValidatorPubKey]]
 
-  if pubkey.kind == Real:
+  case pubkey.kind:
+  of Real:
     return some(pubkey)
-
-  doAssert pubkey.kind == OpaqueBlob
-
-  let key = hash(pubkey.blob)
-  try:
-    validatorKeyCache[key]
-  except KeyError:
-    var val: blscurve.PublicKey
-    let maybeRealKey =
-      if fromBytes(val, pubkey.blob):
-        some ValidatorPubKey(kind: Real, blsValue: val)
-      else:
-        none ValidatorPubKey
-    validatorKeyCache[key] = maybeRealKey
-    maybeRealKey
+  of OpaqueBlob:
+    let key = hash(pubkey.blob)
+    try:
+      validatorKeyCache[key]
+    except KeyError:
+      var val: blscurve.PublicKey
+      let maybeRealKey =
+        if fromBytes(val, pubkey.blob):
+          some ValidatorPubKey(kind: Real, blsValue: val)
+        else:
+          none ValidatorPubKey
+      validatorKeyCache[key] = maybeRealKey
+      maybeRealKey
 
 proc initPubKey*(pubkey: ValidatorPubKey): ValidatorPubKey =
   let key = toRealPubKey(pubkey)

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -29,7 +29,7 @@ func get_slot_signature*(
 
   blsSign(privKey, signing_root.data)
 
-func verify_slot_signature*(
+proc verify_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     pubkey: ValidatorPubKey, signature: SomeSig): bool =
   withTrust(signature):
@@ -51,7 +51,7 @@ func get_epoch_signature*(
 
   blsSign(privKey, signing_root.data)
 
-func verify_epoch_signature*(
+proc verify_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
     pubkey: ValidatorPubKey, signature: SomeSig): bool =
   withTrust(signature):
@@ -73,7 +73,7 @@ func get_block_signature*(
 
   blsSign(privKey, signing_root.data)
 
-func verify_block_signature*(
+proc verify_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     blck: Eth2Digest | SomeBeaconBlock | BeaconBlockHeader,
     pubkey: ValidatorPubKey,
@@ -99,7 +99,7 @@ func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth
 
   blsSign(privKey, signing_root.data)
 
-func verify_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
+proc verify_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
                                            aggregate_and_proof: AggregateAndProof,
                                            pubkey: ValidatorPubKey, signature: SomeSig): bool =
   withTrust(signature):
@@ -124,7 +124,7 @@ func get_attestation_signature*(
 
   blsSign(privKey, signing_root.data)
 
-func verify_attestation_signature*(
+proc verify_attestation_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     attestation_data: AttestationData,
     pubkeys: openArray[ValidatorPubKey],
@@ -150,7 +150,7 @@ func get_deposit_signature*(preset: RuntimePreset,
 
   blsSign(privKey, signing_root.data)
 
-func verify_deposit_signature*(preset: RuntimePreset,
+proc verify_deposit_signature*(preset: RuntimePreset,
                                deposit: DepositData): bool =
   let
     deposit_message = deposit.getDepositMessage()
@@ -160,7 +160,7 @@ func verify_deposit_signature*(preset: RuntimePreset,
 
   blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
 
-func verify_voluntary_exit_signature*(
+proc verify_voluntary_exit_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     voluntary_exit: VoluntaryExit,
     pubkey: ValidatorPubKey, signature: SomeSig): bool =

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -60,10 +60,10 @@ proc addLocalValidators*(node: BeaconNode) =
 
   info "Local validators attached ", count = node.attachedValidators.count
 
-func getAttachedValidator*(node: BeaconNode,
+proc getAttachedValidator*(node: BeaconNode,
                            state: BeaconState,
                            idx: ValidatorIndex): AttachedValidator =
-  let validatorKey = state.validators[idx].pubkey
+  let validatorKey = state.validators[idx].pubkey.initPubKey
   node.attachedValidators.getValidator(validatorKey)
 
 proc isSynced*(node: BeaconNode, head: BlockRef): bool =


### PR DESCRIPTION
It's a global (per-thread for safety) cache valid across `BeaconState`s and across forks, because it indexes by public key itself and not the validator index. For similar reasons, there are no cache evictions or invalidation, though if necessary, that can be pursued in the future.

The motivation here is that increasingly, as other bottlenecks have been removed, Altona syncing had been bottlenecked on `dag.getState()`, because when the SSZ was deserialized, it initialized the public keys in `BeaconState.validators`, consuming nearly 100% of `getState()` time. With this PR, `getState()` basically disappears from the `perf` trace.

It's a somewhat kludgy approach to https://github.com/status-im/nim-beacon-chain/issues/412 which sidesteps changing case objects in-place and the issues associated with that, but its kludginess is mostly localized and can be removed if/when appropriate.

Remaining time usage, syncing with Altona, broken out by mutually exclusive partitions:
- `multiPairing()`: 33%
- `coreVerify()`: 32%
- `push()` / `syncUpdate()` / `updateLocalBlocks()` / `storeBlock()` at 22-24%

`toRealPubKey()` / `initPubKey()` don't show up noticeably, so it looks like a good trade.

I'm not thrilled with the implicit type system between "maybe raw" `ValidatorPubKey`s and initialized `ValidatorPubKey`s not being part of something like a `type RawValidatorPubKey* = distinct ValidatorPubKey` setup for type-safety, but that threw odd compile errors about not being able to find the `kind` field of the `BlsValue` case object, but only for the `distinct`-declared alias type. The idea is that all the signature verification functions handle it already, so only a few remnants need to manually care about this distinction, largely when they search for a public key by contents, at which point the representations must match.