### PR TITLE
Revert "ARM64 BLST hotfix - disable BLST on ARM64 (#1753)"

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,9 +1,5 @@
 # Emergency fixes
 # ---------------------------------------------------
-if defined(arm64):
-  # https://twitter.com/EthereumOnARM/status/1309477357938499585?s=20
-  # https://github.com/supranational/blst/issues/31
-  switch("define", "BLS_FORCE_BACKEND=miracl")
 
 # ---------------------------------------------------
 


### PR DESCRIPTION
This reverts commit feece1382deeb39689986f097a9a4b3e4818688b.

A fix was applied upstream
- https://github.com/status-im/nim-blscurve/pull/88
- https://github.com/supranational/blst/commit/bf7f1e6b5f1297005f99b6ba44d7c517f6f36ffb
- https://github.com/supranational/blst/issues/31