### PR TITLE
Revisiting log levels

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -296,7 +296,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
     result.add(attestation)
 
     if result.lenu64 >= MAX_ATTESTATIONS:
-      info "getAttestationsForBlock: returning early after hitting MAX_ATTESTATIONS",
+      debug "getAttestationsForBlock: returning early after hitting MAX_ATTESTATIONS",
         attestationSlot = newBlockSlot - 1
       return
 

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -55,7 +55,7 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
 
     doAssert status.isOk(), "Error in preloading the fork choice: " & $status.error
 
-  info "Fork choice initialized",
+  debug "Fork choice initialized",
     justified_epoch = chainDag.headState.data.data.current_justified_checkpoint.epoch,
     finalized_epoch = chainDag.headState.data.data.finalized_checkpoint.epoch,
     finalized_root = shortlog(chainDag.finalizedHead.blck.root)
@@ -184,7 +184,7 @@ proc addAttestation*(pool: var AttestationPool,
           attestation.data.slot, participants, attestation.data.beacon_block_root,
           wallSlot)
 
-        info "Attestation resolved",
+        debug "Attestation resolved",
           attestation = shortLog(attestation),
           validations = a.validations.len()
 
@@ -201,7 +201,7 @@ proc addAttestation*(pool: var AttestationPool,
       attestation.data.slot, participants, attestation.data.beacon_block_root,
       wallSlot)
 
-    info "Attestation resolved",
+    debug "Attestation resolved",
       attestation = shortLog(attestation),
       validations = 1
 
