### PR TITLE
bump vendor/nim-blscurve

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -13,7 +13,7 @@ import
   # Nimble packages
   stew/[objects, byteutils, endians2], stew/shims/macros,
   chronos, confutils, metrics, json_rpc/[rpcserver, jsonmarshal],
-  chronicles, bearssl,
+  chronicles, bearssl, blscurve,
   json_serialization/std/[options, sets, net], serialization/errors,
 
   eth/[keys, async_utils],
@@ -1156,6 +1156,7 @@ programMain:
   of noCommand:
     debug "Launching beacon node",
           version = fullVersionStr,
+          bls_backend = $BLS_BACKEND,
           cmdParams = commandLineParams(),
           config
 


### PR DESCRIPTION
and log the BLS backend

(pointing to a non-master branch of nim-blscurve, temporarily, to see the CI tests before declaring https://github.com/status-im/nim-blscurve/pull/72 ready to merge)