### PR TITLE
CI: build and publish a Docker image for end-users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,22 @@ jobs:
           asset_path: ./dist/${{ steps.make_dist.outputs.linux_amd64_archive }}
           asset_name: ${{ steps.make_dist.outputs.linux_amd64_archive }}
           asset_content_type: application/gzip
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push a Docker image for end users
+        run: |
+          cd dist
+          tar -xzf ${{ steps.make_dist.outputs.linux_amd64_archive }}
+          mv nimbus-eth2_Linux_amd64_*/ ../docker/dist/binaries/nimbus-eth2
+          cd ../docker/dist/binaries
+          REFNAME="${{ github.ref }}"
+          TAG="${REFNAME#refs/tags/}"
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile.amd64 -t statusim/nimbus-eth2:amd64-${TAG} -t statusim/nimbus-eth2:amd64-latest .
+          docker push statusim/nimbus-eth2:amd64-${TAG}
+          docker push statusim/nimbus-eth2:amd64-latest
   build-arm64:
     name: ARM64 release asset
     runs-on: ubuntu-latest

--- a/docker/dist/binaries/Dockerfile.amd64
+++ b/docker/dist/binaries/Dockerfile.amd64
@@ -1,0 +1,17 @@
+FROM debian:bullseye-slim
+
+SHELL ["/bin/bash", "-c"]
+
+# Likely to match the first regular user:group created on the host.
+RUN addgroup --gid 1000 user; \
+	adduser --disabled-password --gecos '' --uid 1000 --gid 1000 user;
+
+USER user
+
+STOPSIGNAL SIGINT
+
+# Docker refuses to copy the source directory here, so read it as "nimbus-eth2/*"
+COPY "nimbus-eth2" "/home/user/nimbus-eth2/"
+WORKDIR "/home/user/nimbus-eth2/"
+ENTRYPOINT ["/home/user/nimbus-eth2/build/nimbus_beacon_node"]
+

--- a/docker/dist/binaries/README.md
+++ b/docker/dist/binaries/README.md
@@ -1,0 +1,5 @@
+Simple Docker image with the contents of a release tarball inside it.
+It's being built and published to Docker Hub from a GitHub action, in CI.
+
+Suitable for end users. Example `docker-compose` configuration files included.
+

--- a/docker/dist/binaries/docker-compose-example1.yml
+++ b/docker/dist/binaries/docker-compose-example1.yml
@@ -1,0 +1,33 @@
+# Using the default entry point, which is the "nimbus_beacon_chain" binary.
+#
+# Example usage:
+#
+# mkdir data
+# docker-compose -f docker-compose-example1.yml up --quiet-pull --no-color --detach
+
+version: "2.4"
+services:
+  nimbus_beacon_node:
+    image: statusim/nimbus-eth2:amd64-latest
+    container_name: nimbus-eth2-amd64-latest
+    restart: unless-stopped
+    stop_grace_period: 1m
+    ports:
+      - 9000:9000/tcp
+      - 9000:9000/udp
+      - 127.0.0.1:9190:9190/tcp
+    volumes:
+      - ./data:/home/user/nimbus-eth2/build/data
+    # you need to make sure that port 9000 is accesible from outside; no automagic port forwarding here
+    command: >-
+      --network=pyrmont
+      --data-dir=/home/user/nimbus-eth2/build/data/shared_pyrmont_0
+      --web3-url=wss://goerli.infura.io/ws/v3/YOUR_TOKEN
+      --nat=extip:YOUR_EXTERNAL_IP
+      --log-level=info
+      --tcp-port=9000
+      --udp-port=9000
+      --rpc
+      --rpc-address=0.0.0.0
+      --rpc-port=9190
+

--- a/docker/dist/binaries/docker-compose-example2.yml
+++ b/docker/dist/binaries/docker-compose-example2.yml
@@ -1,0 +1,27 @@
+# Using a wrapper script as the entry point.
+#
+# Example usage:
+#
+# mkdir data
+# docker-compose -f docker-compose-example2.yml up --quiet-pull --no-color --detach
+
+version: "2.4"
+services:
+  nimbus_beacon_node:
+    image: statusim/nimbus-eth2:amd64-latest
+    container_name: nimbus-eth2-amd64-latest
+    restart: unless-stopped
+    stop_grace_period: 1m
+    ports:
+      - 9000:9000/tcp
+      - 9000:9000/udp
+      - 127.0.0.1:9190:9190/tcp
+    volumes:
+      - ./data:/home/user/nimbus-eth2/build/data
+    entrypoint: /home/user/nimbus-eth2/run-pyrmont-beacon-node.sh
+    environment:
+      WEB3_URL: wss://goerli.infura.io/ws/v3/YOUR_TOKEN
+    # you need to make sure that port 9000 is accesible from outside; no automagic port forwarding here
+    command: >-
+      --nat=extip:YOUR_EXTERNAL_IP
+

