### PR TITLE
more fork-choice fixes

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -273,7 +273,7 @@ proc init*(T: type BeaconNode,
       onBeaconBlock(res, signedBlock)
   )
 
-  await res.addLocalValidators()
+  res.addLocalValidators()
 
   # This merely configures the BeaconSync
   # The traffic will be started when we join the network.

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -928,9 +928,8 @@ when hasPrompt:
       # p.useHistoryFile()
 
       proc dataResolver(expr: string): string =
-        template justified: untyped = node.blockPool.head.atSlot(
-          node.blockPool.headState.data.data.current_justified_checkpoint.epoch.
-            compute_start_slot_at_epoch)
+        template justified: untyped = node.blockPool.head.atEpochStart(
+          node.blockPool.headState.data.data.current_justified_checkpoint.epoch)
         # TODO:
         # We should introduce a general API for resolving dot expressions
         # such as `db.latest_block.slot` or `metrics.connected_peers`.

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -25,7 +25,8 @@ import
   spec/state_transition,
   conf, time, beacon_chain_db, validator_pool, extras,
   attestation_pool, block_pool, eth2_network, eth2_discovery,
-  beacon_node_common, beacon_node_types, block_pools/block_pools_types,
+  beacon_node_common, beacon_node_types,
+  block_pools/[block_pools_types, candidate_chains],
   nimbus_binary_common, network_metadata,
   mainchain_monitor, version, ssz/[merkleization], sszdump, merkle_minimal,
   sync_protocol, request_manager, keystore_management, interop, statusbar,
