### PR TITLE
[Don't merge - RFC] No copy beacon state

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -19,7 +19,7 @@ logScope:
   topics = "att_aggr"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/validator.md#aggregation-selection
-func is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex,
+func is_aggregator(state: BeaconStateView, slot: Slot, index: CommitteeIndex,
     slot_signature: ValidatorSig, cache: var StateCache): bool =
   let
     committee_len = get_beacon_committee_len(state, slot, index, cache)
@@ -27,7 +27,7 @@ func is_aggregator(state: BeaconState, slot: Slot, index: CommitteeIndex,
   bytes_to_uint64(eth2digest(slot_signature.toRaw()).data[0..7]) mod modulo == 0
 
 proc aggregate_attestations*(
-    pool: AttestationPool, state: BeaconState, index: CommitteeIndex,
+    pool: AttestationPool, state: BeaconStateView, index: CommitteeIndex,
     validatorIndex: ValidatorIndex, privkey: ValidatorPrivKey,
     cache: var StateCache):
     Option[AggregateAndProof] =

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -246,7 +246,7 @@ proc getAttestationsForSlot*(pool: AttestationPool, newBlockSlot: Slot):
   some(pool.candidates[candidateIdx.get()])
 
 proc getAttestationsForBlock*(pool: AttestationPool,
-                              state: BeaconState): seq[Attestation] =
+                              state: BeaconStateView): seq[Attestation] =
   ## Retrieve attestations that may be added to a new block at the slot of the
   ## given state
   logScope: pcs = "retrieve_attestation"

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -122,7 +122,7 @@ proc getStateFromSnapshot(conf: BeaconNodeConf, stateSnapshotContents: ref strin
         err = err.msg, genesisFile = conf.dataDir/genesisFile
       quit 1
 
-func enrForkIdFromState(state: BeaconState): ENRForkID =
+func enrForkIdFromState(state: BeaconStateView): ENRForkID =
   let
     forkVer = state.fork.current_version
     forkDigest = compute_fork_digest(forkVer, state.genesis_validators_root)

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -64,7 +64,7 @@ proc addResolvedBlock(
   if epochRef == nil:
     let prevEpochRef = blockRef.findEpochRef(blockEpoch - 1)
 
-    epochRef = EpochRef.init(state.data.data, cache, prevEpochRef)
+    epochRef = EpochRef.init(state.data.data.unsafeView(), cache, prevEpochRef)
     blockRef.epochAncestor(blockEpoch).blck.epochRefs.add epochRef
 
   dag.blocks[blockRoot] = blockRef

--- a/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/beacon_callsigs.nim
@@ -14,7 +14,7 @@ proc get_v1_beacon_states_fork(stateId: string): Fork
 
 # TODO stateId is part of the REST path
 proc get_v1_beacon_states_finality_checkpoints(
-  stateId: string): BeaconStatesFinalityCheckpointsTuple
+  stateId: string): BeaconStateViewsFinalityCheckpointsTuple
 
 # TODO stateId is part of the REST path
 proc get_v1_beacon_states_stateId_validators(
@@ -23,7 +23,7 @@ proc get_v1_beacon_states_stateId_validators(
 
 # TODO stateId and validatorId are part of the REST path
 proc get_v1_beacon_states_stateId_validators_validatorId(
-  stateId: string, validatorId: string): BeaconStatesValidatorsTuple
+  stateId: string, validatorId: string): BeaconStateViewsValidatorsTuple
 
 # TODO stateId and epoch are part of the REST path
 proc get_v1_beacon_states_stateId_committees_epoch(stateId: string,
@@ -60,7 +60,7 @@ proc post_v1_beacon_pool_attestations(attestation: Attestation): bool
 proc get_v1_config_fork_schedule(): seq[tuple[epoch: uint64, version: Version]]
 
 # TODO stateId is part of the REST path
-proc get_v1_debug_beacon_states_stateId(stateId: string): BeaconState
+proc get_v1_debug_beacon_states_stateId(stateId: string): BeaconStateView
 
 
 # TODO: delete old stuff
@@ -69,8 +69,7 @@ proc get_v1_debug_beacon_states_stateId(stateId: string): BeaconState
 #
 proc getBeaconHead(): Slot
 proc getBeaconBlock(slot = none(Slot), root = none(Eth2Digest)): BeaconBlock
-proc getBeaconState(slot = none(Slot), root = none(Eth2Digest)): BeaconState
+proc getBeaconState(slot = none(Slot), root = none(Eth2Digest)): BeaconStateView
 proc getNetworkPeerId()
 proc getNetworkPeers()
 proc getNetworkEnr()
-

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -57,7 +57,7 @@ func is_active_validator*(validator: Validator, epoch: Epoch): bool =
   validator.activation_epoch <= epoch and epoch < validator.exit_epoch
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_active_validator_indices
-func get_active_validator_indices*(state: BeaconState, epoch: Epoch):
+func get_active_validator_indices*(state: BeaconStateView, epoch: Epoch):
     seq[ValidatorIndex] =
   # Return the sequence of active validator indices at ``epoch``.
   for idx, val in state.validators:
@@ -65,13 +65,13 @@ func get_active_validator_indices*(state: BeaconState, epoch: Epoch):
       result.add idx.ValidatorIndex
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_current_epoch
-func get_current_epoch*(state: BeaconState): Epoch =
+func get_current_epoch*(state: BeaconStateView): Epoch =
   # Return the current epoch.
   doAssert state.slot >= GENESIS_SLOT, $state.slot
   compute_epoch_at_slot(state.slot)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_randao_mix
-func get_randao_mix*(state: BeaconState,
+func get_randao_mix*(state: BeaconStateView,
                      epoch: Epoch): Eth2Digest =
   ## Returns the randao mix at a recent ``epoch``.
   state.randao_mixes[epoch mod EPOCHS_PER_HISTORICAL_VECTOR]
@@ -145,7 +145,7 @@ func get_domain*(
   compute_domain(domain_type, fork_version, genesis_validators_root)
 
 func get_domain*(
-    state: BeaconState, domain_type: DomainType, epoch: Epoch): Domain =
+    state: BeaconStateView, domain_type: DomainType, epoch: Epoch): Domain =
   ## Return the signature domain (fork version concatenated with domain type)
   ## of a message.
   get_domain(state.fork, domain_type, epoch, state.genesis_validators_root)
@@ -161,7 +161,7 @@ func compute_signing_root*(ssz_object: auto, domain: Domain): Eth2Digest =
   hash_tree_root(domain_wrapped_object)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#get_seed
-func get_seed*(state: BeaconState, epoch: Epoch, domain_type: DomainType): Eth2Digest =
+func get_seed*(state: BeaconStateView, epoch: Epoch, domain_type: DomainType): Eth2Digest =
   # Return the seed at ``epoch``.
 
   var seed_input : array[4+8+32, byte]

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -99,7 +99,7 @@ func getAttestationTopic*(forkDigest: ForkDigest,
       attestation.data.slot, attestation.data.index.CommitteeIndex))
 
 func get_committee_assignments(
-    state: BeaconState, epoch: Epoch,
+    state: BeaconStateView, epoch: Epoch,
     validator_indices: HashSet[ValidatorIndex]):
     seq[tuple[subnetIndex: uint64, slot: Slot]] =
   var cache = StateCache()
@@ -123,7 +123,7 @@ proc getStabilitySubnetLength*(): uint64 =
     rand(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION.int).uint64
 
 proc get_attestation_subnet_changes*(
-    state: BeaconState, attachedValidators: openarray[ValidatorIndex],
+    state: BeaconStateView, attachedValidators: openarray[ValidatorIndex],
     prevAttestationSubnets: AttestationSubnets, epoch: Epoch):
     tuple[a: AttestationSubnets, b: set[uint8], c: set[uint8]] =
   static:

--- a/beacon_chain/spec/state_transition_helpers.nim
+++ b/beacon_chain/spec/state_transition_helpers.nim
@@ -18,7 +18,7 @@ import
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#helper-functions-1
 func get_attesting_indices*(
-    state: BeaconState, attestations: openArray[PendingAttestation],
+    state: BeaconStateView, attestations: openArray[PendingAttestation],
     cache: var StateCache): HashSet[ValidatorIndex] =
   # This is part of get_unslashed_attesting_indices(...) in spec.
   # Exported bceause of external trace-level chronicles logging.
@@ -29,7 +29,7 @@ func get_attesting_indices*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#helper-functions-1
 func get_unslashed_attesting_indices*(
-    state: BeaconState, attestations: openArray[PendingAttestation],
+    state: BeaconStateView, attestations: openArray[PendingAttestation],
     cache: var StateCache): HashSet[ValidatorIndex] =
   result = initHashSet[ValidatorIndex]()
   for a in attestations:

--- a/beacon_chain/time.nim
+++ b/beacon_chain/time.nim
@@ -36,7 +36,7 @@ proc init*(T: type BeaconClock, genesis_time: uint64): T =
 
   T(genesis: unixGenesis - unixGenesisOffset)
 
-proc init*(T: type BeaconClock, state: BeaconState): T =
+proc init*(T: type BeaconClock, state: BeaconStateView): T =
   ## Initialize time from a beacon state. The genesis time of a beacon state is
   ## constant throughout its lifetime, so the state from any slot will do,
   ## including the genesis state.

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -52,7 +52,7 @@ proc doChecksAndGetCurrentHead(node: BeaconNode, epoch: Epoch): BlockRef =
 
 # TODO currently this function throws if the validator isn't found - is this OK?
 proc getValidatorInfoFromValidatorId(
-    state: BeaconState,
+    state: BeaconStateView,
     current_epoch: Epoch,
     validatorId: string,
     status = ""):

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -42,7 +42,7 @@ proc saveValidatorKey*(keyName, key: string, conf: BeaconNodeConf) =
   info "Imported validator key", file = outputFile
 
 proc addLocalValidator*(node: BeaconNode,
-                        state: BeaconState,
+                        state: BeaconStateView,
                         privKey: ValidatorPrivKey) =
   let pubKey = privKey.toPubKey()
 
@@ -65,7 +65,7 @@ proc getAttachedValidator*(node: BeaconNode,
   node.attachedValidators.getValidator(pubkey)
 
 proc getAttachedValidator*(node: BeaconNode,
-                           state: BeaconState,
+                           state: BeaconStateView,
                            idx: ValidatorIndex): AttachedValidator =
   if idx < state.validators.len.ValidatorIndex:
     node.getAttachedValidator(state.validators[idx].pubkey)

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -34,7 +34,7 @@ func verifyConsensus*(state: BeaconState, attesterRatio: auto) =
   if attesterRatio < 0.72:
     return
 
-  let current_epoch = get_current_epoch(state)
+  let current_epoch = get_current_epoch(state.unsafeView())
   if current_epoch >= 3:
     doAssert state.current_justified_checkpoint.epoch + 1 >= current_epoch
   if current_epoch >= 4:

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -18,7 +18,7 @@ import
 # ---------------------------------------------------------------
 
 proc signMockBlockImpl(
-      state: BeaconState,
+      state: BeaconStateView,
       signedBlock: var SignedBeaconBlock
     ) =
   let block_slot = signedBlock.message.slot
@@ -34,11 +34,11 @@ proc signMockBlockImpl(
     state.fork, state.genesis_validators_root, block_slot,
     signedBlock.root, privkey)
 
-proc signMockBlock*(state: BeaconState, signedBlock: var SignedBeaconBlock) =
+proc signMockBlock*(state: BeaconStateView, signedBlock: var SignedBeaconBlock) =
   signMockBlockImpl(state, signedBlock)
 
 proc mockBlock(
-    state: BeaconState,
+    state: BeaconStateView,
     slot: Slot,
     flags: UpdateFlags = {}): SignedBeaconBlock =
   ## TODO don't do this gradual construction, for exception safety
@@ -53,12 +53,12 @@ proc mockBlock(
 
   var previous_block_header = state.latest_block_header
   if previous_block_header.state_root == ZERO_HASH:
-    previous_block_header.state_root = state.hash_tree_root()
+    previous_block_header.state_root = state.unsafeDeref().hash_tree_root()
   result.message.parent_root = previous_block_header.hash_tree_root()
 
   if skipBlsValidation notin flags:
     signMockBlock(state, result)
 
-proc mockBlockForNextSlot*(state: BeaconState, flags: UpdateFlags = {}):
+proc mockBlockForNextSlot*(state: BeaconStateView, flags: UpdateFlags = {}):
     SignedBeaconBlock =
   mockBlock(state, state.slot + 1, flags)

--- a/tests/official/test_fixture_rewards.nim
+++ b/tests/official/test_fixture_rewards.nim
@@ -45,7 +45,7 @@ proc runTest(identifier: string) =
         state = newClone(parseTest(testDir/"pre.ssz", SSZ, BeaconState))
         cache = StateCache()
       let
-        total_balance = get_total_active_balance(state[], cache)
+        total_balance = get_total_active_balance(state[].unsafeView(), cache)
         sourceDeltas = parseTest(testDir/"source_deltas.ssz", SSZ, Deltas)
         targetDeltas = parseTest(testDir/"target_deltas.ssz", SSZ, Deltas)
         headDeltas = parseTest(testDir/"head_deltas.ssz", SSZ, Deltas)
@@ -55,13 +55,13 @@ proc runTest(identifier: string) =
           parseTest(testDir/"inactivity_penalty_deltas.ssz", SSZ, Deltas)
 
       check:
-        compareDeltas(sourceDeltas, get_source_deltas(state[], total_balance, cache))
-        compareDeltas(targetDeltas, get_target_deltas(state[], total_balance, cache))
-        compareDeltas(headDeltas, get_head_deltas(state[], total_balance, cache))
+        compareDeltas(sourceDeltas, get_source_deltas(state[].unsafeView, total_balance, cache))
+        compareDeltas(targetDeltas, get_target_deltas(state[].unsafeView, total_balance, cache))
+        compareDeltas(headDeltas, get_head_deltas(state[].unsafeView, total_balance, cache))
         inclusionDelayDeltas.rewards.asSeq ==
-          get_inclusion_delay_deltas(state[], total_balance, cache)
+          get_inclusion_delay_deltas(state[].unsafeView, total_balance, cache)
         inactivityPenaltyDeltas.penalties.asSeq ==
-          get_inactivity_penalty_deltas(state[], total_balance, cache)
+          get_inactivity_penalty_deltas(state[].unsafeView, total_balance, cache)
 
   `testImpl _ rewards _ identifier`()
 

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -54,18 +54,18 @@ suiteReport "[Unit - Spec - Block processing] Attestations " & preset():
       ).isOk
 
       # Check that the attestation was processed
-      if attestation.data.target.epoch == get_current_epoch(state.data):
+      if attestation.data.target.epoch == get_current_epoch(state.data.unsafeView()):
         check(state.data.current_epoch_attestations.len == current_epoch_count + 1)
       else:
         check(state.data.previous_epoch_attestations.len == previous_epoch_count + 1)
 
   valid_attestation("Valid attestation"):
-    let attestation = mockAttestation(state.data)
+    let attestation = mockAttestation(state.data.unsafeView())
     state.data.slot += MIN_ATTESTATION_INCLUSION_DELAY
 
   valid_attestation("Valid attestation from previous epoch"):
     nextSlot(state[])
-    let attestation = mockAttestation(state.data)
+    let attestation = mockAttestation(state.data.unsafeView())
     state.data.slot = Slot(SLOTS_PER_EPOCH - 1)
     nextEpoch(state[])
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -65,16 +65,16 @@ suiteReport "Attestation pool processing" & preset():
     let
       # Create an attestation for slot 1!
       beacon_committee = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+        state.data.data.unsafeView(), state.data.data.slot, 0.CommitteeIndex, cache)
       attestation = makeAttestation(
-        state.data.data, state.blck.root, beacon_committee[0], cache)
+        state.data.data.unsafeView(), state.blck.root, beacon_committee[0], cache)
 
     pool[].addAttestation(attestation, attestation.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-    let attestations = pool[].getAttestationsForBlock(state.data.data)
+    let attestations = pool[].getAttestationsForBlock(state.data.data.unsafeView())
 
     check:
       attestations.len == 1
@@ -84,18 +84,18 @@ suiteReport "Attestation pool processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+        state.data.data.unsafeView(), state.data.data.slot, 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[0], cache)
 
     check:
       process_slots(state.data, state.data.data.slot + 1)
 
     let
-      bc1 = get_beacon_committee(state.data.data,
+      bc1 = get_beacon_committee(state.data.data.unsafeView(),
         state.data.data.slot, 0.CommitteeIndex, cache)
       attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc1[0], cache)
+        state.data.data.unsafeView(), state.blck.root, bc1[0], cache)
 
     # test reverse order
     pool[].addAttestation(attestation1, attestation1.data.slot)
@@ -103,7 +103,7 @@ suiteReport "Attestation pool processing" & preset():
 
     discard process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-    let attestations = pool[].getAttestationsForBlock(state.data.data)
+    let attestations = pool[].getAttestationsForBlock(state.data.data.unsafeView())
 
     check:
       attestations.len == 1
@@ -113,11 +113,11 @@ suiteReport "Attestation pool processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+        state.data.data.unsafeView(), state.data.data.slot, 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[0], cache)
       attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[1], cache)
 
     pool[].addAttestation(attestation0, attestation0.data.slot)
     pool[].addAttestation(attestation1, attestation1.data.slot)
@@ -125,7 +125,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-    let attestations = pool[].getAttestationsForBlock(state.data.data)
+    let attestations = pool[].getAttestationsForBlock(state.data.data.unsafeView())
 
     check:
       attestations.len == 1
@@ -136,11 +136,11 @@ suiteReport "Attestation pool processing" & preset():
     var
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+        state.data.data.unsafeView(), state.data.data.slot, 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[0], cache)
       attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[1], cache)
 
     attestation0.combine(attestation1, {})
 
