### PR TITLE
Fix security issue #1362.

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -106,12 +106,12 @@ type
         name: "udp-port" }: Port
 
       maxPeers* {.
-        defaultValue: 100 # The Wall gets released
+        defaultValue: 101 # The Wall gets released
         desc: "The maximum number of connected peers"
         name: "max-peers" }: int
 
       maxIncomingPeers* {.
-        defaultValue: 21
+        defaultValue: 23
         desc: "The maximum number of inbound peer's connections"
         name: "max-incoming-peers"}: int
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -106,9 +106,14 @@ type
         name: "udp-port" }: Port
 
       maxPeers* {.
-        defaultValue: 79 # The Wall gets released
-        desc: "The maximum number of peers to connect to"
+        defaultValue: 100 # The Wall gets released
+        desc: "The maximum number of connected peers"
         name: "max-peers" }: int
+
+      maxIncomingPeers* {.
+        defaultValue: 21
+        desc: "The maximum number of inbound peer's connections"
+        name: "max-incoming-peers"}: int
 
       nat* {.
         desc: "Specify method to use for determining public address. " &

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -859,6 +859,10 @@ proc init*(T: type Eth2Node, conf: BeaconNodeConf, enrForkId: ENRForkID,
   new result
   result.switch = switch
   result.wantedPeers = (conf.maxPeers - conf.maxIncomingPeers)
+  # We are limiting number of incoming connections (peers) to some value,
+  # otherwise it is possible to fill our PeerPool with only incoming connections
+  # This is undesired behavior, because in such way attackers could easily
+  # falsify our vision of network and beacon chain.
   result.peerPool = newPeerPool[Peer, PeerID](
     maxPeers = conf.maxPeers, maxIncomingPeers = conf.maxIncomingPeers)
   result.connectTimeout = 10.seconds

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -709,12 +709,15 @@ proc handleIncomingPeer*(peer: Peer): Future[bool] {.async.} =
     debug "Peer (incoming) lost", peer
     nbc_peers.set int64(len(network.peerPool))
 
-  let res = await network.peerPool.addIncomingPeer(peer)
+  let res = network.peerPool.addIncomingPeerNoWait(peer)
   if res:
     peer.updateScore(NewPeerScore)
     debug "Peer (incoming) has been added to PeerPool", peer
     peer.getFuture().addCallback(onPeerClosed)
     result = true
+  else:
+    debug "Too many incoming connections in PeerPool, disconnecting", peer
+    result = false
 
   nbc_peers.set int64(len(network.peerPool))
 


### PR DESCRIPTION
* Introducing new configuration parameter `maxIncomingPeers` with default value of `21`
* Changing default value of configuration parameter `maxPeers` from `79` to `100`.
* Initialization of PeerPool with maximum number of incoming peers.
* Fix variable names and 80 chars per line.
* Removal of unnecessary sleepAsync.