### PR TITLE
Ctrl+C now stops the BN when waiting for genesis

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -26,7 +26,7 @@ import
   spec/state_transition,
   conf, time, beacon_chain_db, validator_pool, extras,
   attestation_pool, exit_pool, eth2_network, eth2_discovery,
-  beacon_node_common, beacon_node_types,
+  beacon_node_common, beacon_node_types, beacon_node_status,
   block_pools/[spec_cache, chain_dag, quarantine, clearance, block_pools_types],
   nimbus_binary_common, network_metadata,
   mainchain_monitor, version, ssz/[merkleization], merkle_minimal,
@@ -41,13 +41,6 @@ const
 
 type
   RpcServer* = RpcHttpServer
-
-  # "state" is already taken by BeaconState
-  BeaconNodeStatus* = enum
-    Starting, Running, Stopping
-
-# this needs to be global, so it can be set in the Ctrl+C signal handler
-var status = BeaconNodeStatus.Starting
 
 template init(T: type RpcHttpServer, ip: ValidIpAddress, port: Port): T =
   newRpcHttpServer([initTAddress(ip, port)])
@@ -849,7 +842,7 @@ proc installMessageValidators(node: BeaconNode) =
       node.processor[].voluntaryExitValidator(signedVoluntaryExit))
 
 proc stop*(node: BeaconNode) =
-  status = BeaconNodeStatus.Stopping
+  bnStatus = BeaconNodeStatus.Stopping
   info "Graceful shutdown"
   if not node.config.inProcessValidators:
     node.vcProcess.close()
@@ -858,9 +851,9 @@ proc stop*(node: BeaconNode) =
   info "Database closed"
 
 proc run*(node: BeaconNode) =
-  if status == BeaconNodeStatus.Starting:
+  if bnStatus == BeaconNodeStatus.Starting:
     # it might have been set to "Stopping" with Ctrl+C
-    status = BeaconNodeStatus.Running
+    bnStatus = BeaconNodeStatus.Running
 
     if node.rpcServer != nil:
       node.rpcServer.installRpcHandlers(node)
@@ -888,7 +881,7 @@ proc run*(node: BeaconNode) =
     node.startSyncManager()
 
   # main event loop
-  while status == BeaconNodeStatus.Running:
+  while bnStatus == BeaconNodeStatus.Running:
     try:
       poll()
     except CatchableError as e:
@@ -1208,7 +1201,7 @@ programMain:
         # workaround for https://github.com/nim-lang/Nim/issues/4057
         setupForeignThreadGc()
       info "Shutting down after having received SIGINT"
-      status = BeaconNodeStatus.Stopping
+      bnStatus = BeaconNodeStatus.Stopping
     setControlCHook(controlCHandler)
 
     when useInsecureFeatures:

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -183,6 +183,8 @@ proc init*(T: type BeaconNode,
       mainchainMonitor.start()
 
       genesisState = await mainchainMonitor.waitGenesis()
+      if bnStatus == BeaconNodeStatus.Stopping:
+        return nil
 
       info "Eth2 genesis state detected",
         genesisTime = genesisState.genesisTime,
@@ -1212,6 +1214,8 @@ programMain:
         metrics.startHttpServer($metricsAddress, config.metricsPort)
 
     var node = waitFor BeaconNode.init(rng, config, stateSnapshotContents)
+    if bnStatus == BeaconNodeStatus.Stopping:
+      return
 
     when hasPrompt:
       initPrompt(node)

--- a/beacon_chain/beacon_node_status.nim
+++ b/beacon_chain/beacon_node_status.nim
@@ -1,0 +1,16 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+type
+  # "state" is already taken by BeaconState
+  BeaconNodeStatus* = enum
+    Starting
+    Running
+    Stopping
+
+# this needs to be global, so it can be set in the Ctrl+C signal handler
+var bnStatus* = BeaconNodeStatus.Starting


### PR DESCRIPTION
This is the output which you would get if you Ctrl+C-ed while waiting for genesis:
```
INF 2020-09-28 11:09:16.773+03:00 Shutting down after having received SIGINT topics="beacnde" tid=4759 file=beacon_node.nim:1203

Traceback (most recent call last, using override)
/home/onqtam/nbc2/beacon_chain/mainchain_monitor.nim(545) main
/home/onqtam/nbc2/beacon_chain/mainchain_monitor.nim(538) NimMain
/home/onqtam/nbc2/beacon_chain/beacon_node.nim(1214) main
/home/onqtam/nbc2/vendor/nim-chronos/chronos/asyncloop.nim(945) waitFor
/home/onqtam/nbc2/vendor/nim-chronos/chronos/asyncloop.nim(276) poll
/home/onqtam/nbc2/vendor/nim-chronos/chronos/asyncmacro2.nim(66) checkForGenesisLoop_continue
/home/onqtam/nbc2/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(407) reportUnhandledError
/home/onqtam/nbc2/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(358) reportUnhandledErrorAux
Error: unhandled exception: Async procedure (&checkForGenesisLoop) yielded `nil`, are you await'ing a `nil` Future? [AssertionError]
make: *** [Makefile:313: spadina] Error 1
```
It's not perfect but at least the process terminates.