### PR TITLE
rework epoch cache referencing

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -54,10 +54,11 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 OK: 5/5 Fail: 0/5 Skip: 0/5
 ## BlockRef and helpers [Preset: mainnet]
 ```diff
++ epochAncestor sanity [Preset: mainnet]                                                     OK
 + get_ancestor sanity [Preset: mainnet]                                                      OK
 + isAncestorOf sanity [Preset: mainnet]                                                      OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## BlockSlot and helpers [Preset: mainnet]
 ```diff
 + atSlot sanity [Preset: mainnet]                                                            OK
@@ -247,4 +248,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 134/141 Fail: 0/141 Skip: 7/141
+OK: 135/142 Fail: 0/142 Skip: 7/142

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -351,9 +351,8 @@ proc storeBlock(
   {.gcsafe.}: # TODO: fork choice and quarantine should sync via messages instead of callbacks
     let blck = node.chainDag.addRawBlock(node.quarantine, signedBlock) do (
         blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-        state: HashedBeaconState):
+        epochRef: EpochRef, state: HashedBeaconState):
       # Callback add to fork choice if valid
-      let epochRef = getEpochInfo(blckRef, state.data)
       node.attestationPool.addForkChoice(
         epochRef, blckRef, signedBlock.message,
         node.beaconClock.now().slotOrZero())

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -157,12 +157,15 @@ type
 
     slot*: Slot # TODO could calculate this by walking to root, but..
 
-    epochsInfo*: seq[EpochRef] ##\
+    epochRefs*: seq[EpochRef] ##\
     ## Cached information about the epochs starting at this block.
     ## Could be multiple, since blocks could skip slots, but usually, not many
     ## Even if competing forks happen later during this epoch, potential empty
-    ## slots beforehand must all be from this fork. getEpochInfo() is the only
-    ## supported way of accesssing these.
+    ## slots beforehand must all be from this fork. find/getEpochRef() are the
+    ## only supported way of accesssing these.
+    ## In particular, epoch refs are only stored with the last block of the
+    ## parent epoch - this way, it's easy to find them from any block in the
+    ## epoch - including when there are forks that skip the epoch slot.
 
   BlockData* = object
     ## Body and graph in one
@@ -190,7 +193,7 @@ type
 
   OnBlockAdded* = proc(
     blckRef: BlockRef, blck: SignedBeaconBlock,
-    state: HashedBeaconState) {.raises: [Defect], gcsafe.}
+    epochRef: EpochRef, state: HashedBeaconState) {.raises: [Defect], gcsafe.}
 
 template validator_keys*(e: EpochRef): untyped = e.validator_key_store[1][]
 

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[sequtils, tables],
+  std/[tables],
   chronicles,
   metrics, stew/results,
   ../extras,
@@ -42,13 +42,16 @@ proc addRawBlock*(
 
 proc addResolvedBlock(
        dag: var ChainDAGRef, quarantine: var QuarantineRef,
-       state: HashedBeaconState, signedBlock: SignedBeaconBlock,
+       state: var StateData, signedBlock: SignedBeaconBlock,
        parent: BlockRef, cache: var StateCache,
        onBlockAdded: OnBlockAdded
-     ): BlockRef =
+     ) =
   # TODO move quarantine processing out of here
   logScope: pcs = "block_resolution"
-  doAssert state.data.slot == signedBlock.message.slot, "state must match block"
+  doAssert state.data.data.slot == signedBlock.message.slot,
+    "state must match block"
+  doAssert state.blck.root == signedBlock.message.parent_root,
+    "the StateData passed into the addResolved function not yet updated!"
 
   let
     blockRoot = signedBlock.root
