### PR TITLE
Start libp2p before writing ENR file

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -852,7 +852,7 @@ proc createPidFile(filename: string) =
   addQuitProc proc {.noconv.} = removeFile gPidFile
 
 proc initializeNetworking(node: BeaconNode) {.async.} =
-  node.network.startListening()
+  await node.network.startListening()
 
   let addressFile = node.config.dataDir / "beacon_node.enr"
   writeFile(addressFile, node.network.announcedENR.toURI)

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -882,14 +882,14 @@ template publicKey*(node: Eth2Node): keys.PublicKey =
 template addKnownPeer*(node: Eth2Node, peer: enr.Record) =
   node.discovery.addNode peer
 
-proc startListening*(node: Eth2Node) =
+proc startListening*(node: Eth2Node) {.async.} =
   node.discovery.open()
+  node.libp2pTransportLoops = await node.switch.start()
 
 proc start*(node: Eth2Node) {.async.} =
   for i in 0 ..< ConcurrentConnections:
     node.connWorkers.add connectWorker(node)
 
-  node.libp2pTransportLoops = await node.switch.start()
   node.discovery.start()
   node.discoveryLoop = node.runDiscoveryLoop()
   traceAsyncErrors node.discoveryLoop


### PR DESCRIPTION
this makes sure that all libp2p transports are open for business when
the file hits the ground