### PR TITLE
Revert "update to v0.12.3 message ID for Spadina launch"

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -4,7 +4,7 @@ import
   std/options as stdOptions,
 
   # Status libs
-  stew/[varints, base58, endians2, results, byteutils], bearssl,
+  stew/[varints, base58, base64, endians2, results, byteutils], bearssl,
   stew/shims/net as stewNet,
   stew/shims/[macros, tables],
   faststreams/[inputs, outputs, buffers], snappy, snappy/framing,
@@ -1219,7 +1219,7 @@ proc getPersistentNetKeys*(
 
 func gossipId(data: openArray[byte]): string =
   # https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/specs/phase0/p2p-interface.md#topics-and-messages
-  string.fromBytes(sha256.digest(data).data.toOpenArray(0, 7))
+  base64.encode(Base64Url, sha256.digest(data).data)
 
 func msgIdProvider(m: messages.Message): string =
   gossipId(m.data)


### PR DESCRIPTION
Reverts status-im/nim-beacon-chain#1762

That PR implements, indeed, what https://github.com/ethereum/eth2.0-specs/blob/v0.12.3/specs/phase0/p2p-interface.md#topics-and-messages specifies:
```
message-id: SHA256(message.data)[0:8]
```

However, since then, https://github.com/ethereum/eth2.0-specs/pull/2044#issuecomment-689610457 and follow-up discussion has pointed to temporarily reverting that change, pending a revised version.