@@ -57,14 +60,12 @@ proc addResolvedBlock(
 
   link(parent, blockRef)
 
-  if parent.slot.compute_epoch_at_slot() == blockEpoch:
-    # If the parent and child blocks are from the same epoch, we can reuse
-    # the epoch cache - but we'll only use the current epoch because the new
-    # block might have affected what the next epoch looks like
-    blockRef.epochsInfo = filterIt(parent.epochsInfo, it.epoch == blockEpoch)
-  else:
-    # Ensure we collect the epoch info if it's missing
-    discard getEpochInfo(blockRef, state.data, cache)
+  var epochRef = blockRef.findEpochRef(blockEpoch)
+  if epochRef == nil:
+    let prevEpochRef = blockRef.findEpochRef(blockEpoch - 1)
+
+    epochRef = EpochRef.init(state.data.data, cache, prevEpochRef)
+    blockRef.epochAncestor(blockEpoch).blck.epochRefs.add epochRef
 
   dag.blocks[blockRoot] = blockRef
   trace "Populating block dag", key = blockRoot, val = blockRef
@@ -90,10 +91,12 @@ proc addResolvedBlock(
     blockRoot = shortLog(blockRoot),
     heads = dag.heads.len()
 
+  state.blck = blockRef
+
   # Notify others of the new block before processing the quarantine, such that
   # notifications for parents happens before those of the children
   if onBlockAdded != nil:
-    onBlockAdded(blockRef, signedBlock, state)
+    onBlockAdded(blockRef, signedBlock, epochRef, state.data)
 
   # Now that we have the new block, we should see if any of the previously
   # unresolved blocks magically become resolved
@@ -114,8 +117,6 @@ proc addResolvedBlock(
 
       for v in resolved:
         discard addRawBlock(dag, quarantine, v, onBlockAdded)
-
-  blockRef
 
 proc addRawBlock*(
        dag: var ChainDAGRef, quarantine: var QuarantineRef,
@@ -190,8 +191,9 @@ proc addRawBlock*(
 
     # TODO if the block is from the future, we should not be resolving it (yet),
     #      but maybe we should use it as a hint that our clock is wrong?
+    var cache = getStateCache(parent, blck.slot.epoch)
     updateStateData(
-      dag, dag.clearanceState, BlockSlot(blck: parent, slot: blck.slot - 1))
+      dag, dag.clearanceState, parent.atSlot(blck.slot), cache)
 
     let
       poolPtr = unsafeAddr dag # safe because restore is short-lived
@@ -202,21 +204,17 @@ proc addRawBlock*(
       doAssert v.addr == addr poolPtr.clearanceState.data
       assign(poolPtr.clearanceState, poolPtr.headState)
 
-    var cache = getEpochCache(parent, dag.clearanceState.data.data)
     if not state_transition(dag.runtimePreset, dag.clearanceState.data, signedBlock,
-                            cache, dag.updateFlags, restore):
+                            cache, dag.updateFlags + {slotProcessed}, restore):
       notice "Invalid block"
 
       return err Invalid
 
     # Careful, clearanceState.data has been updated but not blck - we need to
     # create the BlockRef first!
-    dag.clearanceState.blck = addResolvedBlock(
-      dag, quarantine, dag.clearanceState.data, signedBlock, parent, cache,
-      onBlockAdded
-    )
-
-    dag.putState(dag.clearanceState)
+    addResolvedBlock(
+      dag, quarantine, dag.clearanceState, signedBlock, parent, cache,
+      onBlockAdded)
 
     return ok dag.clearanceState.blck
 

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -27,5 +27,8 @@ type
     skipStateRootValidation ##\
     ## Skip verification of block state root.
     verifyFinalization
+    slotProcessed ##\
+    ## Allow blocks to be applied to states with the same slot number as the
+    ## block which is what happens when `process_block` is called separately
 
   UpdateFlags* = set[UpdateFlag]

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -163,13 +163,14 @@ proc process_slots*(state: var HashedBeaconState, slot: Slot,
   #      slots "automatically" in `state_transition`, perhaps it would be better
   #      to keep a pre-condition that state must be at the right slot already?
   if not (state.data.slot < slot):
-    notice(
-      "Unusual request for a slot in the past",
-      state_root = shortLog(state.root),
-      current_slot = state.data.slot,
-      target_slot = slot
-    )
-    return false
+    if slotProcessed notin updateFlags or state.data.slot != slot:
+      notice(
+        "Unusual request for a slot in the past",
+        state_root = shortLog(state.root),
+        current_slot = state.data.slot,
+        target_slot = slot
+      )
+      return false
 
   # Catch up to the target slot
   var cache = StateCache()

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -229,8 +229,6 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       stateId: string, epoch: uint64, index: uint64, slot: uint64) ->
       seq[BeaconStatesCommitteesTuple]:
     withStateForStateId(stateId):
-      var cache = StateCache() # TODO is this OK?
-
       proc getCommittee(slot: Slot, index: CommitteeIndex): BeaconStatesCommitteesTuple =
         let vals = get_beacon_committee(state, slot, index, cache).mapIt(it.uint64)
         return (index: index.uint64, slot: slot.uint64, validators: vals)

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -205,7 +205,6 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       doAssert v.addr == addr poolPtr.tmpState.data
       assign(poolPtr.tmpState, poolPtr.headState)
 
-    var cache = StateCache()
     let message = makeBeaconBlock(
       node.config.runtimePreset,
       hashedState,
@@ -237,9 +236,8 @@ proc proposeSignedBlock*(node: BeaconNode,
     let newBlockRef = node.chainDag.addRawBlock(node.quarantine,
                                                      newBlock) do (
         blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-        state: HashedBeaconState):
+        epochRef: EpochRef, state: HashedBeaconState):
       # Callback add to fork choice if valid
-      let epochRef = getEpochInfo(blckRef, state.data)
       node.attestationPool.addForkChoice(
         epochRef, blckRef, signedBlock.message,
         node.beaconClock.now().slotOrZero())
@@ -402,7 +400,6 @@ proc broadcastAggregatedAttestations(
 
   let bs = BlockSlot(blck: aggregationHead, slot: aggregationSlot)
   node.chainDag.withState(node.chainDag.tmpState, bs):
-    var cache = getEpochCache(aggregationHead, state)
     let
       committees_per_slot =
         get_committee_count_per_slot(state, aggregationSlot.epoch, cache)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -185,9 +185,8 @@ suiteReport "Attestation pool processing" & preset():
       b1 = addTestBlock(state.data, chainDag.tail.root, cache)
       b1Add = chainDag.addRawBlock(quarantine, b1) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     let head = pool[].selectHead(b1Add[].slot)
@@ -199,9 +198,8 @@ suiteReport "Attestation pool processing" & preset():
       b2 = addTestBlock(state.data, b1.root, cache)
       b2Add = chainDag.addRawBlock(quarantine, b2) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     let head2 = pool[].selectHead(b2Add[].slot)
@@ -215,9 +213,8 @@ suiteReport "Attestation pool processing" & preset():
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     let head = pool[].selectHead(b10Add[].slot)
@@ -231,9 +228,8 @@ suiteReport "Attestation pool processing" & preset():
       )
       b11Add = chainDag.addRawBlock(quarantine, b11) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
       bc1 = get_beacon_committee(
@@ -274,9 +270,8 @@ suiteReport "Attestation pool processing" & preset():
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     let head = pool[].selectHead(b10Add[].slot)
@@ -289,9 +284,8 @@ suiteReport "Attestation pool processing" & preset():
     let b10_clone = b10 # Assumes deep copy
     let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     doAssert: b10Add_clone.error == Duplicate
@@ -304,9 +298,8 @@ suiteReport "Attestation pool processing" & preset():
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     let head = pool[].selectHead(b10Add[].slot)
@@ -339,9 +332,8 @@ suiteReport "Attestation pool processing" & preset():
         block_root = new_block.root
         let blockRef = chainDag.addRawBlock(quarantine, new_block) do (
             blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-            state: HashedBeaconState):
+            epochRef: EpochRef, state: HashedBeaconState):
           # Callback add to fork choice if valid
-          let epochRef = getEpochInfo(blckRef, state.data)
           pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
         let head = pool[].selectHead(blockRef[].slot)
@@ -381,9 +373,8 @@ suiteReport "Attestation pool processing" & preset():
     # Add back the old block to ensure we have a duplicate error
     let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
           blckRef: BlockRef, signedBlock: SignedBeaconBlock,
-          state: HashedBeaconState):
+          epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
-        let epochRef = getEpochInfo(blckRef, state.data)
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
     doAssert: b10Add_clone.error == Duplicate


### PR DESCRIPTION
* collect all epochrefs in specific blocks to make them easier to find
and to avoid lots of small seqs
* reuse validator key databases more aggressively by comparing keys
* make state cache available from within `withState`
* make epochRef available from within onBlockAdded callback
* integrate getEpochInfo into block resolution and epoch ref logic such
that epochrefs are created when blocks are added to pool or lazily when
needed by a getEpochRef
* fill state cache better from EpochRef, speeding up replay and
validation
* store epochRef in specific blocks to make them easier to find and
reuse
* fix database corruption when state is saved while replaying quarantine
* replay slots fully from block pool before processing state
* compare bls values more smartly
* store epoch state without block applied in database - it's recommended
to resync the node!

this branch will drastically speed up processing in times of long
non-finality, as well as cut memory usage by 10x during the recent
medalla madness.