### PR TITLE
don't special-case zero-validator subnet cycling

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -407,9 +407,6 @@ proc cycleAttestationSubnets(node: BeaconNode, wallSlot: Slot) =
         node.chainDag.headState.data.data, validatorIndex.ValidatorIndex) != nil:
       attachedValidators.add validatorIndex.ValidatorIndex
 
-  if attachedValidators.len == 0:
-    return
-
   let (newAttestationSubnets, expiringSubnets, newSubnets) =
     get_attestation_subnet_changes(
       node.chainDag.headState.data.data, attachedValidators,

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -118,7 +118,6 @@ proc get_attestation_subnet_changes*(
     prevAttestationSubnets: AttestationSubnets):
     tuple[a: AttestationSubnets, b: set[uint8], c: set[uint8]] =
   static: doAssert ATTESTATION_SUBNET_COUNT == 64  # Fits in a set[uint8]
-  doAssert attachedValidators.len > 0
 
   # Guaranteed equivalent to wallSlot by cycleAttestationSubnets(), especially
   # since it'll try to run early in epochs, avoiding race conditions.


### PR DESCRIPTION
The steady-state for 0 validators becomes zero attestation subnet subscriptions:

> "lvl":"DBG","ts":"2021-01-12 11:05:19.272+00:00","msg":"Attestation subnets","topics":"beacnde","tid":219570,"file":"nimbus_beacon_node.nim:419","expiring_subnets":[],"current_epoch_subnets":[],"upcoming_subnets":[],"new_subnets":[],"epoch":12357,"num_stability_subnets":0