### PR TITLE
Deactivate windows 32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
           - os: windows
             cpu: amd64
             TEST_KIND: unit-tests
-          - os: windows
-            cpu: i386
-            TEST_KIND: unit-tests
+          # Devel cache corrupted for mingw? missing propidl.h on PR but not push CI
+          # - os: windows
+          #   cpu: i386
+          #   TEST_KIND: unit-tests
 
           # # Minimal integration tests
           # - os: linux


### PR DESCRIPTION
Temporarily disable Win32

Rationale, failing in devel PR but not push, probably a caching bug

![image](https://user-images.githubusercontent.com/22738317/94428596-3a019500-0191-11eb-96e6-74dfacf7919e.png)

The windows 32 target was important to ensure our node works on 32-bit targets, mainly Raspberry Pi as Raspbian is mainly 32-bit (at least until 2019 / Debian Buster). Now that we have proper Linux i386 tests, this is less critical.


![image](https://user-images.githubusercontent.com/22738317/94428557-25bd9800-0191-11eb-969f-4453a61b3e6e.png)
