### PR TITLE
Slash protection fixes

### DIFF
--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -566,3 +566,41 @@ suiteReport "Slashing Protection DB" & preset():
           fakeValidator(100),
           Epoch 0, Epoch 21
         ).error.kind == SurroundingVote
+
+  wrappedTimedTest "Attestation ordering #1698":
+    block:
+      let db = SlashingProtectionDB.init(default(Eth2Digest), kvStore MemStoreRef.init())
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 1, Epoch 2,
+        fakeRoot(20)
+      )
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 8, Epoch 10,
+        fakeRoot(20)
+      )
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 14, Epoch 15,
+        fakeRoot(20)
+      )
+
+      # The current list is, 2 -> 10 -> 15
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 3, Epoch 6,
+        fakeRoot(20)
+      )
+
+      # The current list is 2 -> 6 -> 10 -> 15
+
+      check:
+        db.checkSlashableAttestation(
+          fakeValidator(100),
+          Epoch 7, Epoch 11
+        ).error.kind == SurroundingVote

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -604,3 +604,25 @@ suiteReport "Slashing Protection DB" & preset():
           fakeValidator(100),
           Epoch 7, Epoch 11
         ).error.kind == SurroundingVote
+
+  wrappedTimedTest "Test valid attestation #1699":
+    block:
+      let db = SlashingProtectionDB.init(default(Eth2Digest), kvStore MemStoreRef.init())
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 10, Epoch 20,
+        fakeRoot(20)
+      )
+
+      db.registerAttestation(
+        fakeValidator(100),
+        Epoch 40, Epoch 50,
+        fakeRoot(20)
+      )
+
+      check:
+        db.checkSlashableAttestation(
+          fakeValidator(100),
+          Epoch 20, Epoch 30
+        ).isOk


### PR DESCRIPTION
This is a hotfix for issues raised in audit #1698 and #1699 

I've also removed any clever attempts to terminate the linked list scanning early for attestations as it was buggy and a complex logic.

Should close #1741 