@@ -296,7 +296,7 @@ proc getAttestationsForBlock*(pool: AttestationPool,
     result.add(attestation)
 
     if result.lenu64 >= MAX_ATTESTATIONS:
-      debug "getAttestationsForBlock: returning early after hitting MAX_ATTESTATIONS",
+      info "getAttestationsForBlock: returning early after hitting MAX_ATTESTATIONS",
         attestationSlot = newBlockSlot - 1
       return
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -186,7 +186,7 @@ proc init*(T: type BeaconNode,
       if bnStatus == BeaconNodeStatus.Stopping:
         return nil
 
-      info "Eth2 genesis state detected",
+      notice "Eth2 genesis state detected",
         genesisTime = genesisState.genesisTime,
         eth1Block = genesisState.eth1_data.block_hash,
         totalDeposits = genesisState.eth1_data.deposit_count
@@ -619,7 +619,7 @@ proc onSlotStart(node: BeaconNode, lastSlot, scheduledSlot: Slot) {.async.} =
 proc handleMissingBlocks(node: BeaconNode) =
   let missingBlocks = node.quarantine.checkMissing()
   if missingBlocks.len > 0:
-    info "Requesting detected missing blocks", blocks = shortLog(missingBlocks)
+    debug "Requesting detected missing blocks", blocks = shortLog(missingBlocks)
     node.requestManager.fetchAncestorBlocks(missingBlocks)
 
 proc onSecond(node: BeaconNode) =
@@ -639,7 +639,7 @@ proc runOnSecondLoop(node: BeaconNode) {.async.} =
     let finished = chronos.now(chronos.Moment)
     let processingTime = finished - afterSleep
     ticks_delay.set(sleepTime.nanoseconds.float / nanosecondsIn1s)
-    debug "onSecond task completed", sleepTime, processingTime
+    trace "onSecond task completed", sleepTime, processingTime
 
 proc startSyncManager(node: BeaconNode) =
   func getLocalHeadSlot(): Slot =
@@ -845,12 +845,12 @@ proc installMessageValidators(node: BeaconNode) =
 
 proc stop*(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping
-  info "Graceful shutdown"
+  notice "Graceful shutdown"
   if not node.config.inProcessValidators:
     node.vcProcess.close()
   waitFor node.network.stop()
   node.db.close()
-  info "Database closed"
+  notice "Database closed"
 
 proc run*(node: BeaconNode) =
   if bnStatus == BeaconNodeStatus.Starting:
@@ -868,7 +868,7 @@ proc run*(node: BeaconNode) =
       nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
       fromNow = saturate(node.beaconClock.fromNow(nextSlot))
 
-    info "Scheduling first slot action",
+    debug "Scheduling first slot action",
       beaconTime = shortLog(node.beaconClock.now()),
       nextSlot = shortLog(nextSlot),
       fromNow = shortLog(fromNow)
@@ -907,7 +907,7 @@ proc initializeNetworking(node: BeaconNode) {.async.} =
 
   await node.network.start()
 
-  info "Networking initialized",
+  notice "Networking initialized",
     enr = node.network.announcedENR.toURI,
     libp2p = shortLog(node.network.switch.peerInfo)
 
@@ -917,7 +917,7 @@ proc start(node: BeaconNode) =
     finalizedHead = node.chainDag.finalizedHead
     genesisTime = node.beaconClock.fromNow(toBeaconTime(Slot 0))
 
-  info "Starting beacon node",
+  notice "Starting beacon node",
     version = fullVersionStr,
     nim = shortNimBanner(),
     timeSinceFinalization =
@@ -1202,14 +1202,14 @@ programMain:
       when defined(windows):
         # workaround for https://github.com/nim-lang/Nim/issues/4057
         setupForeignThreadGc()
-      info "Shutting down after having received SIGINT"
+      notice "Shutting down after having received SIGINT"
       bnStatus = BeaconNodeStatus.Stopping
     setControlCHook(controlCHandler)
 
     when useInsecureFeatures:
       if config.metricsEnabled:
         let metricsAddress = config.metricsAddress
-        info "Starting metrics HTTP server",
+        notice "Starting metrics HTTP server",
           address = metricsAddress, port = config.metricsPort
         metrics.startHttpServer($metricsAddress, config.metricsPort)
 
@@ -1282,7 +1282,7 @@ programMain:
           mapIt(deposits.value, LaunchPadDeposit.init(config.runtimePreset, it))
 
         Json.saveFile(depositDataPath, launchPadDeposits)
-        info "Deposit data written", filename = depositDataPath
+        notice "Deposit data written", filename = depositDataPath
 
         walletPath.wallet.nextAccount += deposits.value.len
         let status = saveWallet(walletPath)

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -868,7 +868,7 @@ proc run*(node: BeaconNode) =
       nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
       fromNow = saturate(node.beaconClock.fromNow(nextSlot))
 
-    debug "Scheduling first slot action",
+    info "Scheduling first slot action",
       beaconTime = shortLog(node.beaconClock.now()),
       nextSlot = shortLog(nextSlot),
       fromNow = shortLog(fromNow)

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -487,7 +487,7 @@ proc putState*(dag: ChainDAGRef, state: StateData) =
   if dag.db.containsState(state.data.root):
     return
 
-  info "Storing state"
+  debug "Storing state"
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
@@ -626,7 +626,7 @@ proc updateStateData*(
 
     return
 
-  debug "UpdateStateData miss",
+  trace "UpdateStateData cache miss",
     bs, stateBlock = state.blck, stateSlot = state.data.data.slot
 
   # Either the state is too new or was created by applying a different block.
@@ -676,7 +676,7 @@ proc updateStateData*(
 
   beacon_state_rewinds.inc()
 
-  debug "State reloaded from database",
+  trace "State reloaded from database",
     blocks = ancestors.len,
     slots = state.data.data.slot - startSlot,
     stateRoot = shortLog(state.data.root),
@@ -707,7 +707,7 @@ proc updateHead*(
     newHead = shortLog(newHead)
 
   if dag.head == newHead:
-    debug "No head block update"
+    trace "No head block update"
 
     return
 
@@ -730,7 +730,7 @@ proc updateHead*(
   dag.head = newHead
 
   if not lastHead.isAncestorOf(newHead):
-    info "Updated head block with reorg",
+    notice "Updated head block with chain reorg",
       lastHead = shortLog(lastHead),
       headParent = shortLog(newHead.parent),
       stateRoot = shortLog(dag.headState.data.root),
@@ -743,7 +743,7 @@ proc updateHead*(
     quarantine.clearQuarantine()
     beacon_reorgs_total.inc()
   else:
-    info "Updated head block",
+    debug "Updated head block",
       stateRoot = shortLog(dag.headState.data.root),
       headBlock = shortLog(dag.headState.blck),
       stateSlot = shortLog(dag.headState.data.data.slot),
@@ -818,7 +818,7 @@ proc updateHead*(
 
     dag.finalizedHead = finalizedHead
 
-    info "Reached new finalization checkpoint",
+    notice "Reached new finalization checkpoint",
       finalizedHead = shortLog(finalizedHead),
       heads = dag.heads.len
 

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -626,7 +626,7 @@ proc updateStateData*(
 
     return
 
-  trace "UpdateStateData cache miss",
+  debug "UpdateStateData cache miss",
     bs, stateBlock = state.blck, stateSlot = state.data.data.slot
 
   # Either the state is too new or was created by applying a different block.

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -211,7 +211,7 @@ proc addRawBlock*(
 
     if not state_transition(dag.runtimePreset, dag.clearanceState.data, signedBlock,
                             cache, dag.updateFlags + {slotProcessed}, restore):
-      debug "Invalid block"
+      info "Invalid block"
 
       return err((EVRESULT_REJECT, Invalid))
 
@@ -228,7 +228,7 @@ proc addRawBlock*(
   # as dag.add(...) requires a SignedBeaconBlock, easier to keep them in
   # pending too.
   if not quarantine.add(dag, signedBlock):
-    warn "Block quarantine full"
+    debug "Block quarantine full"
 
   # TODO possibly, it makes sense to check the database - that would allow sync
   #      to simply fill up the database with random blocks the other clients

--- a/beacon_chain/deposit_contract.nim
+++ b/beacon_chain/deposit_contract.nim
@@ -139,7 +139,7 @@ proc sendDeposits*(deposits: seq[LaunchPadDeposit],
                    web3Url, privateKey: string,
                    depositContractAddress: Eth1Address,
                    delayGenerator: DelayGenerator = nil) {.async.} =
-  info "Sending deposits",
+  notice "Sending deposits",
     web3 = web3Url,
     depositContract = depositContractAddress
 
@@ -197,7 +197,7 @@ proc main() {.async.} =
       mapIt(deposits.value, LaunchPadDeposit.init(runtimePreset, it))
 
     Json.saveFile(string cfg.outDepositsFile, launchPadDeposits)
-    info "Deposit data written", filename = cfg.outDepositsFile
+    notice "Deposit data written", filename = cfg.outDepositsFile
     quit 0
 
   var deposits: seq[LaunchPadDeposit]

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -981,7 +981,7 @@ proc start*(node: Eth2Node) {.async.} =
     node.discovery.start()
     traceAsyncErrors node.runDiscoveryLoop()
   else:
-    notice "Discovery disabled, trying bootstrap nodes",
+    notice "Discovery disabled; trying bootstrap nodes",
       nodes = node.discovery.bootstrapRecords.len
     for enr in node.discovery.bootstrapRecords:
       let tr = enr.toTypedRecord()

--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -301,7 +301,7 @@ proc attestationValidator*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime - attestation.data.slot.toBeaconTime
-  debug "Attestation received", delay
+  trace "Attestation received", delay
   let v = self.attestationPool[].validateAttestation(
       attestation, wallTime, committeeIndex)
   if v.isErr():

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -343,7 +343,7 @@ proc find_head*(
   ? self.proto_array.find_head(new_head, justified_root)
 
   {.noSideEffect.}:
-    debug "Fork choice requested",
+    trace "Fork choice requested",
       justified_epoch = justified_epoch,
       justified_root = shortLog(justified_root),
       finalized_epoch = finalized_epoch,

--- a/beacon_chain/keystore_management.nim
+++ b/beacon_chain/keystore_management.nim
@@ -157,7 +157,7 @@ proc generateDeposits*(preset: RuntimePreset,
                        secretsDir: string): Result[seq[DepositData], KeystoreGenerationError] =
   var deposits: seq[DepositData]
 
-  info "Generating deposits", totalNewValidators, validatorsDir, secretsDir
+  notice "Generating deposits", totalNewValidators, validatorsDir, secretsDir
 
   let withdrawalKeyPath = makeKeyPath(0, withdrawalKeyKind)
   # TODO: Explain why we are using an empty password
@@ -256,7 +256,7 @@ proc importKeystoresFromDir*(rng: var BrHmacDrbgContext,
       let keystore = try:
         Json.loadFile(file, Keystore)
       except SerializationError as e:
-        trace "Invalid keystore", err = e.formatMsg(file)
+        warn "Invalid keystore", err = e.formatMsg(file)
         continue
       except IOError as e:
         warn "Failed to read keystore file", file, err = e.msg
@@ -292,7 +292,7 @@ proc importKeystoresFromDir*(rng: var BrHmacDrbgContext,
                                       privKey.value, pubKey,
                                       keystore.path)
             if status.isOk:
-              info "Keystore imported", file
+              notice "Keystore imported", file
             else:
               error "Failed to import keystore", file, err = status.error
           else:
@@ -398,7 +398,7 @@ proc pickPasswordAndSaveWallet(rng: var BrHmacDrbgContext,
       if status.isErr:
         return err("failure to create wallet file due to " & status.error)
 
-      info "Wallet file written", path = outWalletFile
+      notice "Wallet file written", path = outWalletFile
       return ok WalletPathPair(wallet: wallet, path: outWalletFile)
     finally:
       burnMem(password)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -172,7 +172,7 @@ proc slash_validator*(state: var BeaconState, slashed_index: ValidatorIndex,
   initiate_validator_exit(state, slashed_index, cache)
   let validator = addr state.validators[slashed_index]
 
-  debug "slash_validator: ejecting validator via slashing (validator_leaving)",
+  notice "slash_validator: ejecting validator via slashing (validator_leaving)",
     index = slashed_index,
     num_validators = state.validators.len,
     current_epoch = get_current_epoch(state),
@@ -388,7 +388,7 @@ proc process_registry_updates*(state: var BeaconState,
 
     if is_active_validator(validator, get_current_epoch(state)) and
         validator.effective_balance <= EJECTION_BALANCE:
-      debug "Registry updating: ejecting validator due to low balance (validator_leaving)",
+      notice "Registry updating: ejecting validator due to low balance (validator_leaving)",
         index = index,
         num_validators = state.validators.len,
         current_epoch = get_current_epoch(state),

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -292,7 +292,7 @@ proc check_voluntary_exit*(
       return err("Exit: invalid signature")
 
   # Initiate exit
-  info "Exit: checking voluntary exit (validator_leaving)",
+  debug "Exit: checking voluntary exit (validator_leaving)",
     index = voluntary_exit.validator_index,
     num_validators = state.validators.len,
     epoch = voluntary_exit.epoch,

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -102,7 +102,7 @@ proc process_randao(
     if not verify_epoch_signature(
         state.fork, state.genesis_validators_root, epoch, proposer_pubkey,
         body.randao_reveal):
-      notice "Randao mismatch", proposer_pubkey = shortLog(proposer_pubkey),
+      debug "Randao mismatch", proposer_pubkey = shortLog(proposer_pubkey),
                                 epoch,
                                 signature = shortLog(body.randao_reveal),
                                 slot = state.slot
@@ -292,7 +292,7 @@ proc check_voluntary_exit*(
       return err("Exit: invalid signature")
 
   # Initiate exit
-  debug "Exit: checking voluntary exit (validator_leaving)",
+  info "Exit: checking voluntary exit (validator_leaving)",
     index = voluntary_exit.validator_index,
     num_validators = state.validators.len,
     epoch = voluntary_exit.epoch,

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -702,7 +702,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
   if peerAge >= man.maxStatusAge:
     # Peer's status information is very old, its time to update it
     man.workers[index].status = SyncWorkerStatus.UpdatingStatus
-    debug "Updating peer's status information", wall_clock_slot = wallSlot,
+    trace "Updating peer's status information", wall_clock_slot = wallSlot,
           remote_head_slot = peerSlot, local_head_slot = headSlot,
           peer = peer, peer_score = peer.getScore(), index = index,
           peer_speed = peer.netKbps(), topics = "syncman"
@@ -742,7 +742,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       peerSlot = newPeerSlot
 
   if headAge <= man.maxHeadAge:
-    debug "We are in sync with network, exiting", wall_clock_slot = wallSlot,
+    info "We are in sync with network", wall_clock_slot = wallSlot,
           remote_head_slot = peerSlot, local_head_slot = headSlot,
           peer = peer, peer_score = peer.getScore(), index = index,
           peer_speed = peer.netKbps(), topics = "syncman"
@@ -752,7 +752,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     return
 
   if headSlot >= peerSlot - man.maxHeadAge:
-    debug "We are in sync with peer, refreshing peer's status information",
+    info "We are in sync with peer, refreshing peer's status information",
           wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
           local_head_slot = headSlot, peer = peer, peer_score = peer.getScore(),
           index = index, peer_speed = peer.netKbps(), topics = "syncman"
@@ -942,7 +942,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
         man.syncSpeed = 0.0
       else:
         if (lsm2.slot - lsm1.slot == 0'u64) and (pending > 1):
-          debug "Syncing process is not progressing, reset the queue",
+          info "Syncing process is not progressing, reset the queue",
                 pending_workers_count = pending,
                 to_slot = man.queue.outSlot,
                 local_head_slot = lsm1.slot, topics = "syncman"
@@ -950,7 +950,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
         else:
           man.syncSpeed = speed(lsm1, lsm2)
 
-      debug "Synchronization loop tick", wall_head_slot = wallSlot,
+      trace "Synchronization loop tick", wall_head_slot = wallSlot,
           local_head_slot = headSlot, queue_start_slot = man.queue.startSlot,
           queue_last_slot = man.queue.lastSlot,
           sync_speed = man.syncSpeed, pending_workers_count = pending,
@@ -964,7 +964,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
 
     let (map, sleeping, waiting, pending) = man.getWorkersStats()
 
-    debug "Current syncing state", workers_map = map,
+    trace "Current syncing state", workers_map = map,
           sleeping_workers_count = sleeping,
           waiting_workers_count = waiting,
           pending_workers_count = pending,

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -752,7 +752,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     return
 
   if headSlot >= peerSlot - man.maxHeadAge:
-    info "We are in sync with peer, refreshing peer's status information",
+    debug "We are in sync with peer; refreshing peer's status information",
           wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
           local_head_slot = headSlot, peer = peer, peer_score = peer.getScore(),
           index = index, peer_speed = peer.netKbps(), topics = "syncman"

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -186,7 +186,7 @@ p2pProtocol BeaconSync(version = 1,
   proc goodbye(peer: Peer,
                reason: uint64)
     {.async, libp2pProtocol("goodbye", 1).} =
-    trace "Received Goodbye message", reason = disconnectReasonName(reason), peer
+    debug "Received Goodbye message", reason = disconnectReasonName(reason), peer
 
 proc setStatusMsg(peer: Peer, statusMsg: StatusMsg) =
   trace "Peer status", peer, statusMsg

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -110,7 +110,7 @@ p2pProtocol BeaconSync(version = 1,
       await peer.handleStatus(peer.networkState,
                               ourStatus, theirStatus.get())
     else:
-      warn "Status response not received in time",
+      debug "Status response not received in time",
         peer, error = theirStatus.error
 
   proc status(peer: Peer,
@@ -186,10 +186,10 @@ p2pProtocol BeaconSync(version = 1,
   proc goodbye(peer: Peer,
                reason: uint64)
     {.async, libp2pProtocol("goodbye", 1).} =
-    debug "Received Goodbye message", reason = disconnectReasonName(reason), peer
+    trace "Received Goodbye message", reason = disconnectReasonName(reason), peer
 
 proc setStatusMsg(peer: Peer, statusMsg: StatusMsg) =
-  debug "Peer status", peer, statusMsg
+  trace "Peer status", peer, statusMsg
   peer.state(BeaconSync).statusMsg = statusMsg
   peer.state(BeaconSync).statusLastTime = Moment.now()
 
@@ -220,7 +220,7 @@ proc handleStatus(peer: Peer,
                   ourStatus: StatusMsg,
                   theirStatus: StatusMsg) {.async, gcsafe.} =
   if theirStatus.forkDigest != state.forkDigest:
-    notice "Irrelevant peer", peer, theirStatus, ourStatus
+    debug "Irrelevant peer", peer, theirStatus, ourStatus
     await peer.disconnect(IrrelevantNetwork)
   else:
     peer.setStatusMsg(theirStatus)

--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -348,7 +348,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       payload: SignedAggregateAndProof) -> bool:
     debug "post_v1_validator_aggregate_and_proofs"
     node.network.broadcast(node.topicAggregateAndProofs, payload)
-    info "Aggregated attestation sent",
+    notice "Aggregated attestation sent",
       attestation = shortLog(payload.message.aggregate)
 
   rpcServer.rpc("get_v1_validator_duties_attester") do (

--- a/beacon_chain/validator_client.nim
+++ b/beacon_chain/validator_client.nim
@@ -114,7 +114,7 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
     nextSlot = slot + 1
     epoch = slot.compute_epoch_at_slot
 
-  debug "Slot start",
+  info "Slot start",
     lastSlot = shortLog(lastSlot),
     scheduledSlot = shortLog(scheduledSlot),
     beaconTime = shortLog(beaconTime),
@@ -249,7 +249,7 @@ proc onSlotStart(vc: ValidatorClient, lastSlot, scheduledSlot: Slot) {.gcsafe, a
   let
     nextSlotStart = saturate(vc.beaconClock.fromNow(nextSlot))
 
-  debug "Slot end",
+  info "Slot end",
     slot = shortLog(slot),
     nextSlot = shortLog(nextSlot),
     portBN = vc.config.rpcPort
@@ -314,7 +314,7 @@ programMain:
     vc.attemptUntilSuccess:
       waitFor vc.getValidatorDutiesForEpoch(curSlot.compute_epoch_at_slot)
 
-    debug "Scheduling first slot action",
+    info "Scheduling first slot action",
       beaconTime = shortLog(vc.beaconClock.now()),
       nextSlot = shortLog(nextSlot),
       fromNow = shortLog(fromNow)

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -40,7 +40,7 @@ proc saveValidatorKey*(keyName, key: string, conf: BeaconNodeConf) =
   let outputFile = validatorsDir / keyName
   createDir validatorsDir
   writeFile(outputFile, key)
-  info "Imported validator key", file = outputFile
+  notice "Imported validator key", file = outputFile
 
 proc checkValidatorInRegistry(state: BeaconState,
                               pubKey: ValidatorPubKey) =
@@ -60,7 +60,7 @@ proc addLocalValidator*(node: BeaconNode,
 proc addLocalValidators*(node: BeaconNode) =
   for validatorKey in node.config.validatorKeys:
     node.addLocalValidator node.chainDag.headState.data.data, validatorKey
-  info "Local validators attached ", count = node.attachedValidators.count
+  notice "Local validators attached ", count = node.attachedValidators.count
 
 proc addRemoteValidators*(node: BeaconNode) =
   # load all the validators from the child process - loop until `end`
@@ -77,7 +77,7 @@ proc addRemoteValidators*(node: BeaconNode) =
                                   outStream: node.vcProcess.outputStream,
                                   pubKeyStr: $key))
       node.attachedValidators.addRemoteValidator(key, v)
-  info "Remote validators attached ", count = node.attachedValidators.count
+  notice "Remote validators attached ", count = node.attachedValidators.count
 
 proc getAttachedValidator*(node: BeaconNode,
                            pubkey: ValidatorPubKey): AttachedValidator =
@@ -340,7 +340,7 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     # TODO the oldest attestations allowed are those that are older than the
     #      finalized epoch.. also, it seems that posting very old attestations
     #      is risky from a slashing perspective. More work is needed here.
-    notice "Skipping attestation, head is too recent",
+    warn "Skipping attestation, head is too recent",
       headSlot = shortLog(head.slot),
       slot = shortLog(slot)
     return
@@ -485,7 +485,7 @@ proc broadcastAggregatedAttestations(
           message: aggregateAndProof.get,
           signature: sig)
         node.network.broadcast(node.topicAggregateAndProofs, signedAP)
-        info "Aggregated attestation sent",
+        notice "Aggregated attestation sent",
           attestation = shortLog(signedAP.message.aggregate),
           validator = shortLog(curr[0].v)
 
@@ -514,7 +514,7 @@ proc handleValidatorDuties*(
     # TODO maybe even collect all work synchronously to avoid unnecessary
     #      state rewinds while waiting for async operations like validator
     #      signature..
-    notice "Catching up",
+    notice "Catching up on validator duties",
       curSlot = shortLog(curSlot),
       lastSlot = shortLog(lastSlot),
       slot = shortLog(slot)

--- a/beacon_chain/validator_pool.nim
+++ b/beacon_chain/validator_pool.nim
@@ -26,13 +26,13 @@ proc addLocalValidator*(pool: var ValidatorPool,
                             kind: inProcess,
                             privKey: privKey)
   pool.validators[pubKey] = v
-  info "Local validator attached", pubKey, validator = shortLog(v)
+  notice "Local validator attached", pubKey, validator = shortLog(v)
 
 proc addRemoteValidator*(pool: var ValidatorPool,
                          pubKey: ValidatorPubKey,
                          v: AttachedValidator) =
   pool.validators[pubKey] = v
-  info "Remote validator attached", pubKey, validator = shortLog(v)
+  notice "Remote validator attached", pubKey, validator = shortLog(v)
 
 proc getValidator*(pool: ValidatorPool,
                    validatorKey: ValidatorPubKey): AttachedValidator =

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,46 @@
+# Logging strategy
+
+This document describes the overall logging strategy of NBC.
+This is a suggested guideline, rare events can have a higher logging level
+than suggested in the guideline for example at beacon node start or stop.
+
+The main objectives are:
+- INFO log level or higher should be suitable for long-term use, i.e. running for months or weeks. Logs are the users' main interface their beacon node and validators. In particular it should not be a denial-of-service vector, either by leading to high CPU usage of the console or filling disk space at an unsustainable rate.
+- INFO logs or higher should be target at users, logs only relevant to devs should be relegated to DEBUG or TRACE or commented out.
+- DEBUG log level should still be readable by visual inspection during a slot time (6 seconds).
+
+Here is the suggestion of content per log level
+
+- Fatal: Node will crash
+- Error: Bugs or critical unexpected behaviors
+  - node cannot proceed with task
+  - node consistency is compromised
+- Warning: Errors that can be expected or handled
+  - networking issue,
+  - node cannot proceed with task but can recover or work in degraded mode (invalid bootstrap address, out of Infura requests)
+- Notice: Important user and validator info and one-time events
+  - node start/quit,
+  - log about validator funds,
+  - own PoS attestations,
+  - own PoS blocks,
+  - chain reached finality,
+  - validators have been slashed (i.e. might indicate malicious activity or network/chain split)
+- Info: standard user target
+  - Networking or consensus information
+- Debug: dev and debugging users
+  - Common networking activity (new peers, kick peers, timeouts),
+  - consensus/proof-of-stake various processing,
+- Trace: dev only
+  - Keep-alive,
+  - routine tasks schedules
+  - "spammy" tasks that clutter debugging (attestations received, status/control messages)
+
+Logs done at high frequency should be summarized even at trace level to avoid drowning other subsystems.
+For example they can use an uint8 counter with
+```
+proc myHighFreqProc() =
+  var counter {.threadvar.}: uint8
+  if counter == 255:
+    trace "Total of 255 myHighFreqProc call"
+  counter += 1
+```


### PR DESCRIPTION
 https://github.com/status-im/nim-beacon-chain/issues/1779 https://github.com/status-im/nim-beacon-chain/issues/1785

### Description/Philosophy

- Fatal: ???
- Error: Bugs or critical unexpected behaviors, node cannot proceed with task, consistency compromised
- Warning: Expected behavior (file not found), node cannot proceed with task but can recover
- Notice: Start/quit, validator funds, own attestations, own blocks, finality checkpoints, (any) slashings
- Info: Important networking issues
- Debug: Common networking (new peers, kick peers, timeouts), consensus stages, block/attestation validation
- Trace: Keep-alive, routine schedule

Note: it is important not to fill disk with logs, this prevent analyzing them visually.
Logs done at high frequency should be summarized even at trace level to avoid drowning other subsystem
For example they can use an uint8 counter with
```
proc myHighFreqProc() =
  var counter {.threadvar.}: uint8
  if counter == 255:
    trace "Total of 255 myHighFreqProc call"
  counter += 1
```
For the keep alive / control message that were done by Gossipsub: https://github.com/status-im/nim-libp2p/pull/381/files

### TODO

The current color of the notice level is confusing, it seems like an issue that needs to be addressed and seems to sit in-between warning and error.

![image](https://user-images.githubusercontent.com/22738317/94824383-3fffac00-0405-11eb-8239-2d97bb924c59.png)
