### PR TITLE
Jenkins: run benchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,45 +99,5 @@ parallel(
 			}
 		}
 	},
-	"benchmarks": {
-		node("metal") {
-			withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
-				try {
-					stage("Clone") {
-						/* source code checkout */
-						checkout scm
-						/* we need to update the submodules before caching kicks in */
-						sh "git submodule update --init --recursive"
-					}
-
-					cache(maxCacheSize: 250, caches: [
-						[$class: "ArbitraryFileCache", excludes: "", includes: "**/*", path: "${WORKSPACE}/vendor/nimbus-build-system/vendor/Nim/bin"],
-					]) {
-						stage("Build") {
-							sh """#!/bin/bash
-							set -e
-							make -j${env.NPROC} update # to allow a newer Nim version to be detected
-							"""
-						}
-					}
-
-					stage("Benchmark") {
-						sh """#!/bin/bash
-						set -e
-						git clone https://github.com/status-im/nimbus-benchmarking.git
-						./nimbus-benchmarking/run_nbc_benchmarks.sh
-						"""
-						benchmark(altInputSchema: "", altInputSchemaLocation: "", inputLocation: "results/*/result.json", schemaSelection: "defaultSchema", truncateStrings: true)
-					}
-				} catch(e) {
-					// we need to rethrow the exception here
-					throw e
-				} finally {
-					// clean the workspace
-					cleanWs(disableDeferredWipeout: true, deleteDirs: true)
-				}
-			}
-		}
-	}
 )
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,6 +127,7 @@ parallel(
 						git clone https://github.com/status-im/nimbus-benchmarking.git
 						./nimbus-benchmarking/run_nbc_benchmarks.sh
 						"""
+						benchmark(inputLocation: "results/*/result.json", schemaSelection: "defaultSchema")
 					}
 				} catch(e) {
 					// we need to rethrow the exception here

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ parallel(
 						git clone https://github.com/status-im/nimbus-benchmarking.git
 						./nimbus-benchmarking/run_nbc_benchmarks.sh
 						"""
-						benchmark(inputLocation: "results/*/result.json", schemaSelection: "defaultSchema")
+						benchmark(altInputSchema: "", altInputSchemaLocation: "", inputLocation: "results/*/result.json", schemaSelection: "defaultSchema", truncateStrings: true)
 					}
 				} catch(e) {
 					// we need to rethrow the exception here

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,10 +124,8 @@ parallel(
 					stage("Benchmark") {
 						sh """#!/bin/bash
 						set -e
-						cd ..
 						git clone https://github.com/status-im/nimbus-benchmarking.git
-						cd -
-						../nimbus-benchmarking/run_nbc_benchmarks.sh
+						./nimbus-benchmarking/run_nbc_benchmarks.sh
 						"""
 					}
 				} catch(e) {

--- a/Jenkinsfile.benchmarks
+++ b/Jenkinsfile.benchmarks
@@ -1,0 +1,46 @@
+// https://stackoverflow.com/questions/40760716/jenkins-abort-running-build-if-new-one-is-started
+def buildNumber = env.BUILD_NUMBER as int
+if (buildNumber > 1) {
+	milestone(buildNumber - 1)
+}
+milestone(buildNumber)
+
+node("metal") {
+	withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
+		try {
+			stage("Clone") {
+				/* source code checkout */
+				checkout scm
+				/* we need to update the submodules before caching kicks in */
+				sh "git submodule update --init --recursive"
+			}
+
+			cache(maxCacheSize: 250, caches: [
+				[$class: "ArbitraryFileCache", excludes: "", includes: "**/*", path: "${WORKSPACE}/vendor/nimbus-build-system/vendor/Nim/bin"],
+			]) {
+				stage("Build") {
+					sh """#!/bin/bash
+					set -e
+					make -j${env.NPROC} update # to allow a newer Nim version to be detected
+					"""
+				}
+			}
+
+			stage("Benchmark") {
+				sh """#!/bin/bash
+				set -e
+				git clone https://github.com/status-im/nimbus-benchmarking.git
+				./nimbus-benchmarking/run_nbc_benchmarks.sh
+				"""
+				benchmark(altInputSchema: "", altInputSchemaLocation: "", inputLocation: "results/*/result.json", schemaSelection: "defaultSchema", truncateStrings: true)
+			}
+		} catch(e) {
+			// we need to rethrow the exception here
+			throw e
+		} finally {
+			// clean the workspace
+			cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+		}
+	}
+}
+


### PR DESCRIPTION
@jakubgs, can you please install this Jenkins plugin: https://plugins.jenkins.io/benchmark/

and configure a post-build event similar to how they do here: https://github.com/jenkinsci/benchmark-plugin/blob/master/doc/HOW_TO_USE_THE_PLUGIN.md

(I hope this event kicks in before we delete the workspace.)

Our output files will be in "results/*/result.json" and we're using the default schema (the one with 3 levels).

I'm open to suggestions on how to make this run on older commits.