### PR TITLE
use a separate process for the private keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ GOERLI_TESTNETS_PARAMS := \
   --rpc \
   --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
-eth2_network_simulation: | clean_eth2_network_simulation_data
+eth2_network_simulation: | build deps clean_eth2_network_simulation_all
 	+ GIT_ROOT="$$PWD" NIMFLAGS="$(NIMFLAGS)" LOG_LEVEL="$(LOG_LEVEL)" tests/simulation/start-in-tmux.sh
 	killall prometheus &>/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ GOERLI_TESTNETS_PARAMS := \
   --rpc \
   --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
-eth2_network_simulation: | build deps clean_eth2_network_simulation_all
+eth2_network_simulation: | clean_eth2_network_simulation_data
 	+ GIT_ROOT="$$PWD" NIMFLAGS="$(NIMFLAGS)" LOG_LEVEL="$(LOG_LEVEL)" tests/simulation/start-in-tmux.sh
 	killall prometheus &>/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -162,14 +162,14 @@ clean-testnet0:
 clean-testnet1:
 	rm -rf build/data/testnet1*
 
-testnet0 testnet1: | beacon_node
+testnet0 testnet1: | beacon_node validator_client
 	build/beacon_node \
 		--network=$@ \
 		--log-level="$(LOG_LEVEL)" \
 		--data-dir=build/data/$@_$(NODE_ID) \
 		$(GOERLI_TESTNETS_PARAMS) $(NODE_PARAMS)
 
-medalla: | beacon_node
+medalla: | beacon_node validator_client
 	mkdir -p build/data/shared_medalla_$(NODE_ID)
 
 	scripts/make_prometheus_config.sh \
@@ -210,7 +210,7 @@ medalla-vc: | beacon_node validator_client
 		--data-dir=build/data/shared_medalla_$(NODE_ID) \
 		--rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
-medalla-dev: | beacon_node
+medalla-dev: | beacon_node validator_client
 	mkdir -p build/data/shared_medalla_$(NODE_ID)
 
 	scripts/make_prometheus_config.sh \
@@ -224,7 +224,7 @@ medalla-dev: | beacon_node
 		--data-dir=build/data/shared_medalla_$(NODE_ID) \
 		$(GOERLI_TESTNETS_PARAMS) --dump $(NODE_PARAMS)
 
-medalla-deposit-data: | beacon_node deposit_contract
+medalla-deposit-data: | beacon_node validator_client deposit_contract
 	build/beacon_node deposits create \
 		--network=medalla \
 		--new-wallet-file=build/data/shared_medalla_$(NODE_ID)/wallet.json \
@@ -233,7 +233,7 @@ medalla-deposit-data: | beacon_node deposit_contract
 		--out-deposits-file=medalla-deposits_data-$$(date +"%Y%m%d%H%M%S").json \
 		--count=$(VALIDATORS)
 
-medalla-deposit: | beacon_node deposit_contract
+medalla-deposit: | beacon_node validator_client deposit_contract
 	build/beacon_node deposits create \
 		--network=medalla \
 		--out-deposits-file=nbc-medalla-deposits.json \
@@ -252,7 +252,7 @@ medalla-deposit: | beacon_node deposit_contract
 clean-medalla:
 	rm -rf build/data/shared_medalla*
 
-altona: | beacon_node
+altona: | beacon_node validator_client
 	build/beacon_node \
 		--network=altona \
 		--log-level="$(LOG_LEVEL)" \
@@ -278,14 +278,14 @@ altona-vc: | beacon_node validator_client
 		--data-dir=build/data/shared_altona_$(NODE_ID) \
 		--rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
-altona-dev: | beacon_node
+altona-dev: | beacon_node validator_client
 	build/beacon_node \
 		--network=altona \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_altona_$(NODE_ID) \
 		$(GOERLI_TESTNETS_PARAMS) --dump $(NODE_PARAMS)
 
-altona-deposit: | beacon_node deposit_contract
+altona-deposit: | beacon_node validator_client deposit_contract
 	build/beacon_node deposits create \
 		--network=altona \
 		--out-deposits-file=nbc-altona-deposits.json \

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ GOERLI_TESTNETS_PARAMS := \
   --metrics \
   --metrics-port=$$(( $(BASE_METRICS_PORT) + $(NODE_ID) )) \
   --rpc \
