### PR TITLE
Revert "pass max peers to libp2p"

### DIFF
--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -1526,13 +1526,7 @@ proc newBeaconSwitch*(conf: BeaconNodeConf, seckey: PrivateKey,
 
   let identify = newIdentify(peerInfo)
 
-  newSwitch(
-    peerInfo,
-    transports,
-    identify,
-    muxers,
-    secureManagers,
-    maxConnections = conf.maxPeers)
+  newSwitch(peerInfo, transports, identify, muxers, secureManagers)
 
 proc createEth2Node*(rng: ref BrHmacDrbgContext,
                      conf: BeaconNodeConf,


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#2265

![2021-01-26-150927_856x652_scrot](https://user-images.githubusercontent.com/11422416/105855712-a9c14880-5fe8-11eb-9972-d5e63da3c207.png)

Not certain if this is the correct fix/PR to target, but try a PR.