### PR TITLE
fix peer connection tracking

### DIFF
--- a/beacon_chain/peer_pool.nim
+++ b/beacon_chain/peer_pool.nim
@@ -600,6 +600,8 @@ proc hasPeer*[A, B](pool: PeerPool[A, B], key: B): bool {.inline.} =
   ## Returns ``true`` if peer with ``key`` present in PeerPool ``pool``.
   pool.registry.hasKey(key)
 
+template contains*[A, B](pool: PeerPool[A, B], key: B): bool = pool.hasPeer(key)
+
 proc getOrDefault*[A, B](pool: PeerPool[A, B], key: B): A {.inline.} =
   ## Retrieves the peer from PeerPool ``pool`` using key ``key``. If peer is
   ## not present, default initialization value for type ``A`` is returned

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -692,148 +692,153 @@ proc syncWorker[A, B](man: SyncManager[A, B], index: int) {.async.} =
     man.workers[index].status = SyncWorkerStatus.WaitingPeer
     let peer = await man.pool.acquire()
 
-    try:
-      let wallSlot = man.getLocalWallSlot()
-      let headSlot = man.getLocalHeadSlot()
-      var peerSlot = peer.getHeadSlot()
+    # Workaround for https://github.com/status-im/nim-chronos/issues/132
 
-      # We updating SyncQueue's last slot all the time
-      man.queue.updateLastSlot(wallSlot)
+    proc process() {.async.} =
+      try:
+        let wallSlot = man.getLocalWallSlot()
+        let headSlot = man.getLocalHeadSlot()
+        var peerSlot = peer.getHeadSlot()
 
-      debug "Peer's syncing status", wall_clock_slot = wallSlot,
-            remote_head_slot = peerSlot, local_head_slot = headSlot,
-            peer_score = peer.getScore(), peer = peer,
-            peer_speed = peer.netKbps(), topics = "syncman"
+        # We updating SyncQueue's last slot all the time
+        man.queue.updateLastSlot(wallSlot)
 
-      # Check if peer's head slot is bigger than our wall clock slot.
-      if peerSlot > wallSlot + man.toleranceValue:
-        # Our wall timer is broken, or peer's status information is invalid.
-        warn "Local timer is broken or peer's status information is invalid",
-              wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
-              local_head_slot = headSlot, peer = peer,
-              tolerance_value = man.toleranceValue, peer_speed = peer.netKbps(),
-              peer_score = peer.getScore(), topics = "syncman"
-        let failure = SyncFailure.init(SyncFailureKind.StatusInvalid, peer)
-        man.failures.add(failure)
-        continue
-
-      # Check if we need to update peer's status information
-      if peerAge >= man.maxStatusAge:
-        # Peer's status information is very old, its time to update it
-        man.workers[index].status = SyncWorkerStatus.UpdatingStatus
-        debug "Updating peer's status information", wall_clock_slot = wallSlot,
+        debug "Peer's syncing status", wall_clock_slot = wallSlot,
               remote_head_slot = peerSlot, local_head_slot = headSlot,
-              peer = peer, peer_score = peer.getScore(),
+              peer_score = peer.getScore(), peer = peer,
               peer_speed = peer.netKbps(), topics = "syncman"
 
-        let res = await peer.updateStatus()
-
-        if not(res):
-          peer.updateScore(PeerScoreNoStatus)
-          debug "Failed to get remote peer's status, exiting", peer = peer,
-                peer_score = peer.getScore(), peer_head_slot = peerSlot,
-                peer_speed = peer.netKbps(), topics = "syncman"
-          let failure = SyncFailure.init(SyncFailureKind.StatusDownload, peer)
+        # Check if peer's head slot is bigger than our wall clock slot.
+        if peerSlot > wallSlot + man.toleranceValue:
+          # Our wall timer is broken, or peer's status information is invalid.
+          warn "Local timer is broken or peer's status information is invalid",
+                wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
+                local_head_slot = headSlot, peer = peer,
+                tolerance_value = man.toleranceValue, peer_speed = peer.netKbps(),
+                peer_score = peer.getScore(), topics = "syncman"
+          let failure = SyncFailure.init(SyncFailureKind.StatusInvalid, peer)
           man.failures.add(failure)
-          continue
+          return
 
-        let newPeerSlot = peer.getHeadSlot()
-        if peerSlot >= newPeerSlot:
-          peer.updateScore(PeerScoreStaleStatus)
-          debug "Peer's status information is stale",
-                wall_clock_slot = wallSlot, remote_old_head_slot = peerSlot,
-                local_head_slot = headSlot, remote_new_head_slot = newPeerSlot,
+        # Check if we need to update peer's status information
+        if peerAge >= man.maxStatusAge:
+          # Peer's status information is very old, its time to update it
+          man.workers[index].status = SyncWorkerStatus.UpdatingStatus
+          debug "Updating peer's status information", wall_clock_slot = wallSlot,
+                remote_head_slot = peerSlot, local_head_slot = headSlot,
                 peer = peer, peer_score = peer.getScore(),
                 peer_speed = peer.netKbps(), topics = "syncman"
