### PR TITLE
address issue #1580

### DIFF
--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -299,6 +299,7 @@ proc attestationValidator*(
 
   logScope: wallSlot
 
+  # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime - attestation.data.slot.toBeaconTime
   debug "Attestation received", delay
   let v = self.attestationPool[].validateAttestation(
@@ -339,6 +340,7 @@ proc aggregateValidator*(
 
   logScope: wallSlot
 
+  # Potential under/overflows are fine; would just create odd logs
   let delay =
     wallTime - signedAggregateAndProof.message.aggregate.data.slot.toBeaconTime
   debug "Aggregate received", delay

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -546,7 +546,7 @@ func check_attestation_inclusion*(data: AttestationData,
   static:
     doAssert SLOTS_PER_EPOCH >= MIN_ATTESTATION_INCLUSION_DELAY
   if data.slot + SLOTS_PER_EPOCH <= data.slot:
-    return err("Potentially malicious attestation data.slot")
+    return err("attestation data.slot overflow, malicious?")
 
   if not (data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= current_slot):
     return err("Attestation too new")

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -322,6 +322,10 @@ func get_block_root_at_slot*(state: BeaconState,
                              slot: Slot): Eth2Digest =
   # Return the block root at a recent ``slot``.
 
+  # Potential overflow/wrap shouldn't occur, as get_block_root_at_slot() called
+  # from internally controlled sources, but flag this explicitly, in case.
+  doAssert slot + SLOTS_PER_HISTORICAL_ROOT > slot
+
   doAssert state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
   doAssert slot < state.slot
   state.block_roots[slot mod SLOTS_PER_HISTORICAL_ROOT]
@@ -538,6 +542,12 @@ func check_attestation_target_epoch*(
 
 func check_attestation_inclusion*(data: AttestationData,
                                   current_slot: Slot): Result[void, cstring] =
+  # Check for overflow
+  static:
+    doAssert SLOTS_PER_EPOCH >= MIN_ATTESTATION_INCLUSION_DELAY
+  if data.slot + SLOTS_PER_EPOCH <= data.slot:
+    return err("Potentially malicious attestation data.slot")
+
   if not (data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= current_slot):
     return err("Attestation too new")
 


### PR DESCRIPTION
It also begins on:
> Long term, identify all the integers that can be controlled by an attacker, and carefully checks the related operations for overflow and underflow

By systematically having gone through all the addition and subtraction in the beacon_chain and validator phase 0 specs. Notably, doing so before with this eye would have caught both https://github.com/status-im/nim-beacon-chain/issues/1542 and this one, which suggests that not having found anything else of note at that level has some value.