### PR TITLE
Block validation flow v2 + Batch (serial) sig verification

### DIFF
--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -231,7 +231,7 @@ proc addAttestation*(pool: var AttestationPool,
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
                     blckRef: BlockRef,
-                    blck: BeaconBlock,
+                    blck: TrustedBeaconBlock,
                     wallSlot: Slot) =
   ## Add a verified block to the fork choice context
   let state = pool.forkChoice.process_block(

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -320,6 +320,9 @@ proc putBlock*(db: BeaconChainDB, value: SignedBeaconBlock) =
 proc putBlock*(db: BeaconChainDB, value: TrustedSignedBeaconBlock) =
   db.put(subkey(SignedBeaconBlock, value.root), value)
   db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
+proc putBlock*(db: BeaconChainDB, value: SigVerifiedSignedBeaconBlock) =
+  db.put(subkey(SignedBeaconBlock, value.root), value)
+  db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
 
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
   # TODO prune old states - this is less easy than it seems as we never know

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -314,6 +314,7 @@ func toBeaconBlockSummary(v: SomeBeaconBlock): BeaconBlockSummary =
     parent_root: v.parent_root,
   )
 
+# TODO: we should only store TrustedSignedBeaconBlock in the DB.
 proc putBlock*(db: BeaconChainDB, value: SignedBeaconBlock) =
   db.put(subkey(type value, value.root), value)
   db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -13,7 +13,7 @@ import
   # Status libraries
   stew/[endians2, byteutils], chronicles,
   # Internals
-  ../spec/[datatypes, crypto, digest],
+  ../spec/[datatypes, crypto, digest, signatures_batch],
   ../beacon_chain_db, ../extras
 
 from libp2p/protocols/pubsub/pubsub import ValidationResult
@@ -64,6 +64,9 @@ type
     missing*: Table[Eth2Digest, MissingBlock] ##\
     ## Roots of blocks that we would like to have (either parent_root of
     ## unresolved blocks or block roots of attestations)
+
+    sigVerifCache*: BatchedBLSVerifierCache ##\
+    ## A cache for batch BLS signature verification contexts
 
     inAdd*: bool
 
@@ -200,7 +203,7 @@ type
       ## has advanced without blocks
 
   OnBlockAdded* = proc(
-    blckRef: BlockRef, blck: SignedBeaconBlock,
+    blckRef: BlockRef, blck: SomeSignedBeaconBlock,
     epochRef: EpochRef, state: HashedBeaconState) {.raises: [Defect], gcsafe.}
 
 template validator_keys*(e: EpochRef): untyped = e.validator_key_store[1][]

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -12,6 +12,7 @@ import
   std/[deques, strformat, tables, hashes],
   # Status libraries
   stew/[endians2, byteutils], chronicles,
+  eth/keys,
   # Internals
   ../spec/[datatypes, crypto, digest, signatures_batch],
   ../beacon_chain_db, ../extras
@@ -67,6 +68,8 @@ type
 
     sigVerifCache*: BatchedBLSVerifierCache ##\
     ## A cache for batch BLS signature verification contexts
+    rng*: ref BrHmacDrbgContext  ##\
+    ## A reference to the Nimbus application-wide RNG
 
     inAdd*: bool
 

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -203,7 +203,7 @@ type
       ## has advanced without blocks
 
   OnBlockAdded* = proc(
-    blckRef: BlockRef, blck: SomeSignedBeaconBlock,
+    blckRef: BlockRef, blck: SignedBeaconBlock,
     epochRef: EpochRef, state: HashedBeaconState) {.raises: [Defect], gcsafe.}
 
 template validator_keys*(e: EpochRef): untyped = e.validator_key_store[1][]

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -203,8 +203,9 @@ type
       ## has advanced without blocks
 
   OnBlockAdded* = proc(
-    blckRef: BlockRef, blck: SignedBeaconBlock,
+    blckRef: BlockRef, blck: TrustedSignedBeaconBlock,
     epochRef: EpochRef, state: HashedBeaconState) {.raises: [Defect], gcsafe.}
