### PR TITLE
add --enable-logtrace argument to launch_local_testnet

### DIFF
--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -150,7 +150,7 @@ func get_domain*(
   ## of a message.
   get_domain(state.fork, domain_type, epoch, state.genesis_validators_root)
 
-# https://github.com/ethereum/eth2.0-specs/blob/v0.11.3/specs/phase0/beacon-chain.md#compute_signing_root
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#compute_signing_root
 func compute_signing_root*(ssz_object: auto, domain: Domain): Eth2Digest =
   # Return the signing root of an object by calculating the root of the
   # object-domain tree.

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -273,7 +273,7 @@ dump_logs() {
 
 dump_logtrace() {
   if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
-    find local_testnet_data -maxdepth 1 -type f -name 'log*.txt' | sed -e's/local_testnet_data\//--nodes=/' | sort | xargs ./build/logtrace asr --log-dir=local_testnet_data --nodes=log0.txt --nodes=log1.txt --nodes=log2.txt --nodes=log3.txt || true
+    find local_testnet_data -maxdepth 1 -type f -name 'log*.txt' | sed -e's/local_testnet_data\//--nodes=/' | sort | xargs ./build/logtrace asr --log-dir=local_testnet_data || true
   fi
 }
 

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -273,7 +273,7 @@ dump_logs() {
 
 dump_logtrace() {
   if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
-    ./build/logtrace asr --log-dir=local_testnet_data --nodes=log0.txt --nodes=log1.txt --nodes=log2.txt --nodes=log3.txt || true
+    find local_testnet_data -maxdepth 1 -type f -name 'log*.txt' | sed -e's/local_testnet_data\//--nodes=/' | sort | xargs ./build/logtrace asr --log-dir=local_testnet_data --nodes=log0.txt --nodes=log1.txt --nodes=log2.txt --nodes=log3.txt || true
   fi
 }
 

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -32,7 +32,7 @@ if [ ${PIPESTATUS[0]} != 4 ]; then
 fi
 
 OPTS="hgt:n:d:"
-LONGOPTS="help,testnet:,nodes:,data-dir:,disable-htop,log-level:,base-port:,base-metrics-port:,with-ganache,reuse-existing-data-dir"
+LONGOPTS="help,testnet:,nodes:,data-dir:,disable-htop,enable-logtrace,log-level:,base-port:,base-metrics-port:,with-ganache,reuse-existing-data-dir"
 
 # default values
 TESTNET="1"
@@ -44,6 +44,7 @@ LOG_LEVEL="DEBUG"
 BASE_PORT="9000"
 BASE_METRICS_PORT="8008"
 REUSE_EXISTING_DATA_DIR="0"
+ENABLE_LOGTRACE="0"
 
 print_help() {
   cat <<EOF
@@ -60,6 +61,7 @@ CI run: $(basename $0) --disable-htop -- --verify-finalization --stop-at-epoch=5
   --base-port                 bootstrap node's Eth2 traffic port (default: ${BASE_PORT})
   --base-metrics-port         bootstrap node's metrics server port (default: ${BASE_METRICS_PORT})
   --disable-htop              don't use "htop" to see the beacon_node processes
+  --enable-logtrace           display logtrace asr analysis
   --log-level                 set the log level (default: ${LOG_LEVEL})
   --reuse-existing-data-dir   instead of deleting and recreating the data dir, keep it and reuse everything we can from it
 EOF
@@ -115,6 +117,10 @@ while true; do
       REUSE_EXISTING_DATA_DIR="1"
       shift
       ;;
+    --enable-logtrace)
+      ENABLE_LOGTRACE="1"
+      shift
+      ;;
     --)
       shift
       break
@@ -161,6 +167,9 @@ fi
 
 NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh ${NETWORK})
 $MAKE -j2 LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" beacon_node deposit_contract
+if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
+  $MAKE LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" logtrace
+fi
 
 PIDS=""
 WEB3_ARG=""
@@ -262,6 +271,12 @@ dump_logs() {
   done
 }
 
+dump_logtrace() {
+  if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
+    ./build/logtrace asr --log-dir=local_testnet_data --nodes=log0.txt --nodes=log1.txt --nodes=log2.txt --nodes=log3.txt || true
+  fi
+}
+
 NODES_WITH_VALIDATORS=${NODES_WITH_VALIDATORS:-4}
 BOOTSTRAP_NODE=0
 SYSTEM_VALIDATORS=$(( TOTAL_VALIDATORS - USER_VALIDATORS ))
@@ -330,6 +345,7 @@ BG_JOBS="$(jobs | wc -l | tr -d ' ')"
 if [[ "$BG_JOBS" != "$NUM_NODES" ]]; then
   echo "$((NUM_NODES - BG_JOBS)) beacon_node instance(s) exited early. Aborting."
   dump_logs
+  dump_logtrace
   exit 1
 fi
 
@@ -344,6 +360,9 @@ else
   if [[ "$FAILED" != "0" ]]; then
     echo "${FAILED} child processes had non-zero exit codes (or exited early)."
     dump_logs
+    dump_logtrace
     exit 1
   fi
 fi
+
+dump_logtrace


### PR DESCRIPTION
This is useful in CI. Example output:
```
 N=0; while ./scripts/launch_local_testnet.sh --testnet 0 --nodes 4 --disable-htop --enable-logtrace -- --verify-finalization --stop-at-epoch=6; do N=$((N+1)); echo "That was run #${N}"; sleep 67; done
Building: build/beacon_node
Building: build/deposit_contract
nim-beacon-chain/beacon_chain/nimbus_binary_common.nim(12, 29) Warning: imported and not used: 'os' [UnusedImport]
Building: build/logtrace
INF 2020-08-13 15:02:56.794+02:00 Generating deposits                        tid=441893 file=keystore_management.nim:143 totalValidators=128 validatorsDir=local_testnet_data/validators secretsDir=local_testnet_data/secrets
INF 2020-08-13 15:03:32.802+02:00 Deposit data written                       tid=441893 file=deposit_contract.nim:195 filename=local_testnet_data/deposits.json
Wrote local_testnet_data/network_dir/genesis.ssz
Wrote local_testnet_data/network_dir/bootstrap_nodes.txt
Wrote local_testnet_data/network.json:
{
  "runtimePreset": {
    "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": 128,
    "MIN_GENESIS_TIME": 0,
    "GENESIS_DELAY": 10,
    "GENESIS_FORK_VERSION": "0x00000000"
  },
  "depositContractAddress": "0x0000000000000000000000000000000000000000",
  "depositContractDeployedAt": "0x0000000000000000000000000000000000000000000000000000000000000000"
}
Beacon-Chain LogTrace Tool, Version 0.0.4 [linux: amd64]
Copyright(C) 2020 Status Research & Development GmbH

INF 2020-08-13 15:09:09.017+02:00 Check for attestations send/receive messages tid=443581 file=logtrace.nim:494
INF 2020-08-13 15:09:09.017+02:00 Processing node                            tid=443581 file=logtrace.nim:506 node=log0.txt
INF 2020-08-13 15:09:09.017+02:00 Processing node's logfile                  tid=443581 file=logtrace.nim:509 node=log0.txt logfile=nim-beacon-chain/local_testnet_data/log0.txt
INF 2020-08-13 15:09:09.094+02:00 Processing node                            tid=443581 file=logtrace.nim:506 node=log1.txt
INF 2020-08-13 15:09:09.094+02:00 Processing node's logfile                  tid=443581 file=logtrace.nim:509 node=log1.txt logfile=nim-beacon-chain/local_testnet_data/log1.txt
INF 2020-08-13 15:09:09.146+02:00 Processing node                            tid=443581 file=logtrace.nim:506 node=log2.txt
INF 2020-08-13 15:09:09.146+02:00 Processing node's logfile                  tid=443581 file=logtrace.nim:509 node=log2.txt logfile=nim-beacon-chain/local_testnet_data/log2.txt
INF 2020-08-13 15:09:09.198+02:00 Processing node                            tid=443581 file=logtrace.nim:506 node=log3.txt
INF 2020-08-13 15:09:09.199+02:00 Processing node's logfile                  tid=443581 file=logtrace.nim:509 node=log3.txt logfile=nim-beacon-chain/local_testnet_data/log3.txt
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=85dd5456 receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=a83f3a28 receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=b6ce462a receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=adf03c20 receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=a77e77fd receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.252+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log0.txt signature=a44dc988 receivers="['log1.txt', 'log2.txt', 'log3.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.252+02:00 Statistics for sender node                 tid=443581 file=logtrace.nim:538 sender=log0.txt sucessfull_broadcasts=184 failed_broadcasts=6 total_broadcasts=190
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=a074a0c0 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=95d6b6ec receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=af93c4e3 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=accdfab6 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=aba3b218 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=abd07700 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=81a21d16 receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log1.txt signature=84eb5d8f receivers="['log2.txt', 'log3.txt', 'log0.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Statistics for sender node                 tid=443581 file=logtrace.nim:538 sender=log1.txt sucessfull_broadcasts=183 failed_broadcasts=8 total_broadcasts=191
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=866aba29 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=b650bfe9 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=960fa2ef receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=b0a59b59 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=b71911ec receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=abd34bc8 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=b3845121 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log2.txt signature=95970f26 receivers="['log3.txt', 'log0.txt', 'log1.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Statistics for sender node                 tid=443581 file=logtrace.nim:538 sender=log2.txt sucessfull_broadcasts=184 failed_broadcasts=8 total_broadcasts=192
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=8baa2868 receivers="['log0.txt', 'log1.txt', 'log2.txt']" send_stamp=2020-08-13T13:04:07Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=b9c475bd receivers="['log0.txt', 'log1.txt', 'log2.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=b1ee5e81 receivers="['log0.txt', 'log1.txt', 'log2.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=aa3ddae3 receivers="['log0.txt', 'log1.txt', 'log2.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=950c927d receivers="['log0.txt', 'log1.txt', 'log2.txt']" send_stamp=2020-08-13T13:04:10Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=a4144cd0 receivers=['log2.txt'] send_stamp=2020-08-13T13:04:52Z
INF 2020-08-13 15:09:09.253+02:00 Attestation was not received               tid=443581 file=logtrace.nim:534 sender=log3.txt signature=a8d4c773 receivers=['log2.txt'] send_stamp=2020-08-13T13:04:52Z
INF 2020-08-13 15:09:09.253+02:00 Statistics for sender node                 tid=443581 file=logtrace.nim:538 sender=log3.txt sucessfull_broadcasts=184 failed_broadcasts=7 total_broadcasts=191
That was run #1
```