### PR TITLE
Lazy crypto [alt design #1369]

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -246,7 +246,7 @@ proc initialize_beacon_state_from_eth1*(
           # This differs from the spec intentionally.
           # We must specify the default value for `ValidatorSig`
           # in order to get a correct `hash_tree_root`.
-          randao_reveal: ValidatorSig(kind: OpaqueBlob)
+          randao_reveal: ValidatorSig(kind: ToBeChecked)
         ))
       )
   )
@@ -309,8 +309,8 @@ func get_initial_beacon_block*(state: BeaconState): SignedBeaconBlock =
       slot: GENESIS_SLOT,
       state_root: hash_tree_root(state),
       body: BeaconBlockBody(
-        # TODO: This shouldn't be necessary if OpaqueBlob is the default
-        randao_reveal: ValidatorSig(kind: OpaqueBlob)))
+        # TODO: This shouldn't be necessary if ToBeChecked is the default
+        randao_reveal: ValidatorSig(kind: ToBeChecked)))
       # parent_root, randao_reveal, eth1_data, signature, and body automatically
       # initialized to default values.
   SignedBeaconBlock(message: message, root: hash_tree_root(message))

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -242,12 +242,10 @@ proc initialize_beacon_state_from_eth1*(
       Eth1Data(block_hash: eth1_block_hash, deposit_count: uint64(len(deposits))),
     latest_block_header:
       BeaconBlockHeader(
-        body_root: hash_tree_root(BeaconBlockBody(
-          # This differs from the spec intentionally.
-          # We must specify the default value for `ValidatorSig`
-          # in order to get a correct `hash_tree_root`.
-          randao_reveal: ValidatorSig(kind: ToBeChecked)
-        ))
+        # This differs from the spec intentionally.
+        # We must specify the default value for `ValidatorSig`/`BeaconBlockBody`
+        # in order to get a correct `hash_tree_root`.
+        body_root: hash_tree_root(BeaconBlockBody())
       )
   )
 
@@ -307,10 +305,7 @@ func is_valid_genesis_state*(preset: RuntimePreset,
 func get_initial_beacon_block*(state: BeaconState): SignedBeaconBlock =
   let message = BeaconBlock(
       slot: GENESIS_SLOT,
-      state_root: hash_tree_root(state),
-      body: BeaconBlockBody(
-        # TODO: This shouldn't be necessary if ToBeChecked is the default
-        randao_reveal: ValidatorSig(kind: ToBeChecked)))
+      state_root: hash_tree_root(state))
       # parent_root, randao_reveal, eth1_data, signature, and body automatically
       # initialized to default values.
   SignedBeaconBlock(message: message, root: hash_tree_root(message))

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -118,6 +118,21 @@ func setBlob*[N, T](a: var BlsValue[N, T], data: array[N, byte]) {.inline.} =
   ## Set a BLS Value lazily
   a.blob = data
 
+func keyGen*(ikm: openArray[byte]): BlsResult[tuple[pub: ValidatorPubKey, priv: ValidatorPrivKey]] {.inline.} =
+  ## Key generation using the BLS Signature draft 2 (https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02)
+  ## Note: As of July-2020, the only use-case is for testing
+  ##
+  ## Validator key generation should use Lamport Signatures (EIP-2333)
+  ## (https://eips.ethereum.org/EIPS/eip-2333)
+  ## and be done in a dedicated hardened module/process.
+  var
+    sk: SecretKey
+    pk: PublicKey
+  if keyGen(ikm, pk, sk):
+    ok((ValidatorPubKey(kind: Real, blsValue: pk), ValidatorPrivKey(sk)))
+  else:
+    err "bls: cannot generate keypair"
+
 # Comparison
 # ----------------------------------------------------------------------
 

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -56,7 +56,8 @@ type
     ##
     ## Fields intentionally private to avoid displaying/logging the raw data
     ## or accessing fields without promoting them
-    ## or trying to iterate on a case object even though the case is wrong (SSZ/Chronicles)
+    ## or trying to iterate on a case object even though the case is wrong.
+    ## Is there a way to prevent macro from doing that? (SSZ/Chronicles)
     #
     # Note, since 0.20 case object transition are very restrictive
     # and do not allow to preserve content (https://github.com/nim-lang/RFCs/issues/56)
