### PR TITLE
remove quadratic deposit Merkle tree initialization

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -237,7 +237,7 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 OK: 8/8 Fail: 0/8 Skip: 0/8
 ## chain DAG finalization tests [Preset: mainnet]
 ```diff
-+ prune heads on finalization [Preset: mainnet]                                              OK
++ init with gaps [Preset: mainnet]                                                           OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## hash

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -72,7 +72,6 @@ task test, "Run all tests":
   # Consensus object SSZ tests
   buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
 
-  # 0.12.1
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", "-d:chronicles_log_level=TRACE -d:const_preset=mainnet"
 
   # State and block sims; getting to 4th epoch triggers consensus checks

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -40,7 +40,7 @@ type Timers = enum
 
 # TODO confutils is an impenetrable black box. how can a help text be added here?
 cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 130, # One per shard is minimum
+       validators = SLOTS_PER_EPOCH * 200, # One per shard is minimum
        attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.73,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -34,7 +34,7 @@ proc writeJson*(fn, v: auto) =
   Json.saveFile(fn, v, pretty = true)
 
 cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 100, # One per shard is minimum
+       validators = SLOTS_PER_EPOCH * 200, # One per shard is minimum
        json_interval = SLOTS_PER_EPOCH,
        write_last_json = false,
        prefix: int = 0,


### PR DESCRIPTION
This enables quicker testing and benchmarking with larger numbers of validators on `state_sim` and `block_sim`.