### PR TITLE
use LTO in release builds

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -9,9 +9,13 @@ if defined(release):
   if defined(macosx): # Clang
     switch("passC", "-flto=thin")
     switch("passL", "-flto=thin")
-  else:
+  elif defined(linux):
     switch("passC", "-flto=auto")
     switch("passL", "-flto=auto")
+  else:
+    # On windows, LTO needs more love and attention so the right linkers
+    # are used
+    discard
 
 if defined(windows):
   # disable timestamps in Windows PE headers - https://wiki.debian.org/ReproducibleBuilds/TimestampsInPEBinaries

--- a/config.nims
+++ b/config.nims
@@ -70,6 +70,11 @@ if not defined(macosx):
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")
 
+# `-flto` gives a significant improvement in processing speed, specially hash tree and state transition (basically any CPU-bound code implemented in nim)
+if defined(release):
+  switch("passC", "-flto")
+  switch("passL", "-flto")
+
 # The compiler doth protest too much, methinks, about all these cases where it can't
 # do its (N)RVO pass: https://github.com/nim-lang/RFCs/issues/230
 switch("warning", "ObservableStores:off")


### PR DESCRIPTION
This significantly (40%) speeds up block replay and hashing - for example replaying first 1000
blocks, without/with LTO:

```
[arnetheduck@tempus ncli]$ ../env.sh nim c -d:release ncli_db
[arnetheduck@tempus ncli]$ ./ncli_db bench --db:db --network:medalla --slots:1000
Loaded 215006 blocks, head slot 307400
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
   25468.481,        0.000,    25468.481,    25468.481,            1, Initialize DB
       0.297,        0.516,        0.053,       13.645,          721, Load block from database
      26.458,        0.000,       26.458,       26.458,            1, Load state from database
      20.737,        8.288,       11.096,      199.325,          690, Apply block
     333.069,       62.798,       45.225,      429.452,           31, Apply epoch block
       0.000,        0.000,        0.000,        0.000,            0, Database block store
```

```
[arnetheduck@tempus ncli]$ ../env.sh nim c -d:release --passc:-flto --passl:-flto --stacktrace:off ncli_db
[arnetheduck@tempus ncli]$ ./ncli_db bench --db:db --network:medalla --slots:1000
Loaded 215006 blocks, head slot 307400
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
   23903.006,        0.000,    23903.006,    23903.006,            1, Initialize DB
       0.253,        0.122,        0.047,        0.731,          721, Load block from database
      24.455,        0.000,       24.455,       24.455,            1, Load state from database
      18.734,        7.062,       10.346,      167.397,          690, Apply block
     194.869,       33.175,       29.311,      226.981,           31, Apply epoch block
```

Epoch processing is heavy on both arithmetics and hash caching, both of which get a
significant boost here.

This makes sense: nim creates lots of small functions spread out over many C files. A much
worse solution is to try to annotate code with `inline` - it copies functions to multiple
C files but still doesn't do intermodule optimizations significantly limiting the
compilers' ability to reason about the code, causing bloat and misrepresenting the usefulness
of a function to the call frequency analysis that drives actual (C-compiler) inlining and many
other optimizations.

In particular, many nim functions are part of `system` or the `C` backend - stack tracing,
memory allocation etc - nim's inlining system is pretty incomplete in that it does not deal
with these and many other cases.