### PR TITLE
[JSON-RPC] Prevent silent uint conversion

### DIFF
--- a/beacon_chain/validator_api.nim
+++ b/beacon_chain/validator_api.nim
@@ -43,7 +43,7 @@ func checkEpochToSlotOverflow(epoch: Epoch) =
   const maxEpoch = compute_epoch_at_slot(not 0'u64)
   if epoch >= maxEpoch:
     raise newException(
-      CatchableError, "Requesting epoch for which slot would overflow")
+      ValueError, "Requesting epoch for which slot would overflow")
 
 proc doChecksAndGetCurrentHead(node: BeaconNode, slot: Slot): BlockRef =
   result = node.chainDag.head

--- a/docs/the_auditors_handbook/src/02.2.2_casting_and_low_level_memory_representation.md
+++ b/docs/the_auditors_handbook/src/02.2.2_casting_and_low_level_memory_representation.md
@@ -2,7 +2,9 @@
 
 ## Conversions
 
-Casting to or from a signed integer will lead to a range check
+Casting to a signed integer will lead to a range check.
+Conversion to an unsigned integer even from a negative signed integer will NOT lead to a range check (https://github.com/nim-lang/RFCs/issues/175)
+https://nim-lang.org/docs/manual.html#statements-and-expressions-type-conversions
 
 ## Casting integers
 


### PR DESCRIPTION
Fix silent uint conversion in json RPC, addresses #1671
- [x] Fix conversion for beacon types
- [x] Fix conversion for raw uint types - requires https://github.com/status-im/nim-json-rpc/pull/85

Source:
Since 1.0.4 conversion to unsigned even from signed are unchecked see https://github.com/nim-lang/RFCs/issues/175, unfortunately I assume that most of the team was still under the impression that they were still checked, and I first given that I wrote the related section in the auditor's handbook.

Mitigation:
`fromJson` from
- https://github.com/status-im/nim-beacon-chain/blob/edc7737/beacon_chain/eth2_json_rpc_serialization.nim#L43-L51
- https://github.com/status-im/nim-json-rpc/blob/dff46c9/json_rpc/jsonmarshal.nim#L87-L89
should have explicit negative check.

Stretch:
- use result/bool instead of exceptions to report those errors

Note:
Issue #1671 was kind of solved by @onqtam in https://github.com/status-im/nim-beacon-chain/pull/1810 in a cross-fire for #1663 but #1671 has a much wider attack surface.

The error message now changes from
![image](https://user-images.githubusercontent.com/22738317/95221514-cc401380-07f7-11eb-9e24-52c3e43c5464.png)
to
![image](https://user-images.githubusercontent.com/22738317/95221560-d9f59900-07f7-11eb-985d-76138eeb2bad.png)
as this is caught earlier in deserialization logic before entering the BN logic

Comment:
*I knew https://github.com/nim-lang/RFCs/issues/175 or the Eth2 spec using unsigned int would bite us again* 