--- a/docker/dist/binaries/docker-compose-example3.yml
+++ b/docker/dist/binaries/docker-compose-example3.yml
@@ -1,0 +1,24 @@
+# Using the host's network, so we can talk with a UPnP-enabled router to
+# redirect ports and get the external IP.
+#
+# Example usage:
+#
+# mkdir data
+# docker-compose -f docker-compose-example3.yml up --quiet-pull --no-color --detach
+
+version: "2.4"
+services:
+  nimbus_beacon_node:
+    image: statusim/nimbus-eth2:amd64-latest
+    container_name: nimbus-eth2-amd64-latest
+    restart: unless-stopped
+    stop_grace_period: 1m
+    network_mode: host
+    volumes:
+      - ./data:/home/user/nimbus-eth2/build/data
+    entrypoint: /home/user/nimbus-eth2/run-pyrmont-beacon-node.sh
+    environment:
+      WEB3_URL: wss://goerli.infura.io/ws/v3/YOUR_TOKEN
+    #command: >-
+      #--nat=any
+

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -12,12 +12,13 @@ fi
 PLATFORM="${1}"
 BINARIES="nimbus_beacon_node nimbus_signing_process"
 
-# we need to build everything against libraries available inside this container, including the Nim compiler
+#- we need to build everything against libraries available inside this container, including the Nim compiler
+#- we disable the log file and log colours; the user only has to worry about logging stdout now
 make clean
 make \
   -j$(nproc) \
   LOG_LEVEL="TRACE" \
-  NIMFLAGS="-d:disableMarchNative" \
+  NIMFLAGS="-d:disableMarchNative -d:chronicles_sinks=textlines -d:chronicles_colors=none" \
   PARTIAL_STATIC_LINKING=1 \
   ${BINARIES}
 

--- a/docs/the_nimbus_book/src/SUMMARY.md
+++ b/docs/the_nimbus_book/src/SUMMARY.md
@@ -22,22 +22,18 @@
 - [Email notifications](./email-notifications.md)
 - [Graffiti the blockchain](./graffiti.md)
 - [Download binaries](./binaries.md)
+- [Using Docker images](./docker.md)
 - [Troubleshoot](./troubleshooting.md)
 - [Recover / generate keys](./more-keys.md)
-- [Migrate keys to another machine]()
 - [Perform a voluntary exit](./voluntary-exit.md)
 - [Setup a systemd service](./beacon-node-systemd.md)
 
 # Tutorials
 - [Grafana and Prometheus](./metrics-pretty-pictures.md)
 - [Create your own Infura endpoint](./infura-guide.md)
-- [Switch between clients]()
 - [Network stats (testnets only)](./eth2-stats.md)
 
 # Reference
-- [Advanced options]()
-- [Hardware and cloud hosting]()
-- [Windows users]()
 - [API](./api.md)
 - [Command line options](./options.md)
 - [For developers](./developers.md)

--- a/docs/the_nimbus_book/src/binaries.md
+++ b/docs/the_nimbus_book/src/binaries.md
@@ -1,16 +1,16 @@
 # Nimbus binaries
 
