### PR TITLE
implement clock disparity for attestation validation

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -13,6 +13,11 @@ AllTests-mainnet
 + Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 ```
 OK: 9/9 Fail: 0/9 Skip: 0/9
+## Attestation validation  [Preset: mainnet]
+```diff
++ Validation sanity                                                                          OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -248,4 +253,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 135/142 Fail: 0/142 Skip: 7/142
+OK: 136/143 Fail: 0/143 Skip: 7/143

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -25,9 +25,6 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
   ## Initialize an AttestationPool from the chainDag `headState`
   ## The `finalized_root` works around the finalized_checkpoint of the genesis block
   ## holding a zero_root.
-  # TODO chainDag/quarantine are only used when resolving orphaned attestations - they
-  #      should probably be removed as a dependency of AttestationPool (or some other
-  #      smart refactoring)
 
   let
     finalizedEpochRef = chainDag.getEpochRef(
@@ -65,24 +62,17 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
   T(
     chainDag: chainDag,
     quarantine: quarantine,
-    unresolved: initTable[Eth2Digest, UnresolvedAttestation](),
     forkChoice: forkChoice
   )
 
 proc processAttestation(
     pool: var AttestationPool, slot: Slot, participants: HashSet[ValidatorIndex],
-    block_root: Eth2Digest, target: Checkpoint, wallSlot: Slot) =
+    block_root: Eth2Digest, wallSlot: Slot) =
   # Add attestation votes to fork choice
   if (let v = pool.forkChoice.on_attestation(
-    pool.chainDag, slot, block_root, toSeq(participants), target, wallSlot);
+    pool.chainDag, slot, block_root, participants, wallSlot);
     v.isErr):
       warn "Couldn't process attestation", err = v.error()
-
-func addUnresolved*(pool: var AttestationPool, attestation: Attestation) =
-  pool.unresolved[attestation.data.beacon_block_root] =
-    UnresolvedAttestation(
-      attestation: attestation,
-    )
 
 func candidateIdx(pool: AttestationPool, slot: Slot): Option[uint64] =
   if slot >= pool.startingSlot and
@@ -109,16 +99,15 @@ proc updateCurrent(pool: var AttestationPool, wallSlot: Slot) =
 
   pool.startingSlot = newWallSlot
 
-proc addResolved(
-    pool: var AttestationPool, blck: BlockRef, attestation: Attestation,
-    wallSlot: Slot) =
+proc addAttestation*(pool: var AttestationPool,
+                     attestation: Attestation,
+                     participants: HashSet[ValidatorIndex],
+                     wallSlot: Slot) =
   # Add an attestation whose parent we know
   logScope:
     attestation = shortLog(attestation)
 
   updateCurrent(pool, wallSlot)
-
-  doAssert blck.root == attestation.data.beacon_block_root
 
   let candidateIdx = pool.candidateIdx(attestation.data.slot)
   if candidateIdx.isNone:
