### PR TITLE
harden beacon_pending_deposits metrics calculation against overflow

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -37,8 +37,6 @@ import
 # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
 declareGauge beacon_current_live_validators, "Number of active validators that successfully included attestation on chain for current epoch" # On block
 declareGauge beacon_previous_live_validators, "Number of active validators that successfully included attestation on chain for previous epoch" # On block
-declareGauge beacon_pending_deposits, "Number of pending deposits (state.eth1_data.deposit_count - state.eth1_deposit_index)" # On block
-declareGauge beacon_processed_deposits_total, "Number of total deposits included on chain" # On block
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#block-header
 func process_block_header*(
@@ -356,11 +354,5 @@ proc process_block*(
       eth1_deposit_index = state.eth1_deposit_index,
       deposit_root = shortLog(state.eth1_data.deposit_root)
     return false
-
-  # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
-  if state.eth1_data.deposit_count < high(int64).uint64:
-    beacon_pending_deposits.set(
-      state.eth1_data.deposit_count.int64 - state.eth1_deposit_index.int64)
-    beacon_processed_deposits_total.set(state.eth1_deposit_index.int64)
 
   true

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -357,6 +357,7 @@ proc process_block*(
       deposit_root = shortLog(state.eth1_data.deposit_root)
     return false
 
+  # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
   if state.eth1_data.deposit_count < high(int64).uint64:
     beacon_pending_deposits.set(
       state.eth1_data.deposit_count.int64 - state.eth1_deposit_index.int64)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -326,13 +326,6 @@ proc process_block*(
   # TODO when there's a failure, we should reset the state!
   # TODO probably better to do all verification first, then apply state changes
 
-  # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics
-  # doesn't seem to specify at what point in block processing this metric is to be read,
-  # and this avoids the early-return issue (could also use defer, etc).
-  beacon_pending_deposits.set(
-    state.eth1_data.deposit_count.int64 - state.eth1_deposit_index.int64)
-  beacon_processed_deposits_total.set(state.eth1_deposit_index.int64)
-
   # Adds nontrivial additional computation, but only does so when metrics
   # enabled.
   beacon_current_live_validators.set(toHashSet(
@@ -363,5 +356,10 @@ proc process_block*(
       eth1_deposit_index = state.eth1_deposit_index,
       deposit_root = shortLog(state.eth1_data.deposit_root)
     return false
+
+  if state.eth1_data.deposit_count < high(int64).uint64:
+    beacon_pending_deposits.set(
+      state.eth1_data.deposit_count.int64 - state.eth1_deposit_index.int64)
+    beacon_processed_deposits_total.set(state.eth1_deposit_index.int64)
 
   true


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-beacon-chain/issues/1544

Rather than rejecting the block as part of the metrics calculation per se, as per the short-term recommendation, has the metric only count after successful block processing, thus taking advantage of all the verification of block correctness already done. In particular, https://github.com/status-im/nim-beacon-chain/pull/1550 in response to https://github.com/status-im/nim-beacon-chain/issues/1542 already tightens verification of `state.eth1_data.deposit_count` and `state.eth1_deposit_index`, so the short-term part left is to avoid hypothetical future `RangeDefect`s if `uint64` to `int64` conversions begin throwing those and the beacon chain legitimately gains 2^63 deposits.