### PR TITLE
increase Azure timeout from 90 to 100 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: Windows
 
-    timeoutInMinutes: 90
+    timeoutInMinutes: 100
 
     pool:
       vmImage: windows-latest

--- a/beacon_chain/logtrace.nim
+++ b/beacon_chain/logtrace.nim
@@ -536,7 +536,7 @@ proc runAttSendReceive(logConf: LogTraceConf, nodes: seq[NodeDirectory]) =
              receivers = misses.toSimple(), send_stamp = item.timestamp
 
     info "Statistics for sender node", sender = srnodes[i].directory.name,
-         sucessfull_broadcasts = success, failed_broadcasts = failed,
+         successful_broadcasts = success, failed_broadcasts = failed,
          total_broadcasts = len(srnodes[i].sends)
 
 proc runLatencyCheck(logConf: LogTraceConf, logFiles: seq[string],


### PR DESCRIPTION
64-bit Azure especially has been slow, slower than 32-bit Azure, and for a while there are also repeated tests with different BLS libraries.

https://github.com/status-im/nim-beacon-chain/pull/1515 and https://github.com/status-im/nim-beacon-chain/pull/1514 are both new and each get run twice, for example, as a result of this BLS duplication, with the finality tests taking nontrivial mounts of time due to applying dozens of blocks each, five time over.

It's not ideal, but for the moment it's probably better to increase Azure timeouts than have basically spurious CI failures.

A survey of recent 64-bit Azure times:

- 1h 25m: https://github.com/status-im/nim-beacon-chain/runs/980660187
- 57m: https://github.com/status-im/nim-beacon-chain/runs/981605503
- 1h 23m: https://github.com/status-im/nim-beacon-chain/runs/984275972
- 1h 3m: https://github.com/status-im/nim-beacon-chain/runs/985763489
- 1h 24m: https://github.com/status-im/nim-beacon-chain/runs/986310205
- 1h 24m: https://github.com/status-im/nim-beacon-chain/runs/988685513
- 1h: https://github.com/status-im/nim-beacon-chain/runs/990081975
- 1h 28m: https://github.com/status-im/nim-beacon-chain/runs/991672982
- 1h 7m: https://github.com/status-im/nim-beacon-chain/runs/992375891
- 55m: https://github.com/status-im/nim-beacon-chain/runs/992502532
- 1h 30m (timed out): https://github.com/status-im/nim-beacon-chain/runs/993474863
- 1h 8m: https://github.com/status-im/nim-beacon-chain/runs/974459199
- 1h 13m: https://github.com/status-im/nim-beacon-chain/runs/972840255
- 1h 3m: https://github.com/status-im/nim-beacon-chain/runs/971804770
- 1h 17m: https://github.com/status-im/nim-beacon-chain/runs/970144716
- 1h 7m: https://github.com/status-im/nim-beacon-chain/runs/968162191
- 56m: https://github.com/status-im/nim-beacon-chain/runs/967741201
- 53m: https://github.com/status-im/nim-beacon-chain/runs/967171193
- 1h 15m: https://github.com/status-im/nim-beacon-chain/runs/966973453
- 1h 13m: https://github.com/status-im/nim-beacon-chain/runs/966809181
- 1h 22m: https://github.com/status-im/nim-beacon-chain/runs/966331146
- 57m: https://github.com/status-im/nim-beacon-chain/runs/966205256
- 59m: https://github.com/status-im/nim-beacon-chain/runs/966191653