### PR TITLE
updating the attester duties endpoint to POST and also to accept validator indexes instead of pubkeys - not in a working state

### DIFF
--- a/beacon_chain/spec/eth2_apis/callsigs_types.nim
+++ b/beacon_chain/spec/eth2_apis/callsigs_types.nim
@@ -29,9 +29,10 @@ type
     finalized: Checkpoint
 
   BeaconStatesValidatorsTuple* = tuple
-    validator: Validator
-    status: string
+    index: uint64
     balance: uint64
+    status: string
+    validator: Validator
 
   BeaconStatesCommitteesTuple* = tuple
     index: uint64

--- a/beacon_chain/spec/eth2_apis/validator_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/validator_callsigs.nim
@@ -21,7 +21,7 @@ proc get_v1_validator_aggregate_attestation(slot: Slot, attestation_data_root: E
 proc post_v1_validator_aggregate_and_proofs(payload: SignedAggregateAndProof): bool
 
 # TODO epoch is part of the REST path
-proc get_v1_validator_duties_attester(epoch: Epoch, public_keys: seq[ValidatorPubKey]): seq[AttesterDuties]
+proc post_v1_validator_duties_attester(epoch: Epoch, validatorIds: seq[uint64]): seq[AttesterDuties]
 
 # TODO epoch is part of the REST path
 proc get_v1_validator_duties_proposer(epoch: Epoch): seq[ValidatorPubkeySlotPair]

--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -129,7 +129,7 @@ curl -d '{"jsonrpc":"2.0","method":"get_v1_validator_attestation_data","params":
 ### [`post_v1_validator_duties_attester`](https://ethereum.github.io/eth2.0-APIs/#/ValidatorRequiredApi/getAttesterDuties)
 
 ```
-curl -d '{"jsonrpc":"2.0","method":"post_v1_validator_duties_attester","params":[1,["a7a0502eae26043d1ac39a39457a6cdf68fae2055d89c7dc59092c25911e4ee55c4e7a31ade61c39480110a393be28e8","a1826dd94cd96c48a81102d316a2af4960d19ca0b574ae5695f2d39a88685a43997cef9a5c26ad911847674d20c46b75"]],"id":1}' -H 'Content-Type: application/json' localhost:9190 -s | jq
+curl -d '{"jsonrpc":"2.0","method":"post_v1_validator_duties_attester","params":[1,[1,2]],"id":1}' -H 'Content-Type: application/json' localhost:9190 -s | jq
 ```
 
 ### [`get_v1_validator_duties_proposer`](https://ethereum.github.io/eth2.0-APIs/#/ValidatorRequiredApi/getProposerDuties)


### PR DESCRIPTION
This is an attempt at transitioning the `validator_duties_attester` endpoint from receiving validator pubkeys to validator indexes, for which we need to request the validator indexes using [`/eth/v1/beacon/states/{state_id}/validators/{validator_id}`](https://ethereum.github.io/eth2.0-APIs/#/ValidatorRequiredApi/getStateValidator).

However, that endpoint returns a full `Validator` object along with the index/ballance/state, and in that full `Validator` object are the `exit_epoch` and `withdrawable_epoch` which are set to `FAR_FUTURE_EPOCH` which when deserialized from JSON is causing problems. In this PR there is an attempt to serialize `Epoch` to string but that clashes with a borrowed proc from `datatypes.nim`.

One very hacky solution would be to manually set those 2 fields of each validator to something within the integer bounds but that is obviously horrible.