### PR TITLE
keep REJECT/IGNORE of messages failing validation for libp2p scoring

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -813,32 +813,32 @@ proc installMessageValidators(node: BeaconNode) =
       node.network.addValidator(
         getAttestationTopic(node.forkDigest, ci),
         # This proc needs to be within closureScope; don't lift out of loop.
-        proc(attestation: Attestation): bool =
+        proc(attestation: Attestation): ValidationResult =
           node.processor[].attestationValidator(attestation, ci))
 
   node.network.addValidator(
     getAggregateAndProofsTopic(node.forkDigest),
-    proc(signedAggregateAndProof: SignedAggregateAndProof): bool =
+    proc(signedAggregateAndProof: SignedAggregateAndProof): ValidationResult =
       node.processor[].aggregateValidator(signedAggregateAndProof))
 
   node.network.addValidator(
     node.topicBeaconBlocks,
-    proc (signedBlock: SignedBeaconBlock): bool =
+    proc (signedBlock: SignedBeaconBlock): ValidationResult =
       node.processor[].blockValidator(signedBlock))
 
   node.network.addValidator(
     getAttesterSlashingsTopic(node.forkDigest),
-    proc (attesterSlashing: AttesterSlashing): bool =
+    proc (attesterSlashing: AttesterSlashing): ValidationResult =
       node.processor[].attesterSlashingValidator(attesterSlashing))
 
   node.network.addValidator(
     getProposerSlashingsTopic(node.forkDigest),
-    proc (proposerSlashing: ProposerSlashing): bool =
+    proc (proposerSlashing: ProposerSlashing): ValidationResult =
       node.processor[].proposerSlashingValidator(proposerSlashing))
 
   node.network.addValidator(
     getVoluntaryExitsTopic(node.forkDigest),
-    proc (voluntaryExit: VoluntaryExit): bool =
+    proc (voluntaryExit: VoluntaryExit): ValidationResult =
       node.processor[].voluntaryExitValidator(voluntaryExit))
 
 proc stop*(node: BeaconNode) =

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -38,7 +38,7 @@ func getOrResolve*(dag: ChainDAGRef, quarantine: var QuarantineRef, root: Eth2Di
 proc addRawBlock*(
       dag: var ChainDAGRef, quarantine: var QuarantineRef,
       signedBlock: SignedBeaconBlock, onBlockAdded: OnBlockAdded
-     ): Result[BlockRef, BlockError] {.gcsafe.}
+     ): Result[BlockRef, (ValidationResult, BlockError)] {.gcsafe.}
 
 proc addResolvedBlock(
        dag: var ChainDAGRef, quarantine: var QuarantineRef,
@@ -124,7 +124,7 @@ proc addRawBlock*(
        dag: var ChainDAGRef, quarantine: var QuarantineRef,
        signedBlock: SignedBeaconBlock,
        onBlockAdded: OnBlockAdded
-     ): Result[BlockRef, BlockError] =
+     ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function.
 
@@ -140,8 +140,9 @@ proc addRawBlock*(
 
     # We should not call the block added callback for blocks that already
     # existed in the pool, as that may confuse consumers such as the fork
-    # choice.
-    return err Duplicate
+    # choice. While the validation result won't be accessed, it's IGNORE,
+    # according to the spec.
+    return err((EVRESULT_IGNORE, Duplicate))
 
   quarantine.missing.del(blockRoot)
 
@@ -154,7 +155,9 @@ proc addRawBlock*(
       finalizedHead = shortLog(dag.finalizedHead),
       tail = shortLog(dag.tail)
 
-    return err Unviable
+    # Doesn't correspond to any specific validation condition, and still won't
+    # be used, but certainly would be IGNORE.
+    return err((EVRESULT_IGNORE, Unviable))
 
   let parent = dag.blocks.getOrDefault(blck.parent_root)
 
@@ -165,7 +168,7 @@ proc addRawBlock*(
       notice "Invalid block slot",
         parentBlock = shortLog(parent)
 
-      return err Invalid
+      return err((EVRESULT_REJECT, Invalid))
 
     if (parent.slot < dag.finalizedHead.slot) or
         (parent.slot == dag.finalizedHead.slot and
@@ -182,7 +185,7 @@ proc addRawBlock*(
         finalizedHead = shortLog(dag.finalizedHead),
         tail = shortLog(dag.tail)
 
-      return err Unviable
+      return err((EVRESULT_IGNORE, Unviable))
 
     # The block might have been in either of `orphans` or `missing` - we don't
     # want any more work done on its behalf
@@ -210,7 +213,7 @@ proc addRawBlock*(
                             cache, dag.updateFlags + {slotProcessed}, restore):
       notice "Invalid block"
 
-      return err Invalid
+      return err((EVRESULT_REJECT, Invalid))
 
     # Careful, clearanceState.data has been updated but not blck - we need to
     # create the BlockRef first!
@@ -238,7 +241,7 @@ proc addRawBlock*(
       orphans = quarantine.orphans.len,
       missing = quarantine.missing.len
 
-    return err MissingParent
+    return err((EVRESULT_IGNORE, MissingParent))
 
   # This is an unresolved block - put its parent on the missing list for now...
   # TODO if we receive spam blocks, one heurestic to implement might be to wait
@@ -257,13 +260,14 @@ proc addRawBlock*(
     orphans = quarantine.orphans.len,
     missing = quarantine.missing.len
 
-  return err MissingParent
+  return err((EVRESULT_IGNORE, MissingParent))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/p2p-interface.md#beacon_block
 proc isValidBeaconBlock*(
        dag: ChainDAGRef, quarantine: var QuarantineRef,
        signed_beacon_block: SignedBeaconBlock, current_slot: Slot,
-       flags: UpdateFlags): Result[void, BlockError] =
+       flags: UpdateFlags):
+       Result[void, (ValidationResult, BlockError)] =
   logScope:
     topics = "clearance valid_blck"
     received_block = shortLog(signed_beacon_block.message)
@@ -281,14 +285,14 @@ proc isValidBeaconBlock*(
   if not (signed_beacon_block.message.slot <= current_slot + 1):
     debug "block is from a future slot",
       current_slot
-    return err(Invalid)
+    return err((EVRESULT_IGNORE, Invalid))
 
   # [IGNORE] The block is from a slot greater than the latest finalized slot --
   # i.e. validate that signed_beacon_block.message.slot >
   # compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
   if not (signed_beacon_block.message.slot > dag.finalizedHead.slot):
     debug "block is not from a slot greater than the latest finalized slot"
-    return err(Invalid)
+    return err((EVRESULT_IGNORE, Invalid))
 
   # [IGNORE] The block is the first block with valid signature received for the
   # proposer for the slot, signed_beacon_block.message.slot.
@@ -328,7 +332,7 @@ proc isValidBeaconBlock*(
       debug "block isn't first block with valid signature received for the proposer",
         blckRef = slotBlockRef,
         existing_block = shortLog(blck.message)
-      return err(Invalid)
+      return err((EVRESULT_IGNORE, Invalid))
 
   # [IGNORE] The block's parent (defined by block.parent_root) has been seen
   # (via both gossip and non-gossip sources) (a client MAY queue blocks for
@@ -347,7 +351,7 @@ proc isValidBeaconBlock*(
       current_slot = shortLog(current_slot)
     if not quarantine.add(dag, signed_beacon_block):
       debug "Block quarantine full"
-    return err(MissingParent)
+    return err((EVRESULT_IGNORE, MissingParent))
 
   # [REJECT] The current finalized_checkpoint is an ancestor of block -- i.e.
   # get_ancestor(store, block.parent_root,
@@ -360,11 +364,11 @@ proc isValidBeaconBlock*(
 
   if ancestor.isNil:
     debug "couldn't find ancestor block"
-    return err(Invalid)
+    return err((EVRESULT_IGNORE, Invalid)) # might just not have received block
 
   if not (finalized_checkpoint.root in [ancestor.root, Eth2Digest()]):
     debug "block not descendent of finalized block"
-    return err(Invalid)
+    return err((EVRESULT_REJECT, Invalid))
 
   # [REJECT] The block is proposed by the expected proposer_index for the
   # block's slot in the context of the current shuffling (defined by
@@ -377,13 +381,13 @@ proc isValidBeaconBlock*(
 
   if proposer.isNone:
     notice "cannot compute proposer for message"
-    return err(Invalid)
+    return err((EVRESULT_IGNORE, Invalid)) # basically an internal issue
 
   if proposer.get()[0] !=
       ValidatorIndex(signed_beacon_block.message.proposer_index):
     debug "block had unexpected proposer",
       expected_proposer = proposer.get()[0]
-    return err(Invalid)
+    return err((EVRESULT_REJECT, Invalid))
 
   # [REJECT] The proposer signature, signed_beacon_block.signature, is valid
   # with respect to the proposer_index pubkey.
@@ -397,6 +401,6 @@ proc isValidBeaconBlock*(
     debug "block failed signature verification",
       signature = shortLog(signed_beacon_block.signature)
 
-    return err(Invalid)
+    return err((EVRESULT_REJECT, Invalid))
 
   ok()

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1280,7 +1280,8 @@ proc subscribe*(node: Eth2Node, topic: string) {.async.} =
 
 proc addValidator*[MsgType](node: Eth2Node,
                             topic: string,
-                            msgValidator: proc(msg: MsgType): bool {.gcsafe.} ) =
+                            msgValidator: proc(msg: MsgType):
+                            ValidationResult {.gcsafe.} ) =
   # Validate messages as soon as subscribed
   proc execValidator(
       topic: string, message: GossipMsg): Future[bool] {.async.} =
@@ -1289,7 +1290,7 @@ proc addValidator*[MsgType](node: Eth2Node,
     try:
       let decompressed = snappy.decode(message.data, GOSSIP_MAX_SIZE)
       if decompressed.len > 0:
-        return msgValidator SSZ.decode(decompressed, MsgType)
+        return msgValidator(SSZ.decode(decompressed, MsgType)) == EVRESULT_ACCEPT
       else:
         # TODO penalize peer?
         debug "Failed to decompress gossip payload"

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -449,6 +449,12 @@ type
     stabilitySubnet*: uint64
     stabilitySubnetExpirationEpoch*: Epoch
 
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/p2p-interface.md#topics-and-messages
+  ValidationResult* = enum
+    EVRESULT_ACCEPT = 0
+    EVRESULT_REJECT = 1
+    EVRESULT_IGNORE = 2
+
 func shortValidatorKey*(state: BeaconState, validatorIdx: int): string =
     ($state.validators[validatorIdx].pubkey)[0..7]
 

--- a/tests/slashing_protection/test_slashing_interchange.nim
+++ b/tests/slashing_protection/test_slashing_interchange.nim
@@ -5,6 +5,8 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   std/[unittest, os],

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -5,6 +5,8 @@
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
   std/unittest,

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -304,7 +304,7 @@ suiteReport "Attestation pool processing" & preset():
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
-    doAssert: b10Add_clone.error == Duplicate
+    doAssert: b10Add_clone.error == (EVRESULT_IGNORE, Duplicate)
 
   wrappedTimedTest "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
     # Note: very sensitive to stack usage
@@ -388,7 +388,7 @@ suiteReport "Attestation pool processing" & preset():
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
-    doAssert: b10Add_clone.error == Duplicate
+    doAssert: b10Add_clone.error == (EVRESULT_IGNORE, Duplicate)
 
 
 suiteReport "Attestation validation " & preset():

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -207,7 +207,7 @@ suiteReport "Block pool processing" & preset():
 
   wrappedTimedTest "Reverse order block add & get" & preset():
     let missing = dag.addRawBlock(quarantine, b2, nil)
-    check: missing.error == MissingParent
+    check: missing.error == (EVRESULT_IGNORE, MissingParent)
 
     check:
       dag.get(b2.root).isNone() # Unresolved, shouldn't show up
@@ -253,7 +253,7 @@ suiteReport "Block pool processing" & preset():
       b11 = dag.addRawBlock(quarantine, b1, nil)
 
     check:
-      b11.error == Duplicate
+      b11.error == (EVRESULT_IGNORE, Duplicate)
       not b10[].isNil
 
   wrappedTimedTest "updateHead updates head and headState" & preset():
@@ -388,7 +388,7 @@ suiteReport "chain DAG finalization tests" & preset():
       # The late block is a block whose parent was finalized long ago and thus
       # is no longer a viable head candidate
       let status = dag.addRawBlock(quarantine, lateBlock, nil)
-      check: status.error == Unviable
+      check: status.error == (EVRESULT_IGNORE, Unviable)
 
     let
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)


### PR DESCRIPTION
Ths is for Gossipsub 1.1.

Pending libp2p API changes, it ultimately passes a `bool` back to libp2p in `eth2_network.addValidator(...)`, but remove that coarsening conversion and lib2b can see the exact validation result, for a clean lib2p bump + isolated change in nbc.