### PR TITLE
improve slot processing speeds

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -43,7 +43,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Reverse order block add & get [Preset: mainnet]                                            OK
 + Simple block add&get [Preset: mainnet]                                                     OK
 + getRef returns nil for missing blocks                                                      OK
-+ loadTailState gets genesis block on first load [Preset: mainnet]                           OK
++ loading tail block works [Preset: mainnet]                                                 OK
 + updateHead updates head and headState [Preset: mainnet]                                    OK
 + updateStateData sanity [Preset: mainnet]                                                   OK
 ```
@@ -173,6 +173,7 @@ OK: 52/59 Fail: 0/59 Skip: 7/59
 + Access peers by key test                                                                   OK
 + Acquire from empty pool                                                                    OK
 + Acquire/Sorting and consistency test                                                       OK
++ Delete peer on release text                                                                OK
 + Iterators test                                                                             OK
 + Peer lifetime test                                                                         OK
 + Safe/Clear test                                                                            OK
@@ -181,7 +182,7 @@ OK: 52/59 Fail: 0/59 Skip: 7/59
 + addPeerNoWait() test                                                                       OK
 + deletePeer() test                                                                          OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## SSZ dynamic navigator
 ```diff
 + navigating fields                                                                          OK
@@ -253,4 +254,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 136/143 Fail: 0/143 Skip: 7/143
+OK: 137/144 Fail: 0/144 Skip: 7/144


### PR DESCRIPTION
about 40% better slot processing times (on top of LTO) - these don't do BLS but are used
heavily during replay (state transition = slot + block transition)

tests using a recent medalla state and advancing it 1000 slots:

```
./ncli slots --preState2:state-302271-3c1dbf19-c1f944bf.ssz --slot:1000 --postState2:xx.ssz
```
pre:

```

All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      39.236,        0.000,       39.236,       39.236,            1, Load state from file
       0.049,        0.002,        0.046,        0.063,          968, Apply slot
     256.504,       81.008,      213.471,      591.902,           32, Apply epoch slot
      28.597,        0.000,       28.597,       28.597,            1, Save state to file
```

cast:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      37.079,        0.000,       37.079,       37.079,            1, Load state from file
       0.042,        0.002,        0.040,        0.090,          968, Apply slot
     215.552,       68.763,      180.155,      500.103,           32, Apply epoch slot
      25.106,        0.000,       25.106,       25.106,            1, Save state to file
```

cast+rewards:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      40.049,        0.000,       40.049,       40.049,            1, Load state from file
       0.048,        0.001,        0.045,        0.060,          968, Apply slot
     164.981,       76.273,      142.099,      477.868,           32, Apply epoch slot
      28.498,        0.000,       28.498,       28.498,            1, Save state to file
```

cast+rewards+shr
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
      12.898,        0.000,       12.898,       12.898,            1, Load state from file
       0.039,        0.002,        0.038,        0.054,          968, Apply slot
     139.971,       68.797,      120.088,      428.844,           32, Apply epoch slot
      24.761,        0.000,       24.761,       24.761,            1, Save state to file

```