### PR TITLE
Full "node" RPC calls implementation and fixes to peer lifetime states.

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1009,6 +1009,7 @@ proc handlePeer*(peer: Peer) {.async.} =
     warn "Peer is already present in PeerPool", peer = peer
   of PeerStatus.Success:
     # Peer was added to PeerPool.
+    peer.score = NewPeerScore
     peer.connectionState = Connected
     # We spawn task which will obtain ENR for this peer.
     asyncSpawn resolvePeer(peer)
@@ -1017,10 +1018,11 @@ proc handlePeer*(peer: Peer) {.async.} =
 
 proc onConnEvent(node: Eth2Node, peerId: PeerID, event: ConnEvent) {.async.} =
   let peer = node.getPeer(peerId)
-  debug "Peer upgraded", peer = $peerId, connections = peer.connections
   case event.kind
   of ConnEventKind.Connected:
     inc peer.connections
+    debug "Peer connection upgraded", peer = $peerId,
+                                      connections = peer.connections
     if peer.connections == 1:
       # Libp2p may connect multiple times to the same peer - using different
       # transports for both incoming and outgoing. For now, we'll count our

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -134,7 +134,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       if (item.connectionState in states) and (item.direction in dirs):
         let address =
           if len(item.info.addrs) > 0:
-            $item.info.addrs[0]
+            $item.info.addrs[len(item.info.addres) - 1]
           else:
             ""
         let rpeer = RpcPeer(

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -1,7 +1,7 @@
 import std/options,
   chronicles,
   json_rpc/[rpcserver, jsonmarshal],
-
+  eth/p2p/discoveryv5/enr,
   ../beacon_node_common, ../eth2_network,
   ../peer_pool, ../version,
   ../spec/[datatypes, digest, presets],
@@ -23,39 +23,72 @@ type
     state*: string
     direction*: string
 
-proc validatePeerState(state: seq[string]): Option[set[ConnectionState]] =
+proc validatePeerState(state: Option[seq[string]]): Option[set[ConnectionState]] =
   var res: set[ConnectionState]
-  for item in state:
-    case item
-    of "disconnected":
-      if ConnectionState.Disconnected notin res:
-        res.incl(ConnectionState.Disconnected)
+  if state.isSome():
+    let states = state.get()
+    for item in states:
+      case item
+      of "disconnected":
+        if ConnectionState.Disconnected notin res:
+          res.incl(ConnectionState.Disconnected)
+        else:
+          # `state` values should be unique
+          return none(set[ConnectionState])
+      of "connecting":
+        if ConnectionState.Disconnected notin res:
+          res.incl(ConnectionState.Connecting)
+        else:
+          # `state` values should be unique
+          return none(set[ConnectionState])
+      of "connected":
+        if ConnectionState.Connected notin res:
+          res.incl(ConnectionState.Connected)
+        else:
+          # `state` values should be unique
+          return none(set[ConnectionState])
+      of "disconnecting":
+        if ConnectionState.Disconnecting notin res:
+          res.incl(ConnectionState.Disconnecting)
+        else:
+          # `state` values should be unique
+          return none(set[ConnectionState])
       else:
+        # Found incorrect `state` string value
         return none(set[ConnectionState])
-    of "connecting":
-      if ConnectionState.Disconnected notin res:
-        res.incl(ConnectionState.Connecting)
-      else:
-        return none(set[ConnectionState])
-    of "connected":
-      if ConnectionState.Connected notin res:
-        res.incl(ConnectionState.Connected)
-      else:
-        return none(set[ConnectionState])
-    of "disconnecting":
-      if ConnectionState.Disconnecting notin res:
-        res.incl(ConnectionState.Disconnecting)
-      else:
-        return none(set[ConnectionState])
-    else:
-      return none(set[ConnectionState])
 
   if res == {}:
     res = {ConnectionState.Connecting, ConnectionState.Connected,
            ConnectionState.Disconnecting, ConnectionState.Disconnected}
   some(res)
 
-proc toString*(state: ConnectionState): string =
+proc validateDirection(direction: Option[seq[string]]): Option[set[PeerType]] =
+  var res: set[PeerType]
+  if direction.isSome():
+    let directions = direction.get()
+    for item in directions:
+      case item
+      of "inbound":
+        if PeerType.Incoming notin res:
+          res.incl(PeerType.Incoming)
+        else:
+          # `direction` values should be unique
+          return none(set[PeerType])
+      of "outbound":
+        if PeerType.Outgoing notin res:
+          res.incl(PeerType.Outgoing)
+        else:
+          # `direction` values should be unique
+          return none(set[PeerType])
+      else:
+        # Found incorrect `direction` string value
+        return none(set[PeerType])
+
+  if res == {}:
+    res = {PeerType.Incoming, PeerType.Outgoing}
+  some(res)
+
+proc toString(state: ConnectionState): string =
   case state
   of ConnectionState.Disconnected:
     "disconnected"
@@ -68,6 +101,13 @@ proc toString*(state: ConnectionState): string =
   else:
     ""
 
+proc toString(direction: PeerType): string =
+  case direction:
+  of PeerType.Incoming:
+    "inbound"
+  of PeerType.Outgoing:
+    "outbound"
+
 proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.rpc("get_v1_node_identity") do () -> NodeIdentityTuple:
     return (
@@ -79,8 +119,33 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       metadata: (0'u64, "")
     )
 
-  rpcServer.rpc("get_v1_node_peers") do () -> seq[RpcPeer]:
-    unimplemented()
+  rpcServer.rpc("get_v1_node_peers") do (state: Option[seq[string]],
+                                direction: Option[seq[string]]) -> seq[RpcPeer]:
+    var res = newSeq[RpcPeer]()
+    let rstates = validatePeerState(state)
+    if rstates.isNone():
+      raise newException(CatchableError, "Incorrect state parameter")
+    let rdirs = validateDirection(direction)
+    if rdirs.isNone():
+      raise newException(CatchableError, "Incorrect direction parameter")
+    let states = rstates.get()
+    let dirs = rdirs.get()
+    for item in node.network.peers.values():
+      if (item.connectionState in states) and (item.direction in dirs):
+        let address =
+          if len(item.info.addrs) > 0:
+            $item.info.addrs[0]
+          else:
+            ""
+        let rpeer = RpcPeer(
+          peer_id: $item.info.peerId,
+          enr: if item.enr.isSome(): item.enr.get().toUri() else: "",
+          last_seen_p2p_address: address,
+          state: item.connectionState.toString(),
+          direction: item.direction.toString()
+        )
+        res.add(rpeer)
+    return res
 
   rpcServer.rpc("get_v1_node_peers_peerId") do () -> JsonNode:
     unimplemented()

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -1,4 +1,4 @@
-import
+import std/options,
   chronicles,
   json_rpc/[rpcserver, jsonmarshal],
 
@@ -15,6 +15,59 @@ type
 template unimplemented() =
   raise (ref CatchableError)(msg: "Unimplemented")
 
+type
+  RpcPeer* = object
+    peer_id*: string
+    enr*: string
+    last_seen_p2p_address*: string
+    state*: string
+    direction*: string
+
+proc validatePeerState(state: seq[string]): Option[set[ConnectionState]] =
+  var res: set[ConnectionState]
+  for item in state:
+    case item
+    of "disconnected":
+      if ConnectionState.Disconnected notin res:
+        res.incl(ConnectionState.Disconnected)
+      else:
+        return none(set[ConnectionState])
+    of "connecting":
+      if ConnectionState.Disconnected notin res:
+        res.incl(ConnectionState.Connecting)
+      else:
+        return none(set[ConnectionState])
+    of "connected":
+      if ConnectionState.Connected notin res:
+        res.incl(ConnectionState.Connected)
+      else:
+        return none(set[ConnectionState])
+    of "disconnecting":
+      if ConnectionState.Disconnecting notin res:
+        res.incl(ConnectionState.Disconnecting)
+      else:
+        return none(set[ConnectionState])
+    else:
+      return none(set[ConnectionState])
+
+  if res == {}:
+    res = {ConnectionState.Connecting, ConnectionState.Connected,
+           ConnectionState.Disconnecting, ConnectionState.Disconnected}
+  some(res)
+
+proc toString*(state: ConnectionState): string =
+  case state
+  of ConnectionState.Disconnected:
+    "disconnected"
+  of ConnectionState.Connecting:
+    "connecting"
+  of ConnectionState.Connected:
+    "connected"
+  of ConnectionState.Disconnecting:
+    "disconnecting"
+  else:
+    ""
+
 proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
   rpcServer.rpc("get_v1_node_identity") do () -> NodeIdentityTuple:
     return (
@@ -26,7 +79,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       metadata: (0'u64, "")
     )
 
-  rpcServer.rpc("get_v1_node_peers") do () -> JsonNode:
+  rpcServer.rpc("get_v1_node_peers") do () -> seq[RpcPeer]:
     unimplemented()
 
   rpcServer.rpc("get_v1_node_peers_peerId") do () -> JsonNode:

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -231,7 +231,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     )
 
   rpcServer.rpc("get_v1_node_version") do () -> JsonNode:
-    return %{"version": "Nimbus/" & fullVersionStr}
+    return %*{"version": "Nimbus/" & fullVersionStr}
 
   rpcServer.rpc("get_v1_node_syncing") do () -> SyncInfo:
     return node.syncManager.getInfo()
@@ -241,6 +241,6 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     # its impossible to return HTTP ERROR 503 according to specification.
     if node.syncManager.inProgress:
       # We need to return HTTP ERROR 206 according to specification
-      return %{"health": 206}
+      return %*{"health": 206}
     else:
-      return %{"health": 200}
+      return %*{"health": 200}

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -134,7 +134,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       if (item.connectionState in states) and (item.direction in dirs):
         let address =
           if len(item.info.addrs) > 0:
-            $item.info.addrs[len(item.info.addres) - 1]
+            $item.info.addrs[len(item.info.addrs) - 1]
           else:
             ""
         let rpeer = RpcPeer(

--- a/beacon_chain/spec/eth2_apis/callsigs_types.nim
+++ b/beacon_chain/spec/eth2_apis/callsigs_types.nim
@@ -5,9 +5,7 @@ import
   # TODO for some reason "../[datatypes, digest, crypto]" results in "Error: cannot open file"
   ../datatypes,
   ../digest,
-  ../crypto,
-  libp2p/[peerid, multiaddress],
-  eth/p2p/discoveryv5/enr
+  ../crypto
 
 type
   AttesterDuties* = tuple
@@ -46,8 +44,23 @@ type
     header: SignedBeaconBlockHeader
 
   NodeIdentityTuple* = tuple
-    peer_id: PeerID
-    enr: Record
-    p2p_addresses: seq[MultiAddress]
-    discovery_addresses: seq[MultiAddress]
+    peer_id: string
+    enr: string
+    p2p_addresses: seq[string]
+    discovery_addresses: seq[string]
     metadata: tuple[seq_number: uint64, attnets: string]
+
+  NodePeerTuple* = tuple
+    peer_id: string
+    enr: string
+    last_seen_p2p_address: string
+    state: string
+    direction: string
+    agent: string # This is not part of specification
+    proto: string # This is not part of specification
+
+  NodePeerCountTuple* = tuple
+    disconnected: int
+    connecting: int
+    connected: int
+    disconnecting: int

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -129,6 +129,10 @@ type
     peer*: T
     stamp*: chronos.Moment
 
+  SyncInfo* = object
+    head_slot*: Slot
+    sync_distance*: int64
+
   SyncManagerError* = object of CatchableError
   BeaconBlocksRes* = NetRes[seq[SignedBeaconBlock]]
 
@@ -1177,3 +1181,9 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
 proc start*[A, B](man: SyncManager[A, B]) =
   ## Starts SyncManager's main loop.
   man.syncFut = man.syncLoop()
+
+proc getInfo*[A, B](man: SyncManager[A, B]): SyncInfo =
+  ## Returns current synchronization information for RPC call.
+  let wallSlot = man.getLocalWallSlot()
+  let headSlot = man.getLocalHeadSlot()
+  SyncInfo(head_slot: headSlot, sync_distance: int64(wallSlot - headSlot))

--- a/beacon_chain/sync_protocol.nim
+++ b/beacon_chain/sync_protocol.nim
@@ -239,6 +239,10 @@ proc handleStatus(peer: Peer,
     await peer.disconnect(IrrelevantNetwork)
   else:
     peer.setStatusMsg(theirStatus)
+    if peer.connectionState == Connecting:
+      # As soon as we get here it means that we passed handshake succesfully. So
+      # we can add this peer to PeerPool.
+      await peer.handlePeer()
 
 proc initBeaconSync*(network: Eth2Node, chainDag: ChainDAGRef,
                      forkDigest: ForkDigest) =


### PR DESCRIPTION
1. Implementation of RPC calls.
    * 25 | /eth/v1/node/identity
    * 26 | /eth/v1/node/peers
    * 27 | /eth/v1/node/peers/{peer_id}
    * 28 | /eth/v1/node/peer_count
    * 30 | /eth/v1/node/syncing
    * 31 | /eth/v1/node/health
2. Peer lifetime tracking is now compatible with specification.
3. Fixed double status request for incoming peers.
4. Added many debug/warning logs to help debug issues in `nim-libp2p` connection manager.

This PR is dependent on https://github.com/status-im/nim-chronos/pull/142 