-        else:
-          debug "Peer's status information updated", wall_clock_slot = wallSlot,
-                remote_old_head_slot = peerSlot, local_head_slot = headSlot,
-                remote_new_head_slot = newPeerSlot, peer = peer,
+
+          let res = await peer.updateStatus()
+
+          if not(res):
+            peer.updateScore(PeerScoreNoStatus)
+            debug "Failed to get remote peer's status, exiting", peer = peer,
+                  peer_score = peer.getScore(), peer_head_slot = peerSlot,
+                  peer_speed = peer.netKbps(), topics = "syncman"
+            let failure = SyncFailure.init(SyncFailureKind.StatusDownload, peer)
+            man.failures.add(failure)
+            return
+
+          let newPeerSlot = peer.getHeadSlot()
+          if peerSlot >= newPeerSlot:
+            peer.updateScore(PeerScoreStaleStatus)
+            debug "Peer's status information is stale",
+                  wall_clock_slot = wallSlot, remote_old_head_slot = peerSlot,
+                  local_head_slot = headSlot, remote_new_head_slot = newPeerSlot,
+                  peer = peer, peer_score = peer.getScore(),
+                  peer_speed = peer.netKbps(), topics = "syncman"
+          else:
+            debug "Peer's status information updated", wall_clock_slot = wallSlot,
+                  remote_old_head_slot = peerSlot, local_head_slot = headSlot,
+                  remote_new_head_slot = newPeerSlot, peer = peer,
+                  peer_score = peer.getScore(), peer_speed = peer.netKbps(),
+                  topics = "syncman"
+            peer.updateScore(PeerScoreGoodStatus)
+            peerSlot = newPeerSlot
+
+        if (peerAge <= man.maxHeadAge) and (headAge <= man.maxHeadAge):
+          debug "We are in sync with peer, exiting", wall_clock_slot = wallSlot,
+                remote_head_slot = peerSlot, local_head_slot = headSlot,
+                peer = peer, peer_score = peer.getScore(),
+                peer_speed = peer.netKbps(), topics = "syncman"
+          return
+
+        man.workers[index].status = SyncWorkerStatus.Requesting
+        let req = man.queue.pop(peerSlot, peer)
+        if req.isEmpty():
+          # SyncQueue could return empty request in 2 cases:
+          # 1. There no more slots in SyncQueue to download (we are synced, but
+          #    our ``notInSyncEvent`` is not yet cleared).
+          # 2. Current peer's known head slot is too low to satisfy request.
+          #
+          # To avoid endless loop we going to wait for RESP_TIMEOUT time here.
+          # This time is enough for all pending requests to finish and it is also
+          # enough for main sync loop to clear ``notInSyncEvent``.
+          debug "Empty request received from queue, exiting", peer = peer,
+                local_head_slot = headSlot, remote_head_slot = peerSlot,
+                queue_input_slot = man.queue.inpSlot,
+                queue_output_slot = man.queue.outSlot,
+                queue_last_slot = man.queue.lastSlot,
+                peer_speed = peer.netKbps(), peer_score = peer.getScore(),
+                topics = "syncman"
+          await sleepAsync(RESP_TIMEOUT)
+          return
+
+        man.workers[index].status = SyncWorkerStatus.Downloading
+        debug "Creating new request for peer", wall_clock_slot = wallSlot,
+              remote_head_slot = peerSlot, local_head_slot = headSlot,
+              request_slot = req.slot, request_count = req.count,
+              request_step = req.step, peer = peer, peer_speed = peer.netKbps(),
+              peer_score = peer.getScore(), topics = "syncman"
+
+        let blocks = await man.getBlocks(peer, req)
+
+        if blocks.isOk:
+          let data = blocks.get()
+          let smap = getShortMap(req, data)
+          debug "Received blocks on request", blocks_count = len(data),
+                blocks_map = smap, request_slot = req.slot,
+                request_count = req.count, request_step = req.step,
+                peer = peer, peer_score = peer.getScore(),
+                peer_speed = peer.netKbps(), topics = "syncman"
+
+          if not(checkResponse(req, data)):
+            peer.updateScore(PeerScoreBadResponse)
+            warn "Received blocks sequence is not in requested range",
+                blocks_count = len(data), blocks_map = smap,
+                request_slot = req.slot, request_count = req.count,
+                request_step = req.step, peer = peer,
                 peer_score = peer.getScore(), peer_speed = peer.netKbps(),
                 topics = "syncman"
-          peer.updateScore(PeerScoreGoodStatus)
-          peerSlot = newPeerSlot
+            let failure = SyncFailure.init(SyncFailureKind.BadResponse, peer)
+            man.failures.add(failure)
+            return
 