-Nimbus binaries exist for Nimbus -- initially `x86 64-bit`, but Windows, MacOS and additional Linux binaries will be added shortly.
+Nimbus binaries exist for Nimbus -- initially Linux `AMD64`, `ARM` and `ARM64`, but Windows and MacOS binaries will be added in the future.
 
 You can find the latest release here: [https://github.com/status-im/nimbus-eth2/releases](https://github.com/status-im/nimbus-eth2/releases)
 
 Scroll to the bottom of the first release you see, and click on `Assets`. You should see a list that looks like the following:
 
-![](https://i.imgur.com/4FBhUpk.png)
+![](https://i.imgur.com/R33o4MG.png)
 
-Click on the first option, the `tar.gz` file, and follow the instructions [here](https://github.com/status-im/nimbus-eth2/blob/master/docker/dist/README.md).
+Click on the `tar.gz` file that corresponds to your OS and architecture, unpack the archive, read the README and run the binary directly or through some provided wrapper script.
 
-We've designed this binary to be reproducible: in practice, this means that anyone who wishes to can verify that no vulnerabilities or backdoors have been introduced during the compilation process. For more on the philosophy and importance of reproducible builds [see here](https://reproducible-builds.org/).
+We've designed the build process to be reproducible. In practice, this means that anyone can verify that these exact binaries were produced from the corresponding source code commits. For more about the philosophy and importance of this feature see [reproducible-builds.org](https://reproducible-builds.org/).
 
 For instructions on how to reproduce the build, [see here](https://github.com/status-im/nimbus-eth2/blob/master/docker/dist/README.md#reproducing-the-build).
 

--- a/docs/the_nimbus_book/src/docker.md
+++ b/docs/the_nimbus_book/src/docker.md
@@ -1,0 +1,34 @@
+# Docker images
+
+Docker images for end-users are generated and published automatically [to Docker Hub](https://hub.docker.com/r/statusim/nimbus-eth2) from the Nimbus-eth2 CI, by a GitHub action, whenever a new release is tagged in Git.
+
+We have version-specific Docker tags (`statusim/nimbus-eth2:amd64-v1.2.3`) and a tag for the latest image (`statusim/nimbus-eth2:amd64-latest`).
+
+These images are simply the contents of [release tarballs](./binaries.md) inside a "debian:bullseye-slim" image, running under a user imaginatively named "user", with UID:GID of 1000:1000.
+
+The unpacked archive is in "/home/user/nimbus-eth2" which is also the default *WORKDIR*. The default *ENTRYPOINT* is the binary itself: "/home/user/nimbus-eth2/build/nimbus\_beacon\_node".
+
+## Usage
+
+You need to create an external data directory and mount it as a volume inside the container, with the mounting point being "/home/user/nimbus-eth2/build/data".
+
+```text
+mkdir data
+docker run -it --rm -v ${PWD}/data:/home/user/nimbus-eth2/build/data statusim/nimbus-eth2:amd64-latest [nimbus_beacon_node args here]
+```
+
+Or you can use a wrapper script instead:
+
+```text
+mkdir data
+docker run -it --rm -v ${PWD}/data:/home/user/nimbus-eth2/build/data -e WEB3_URL="wss://mainnet.infura.io/ws/v3/YOUR_TOKEN" --entrypoint /home/user/nimbus-eth2/run-mainnet-beacon-node.sh statusim/nimbus-eth2:amd64-latest [nimbus_beacon_node args here]
+```
+
+Better yet, use `docker-compose`, with one of the [example configuration files](https://github.com/status-im/nimbus-eth2/tree/stable/docker/dist/binaries) as a base for your custom configuration:
+
+```text
+mkdir data
+docker-compose -f docker-compose-example1.yml up --quiet-pull --no-color --detach
+```
+
+The rather voluminous logging is done on stdout, so you might want to change the system-wide Docker logging defaults (dumping everything in "/var/lib/docker/containers/CONTAINER_ID/CONTAINER_ID-json.log") to something like "syslog". Make sure there's some log rotation system in use and the intervals make sense for these large logs.

--- a/run-mainnet-beacon-node.sh
+++ b/run-mainnet-beacon-node.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 cd "$(dirname $0)"
-scripts/run-beacon-node.sh nimbus_beacon_node mainnet $@
+# Allow the binary to receive signals directly.
+exec scripts/run-beacon-node.sh nimbus_beacon_node mainnet $@
 

--- a/run-pyrmont-beacon-node.sh
+++ b/run-pyrmont-beacon-node.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 cd "$(dirname $0)"
-scripts/run-beacon-node.sh nimbus_beacon_node pyrmont $@
+# Allow the binary to receive signals directly.
+exec scripts/run-beacon-node.sh nimbus_beacon_node pyrmont $@
 

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -65,7 +65,8 @@ WEB3_HELP
   read WEB3_URL
 fi
 
-build/${NBC_BINARY} \
+# Allow the binary to receive signals directly.
+exec build/${NBC_BINARY} \
   --network=${NETWORK} \
   --data-dir="${DATA_DIR}" \
   --log-file="${DATA_DIR}/nbc_bn_$(date +"%Y%m%d%H%M%S").log" \


### PR DESCRIPTION
The resulting images will show up here: https://hub.docker.com/r/statusim/nimbus-eth2/tags?page=1&ordering=last_updated

Also disable the log file and log colours for distribution binaries, to avoid duplicate logs.

TODO: proper documentation and a Systemd service example for launching `docker-compose` on boot.

Related issue: https://github.com/status-im/nimbus-eth2/issues/2019