+    # The `{.gcsafe.}` annotation is needed to shut up the compiler.
 
 template validator_keys*(e: EpochRef): untyped = e.validator_key_store[1][]
 

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -43,7 +43,7 @@ declareGauge beacon_processed_deposits_total, "Number of total deposits included
 logScope: topics = "chaindag"
 
 proc putBlock*(
-    dag: var ChainDAGRef, signedBlock: SignedBeaconBlock or SigVerifiedSignedBeaconBlock) =
+    dag: var ChainDAGRef, signedBlock: TrustedSignedBeaconBlock) =
   dag.db.putBlock(signedBlock)
 
 proc updateStateData*(

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -43,7 +43,7 @@ declareGauge beacon_processed_deposits_total, "Number of total deposits included
 logScope: topics = "chaindag"
 
 proc putBlock*(
-    dag: var ChainDAGRef, signedBlock: SignedBeaconBlock) =
+    dag: var ChainDAGRef, signedBlock: SignedBeaconBlock or SigVerifiedSignedBeaconBlock) =
   dag.db.putBlock(signedBlock)
 
 proc updateStateData*(

--- a/beacon_chain/block_pools/clearance.nim
+++ b/beacon_chain/block_pools/clearance.nim
@@ -206,7 +206,9 @@ proc addRawBlockKnownParent(
   # Careful, clearanceState.data has been updated but not blck - we need to
   # create the BlockRef first!
   addResolvedBlock(
-    dag, quarantine, dag.clearanceState, sigVerifBlock, parent, cache,
+    dag, quarantine, dag.clearanceState,
+    signedBlock, # We don't pass the sigVerifBlock here to simplify "onBlockAdded" callback.
+    parent, cache,
     onBlockAdded)
 
   return ok dag.clearanceState.blck

--- a/beacon_chain/block_pools/quarantine.nim
+++ b/beacon_chain/block_pools/quarantine.nim
@@ -11,6 +11,7 @@ import
   std/[tables, options],
   chronicles,
   stew/bitops2,
+  eth/keys,
   ../spec/[crypto, datatypes, digest],
   ./block_pools_types
 
@@ -18,6 +19,10 @@ export options, block_pools_types
 
 logScope:
   topics = "quarant"
+
+func init*(T: type QuarantineRef, rng: ref BrHmacDrbgContext): T =
+  result = T()
+  result.rng = rng
 
 func checkMissing*(quarantine: var QuarantineRef): seq[FetchRecord] =
   ## Return a list of blocks that we should try to resolve from other client -

--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -141,11 +141,11 @@ proc storeBlock(
     attestationPool = self.attestationPool
 
   let blck = self.chainDag.addRawBlock(self.quarantine, signedBlock) do (
-      blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+      blckRef: BlockRef, trustedBlock: TrustedSignedBeaconBlock,
       epochRef: EpochRef, state: HashedBeaconState):
     # Callback add to fork choice if valid
     attestationPool[].addForkChoice(
-      epochRef, blckRef, signedBlock.message, wallSlot)
+      epochRef, blckRef, trustedBlock.message, wallSlot)
 
   # Trigger attestation sending
   if blck.isOk and not self.blockReceivedDuringSlot.finished:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -208,7 +208,7 @@ proc init*(T: type BeaconNode,
                      else: {}
     chainDag = ChainDAGRef.init(conf.runtimePreset, db, chainDagFlags)
     beaconClock = BeaconClock.init(chainDag.headState.data.data)
-    quarantine = QuarantineRef()
+    quarantine = QuarantineRef.init(rng)
     databaseGenesisValidatorsRoot =
       chainDag.headState.data.data.genesis_validators_root
 

--- a/beacon_chain/rpc/beacon_api.nim
+++ b/beacon_chain/rpc/beacon_api.nim
@@ -372,7 +372,9 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
       tuple[canonical: bool, header: SignedBeaconBlockHeader]:
     let bd = node.getBlockDataFromBlockId(blockId)
     let tsbb = bd.data
-    result.header.signature = ValidatorSig.init tsbb.signature.data
+    static: doAssert tsbb.signature is TrustedSig and
+              sizeof(ValidatorSig) == sizeof(tsbb.signature)
+    result.header.signature = cast[ValidatorSig](tsbb.signature)
 
     result.header.message.slot = tsbb.message.slot
     result.header.message.proposer_index = tsbb.message.proposer_index

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -98,6 +98,12 @@ template maxSize*(n: int) {.pragma.}
 #
 # At the moment we only introduce SigVerifiedBeaconBlock
 # and keep the old naming where BeaconBlock == UntrustedbeaconBlock
+# Also for Attestation, IndexedAttestation, AttesterSlashing, ProposerSlashing.
+# We only distinguish between the base version and the Trusted version
+# (i.e. Attestation and TrustedAttestation)
+# The Trusted version, at the moment, implies that the cryptographic signature was checked.
+# It DOES NOT imply that the state transition was verified.
+# Currently the code MUST verify the state transition as soon as the signature is verified
 #
 # TODO We could implement the trust level as either static enums or generic tags
 # and reduce duplication and improve maintenance and readability,
@@ -148,6 +154,9 @@ type
     signed_header_2*: SignedBeaconBlockHeader
 
   TrustedProposerSlashing* = object
+    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
+    # It DOES NOT imply that the state transition was verified.
+    # Currently the code MUST verify the state transition as soon as the signature is verified
     signed_header_1*: TrustedSignedBeaconBlockHeader
     signed_header_2*: TrustedSignedBeaconBlockHeader
 
@@ -157,6 +166,9 @@ type
     attestation_2*: IndexedAttestation
 
   TrustedAttesterSlashing* = object
+    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
+    # It DOES NOT imply that the state transition was verified.
+    # Currently the code MUST verify the state transition as soon as the signature is verified
     attestation_1*: TrustedIndexedAttestation
     attestation_2*: TrustedIndexedAttestation
 
@@ -167,6 +179,9 @@ type
     signature*: ValidatorSig
 
   TrustedIndexedAttestation* = object
+    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
+    # It DOES NOT imply that the state transition was verified.
+    # Currently the code MUST verify the state transition as soon as the signature is verified
     attesting_indices*: List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE]
     data*: AttestationData
     signature*: TrustedSig
@@ -180,6 +195,9 @@ type
     signature*: ValidatorSig
 
   TrustedAttestation* = object
+    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
+    # It DOES NOT imply that the state transition was verified.
+    # Currently the code MUST verify the state transition as soon as the signature is verified
     aggregation_bits*: CommitteeValidatorsBits
     data*: AttestationData
     signature*: TrustedSig

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -86,14 +86,14 @@ template maxSize*(n: int) {.pragma.}
 # if the signature and/or transition logic of a
 # a block have been verified:
 #
-# |                            | Signature unchecked             | Signature verified          |                                                    |   |   |
+# |                            | Signature unchecked             | Signature verified          |
 # |----------------------------|-------------------------------  |-----------------------------|
 # | State transition unchecked | - UntrustedBeaconBlock          | - SigVerifiedBeaconBlock    |
 # |                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |
 # |                            | - UntrustedAttestation          | - TrustedAttestation        |
 # |----------------------------|-------------------------------  |-----------------------------|
 # | State transition verified  | - TransitionVerifiedBeaconBlock | - TrustedSignedBeaconBlock  |
-# |                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |                                                                        |   |   |
+# |                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |
 # |                            | - UntrustedAttestation          | - TrustedAttestation        |
 #
 # At the moment we only introduce SigVerifiedBeaconBlock

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -81,6 +81,30 @@ const
 
 template maxSize*(n: int) {.pragma.}
 
+# Block validation flow
+# We distinguish 4 cases depending
+# if the signature and/or transition logic of a
+# a block have been verified:
+#
+# |                            | Signature unchecked             | Signature verified          |                                                    |   |   |
+# |----------------------------|-------------------------------  |-----------------------------|
+# | State transition unchecked | - UntrustedBeaconBlock          | - SigVerifiedBeaconBlock    |
+# |                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |
+# |                            | - UntrustedAttestation          | - TrustedAttestation        |
+# |----------------------------|-------------------------------  |-----------------------------|
+# | State transition verified  | - TransitionVerifiedBeaconBlock | - TrustedSignedBeaconBlock  |
+# |                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |                                                                        |   |   |
+# |                            | - UntrustedAttestation          | - TrustedAttestation        |
+#
+# At the moment we only introduce SigVerifiedBeaconBlock
+# and keep the old naming where BeaconBlock == UntrustedbeaconBlock
+#
+# TODO We could implement the trust level as either static enums or generic tags
+# and reduce duplication and improve maintenance and readability,
+# however this caused problems respectively of:
+# - ambiguous calls, in particular for chronicles, with static enums
+# - broke the compiler in SSZ and nim-serialization
+
 type
   # Domains
   # ---------------------------------------------------------------
@@ -123,10 +147,18 @@ type
     signed_header_1*: SignedBeaconBlockHeader
     signed_header_2*: SignedBeaconBlockHeader
 
+  TrustedProposerSlashing* = object
+    signed_header_1*: TrustedSignedBeaconBlockHeader
+    signed_header_2*: TrustedSignedBeaconBlockHeader
+
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#attesterslashing
   AttesterSlashing* = object
     attestation_1*: IndexedAttestation
     attestation_2*: IndexedAttestation
+
+  TrustedAttesterSlashing* = object
+    attestation_1*: TrustedIndexedAttestation
+    attestation_2*: TrustedIndexedAttestation
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#indexedattestation
   IndexedAttestation* = object
@@ -225,6 +257,20 @@ type
 
     body*: BeaconBlockBody
 
+  SigVerifiedBeaconBlock* = object
+    ## A BeaconBlock that contains verified signatures
+    ## but that has not been verified for state transition
+    slot*: Slot
+    proposer_index*: uint64
+
+    parent_root*: Eth2Digest ##\
+    ## Root hash of the previous block
+
+    state_root*: Eth2Digest ##\
+    ## The state root, _after_ this block has been processed
+
+    body*: SigVerifiedBeaconBlockBody
+
   TrustedBeaconBlock* = object
     ## When we receive blocks from outside sources, they are untrusted and go
     ## through several layers of validation. Blocks that have gone through
@@ -276,23 +322,51 @@ type
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
 
-  TrustedBeaconBlockBody* = object
+  SigVerifiedBeaconBlockBody* = object
+    ## A BeaconBlock body with signatures verified
+    ## including:
+    ## - Randao reveal
+    ## - Attestations
+    ## - ProposerSlashing (SignedBeaconBlockHeader)
+    ## - AttesterSlashing (IndexedAttestation)
+    ## - SignedVoluntaryExits
+    ##
+    ## - ETH1Data (Deposits) can contain invalid BLS signatures
+    ##
+    ## The block state transition has NOT been verified
     randao_reveal*: TrustedSig
     eth1_data*: Eth1Data
     graffiti*: GraffitiBytes
 
     # Operations
-    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
-    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
 
-  SomeSignedBeaconBlock* = SignedBeaconBlock | TrustedSignedBeaconBlock
-  SomeBeaconBlock* = BeaconBlock | TrustedBeaconBlock
-  SomeBeaconBlockBody* = BeaconBlockBody | TrustedBeaconBlockBody
+  TrustedBeaconBlockBody* = object
+    ## A full verified block
+    randao_reveal*: TrustedSig
+    eth1_data*: Eth1Data
+    graffiti*: GraffitiBytes
+
+    # Operations
+    proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+  SomeSignedBeaconBlock* = SignedBeaconBlock | SigVerifiedSignedBeaconBlock | TrustedSignedBeaconBlock
+  SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
+  SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
   SomeAttestation* = Attestation | TrustedAttestation
   SomeIndexedAttestation* = IndexedAttestation | TrustedIndexedAttestation
+  SomeProposerSlashing* = ProposerSlashing | TrustedProposerSlashing
+  SomeAttesterSlashing* = AttesterSlashing | TrustedAttesterSlashing
+  SomeSignedBeaconBlockHeader* = SignedBeaconBlockHeader | TrustedSignedBeaconBlockHeader
+  SomeSignedVoluntaryExit* = SignedVoluntaryExit | TrustedSignedVoluntaryExit
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beaconstate
   BeaconState* = object
@@ -413,10 +487,33 @@ type
     message*: VoluntaryExit
     signature*: ValidatorSig
 
+  TrustedSignedVoluntaryExit* = object
+    message*: VoluntaryExit
+    signature*: TrustedSig
+
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#signedbeaconblock
   SignedBeaconBlock* = object
     message*: BeaconBlock
     signature*: ValidatorSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
+  SigVerifiedSignedBeaconBlock* = object
+    ## A SignedBeaconBlock with signatures verified
+    ## including:
+    ## - Block signature
+    ## - BeaconBlockBody
+    ##   - Randao reveal
+    ##   - Attestations
+    ##   - ProposerSlashing (SignedBeaconBlockHeader)
+    ##   - AttesterSlashing (IndexedAttestation)
+    ##   - SignedVoluntaryExits
+    ##
+    ##   - ETH1Data (Deposits) can contain invalid BLS signatures
+    ##
+    ## The block state transition has NOT been verified
+    message*: SigVerifiedBeaconBlock
+    signature*: TrustedSig
 
     root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
 
@@ -430,6 +527,10 @@ type
   SignedBeaconBlockHeader* = object
     message*: BeaconBlockHeader
     signature*: ValidatorSig
+
+  TrustedSignedBeaconBlockHeader* = object
+    message*: BeaconBlockHeader
+    signature*: TrustedSig
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#aggregateandproof
   AggregateAndProof* = object
@@ -764,7 +865,7 @@ func shortLog*(v: BeaconBlockHeader): auto =
     state_root: shortLog(v.state_root)
   )
 
-func shortLog*(v: SignedBeaconBlockHeader): auto =
+func shortLog*(v: SomeSignedBeaconBlockHeader): auto =
   (
     message: shortLog(v.message),
     signature: shortLog(v.signature)
@@ -815,13 +916,13 @@ func shortLog*(v: SomeIndexedAttestation): auto =
     signature: shortLog(v.signature)
   )
 
-func shortLog*(v: AttesterSlashing): auto =
+func shortLog*(v: SomeAttesterSlashing): auto =
   (
     attestation_1: shortLog(v.attestation_1),
     attestation_2: shortLog(v.attestation_2),
   )
 
-func shortLog*(v: ProposerSlashing): auto =
+func shortLog*(v: SomeProposerSlashing): auto =
   (
     signed_header_1: shortLog(v.signed_header_1),
     signed_header_2: shortLog(v.signed_header_2)
@@ -833,7 +934,7 @@ func shortLog*(v: VoluntaryExit): auto =
     validator_index: v.validator_index
   )
 
-func shortLog*(v: SignedVoluntaryExit): auto =
+func shortLog*(v: SomeSignedVoluntaryExit): auto =
   (
     message: shortLog(v.message),
     signature: shortLog(v.signature)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -186,6 +186,10 @@ proc collectSignatureSets*(
 
   # 3. Proposer slashings
   # ----------------------------------------------------
+  # Denial-of-service:
+  #   SSZ deserialization guarantees that blocks received from random sources
+  #   including peer or RPC
+  #   have at most MAX_PROPOSER_SLASHINGS proposer slashings.
   for i in 0 ..< signed_block.message.body.proposer_slashings.len:
     # don't use "items" for iterating over large type
     # due to https://github.com/nim-lang/Nim/issues/14421
@@ -228,6 +232,10 @@ proc collectSignatureSets*(
 
   # 4. Attester slashings
   # ----------------------------------------------------
+  # Denial-of-service:
+  #   SSZ deserialization guarantees that blocks received from random sources
+  #   including peer or RPC
+  #   have at most MAX_ATTESTER_SLASHINGS attester slashings.
   for i in 0 ..< signed_block.message.body.attester_slashings.len:
     # don't use "items" for iterating over large type
     # due to https://github.com/nim-lang/Nim/issues/14421
@@ -250,6 +258,10 @@ proc collectSignatureSets*(
 
   # 5. Attestations
   # ----------------------------------------------------
+  # Denial-of-service:
+  #   SSZ deserialization guarantees that blocks received from random sources
+  #   including peer or RPC
+  #   have at most MAX_ATTESTATIONS attestations.
   for i in 0 ..< signed_block.message.body.attestations.len:
     # don't use "items" for iterating over large type
     # due to https://github.com/nim-lang/Nim/issues/14421
@@ -261,6 +273,10 @@ proc collectSignatureSets*(
 
   # 6. VoluntaryExits
   # ----------------------------------------------------
+  # Denial-of-service:
+  #   SSZ deserialization guarantees that blocks received from random sources
+  #   including peer or RPC
+  #   have at most MAX_VOLUNTARY_EXITS voluntary exits.
   for i in 0 ..< signed_block.message.body.voluntary_exits.len:
     # don't use "items" for iterating over large type
     # due to https://github.com/nim-lang/Nim/issues/14421

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -1,0 +1,248 @@
+# beacon_chain
+# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  blscurve,
+  ../ssz/merkleization,
+  ./crypto, ./datatypes, ./helpers, ./presets,
+  ./beaconstate
+
+func addSignatureSet[T](
+      sigs: var seq[SignatureSet],
+      pubkey: blscurve.PublicKey,
+      sszObj: T,
+      signature: ValidatorSig,
+      state: BeaconState,
+      epoch: Epoch,
+      domain: DomainType): bool {.raises: [Defect].}=
+  ## Add a new signature set triplet (pubkey, message, signature)
+  ## to a collection of signature sets for batch verification.
+  ## Can return false if `signature` wasn't deserialized to a valid BLS signature.
+  try:
+    sigs.add((
+      pubkey,
+      compute_signing_root(
+        sszObj,
+        get_domain(
+          state.fork, domain,
+          epoch,
+          state.genesis_validators_root
+        )
+      ).data,
+      signature.blsValue
+    ))
+    return true
+  except FieldError: # bad discriminant when accessing signature.blsValue
+    return false
+
+proc aggregateAttesters(
+      attestation: IndexedAttestation,
+      state: BeaconState
+     ): blscurve.PublicKey {.noInit.} =
+  doAssert attestation.attesting_indices.len > 0
+  var attestersAgg{.noInit.}: AggregatePublicKey
+  attestersAgg.init(state.validators[attestation.attesting_indices[0]].pubkey.toRealPubKey().get().blsValue)
+  for i in 1 ..< attestation.attesting_indices.len:
+    attestersAgg.aggregate(state.validators[attestation.attesting_indices[i]].pubkey.toRealPubKey().get().blsValue)
+  result.finish(attestersAgg)
+
+proc addIndexedAttestation(
+      sigs: var seq[SignatureSet],
+      attestation: IndexedAttestation,
+      state: BeaconState
+     ): bool =
+  if attestation.attesting_indices.len == 0:
+    # Aggregation spec requires non-empty collection
+    # - https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04
+    # Eth2 spec requires at least one attesting indice in slashing
+    # - https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
+    return false
+
+  if not sigs.addSignatureSet(
+          attestation.aggregateAttesters(state),
+          attestation.data,
+          attestation.signature,
+          state, attestation.data.target.epoch,
+          DOMAIN_BEACON_ATTESTER):
+    return false
+  return true
+
+proc addAttestation(
+      sigs: var seq[SignatureSet],
+      attestation: Attestation,
+      state: BeaconState,
+      cache: var StateCache
+     ): bool =
+  result = false
+
+  var attestersAgg{.noInit.}: AggregatePublicKey
+  for valIndex in state.get_attesting_indices(
+                    attestation.data,
+                    attestation.aggregation_bits,
+                    cache
+                  ):
+    if not result: # first iteration
+      attestersAgg.init(state.validators[valIndex].pubkey.toRealPubKey().get().blsValue)
+      result = true
+    else:
+      attestersAgg.aggregate(state.validators[valIndex].pubkey.toRealPubKey().get().blsValue)
+
+  if not result:
+    # There was no attesters
+    return false
+
+  var attesters{.noinit.}: blscurve.PublicKey
+  attesters.finish(attestersAgg)
+
+  if not sigs.addSignatureSet(
+          attesters,
+          attestation.data,
+          attestation.signature,
+          state, attestation.data.target.epoch,
+          DOMAIN_BEACON_ATTESTER):
+    return false
+  return true
+
+proc collectSignatureSets(sigs: var seq[SignatureSet], signed_block: SignedBeaconBlock, state: BeaconState): bool =
+  ## Collect all signatures in a single signed block.
+  ## This includes
+  ## - Block proposer
+  ## - Randao Reaveal
+  ## - Proposer slashings
+  ## - Attester slashings
+  ## - Attestations
+  ## - VoluntaryExits
+  ##
+  ## We do not include deposits as they can be invalid per protocol
+  ## (secp256k1 signature instead of BLS)
+
+  # Metadata
+  # ----------------------------------------------------
+
+  let
+    proposer_index = signed_block.message.proposer_index
+  if proposer_index >= state.validators.lenu64:
+    return false
+
+  let pubkey = block:
+    let pk = state.validators[proposer_index].pubkey.toRealPubKey()
+    if pk.isNone:
+      return false
+    pk.unsafeGet().blsValue
+  let epoch = signed_block.message.slot.compute_epoch_at_slot()
+
+  # 1. Block proposer
+  # ----------------------------------------------------
+  if not sigs.addSignatureSet(
+          pubkey,
+          signed_block.message,
+          signed_block.signature,
+          state, epoch,
+          DOMAIN_BEACON_PROPOSER):
+    return false
+
+  # 2. Randao Reveal
+  # ----------------------------------------------------
+  if not sigs.addSignatureSet(
+          pubkey,
+          signed_block.message,
+          signed_block.message.body.randao_reveal,
+          state, epoch,
+          DOMAIN_RANDAO):
+    return false
+
+  # 3. Proposer slashings
+  # ----------------------------------------------------
+  for i in 0 ..< signed_block.message.body.proposer_slashings.len:
+    # don't use "items" for iterating over large type
+    # due to https://github.com/nim-lang/Nim/issues/14421
+    # fixed in 1.4.2
+
+    # Alias
+    template slashing: untyped = signed_block.message.body.proposer_slashings[i]
+
+    # Proposed block 1
+    block:
+      let header_1 = slashing.signed_header_1
+      let proposer1 = state.validators[header_1.message.proposer_index]
+      let epoch1 = header_1.message.slot.compute_epoch_at_slot()
+      if not sigs.addSignatureSet(
+              proposer1.pubkey.toRealPubKey().get().blsValue,
+              header_1.message,
+              header_1.signature,
+              state, epoch1,
+              DOMAIN_BEACON_PROPOSER
+            ):
+        return false
+
+    # Conflicting block 2
+    block:
+      let header_2 = slashing.signed_header_2
+      let proposer2 = state.validators[header_2.message.proposer_index]
+      let epoch2 = header_2.message.slot.compute_epoch_at_slot()
+      if not sigs.addSignatureSet(
+              proposer2.pubkey.toRealPubKey().get().blsValue,
+              header_2.message,
+              header_2.signature,
+              state, epoch2,
+              DOMAIN_BEACON_PROPOSER
+            ):
+        return false
+
+  # 4. Attester slashings
+  # ----------------------------------------------------
+  for i in 0 ..< signed_block.message.body.attester_slashings.len:
+    # don't use "items" for iterating over large type
+    # due to https://github.com/nim-lang/Nim/issues/14421
+    # fixed in 1.4.2
+
+    # Alias
+    template slashing: untyped = signed_block.message.body.attester_slashings[i]
+
+    # Attestation 1
+    if not sigs.addIndexedAttestation(
+            slashing.attestation_1,
+            state):
+      return false
+
+    # Conflicting attestation 2
+    if not sigs.addIndexedAttestation(
+            slashing.attestation_2,
+            state):
+      return false
+
+  # 5. Attestations
+  # ----------------------------------------------------
+  var cache = StateCache()
+  for i in 0 ..< signed_block.message.body.attestations.len:
+    # don't use "items" for iterating over large type
+    # due to https://github.com/nim-lang/Nim/issues/14421
+    # fixed in 1.4.2
+    if not sigs.addAttestation(
+            signed_block.message.body.attestations[i],
+            state, cache):
+      return false
+
+  # 6. VoluntaryExits
+  # ----------------------------------------------------
+  for i in 0 ..< signed_block.message.body.voluntary_exits.len:
+    # don't use "items" for iterating over large type
+    # due to https://github.com/nim-lang/Nim/issues/14421
+    # fixed in 1.4.2
+    template volex: untyped = signed_block.message.body.voluntary_exits[i]
+
+    if not sigs.addSignatureSet(
+            state.validators[volex.message.validator_index].pubkey.toRealPubKey().get().blsValue,
+            volex.message,
+            volex.signature,
+            state, volex.message.epoch,
+            DOMAIN_VOLUNTARY_EXIT):
+      return false
+
+  return true

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -23,10 +23,27 @@ func `$`*(s: SignatureSet): string =
     ", signing_root: 0x" & s.message.toHex() &
     ", signature: 0x" & s.signature.toHex() & ')'
 
-# TODO:
-# Now that we deserialize pubkeys and signatures lazily
-# this module needs graceful handling of rogue pubkey and signature
-# since they can come unchecked directly from the network.
+# Important:
+#   - Due to lazy loading, when we do crypto verification
+#     and only then state-transition verification,
+#     there is no guarantee that pubkeys and signatures received are valid
+#     unlike when Nimbus did eager loading which ensured they were correct beforehand
+
+template loadOrExitFalse(signature: ValidatorSig): blscurve.Signature =
+  ## Load a BLS signature from a raw signature
+  ## Exists the **caller** with false if the signature is invalid
+  let sig = signature.load()
+  if sig.isNone:
+    return false # this exists the calling scope, as templates are inlined.
+  sig.unsafeGet()
+
+template loadWithCacheOrExitFalse(pubkey: ValidatorPubKey): blscurve.PublicKey =
+  ## Load a BLS signature from a raw public key
+  ## Exists the **caller** with false if the public key is invalid
+  let pk = pubkey.loadWithCache()
+  if pk.isNone:
+    return false # this exists the calling scope, as templates are inlined.
+  pk.unsafeGet()
 
 func addSignatureSet[T](
       sigs: var seq[SignatureSet],
@@ -52,21 +69,25 @@ func addSignatureSet[T](
   sigs.add((
     pubkey,
     signing_root,
-    signature.load().get()
+    signature.loadOrExitFalse()
   ))
 
   return true
 
 proc aggregateAttesters(
+      aggPK: var blscurve.PublicKey,
       attestation: IndexedAttestation,
       state: BeaconState
-     ): blscurve.PublicKey {.noInit.} =
+     ): bool =
   doAssert attestation.attesting_indices.len > 0
   var attestersAgg{.noInit.}: AggregatePublicKey
-  attestersAgg.init(state.validators[attestation.attesting_indices[0]].pubkey.loadWithCache().get())
+  attestersAgg.init(state.validators[attestation.attesting_indices[0]]
+                         .pubkey.loadWithCacheOrExitFalse())
   for i in 1 ..< attestation.attesting_indices.len:
-    attestersAgg.aggregate(state.validators[attestation.attesting_indices[i]].pubkey.loadWithCache().get())
-  result.finish(attestersAgg)
+    attestersAgg.aggregate(state.validators[attestation.attesting_indices[i]]
+                                .pubkey.loadWithCacheOrExitFalse())
+  aggPK.finish(attestersAgg)
+  return true
 
 proc addIndexedAttestation(
       sigs: var seq[SignatureSet],
@@ -80,8 +101,12 @@ proc addIndexedAttestation(
     # - https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
     return false
 
+  var aggPK {.noInit.}: blscurve.PublicKey
+  if not aggPK.aggregateAttesters(attestation, state):
+    return false
+
   if not sigs.addSignatureSet(
-          attestation.aggregateAttesters(state),
+          aggPK,
           attestation.data,
           attestation.signature,
           state.genesis_validators_root,
@@ -106,10 +131,12 @@ proc addAttestation(
                     cache
                   ):
     if not result: # first iteration
-      attestersAgg.init(state.validators[valIndex].pubkey.loadWithCache().get())
+      attestersAgg.init(state.validators[valIndex]
+                             .pubkey.loadWithCacheOrExitFalse())
       result = true
     else:
-      attestersAgg.aggregate(state.validators[valIndex].pubkey.loadWithCache().get())
+      attestersAgg.aggregate(state.validators[valIndex]
+                                  .pubkey.loadWithCacheOrExitFalse())
 
   if not result:
     # There was no attesters
@@ -154,11 +181,8 @@ proc collectSignatureSets*(
   if proposer_index >= state.validators.lenu64:
     return false
 
-  let pubkey = block:
-    let pk = state.validators[proposer_index].pubkey.loadWithCache()
-    if pk.isNone:
-      return false
-    pk.unsafeGet()
+  let pubkey = state.validators[proposer_index]
+                    .pubkey.loadWithCacheOrExitFalse()
   let epoch = signed_block.message.slot.compute_epoch_at_slot()
 
   # 1. Block proposer
@@ -205,7 +229,7 @@ proc collectSignatureSets*(
       let proposer1 = state.validators[header_1.message.proposer_index]
       let epoch1 = header_1.message.slot.compute_epoch_at_slot()
       if not sigs.addSignatureSet(
-              proposer1.pubkey.loadWithCache().get(),
+              proposer1.pubkey.loadWithCacheOrExitFalse(),
               header_1.message,
               header_1.signature,
               state.genesis_validators_root,
@@ -221,7 +245,7 @@ proc collectSignatureSets*(
       let proposer2 = state.validators[header_2.message.proposer_index]
       let epoch2 = header_2.message.slot.compute_epoch_at_slot()
       if not sigs.addSignatureSet(
-              proposer2.pubkey.loadWithCache().get(),
+              proposer2.pubkey.loadWithCacheOrExitFalse(),
               header_2.message,
               header_2.signature,
               state.genesis_validators_root,
@@ -285,7 +309,8 @@ proc collectSignatureSets*(
     template volex: untyped = signed_block.message.body.voluntary_exits[i]
 
     if not sigs.addSignatureSet(
-            state.validators[volex.message.validator_index].pubkey.loadWithCache().get(),
+            state.validators[volex.message.validator_index]
+                 .pubkey.loadWithCacheOrExitFalse(),
             volex.message,
             volex.signature,
             state.genesis_validators_root,

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -29,7 +29,8 @@ func addSignatureSet[T](
       pubkey: blscurve.PublicKey,
       sszObj: T,
       signature: ValidatorSig,
-      state: BeaconState,
+      genesis_validators_root: Eth2Digest,
+      fork: Fork,
       epoch: Epoch,
       domain: DomainType): bool {.raises: [Defect].}=
   ## Add a new signature set triplet (pubkey, message, signature)
@@ -41,9 +42,9 @@ func addSignatureSet[T](
   let signing_root = compute_signing_root(
       sszObj,
       get_domain(
-        state.fork, domain,
+        fork, domain,
         epoch,
-        state.genesis_validators_root
+        genesis_validators_root
       )
     ).data
 
@@ -82,7 +83,9 @@ proc addIndexedAttestation(
           attestation.aggregateAttesters(state),
           attestation.data,
           attestation.signature,
-          state, attestation.data.target.epoch,
+          state.genesis_validators_root,
+          state.fork,
+          attestation.data.target.epoch,
           DOMAIN_BEACON_ATTESTER):
     return false
   return true
@@ -118,7 +121,9 @@ proc addAttestation(
           attesters,
           attestation.data,
           attestation.signature,
-          state, attestation.data.target.epoch,
+          state.genesis_validators_root,
+          state.fork,
+          attestation.data.target.epoch,
           DOMAIN_BEACON_ATTESTER):
     return false
   return true
@@ -161,7 +166,9 @@ proc collectSignatureSets*(
           pubkey,
           signed_block.message,
           signed_block.signature,
-          state, epoch,
+          state.genesis_validators_root,
+          state.fork,
+          epoch,
           DOMAIN_BEACON_PROPOSER):
     return false
 
@@ -171,7 +178,9 @@ proc collectSignatureSets*(
           pubkey,
           epoch,
           signed_block.message.body.randao_reveal,
-          state, epoch,
+          state.genesis_validators_root,
+          state.fork,
+          epoch,
           DOMAIN_RANDAO):
     return false
 
@@ -194,7 +203,9 @@ proc collectSignatureSets*(
               proposer1.pubkey.toRealPubKey().get().blsValue,
               header_1.message,
               header_1.signature,
-              state, epoch1,
+              state.genesis_validators_root,
+              state.fork,
+              epoch1,
               DOMAIN_BEACON_PROPOSER
             ):
         return false
@@ -208,7 +219,9 @@ proc collectSignatureSets*(
               proposer2.pubkey.toRealPubKey().get().blsValue,
               header_2.message,
               header_2.signature,
-              state, epoch2,
+              state.genesis_validators_root,
+              state.fork,
+              epoch2,
               DOMAIN_BEACON_PROPOSER
             ):
         return false
@@ -258,7 +271,9 @@ proc collectSignatureSets*(
             state.validators[volex.message.validator_index].pubkey.toRealPubKey().get().blsValue,
             volex.message,
             volex.signature,
-            state, volex.message.epoch,
+            state.genesis_validators_root,
+            state.fork,
+            volex.message.epoch,
             DOMAIN_VOLUNTARY_EXIT):
       return false
 

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -35,25 +35,25 @@ func addSignatureSet[T](
   ## Add a new signature set triplet (pubkey, message, signature)
   ## to a collection of signature sets for batch verification.
   ## Can return false if `signature` wasn't deserialized to a valid BLS signature.
-  try:
-    let signing_root = compute_signing_root(
-        sszObj,
-        get_domain(
-          state.fork, domain,
-          epoch,
-          state.genesis_validators_root
-        )
-      ).data
-
-    sigs.add((
-      pubkey,
-      signing_root,
-      signature.blsValue
-    ))
-
-    return true
-  except FieldError: # bad discriminant when accessing signature.blsValue
+  if signature.kind != Real:
     return false
+
+  let signing_root = compute_signing_root(
+      sszObj,
+      get_domain(
+        state.fork, domain,
+        epoch,
+        state.genesis_validators_root
+      )
+    ).data
+
+  sigs.add((
+    pubkey,
+    signing_root,
+    signature.blsValue
+  ))
+
+  return true
 
 proc aggregateAttesters(
       attestation: IndexedAttestation,

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -273,8 +273,8 @@ proc batchVerify*(
   #       but only to mix non-public data a malicious party
   #       cannot control.
   #       We still likely want to use the application RNG instance
-  var rng {.threadvar.}: ref BrHmacDrbgContext
-  var rngInit {.threadvar.}: bool
+  var rng {.global.}: ref BrHmacDrbgContext
+  var rngInit {.global.}: bool
   if not rngInit:
     rng = keys.newRng()
     rngInit = true

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -15,7 +15,7 @@ import
   # Internal
   ../ssz/merkleization,
   ./crypto, ./datatypes, ./helpers, ./presets,
-  ./beaconstate
+  ./beaconstate, ./digest
 
 export SignatureSet, BatchedBLSVerifierCache
 
@@ -288,8 +288,8 @@ proc batchVerify*(
   #       but only to mix non-public data a malicious party
   #       cannot control.
   #       We still likely want to use the application RNG instance
-  var rng {.global.}: ref BrHmacDrbgContext
-  var rngInit {.global.}: bool
+  var rng {.threadvar.}: ref BrHmacDrbgContext
+  var rngInit {.threadvar.}: bool
   if not rngInit:
     rng = keys.newRng()
     rngInit = true

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -70,7 +70,7 @@ proc verify_block_signature*(
   true
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc verifyStateRoot(state: BeaconState, blck: BeaconBlock): bool =
+proc verifyStateRoot(state: BeaconState, blck: BeaconBlock or SigVerifiedBeaconBlock): bool =
   # This is inlined in state_transition(...) in spec.
   let state_root = hash_tree_root(state)
   if state_root != blck.state_root:

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -27,6 +27,10 @@ import
   ./signatures, ./presets,
   ../../nbench/bench_lab
 
+# Generics visibility issue with toSeq(items(intersection(HashSet, HashSet)))
+# https://github.com/nim-lang/Nim/issues/11225
+export sets
+
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#block-header
 func process_block_header*(
     state: var BeaconState, blck: SomeBeaconBlock, flags: UpdateFlags,
@@ -124,7 +128,7 @@ func is_slashable_validator(validator: Validator, epoch: Epoch): bool =
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#proposer-slashings
 proc check_proposer_slashing*(
-    state: var BeaconState, proposer_slashing: ProposerSlashing,
+    state: var BeaconState, proposer_slashing: SomeProposerSlashing,
     flags: UpdateFlags):
     Result[void, cstring] {.nbench.} =
 
@@ -166,7 +170,7 @@ proc check_proposer_slashing*(
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#proposer-slashings
 proc process_proposer_slashing*(
-    state: var BeaconState, proposer_slashing: ProposerSlashing,
+    state: var BeaconState, proposer_slashing: SomeProposerSlashing,
     flags: UpdateFlags, cache: var StateCache):
     Result[void, cstring] {.nbench.} =
   ? check_proposer_slashing(state, proposer_slashing, flags)
@@ -191,7 +195,7 @@ func is_slashable_attestation_data*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#attester-slashings
 proc check_attester_slashing*(
        state: var BeaconState,
-       attester_slashing: AttesterSlashing,
+       attester_slashing: SomeAttesterSlashing,
        flags: UpdateFlags
      ): Result[seq[ValidatorIndex], cstring] {.nbench.} =
   let
@@ -224,7 +228,7 @@ proc check_attester_slashing*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#attester-slashings
 proc process_attester_slashing*(
        state: var BeaconState,
-       attester_slashing: AttesterSlashing,
+       attester_slashing: SomeAttesterSlashing,
        flags: UpdateFlags,
        cache: var StateCache
      ): Result[void, cstring] {.nbench.} =
@@ -242,7 +246,7 @@ proc process_attester_slashing*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#voluntary-exits
 proc check_voluntary_exit*(
     state: BeaconState,
-    signed_voluntary_exit: SignedVoluntaryExit,
+    signed_voluntary_exit: SomeSignedVoluntaryExit,
     flags: UpdateFlags): Result[void, cstring] {.nbench.} =
 
   let voluntary_exit = signed_voluntary_exit.message
@@ -294,7 +298,7 @@ proc check_voluntary_exit*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#voluntary-exits
 proc process_voluntary_exit*(
     state: var BeaconState,
-    signed_voluntary_exit: SignedVoluntaryExit,
+    signed_voluntary_exit: SomeSignedVoluntaryExit,
     flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] {.nbench.} =
   ? check_voluntary_exit(state, signed_voluntary_exit, flags)

--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -282,11 +282,11 @@ proc proposeSignedBlock*(node: BeaconNode,
                          newBlock: SignedBeaconBlock): BlockRef =
 
   let newBlockRef = node.chainDag.addRawBlock(node.quarantine, newBlock) do (
-      blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+      blckRef: BlockRef, trustedBlock: TrustedSignedBeaconBlock,
       epochRef: EpochRef, state: HashedBeaconState):
-    # Callback add to fork choice if valid
+    # Callback add to fork choice if signed block valid (and becomes trusted)
     node.attestationPool[].addForkChoice(
-      epochRef, blckRef, signedBlock.message,
+      epochRef, blckRef, trustedBlock.message,
       node.beaconClock.now().slotOrZero())
 
   if newBlockRef.isErr:
@@ -717,4 +717,3 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
     let finalizedEpochRef = node.chainDag.getFinalizedEpochRef()
     discard node.eth1Monitor.trackFinalizedState(
       finalizedEpochRef.eth1_data, finalizedEpochRef.eth1_deposit_index)
-

--- a/docs/block_validation_flow.md
+++ b/docs/block_validation_flow.md
@@ -28,6 +28,18 @@ The base types are defined in the Eth2 specs.
 On top, Nimbus builds new types to represent the level of trust and validation we have with regards to each BeaconBlock.
 Those types allow the Nim compiler to help us ensure proper usage at compile-time and zero runtime cost.
 
+### BeaconBlocks
+
+Those are spec-defined types.
+
+On deserialization the SSZ code guarantees that BeaconBlock are correctly max-sized
+according to:
+- MAX_PROPOSER_SLASHINGS
+- MAX_ATTESTER_SLASHINGS
+- MAX_ATTESTATIONS
+- MAX_DEPOSITS
+- MAX_VOLUNTARY_EXITS
+
 ### TrustedBeaconBlocks
 
 A block that has been fully checked to be sound

--- a/docs/block_validation_flow.md
+++ b/docs/block_validation_flow.md
@@ -1,0 +1,49 @@
+# Block Validation Flow
+
+This is a WIP document to explain the block validation flow.
+This should be transformed into diagram that explain
+the implicit block validation state machine.
+
+## Inputs
+
+Blocks can be received from the following sources:
+- Gossipsub
+- the NBC database
+- a local validator block proposal
+- Devtools: test suite, ncli, fuzzing
+
+The related base types are:
+- BeaconBlockBody
+- BeaconBlock
+  - BeaconBlockBody
+  - + metadata (slot, blockchain state before/after, proposer)
+- BeaconBlockHeader
+  - metadata (slot, blockchain state before/after, proposer)
+  - merkle hash of the BeaconBlockBody
+- SignedBeaconBlock
+  - BeaconBLock
+  - + BLS signature
+
+The base types are defined in the Eth2 specs.
+On top, Nimbus builds new types to represent the level of trust and validation we have with regards to each BeaconBlock.
+Those types allow the Nim compiler to help us ensure proper usage at compile-time and zero runtime cost.
+
+### TrustedBeaconBlocks
+
+A block that has been fully checked to be sound
+both in regards to the blockchain protocol and its cryptographic signatures is known as a `TrustedBeaconBlock` or `TrustedSignedBeaconBlock`.
+This allows skipping expensive signature checks.
+Blocks are considered trusted if they come from:
+- the NBC database
+- produced by a local validator
+
+### SigVerifiedBeaconBlocks
+
+A block with a valid cryptographic signature is considered SigVerified.
+This is a weaker guarantee than Trusted as the block might still be invalid according to the state transition function.
+Such a block are produced if incoming gossip blocks' signatures are batched together for batch verification **before** being passed to state transition.
+
+### TransitionVerifiedBeaconBlocks
+
+A block that passes the state transition checks and can be successfully applied to the beacon chain is considered `TransitionVerified`.
+Such a block can be produced if incoming blocks' signatures are batched together for batch verification **after** successfully passing state transition.

--- a/docs/block_validation_flow.md
+++ b/docs/block_validation_flow.md
@@ -21,7 +21,7 @@ The related base types are:
   - metadata (slot, blockchain state before/after, proposer)
   - merkle hash of the BeaconBlockBody
 - SignedBeaconBlock
-  - BeaconBLock
+  - BeaconBlock
   - + BLS signature
 
 The base types are defined in the Eth2 specs.

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -166,7 +166,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
           blockRoot, privKey)
 
       let added = chainDag.addRawBlock(quarantine, newBlock) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         attPool.addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -18,6 +18,7 @@ import
   math, stats, times, strformat,
   options, random, tables, os,
   confutils, chronicles, eth/db/kvstore_sqlite3,
+  eth/keys,
   ../tests/[testblockutil],
   ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest, presets,
                         helpers, validator, signatures, state_transition],
@@ -73,7 +74,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     chainDag = ChainDAGRef.init(runtimePreset, db)
     eth1Chain = Eth1Chain.init(runtimePreset, db)
     merkleizer = depositContractSnapshot.createMerkleizer
-    quarantine = QuarantineRef()
+    quarantine = QuarantineRef.init(keys.newRng())
     attPool = AttestationPool.init(chainDag, quarantine)
     timers: array[Timers, RunningStat]
     attesters: RunningStat

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,16 +8,20 @@
 {.used.}
 
 import
+  # Standard library
   std/unittest,
+  # Status lib
   chronicles, chronos,
   stew/byteutils,
-  ./testutil, ./testblockutil,
+  # Internal
   ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
                         helpers, beaconstate, presets, network],
   ../beacon_chain/[
     beacon_node_types, attestation_pool, attestation_aggregation, extras, time],
   ../beacon_chain/fork_choice/[fork_choice_types, fork_choice],
-  ../beacon_chain/block_pools/[chain_dag, clearance]
+  ../beacon_chain/block_pools/[chain_dag, clearance],
+  # Test utilities
+  ./testutil, ./testblockutil
 
 func combine(tgt: var Attestation, src: Attestation) =
   ## Combine the signature and participation bitfield, with the assumption that
@@ -403,6 +407,7 @@ suiteReport "Attestation validation " & preset():
       process_slots(state.data, state.data.data.slot + 1, cache)
 
   wrappedTimedTest "Validation sanity":
+    # TODO: refactor tests to avoid skipping BLS validation
     chainDag.updateFlags.incl {skipBLSValidation}
 
     var

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -200,7 +200,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       b1 = addTestBlock(state.data, chainDag.tail.root, cache)
       b1Add = chainDag.addRawBlock(quarantine, b1) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -213,7 +213,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       b2 = addTestBlock(state.data, b1.root, cache)
       b2Add = chainDag.addRawBlock(quarantine, b2) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -228,7 +228,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -243,7 +243,7 @@ suiteReport "Attestation pool processing" & preset():
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       )
       b11Add = chainDag.addRawBlock(quarantine, b11) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -288,7 +288,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -302,7 +302,7 @@ suiteReport "Attestation pool processing" & preset():
     # Add back the old block to ensure we have a duplicate error
     let b10_clone = b10 # Assumes deep copy
     let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -317,7 +317,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       b10 = addTestBlock(state.data, chainDag.tail.root, cache)
       b10Add = chainDag.addRawBlock(quarantine, b10) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -345,7 +345,7 @@ suiteReport "Attestation pool processing" & preset():
 
         block_root = new_block.root
         let blockRef = chainDag.addRawBlock(quarantine, new_block) do (
-            blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+            blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
             epochRef: EpochRef, state: HashedBeaconState):
           # Callback add to fork choice if valid
           pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -385,7 +385,7 @@ suiteReport "Attestation pool processing" & preset():
 
     # Add back the old block to ensure we have a duplicate error
     let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
@@ -416,7 +416,7 @@ suiteReport "Attestation validation " & preset():
         chainDag.headState.data, chainDag.head.root, cache,
         int(SLOTS_PER_EPOCH * 5), false):
       let added = chainDag.addRawBlock(quarantine, blck) do (
-          blckRef: BlockRef, signedBlock: SignedBeaconBlock,
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -13,13 +13,14 @@ import
   # Status lib
   chronicles, chronos,
   stew/byteutils,
+  eth/keys,
   # Internal
   ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
                         helpers, beaconstate, presets, network],
   ../beacon_chain/[
     beacon_node_types, attestation_pool, attestation_aggregation, extras, time],
   ../beacon_chain/fork_choice/[fork_choice_types, fork_choice],
-  ../beacon_chain/block_pools/[chain_dag, clearance],
+  ../beacon_chain/block_pools/[quarantine, chain_dag, clearance],
   # Test utilities
   ./testutil, ./testblockutil
 
@@ -59,7 +60,7 @@ suiteReport "Attestation pool processing" & preset():
     # Genesis state that results in 3 members per committee
     var
       chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
-      quarantine = QuarantineRef()
+      quarantine = QuarantineRef.init(keys.newRng())
       pool = newClone(AttestationPool.init(chainDag, quarantine))
       state = newClone(chainDag.headState)
       cache = StateCache()
@@ -398,7 +399,7 @@ suiteReport "Attestation validation " & preset():
     # Genesis state that results in 3 members per committee
     var
       chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
-      quarantine = QuarantineRef()
+      quarantine = QuarantineRef.init(keys.newRng())
       pool = newClone(AttestationPool.init(chainDag, quarantine))
       state = newClone(chainDag.headState)
       cache = StateCache()

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -10,6 +10,7 @@
 import
   std/[options, sequtils, unittest],
   stew/assign2,
+  eth/keys,
   ./testutil, ./testblockutil,
   ../beacon_chain/spec/[datatypes, digest, helpers, state_transition, presets],
   ../beacon_chain/[beacon_node_types, ssz],
@@ -123,7 +124,7 @@ suiteReport "Block pool processing" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
-      quarantine = QuarantineRef()
+      quarantine = QuarantineRef.init(keys.newRng())
       stateData = newClone(dag.headState)
       cache = StateCache()
       b1 = addTestBlock(stateData.data, dag.tail.root, cache)
@@ -335,7 +336,7 @@ suiteReport "chain DAG finalization tests" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
-      quarantine = QuarantineRef()
+      quarantine = QuarantineRef.init(keys.newRng())
       cache = StateCache()
 
   wrappedTimedTest "prune heads on finalization" & preset():
@@ -463,7 +464,7 @@ suiteReport "chain DAG finalization tests" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
-      quarantine = QuarantineRef()
+      quarantine = QuarantineRef.init(keys.newRng())
       cache = StateCache()
 
   timedTest "init with gaps" & preset():

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -9,14 +9,15 @@
 
 import std/unittest
 import chronicles, chronos, testutil
+import eth/keys
 import ../beacon_chain/spec/[datatypes, presets]
 import ../beacon_chain/exit_pool
-import ../beacon_chain/block_pools/chain_dag
+import ../beacon_chain/block_pools/[quarantine, chain_dag]
 
 proc getExitPool(): auto =
   let chainDag =
     init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
-  newClone(ExitPool.init(chainDag, QuarantineRef()))
+  newClone(ExitPool.init(chainDag, QuarantineRef.init(keys.newRng())))
 
 suiteReport "Exit pool testing suite":
   setup:


### PR DESCRIPTION
## Overview

This reworks the block validation flow to introduce `SigVerified` blocks besides the existing blocks and `trusted` blocks.

This mention but does not introduce `TransitionVerified` blocks as without generics or static enum that would lead to lots of duplication.

The flow matrix is the following

|                            | Signature unchecked             | Signature verified          | 
|----------------------------|-------------------------------  |-----------------------------|
| State transition unchecked | - UntrustedBeaconBlock          | - SigVerifiedBeaconBlock    |
|                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |
|                            | - UntrustedAttestation          | - TrustedAttestation        |
|----------------------------|-------------------------------  |-----------------------------|
| State transition verified  | - TransitionVerifiedBeaconBlock | - TrustedSignedBeaconBlock  |
|                            | - UntrustedIndexedAttestation   | - TrustedIndexedAttestation |
|                            | - UntrustedAttestation          | - TrustedAttestation        |

Notice that at the moment `TrustedAttestation` is imprecise and actually means `SigVerifiedAttestation`.

The current code checks cryptography then state meaning `SigVerifiedAttestation` is a state that only exists between those lines of code: https://github.com/status-im/nimbus-eth2/blob/ea8fe258c59220530340c7436723b5a18406086d/beacon_chain/block_pools/clearance.nim#L199-L205

## Implementation
This reimplements the branch https://github.com/status-im/nimbus-eth2/tree/block-validation-flow which is stuck due to issues mentioned in https://github.com/status-im/nimbus-eth2/issues/2219. In particular, besides workarounds needed to avoid compiler ICE, the branch is stuck trying to deal with generic types in macro https://github.com/nim-lang/RFCs/issues/44

## Switching to multithreading

Switching to multithreading requires changing this line
https://github.com/status-im/nimbus-eth2/blob/ea8fe258c59220530340c7436723b5a18406086d/beacon_chain/spec/signatures_batch.nim#L285-L286

to `batchVerify` and compile with `-d:openmp`.
