### PR TITLE
Run setup_offficial_test even with cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,10 @@ jobs:
           path: nim-beacon-chain/fixturesCache
           key: 'eth2-scenarios-${{ steps.fixtures_version.outputs.fixtures }}'
 
+      # Important: even with a cache hit, this should be run
+      # as it symlinks the cached items in their proper place
       - name: Get the Ethereum Foundation fixtures
-        if: >
-          matrix.target.TEST_KIND == 'unit-tests' &&
-          steps.fixtures-cache.outputs.cache-hit != 'true'
+        if: matrix.target.TEST_KIND == 'unit-tests'
         shell: bash
         working-directory: nim-beacon-chain
         run: |


### PR DESCRIPTION
Forgot that whether there is cache hit or not `scripts/setup_official_tests.sh fixturesCache` is needed for symlinking