### PR TITLE
minimal v0.12.3 update

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -110,6 +110,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + BASE_REWARD_FACTOR                                64                   [Preset: mainnet]   OK
 + BLS_WITHDRAWAL_PREFIX                             "0x00"               [Preset: mainnet]   OK
 + CHURN_LIMIT_QUOTIENT                              65536                [Preset: mainnet]   OK
+  CONFIG_NAME                                       "mainnet"            [Preset: mainnet]   Skip
   DEPOSIT_CHAIN_ID                                  1                    [Preset: mainnet]   Skip
   DEPOSIT_CONTRACT_ADDRESS                          "0x1234567890123456789012345678901234567 Skip
   DEPOSIT_NETWORK_ID                                1                    [Preset: mainnet]   Skip
@@ -139,7 +140,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + MAX_COMMITTEES_PER_SLOT                           64                   [Preset: mainnet]   OK
 + MAX_DEPOSITS                                      16                   [Preset: mainnet]   OK
 + MAX_EFFECTIVE_BALANCE                             32000000000          [Preset: mainnet]   OK
-+ MAX_EPOCHS_PER_CROSSLINK                          64                   [Preset: mainnet]   OK
 + MAX_PROPOSER_SLASHINGS                            16                   [Preset: mainnet]   OK
 + MAX_SEED_LOOKAHEAD                                4                    [Preset: mainnet]   OK
 + MAX_VALIDATORS_PER_COMMITTEE                      2048                 [Preset: mainnet]   OK
@@ -153,6 +153,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + MIN_SEED_LOOKAHEAD                                1                    [Preset: mainnet]   OK
 + MIN_SLASHING_PENALTY_QUOTIENT                     32                   [Preset: mainnet]   OK
 + MIN_VALIDATOR_WITHDRAWABILITY_DELAY               256                  [Preset: mainnet]   OK
++ PROPORTIONAL_SLASHING_MULTIPLIER                  3                    [Preset: mainnet]   OK
 + PROPOSER_REWARD_QUOTIENT                          8                    [Preset: mainnet]   OK
 + RANDOM_SUBNETS_PER_VALIDATOR                      1                    [Preset: mainnet]   OK
 + SAFE_SLOTS_TO_UPDATE_JUSTIFIED                    8                    [Preset: mainnet]   OK
@@ -167,7 +168,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + VALIDATOR_REGISTRY_LIMIT                          1099511627776        [Preset: mainnet]   OK
 + WHISTLEBLOWER_REWARD_QUOTIENT                     512                  [Preset: mainnet]   OK
 ```
-OK: 52/59 Fail: 0/59 Skip: 7/59
+OK: 52/60 Fail: 0/60 Skip: 8/60
 ## PeerPool testing suite
 ```diff
 + Access peers by key test                                                                   OK
@@ -195,6 +196,22 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + simple object fields                                                                       OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
+## Slashing Protection DB - Interchange [Preset: mainnet]
+```diff
++ Smoke test - Complete format [Preset: mainnet]                                             OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Slashing Protection DB [Preset: mainnet]
+```diff
++ Empty database [Preset: mainnet]                                                           OK
++ SP for block proposal - backtracking append                                                OK
++ SP for block proposal - linear append                                                      OK
++ SP for same epoch attestation target - backtracking append                                 OK
++ SP for same epoch attestation target - linear append                                       OK
++ SP for surrounded attestations                                                             OK
++ SP for surrounding attestations                                                            OK
+```
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Spec datatypes
 ```diff
 + Graffiti bytes                                                                             OK
@@ -254,4 +271,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 137/144 Fail: 0/144 Skip: 7/144
+OK: 145/153 Fail: 0/153 Skip: 8/153

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -63,8 +63,10 @@ task test, "Run all tests":
 
   # Generic SSZ test, doesn't use consensus objects minimal/mainnet presets
   buildAndRunBinary "test_fixture_ssz_generic_types", "tests/official/", """-d:chronicles_log_level=TRACE -d:chronicles_sinks="json[file]""""
