### PR TITLE
update medalla troubleshooting

### DIFF
--- a/docs/the_nimbus_book/src/medalla-troubleshooting.md
+++ b/docs/the_nimbus_book/src/medalla-troubleshooting.md
@@ -25,9 +25,6 @@ If, after updating to the latest `devel`, you feel like your node is functioning
 
 The directory that stores the blockchain data of the testnet is `build/data/shared_medalla_0` (if you're connecting to another testnet, replace `medalla` with that testnet's name). Delete this folder to start over (for example, if you started building medalla with the wrong private keys).
 
-### Syncing
-If you’re experiencing sync problems, or have been running an old version of medalla, we recommend running `make clean-medalla` to restart your sync (make sure you’ve updated to the latest `devel` branch first though).
-
 ### Keeping up with the head of the chain
 
 As it stands, logging seems to be slowing down the client,  and quite a few users are experiencing trouble either catching up or keeping up with the head of the chain. You can use the `LOG_LEVEL=INFO` option to reduce verbosity and speed up the client.
@@ -47,3 +44,9 @@ make NODE_PARAMS="--nat:\"extip:35.124.65.104\" medalla
 ### Resource leaks
 
 If you're experiencing RAM related resource leaks, try restarting your client (**we recommend restarting every 6 hours** until we get to the bottom of this issue). If you have a [local Grafana setup](https://github.com/status-im/nim-beacon-chain#getting-metrics-from-a-local-testnet-client), you can try monitoring the severity of these leaks and playing around with the restart interval.
+
+### Syncing
+If you’re experiencing sync problems,  we recommend running `make clean-medalla` to restart your sync (make sure you’ve updated to the latest `devel` branch first though).
+
+> **Warning**: `make clean-medalla` will erase all of your syncing progress so far, so it should only be used as a last resort -- if your client gets stuck for a long time (because it's unable to find the right chain and/or stay with the same head value) and a normal restart doesn't improve things.
+


### PR DESCRIPTION
make it clear the `make clean-medalla` erases sync progress and should only be used as a last resort.