-  --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
+  --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) )) \
+  --rpc-push-port=$(( $BASE_RPC_PORT + $NODE_ID + 100 ))
 
 eth2_network_simulation: | build deps clean_eth2_network_simulation_all
 	+ GIT_ROOT="$$PWD" NIMFLAGS="$(NIMFLAGS)" LOG_LEVEL="$(LOG_LEVEL)" tests/simulation/start-in-tmux.sh

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  options, chronicles,
+  options, chronos, chronicles,
   ./spec/[
     beaconstate, datatypes, crypto, digest, helpers, network, validator,
     signatures],
@@ -28,7 +28,7 @@ func is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex,
 
 proc aggregate_attestations*(
     pool: AttestationPool, state: BeaconState, index: CommitteeIndex,
-    privkey: ValidatorPrivKey, trailing_distance: uint64,
+    slot_signature: ValidatorSig, trailing_distance: uint64,
     cache: var StateCache): Option[AggregateAndProof] =
   doAssert state.slot >= trailing_distance
 
@@ -37,8 +37,6 @@ proc aggregate_attestations*(
 
   let
     slot = state.slot - trailing_distance
-    slot_signature = get_slot_signature(
-      state.fork, state.genesis_validators_root, slot, privkey)
 
   doAssert slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= state.slot
   doAssert state.slot >= slot
@@ -71,7 +69,7 @@ proc aggregate_attestations*(
         aggregate: attestation,
         selection_proof: slot_signature))
 
-  none(AggregateAndProof)
+  return none(AggregateAndProof)
 
 proc isValidAttestationSlot(
     pool: AttestationPool, attestationSlot: Slot, attestationBlck: BlockRef): bool =

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -9,10 +9,10 @@
 
 import
   # Standard library
-  tables,
+  tables, osproc,
 
   # Nimble packages
-  chronos, json_rpc/rpcserver, metrics,
+  chronos, json_rpc/[rpcclient, rpcserver], metrics,
   chronicles,
 
   # Local modules
@@ -45,6 +45,8 @@ type
     mainchainMonitor*: MainchainMonitor
     beaconClock*: BeaconClock
     rpcServer*: RpcServer
+    rpcPushClient*: RpcHttpClient
+    vcProcess*: Process
     forkDigest*: ForkDigest
     blocksQueue*: AsyncQueue[SyncBlock]
     requestManager*: RequestManager
@@ -55,6 +57,8 @@ type
     onSecondLoop*: Future[void]
     genesisSnapshotContent*: string
     attestationSubnets*: AttestationSubnets
+
+var externalVcProcessPtr*: ptr Process
 
 const
   MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -3,6 +3,7 @@
 import
   deques, tables,
   stew/endians2,
+  json_rpc/rpcclient,
   spec/[datatypes, crypto, digest],
   block_pools/block_pools_types,
   fork_choice/fork_choice_types
@@ -80,6 +81,7 @@ type
     remote
 
   ValidatorConnection* = object
