### PR TITLE
Fix selection of bootstrap nodes from metadata

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1500,7 +1500,7 @@ programMain:
     config.runtimePreset = metadata.runtimePreset
 
     if config.cmd == noCommand:
-      for node in mainnetMetadata.bootstrapNodes:
+      for node in metadata.bootstrapNodes:
         config.bootstrapNodes.add node
 
       if metadata.genesisData.len > 0:

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -373,7 +373,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --log-level="${LOG_LEVEL}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE )) \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
-    --max-peers=$(( NUM_NODES * 2 - 1 )) \
+    --max-peers=$(( NUM_NODES - 1 )) \
     --data-dir="${NODE_DATA_DIR}" \
     ${BOOTSTRAP_ARG} \
     ${STATE_SNAPSHOT_ARG} \


### PR DESCRIPTION
This should hopefully be the real fix for https://github.com/status-im/nimbus-eth2/pull/2272/files#diff-116f5b860ba22e2b345200aeb3803293de012d9c3cbb7d011b5a70d2b5f77189R376

This also means that before this fix, starting a node for the pyrmont network would actually load the mainnet bootstrap nodes.