### PR TITLE
Use one single async queue and loop for processing blocks.

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -559,7 +559,7 @@ proc runOnSecondLoop(node: BeaconNode) {.async.} =
 proc importBlock(node: BeaconNode,
                  sblock: SignedBeaconBlock): Result[void, BlockError] =
   let sm1 = now(chronos.Moment)
-  let res = node.storeBlock(sblock.blk)
+  let res = node.storeBlock(sblock)
   let em1 = now(chronos.Moment)
   if res.isOk() or (res.error() in {BlockError.Duplicate, BlockError.Old}):
     let sm2 = now(chronos.Moment)

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -284,13 +284,9 @@ proc init*(T: type BeaconNode,
     forkDigest: enrForkId.forkDigest,
     topicBeaconBlocks: topicBeaconBlocks,
     topicAggregateAndProofs: topicAggregateAndProofs,
+    blocksQueue: newAsyncQueue[SyncBlock](1),
   )
-
-  res.requestManager = RequestManager.init(network,
-    proc(signedBlock: SignedBeaconBlock) =
-      onBeaconBlock(res, signedBlock)
-  )
-
+  res.requestManager = RequestManager.init(network, res.blocksQueue)
   res.addLocalValidators()
 
   # This merely configures the BeaconSync
@@ -560,14 +556,45 @@ proc runOnSecondLoop(node: BeaconNode) {.async.} =
     ticks_delay.set(sleepTime.nanoseconds.float / nanosecondsIn1s)
     debug "onSecond task completed", sleepTime, processingTime
 
-proc runForwardSyncLoop(node: BeaconNode) {.async.} =
+proc importBlock(node: BeaconNode,
+                 sblock: SignedBeaconBlock): Result[void, BlockError] =
+  let sm1 = now(chronos.Moment)
+  let res = node.storeBlock(sblock.blk)
+  let em1 = now(chronos.Moment)
+  if res.isOk() or (res.error() in {BlockError.Duplicate, BlockError.Old}):
+    let sm2 = now(chronos.Moment)
+    discard node.updateHead(node.beaconClock.now().slotOrZero)
+    let em2 = now(chronos.Moment)
+    let duration1 = if res.isOk(): em1 - sm1 else: ZeroDuration
+    let duration2 = if res.isOk(): em2 - sm2 else: ZeroDuration
+    let duration = if res.isOk(): em2 - sm1 else: ZeroDuration
+    let storeSpeed =
+      block:
+        let secs = float(chronos.seconds(1).nanoseconds)
+        if not(duration.isZero()):
+          let v = secs / float(duration.nanoseconds)
+          round(v * 10_000) / 10_000
+        else:
+          0.0
+    debug "Block got imported successfully",
+           local_head_slot = node.chainDag.head.slot, store_speed = storeSpeed,
+           block_root = shortLog(sblock.root),
+           block_slot = sblock.message.slot,
+           store_block_duration = $duration1,
+           update_head_duration = $duration2,
+           store_duration = $duration
+    ok()
+  else:
+    err(res.error())
+
+proc startSyncManager(node: BeaconNode) =
   func getLocalHeadSlot(): Slot =
-    result = node.chainDag.head.slot
+    node.chainDag.head.slot
 
   proc getLocalWallSlot(): Slot {.gcsafe.} =
     let epoch = node.beaconClock.now().slotOrZero.compute_epoch_at_slot() +
                 1'u64
-    result = epoch.compute_start_slot_at_epoch()
+    epoch.compute_start_slot_at_epoch()
 
   func getFirstSlotAtFinalizedEpoch(): Slot {.gcsafe.} =
     let fepoch = node.chainDag.headState.data.data.finalized_checkpoint.epoch
@@ -581,47 +608,23 @@ proc runForwardSyncLoop(node: BeaconNode) {.async.} =
               score_high_limit = PeerScoreHighLimit
       except:
         discard
-      result = false
+      false
     else:
-      result = true
+      true
 
   node.network.peerPool.setScoreCheck(scoreCheck)
-
   node.syncManager = newSyncManager[Peer, PeerID](
     node.network.peerPool, getLocalHeadSlot, getLocalWallSlot,
-    getFirstSlotAtFinalizedEpoch, chunkSize = 32
+    getFirstSlotAtFinalizedEpoch, node.blocksQueue, chunkSize = 32
   )
-
   node.syncManager.start()
 
+proc runBlockProcessingLoop(node: BeaconNode) {.async.} =
   while true:
-    let sblock = await node.syncManager.getBlock()
-    let sm1 = now(chronos.Moment)
-    let res = node.storeBlock(sblock.blk)
-    let em1 = now(chronos.Moment)
-    if res.isOk() or (res.error() in {BlockError.Duplicate, BlockError.Old}):
-      let sm2 = now(chronos.Moment)
-      discard node.updateHead(node.beaconClock.now().slotOrZero)
-      let em2 = now(chronos.Moment)
+    let sblock = await node.blocksQueue.popFirst()
+    let res = node.importBlock(sblock.blk)
+    if res.isOk():
       sblock.done()
