### PR TITLE
Nim define for disabling LTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,18 @@ make -j$(nproc) NIMFLAGS="-d:release" USE_MULTITAIL=yes eth2_network_simulation
 make USE_LIBBACKTRACE=0 # expect the resulting binaries to be 2-3 times slower
 ```
 
+- disable `-march=native` because you want to run the binary on a different machine than the one you're building it on:
+
+```bash
+make NIMFLAGS="-d:disableMarchNative" beacon_node
+```
+
+- disable link-time optimisation (LTO):
+
+```bash
+make NIMFLAGS="-d:disableLTO" beacon_node
+```
+
 - publish a book using [mdBook](https://github.com/rust-lang/mdBook) from sources in "docs/" to GitHub pages:
 
 ```bash

--- a/config.nims
+++ b/config.nims
@@ -5,7 +5,7 @@ else:
 
 # `-flto` gives a significant improvement in processing speed, specially hash tree and state transition (basically any CPU-bound code implemented in nim)
 # With LTO enabled, optimization flags should be passed to both compiler and linker!
-if defined(release):
+if defined(release) and not defined(disableLTO):
   if defined(macosx): # Clang
     switch("passC", "-flto=thin")
     switch("passL", "-flto=thin")


### PR DESCRIPTION
LTO disabled:

```text
$ rm -rf nimcache; time make NIMFLAGS="-d:disableLTO" beacon_node
real	2m20.616s
user	10m9.889s
sys	0m51.908s

$ time make NIMFLAGS="-d:disableLTO" beacon_node
real	1m25.439s
user	1m45.581s
sys	0m23.959s
```

LTO enabled:

```text
$ rm -rf nimcache; time make beacon_node
real	2m17.761s
user	10m26.322s
sys	0m55.449s

$ time make beacon_node
real	2m2.465s
user	9m0.609s
sys	0m34.250s
```

So rebuilds on a warm cache are faster with LTO disabled, which might be relevant during development.