### PR TITLE
Actions cache fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,14 +220,6 @@ jobs:
           #   make -j$ncpu ARCH_OVERRIDE=$PLATFORM fetch-dlls
           # fi
 
-      - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
-        if: matrix.target.TEST_KIND == 'unit-tests'
-        shell: bash
-        working-directory: nim-beacon-chain
-        run: |
-          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" beacon_node
-          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" validator_client
-
       - name: Get latest fixtures commit hash
         if: matrix.target.TEST_KIND == 'unit-tests'
         id: fixtures_version
@@ -255,6 +247,14 @@ jobs:
         working-directory: nim-beacon-chain
         run: |
           scripts/setup_official_tests.sh fixturesCache
+
+      - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
+        if: matrix.target.TEST_KIND == 'unit-tests'
+        shell: bash
+        working-directory: nim-beacon-chain
+        run: |
+          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" beacon_node
+          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" validator_client
 
       - name: Run nim-beacon-chain tests
         if: matrix.target.TEST_KIND == 'unit-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Restore MinGW-W64 (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-mingw-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: /external/mingw-${{ matrix.target.cpu }}
           key: 'mingw-${{ matrix.target.cpu }}'
@@ -134,7 +134,7 @@ jobs:
       - name: Restore Nim DLLs dependencies (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-dlls-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: /external/dlls-${{ matrix.target.cpu }}
           key: 'dlls-${{ matrix.target.cpu }}'
@@ -187,7 +187,7 @@ jobs:
 
       - name: Restore prebuilt Nim binaries from cache
         id: nim-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: nim-beacon-chain/NimBinaries
           key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
@@ -242,10 +242,10 @@ jobs:
       - name: Restore Ethereum Foundation fixtures from cache
         if: matrix.target.TEST_KIND == 'unit-tests'
         id: fixtures-cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: nim-beacon-chain/fixturesCache
-          key: 'scenarios-${{ steps.fixtures_version.outputs.fixtures }}'
+          key: 'eth2-scenarios-${{ steps.fixtures_version.outputs.fixtures }}'
 
       - name: Get the Ethereum Foundation fixtures
         if: >


### PR DESCRIPTION
This:
- uses cache@v2
- changes the cache key for the EF fixtures has the cache got corrupted between https://github.com/status-im/nim-beacon-chain/commit/a02a9b3dc8aff01ed8439f9bf4267ba472fc67dc and https://github.com/status-im/nim-beacon-chain/commit/f96ad87d28ce6751a09acb96fc96eb449b6ff42e

![image](https://user-images.githubusercontent.com/22738317/94269811-776ee400-ff3f-11ea-982d-e83b889fadf5.png)
