### PR TITLE
remove one cache, add another

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -29,10 +29,9 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
   #      should probably be removed as a dependency of AttestationPool (or some other
   #      smart refactoring)
 
-  chainDag.withState(chainDag.tmpState, chainDag.finalizedHead):
-    var forkChoice = initForkChoice(
-      chainDag.tmpState,
-    ).get()
+  let tmpState = newClone(chainDag.headState)
+  chainDag.withState(tmpState[], chainDag.finalizedHead):
+    var forkChoice = initForkChoice(tmpState[]).get()
 
   # Feed fork choice with unfinalized history - during startup, block pool only
   # keeps track of a single history so we just need to follow it

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -115,9 +115,6 @@ type
     # -----------------------------------
     # Rewinder - Mutable state processing
 
-    cachedStates*: seq[tuple[blockRoot: Eth2Digest, slot: Slot,
-      state: ref HashedBeaconState]]
-
     headState*: StateData ##\
     ## State given by the head block; only update in `updateHead`, not anywhere
     ## else via `withState`
@@ -143,6 +140,10 @@ type
     beacon_proposers*: array[
       SLOTS_PER_EPOCH, Option[(ValidatorIndex, ValidatorPubKey)]]
     shuffled_active_validator_indices*: seq[ValidatorIndex]
+    # This is an expensive cache that could probably be shared among epochref
+    # instances - in particular, validators keep their keys and locations in the
+    # structure
+    validator_keys*: seq[ValidatorPubKey]
 
   BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to tail block, and to have

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -388,7 +388,7 @@ proc isValidBeaconBlock*(
       dag.headState.data.data.genesis_validators_root,
       signed_beacon_block.message.slot,
       signed_beacon_block.message,
-      proposer.get()[1].initPubKey(),
+      proposer.get()[1],
       signed_beacon_block.signature):
     debug "block failed signature verification",
       signature = shortLog(signed_beacon_block.signature)

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -388,7 +388,7 @@ proc isValidBeaconBlock*(
       dag.headState.data.data.genesis_validators_root,
       signed_beacon_block.message.slot,
       signed_beacon_block.message,
-      proposer.get()[1],
+      proposer.get()[1].initPubKey(),
       signed_beacon_block.signature):
     debug "block failed signature verification",
       signature = shortLog(signed_beacon_block.signature)

--- a/beacon_chain/block_pools/spec_cache.nim
+++ b/beacon_chain/block_pools/spec_cache.nim
@@ -18,9 +18,11 @@ import
 func count_active_validators*(epochInfo: EpochRef): uint64 =
   epochInfo.shuffled_active_validator_indices.lenu64
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_committee_count_per_slot
 func get_committee_count_per_slot*(epochInfo: EpochRef): uint64 =
   get_committee_count_per_slot(count_active_validators(epochInfo))
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee*(
     epochRef: EpochRef, slot: Slot, index: CommitteeIndex): seq[ValidatorIndex] =
   # Return the beacon committee at ``slot`` for ``index``.
@@ -58,6 +60,7 @@ func get_indexed_attestation*(epochRef: EpochRef, attestation: Attestation): Ind
     signature: attestation.signature
   )
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee_len*(
     epochRef: EpochRef, slot: Slot, index: CommitteeIndex): uint64 =
   # Return the number of members in the beacon committee at ``slot`` for ``index``.
@@ -72,6 +75,7 @@ func get_beacon_committee_len*(
     committees_per_slot * SLOTS_PER_EPOCH
   )
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/validator.md#aggregation-selection
 func is_aggregator*(epochRef: EpochRef, slot: Slot, index: CommitteeIndex,
     slot_signature: ValidatorSig): bool =
   let
@@ -79,6 +83,7 @@ func is_aggregator*(epochRef: EpochRef, slot: Slot, index: CommitteeIndex,
     modulo = max(1'u64, committee_len div TARGET_AGGREGATORS_PER_COMMITTEE)
   bytes_to_uint64(eth2digest(slot_signature.toRaw()).data[0..7]) mod modulo == 0
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     epochRef: EpochRef, indexed_attestation: SomeIndexedAttestation,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -172,7 +172,7 @@ func compute_committee*(shuffled_indices: seq[ValidatorIndex],
   except KeyError:
     raiseAssert("Cached entries are added before use")
 
-func compute_committee_len(active_validators: uint64,
+func compute_committee_len*(active_validators: uint64,
     index: uint64, count: uint64): uint64 =
   ## Return the committee corresponding to ``indices``, ``seed``, ``index``,
   ## and committee ``count``.

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -206,6 +206,7 @@ func get_beacon_committee*(
     committees_per_slot * SLOTS_PER_EPOCH
   )
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee_len*(
     state: BeaconState, slot: Slot, index: CommitteeIndex,
     cache: var StateCache): uint64 =

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -375,7 +375,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       let currSlot = compute_start_slot_at_epoch(epoch) + i
       let proposer = node.chainDag.getProposer(head, currSlot)
       if proposer.isSome():
-        result.add((public_key: proposer.get()[1], slot: currSlot))
+        result.add((public_key: proposer.get()[1].initPubKey(), slot: currSlot))
 
   rpcServer.rpc("post_v1_validator_beacon_committee_subscriptions") do (
       committee_index: CommitteeIndex, slot: Slot, aggregator: bool,

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -358,7 +358,8 @@ proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
   if proposer.isNone():
     return head
 
-  let validator = node.attachedValidators.getValidator(proposer.get()[1])
+  let validator =
+    node.attachedValidators.getValidator(proposer.get()[1].initPubKey())
 
   if validator != nil:
     return await proposeBlock(node, validator, proposer.get()[0], head, slot)
@@ -367,7 +368,7 @@ proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
     headRoot = shortLog(head.root),
     slot = shortLog(slot),
     proposer_index = proposer.get()[0],
-    proposer = shortLog(proposer.get()[1]),
+    proposer = shortLog(proposer.get()[1].initPubKey()),
     pcs = "wait_for_proposal"
 
   return head


### PR DESCRIPTION
This cache removes the need for rewinding in most attestation validation
flow since the attestations come from one of two epochs and must be
targetting a viable block.

Additionally, it also removes all state caches which are less likely to
be used over-all - more metrics are needed to track the rewinding.

On risk is that when chains don't finalize, we'll have lots of epochrefs
in memory meaning lots of validator key databases, most being exactly
the same. This can be addressed in any number of ways. Some of the
memory usage is mitigated by the fact that we previously had lots of big
state caches and now we're keeping only keys instead.