### PR TITLE
Bump nim-blscurve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 
 # https://docs.travis-ci.com/user/caching/
 cache:
-  ccache: false
+  ccache: true
   directories:
     - vendor/nimbus-build-system/vendor/Nim/bin
     - jsonTestsCache

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: bionic
 
 # https://docs.travis-ci.com/user/caching/
 cache:
-  ccache: true
+  ccache: false
   directories:
     - vendor/nimbus-build-system/vendor/Nim/bin
     - jsonTestsCache
@@ -53,4 +53,3 @@ script:
   - make -j${NPROC} NIMFLAGS="--parallelBuild:2" LOG_LEVEL=TRACE
   - make -j${NPROC} NIMFLAGS="--parallelBuild:2 -d:testnet_servers_image" LOG_LEVEL=TRACE beacon_node
   - make -j${NPROC} NIMFLAGS="--parallelBuild:2" DISABLE_TEST_FIXTURES_SCRIPT=1 test
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,14 @@ def runStages() {
 						./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
 						"""
 					}
+					stage("testnet finalization - Miracl/Milagro fallback") {
+						// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
+						sh """#!/bin/bash
+						set -e
+						NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+						NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+						"""
+					}
 				}
 			)
 		}
@@ -92,4 +100,3 @@ parallel(
 		}
 	}
 )
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,14 +51,14 @@ def runStages() {
 						./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
 						"""
 					}
-					stage("testnet finalization - Miracl/Milagro fallback") {
-						// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
-						sh """#!/bin/bash
-						set -e
-						NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
-						NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
-						"""
-					}
+					// stage("testnet finalization - Miracl/Milagro fallback") {
+					// 	// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
+					// 	sh """#!/bin/bash
+					// 	set -e
+					// 	NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+					// 	NIMFLAGS="-d:BLS_FORCE_BACKEND=miracl" ./scripts/launch_local_testnet.sh --testnet 1 --nodes 4 --log-level INFO --disable-htop --data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) -- --verify-finalization --stop-at-epoch=5
+					// 	"""
+					// }
 				}
 			)
 		}

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -66,6 +66,14 @@ task test, "Run all tests":
   buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", "-d:const_preset=mainnet"
   buildAndRunBinary "all_tests", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
 
+  # Check Miracl/Milagro fallback on select tests
+  buildAndRunBinary "test_interop", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "test_attestation_pool", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "test_block_pool", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
   buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", "-d:chronicles_log_level=TRACE"
 
@@ -76,4 +84,6 @@ task test, "Run all tests":
 
   # State and block sims; getting to 4th epoch triggers consensus checks
   buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
+  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -85,6 +85,6 @@ task test, "Run all tests":
 
   # State and block sims; getting to 4th epoch triggers consensus checks
   buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
+  # buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
-  buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"
+  # buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -59,31 +59,32 @@ task test, "Run all tests":
   # price we pay for that.
 
   # Just the part of minimal config which explicitly differs from mainnet
-  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", "-d:const_preset=minimal"
+  buildAndRunBinary "test_fixture_const_sanity_check", "tests/official/", """-d:const_preset=minimal -d:chronicles_sinks="json[file]""""
 
   # Mainnet config
