### PR TITLE
spec cleanups

### DIFF
--- a/beacon_chain/block_pool.nim
+++ b/beacon_chain/block_pool.nim
@@ -8,7 +8,7 @@
 import
   extras, beacon_chain_db,
   stew/results,
-  spec/[crypto, datatypes, digest, helpers, presets]
+  spec/[crypto, datatypes, digest, presets, validator]
 
 
 import

--- a/beacon_chain/mainchain_monitor.nim
+++ b/beacon_chain/mainchain_monitor.nim
@@ -1,8 +1,8 @@
 import
-  deques, tables, hashes, options, strformat,
+  std/[deques, tables, hashes, options, strformat],
   chronos, web3, web3/ethtypes as web3Types, json, chronicles,
   eth/common/eth_types, eth/async_utils,
-  spec/[datatypes, digest, crypto, beaconstate, helpers],
+  spec/[datatypes, digest, crypto, beaconstate, helpers, validator],
   network_metadata, merkle_minimal
 
 from times import epochTime
@@ -506,7 +506,8 @@ proc createBeaconStateAux(preset: RuntimePreset,
                                              eth1Block.voteData.block_hash,
                                              eth1Block.timestamp.uint64,
                                              deposits, {})
-  let activeValidators = count_active_validators(result[], GENESIS_EPOCH, StateCache())
+  var cache = StateCache()
+  let activeValidators = count_active_validators(result[], GENESIS_EPOCH, cache)
   eth1Block.knownGoodDepositsCount = some activeValidators
 
 proc createBeaconState(m: MainchainMonitor, eth1Block: Eth1Block): BeaconStateRef =

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -650,15 +650,19 @@ func shortLog*(v: DepositData): auto =
     signature: shortLog(v.signature)
   )
 
+func shortLog*(v: Checkpoint): auto =
+  (
+    epoch: shortLog(v.epoch),
+    root: shortLog(v.root),
+  )
+
 func shortLog*(v: AttestationData): auto =
   (
     slot: shortLog(v.slot),
     index: v.index,
     beacon_block_root: shortLog(v.beacon_block_root),
-    source_epoch: shortLog(v.source.epoch),
-    source_root: shortLog(v.source.root),
-    target_epoch: shortLog(v.target.epoch),
-    target_root: shortLog(v.target.root)
+    source: shortLog(v.source),
+    target: shortLog(v.target),
   )
 
 func shortLog*(v: SomeAttestation): auto =
@@ -673,6 +677,7 @@ chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt AttestationData: it.shortLog
 chronicles.formatIt Attestation: it.shortLog
+chronicles.formatIt Checkpoint: it.shortLog
 
 import json_serialization
 export json_serialization

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -61,14 +61,9 @@ func get_total_active_balance*(state: BeaconState, cache: var StateCache): Gwei 
 
   let
     epoch = state.get_current_epoch()
-  try:
-    if epoch notin cache.shuffled_active_validator_indices:
-      cache.shuffled_active_validator_indices[epoch] =
-        get_shuffled_active_validator_indices(state, epoch)
 
