### PR TITLE
put the RPC server behind "-d:insecure"

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -234,7 +234,7 @@ proc init*(T: type BeaconNode,
     #      monitor
     mainchainMonitor.start()
 
-  let rpcServer = if conf.rpcEnabled:
+  let rpcServer = if conf.rpcEnabled and useInsecureFeatures:
     RpcServer.init(conf.rpcAddress, conf.rpcPort)
   else:
     nil

--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -2,7 +2,9 @@
 
 NBC exposes a collection of APIs for querying the state of the application at runtime.
 
-> **Note:** Where applicable, these APIs mimic the [eth2 APIs](https://github.com/ethereum/eth2.0-APIs) with the exception that JSON-RPC is used instead of http rest (the method names, parameters and results are all the same except for the encoding / access method).
+> **Note:** Where applicable, these APIs mimic the [eth2 APIs](https://github.com/ethereum/eth2.0-APIs) with the exception that JSON-RPC is used instead of HTTP REST (the method names, parameters and results are all the same except for the encoding / access method).
+
+This JSON-RPC endpoint should not be exposed to the Internet, because it's inherently vulnerable to uncontrolled input. To make this clear, you need to enable it by building the software with `make NIMFLAGS="-d:insecure" ...`.
 
 ## Introduction
 


### PR DESCRIPTION
To quote @cheatfate: "the only way to enable insecure things in `nbc` is `-d:insecure`".

This RPC server is inherently vulnerable to uncontrolled input and securing it properly is almost as complicated as securing a web server properly, as shown by all these security issues (that probably just scratch the surface): https://github.com/status-im/nim-beacon-chain/issues/1680 https://github.com/status-im/nim-beacon-chain/issues/1671 https://github.com/status-im/nim-beacon-chain/issues/1653 https://github.com/status-im/nim-beacon-chain/issues/1652 https://github.com/status-im/nim-beacon-chain/issues/1665

So we raise a barrier to entry by requiring users to build the software with `make NIMFLAGS="-d:insecure" ...` in order to access insecure parts of the code. This should dissuade them from thinking this is something that should be open to the outside world.