-  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", "-d:const_preset=mainnet"
-  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", "-d:const_preset=mainnet"
-  buildAndRunBinary "all_tests", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
+  buildAndRunBinary "proto_array", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "fork_choice", "beacon_chain/fork_choice/", """-d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_tests", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
 
   # Check Miracl/Milagro fallback on select tests
-  buildAndRunBinary "test_interop", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
-  buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
-  buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
-  buildAndRunBinary "test_attestation_pool", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
-  buildAndRunBinary "test_block_pool", "tests/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl"
+  buildAndRunBinary "test_interop", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_process_attestation", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_process_deposits", "tests/spec_block_processing/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_attestation_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
+  buildAndRunBinary "test_block_pool", "tests/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_sinks="json[file]""""
 
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
-  buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", "-d:chronicles_log_level=TRACE"
+  buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", """-d:chronicles_log_level=TRACE -d:chronicles_sinks="json[file]""""
 
   # Consensus object SSZ tests
-  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
+  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
 
-  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
+  # 0.12.1
+  buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
 
   # State and block sims; getting to 4th epoch triggers consensus checks
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128 -d:chronicles_log_level=INFO"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128 -d:chronicles_log_level=INFO"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -84,7 +84,7 @@ task test, "Run all tests":
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
 
   # State and block sims; getting to 4th epoch triggers consensus checks
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128 -d:chronicles_log_level=INFO"
-  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128 -d:chronicles_log_level=INFO"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
+  buildAndRunBinary "state_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl -d:chronicles_log_level=INFO", "--validators=3000 --slots=128"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet", "--validators=3000 --slots=128"
   buildAndRunBinary "block_sim", "research/", "-d:const_preset=mainnet -d:BLS_FORCE_BACKEND=miracl", "--validators=3000 --slots=128"

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -283,6 +283,9 @@ proc getAttestationsForBlock*(pool: AttestationPool,
         signature: a.validations[0].aggregate_signature
       )
 
+      agg {.noInit.}: AggregateSignature
+    agg.init(a.validations[0].aggregate_signature)
+
     # TODO what's going on here is that when producing a block, we need to
     #      include only such attestations that will not cause block validation
     #      to fail. How this interacts with voting and the acceptance of
@@ -308,8 +311,9 @@ proc getAttestationsForBlock*(pool: AttestationPool,
       #      one new attestation in there
       if not attestation.aggregation_bits.overlaps(v.aggregation_bits):
         attestation.aggregation_bits.combine(v.aggregation_bits)
-        attestation.signature.aggregate(v.aggregate_signature)
+        agg.aggregate(v.aggregate_signature)
 
+    attestation.signature = agg.finish()
     result.add(attestation)
 
     if result.lenu64 >= MAX_ATTESTATIONS:

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -232,9 +232,7 @@ func `$`*(x: BlsValue): string =
 
 func toRaw*(x: ValidatorPrivKey): array[32, byte] =
   # TODO: distinct type - see https://github.com/status-im/nim-blscurve/pull/67
-  when BLS_BACKEND == "blst" or (
-    BLS_BACKEND == "auto" and (defined(arm64) or defined(amd64))
-  ):
+  when BLS_BACKEND == BLST:
     result = SecretKey(x).exportRaw()
   else:
     # Miracl exports to 384-bit arrays, but Curve order is 256-bit

--- a/config.nims
+++ b/config.nims
@@ -26,7 +26,7 @@ if defined(windows):
 if defined(disableMarchNative):
   switch("passC", "-msse3")
 else:
-  # switch("passC", "-march=native")
+  switch("passC", "-march=native")
   if defined(windows):
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
     # ("-fno-asynchronous-unwind-tables" breaks Nim's exception raising, sometimes)
@@ -34,7 +34,6 @@ else:
 
 --threads:on
 --opt:speed
-switch("passC", "-fno-tree-vectorize")
 --excessiveStackTrace:on
 # enable metric collection
 --define:metrics
@@ -53,7 +52,7 @@ const useLibStackTrace = not defined(macosx) and
                          not defined(windows) and
                          not defined(disable_libbacktrace)
 
-when false: # useLibStackTrace:
+when useLibStackTrace:
   --define:nimStackTraceOverride
   switch("import", "libbacktrace")
 else:

--- a/config.nims
+++ b/config.nims
@@ -33,8 +33,8 @@ else:
     switch("passC", "-mno-avx512vl")
 
 --threads:on
-# --opt:speed
-switch("passC", "-O2 -fno-strict-aliasing -fno-ident")
+--opt:speed
+switch("passC", "-fno-tree-vectorize")
 --excessiveStackTrace:on
 # enable metric collection
 --define:metrics

--- a/config.nims
+++ b/config.nims
@@ -26,14 +26,15 @@ if defined(windows):
 if defined(disableMarchNative):
   switch("passC", "-msse3")
 else:
-  switch("passC", "-march=native")
+  # switch("passC", "-march=native")
   if defined(windows):
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
     # ("-fno-asynchronous-unwind-tables" breaks Nim's exception raising, sometimes)
     switch("passC", "-mno-avx512vl")
 
 --threads:on
---opt:speed
+# --opt:speed
+switch("passC", "-O2 -fno-strict-aliasing -fno-ident")
 --excessiveStackTrace:on
 # enable metric collection
 --define:metrics
@@ -52,7 +53,7 @@ const useLibStackTrace = not defined(macosx) and
                          not defined(windows) and
                          not defined(disable_libbacktrace)
 
-when useLibStackTrace:
+when false: # useLibStackTrace:
   --define:nimStackTraceOverride
   switch("import", "libbacktrace")
 else:
@@ -79,4 +80,3 @@ switch("warning", "LockLevel:off")
 
 # Useful for Chronos metrics.
 --define:chronosFutureTracking
-

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -99,19 +99,3 @@ proc printTimers*[Timers: enum](
   echo "Validators: ", state.validators.len, ", epoch length: ", SLOTS_PER_EPOCH
   echo "Validators per attestation (mean): ", attesters.mean
   printTimers(validate, timers)
-
-proc combine*(tgt: var Attestation, src: Attestation, flags: UpdateFlags) =
-  ## Combine the signature and participation bitfield, with the assumption that
-  ## the same data is being signed - if the signatures overlap, they are not
-  ## combined.
-
-  doAssert tgt.data == src.data
-
-  # In a BLS aggregate signature, one needs to count how many times a
-  # particular public key has been added - since we use a single bit per key, we
-  # can only it once, thus we can never combine signatures that overlap already!
-  if not tgt.aggregation_bits.overlaps(src.aggregation_bits):
-    tgt.aggregation_bits.combine(src.aggregation_bits)
-
-    if skipBlsValidation notin flags:
-      tgt.signature.aggregate(src.signature)

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -160,7 +160,7 @@ else
 fi
 
 NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh ${NETWORK})
-$MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="-d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" beacon_node deposit_contract
+$MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" beacon_node deposit_contract
 
 PIDS=""
 WEB3_ARG=""
@@ -347,4 +347,3 @@ else
     exit 1
   fi
 fi
-

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -7,29 +7,10 @@
 
 import
   macros,
-  nimcrypto/utils,
   ../../beacon_chain/spec/[datatypes, crypto, digest], ../../beacon_chain/ssz/types
   # digest is necessary for them to be printed as hex
 
-# Define comparison of object variants for BLSValue
-# https://github.com/nim-lang/Nim/issues/6676
-# (fully generic available - see also https://github.com/status-im/nim-beacon-chain/commit/993789bad684721bd7c74ea14b35c2d24dbb6e51)
-# ----------------------------------------------------------------
-
-proc `==`*(a, b: BlsValue): bool =
-  ## We sometimes need to compare real BlsValue
-  ## from parsed opaque blobs that are not really on the BLS curve
-  ## and full of zeros
-  if a.kind == Real:
-    if b.kind == Real:
-      a.blsvalue == b.blsValue
-    else:
-      $a.blsvalue == toHex(b.blob, true)
-  else:
-    if b.kind == Real:
-      toHex(a.blob, true) == $b.blsValue
-    else:
-      a.blob == b.blob
+export crypto.`==`
 
 # ---------------------------------------------------------------------
 
@@ -48,9 +29,10 @@ proc compareStmt(xSubField, ySubField: NimNode, stmts: var NimNode) =
   let xStr = $xSubField.toStrLit
   let yStr = $ySubField.toStrLit
 
+  let isEqual = bindSym("==") # Bind all expose equality, in particular for BlsValue
   stmts.add quote do:
     doAssert(
-      `xSubField` == `ySubField`,
+      `isEqual`(`xSubField`, `ySubField`),
       "\nDiff: " & `xStr` & " = " & $`xSubField` & "\n" &
       "and   " & `yStr` & " = " & $`ySubField` & "\n"
     )
@@ -59,16 +41,16 @@ proc compareContainerStmt(xSubField, ySubField: NimNode, stmts: var NimNode) =
   let xStr = $xSubField.toStrLit
   let yStr = $ySubField.toStrLit
 
-
+  let isEqual = bindSym("==") # Bind all expose equality, in particular for BlsValue
   stmts.add quote do:
     doAssert(
-      `xSubField`.len == `ySubField`.len,
+      `isEqual`(`xSubField`.len, `ySubField`.len),
         "\nDiff: " & `xStr` & ".len = " & $`xSubField`.len & "\n" &
         "and   " & `yStr` & ".len = " & $`ySubField`.len & "\n"
     )
     for idx in `xSubField`.low .. `xSubField`.high:
       doAssert(
-        `xSubField`[idx] == `ySubField`[idx],
+        `isEqual`(`xSubField`[idx], `ySubField`[idx]),
         "\nDiff: " & `xStr` & "[" & $idx & "] = " & $`xSubField`[idx] & "\n" &
         "and   " & `yStr` & "[" & $idx & "] = " & $`ySubField`[idx] & "\n"
       )

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -63,6 +63,7 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
     cache
   )
 
+  var agg {.noInit.}: AggregateSignature
   var first_iter = true # Can't do while loop on hashset
   for validator_index in participants:
     let sig = get_attestation_signature(
@@ -70,10 +71,14 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
       MockPrivKeys[validator_index]
     )
     if first_iter:
-      attestation.signature = sig
+      agg.init(sig)
       first_iter = false
     else:
-      aggregate(attestation.signature, sig)
+      agg.aggregate(sig)
+
+  if first_iter != true:
+    attestation.signature = agg.finish()
+    # Otherwise no participants so zero sig
 
 proc mockAttestationImpl(
        state: BeaconState,

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -11,6 +11,8 @@
 import
   # Standard library
   sets,
+  # Status
+  chronicles,
   # Specs
   ../../beacon_chain/spec/[datatypes, beaconstate, helpers, validator, crypto,
                            signatures, state_transition, presets],

--- a/tests/mocking/mock_validator_keys.nim
+++ b/tests/mocking/mock_validator_keys.nim
@@ -10,7 +10,7 @@
 
 import
   bearssl, eth/keys,
-  blscurve/bls_signature_scheme,
+  blscurve,
   ../../beacon_chain/spec/[datatypes, crypto, presets]
 
 proc newKeyPair(rng: var BrHmacDrbgContext): BlsResult[tuple[pub: ValidatorPubKey, priv: ValidatorPrivKey]] =
@@ -25,7 +25,7 @@ proc newKeyPair(rng: var BrHmacDrbgContext): BlsResult[tuple[pub: ValidatorPubKe
 
   var
     sk: SecretKey
-    pk: bls_signature_scheme.PublicKey
+    pk: blscurve.PublicKey
   if keyGen(ikm, pk, sk):
     ok((ValidatorPubKey(kind: Real, blsValue: pk), ValidatorPrivKey(sk)))
   else:

--- a/tests/official/test_fixture_operations_block_header.nim
+++ b/tests/official/test_fixture_operations_block_header.nim
@@ -13,7 +13,7 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/[datatypes, state_transition_block],
+  ../../beacon_chain/spec/[datatypes, state_transition_block, crypto],
   ../../beacon_chain/ssz,
   # Test utilities
   ../testutil,

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -124,7 +124,7 @@ suiteReport "Interop":
 
       check:
         # getBytes is bigendian and returns full 48 bytes of key..
-        Uint256.fromBytesBE(key.toRaw()[48-32..<48]) == v
+        Uint256.fromBytesBE(key.toRaw()) == v
 
   timedTest "Interop signatures":
     for dep in depositsConfig:

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -21,7 +21,7 @@ func isEqual*(a, b: ValidatorPrivKey): bool =
   let pb = cast[ptr UncheckedArray[byte]](b.unsafeAddr)
   result = true
   for i in 0 ..< sizeof(a):
-    result = result and pa[i] == pdec[i]
+    result = result and pa[i] == pb[i]
 
 const
   scryptVector = """{

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -15,8 +15,13 @@ import
 
 from strutils import replace
 
-template `==`*(a, b: ValidatorPrivKey): bool =
-  blscurve.SecretKey(a) == blscurve.SecretKey(b)
+func isEqual*(a, b: ValidatorPrivKey): bool =
+  # `==` on secret keys is not allowed
+  let pa = cast[ptr UncheckedArray[byte]](a.unsafeAddr)
+  let pb = cast[ptr UncheckedArray[byte]](b.unsafeAddr)
+  result = true
+  for i in 0 ..< sizeof(a):
+    result = result and pa[i] == pdec[i]
 
 const
   scryptVector = """{
@@ -103,7 +108,7 @@ suiteReport "Keystore":
       decrypt = decryptKeystore(keystore, KeystorePass password)
 
     check decrypt.isOk
-    check secret == decrypt.get()
+    check secret.isEqual(decrypt.get())
 
   timedTest "Scrypt decryption":
     let
@@ -111,7 +116,7 @@ suiteReport "Keystore":
       decrypt = decryptKeystore(keystore, KeystorePass password)
 
     check decrypt.isOk
-    check secret == decrypt.get()
+    check secret.isEqual(decrypt.get())
 
   timedTest "Pbkdf2 encryption":
     let keystore = createKeystore(kdfPbkdf2, rng[], secret,

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -8,9 +8,9 @@
 {.used.}
 
 import
-  unittest,
+  unittest, chronicles,
   ./testutil, ./testblockutil,
-  ../beacon_chain/spec/[beaconstate, datatypes, digest,
+  ../beacon_chain/spec/[beaconstate, datatypes, digest, crypto,
                         validator, state_transition, presets],
   ../beacon_chain/ssz
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -233,14 +233,18 @@ proc makeFullAttestations*(
         state.fork, state.genesis_validators_root, data,
         hackPrivKey(state.validators[committee[0]]))
     )
+    var agg {.noInit.}: AggregateSignature
+    agg.init(attestation.signature)
+
     # Aggregate the remainder
     attestation.aggregation_bits.setBit 0
     for j in 1 ..< committee.len():
       attestation.aggregation_bits.setBit j
       if skipBLSValidation notin flags:
-        attestation.signature.aggregate(get_attestation_signature(
+        agg.aggregate(get_attestation_signature(
           state.fork, state.genesis_validators_root, data,
           hackPrivKey(state.validators[committee[j]])
         ))
 
+    attestation.signature = agg.finish()
     result.add attestation


### PR DESCRIPTION
This bumps BLSCurve with the following PRs:

- https://github.com/status-im/nim-blscurve/pull/65:
  - Update EIP2333 with latest keygen changes (not used in NBC but the keystore already uses the new version)
  - Drop legacy code for old specs
- https://github.com/status-im/nim-blscurve/pull/66
  - Update Milagro to latest Miracl
- https://github.com/status-im/nim-blscurve/pull/68
  - Add BLST as an alternative backend, which can be switched with `-d:BLS_FORCE_BACKEND=miracl`/`-d:BLS_FORCE_BACKEND=blst`/`-d:BLS_FORCE_BACKEND=auto`, auto is default and will use BLST on supported platforms (arm64 and x86_64) with Milagro as fallback.

Benefits:

- Up-to-date code for audit
- Speed improvement.

Note that unlike the Rust and Go code for aggregate verification, multithreading was not added. See multithreading usage:
- https://github.com/supranational/blst/blob/d661d166/bindings/rust/src/lib.rs#L547-L638
- https://github.com/supranational/blst/blob/d661d166/bindings/go/blst.go#L385-L484

Yuriy's threadpool would be a simple, short and maintainable solution if we wanted to go that route https://github.com/yglukhov/threadpools