-    get_total_balance(state, cache.shuffled_active_validator_indices[epoch])
-  except KeyError:
-    raiseAssert("get_total_active_balance(): cache always filled before usage")
+  get_total_balance(
+    state, cache.get_shuffled_active_validator_indices(state, epoch))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_matching_source_attestations(state: BeaconState,

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -9,17 +9,9 @@
 
 import
   # Standard library
-  sets,
+  std/sets,
   # Internals
-  ./datatypes, ./digest, ./beaconstate
-
-# Logging utilities
-# --------------------------------------------------------
-
-# TODO: gather all logging utilities
-#       from crypto, digest, etc in a single file
-func shortLog*(x: Checkpoint): string =
-  "(epoch: " & $x.epoch & ", root: \"" & shortLog(x.root) & "\")"
+  ./datatypes, ./beaconstate
 
 # Helpers used in epoch transition and trace-level block transition
 # --------------------------------------------------------
@@ -27,19 +19,19 @@ func shortLog*(x: Checkpoint): string =
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_attesting_indices*(
     state: BeaconState, attestations: openArray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
+    cache: var StateCache): HashSet[ValidatorIndex] =
   # This is part of get_unslashed_attesting_indices(...) in spec.
   # Exported bceause of external trace-level chronicles logging.
   result = initHashSet[ValidatorIndex]()
   for a in attestations:
     result.incl get_attesting_indices(
-      state, a.data, a.aggregation_bits, stateCache)
+      state, a.data, a.aggregation_bits, cache)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#helper-functions-1
 func get_unslashed_attesting_indices*(
     state: BeaconState, attestations: openArray[PendingAttestation],
-    stateCache: var StateCache): HashSet[ValidatorIndex] =
-  result = get_attesting_indices(state, attestations, stateCache)
+    cache: var StateCache): HashSet[ValidatorIndex] =
+  result = get_attesting_indices(state, attestations, cache)
   for index in result:
     if state.validators[index].slashed:
       result.excl index

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -414,7 +414,7 @@ proc broadcastAggregatedAttestations(
               # TODO https://github.com/status-im/nim-beacon-chain/issues/545
               # this assumes in-process private keys
               validator.privKey,
-              trailing_distance)
+              trailing_distance, cache)
 
           # Don't broadcast when, e.g., this node isn't an aggregator
           if aggregateAndProof.isSome:

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -188,12 +188,6 @@ template processEpochScenarioImpl(
 
   when needCache:
     var cache = StateCache()
-    let epoch = state.data.get_current_epoch()
-    cache.shuffled_active_validator_indices[epoch] =
-      get_shuffled_active_validator_indices(state.data, epoch)
-
-  # Epoch transitions can't fail (TODO is this true?)
-  when needCache:
     transitionFn(state.data, cache)
   else:
     transitionFn(state.data)

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -3,7 +3,7 @@ import
   ../tests/[testblockutil],
   ../beacon_chain/[extras],
   ../beacon_chain/ssz/[merkleization, ssz_serialization],
-  ../beacon_chain/spec/[beaconstate, datatypes, digest, helpers, presets]
+  ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, helpers, presets]
 
 template withTimer*(stats: var RunningStat, body: untyped) =
   # TODO unify timing somehow
@@ -99,3 +99,19 @@ proc printTimers*[Timers: enum](
   echo "Validators: ", state.validators.len, ", epoch length: ", SLOTS_PER_EPOCH
   echo "Validators per attestation (mean): ", attesters.mean
   printTimers(validate, timers)
+
+proc combine*(tgt: var Attestation, src: Attestation, flags: UpdateFlags) =
+  ## Combine the signature and participation bitfield, with the assumption that
+  ## the same data is being signed - if the signatures overlap, they are not
+  ## combined.
+
+  doAssert tgt.data == src.data
+
+  # In a BLS aggregate signature, one needs to count how many times a
+  # particular public key has been added - since we use a single bit per key, we
+  # can only it once, thus we can never combine signatures that overlap already!
+  if not tgt.aggregation_bits.overlaps(src.aggregation_bits):
+    tgt.aggregation_bits.combine(src.aggregation_bits)
+
+    if skipBlsValidation notin flags:
+      tgt.signature.aggregate(src.signature)

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -35,8 +35,6 @@ proc addMockAttestations*(
 
   # TODO: Working with an unsigned Gwei balance is a recipe for underflows to happen
   var cache = StateCache()
-  cache.shuffled_active_validator_indices[epoch] =
-    get_shuffled_active_validator_indices(state, epoch)
   var remaining_balance = state.get_total_active_balance(cache).int64 * 2 div 3
 
   let

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,15 +8,11 @@
 {.used.}
 
 import
-  ../beacon_chain/spec/datatypes,
-  ../beacon_chain/ssz
-
-import
   unittest,
   chronicles,
   stew/byteutils,
-  ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[digest, validator, state_transition,
+  ./testutil, ./testblockutil, ../research/simutils,
+  ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
                         helpers, beaconstate, presets],
   ../beacon_chain/[beacon_node_types, attestation_pool, block_pool, extras],
   ../beacon_chain/fork_choice/[fork_choice_types, fork_choice]


### PR DESCRIPTION
* add helper for beacon committee length (used for quickly validating
attestations)
* refactor some attestation checks to do cheap checks early
* validate attestation epoch before computing active validator set
* clean up documentation / comments
* fill state cache on demand