@@ -247,7 +248,7 @@ proc init*(T: type BeaconNode,
     enrForkId = enrForkIdFromState(blockPool.headState.data.data)
     topicBeaconBlocks = getBeaconBlocksTopic(enrForkId.forkDigest)
     topicAggregateAndProofs = getAggregateAndProofsTopic(enrForkId.forkDigest)
-    network = await createEth2Node(rng, conf, enrForkId)
+    network = createEth2Node(rng, conf, enrForkId)
 
   var res = BeaconNode(
     nickname: nickname,

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -153,7 +153,8 @@ type
 
     slot*: Slot # TODO could calculate this by walking to root, but..
 
-    epochsInfo*: seq[EpochRef]
+    epochsInfo*: seq[EpochRef] ##\
+    ## Cached information about the epochs starting at this block.
     ## Could be multiple, since blocks could skip slots, but usually, not many
     ## Even if competing forks happen later during this epoch, potential empty
     ## slots beforehand must all be from this fork. getEpochInfo() is the only

--- a/beacon_chain/block_pools/candidate_chains.nim
+++ b/beacon_chain/block_pools/candidate_chains.nim
@@ -162,6 +162,14 @@ func atSlot*(blck: BlockRef, slot: Slot): BlockSlot =
   ## block proposal)
   BlockSlot(blck: blck.getAncestorAt(slot), slot: slot)
 
+func atEpochStart*(blck: BlockRef, epoch: Epoch): BlockSlot =
+  ## Return the BlockSlot corresponding to the first slot in the given epoch
+  atSlot(blck, epoch.compute_start_slot_at_epoch)
+
+func atEpochEnd*(blck: BlockRef, epoch: Epoch): BlockSlot =
+  ## Return the BlockSlot corresponding to the last slot in the given epoch
+  atSlot(blck, (epoch + 1).compute_start_slot_at_epoch - 1)
+
 func getEpochInfo*(blck: BlockRef, state: BeaconState): EpochRef =
   # This is the only intended mechanism by which to get an EpochRef
   let
@@ -186,12 +194,14 @@ func getEpochInfo*(blck: BlockRef, state: BeaconState): EpochRef =
 
 func getEpochCache*(blck: BlockRef, state: BeaconState): StateCache =
   let epochInfo = getEpochInfo(blck, state)
-  if blck.slot.compute_epoch_at_slot > 1:
+  if epochInfo.epoch > 0:
     # When doing state transitioning, both the current and previous epochs are
-    # useful from a cache perspective since attestations may come from either
+    # useful from a cache perspective since attestations may come from either -
+    # we'll use the last slot from the epoch because it is more likely to
+    # be filled in already, compared to the first slot where the block might
+    # be from the epoch before.
     let
-      prevEpochBlck =
-        blck.atSlot(epochInfo.epoch.compute_start_slot_at_epoch - 1).blck
+      prevEpochBlck = blck.atEpochEnd(epochInfo.epoch - 1).blck
 
     for ei in prevEpochBlck.epochsInfo:
       if ei.epoch == epochInfo.epoch - 1:
@@ -290,9 +300,8 @@ proc init*(T: type CandidateChains,
   # from the same epoch as the head, thus the finalized and justified slots are
   # the same - these only change on epoch boundaries.
   let
-    finalizedSlot =
-       tmpState.data.data.finalized_checkpoint.epoch.compute_start_slot_at_epoch()
-    finalizedHead = headRef.atSlot(finalizedSlot)
+    finalizedHead = headRef.atEpochStart(
+      tmpState.data.data.finalized_checkpoint.epoch)
 
   let res = CandidateChains(
     blocks: blocks,
@@ -327,12 +336,18 @@ proc init*(T: type CandidateChains,
   res
 
 proc getEpochRef*(pool: CandidateChains, blck: BlockRef, epoch: Epoch): EpochRef =
-  let bs = blck.atSlot(epoch.compute_start_slot_at_epoch)
-  for e in bs.blck.epochsInfo:
-    if e.epoch == epoch:
-      return e
+  var bs = blck.atEpochEnd(epoch)
 
-  # TODO use any state from epoch
+  while true:
+    # Any block from within the same epoch will carry the same epochinfo, so
+    # we start at the most recent one
+    for e in bs.blck.epochsInfo:
+      if e.epoch == epoch:
+        return e
+    if bs.slot == epoch.compute_start_slot_at_epoch:
+      break
+    bs = bs.parent
+
   pool.withState(pool.tmpState, bs):
     getEpochInfo(blck, state)
 
@@ -743,11 +758,10 @@ proc updateHead*(dag: CandidateChains, newHead: BlockRef) =
     assign(dag.headState, dag.clearanceState)
   else:
     updateStateData(
-      dag, dag.headState, BlockSlot(blck: newHead, slot: newHead.slot))
+      dag, dag.headState, newHead.atSlot(newHead.slot))
 
   dag.head = newHead
 
-  # TODO isAncestorOf may be expensive - too expensive?
   if not lastHead.isAncestorOf(newHead):
     info "Updated head block with reorg",
       lastHead = shortLog(lastHead),
@@ -768,10 +782,8 @@ proc updateHead*(dag: CandidateChains, newHead: BlockRef) =
       justified = shortLog(dag.headState.data.data.current_justified_checkpoint),
       finalized = shortLog(dag.headState.data.data.finalized_checkpoint)
   let
-    finalizedEpochStartSlot =
-      dag.headState.data.data.finalized_checkpoint.epoch.
-      compute_start_slot_at_epoch()
-    finalizedHead = newHead.atSlot(finalizedEpochStartSlot)
+    finalizedHead = newHead.atEpochStart(
+      dag.headState.data.data.finalized_checkpoint.epoch)
 
   doAssert (not finalizedHead.blck.isNil),
     "Block graph should always lead to a finalized block"
@@ -790,7 +802,6 @@ proc updateHead*(dag: CandidateChains, newHead: BlockRef) =
       # while cur != dag.finalizedHead:
       #  cur = cur.parent
       #  dag.delState(cur)
-
 
     block: # Clean up block refs, walking block by block
       # Finalization means that we choose a single chain as the canonical one -

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -46,11 +46,7 @@ proc addResolvedBlock(
        parent: BlockRef, cache: StateCache,
        onBlockAdded: OnBlockAdded
      ): BlockRef =
-  # TODO: `addResolvedBlock` is accumulating significant cruft
-  # and is in dire need of refactoring
-  # - the ugly `quarantine.inAdd` field
-  # - the callback
-  # - callback may be problematic as it's called in async validator duties
+  # TODO move quarantine processing out of here
   logScope: pcs = "block_resolution"
   doAssert state.data.slot == signedBlock.message.slot, "state must match block"
 
@@ -93,7 +89,8 @@ proc addResolvedBlock(
     blockRoot = shortLog(blockRoot),
     heads = dag.heads.len()
 
-  # This MUST be added before the quarantine
+  # Notify others of the new block before processing the quarantine, such that
+  # notifications for parents happens before those of the children
   if onBlockAdded != nil:
     onBlockAdded(blockRef, signedBlock, state)
 
@@ -124,13 +121,8 @@ proc addRawBlock*(
        signedBlock: SignedBeaconBlock,
        onBlockAdded: OnBlockAdded
      ): Result[BlockRef, BlockError] =
-  ## return the block, if resolved...
-
-  # TODO: `addRawBlock` is accumulating significant cruft
-  # and is in dire need of refactoring
-  # - the ugly `quarantine.inAdd` field
-  # - the callback
-  # - callback may be problematic as it's called in async validator duties
+  ## Try adding a block to the chain, verifying first that it passes the state
+  ## transition function.
 
   logScope:
     blck = shortLog(signedBlock.message)
@@ -139,14 +131,12 @@ proc addRawBlock*(
   template blck(): untyped = signedBlock.message # shortcuts without copy
   template blockRoot(): untyped = signedBlock.root
 
-  # Already seen this block??
   if blockRoot in dag.blocks:
     debug "Block already exists"
 
-    # There can be a scenario where we receive a block we already received.
-    # However this block was before the last finalized epoch and so its parent
-    # was pruned from the ForkChoice. Trying to add it again, even if the fork choice
-    # supports duplicate will lead to a crash.
+    # We should not call the block added callback for blocks that already
+    # existed in the pool, as that may confuse consumers such as the fork
+    # choice.
     return err Duplicate
 
   quarantine.missing.del(blockRoot)
@@ -173,7 +163,9 @@ proc addRawBlock*(
 
       return err Invalid
 
-    if parent.slot < dag.finalizedHead.slot:
+    if (parent.slot < dag.finalizedHead.slot) or
+        (parent.slot == dag.finalizedHead.slot and
+          parent != dag.finalizedHead.blck):
       # We finalized a block that's newer than the parent of this block - this
       # block, although recent, is thus building on a history we're no longer
       # interested in pursuing. This can happen if a client produces a block

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1142,7 +1142,7 @@ func gossipId(data: openArray[byte]): string =
 func msgIdProvider(m: messages.Message): string =
   gossipId(m.data)
 
-proc createEth2Node*(rng: ref BrHmacDrbgContext, conf: BeaconNodeConf, enrForkId: ENRForkID): Future[Eth2Node] {.async, gcsafe.} =
+proc createEth2Node*(rng: ref BrHmacDrbgContext, conf: BeaconNodeConf, enrForkId: ENRForkID): Eth2Node {.gcsafe.} =
   var
     (extIp, extTcpPort, extUdpPort) = setupNat(conf)
     hostAddress = tcpEndPoint(conf.libp2pAddress, conf.tcpPort)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -194,8 +194,8 @@ proc process_state(self: var Checkpoints,
 
   if (state.current_justified_checkpoint.epoch > self.current.justified.epoch) and
       (state.finalized_checkpoint.epoch >= self.current.finalized.epoch):
-    let justifiedBlck = blck.atSlot(
-      state.current_justified_checkpoint.epoch.compute_start_slot_at_epoch)
+    let justifiedBlck = blck.atEpochStart(
+      state.current_justified_checkpoint.epoch)
 
     if justifiedBlck.blck.root != state.current_justified_checkpoint.root:
       return err("invalid history?")
@@ -303,9 +303,8 @@ proc process_block*(self: var ForkChoice,
       state.current_justified_checkpoint.epoch, state.finalized_checkpoint.epoch
     )
 
-  {.noSideEffect.}:
-    trace "Integrating block in fork choice",
-      block_root = shortLog(blckRef)
+  trace "Integrating block in fork choice",
+    block_root = shortLog(blckRef)
 
   return ok()
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -177,8 +177,8 @@ func contains*(self: ForkChoiceBackend, block_root: Eth2Digest): bool =
   ## In particular, before adding a block, its parent must be known to the fork choice
   self.proto_array.indices.contains(block_root)
 
-proc get_balances_for_block(self: var Checkpoints, blck: BlockRef, pool: BlockPool): seq[Gwei] =
-  pool.withState(pool.balanceState, blck.atSlot(blck.slot)):
+proc get_balances_for_block(self: var Checkpoints, blck: BlockSlot, pool: BlockPool): seq[Gwei] =
+  pool.withState(pool.balanceState, blck):
     get_effective_balances(state)
 
 proc process_state(self: var Checkpoints,
@@ -204,7 +204,7 @@ proc process_state(self: var Checkpoints,
       justified: BalanceCheckpoint(
           blck: justifiedBlck.blck,
           epoch: state.current_justified_checkpoint.epoch,
-          balances: self.get_balances_for_block(justifiedBlck.blck, pool),
+          balances: self.get_balances_for_block(justifiedBlck, pool),
       ),
       finalized: state.finalized_checkpoint,
     )
@@ -279,7 +279,7 @@ proc process_block*(self: var ForkChoice,
                     blck: SomeBeaconBlock,
                     wallSlot: Slot): Result[void, string] =
   ? process_state(self.checkpoints, pool, state, blckRef)
-  # TODO current time
+
   maybe_update(self.checkpoints, wallSlot, pool)
 
   for attestation in blck.body.attestations:

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -11,6 +11,8 @@ import
   # Standard library
   std/[tables, options],
   # Status
+  stew/results,
+
   chronicles,
   # Internal
   ../spec/[datatypes, digest],
@@ -28,27 +30,26 @@ import
 # ----------------------------------------------------------------------
 
 type
-  FcErrKind* = enum
+  fcKind* = enum
     ## Fork Choice Error Kinds
-    fcSuccess
-    fcErrFinalizedNodeUnknown
-    fcErrJustifiedNodeUnknown
-    fcErrInvalidFinalizedRootCHange
-    fcErrInvalidNodeIndex
-    fcErrInvalidParentIndex
-    fcErrInvalidBestChildIndex
-    fcErrInvalidJustifiedIndex
-    fcErrInvalidBestDescendant
-    fcErrInvalidParentDelta
-    fcErrInvalidNodeDelta
-    fcErrDeltaUnderflow
-    fcErrIndexUnderflow
-    fcErrInvalidDeltaLen
-    fcErrRevertedFinalizedEpoch
-    fcErrInvalidBestNode
+    fcFinalizedNodeUnknown
+    fcJustifiedNodeUnknown
+    fcInvalidFinalizedRootCHange
+    fcInvalidNodeIndex
+    fcInvalidParentIndex
+    fcInvalidBestChildIndex
+    fcInvalidJustifiedIndex
+    fcInvalidBestDescendant
+    fcInvalidParentDelta
+    fcInvalidNodeDelta
+    fcDeltaUnderflow
+    fcIndexUnderflow
+    fcInvalidDeltaLen
+    fcRevertedFinalizedEpoch
+    fcInvalidBestNode
     # -------------------------
     # TODO: Extra error modes beyond Proto/Lighthouse to be reviewed
-    fcErrUnknownParent
+    fcUnknownParent
 
   FcUnderflowKind* = enum
     ## Fork Choice Overflow Kinds
@@ -61,41 +62,41 @@ type
     ## Delta indices
 
   ForkChoiceError* = object
-    case kind*: FcErrKind
-    of fcSuccess:
-      discard
-    of fcErrFinalizedNodeUnknown,
-       fcErrJustifiedNodeUnknown:
+    case kind*: fcKind
+    of fcFinalizedNodeUnknown,
+       fcJustifiedNodeUnknown:
          block_root*: Eth2Digest
-    of fcErrInvalidFinalizedRootChange:
+    of fcInvalidFinalizedRootChange:
       discard
-    of fcErrInvalidNodeIndex,
-       fcErrInvalidParentIndex,
-       fcErrInvalidBestChildIndex,
-       fcErrInvalidJustifiedIndex,
-       fcErrInvalidBestDescendant,
-       fcErrInvalidParentDelta,
-       fcErrInvalidNodeDelta,
-       fcErrDeltaUnderflow:
+    of fcInvalidNodeIndex,
+       fcInvalidParentIndex,
+       fcInvalidBestChildIndex,
+       fcInvalidJustifiedIndex,
+       fcInvalidBestDescendant,
+       fcInvalidParentDelta,
+       fcInvalidNodeDelta,
+       fcDeltaUnderflow:
          index*: Index
-    of fcErrIndexUnderflow:
+    of fcIndexUnderflow:
       underflowKind*: FcUnderflowKind
-    of fcErrInvalidDeltaLen:
+    of fcInvalidDeltaLen:
       deltasLen*: int
       indicesLen*: int
-    of fcErrRevertedFinalizedEpoch:
+    of fcRevertedFinalizedEpoch:
       current_finalized_epoch*: Epoch
       new_finalized_epoch*: Epoch
-    of fcErrInvalidBestNode:
+    of fcInvalidBestNode:
       start_root*: Eth2Digest
       justified_epoch*: Epoch
       finalized_epoch*: Epoch
       head_root*: Eth2Digest
       head_justified_epoch*: Epoch
       head_finalized_epoch*: Epoch
-    of fcErrUnknownParent:
+    of fcUnknownParent:
       child_root*: Eth2Digest
       parent_root*: Eth2Digest
+
+  FcResult*[T] = Result[T, ForkChoiceError]
 
   ProtoArray* = object
     prune_threshold*: int
@@ -126,8 +127,6 @@ type
     current*: FFGCheckpoints
     best*: FFGCheckpoints
     updateAt*: Option[Epoch]
-
-const ForkChoiceSuccess* = ForkChoiceError(kind: fcSuccess)
 
 # Fork choice high-level types
 # ----------------------------------------------------------------------

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -160,9 +160,8 @@ proc stateIdToBlockSlot(node: BeaconNode, stateId: string): BlockSlot =
     of "finalized":
       node.blockPool.finalizedHead
     of "justified":
-      node.blockPool.head.atSlot(
-        node.blockPool.headState.data.data.current_justified_checkpoint.
-          epoch.compute_start_slot_at_epoch)
+      node.blockPool.head.atEpochStart(
+        node.blockPool.headState.data.data.current_justified_checkpoint.epoch)
     else:
       if stateId.startsWith("0x"):
         let blckRoot = parseRoot(stateId)
@@ -353,7 +352,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     debug "post_v1_validator_duties_attester", epoch = epoch
     let head = node.doChecksAndGetCurrentHead(epoch)
 
-    let attestationHead = head.atSlot(compute_start_slot_at_epoch(epoch))
+    let attestationHead = head.atEpochStart(epoch)
     node.blockPool.withState(node.blockPool.tmpState, attestationHead):
       for pubkey in public_keys:
         let idx = state.validators.asSeq.findIt(it.pubKey == pubkey)

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -16,7 +16,7 @@ import
 
   # Local modules
   spec/[datatypes, digest, crypto, validator, beaconstate, helpers],
-  block_pool, ssz/merkleization,
+  block_pool, block_pools/candidate_chains, ssz/merkleization,
   beacon_node_common, beacon_node_types,
   validator_duties, eth2_network,
   spec/eth2_apis/callsigs_types,

--- a/tests/test_peer_connection.nim
+++ b/tests/test_peer_connection.nim
@@ -20,7 +20,7 @@ asyncTest "connect two nodes":
   var n1PersistentAddress = c1.getPersistenBootstrapAddr(
     ValidIpAddress.init("127.0.0.1"), Port c1.tcpPort)
 
-  var n1 = await createEth2Node(c1, ENRForkID())
+  var n1 = createEth2Node(c1, ENRForkID())
 
   echo "Node 1 persistent address: ", n1PersistentAddress
 
@@ -34,7 +34,7 @@ asyncTest "connect two nodes":
   c2.dataDir = OutDir(tempDir / "node-2")
   c2.tcpPort = 50001
   c2.nat = "none"
-  var n2 = await createEth2Node(c2, ENRForkID())
+  var n2 = createEth2Node(c2, ENRForkID())
 
   await n2.startLookingForPeers(@[n1PersistentAddress])
 


### PR DESCRIPTION
* use target block/epoch to validate attestations
* make addLocalValidators sync
* add current and previous epoch to cache before doing state transition
* update head state using clearance state as a shortcut, when possible
* use blockslot for fork choice balances
* send attestations using epochref cache