-      let duration1 = if res.isOk(): em1 - sm1 else: ZeroDuration
-      let duration2 = if res.isOk(): em2 - sm2 else: ZeroDuration
-      let duration = if res.isOk(): em2 - sm1 else: ZeroDuration
-      let storeSpeed =
-        block:
-          let secs = float(chronos.seconds(1).nanoseconds)
-          if not(duration.isZero()):
-            let v = secs / float(duration.nanoseconds)
-            round(v * 10_000) / 10_000
-          else:
-            0.0
-      debug "Block got imported successfully",
-             local_head_slot = getLocalHeadSlot(), store_speed = storeSpeed,
-             block_root = shortLog(sblock.blk.root),
-             block_slot = sblock.blk.message.slot,
-             store_block_duration = $duration1,
-             update_head_duration = $duration2,
-             store_duration = $duration
     else:
       sblock.fail(res.error)
 
@@ -866,9 +869,10 @@ proc run*(node: BeaconNode) =
       asyncCheck node.onSlotStart(curSlot, nextSlot)
 
     node.onSecondLoop = runOnSecondLoop(node)
-    node.forwardSyncLoop = runForwardSyncLoop(node)
+    node.blockProcessingLoop = runBlockProcessingLoop(node)
 
     node.requestManager.start()
+    node.startSyncManager()
 
   # main event loop
   while status == BeaconNodeStatus.Running:

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -36,7 +36,6 @@ type
     graffitiBytes*: GraffitiBytes
     network*: Eth2Node
     netKeys*: KeyPair
-    requestManager*: RequestManager
     db*: BeaconChainDB
     config*: BeaconNodeConf
     attachedValidators*: ValidatorPool
@@ -47,10 +46,12 @@ type
     beaconClock*: BeaconClock
     rpcServer*: RpcServer
     forkDigest*: ForkDigest
+    blocksQueue*: AsyncQueue[SyncBlock]
+    requestManager*: RequestManager
     syncManager*: SyncManager[Peer, PeerID]
     topicBeaconBlocks*: string
     topicAggregateAndProofs*: string
-    forwardSyncLoop*: Future[void]
+    blockProcessingLoop*: Future[void]
     onSecondLoop*: Future[void]
     genesisSnapshotContent*: string
 

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -440,7 +440,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
     var res: Result[void, BlockError]
     if len(item.data) > 0:
       for blk in item.data:
-        debug "Pushing block", block_root = blk.root,
+        trace "Pushing block", block_root = blk.root,
                                block_slot = blk.message.slot
         res = await sq.validate(blk)
         if not(res.isOk):
@@ -981,11 +981,16 @@ proc start*[A, B](man: SyncManager[A, B]) =
   man.syncFut = man.syncLoop()
 
 proc done*(blk: SyncBlock) =
-  ## Send signal to SyncManager that the block ``blk`` has passed
+  ## Send signal to [Sync/Request]Manager that the block ``blk`` has passed
   ## verification successfully.
   blk.resfut.complete(Result[void, BlockError].ok())
 
 proc fail*(blk: SyncBlock, error: BlockError) =
-  ## Send signal to SyncManager that the block ``blk`` has NOT passed
+  ## Send signal to [Sync/Request]Manager that the block ``blk`` has NOT passed
   ## verification with specific ``error``.
   blk.resfut.complete(Result[void, BlockError].err(error))
+
+proc complete*(blk: SyncBlock, res: Result[void, BlockError]) {.inline.} =
+  ## Send signal to [Sync/Request]Manager about result ``res`` of block ``blk``
+  ## verification.
+  blk.resfut.complete(res)

--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -80,7 +80,7 @@ suiteReport "PeerPool testing suite":
       doAssert(fut1.finished == false)
       doAssert(fut2.finished == false)
       peer0.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut1.finished == false)
       doAssert(fut2.finished == true and fut2.failed == false)
       result = true
@@ -102,11 +102,11 @@ suiteReport "PeerPool testing suite":
       doAssert(fut2.finished == false)
       doAssert(fut3.finished == false)
       peer0.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut2.finished == true and fut2.failed == false)
       doAssert(fut3.finished == false)
       peer1.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut3.finished == true and fut3.failed == false)
       result = true
 
@@ -128,11 +128,11 @@ suiteReport "PeerPool testing suite":
       doAssert(fut2.finished == true and fut2.failed == false)
       doAssert(fut3.finished == false)
       peer0.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut1.finished == true and fut1.failed == false)
       doAssert(fut3.finished == false)
       peer2.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut3.finished == true and fut3.failed == false)
       result = true
 
@@ -160,21 +160,21 @@ suiteReport "PeerPool testing suite":
       doAssert(fut4.finished == false)
       doAssert(fut5.finished == false)
 
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut3.finished == false)
       doAssert(fut4.finished == false)
       doAssert(fut5.finished == false)
       peer0.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut3.finished == true and fut3.failed == false)
       doAssert(fut4.finished == false)
       doAssert(fut5.finished == false)
       peer1.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut4.finished == true and fut4.failed == false)
       doAssert(fut5.finished == false)
       peer2.close()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       doAssert(fut5.finished == true and fut5.failed == false)
       result = true
 
@@ -442,7 +442,7 @@ suiteReport "PeerPool testing suite":
 
     proc testConsumer() {.async.} =
       var p = await pool.acquire()
-      await sleepAsync(10.milliseconds)
+      await sleepAsync(100.milliseconds)
       pool.release(p)
 
     proc testClose(): Future[bool] {.async.} =


### PR DESCRIPTION
Add one by one block processing for RequestManager.
Change SyncManager and RequestManager to use one single async queue for block processing.

Fix flaky PeerPool test with 10x bigger timeout values.