+    rpcPushClient*: RpcHttpClient
 
   AttachedValidator* = ref object
     pubKey*: ValidatorPubKey

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -388,7 +388,7 @@ type
     of pushMode:
       rpcPushPort* {.
         defaultValue: defaultEth2RpcPort + 1
-        desc: "HTTP port of the RPC server in the push model (the beacon node tells the validator client what to do and when)"
+        desc: "HTTP port of the RPC server in the push model (the beacon node tells the validator client what to do and when) - on by default."
         name: "rpc-push-port" }: Port
 
       rpcPushAddress* {.

--- a/beacon_chain/spec/eth2_apis/validator_push_model_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/validator_push_model_callsigs.nim
@@ -6,6 +6,8 @@ import
   json_rpc/jsonmarshal,
   callsigs_types
 
+proc areAllKeysLoaded(): bool
+
 proc getAllValidatorPubkeys(): seq[ValidatorPubKey]
 
 proc signBlockProposal(pubkey: ValidatorPubKey,

--- a/beacon_chain/spec/eth2_apis/validator_push_model_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/validator_push_model_callsigs.nim
@@ -1,0 +1,35 @@
+import
+  # Standard library
+  options,
+  # Local modules
+  ../[datatypes, digest, crypto],
+  json_rpc/jsonmarshal,
+  callsigs_types
+
+proc getAllValidatorPubkeys(): seq[ValidatorPubKey]
+
+proc signBlockProposal(pubkey: ValidatorPubKey,
+                       fork: Fork,
+                       genesis_validators_root: Eth2Digest,
+                       slot: Slot,
+                       blockRoot: Eth2Digest): ValidatorSig
+
+proc signAttestation(pubkey: ValidatorPubKey,
+                     fork: Fork,
+                     genesis_validators_root: Eth2Digest,
+                     attestation_data: AttestationData): ValidatorSig
+
+proc signAggregateAndProof(pubkey: ValidatorPubKey,
+                           fork: Fork,
+                           genesis_validators_root: Eth2Digest,
+                           aggregate_and_proof: AggregateAndProof): ValidatorSig
+
+proc genRandaoReveal(pubkey: ValidatorPubKey,
+                     fork: Fork,
+                     genesis_validators_root: Eth2Digest,
+                     slot: Slot): ValidatorSig
+
+proc getSlotSig(pubkey: ValidatorPubKey,
+                fork: Fork,
+                genesis_validators_root: Eth2Digest,
+                slot: Slot): ValidatorSig

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -310,7 +310,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       raise newException(CatchableError, "could not retrieve block for slot: " & $slot)
     let valInfo = ValidatorInfoForMakeBeaconBlock(kind: viRandao_reveal,
                                                   randao_reveal: randao_reveal)
-    let res = makeBeaconBlockForHeadAndSlot(
+    let res = await makeBeaconBlockForHeadAndSlot(
       node, valInfo, proposer.get()[0], graffiti, head, slot)
     if res.message.isNone():
       raise newException(CatchableError, "could not retrieve block for slot: " & $slot)

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -459,7 +459,6 @@ proc broadcastAggregatedAttestations(
           state.genesis_validators_root)
         var signedAP = SignedAggregateAndProof(
           message: aggregateAndProof.get,
-          # TODO Make the signing async here
           signature: sig)
         node.network.broadcast(node.topicAggregateAndProofs, signedAP)
         info "Aggregated attestation sent",

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -43,11 +43,6 @@ proc signBlockProposal*(v: AttachedValidator, fork: Fork,
                         blockRoot: Eth2Digest): Future[ValidatorSig] {.async.} =
 
   if v.kind == inProcess:
-    # TODO this is an ugly hack to fake a delay and subsequent async reordering
-    #      for the purpose of testing the external validator delay - to be
-    #      replaced by something more sensible
-    await sleepAsync(chronos.milliseconds(1))
-
     result = get_block_signature(
       fork, genesis_validators_root, slot, blockRoot, v.privKey)
   else:
@@ -59,11 +54,6 @@ proc signAttestation*(v: AttachedValidator,
                       fork: Fork, genesis_validators_root: Eth2Digest):
                       Future[ValidatorSig] {.async.} =
   if v.kind == inProcess:
-    # TODO this is an ugly hack to fake a delay and subsequent async reordering
-    #      for the purpose of testing the external validator delay - to be
-    #      replaced by something more sensible
-    await sleepAsync(chronos.milliseconds(1))
-
     result = get_attestation_signature(
       fork, genesis_validators_root, attestation, v.privKey)
   else:
@@ -115,11 +105,6 @@ proc getSlotSig*(v: AttachedValidator, fork: Fork,
   let slot = state_slot - trailing_distance
 
   if v.kind == inProcess:
-    # TODO this is an ugly hack to fake a delay and subsequent async reordering
-    #      for the purpose of testing the external validator delay - to be
-    #      replaced by something more sensible
-    await sleepAsync(chronos.milliseconds(1))
-
     result = get_slot_signature(
       fork, genesis_validators_root, slot, v.privKey)
   else:

--- a/docker/shared_testnet/entry_point.sh
+++ b/docker/shared_testnet/entry_point.sh
@@ -91,7 +91,7 @@ if [[ "$BUILD" == "1" ]]; then
   git pull
   # don't use too much RAM
   make update
-  make LOG_LEVEL="TRACE" NIMFLAGS="-d:insecure -d:testnet_servers_image --parallelBuild:1" beacon_node
+  make LOG_LEVEL="TRACE" NIMFLAGS="-d:insecure -d:testnet_servers_image --parallelBuild:1" beacon_node validator_client
 fi
 
 #######

--- a/docs/the_nimbus_book/src/beacon_node.md
+++ b/docs/the_nimbus_book/src/beacon_node.md
@@ -120,6 +120,14 @@ The following options are available:
      --rpc                     Enable the JSON-RPC server.
      --rpc-port                HTTP port for the JSON-RPC service.
      --rpc-address             Listening address of the RPC server.
+     --push-mode               Enable the push model (the beacon node tells the validator client what to do and
+                               when) - on by default.
+     --rpc-push-port           HTTP port of the client to connect to for RPC - used for remote signing in a
+                               push model (the beacon node tells the validator client what to do and when).
+     --rpc-push-address        Address of the validator client to connect to for RPC - used for remote signing
+                               in a push model (the beacon node tells the validator client what to do and
+                               when).
+
      --dump                    Write SSZ dumps of blocks, attestations and states to data dir.
 
 Available sub-commands:

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -160,7 +160,7 @@ else
 fi
 
 NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh ${NETWORK})
-$MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="-d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" beacon_node deposit_contract
+$MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="-d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" beacon_node validator_client deposit_contract
 
 PIDS=""
 WEB3_ARG=""

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -307,6 +307,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --log-level="${LOG_LEVEL}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE )) \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
+    --rpc-push-port=$(( BASE_PORT + NUM_NODE + 100 )) \
     --data-dir="${NODE_DATA_DIR}" \
     ${BOOTSTRAP_ARG} \
     ${STATE_SNAPSHOT_ARG} \

--- a/scripts/reset_testnet.sh
+++ b/scripts/reset_testnet.sh
@@ -66,7 +66,7 @@ if [ "$ETH1_PRIVATE_KEY" != "" ]; then
 fi
 
 echo "Building a local beacon_node instance for 'deposits create' and 'createTestnet'"
-make -j2 NIMFLAGS="-d:insecure -d:testnet_servers_image ${NETWORK_NIM_FLAGS}" beacon_node process_dashboard
+make -j2 NIMFLAGS="-d:insecure -d:testnet_servers_image ${NETWORK_NIM_FLAGS}" beacon_node validator_client process_dashboard
 
 echo "Generating Grafana dashboards for remote testnet servers"
 for testnet in 0 1; do

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -96,6 +96,8 @@ $BEACON_NODE_BIN \
   --rpc \
   --rpc-address="127.0.0.1" \
   --rpc-port="$(( $BASE_RPC_PORT + $NODE_ID ))" \
+  --rpc-push-address="127.0.0.1" \
+  --rpc-push-port="$(( $BASE_RPC_PORT + $NODE_ID + 100 ))" \
   --metrics \
   --metrics-address="127.0.0.1" \
   --metrics-port="$(( $BASE_METRICS_PORT + $NODE_ID ))" \


### PR DESCRIPTION
The validator_client binary now has a `pushMode` subcommand and by default all validators of the beacon node get loaded in an external processes which the BN starts itself and then dictates through RPC calls what to sign and when.

This probably addresses a big chunk from #545

Jacek had suggested that only `blsSign` be somehow used by an external process and that each validator could use a separate process: https://discord.com/channels/613988663034118151/614014714590134292/732970154626908270
The current approach uses only 1 VC process per BN for all it's keys and sends more than a simple `Eth2Digest` to be signed (see `installRpcHandlers` in `validator_client.nim`) - this potentially increases the attack surface of the RPC calls but I'm not sure if it's really a compromise in it's current form - this way the code in `signatures.nim` stays as close as possible to the spec. Not sure if the data should be sanitized on the VC side somehow.

My only concern with this approach is the way I terminate the VC process from within the BN if there is a crash - not sure if all child processes will be terminated properly - currently it works fine if the BN asserts or is `Ctrl+C`-ed, but I don't know if all possible cases are covered.