### PR TITLE
add attestations received before referred-to blocks to unresolved list

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -162,6 +162,7 @@ proc isValidAttestation*(
   let attestationBlck = pool.chainDag.getRef(attestation.data.beacon_block_root)
   if attestationBlck.isNil:
     debug "Block not found"
+    pool.addUnresolved(attestation)
     pool.quarantine.addMissing(attestation.data.beacon_block_root)
     return false
 

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -78,7 +78,7 @@ func processAttestation(
   for validator in participants:
     pool.forkChoice.process_attestation(validator, block_root, target_epoch)
 
-func addUnresolved(pool: var AttestationPool, attestation: Attestation) =
+func addUnresolved*(pool: var AttestationPool, attestation: Attestation) =
   pool.unresolved[attestation.data.beacon_block_root] =
     UnresolvedAttestation(
       attestation: attestation,


### PR DESCRIPTION
This doesn't break the in front of/behind firewall setup: `addUnresolved` adds to a data structure in front of the firewall, and is checked separately/as usual by `addResolved()` when the block to which it refers comes into view.