### PR TITLE
Fix discv5 loop in case of no nodes

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -916,8 +916,10 @@ proc runDiscoveryLoop*(node: Eth2Node) {.async.} =
           warn "Peer count low, no new peers discovered",
             discovered_nodes = len(discoveredNodes), new_peers = newPeers,
             current_peers = currentPeers, wanted_peers = node.wantedPeers
-    else:
-      await sleepAsync(1.seconds)
+
+    # Discovery `queryRandom` can have a synchronous fast path for example
+    # when no peers are in the routing table. Don't run it in continuous loop.
+    await sleepAsync(1.seconds)
 
 proc getPersistentNetMetadata*(conf: BeaconNodeConf): Eth2Metadata =
   let metadataPath = conf.dataDir / nodeMetadataFilename

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -373,6 +373,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --log-level="${LOG_LEVEL}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE )) \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
+    --max-peers=$(( NUM_NODES - 1 )) \
     --data-dir="${NODE_DATA_DIR}" \
     ${BOOTSTRAP_ARG} \
     ${STATE_SNAPSHOT_ARG} \


### PR DESCRIPTION
Also set max peers to the amount of peers in local testnet - 1, so that discovery stops doing queries when max is reached.