### PR TITLE
Update issue template tag for phase 1

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-assessment-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-assessment-issue.md
@@ -2,7 +2,7 @@
 name: Security-assessment-issue
 about: File a Nimbus Security Assessment issue
 title: "[SEC]"
-labels: nbc-audit-2020-0 :passport_control:, status:reported
+labels: nbc-audit-2020-1 :passport_control:, status:reported
 assignees: ''
 
 ---


### PR DESCRIPTION
Change the default tag for phase 1 of the audit

Alternatively we could create another template but that seems overkill.