@@ -150,7 +150,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-    let attestations = pool[].getAttestationsForBlock(state.data.data)
+    let attestations = pool[].getAttestationsForBlock(state.data.data.unsafeView())
 
     check:
       attestations.len == 1
@@ -159,12 +159,12 @@ suiteReport "Attestation pool processing" & preset():
     var cache = StateCache()
     var
       # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(state.data.data,
+      bc0 = get_beacon_committee(state.data.data.unsafeView(),
         state.data.data.slot, 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state.data.data, state.blck.root, bc0[0], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[0], cache)
       attestation1 = makeAttestation(
-        state.data.data, state.blck.root, bc0[1], cache)
+        state.data.data.unsafeView(), state.blck.root, bc0[1], cache)
 
     attestation0.combine(attestation1, {})
 
@@ -174,7 +174,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1)
 
-    let attestations = pool[].getAttestationsForBlock(state.data.data)
+    let attestations = pool[].getAttestationsForBlock(state.data.data.unsafeView())
 
     check:
       attestations.len == 1
@@ -233,8 +233,8 @@ suiteReport "Attestation pool processing" & preset():
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
       bc1 = get_beacon_committee(
-        state.data.data, state.data.data.slot - 1, 1.CommitteeIndex, cache)
-      attestation0 = makeAttestation(state.data.data, b10.root, bc1[0], cache)
+        state.data.data.unsafeView(), state.data.data.slot - 1, 1.CommitteeIndex, cache)
+      attestation0 = makeAttestation(state.data.data.unsafeView(), b10.root, bc1[0], cache)
 
     pool[].addAttestation(attestation0, attestation0.data.slot)
 
