### PR TITLE
Jenkins: run local testnet test on macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,15 +35,13 @@ def runStages() {
 					stage("Test suite") {
 						sh "make -j${env.NPROC} DISABLE_TEST_FIXTURES_SCRIPT=1 test"
 					}
-					if ("${NODE_NAME}" ==~ /linux.*/) {
-						stage("testnet finalization") {
-							// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
-							sh """#!/bin/bash
-							set -e
-							timeout -k 20s 10m ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
-							timeout -k 20s 40m ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
-							"""
-						}
+					stage("testnet finalization") {
+						// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
+						sh """#!/bin/bash
+						set -e
+						./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+						./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+						"""
 					}
 				}
 			)
@@ -53,14 +51,12 @@ def runStages() {
 		throw e
 	} finally {
 		// archive testnet logs
-		if ("${NODE_NAME}" ==~ /linux.*/) {
-			sh """#!/bin/bash
-			for D in local_testnet0_data local_testnet1_data; do
-				[[ -d "\$D" ]] && tar cjf "\${D}.tar.bz2" "\${D}"/*.txt || true
-			done
-			"""
-			archiveArtifacts("*.tar.bz2")
-		}
+		sh """#!/bin/bash
+		for D in local_testnet0_data local_testnet1_data; do
+			[[ -d "\$D" ]] && tar cjf "\${D}-\${NODE_NAME}.tar.bz2" "\${D}"/*.txt || true
+		done
+		"""
+		archiveArtifacts("*.tar.bz2")
 		// clean the workspace
 		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
 	}

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -17,7 +17,15 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/..
 ####################
 # argument parsing #
 ####################
-! getopt --test > /dev/null
+
+GETOPT_BINARY="getopt"
+if uname | grep -qi darwin; then
+  # macOS
+  GETOPT_BINARY="/usr/local/opt/gnu-getopt/bin/getopt"
+	[[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
+fi
+
+! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then
 	echo '`getopt --test` failed in this environment.'
 	exit 1
@@ -55,7 +63,7 @@ CI run: $(basename $0) --disable-htop -- --verify-finalization --stop-at-epoch=5
 EOF
 }
 
-! PARSED=$(getopt --options=${OPTS} --longoptions=${LONGOPTS} --name "$0" -- "$@")
+! PARSED=$(${GETOPT_BINARY} --options=${OPTS} --longoptions=${LONGOPTS} --name "$0" -- "$@")
 if [ ${PIPESTATUS[0]} != 0 ]; then
 	# getopt has complained about wrong arguments to stdout
 	exit 1
@@ -279,7 +287,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
 
 	if [[ $NUM_NODE -lt $NODES_WITH_VALIDATORS ]]; then
 		for VALIDATOR in $(ls ${VALIDATORS_DIR} | tail -n +$(( $USER_VALIDATORS + ($VALIDATORS_PER_NODE * $NUM_NODE) + 1 )) | head -n $VALIDATORS_PER_NODE); do
-			cp -ar "${VALIDATORS_DIR}/$VALIDATOR" "${NODE_DATA_DIR}/validators/"
+			cp -a "${VALIDATORS_DIR}/$VALIDATOR" "${NODE_DATA_DIR}/validators/"
 			cp -a "${SECRETS_DIR}/${VALIDATOR}" "${NODE_DATA_DIR}/secrets/"
 		done
 	fi
@@ -310,7 +318,7 @@ done
 
 # give the regular nodes time to crash
 sleep 5
-BG_JOBS="$(jobs | wc -l)"
+BG_JOBS="$(jobs | wc -l | tr -d ' ')"
 if [[ "$BG_JOBS" != "$NUM_NODES" ]]; then
 	echo "$((NUM_NODES - BG_JOBS)) beacon_node instance(s) exited early. Aborting."
 	dump_logs

--- a/scripts/make_prometheus_config.sh
+++ b/scripts/make_prometheus_config.sh
@@ -12,7 +12,15 @@ set -e
 ####################
 # argument parsing #
 ####################
-! getopt --test > /dev/null
+
+GETOPT_BINARY="getopt"
+if uname | grep -qi darwin; then
+  # macOS
+  GETOPT_BINARY="/usr/local/opt/gnu-getopt/bin/getopt"
+	[[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
+fi
+
+! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then
 	echo '`getopt --test` failed in this environment.'
 	exit 1
@@ -37,7 +45,7 @@ Usage: $(basename $0) --nodes ${NUM_NODES} --base-metrics-port ${BASE_METRICS_PO
 EOF
 }
 
-! PARSED=$(getopt --options=${OPTS} --longoptions=${LONGOPTS} --name "$0" -- "$@")
+! PARSED=$(${GETOPT_BINARY} --options=${OPTS} --longoptions=${LONGOPTS} --name "$0" -- "$@")
 if [ ${PIPESTATUS[0]} != 0 ]; then
 	# getopt has complained about wrong arguments to stdout
 	exit 1

--- a/tests/simulation/run_validator.sh
+++ b/tests/simulation/run_validator.sh
@@ -34,7 +34,7 @@ if [[ $NODE_ID -lt $TOTAL_NODES ]]; then
 
   pushd "$VALIDATORS_DIR" >/dev/null
   for VALIDATOR in $(ls | tail -n +$(( $VALIDATOR_OFFSET + ($VALIDATORS_PER_NODE * $NODE_ID) + 1 )) | head -n $VALIDATORS_PER_NODE); do
-      cp -ar "$VALIDATOR" "$NODE_VALIDATORS_DIR"
+      cp -a "$VALIDATOR" "$NODE_VALIDATORS_DIR"
       cp -a "$SECRETS_DIR/$VALIDATOR" "$NODE_SECRETS_DIR"
     done
   popd >/dev/null


### PR DESCRIPTION
This is a copy of changes already tested in https://github.com/status-im/nim-beacon-chain/pull/1382

We're enabling the local testnet integration test in macOS because it gives us an extra data point on the thin red line between failure and success, without making the total runtime longer.

Only drawback: having to disable timeouts, but I'm pretty sure we don't need them anymore.