### PR TITLE
fix req/resp protocol

### DIFF
--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -633,7 +633,7 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
       debug "Error, while reading getBlocks response",
             peer = peer, slot = req.slot, count = req.count,
             step = req.step, peer_speed = peer.netKbps(),
-            topics = "syncman", error = res.error()
+            topics = "syncman", error = $res.error()
     result = res
 
 template headAge(): uint64 =


### PR DESCRIPTION
per spec, we must half-close request stream - not doing so may lead to
failure of the other end to start processing our request leading to
timeouts.

In particular, this fixes many sync problems that have been seen on
medalla.

* remove safeClose - close no longer raises
* use per-chunk timeouts in request processing