### PR TITLE
disable ProveInit warnings

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -77,3 +77,5 @@ switch("warning", "ObservableStores:off")
 # Too many false positives for "Warning: method has lock level <unknown>, but another method has 0 [LockLevel]"
 switch("warning", "LockLevel:off")
 
+# https://github.com/nim-lang/Nim/issues/3608
+switch("warning", "ProveInit:off")


### PR DESCRIPTION
This leaves the specific disablings in place, so the global enable/disable switch can be removed easily if/when desired.

Warnings should be actionable, and this one evidently isn't at this point, as https://github.com/nim-lang/Nim/issues/3608 hasn't seen activity in almost 5 years. Apparently, the result looks disconcerting to some users building nim-beacon-chain for little/no remaining advantage for developing nbc.