### PR TITLE
Partial LTO

### DIFF
--- a/beacon_chain/keystore_management.nim
+++ b/beacon_chain/keystore_management.nim
@@ -9,6 +9,7 @@ export
   keystore
 
 {.push raises: [Defect].}
+{.localPassC: "-fno-lto".} # no LTO for crypto
 
 const
   keystoreFileName* = "keystore.json"

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -19,6 +19,7 @@ export
   results, burnMem, writeValue, readValue
 
 {.push raises: [Defect].}
+{.localPassC: "-fno-lto".} # no LTO for crypto
 
 type
   ChecksumFunctionKind* = enum

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,0 +1,18 @@
+
+# ############################################################
+#
+#                    No LTO for crypto
+#
+# ############################################################
+
+# This applies per-file compiler flags to C files
+# which do not support {.localPassC: "-fno-lto".}
+# Unfortunately this is filename based instead of path-based
+# Assumes GCC
+
+# BLST
+server.always = "-fno-lto"
+assembly.always = "-fno-lto"
+
+# Secp256k1
+secp256k1.always = "-fno-lto"

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,4 +1,3 @@
-
 # ############################################################
 #
 #                    No LTO for crypto
@@ -16,3 +15,21 @@ assembly.always = "-fno-lto"
 
 # Secp256k1
 secp256k1.always = "-fno-lto"
+
+# BearSSL - only RNGs
+aesctr_drbg.always = "-fno-lto"
+hmac_drbg.always = "-fno-lto"
+sysrng.always = "-fno-lto"
+
+# Miracl - only ECP to derive public key from private key
+ecp_BLS12381.always = "-fno-lto"
+
+# ############################################################
+#
+#                    Spurious warnings
+#
+# ############################################################
+
+# sqlite3.c: In function ‘sqlite3SelectNew’:
+# vendor/nim-sqlite3-abi/sqlite3.c:124500: warning: function may return address of local variable [-Wreturn-local-addr]
+sqlite3.always = "-fno-lto" # -Wno-return-local-addr


### PR DESCRIPTION
This shows how to address #1666 

For now

* [x] blst
* [x] libsecp256k1
* [x] milagro
* [x] bearssl

Note that we still have a SQLite3 warnings when building

![image](https://user-images.githubusercontent.com/22738317/94834858-38460480-0411-11eb-93ba-e41a4250404a.png)


The nim.cfg file can be done either:
- In NBC like in this PR
- In the crypto wrapper provided if we can put it next to the C file
- I'm unsure if a project-wide nim.cfg in blscurve will be picked up if we compile from within NBC repo.

We might want to ask for custom passC flags when we do {.compile: "foo.c".}

The good news is that this method seem to also work for assembly files.