### PR TITLE
await validator duties

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -510,7 +510,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.gcsafe, asyn
   beacon_head_slot.set slot.int64
 
   # Time passes in here..
-  asyncCheck node.handleValidatorDuties(lastSlot, slot)
+  await node.handleValidatorDuties(lastSlot, slot)
 
   let
     nextSlotStart = saturate(node.beaconClock.fromNow(nextSlot))


### PR DESCRIPTION
Validator duties proceed slot-by-slot - we should not start a new
validator duty iteration before the previous one is gone or we might run
into consistency and voting issues