### PR TITLE
refactor topic (un)subscribing/validating to collate each

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1264,13 +1264,6 @@ proc addValidator*[MsgType](node: Eth2Node,
 
   node.switch.addValidator(topic & "_snappy", execValidator)
 
-proc subscribe*[MsgType](node: Eth2Node,
-                         topic: string,
-                         msgHandler: proc(msg: MsgType) {.gcsafe.},
-                         msgValidator: proc(msg: MsgType): bool {.gcsafe.} ) {.async, gcsafe.} =
-  node.addValidator(topic, msgValidator)
-  await node.subscribe(topic, msgHandler)
-
 proc unsubscribe*(node: Eth2Node, topic: string): Future[void] =
   node.switch.unsubscribeAll(topic)
 

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -75,7 +75,7 @@ func compute_subnet_for_attestation*(
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/validator.md#broadcast-attestation
 func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
     string =
-  # This is for subscribing or broadcasting manually to a known index.
+  ## For subscribing, unsubscribing, or broadcasting manually to/from an index.
   doAssert subnetIndex < ATTESTATION_SUBNET_COUNT
 
   try:

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -75,7 +75,7 @@ func compute_subnet_for_attestation*(
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/validator.md#broadcast-attestation
 func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
     string =
-  ## For subscribing, unsubscribing, or broadcasting manually to/from a subnet.
+  ## For subscribing and unsubscribing to/from a subnet.
   doAssert subnetIndex < ATTESTATION_SUBNET_COUNT
 
   try:

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -75,7 +75,7 @@ func compute_subnet_for_attestation*(
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/validator.md#broadcast-attestation
 func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
     string =
-  ## For subscribing, unsubscribing, or broadcasting manually to/from an index.
+  ## For subscribing, unsubscribing, or broadcasting manually to/from a subnet.
   doAssert subnetIndex < ATTESTATION_SUBNET_COUNT
 
   try:

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -259,14 +259,13 @@ func get_finality_delay(state: BeaconState): uint64 =
 func is_in_inactivity_leak(state: BeaconState): bool =
   get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 
-func get_eligible_validator_indices(state: BeaconState): seq[ValidatorIndex] =
-  # TODO iterator/yield, also, probably iterates multiple times over epoch
-  # transitions
+iterator get_eligible_validator_indices(state: BeaconState): ValidatorIndex =
+  # TODO probably iterates multiple times over epoch transitions
   let previous_epoch = get_previous_epoch(state)
   for idx, v in state.validators:
     if is_active_validator(v, previous_epoch) or
         (v.slashed and previous_epoch + 1 < v.withdrawable_epoch):
-      result.add idx.ValidatorIndex
+      yield idx.ValidatorIndex
 
 func get_attestation_component_deltas(state: BeaconState,
                                       attestations: seq[PendingAttestation],


### PR DESCRIPTION
This begins to implement https://github.com/status-im/nim-beacon-chain/issues/1498

Validators can stay always present, and don't currently have a great way to be removed without remembering exactly the callbacks that were used to set them up, while subscribed topics can with this structure be readily separately enabled and disabled.