### PR TITLE
cycle attestation subnets every slot

### DIFF
--- a/beacon_chain/deposit_contract.nim
+++ b/beacon_chain/deposit_contract.nim
@@ -1,5 +1,5 @@
 import
-  os, sequtils, strutils, options, json, terminal, random,
+  os, sequtils, strutils, options, json, terminal,
   chronos, chronicles, confutils, stint, json_serialization,
   ../beacon_chain/network_metadata,
   web3, web3/confutils_defs, eth/keys, stew/io2, filepath,

--- a/beacon_chain/deposit_contract.nim
+++ b/beacon_chain/deposit_contract.nim
@@ -1,5 +1,5 @@
 import
-  os, sequtils, strutils, options, json, terminal,
+  os, sequtils, strutils, options, json, terminal, random,
   chronos, chronicles, confutils, stint, json_serialization,
   ../beacon_chain/network_metadata,
   web3, web3/confutils_defs, eth/keys, stew/io2, filepath,

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1095,6 +1095,7 @@ proc init*(T: type Eth2Node, conf: BeaconNodeConf, enrForkId: ENRForkID,
     {"eth2": SSZ.encode(result.forkId), "attnets": SSZ.encode(result.metadata.attnets)},
     rng)
   result.discoveryEnabled = discovery
+  result.rng = rng
 
   newSeq result.protocolStates, allProtocols.len
   for proto in allProtocols:

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -145,12 +145,21 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     let
       head = node.doChecksAndGetCurrentHead(epoch)
       epochRef = node.chainDag.getEpochRef(head, epoch)
-    let subnet = compute_subnet_for_attestation(
-      get_committee_count_per_slot(epochRef), slot, committee_index).uint8
-    if  subnet notin node.attestationSubnets.subscribedSubnets[0] and
-        subnet notin node.attestationSubnets.subscribedSubnets[1]:
-      node.network.subscribe(getAttestationTopic(node.forkDigest, subnet))
+      subnet = compute_subnet_for_attestation(
+        get_committee_count_per_slot(epochRef), slot, committee_index).uint8
 
-    # But it might only be in current
-    node.attestationSubnets.subscribedSubnets[0].incl subnet
-    node.attestationSubnets.subscribedSubnets[1].incl subnet
+    # Either subnet already subscribed or not. If not, subscribe. If it is,
+    # extend subscription. All one knows from the API combined with how far
+    # ahead one can check for attestation schedule is that it might be used
+    # for up to the end of next epoch. Therefore, arrange for subscriptions
+    # to last at least that long.
+    if subnet notin node.attestationSubnets.subscribedSubnets:
+      # When to subscribe. Since it's not clear when from the API it's first
+      # needed, do so immediately.
+      node.attestationSubnets.subscribeSlot[subnet] =
+        min(node.attestationSubnets.subscribeSlot[subnet], wallSlot)
+
+    node.attestationSubnets.unsubscribeSlot[subnet] =
+      max(
+        compute_start_slot_at_epoch(epoch + 2),
+        node.attestationSubnets.unsubscribeSlot[subnet])

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -458,7 +458,7 @@ type
     stabilitySubnets*: seq[tuple[subnet: uint8, expiration: Epoch]]
     nextCycleEpoch*: Epoch
 
-    # These function as the states in a state machine per subnet
+    # These encode states in per-subnet state machines
     subscribedSubnets*: set[uint8]
     subscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
     unsubscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -61,6 +61,7 @@ const
   # Not part of spec. Still useful, pending removing usage if appropriate.
   ZERO_HASH* = Eth2Digest()
   MAX_GRAFFITI_SIZE = 32
+  FAR_FUTURE_SLOT* = (not 0'u64).Slot
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/p2p-interface.md#configuration
   MAXIMUM_GOSSIP_CLOCK_DISPARITY* = 500.millis
@@ -70,6 +71,9 @@ const
 
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
   BASE_REWARDS_PER_EPOCH* = 4
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#misc
+  ATTESTATION_SUBNET_COUNT* = 64
 
   # https://github.com/ethereum/eth2.0-specs/pull/2101
   ATTESTATION_PRODUCTION_DIVISOR* = 3
@@ -451,9 +455,13 @@ type
 
   AttestationSubnets* = object
     enabled*: bool
-    nextCycleEpoch*: Epoch
-    subscribedSubnets*: array[2, set[uint8]]
     stabilitySubnets*: seq[tuple[subnet: uint8, expiration: Epoch]]
+    nextCycleEpoch*: Epoch
+
+    # These function as the states in a state machine per subnet
+    subscribedSubnets*: set[uint8]
+    subscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
+    unsubscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
 
   # This matches the mutable state of the Solidity deposit contract
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/solidity_deposit_contract/deposit_contract.sol

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[strformat, sets, random],
+  std/[strformat, sets],
   ./datatypes, ./helpers, ./validator
 
 const
@@ -104,8 +104,3 @@ func get_committee_assignments*(
         result.add(
           (compute_subnet_for_attestation(committees_per_slot, slot, idx).uint8,
             slot))
-
-# https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#phase-0-attestation-subnet-stability
-proc getStabilitySubnetLength*(): uint64 =
-  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION +
-    rand(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION.int).uint64


### PR DESCRIPTION
Currently, it only cycles at epoch boundaries. This cycles every slot, as appropriate.

This therefore can wait a little longer to subscribe to subnets, though it still allows for 32 slots to emulate the worst-case of the previous epoch-only mode (discovering at the beginning of epoch `n` that it needs to be on a subnet by the first slot of epoch `n+1`). If subscribing to a subnet proves reliably quicker, this can be shortened.

It also unsubscribes from a subnet's topic, when possible, immediately after it's used in an epoch. For example, if a subnet's used in slot 10, but not after that, the previous design remained on it for the rest of the epoch regardless. This gets off immediately.

It'd be possible to encode the subscribe/unsubscribe slot information somewhat more compactly, based on several Eth2 protocol assumptions, but most of the approaches I tried were either fragile in other ways or created overhead when, e.g., a relative-slot-offset encoding would need updating if it was discovered that one had to subscribe to a topic earlier than initially known. One can encode only the least significant few bits and unambiguously identify which slots are intended, but then it's more involved to run `max` and `min` on such encodings. As a result, this uses a straightforward encoding, of approximately 64 subnets * 16 bytes/subnet = 1k of constant-sized information.

This should still be a net win for memory usage, because it typically saves lots of subnet attestation messages: on average in the few-validators approximations, where validator overlap in subnets and from stability subnets is unlikely to dominate, about half of the on-subnet time is just currently wasted CPU, memory, and network, including libp2p buffers and the like. In particular, when in beginning epoch `n`, it sees that in epoch `n+1`, slot `m` (`0 <= m < SLOTS_PER_EPOCH`) is required, it currently immediately subscribes to that subnet topic, for a total of at least `2*SLOTS_PER_EPOCH` slots.

This PR reduces that to from slots from `m - SLOTS_PER_EPOCH` to `m + 1`, or about `SLOTS_PER_EPOCH` slots, for half the average (non-stability) overall subnet topic subscription time. Since approximately half the topics (in the, again, low-validator case) are from stability subnets, which are unaffected by this, it's not a 50% reduction, but a 25% reduction in attestation subnet topic subscription in the ideal case.

As one approaches the the saturated-subnet case, such as the fleet nodes, machines are big enough that 1k here or there shouldn't matter as much.