### PR TITLE
USE_LIBBACKTRACE=0: speed up compilation by 3.31%

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ DEPOSITS_DELAY := 0
 
 # "--define:release" cannot be added to config.nims
 ifeq ($(USE_LIBBACKTRACE), 0)
-NIM_PARAMS := $(NIM_PARAMS) -d:release --stacktrace:on --excessiveStackTrace:on --linetrace:on -d:disable_libbacktrace
+# Blame Jacek for the lack of line numbers in your stack traces ;-)
+NIM_PARAMS := $(NIM_PARAMS) -d:release --stacktrace:on --excessiveStackTrace:on --linetrace:off -d:disable_libbacktrace
 else
 NIM_PARAMS := $(NIM_PARAMS) -d:release
 endif

--- a/Makefile
+++ b/Makefile
@@ -111,9 +111,9 @@ endif
 
 DEPOSITS_DELAY := 0
 
-# "--define:release" implies "--stacktrace:off" and it cannot be added to config.nims
+# "--define:release" cannot be added to config.nims
 ifeq ($(USE_LIBBACKTRACE), 0)
-NIM_PARAMS := $(NIM_PARAMS) -d:debug -d:disable_libbacktrace
+NIM_PARAMS := $(NIM_PARAMS) -d:release --stacktrace:on --excessiveStackTrace:on --linetrace:on -d:disable_libbacktrace
 else
 NIM_PARAMS := $(NIM_PARAMS) -d:release
 endif


### PR DESCRIPTION
Inspired by https://github.com/status-im/nim-beacon-chain/pull/745#issuecomment-694424270