@@ -148,6 +149,9 @@ func toPubKey*(privkey: ValidatorPrivKey): ValidatorPubKey =
 func aggregate*(x: var ValidatorSig, other: ValidatorSig) =
   ## Aggregate 2 Validator Signatures
   ## This assumes that they are real signatures
+  ## and will crash if they are not
+  unsafePromote(x.addr)
+  unsafePromote(other.unsafeAddr)
   x.blsValue.aggregate(other.blsValue)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#bls-signatures

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -265,7 +265,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       blockId: string) -> tuple[canonical: bool, header: SignedBeaconBlockHeader]:
     let bd = node.getBlockDataFromBlockId(blockId)
     let tsbb = bd.data
-    result.header.signature.blob = tsbb.signature.data
+    result.header.signature.setBlob(tsbb.signature.data)
 
     result.header.message.slot = tsbb.message.slot
     result.header.message.proposer_index = tsbb.message.proposer_index

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -7,31 +7,10 @@
 
 import
   macros,
-  nimcrypto/utils,
   ../../beacon_chain/spec/[datatypes, crypto, digest], ../../beacon_chain/ssz/types
   # digest is necessary for them to be printed as hex
 
-# Define comparison of object variants for BLSValue
-# https://github.com/nim-lang/Nim/issues/6676
-# (fully generic available - see also https://github.com/status-im/nim-beacon-chain/commit/993789bad684721bd7c74ea14b35c2d24dbb6e51)
-# ----------------------------------------------------------------
-
-proc `==`*(a, b: BlsValue): bool =
-  ## We sometimes need to compare real BlsValue
-  ## from parsed opaque blobs that are not really on the BLS curve
-  ## and full of zeros
-  unsafePromote(a.unsafeAddr)
-  unsafePromote(b.unsafeAddr)
-  if a.kind == Real:
-    if b.kind == Real:
-      a.blsvalue == b.blsValue
-    else:
-      $a.blsvalue == toHex(b.blob, true)
-  else:
-    if b.kind == Real:
-      toHex(a.blob, true) == $b.blsValue
-    else:
-      a.blob == b.blob
+export crypto.`==`
 
 # ---------------------------------------------------------------------
 
@@ -50,9 +29,10 @@ proc compareStmt(xSubField, ySubField: NimNode, stmts: var NimNode) =
   let xStr = $xSubField.toStrLit
   let yStr = $ySubField.toStrLit
 
+  let isEqual = bindSym("==") # Bind all expose equality, in particular for BlsValue
   stmts.add quote do:
     doAssert(
-      `xSubField` == `ySubField`,
+      `isEqual`(`xSubField`, `ySubField`),
       "\nDiff: " & `xStr` & " = " & $`xSubField` & "\n" &
       "and   " & `yStr` & " = " & $`ySubField` & "\n"
     )
@@ -61,16 +41,16 @@ proc compareContainerStmt(xSubField, ySubField: NimNode, stmts: var NimNode) =
   let xStr = $xSubField.toStrLit
   let yStr = $ySubField.toStrLit
 
-
+  let isEqual = bindSym("==") # Bind all expose equality, in particular for BlsValue
   stmts.add quote do:
     doAssert(
-      `xSubField`.len == `ySubField`.len,
+      `isEqual`(`xSubField`.len, `ySubField`.len),
         "\nDiff: " & `xStr` & ".len = " & $`xSubField`.len & "\n" &
         "and   " & `yStr` & ".len = " & $`ySubField`.len & "\n"
     )
     for idx in `xSubField`.low .. `xSubField`.high:
       doAssert(
-        `xSubField`[idx] == `ySubField`[idx],
+        `isEqual`(`xSubField`[idx], `ySubField`[idx]),
         "\nDiff: " & `xStr` & "[" & $idx & "] = " & $`xSubField`[idx] & "\n" &
         "and   " & `yStr` & "[" & $idx & "] = " & $`ySubField`[idx] & "\n"
       )

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -20,6 +20,8 @@ proc `==`*(a, b: BlsValue): bool =
   ## We sometimes need to compare real BlsValue
   ## from parsed opaque blobs that are not really on the BLS curve
   ## and full of zeros
