### PR TITLE
only subscribe to subnets when aggregating

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -225,6 +225,11 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Compile                                                                                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## Time utilities
+```diff
++ humaneStr                                                                                  OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Zero signature sanity checks
 ```diff
 + SSZ serialization roundtrip of SignedBeaconBlockHeader                                     OK
@@ -275,4 +280,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 2/2 Fail: 0/2 Skip: 0/2
 
 ---TOTAL---
-OK: 148/157 Fail: 0/157 Skip: 9/157
+OK: 149/158 Fail: 0/158 Skip: 9/158

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -711,7 +711,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) =
   # subnets and they'll all remain subscribed.
   if node.getTopicSubscriptionEnabled and not node.config.subscribeAllSubnets:
     # This exits early all but one call each epoch.
-    discard node.cycleAttestationSubnets(slot)
+    traceAsyncErrors node.cycleAttestationSubnets(slot)
 
 proc onSlotEnd(node: BeaconNode, slot, nextSlot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -454,15 +454,15 @@ proc updateSubscriptionSchedule(node: BeaconNode, epoch: Epoch) {.async.} =
         node.chainDag.headState.data.data, epoch, validatorIndices, cache):
 
     doAssert compute_epoch_at_slot(slot) == epoch
+    let committeeLen =
+      if isConstAggregationLen:
+        probeCommitteeLen
+      else:
+        get_beacon_committee_len(
+          node.chainDag.headState.data.data, slot, committeeIndex, cache)
 
     if not isAnyCommitteeValidatorAggregating(
-        validatorIndices,
-        if isConstAggregationLen:
-          probeCommitteeLen
-        else:
-          get_beacon_committee_len(
-            node.chainDag.headState.data.data, slot, committeeIndex, cache),
-        slot):
+        validatorIndices, committeeLen, slot):
       continue
 
     node.attestationSubnets.unsubscribeSlot[subnetIndex] =

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -86,13 +86,13 @@ func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
   except ValueError as e:
     raiseAssert e.msg
 
-func get_committee_assignments*(
+iterator get_committee_assignments*(
     state: BeaconState, epoch: Epoch,
     validator_indices: HashSet[ValidatorIndex],
     cache: var StateCache):
-    seq[tuple[validatorIndices: HashSet[ValidatorIndex],
+    tuple[validatorIndices: HashSet[ValidatorIndex],
       committeeIndex: CommitteeIndex,
-      subnetIndex: uint8, slot: Slot]] =
+      subnetIndex: uint8, slot: Slot] =
   let
     committees_per_slot = get_committee_count_per_slot(state, epoch, cache)
     start_slot = compute_start_slot_at_epoch(epoch)
@@ -104,8 +104,8 @@ func get_committee_assignments*(
         includedIndices =
           toHashSet(get_beacon_committee(state, slot, idx, cache)) *
             validator_indices
-      if includedIndices.len > 0:
-        result.add(
-           (includedIndices, idx,
-            compute_subnet_for_attestation(committees_per_slot, slot, idx).uint8,
-            slot))
+      if includedIndices.len == 0:
+        yield (
+          includedIndices, idx,
+          compute_subnet_for_attestation(committees_per_slot, slot, idx).uint8,
+          slot)

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -104,7 +104,7 @@ iterator get_committee_assignments*(
         includedIndices =
           toHashSet(get_beacon_committee(state, slot, idx, cache)) *
             validator_indices
-      if includedIndices.len == 0:
+      if includedIndices.len > 0:
         yield (
           includedIndices, idx,
           compute_subnet_for_attestation(committees_per_slot, slot, idx).uint8,


### PR DESCRIPTION
https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#lookahead

Example logs from Pyrmont validators:
```
{"lvl":"DBG","ts":"2021-01-21 12:56:39.091+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[],"newSubnets":[],"wallSlot":461082,"wallEpoch":14408,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
{"lvl":"DBG","ts":"2021-01-21 12:56:51.124+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[50],"wallSlot":461083,"wallEpoch":14408,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[50],"unsubscribedSubnets":[]}
{"lvl":"DBG","ts":"2021-01-21 12:57:03.071+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[],"wallSlot":461084,"wallEpoch":14408,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
{"lvl":"DBG","ts":"2021-01-21 12:57:15.080+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[],"wallSlot":461085,"wallEpoch":14408,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}

...

{"lvl":"DBG","ts":"2021-01-21 13:03:15.103+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[],"wallSlot":461115,"wallEpoch":14409,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
{"lvl":"DBG","ts":"2021-01-21 13:03:27.110+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[],"wallSlot":461116,"wallEpoch":14409,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
{"lvl":"NOT","ts":"2021-01-21 13:03:39.012+00:00","msg":"Aggregated attestation sent","topics":"beacval","tid":302703,"file":"validator_duties.nim:532","attestation":{"aggregation_bits":"0xcfa7fd71edbffd58f57ffef4bfe2ee2707","data":{"slot":461117,"index":6,"beacon_block_root":"623bec9d","source":{"epoch":14408,"root":"0053ef27"},"target":{"epoch":14409,"root":"80f03389"}},"signature":"8d76190e"},"validator":"996920c5","aggregationSlot":461117}
{"lvl":"DBG","ts":"2021-01-21 13:03:39.122+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[50],"newSubnets":[],"wallSlot":461117,"wallEpoch":14409,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
{"lvl":"DBG","ts":"2021-01-21 13:03:51.093+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[50],"subnets":[],"newSubnets":[],"wallSlot":461118,"wallEpoch":14409,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[50]}
{"lvl":"DBG","ts":"2021-01-21 13:04:03.082+00:00","msg":"Attestation subnets","topics":"beacnde","tid":302703,"file":"nimbus_beacon_node.nim:545","expiringSubnets":[],"subnets":[],"newSubnets":[],"wallSlot":461119,"wallEpoch":14409,"num_stability_subnets":3,"expiring_stability_subnets":[],"new_stability_subnets":[],"subscribedSubnets":[],"unsubscribedSubnets":[]}
```