-  # Consensus object SSZ tests
-  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
+
+  # Consensus object SSZ tests; TODO switch back to mainnet when vectors exist
+  buildAndRunBinary "test_fixture_ssz_consensus_objects", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=minimal -d:chronicles_sinks="json[file]""""
+
   # EF tests
   buildAndRunBinary "all_fixtures_require_ssz", "tests/official/", """-d:chronicles_log_level=TRACE -d:const_preset=mainnet -d:chronicles_sinks="json[file]""""
 

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -47,7 +47,7 @@ export
 # internal state that's gone through sanity checks already.
 
 const
-  SPEC_VERSION* = "0.12.2" ## \
+  SPEC_VERSION* = "0.12.3" ## \
   ## Spec version we're aiming to be compatible with, right now
 
   GENESIS_SLOT* = Slot(0)

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -138,12 +138,12 @@ const
 
 when const_preset == "mainnet":
   template defaultRuntimePreset*: auto = mainnetRuntimePreset
-  import ./presets/v0_12_2/mainnet
+  import ./presets/v0_12_3/mainnet
   export mainnet
 
 elif const_preset == "minimal":
   template defaultRuntimePreset*: auto = minimalRuntimePreset
-  import ./presets/v0_12_2/minimal
+  import ./presets/v0_12_3/minimal
   export minimal
 
 else:

--- a/beacon_chain/spec/presets/v0_12_3/mainnet.nim
+++ b/beacon_chain/spec/presets/v0_12_3/mainnet.nim
@@ -1,0 +1,170 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# This file contains constants that are part of the spec and thus subject to
+# serialization and spec updates.
+
+import
+  math
+
+{.experimental: "codeReordering".} # SLOTS_PER_EPOCH is use before being defined in spec
+
+const
+  # Misc
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L6
+
+  MAX_COMMITTEES_PER_SLOT* {.intdefine.}: uint64 = 64
+
+  TARGET_COMMITTEE_SIZE*: uint64 = 128 ##\
+  ## Number of validators in the committee attesting to one shard
+  ## Per spec:
+  ## For the safety of crosslinks `TARGET_COMMITTEE_SIZE` exceeds
+  ## [the recommended minimum committee size of 111](https://vitalik.ca/files/Ithaca201807_Sharding.pdf);
+  ## with sufficient active validators (at least
+  ## `SLOTS_PER_EPOCH * TARGET_COMMITTEE_SIZE`), the shuffling algorithm ensures
+  ## committee sizes at least `TARGET_COMMITTEE_SIZE`. (Unbiasable randomness
+  ## with a Verifiable Delay Function (VDF) will improve committee robustness
+  ## and lower the safe minimum committee size.)
+
+  MAX_VALIDATORS_PER_COMMITTEE*: uint64 = 2048 ##\
+  ## votes
+
+  MIN_PER_EPOCH_CHURN_LIMIT*: uint64 = 4
+  CHURN_LIMIT_QUOTIENT*: uint64 = 2'u64 ^ 16
+  SHUFFLE_ROUND_COUNT*: uint64 = 90
+
+  HYSTERESIS_QUOTIENT*: uint64 = 4
+  HYSTERESIS_DOWNWARD_MULTIPLIER*: uint64 = 1
+  HYSTERESIS_UPWARD_MULTIPLIER*: uint64 = 5
+
+  PROPORTIONAL_SLASHING_MULTIPLIER* = 3
+
+  # Gwei values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L61
+
+  MIN_DEPOSIT_AMOUNT*: uint64 = 2'u64^0 * 10'u64^9 ##\
+  ## Minimum amounth of ETH that can be deposited in one call - deposits can
+  ## be used either to top up an existing validator or commit to a new one
+
+  MAX_EFFECTIVE_BALANCE*: uint64 = 2'u64^5 * 10'u64^9 ##\
+  ## Maximum amounth of ETH that can be deposited in one call
+
+  EJECTION_BALANCE*: uint64 = 2'u64^4 * 10'u64^9 ##\
+  ## Once the balance of a validator drops below this, it will be ejected from
+  ## the validator pool
+
+  EFFECTIVE_BALANCE_INCREMENT*: uint64 = 2'u64^0 * 10'u64^9
+
+  # Initial values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L73
+  BLS_WITHDRAWAL_PREFIX*: byte = 0
+
+  # Time parameters
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L80
+  SECONDS_PER_SLOT* {.intdefine.}: uint64 = 12'u64 # Compile with -d:SECONDS_PER_SLOT=1 for 12x faster slots
+  ## TODO consistent time unit across projects, similar to C++ chrono?
+
+  MIN_ATTESTATION_INCLUSION_DELAY*: uint64 = 1 ##\
+  ## (12 seconds)
+  ## Number of slots that attestations stay in the attestation
+  ## pool before being added to a block.
+  ## The attestation delay exists so that there is time for attestations to
+  ## propagate before the block is created.
+  ## When creating an attestation, the validator will look at the best
+  ## information known to at that time, and may not revise it during the same
+  ## slot (see `is_double_vote`) - the delay gives the validator a chance to
+  ## wait towards the end of the slot and still have time to publish the
+  ## attestation.
+
+  SLOTS_PER_EPOCH* {.intdefine.}: uint64 = 32 ##\
+  ## (~6.4 minutes)
+  ## slots that make up an epoch, at the end of which more heavy
+  ## processing is done
+  ## Compile with -d:SLOTS_PER_EPOCH=4 for shorter epochs
+
+  MIN_SEED_LOOKAHEAD*: uint64 = 1 ##\
+  ## epochs (~6.4 minutes)
+
+  MAX_SEED_LOOKAHEAD*: uint64 = 4 ##\
+  ## epochs (~25.6 minutes)
+
+  EPOCHS_PER_ETH1_VOTING_PERIOD*: uint64 = 32 ##\
+  ##  epochs (~3.4 hours)
+
+  SLOTS_PER_HISTORICAL_ROOT*: uint64 = 8192 ##\
+  ## slots (13 hours)
+
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY*: uint64 = 2'u64^8 ##\
+  ## epochs (~27 hours)
+
+  SHARD_COMMITTEE_PERIOD*: uint64 = 256 # epochs (~27 hours)
+
+  MAX_EPOCHS_PER_CROSSLINK*: uint64 = 2'u64^6 ##\
+  ## epochs (~7 hours)
+
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY*: uint64 = 2'u64^2 ##\
+  ## epochs (25.6 minutes)
+
+  # State vector lengths
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L108
+
+  EPOCHS_PER_HISTORICAL_VECTOR*: uint64 = 65536 ##\
+  ## epochs (~0.8 years)
+
+  EPOCHS_PER_SLASHINGS_VECTOR*: uint64 = 8192 ##\
+  ## epochs (~36 days)
+
+  HISTORICAL_ROOTS_LIMIT*: uint64 = 16777216 ##\
+  ## epochs (~26,131 years)
+
+  VALIDATOR_REGISTRY_LIMIT*: uint64 = 1099511627776'u64
+
+  # Reward and penalty quotients
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L120
+  BASE_REWARD_FACTOR*: uint64 = 2'u64^6
+  WHISTLEBLOWER_REWARD_QUOTIENT*: uint64 = 2'u64^9
+  PROPOSER_REWARD_QUOTIENT*: uint64 = 2'u64^3
+  INACTIVITY_PENALTY_QUOTIENT*: uint64 = 2'u64^24
+  MIN_SLASHING_PENALTY_QUOTIENT*: uint64 = 32 # 2^5
+
+  # Max operations per block
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L134
+  MAX_PROPOSER_SLASHINGS*: uint64 = 2'u64 ^ 4
+  MAX_ATTESTER_SLASHINGS*: uint64 = 2'u64 ^ 1
+  MAX_ATTESTATIONS*: uint64 = 2'u64 ^ 7
+  MAX_DEPOSITS*: uint64 = 2'u64 ^ 4
+  MAX_VOLUNTARY_EXITS*: uint64 = 2'u64 ^ 4
+
+  # Fork choice
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L32
+  SAFE_SLOTS_TO_UPDATE_JUSTIFIED*: uint64 = 8 # 96 seconds
+
+  # Validators
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L38
+  ETH1_FOLLOW_DISTANCE* {.intdefine.}: uint64 = 1024 # blocks ~ 4 hours
+  TARGET_AGGREGATORS_PER_COMMITTEE*: uint64 = 16 # validators
+  RANDOM_SUBNETS_PER_VALIDATOR*: uint64 = 1 # subnet
+  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION*: uint64 = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* {.intdefine.}: uint64 = 14 # (estimate from Eth1 mainnet)
+
+  # Deposit contract
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/mainnet/phase0.yaml#L52
+
+  # Ethereum PoW Mainnet
+  # TODO These violate the spec (this is a temporary change to allow `make medalla` to work)
+  DEPOSIT_CHAIN_ID* = 5
+  DEPOSIT_NETWORK_ID* = 5

--- a/beacon_chain/spec/presets/v0_12_3/minimal.nim
+++ b/beacon_chain/spec/presets/v0_12_3/minimal.nim
@@ -1,0 +1,148 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+# This file contains constants that are part of the spec and thus subject to
+# serialization and spec updates.
+
+import
+  math
+
+{.experimental: "codeReordering".} # SLOTS_PER_EPOCH is use before being defined in spec
+
+const
+  # Misc
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L4
+
+  # Changed
+  MAX_COMMITTEES_PER_SLOT*: uint64 = 4
+  TARGET_COMMITTEE_SIZE*: uint64 = 4
+
+  # Unchanged
+  MAX_VALIDATORS_PER_COMMITTEE*: uint64 = 2048
+  MIN_PER_EPOCH_CHURN_LIMIT*: uint64 = 4
+  CHURN_LIMIT_QUOTIENT*: uint64 = 2'u64 ^ 16
+
+  # Changed
+  SHUFFLE_ROUND_COUNT*: uint64 = 10
+
+  # Unchanged
+  HYSTERESIS_QUOTIENT*: uint64 = 4
+  HYSTERESIS_DOWNWARD_MULTIPLIER*: uint64 = 1
+  HYSTERESIS_UPWARD_MULTIPLIER*: uint64 = 5
+
+  PROPORTIONAL_SLASHING_MULTIPLIER* = 3
+
+  # Gwei values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L61
+
+  # Changed
+  ETH1_FOLLOW_DISTANCE* {.intdefine.}: uint64 = 16 # blocks
+
+  # Unchanged
+  MIN_DEPOSIT_AMOUNT*: uint64 = 2'u64^0 * 10'u64^9
+  MAX_EFFECTIVE_BALANCE*: uint64 = 2'u64^5 * 10'u64^9
+  EJECTION_BALANCE*: uint64 = 2'u64^4 * 10'u64^9
+  EFFECTIVE_BALANCE_INCREMENT*: uint64 = 2'u64^0 * 10'u64^9
+
+  # Initial values
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L73
+
+  BLS_WITHDRAWAL_PREFIX*: byte = 0
+
+  # Time parameters
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L80
+  # Changed: Faster to spin up testnets, but does not give validator
+  # reasonable warning time for genesis
+
+  # Unchanged
+  SECONDS_PER_SLOT*{.intdefine.}: uint64 = 6
+
+  # Unchanged
+  MIN_ATTESTATION_INCLUSION_DELAY*: uint64 = 1
+
+  # Changed
+  SLOTS_PER_EPOCH* {.intdefine.}: uint64 = 8
+
+  # Unchanged
+  MIN_SEED_LOOKAHEAD*: uint64 = 1
+  MAX_SEED_LOOKAHEAD*: uint64 = 4
+
+  # Changed
+  EPOCHS_PER_ETH1_VOTING_PERIOD*: uint64 = 4
+  SLOTS_PER_HISTORICAL_ROOT*: uint64 = 64
+
+  # Unchanged
+  MIN_VALIDATOR_WITHDRAWABILITY_DELAY*: uint64 = 2'u64^8
+
+  SHARD_COMMITTEE_PERIOD*: uint64 = 64 # epochs
+
+  # Unchanged
+  MAX_EPOCHS_PER_CROSSLINK*: uint64 = 4
+
+  # Changed
+  MIN_EPOCHS_TO_INACTIVITY_PENALTY*: uint64 = 2'u64^2
+
+  # State vector lengths
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L108
+
+  # Changed
+  EPOCHS_PER_HISTORICAL_VECTOR*: uint64 = 64
+  EPOCHS_PER_SLASHINGS_VECTOR*: uint64 = 64
+
+  # Unchanged
+  HISTORICAL_ROOTS_LIMIT*: uint64 = 16777216
+  VALIDATOR_REGISTRY_LIMIT*: uint64 = 1099511627776'u64
+
+  # Reward and penalty quotients
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L120
+
+  BASE_REWARD_FACTOR*: uint64 = 2'u64^6
+  WHISTLEBLOWER_REWARD_QUOTIENT*: uint64 = 2'u64^9
+  PROPOSER_REWARD_QUOTIENT*: uint64 = 2'u64^3
+  INACTIVITY_PENALTY_QUOTIENT*: uint64 = 2'u64^24
+  MIN_SLASHING_PENALTY_QUOTIENT*: uint64 = 32 # 2^5
+
+  # Max operations per block
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L134
+
+  MAX_PROPOSER_SLASHINGS*: uint64 = 2'u64 ^ 4
+  MAX_ATTESTER_SLASHINGS*: uint64 = 2'u64 ^ 1
+  MAX_ATTESTATIONS*: uint64 = 2'u64 ^ 7
+  MAX_DEPOSITS*: uint64 = 2'u64 ^ 4
+  MAX_VOLUNTARY_EXITS*: uint64 = 2'u64 ^ 4
+
+  # Deposit contract
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L52
+
+  # Ethereum Goerli testnet
+  DEPOSIT_CHAIN_ID* = 5
+  DEPOSIT_NETWORK_ID* = 5
+
+  # Fork choice
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L32
+
+  # Changed
+  SAFE_SLOTS_TO_UPDATE_JUSTIFIED*: uint64 = 2
+
+  # Validators
+  # ---------------------------------------------------------------
+  # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/configs/minimal/phase0.yaml#L38
+
+  # Unchanged
+  TARGET_AGGREGATORS_PER_COMMITTEE*: uint64 = 16 # validators
+  RANDOM_SUBNETS_PER_VALIDATOR*: uint64 = 1 # subnet
+  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION*: uint64 = 256 # epochs ~ 27 hours
+  SECONDS_PER_ETH1_BLOCK* {.intdefine.}: uint64 = 14 # estimate from Eth1 mainnet)

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -91,6 +91,7 @@ else:
 
 const IgnoreKeys = [
   # Ignore all non-numeric types
+  "CONFIG_NAME",
   "DEPOSIT_CONTRACT_ADDRESS",
   "GENESIS_FORK_VERSION",
   "SHARD_BLOCK_OFFSETS",

--- a/tests/official/test_fixture_rewards.nim
+++ b/tests/official/test_fixture_rewards.nim
@@ -19,7 +19,11 @@ import
   ../testutil,
   ./fixtures_utils
 
-const RewardsDir = SszTestsDir/const_preset/"phase0"/"rewards"/"core"/"pyspec_tests"
+const
+  RewardsDirBase = SszTestsDir/const_preset/"phase0"/"rewards"
+  RewardsDirBasic = RewardsDirBase/"basic"/"pyspec_tests"
+  RewardsDirLeak = RewardsDirBase/"leak"/"pyspec_tests"
+  RewardsDirRandom = RewardsDirBase/"random"/"pyspec_tests"
 
 # https://github.com/ethereum/eth2.0-specs/tree/v0.12.2/tests/formats/rewards#rewards-tests
 type Deltas = object
@@ -32,12 +36,12 @@ func compareDeltas(
   deltas.rewards.asSeq == rewardsPenalties[0] and
     deltas.penalties.asSeq == rewardsPenalties[1]
 
-proc runTest(identifier: string) =
+proc runTest(rewardsDir, identifier: string) =
   # We wrap the tests in a proc to avoid running out of globals
   # in the future: Nim supports up to 3500 globals
   # but unittest with the macro/templates put everything as globals
   # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
-  let testDir = RewardsDir / identifier
+  let testDir = rewardsDir / identifier
 
   proc `testImpl _ rewards _ identifier`() =
     timedTest "Rewards" & " - " & identifier & preset():
@@ -76,5 +80,6 @@ proc runTest(identifier: string) =
   `testImpl _ rewards _ identifier`()
 
 suiteReport "Official - Rewards " & preset():
-  for kind, path in walkDir(RewardsDir, true):
-    runTest(path)
+  for rewardsDir in [RewardsDirBasic, RewardsDirLeak, RewardsDirRandom]:
+    for kind, path in walkDir(rewardsDir, true):
+      runTest(rewardsDir, path)


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/releases/tag/v0.12.3

Doesn't do the niceties such as going through the spec refs, etc.

It also doesn't address
> At the bare minimum, please update the gossipsub message-id ASAP (https://github.com/ethereum/eth2.0-specs/pull/2044)!

Regarding the mainnet -> minimal change of ssz_static, https://github.com/ethereum/eth2.0-specs/issues/2076