### PR TITLE
verifyFinalization checks for justification being consistent with finalization

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -500,6 +500,9 @@ proc process_epoch*(state: var BeaconState, updateFlags: UpdateFlags,
   process_justification_and_finalization(state, per_epoch_cache, updateFlags)
 
   # state.slot hasn't been incremented yet.
+  if verifyFinalization in updateFlags and currentEpoch >= 2:
+    doAssert state.current_justified_checkpoint.epoch + 2 >= currentEpoch
+
   if verifyFinalization in updateFlags and currentEpoch >= 3:
     # Rule 2/3/4 finalization results in the most pessimal case. The other
     # three finalization rules finalize more quickly as long as the any of


### PR DESCRIPTION
This catches would-be finalization failures an epoch earlier.

```
$ N=0; while ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --disable-htop -- --verify-finalization --stop-at-epoch=8; do N=$((N+1)); echo "That was run #${N}"; sleep 71; done
Building: build/deposit_contract
INF 2020-07-28 17:11:31+02:00 Generating deposits                        tid=336088 file=keystore_management.nim:107 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-07-28 17:12:13+02:00 Deposit data written                       tid=336088 file=deposit_contract.nim:184 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
That was run #1
Building: build/deposit_contract
INF 2020-07-28 17:21:48+02:00 Generating deposits                        tid=338636 file=keystore_management.nim:107 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-07-28 17:22:29+02:00 Deposit data written                       tid=338636 file=deposit_contract.nim:184 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
That was run #2
```