@@ -127,13 +116,10 @@ proc addResolved(
     return
 
   let
-    epochRef = pool.chainDag.getEpochRef(blck, attestation.data.target.epoch)
     attestationsSeen = addr pool.candidates[candidateIdx.get]
     validation = Validation(
       aggregation_bits: attestation.aggregation_bits,
       aggregate_signature: attestation.signature)
-    participants = get_attesting_indices(
-      epochRef, attestation.data, validation.aggregation_bits)
 
   var found = false
   for a in attestationsSeen.attestations.mitems():
@@ -164,12 +150,11 @@ proc addResolved(
         a.validations.add(validation)
         pool.processAttestation(
           attestation.data.slot, participants, attestation.data.beacon_block_root,
-          attestation.data.target, wallSlot)
+          wallSlot)
 
         info "Attestation resolved",
           attestation = shortLog(attestation),
-          validations = a.validations.len(),
-          blockSlot = shortLog(blck.slot)
+          validations = a.validations.len()
 
         found = true
 
@@ -178,36 +163,15 @@ proc addResolved(
   if not found:
     attestationsSeen.attestations.add(AttestationEntry(
       data: attestation.data,
-      blck: blck,
       validations: @[validation]
     ))
     pool.processAttestation(
       attestation.data.slot, participants, attestation.data.beacon_block_root,
-      attestation.data.target, wallSlot)
+      wallSlot)
 
     info "Attestation resolved",
       attestation = shortLog(attestation),
-      validations = 1,
-      blockSlot = shortLog(blck.slot)
-
-proc addAttestation*(pool: var AttestationPool,
-                     attestation: Attestation,
-                     wallSlot: Slot) =
-  ## Add a verified attestation to the fork choice context
-  logScope: pcs = "atp_add_attestation"
-
-  # Fetch the target block or notify the block pool that it's needed
-  let blck = pool.chainDag.getOrResolve(
-    pool.quarantine,
-    attestation.data.beacon_block_root)
-
-  # If the block exist, add it to the fork choice context
-  # Otherwise delay until it resolves
-  if blck.isNil:
-    pool.addUnresolved(attestation)
-    return
-
-  pool.addResolved(blck, attestation, wallSlot)
+      validations = 1
 
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
@@ -261,7 +225,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
   # intended thing -- sure, _blocks_ have to be popular (via attestation)
   # but _attestations_ shouldn't have to be so frequently repeated, as an
   # artifact of this state-free, identical-across-clones choice basis. In
-  # addResolved, too, the new attestations get added to the end, while in
+  # addAttestation, too, the new attestations get added to the end, while in
   # these functions, it's reading from the beginning, et cetera. This all
   # needs a single unified strategy.
   for i in max(1, newBlockSlot.int64 - ATTESTATION_LOOKBACK.int64) .. newBlockSlot.int64:
@@ -354,30 +318,6 @@ proc getAggregatedAttestation*(pool: AttestationPool,
     return some(attestation)
 
   none(Attestation)
-
-proc resolve*(pool: var AttestationPool, wallSlot: Slot) =
-  ## Check attestations in our unresolved deque
-  ## if they can be integrated to the fork choice
-  logScope: pcs = "atp_resolve"
-
-  var
-    done: seq[Eth2Digest]
-    resolved: seq[tuple[blck: BlockRef, attestation: Attestation]]
-
-  for k, v in pool.unresolved.mpairs():
-    if (let blck = pool.chainDag.getRef(k); not blck.isNil()):
-      resolved.add((blck, v.attestation))
-      done.add(k)
-    elif v.tries > 8:
-      done.add(k)
-    else:
-      inc v.tries
-
-  for k in done:
-    pool.unresolved.del(k)
-
-  for a in resolved:
-    pool.addResolved(a.blck, a.attestation, wallSlot)
 
 proc selectHead*(pool: var AttestationPool, wallSlot: Slot): BlockRef =
   ## Trigger fork choice and returns the new head block.

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -867,8 +867,8 @@ proc start(node: BeaconNode) =
     version = fullVersionStr,
     nim = shortNimBanner(),
     timeSinceFinalization =
-      int64(finalizedHead.slot.toBeaconTime()) -
-      int64(node.beaconClock.now()),
+      finalizedHead.slot.toBeaconTime() -
+      node.beaconClock.now(),
     head = shortLog(head),
     finalizedHead = shortLog(finalizedHead),
     SLOTS_PER_EPOCH,

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -3,7 +3,7 @@
 import
   deques, tables,
   stew/endians2,
-  spec/[datatypes, crypto, digest],
+  spec/[datatypes, crypto],
   block_pools/block_pools_types,
   fork_choice/fork_choice_types
 
@@ -44,10 +44,6 @@ type
     ## TODO this could be a Table[AttestationData, seq[Validation] or something
     ##      less naive
 
-  UnresolvedAttestation* = object
-    attestation*: Attestation
-    tries*: int
-
   AttestationPool* = object
     ## The attestation pool keeps track of all attestations that potentially
     ## could be added to a block during block production.
@@ -65,8 +61,6 @@ type
 
     chainDag*: ChainDAGRef
     quarantine*: QuarantineRef
-
-    unresolved*: Table[Eth2Digest, UnresolvedAttestation]
 
     forkChoice*: ForkChoice
 

--- a/beacon_chain/block_pools/spec_cache.nim
+++ b/beacon_chain/block_pools/spec_cache.nim
@@ -121,6 +121,31 @@ proc is_valid_indexed_attestation*(
 
   ok()
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
+proc is_valid_indexed_attestation*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    epochRef: EpochRef, attesting_indices: HashSet[ValidatorIndex],
+    attestation: SomeAttestation, flags: UpdateFlags): Result[void, cstring] =
+  # This is a variation on `is_valid_indexed_attestation` that works directly
+  # with an attestation instead of first constructing an `IndexedAttestation`
+  # and then validating it - for the purpose of validating the signature, the
+  # order doesn't matter and we can proceed straight to validating the
+  # signature instead
+  if attesting_indices.len == 0:
+    return err("indexed_attestation: no attesting indices")
+
+  # Verify aggregate signature
+  if skipBLSValidation notin flags:
+     # TODO: fuse loops with blsFastAggregateVerify
+    let pubkeys = mapIt(
+      attesting_indices, epochRef.validator_keys[it])
+    if not verify_attestation_signature(
+        fork, genesis_validators_root, attestation.data,
+        pubkeys, attestation.signature):
+      return err("indexed attestation: signature verification failure")
+
+  ok()
+
 func makeAttestationData*(
     epochRef: EpochRef, bs: BlockSlot,
     committee_index: uint64): AttestationData =

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[tables, options],
+  std/[options, tables],
   # Status
   stew/results,
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -93,7 +93,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
                 data: data,
                 aggregation_bits: aggregation_bits,
                 signature: sig
-              ), data.slot)
+              ), [validatorIdx].toHashSet(), data.slot)
 
   proc proposeBlock(slot: Slot) =
     if rand(r, 1.0) > blockRatio:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -248,3 +248,27 @@ proc makeFullAttestations*(
 
     attestation.signature = agg.finish()
     result.add attestation
+
+iterator makeTestBlocks*(
+  state: HashedBeaconState,
+  parent_root: Eth2Digest,
+  cache: var StateCache,
+  blocks: int,
+  attested: bool,
+  flags: set[UpdateFlag] = {}
+): SignedBeaconBlock =
+  var
+    state = assignClone(state)
+    parent_root = parent_root
+  for _ in 0..<blocks:
+    let attestations = if attested:
+      makeFullAttestations(
+        state[].data, parent_root,
+        state[].data.slot, cache, flags)
+    else:
+      @[]
+
+    let blck = addTestBlock(
+      state[], parent_root, cache, attestations = attestations, flags = flags)
+    yield blck
+    parent_root = blck.root


### PR DESCRIPTION
This implements disparity, resolving a part of
https://github.com/status-im/nim-beacon-chain/issues/1367

* make BeaconTime a duration for fractional seconds
* factor out attestation/aggregate validation
* simplify recording of queued attestations
* simplify attestation signature check
* fix blocks_received metric
* add some trivial validation tests
* remove unresolved attestation table - attestations for unknown blocks
are dropped instead (cannot verify their signature)