### PR TITLE
fix for the BN/VC communication since the #1371 PR

### DIFF
--- a/beacon_chain/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/eth2_json_rpc_serialization.nim
@@ -14,6 +14,7 @@ proc fromJson*(n: JsonNode, argName: string, result: var ValidatorPubKey) =
   result = ValidatorPubKey.fromHex(n.getStr()).tryGet()
 
 proc `%`*(pubkey: ValidatorPubKey): JsonNode =
+  unsafePromote(pubkey.unsafeAddr)
   result = newJString($pubkey)
 
 proc fromJson*(n: JsonNode, argName: string, result: var List) =
@@ -31,6 +32,7 @@ proc fromJson*(n: JsonNode, argName: string, result: var ValidatorSig) =
   result = ValidatorSig.fromHex(n.getStr()).tryGet()
 
 proc `%`*(value: ValidatorSig): JsonNode =
+  unsafePromote(value.unsafeAddr)
   result = newJString($value)
 
 proc fromJson*(n: JsonNode, argName: string, result: var Version) =


### PR DESCRIPTION
Not sure if this is the correct fix for it (this is the first use of `unsafePromote` outside of `crypto.nim`) but it does work - the problem was the serialization of `BlsValue` which had it's `kind == ToBeChecked` - that got serialized to `raw: <hex_encoded_pubkey>` instead of `<hex_encoded_pubkey>` and then couldn't get deserialized on the other end which led to errors such as `Trying to access value with err: bls: cannot parse value`.

The use of VCs for the local sim should be made on by default as soon as I fix another issue with finalization at around slot 600 for the local sim.