@@ -245,8 +245,8 @@ suiteReport "Attestation pool processing" & preset():
       head2 == b10Add[]
 
     let
-      attestation1 = makeAttestation(state.data.data, b11.root, bc1[1], cache)
-      attestation2 = makeAttestation(state.data.data, b11.root, bc1[2], cache)
+      attestation1 = makeAttestation(state.data.data.unsafeView(), b11.root, bc1[1], cache)
+      attestation2 = makeAttestation(state.data.data.unsafeView(), b11.root, bc1[2], cache)
     pool[].addAttestation(attestation1, attestation1.data.slot)
 
     let head3 = pool[].selectHead(b10Add[].slot)
@@ -321,7 +321,7 @@ suiteReport "Attestation pool processing" & preset():
     for epoch in 0 ..< 5:
       let start_slot = compute_start_slot_at_epoch(Epoch epoch)
       let committees_per_slot =
-        get_committee_count_per_slot(state.data.data, Epoch epoch, cache)
+        get_committee_count_per_slot(state.data.data.unsafeView(), Epoch epoch, cache)
       for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
         let new_block = makeTestBlock(
           state.data, block_root, cache, attestations = attestations)
@@ -343,7 +343,7 @@ suiteReport "Attestation pool processing" & preset():
         attestations.setlen(0)
         for index in 0'u64 ..< committees_per_slot:
           let committee = get_beacon_committee(
-              state.data.data, state.data.data.slot, index.CommitteeIndex, cache)
+              state.data.data.unsafeView(), state.data.data.slot, index.CommitteeIndex, cache)
 
           # Create a bitfield filled with the given count per attestation,
           # exactly on the right-most part of the committee field.