-      if (peerAge <= man.maxHeadAge) and (headAge <= man.maxHeadAge):
-        debug "We are in sync with peer, exiting", wall_clock_slot = wallSlot,
-              remote_head_slot = peerSlot, local_head_slot = headSlot,
-              peer = peer, peer_score = peer.getScore(),
-              peer_speed = peer.netKbps(), topics = "syncman"
-        continue
+          # Scoring will happen in `syncUpdate`.
+          man.workers[index].status = SyncWorkerStatus.Processing
+          await man.queue.push(req, data)
 
-      man.workers[index].status = SyncWorkerStatus.Requesting
-      let req = man.queue.pop(peerSlot, peer)
-      if req.isEmpty():
-        # SyncQueue could return empty request in 2 cases:
-        # 1. There no more slots in SyncQueue to download (we are synced, but
-        #    our ``notInSyncEvent`` is not yet cleared).
-        # 2. Current peer's known head slot is too low to satisfy request.
-        #
-        # To avoid endless loop we going to wait for RESP_TIMEOUT time here.
-        # This time is enough for all pending requests to finish and it is also
-        # enough for main sync loop to clear ``notInSyncEvent``.
-        debug "Empty request received from queue, exiting", peer = peer,
-              local_head_slot = headSlot, remote_head_slot = peerSlot,
-              queue_input_slot = man.queue.inpSlot,
-              queue_output_slot = man.queue.outSlot,
-              queue_last_slot = man.queue.lastSlot,
-              peer_speed = peer.netKbps(), peer_score = peer.getScore(),
-              topics = "syncman"
-        await sleepAsync(RESP_TIMEOUT)
-        continue
-
-      man.workers[index].status = SyncWorkerStatus.Downloading
-      debug "Creating new request for peer", wall_clock_slot = wallSlot,
-            remote_head_slot = peerSlot, local_head_slot = headSlot,
-            request_slot = req.slot, request_count = req.count,
-            request_step = req.step, peer = peer, peer_speed = peer.netKbps(),
-            peer_score = peer.getScore(), topics = "syncman"
-
-      let blocks = await man.getBlocks(peer, req)
-
-      if blocks.isOk:
-        let data = blocks.get()
-        let smap = getShortMap(req, data)
-        debug "Received blocks on request", blocks_count = len(data),
-              blocks_map = smap, request_slot = req.slot,
-              request_count = req.count, request_step = req.step,
-              peer = peer, peer_score = peer.getScore(),
-              peer_speed = peer.netKbps(), topics = "syncman"
-
-        if not(checkResponse(req, data)):
-          peer.updateScore(PeerScoreBadResponse)
-          warn "Received blocks sequence is not in requested range",
-               blocks_count = len(data), blocks_map = smap,
-               request_slot = req.slot, request_count = req.count,
-               request_step = req.step, peer = peer,
-               peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-               topics = "syncman"
-          let failure = SyncFailure.init(SyncFailureKind.BadResponse, peer)
+          # Cleaning up failures.
+          man.failures.setLen(0)
+        else:
+          peer.updateScore(PeerScoreNoBlocks)
+          man.queue.push(req)
+          debug "Failed to receive blocks on request",
+                request_slot = req.slot, request_count = req.count,
+                request_step = req.step, peer = peer,
+                peer_score = peer.getScore(), peer_speed = peer.netKbps(),
+                topics = "syncman"
+          let failure = SyncFailure.init(SyncFailureKind.BlockDownload, peer)
           man.failures.add(failure)
-          continue
 
-        # Scoring will happen in `syncUpdate`.
-        man.workers[index].status = SyncWorkerStatus.Processing
-        await man.queue.push(req, data)
+      except CatchableError as exc:
+        debug "Unexpected exception happened", topics = "syncman",
+              excName = $exc.name, excMsg = exc.msg
+      finally:
+        man.pool.release(peer)
 
-        # Cleaning up failures.
-        man.failures.setLen(0)
-      else:
-        peer.updateScore(PeerScoreNoBlocks)
-        man.queue.push(req)
-        debug "Failed to receive blocks on request",
-              request_slot = req.slot, request_count = req.count,
-              request_step = req.step, peer = peer,
-              peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-              topics = "syncman"
-        let failure = SyncFailure.init(SyncFailureKind.BlockDownload, peer)
-        man.failures.add(failure)
-
-    except CatchableError as exc:
-      debug "Unexpected exception happened", topics = "syncman",
-            excName = $exc.name, excMsg = exc.msg
-    finally:
-      man.pool.release(peer)
+    await process()
 
 proc getWorkersStats[A, B](man: SyncManager[A, B]): tuple[map: string,
                                                           sleeping: int,


### PR DESCRIPTION
because of https://github.com/status-im/nim-chronos/issues/132, peers
are never removed from `connTable` meaning that we never try to
reconnect to them - it also prevents sync manager from returning peers
to the peer pool causing peer starvation

* fix conntable never being emptied leading to no reconnects
* fix sync manager never returning peer
* remove connection timeout - libp2p has a native timeout