### PR TITLE
assert on missing active validators' attestations when verifying finalization

### DIFF
--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -12,9 +12,9 @@ import
   confutils, stats, times,
   strformat,
   options, sequtils, random, tables,
-  ../tests/[testblockutil],
+  ../tests/testblockutil,
   ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, helpers, validator],
-  ../beacon_chain/[attestation_pool, extras],
+  ../beacon_chain/extras,
   ../beacon_chain/ssz/[merkleization, ssz_serialization],
   ./simutils
 


### PR DESCRIPTION
Along the lines of https://github.com/status-im/nim-beacon-chain/pull/1386, but where that one shouldn't flag any conditions that wouldn't already (an epoch later) have triggered finalization failure, this tightens the requirements the 2/3 balance quorum, to being able not to receive only 10 of the testnet0/testnet1) 128 active validators' attestations. 8 of those will already come from some validators programmed not to attest, so that leaves a tolerance currently of 3 validators allowed not to attest without this firing.

So, this is quite a tighter check on the interactions between nbc and libp2p losing track of attestations in the context of justification and finalization.

```
Building: build/beacon_node
Building: build/deposit_contract
INF 2020-07-28 17:39:22+02:00 Generating deposits                        tid=343442 file=keystore_management.nim:107 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-07-28 17:40:04+02:00 Deposit data written                       tid=343442 file=deposit_contract.nim:184 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
That was run #1
Building: build/beacon_node
Building: build/deposit_contract
INF 2020-07-28 17:48:53+02:00 Generating deposits                        tid=346112 file=keystore_management.nim:107 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-07-28 17:49:34+02:00 Deposit data written                       tid=346112 file=deposit_contract.nim:184 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
That was run #2
Building: build/beacon_node
Building: build/deposit_contract
INF 2020-07-28 18:00:28+02:00 Generating deposits                        tid=350773 file=keystore_management.nim:107 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-07-28 18:01:10+02:00 Deposit data written                       tid=350773 file=deposit_contract.nim:184 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
That was run #3
```