### PR TITLE
remove superfluous/overly aggressive, timing-dependent assertion

### DIFF
--- a/beacon_chain/validator_duties.nim
+++ b/beacon_chain/validator_duties.nim
@@ -617,9 +617,6 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
 
   # The dontcheck option's a deliberately undocumented escape hatch for the
   # local testnets and similar development and testing use cases.
-  doAssert node.config.gossipSlashingProtection == GossipSlashingProtectionMode.dontcheck or (
-    node.processor[].gossipSlashingProtection.probeEpoch <
-    node.processor[].gossipSlashingProtection.broadcastStartEpoch)
   if curSlot.epoch <
         node.processor[].gossipSlashingProtection.broadcastStartEpoch and
       curSlot.epoch != node.processor[].gossipSlashingProtection.probeEpoch and


### PR DESCRIPTION
It's already checked at https://github.com/status-im/nimbus-eth2/blob/5713a3ce4c7b4b2e0d67a14bde2ea320f421c326/beacon_chain/nimbus_beacon_node.nim#L647-L664