### PR TITLE
Keystore: Fix 32-bit derivation paths on 32-bit arch

### DIFF
--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -123,7 +123,7 @@ suiteReport "Keystore":
                                   KeystorePass password,
                                   salt=salt, iv=iv,
                                   description = "This is a test keystore that uses PBKDF2 to secure the secret.",
-                                  path = validateKeyPath "m/12381/60/0/0")
+                                  path = validateKeyPath("m/12381/60/0/0").expect("Valid Keypath"))
     var
       encryptJson = parseJson Json.encode(keystore)
       pbkdf2Json = parseJson(pbkdf2Vector)
@@ -137,7 +137,7 @@ suiteReport "Keystore":
                                   KeystorePass password,
                                   salt=salt, iv=iv,
                                   description = "This is a test keystore that uses scrypt to secure the secret.",
-                                  path = validateKeyPath "m/12381/60/3141592653/589793238")
+                                  path = validateKeyPath("m/12381/60/3141592653/589793238").expect("Valid keypath"))
     var
       encryptJson = parseJson Json.encode(keystore)
       scryptJson = parseJson(scryptVector)


### PR DESCRIPTION
This fixes #1701.

Also this adds a comment on the exceptional case where we:
1. forget to validate the key derivation path
2. try to derive a child secret key
3. We have an exception in the derivation process

In that case we might want to BurnMem the secret keys? #1714

Normally this scenario is enforced impossible via the type-system as `TaintedString` -> `KeyPath` conversion has to go through `validateKeyPath`

cc @eschorn1 