### PR TITLE
add cname file to docs to fix domain issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ publish-book: | book auditors-book
 	git worktree add tmp-book gh-pages && \
 	rm -rf tmp-book/* && \
 	mkdir -p tmp-book/auditors-book && \
+	cp -a docs/the_nimbus_book/CNAME tmp-book/ && \
 	cp -a docs/the_nimbus_book/book/* tmp-book/ && \
 	cp -a docs/the_auditors_handbook/book/* tmp-book/auditors-book/ && \
 	cd tmp-book && \

--- a/docs/the_nimbus_book/CNAME
+++ b/docs/the_nimbus_book/CNAME
@@ -1,0 +1,1 @@
+nimbus.guide


### PR DESCRIPTION
mdbook has an option called `cname`:
https://rust-lang.github.io/mdBook/format/config.html#html-renderer-options

But it appears to be only included starting from `0.4.3`:
https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-043

Which means this will be more robust, if uglier.