### PR TITLE
remove chronos future tracking from default build

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -78,4 +78,4 @@ switch("warning", "ObservableStores:off")
 switch("warning", "LockLevel:off")
 
 # Useful for Chronos metrics.
---define:chronosFutureTracking
+#--define:chronosFutureTracking


### PR DESCRIPTION
uses a lot of memory, specially during sync