### PR TITLE
address issue #1552

### DIFF
--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -51,7 +51,7 @@ type
     ##
     ## Invalid blocks are dropped immediately.
 
-    orphans*: Table[Eth2Digest, SignedBeaconBlock] ##\
+    orphans*: Table[(Eth2Digest, ValidatorSig), SignedBeaconBlock] ##\
     ## Blocks that have passed validation but that we lack a link back to tail
     ## for - when we receive a "missing link", we can use this data to build
     ## an entire branch

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -187,7 +187,7 @@ proc addRawBlock*(
 
     # The block might have been in either of `orphans` or `missing` - we don't
     # want any more work done on its behalf
-    quarantine.orphans.del(blockRoot)
+    quarantine.removeOrphan(signedBlock)
 
     # The block is resolved, now it's time to validate it to ensure that the
     # blocks we add to the database are clean for the given state
@@ -234,7 +234,7 @@ proc addRawBlock*(
   #      junk that's not part of the block graph
 
   if blck.parent_root in quarantine.missing or
-      blck.parent_root in quarantine.orphans:
+      containsOrphan(quarantine, signedBlock):
     debug "Unresolved block (parent missing or orphaned)",
       orphans = quarantine.orphans.len,
       missing = quarantine.missing.len


### PR DESCRIPTION
It's a pretty overarching issue with `sequtils` that they don't compose without allocating however many intermediate, complete `seq`s as function calls, even for easy cases. This is, of course, well-known, and 0-overhead functional libraries try to handle this, but this is enough here.

https://github.com/status-im/nim-beacon-chain/issues/1597 tracks this hardening more generally.

There's also a question of factoring out the quarantine better. Right now, it's haphazardly shared with `block_pools/clearance`, with all sorts of internal access required. Most of that could be ameliorated, but this PR aims to minimally and distinctly address the audit results.