### PR TITLE
Logging update

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -832,7 +832,7 @@ proc runDiscoveryLoop*(node: Eth2Node) {.async.} =
           new_peers = newPeers
 
     if newPeers == 0:
-      if node.peerPool.lenSpace() <= node.wantedPeers shr 2:
+      if node.peerPool.lenCurrent() <= node.wantedPeers shr 2:
         warn "Less than 25% wanted peers and could not discover new nodes",
               discovered = len(discoveredNodes), new_peers = newPeers,
               wanted_peers = node.wantedPeers


### PR DESCRIPTION
1. Fix misunderstanding in peer counting in peer pools, warning message was displayed when I had 78/79 peers instead of 7/79 peers

2. Update with a tentative new color scheme for log that has notice in a less "scary" than warning. We assume that users don't run in trace (white) or debug (grey which is not contrasted enough notice on white/bright background) and assume that we would mostly use tools for handling trace and tools/visual for debug level. So optimization went into having good distinction between Info/Notice/warning: https://github.com/status-im/nim-chronicles/pull/89 

![image](https://user-images.githubusercontent.com/22738317/94922823-24ef7380-04bb-11eb-82c8-0ac8b4419d44.png)
![image](https://user-images.githubusercontent.com/22738317/94922833-29b42780-04bb-11eb-992a-c5aaab93d7cd.png)
