### PR TITLE
Add a CPU_LIMIT option for the Medalla and Altona targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ BASE_RPC_PORT := 9190
 BASE_METRICS_PORT := 8008
 GOERLI_WEB3_URL := "wss://goerli.infura.io/ws/v3/809a18497dd74102b5f37d25aae3c85a"
 VALIDATORS := 1
+CPU_LIMIT := 0
+
+ifeq ($(CPU_LIMIT), 0)
+	CPU_LIMIT_CMD :=
+else
+	CPU_LIMIT_CMD := cpulimit --limit=$(CPU_LIMIT) --foreground --
+endif
 
 # unconditionally built by the default Make target
 # TODO re-enable ncli_query if/when it works again
@@ -177,7 +184,7 @@ medalla: | beacon_node
 		--base-metrics-port $$(($(BASE_METRICS_PORT) + $(NODE_ID))) \
 		--config-file "build/data/shared_medalla_$(NODE_ID)/prometheus.yml"
 
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=medalla \
 		--log-level="$(LOG_LEVEL)" \
 		--log-file=build/data/shared_medalla_$(NODE_ID)/nbc_bn_$$(date +"%Y%m%d%H%M%S").log \
@@ -193,7 +200,7 @@ medalla-vc: | beacon_node validator_client
 		--base-metrics-port $$(($(BASE_METRICS_PORT) + $(NODE_ID))) \
 		--config-file "build/data/shared_medalla_$(NODE_ID)/prometheus.yml"
 
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=medalla \
 		--log-level="$(LOG_LEVEL)" \
 		--log-file=build/data/shared_medalla_$(NODE_ID)/nbc_bn_$$(date +"%Y%m%d%H%M%S").log \
@@ -218,7 +225,7 @@ medalla-dev: | beacon_node
 		--base-metrics-port $$(($(BASE_METRICS_PORT) + $(NODE_ID))) \
 		--config-file "build/data/shared_medalla_$(NODE_ID)/prometheus.yml"
 
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=medalla \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_medalla_$(NODE_ID) \
@@ -255,7 +262,7 @@ clean-medalla:
 	rm -rf build/data/shared_medalla*/*.log
 
 altona: | beacon_node
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=altona \
 		--log-level="$(LOG_LEVEL)" \
 		--log-file=build/data/shared_altona_$(NODE_ID)/nbc_bn_$$(date +"%Y%m%d%H%M%S").log \
@@ -265,7 +272,7 @@ altona: | beacon_node
 altona-vc: | beacon_node validator_client
 	# if launching a VC as well - send the BN looking nowhere for validators/secrets
 	mkdir -p build/data/shared_altona_$(NODE_ID)/empty_dummy_folder
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=altona \
 		--log-level="$(LOG_LEVEL)" \
 		--log-file=build/data/shared_altona_$(NODE_ID)/nbc_bn_$$(date +"%Y%m%d%H%M%S").log \
@@ -281,7 +288,7 @@ altona-vc: | beacon_node validator_client
 		--rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
 
 altona-dev: | beacon_node
-	build/beacon_node \
+	$(CPU_LIMIT_CMD) build/beacon_node \
 		--network=altona \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_altona_$(NODE_ID) \

--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ prometheus --config.file=./prometheus.yml --storage.tsdb.path=./prometheus
 
 For some pretty pictures, get [Grafana](https://grafana.com/) up and running, then import the dashboard definition in "grafana/beacon\_nodes\_Grafana\_dashboard.json".
 
+### Stress-testing the client by limiting the CPU power
+
+```bash
+make medalla CPU_LIMIT=20
+```
+
+The limiting is provided by the cpulimit utility, available on Linux and macOS.
+The specified value is a percentage of a single CPU core. Usually 1 - 100, but can be higher on multi-core CPUs.
+
 ## Interop (for other Eth2 clients)
 
 After installing the [prerequisites](#prerequisites)


### PR DESCRIPTION
This can be used to trigger problems such as peer dropping that manifest only on higher CPU loads.