+  unsafePromote(a.unsafeAddr)
+  unsafePromote(b.unsafeAddr)
   if a.kind == Real:
     if b.kind == Real:
       a.blsvalue == b.blsValue

--- a/tests/mocking/mock_validator_keys.nim
+++ b/tests/mocking/mock_validator_keys.nim
@@ -10,7 +10,6 @@
 
 import
   bearssl, eth/keys,
-  blscurve/bls_signature_scheme,
   ../../beacon_chain/spec/[datatypes, crypto, presets]
 
 proc newKeyPair(rng: var BrHmacDrbgContext): BlsResult[tuple[pub: ValidatorPubKey, priv: ValidatorPrivKey]] =
@@ -22,14 +21,7 @@ proc newKeyPair(rng: var BrHmacDrbgContext): BlsResult[tuple[pub: ValidatorPubKe
 
   var ikm: array[32, byte]
   brHmacDrbgGenerate(rng, ikm)
-
-  var
-    sk: SecretKey
-    pk: bls_signature_scheme.PublicKey
-  if keyGen(ikm, pk, sk):
-    ok((ValidatorPubKey(kind: Real, blsValue: pk), ValidatorPrivKey(sk)))
-  else:
-    err "bls: cannot generate keypair"
+  return ikm.keygen()
 
 # this is being indexed inside "mock_deposits.nim" by a value up to `validatorCount`
 # which is `num_validators` which is `MIN_GENESIS_ACTIVE_VALIDATOR_COUNT`

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -39,14 +39,17 @@ suiteReport "Zero signature sanity checks":
   timedTest "SSZ serialization roundtrip of SignedBeaconBlockHeader":
 
     let defaultBlockHeader = SignedBeaconBlockHeader(
-      signature: ValidatorSig(kind: ToBeChecked)
+      signature: ValidatorSig()
     )
 
     check:
       block:
+        let sigBytes = cast[ptr array[ValidatorSig.sizeof(), byte]](
+          defaultBlockHeader.signature.unsafeAddr)
+
         var allZeros = true
-        for val in defaultBlockHeader.signature.blob:
-          allZeros = allZeros and val == 0
+        for i in 0 ..< ValidatorSig.sizeof():
+          allZeros = allZeros and sigBytes[i] == byte 0
         allZeros
 
     let sszDefaultBlockHeader = SSZ.encode(defaultBlockHeader)

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -39,7 +39,7 @@ suiteReport "Zero signature sanity checks":
   timedTest "SSZ serialization roundtrip of SignedBeaconBlockHeader":
 
     let defaultBlockHeader = SignedBeaconBlockHeader(
-      signature: ValidatorSig(kind: OpaqueBlob)
+      signature: ValidatorSig(kind: ToBeChecked)
     )
 
     check:


### PR DESCRIPTION
This is a reboot of #457 which was abandoned because of noSideEffect limitations in Nim 0.20 and the old nim-blscurve (https://github.com/status-im/nim-blscurve/issues/27).

This is an alternative to https://github.com/status-im/nim-beacon-chain/pull/1369#issuecomment-663545096.

Unfortunately there is no free lunch and this has tradeoffs somewhat similar to copy-on-write schemes:

- Mutability is hidden and done through an unsafe pointer (though can only happen once)

Also with regards to serialization and compared to #1369 it's stateless. This is the main difference between both PR:

Stateful requires yet another table, increasing memory usage and complicating threading in the future. It also requires more hashing, indirection and copy to manipulate both cached and non-cached BLS objects.

Stateless (this PR) tricks the compiler with pointers but uses significantly less memory and has no indirection.
It will have to deserialize objects that are received multiple times in different contexts (for example a public key from the network which may be received multiple times).

I.e. in terms of perf, the main difference is deserializing a public key vs looking it up in a table.
The full impact depends on how often we receive the same object in an unrelated context

Both should solve the loading latency from BeaconChainDB.