### PR TITLE
CI: Fix caching of EF fixtures + separate submodules install 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,12 @@ jobs:
           #   make -j$ncpu ARCH_OVERRIDE=$PLATFORM fetch-dlls
           # fi
 
+      - name: Prepare submodules & dependencies
+        shell: bash
+        working-directory: nim-beacon-chain
+        run: |
+          make -j$ncpu deps
+
       - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
         if: matrix.target.TEST_KIND == 'unit-tests'
         shell: bash
@@ -245,7 +251,7 @@ jobs:
         id: fixtures-cache
         uses: actions/cache@v1
         with:
-          path: fixturesCache
+          path: nim-beacon-chain/fixturesCache
           key: 'scenarios-${{ steps.fixtures_version.outputs.fixtures }}'
 
       - name: Get the Ethereum Foundation fixtures

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,8 +192,7 @@ jobs:
           path: nim-beacon-chain/NimBinaries
           key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
 
-      - name: Build Nim and associated tools
-        if: steps.nim-cache.outputs.cache-hit != 'true'
+      - name: Build Nim and NBC dependencies
         shell: bash
         working-directory: nim-beacon-chain
         run: |
@@ -220,12 +219,6 @@ jobs:
           # if [[ '${{ runner.os }}' == 'Windows' ]]; then
           #   make -j$ncpu ARCH_OVERRIDE=$PLATFORM fetch-dlls
           # fi
-
-      - name: Prepare submodules & dependencies
-        shell: bash
-        working-directory: nim-beacon-chain
-        run: |
-          make -j$ncpu deps
 
       - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
         if: matrix.target.TEST_KIND == 'unit-tests'


### PR DESCRIPTION
This PR does 2 things

1. It fixes the cache path for EF fixtures 
![image](https://user-images.githubusercontent.com/22738317/94249088-aecd9880-ff1f-11ea-9efd-9d7ff355acdd.png)

2. It separates submodule/libraries installation from the compilation of the beacon node so that we better account for our build time:

![image](https://user-images.githubusercontent.com/22738317/94249195-d3c20b80-ff1f-11ea-8476-3ad10ea0e5aa.png)

