### PR TITLE
[DO NOT MERGE] Connection limits and dial cancelation

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -808,7 +808,7 @@ proc dialPeer*(node: Eth2Node, peerAddr: PeerAddr, index = 0) {.async.} =
       # TODO: As soon as `nim-libp2p` will be able to handle cancellation
       # properly and will have cancellation tests, we need add here cancellation
       # of `workfut`.
-      # workfut.cancel()
+      workfut.cancel()
       debug "Connection to remote peer timed out"
       inc nbc_timeout_dials
       node.addSeen(peerAddr.peerId, SeenTableTimeTimeout)


### PR DESCRIPTION
I'm opening this trial PR to request some assistance in testing out a significant rework in the connection upgrade and management flow as well as new futures related to connection limits. The libp2p PR is here - https://github.com/status-im/nim-libp2p/pull/384. Please try it out and report any issues you find in this PR.

Please make sure to run with metrics enabled and in particular pay attention to the the `libp2p_peers` and `libp2p_pubsub_peers`. The metrics should look similar to the image below, where both the number of peers as well as the number of pubsub peers is the same.

<img width="604" alt="Screen Shot 2020-10-30 at 2 38 21 PM" src="https://user-images.githubusercontent.com/1094341/97754772-b4d60c80-1abd-11eb-9d3a-65503d7eb206.png">

Currently the connection limits are se to set to 100 - 50 for inbound and 50 for outbound. This is tracked by the `libp2p_open_streams` metric. This counts are broken down by stream type as well as direction. 

<img width="605" alt="Screen Shot 2020-10-30 at 2 38 04 PM" src="https://user-images.githubusercontent.com/1094341/97754995-07172d80-1abe-11eb-9020-78749244d1d0.png">

This counts show the different stream objects that libp2p is currently using. The way to read it should be as follows:

- `ChronosStreams` - this is the number of sockets currently active
  - it should never go above the current connection limit (100 by default)
- `SecureConn` - this is the number of sockets that have been secured with either noise or secio
  - it should match the number of connected peers as tracked by the `libp2p_peers` metric
- `LPChannel` - this is the number of active multiplexed (virtual) streams
  - it should match the number of active requests, and hovers around 50-300 concurrent streams

If you use grafana, here is the dashboard used to generate the screenshots above - https://gist.github.com/dryajov/456605ef161fbc93ae60b20284a33f72.