@@ -354,7 +354,7 @@ suiteReport "Attestation pool processing" & preset():
           attestations.add Attestation(
             aggregation_bits: aggregation_bits,
             data: makeAttestationData(
-              state.data.data, state.data.data.slot,
+              state.data.data.unsafeView(), state.data.data.slot,
               index, blockroot
             )
             # signature: ValidatorSig()

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -334,7 +334,7 @@ suiteReport "chain DAG finalization tests" & preset():
       blck = makeTestBlock(
         dag.headState.data, dag.head.root, cache,
         attestations = makeFullAttestations(
-          dag.headState.data.data, dag.head.root,
+          dag.headState.data.data.unsafeView(), dag.head.root,
           dag.headState.data.data.slot, cache, {}))
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
@@ -416,7 +416,7 @@ suiteReport "chain DAG finalization tests" & preset():
         blck = makeTestBlock(
           dag.headState.data, dag.head.root, cache,
           attestations = makeFullAttestations(
-            dag.headState.data.data, dag.head.root,
+            dag.headState.data.data.unsafeView(), dag.head.root,
             dag.headState.data.data.slot, cache, {}))
 
       let added = dag.addRawBlock(quarantine, blck, nil)
@@ -431,7 +431,7 @@ suiteReport "chain DAG finalization tests" & preset():
     var blck = makeTestBlock(
       dag.headState.data, dag.head.root, cache,
       attestations = makeFullAttestations(
-        dag.headState.data.data, dag.head.root,
+        dag.headState.data.data.unsafeView(), dag.head.root,
         dag.headState.data.data.slot, cache, {}))
 
     let added = dag.addRawBlock(quarantine, blck, nil)

--- a/tests/test_state_transition.nim
+++ b/tests/test_state_transition.nim
@@ -23,7 +23,7 @@ suiteReport "Block processing" & preset():
     # TODO bls verification is a bit of a bottleneck here
     genesisState = newClone(initialize_hashed_beacon_state_from_eth1(
       defaultRuntimePreset, Eth2Digest(), 0, makeInitialDeposits(), {}))
-    genesisBlock = get_initial_beacon_block(genesisState.data)
+    genesisBlock = get_initial_beacon_block(genesisState.data.unsafeView())
     genesisRoot = hash_tree_root(genesisBlock.message)
 
   setup:
@@ -82,9 +82,9 @@ suiteReport "Block processing" & preset():
     let
       # Create an attestation for slot 1 signed by the only attester we have!
       beacon_committee =
-        get_beacon_committee(state.data, state.data.slot, 0.CommitteeIndex, cache)
+        get_beacon_committee(state.data.unsafeView(), state.data.slot, 0.CommitteeIndex, cache)
       attestation = makeAttestation(
-        state.data, previous_block_root, beacon_committee[0], cache)
+        state.data.unsafeView(), previous_block_root, beacon_committee[0], cache)
 
     # Some time needs to pass before attestations are included - this is
     # to let the attestation propagate properly to interested participants

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -98,7 +98,7 @@ proc addTestBlock*(
   advance_slot(state, flags, cache)
 
   let
-    proposer_index = get_beacon_proposer_index(state.data, cache)
+    proposer_index = get_beacon_proposer_index(state.data.unsafeView(), cache)
     privKey = hackPrivKey(state.data.validators[proposer_index.get])
     randao_reveal =
       if skipBlsValidation notin flags:
@@ -153,7 +153,7 @@ proc makeTestBlock*(
     graffiti, flags)
 
 proc makeAttestation*(
-    state: BeaconState, beacon_block_root: Eth2Digest,
+    state: BeaconStateView, beacon_block_root: Eth2Digest,
     committee: seq[ValidatorIndex], slot: Slot, index: uint64,
     validator_index: auto, cache: var StateCache,
     flags: UpdateFlags = {}): Attestation =
@@ -186,7 +186,7 @@ proc makeAttestation*(
   )
 
 proc find_beacon_committee(
-    state: BeaconState, validator_index: ValidatorIndex,
+    state: BeaconStateView, validator_index: ValidatorIndex,
     cache: var StateCache): auto =
   let epoch = compute_epoch_at_slot(state.slot)
   for epoch_committee_index in 0'u64 ..< get_committee_count_per_slot(
@@ -201,7 +201,7 @@ proc find_beacon_committee(
   doAssert false
 
 proc makeAttestation*(
-    state: BeaconState, beacon_block_root: Eth2Digest,
+    state: BeaconStateView, beacon_block_root: Eth2Digest,
     validator_index: ValidatorIndex, cache: var StateCache,
     flags: UpdateFlags = {}): Attestation =
   let (committee, slot, index) =
@@ -210,7 +210,7 @@ proc makeAttestation*(
     validator_index, cache, flags)
 
 proc makeFullAttestations*(
-    state: BeaconState, beacon_block_root: Eth2Digest, slot: Slot,
+    state: BeaconStateView, beacon_block_root: Eth2Digest, slot: Slot,
     cache: var StateCache,
     flags: UpdateFlags = {}): seq[Attestation] =
   # Create attestations in which the full committee participates for each shard

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -97,7 +97,7 @@ template timedTest*(name, body) =
   # TODO noto thread-safe as-is
   testTimes.add (f, name)
 
-proc makeTestDB*(tailState: BeaconState, tailBlock: SignedBeaconBlock): BeaconChainDB =
+proc makeTestDB*(tailState: BeaconStateView, tailBlock: SignedBeaconBlock): BeaconChainDB =
   result = init(BeaconChainDB, kvStore MemStoreRef.init())
   ChainDAGRef.preInit(result, tailState, tailBlock)
 
@@ -107,7 +107,7 @@ proc makeTestDB*(validators: Natural): BeaconChainDB =
       defaultRuntimePreset, Eth2Digest(), 0,
       makeInitialDeposits(validators.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation})
-    genBlock = get_initial_beacon_block(genState[])
-  makeTestDB(genState[], genBlock)
+    genBlock = get_initial_beacon_block(genState[].unsafeView())
+  makeTestDB(genState[].unsafeView(), genBlock)
 
 export inMicroseconds


### PR DESCRIPTION
This introduces a BeaconStateView type to workaround spurious stack allocation of BeaconState as raised in #1549.

In particular #1549 happens in `check_attestation` which might be called up to 128 times per block, i.e. 128 copies of 5.5MB per block synced. This is without counting triggering slowness due to Nim conservative stack scanning like in #370.

**Don't merge for discussion only**

![image](https://user-images.githubusercontent.com/22738317/90900754-2dd42c00-e3ca-11ea-93bf-d3b1f0f10315.png)

Impact:
- state_sim: non-epoch slot 3x slower
- block_sim: non-epoch slot 26% slower
- block_sim: epoch slot 23% faster (!)
