### PR TITLE
Use async queryRandom instead of inefficient randomNodes to discovery nodes

### DIFF
--- a/beacon_chain/eth2_discovery.nim
+++ b/beacon_chain/eth2_discovery.nim
@@ -14,7 +14,7 @@ type
   PublicKey = keys.PublicKey
 
 export
-  Eth2DiscoveryProtocol, open, start, close, closeWait, randomNodes,
+  Eth2DiscoveryProtocol, open, start, close, closeWait, queryRandom,
     updateRecord, results
 
 proc parseBootstrapAddress*(address: TaintedString):


### PR DESCRIPTION
Least amount of changes for doing the async query approach of finding peers.
This will allow for finding a broader set of unique peers (as not only the ones of the routing table are searched).

When running this you will notice that the discovery tick will pretty much always render new peers and `if newPeers == 0:` will not occur.

Eventually, we could change the code so that `queryRandom` gets called directly from peer pool or libp2p connection manager or so when the peers drop instead of doing this loop. 
And an additional queryRandom should be added also to search for specific `attnets` in ENR, again, to be triggered from libp2p or through information provided by libp2p (unhealthy meshes).

Depends on https://github.com/status-im/nim-eth/pull/322