### PR TITLE
don't used sorted() in get_indexed_attestation()

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[algorithm, intsets, math, options, sequtils, tables],
+  std/[algorithm, collections/heapqueue, math, options, sequtils, tables],
   stew/assign2,
   json_serialization/std/sets,
   chronicles,
@@ -476,34 +476,11 @@ proc is_valid_indexed_attestation*(
   ok()
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#get_attesting_indices
-iterator get_attesting_indices*(bits: CommitteeValidatorsBits,
-                                committee: openArray[ValidatorIndex]):
-                                  ValidatorIndex =
-  if bits.len == committee.len:
-    for i, index in committee:
-      if bits[i]:
-        yield index
-  else:
-    # This shouldn't happen if one begins with a valid BeaconState and applies
-    # valid updates, but one can construct a BeaconState where it does. Do not
-    # do anything here since the PendingAttestation wouldn't have made it past
-    # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#attestations
-    # which checks len(attestation.aggregation_bits) == len(committee) that in
-    # nimbus-eth2 lives in check_attestation(...).
-    # Addresses https://github.com/status-im/nimbus-eth2/issues/922
-
-    trace "get_attesting_indices: inconsistent aggregation and committee length"
-
-func get_attesting_indices*(bits: CommitteeValidatorsBits,
-                            committee: openArray[ValidatorIndex]): IntSet =
-  for idx in get_attesting_indices(bits, committee):
-    result.incl idx.int
-
-# https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#get_attesting_indices
 iterator get_attesting_indices*(state: BeaconState,
                                 data: AttestationData,
                                 bits: CommitteeValidatorsBits,
                                 cache: var StateCache): ValidatorIndex =
+  ## Return the set of attesting indices corresponding to ``data`` and ``bits``.
   if bits.lenu64 != get_beacon_committee_len(state, data.slot, data.index.CommitteeIndex, cache):
     trace "get_attesting_indices: inconsistent aggregation and committee length"
   else:
@@ -513,28 +490,30 @@ iterator get_attesting_indices*(state: BeaconState,
         yield index
       inc i
 
-# https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#get_attesting_indices
-func get_attesting_indices*(state: BeaconState,
-                            data: AttestationData,
-                            bits: CommitteeValidatorsBits,
-                            cache: var StateCache): IntSet =
-  # Return the set of attesting indices corresponding to ``data`` and ``bits``.
+iterator get_sorted_attesting_indices*(state: BeaconState,
+                                       data: AttestationData,
+                                       bits: CommitteeValidatorsBits,
+                                       cache: var StateCache): ValidatorIndex =
+  var heap = initHeapQueue[ValidatorIndex]()
   for index in get_attesting_indices(state, data, bits, cache):
-    result.incl index.int
+    heap.push(index)
+
+  while heap.len > 0:
+    yield heap.pop()
+
+func get_sorted_attesting_indices_list*(
+    state: BeaconState, data: AttestationData, bits: CommitteeValidatorsBits,
+    cache: var StateCache): List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE] =
+  for index in get_sorted_attesting_indices(state, data, bits, cache):
+    result.add index.uint64
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#get_indexed_attestation
 func get_indexed_attestation(state: BeaconState, attestation: Attestation,
     cache: var StateCache): IndexedAttestation =
   ## Return the indexed attestation corresponding to ``attestation``.
-  let
-    attesting_indices =
-      get_attesting_indices(
-        state, attestation.data, attestation.aggregation_bits, cache)
-
   IndexedAttestation(
-    attesting_indices:
-      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE].init(
-        sorted(mapIt(attesting_indices.toSeq, it.uint64), system.cmp)),
+    attesting_indices: get_sorted_attesting_indices_list(
+      state, attestation.data, attestation.aggregation_bits, cache),
     data: attestation.data,
     signature: attestation.signature
   )
@@ -542,15 +521,9 @@ func get_indexed_attestation(state: BeaconState, attestation: Attestation,
 func get_indexed_attestation(state: BeaconState, attestation: TrustedAttestation,
     cache: var StateCache): TrustedIndexedAttestation =
   ## Return the indexed attestation corresponding to ``attestation``.
-  let
-    attesting_indices =
-      get_attesting_indices(
-        state, attestation.data, attestation.aggregation_bits, cache)
-
   TrustedIndexedAttestation(
-    attesting_indices:
-      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE].init(
-        sorted(mapIt(attesting_indices.toSeq, it.uint64), system.cmp)),
+    attesting_indices: get_sorted_attesting_indices_list(
+      state, attestation.data, attestation.aggregation_bits, cache),
     data: attestation.data,
     signature: attestation.signature
   )

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -86,6 +86,7 @@ func getAttestationTopic*(forkDigest: ForkDigest, subnetIndex: uint64):
   except ValueError as e:
     raiseAssert e.msg
 
+# https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#validator-assignments
 iterator get_committee_assignments*(
     state: BeaconState, epoch: Epoch,
     validator_indices: IntSet,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -369,31 +369,3 @@ func get_beacon_proposer_index*(state: BeaconState, cache: var StateCache, slot:
 func get_beacon_proposer_index*(state: BeaconState, cache: var StateCache):
     Option[ValidatorIndex] =
   get_beacon_proposer_index(state, cache, state.slot)
-
-# https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/validator.md#validator-assignments
-func get_committee_assignment*(
-    state: BeaconState, epoch: Epoch,
-    validator_index: ValidatorIndex):
-    Option[tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot]] =
-  ## Return the committee assignment in the ``epoch`` for ``validator_index``.
-  ## ``assignment`` returned is a tuple of the following form:
-  ##     * ``assignment[0]`` is the list of validators in the committee
-  ##     * ``assignment[1]`` is the index to which the committee is assigned
-  ##     * ``assignment[2]`` is the slot at which the committee is assigned
-  ## Return None if no assignment.
-  let next_epoch = get_current_epoch(state) + 1
-  doAssert epoch <= next_epoch
-
-  var cache = StateCache()
-
-  let
-    start_slot = compute_start_slot_at_epoch(epoch)
-    committee_count_per_slot =
-      get_committee_count_per_slot(state, epoch, cache)
-  for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
-    for index in 0'u64 ..< committee_count_per_slot:
-      let idx = index.CommitteeIndex
-      let committee = get_beacon_committee(state, slot, idx, cache)
-      if validator_index in committee:
-        return some((committee, idx, slot))
-  none(tuple[a: seq[ValidatorIndex], b: CommitteeIndex, c: Slot])

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -58,16 +58,15 @@ proc mockAttestationData(
 
 proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
   var cache = StateCache()
-  let participants = get_attesting_indices(
-    state,
-    attestation.data,
-    attestation.aggregation_bits,
-    cache
-  )
 
   var agg {.noInit.}: AggregateSignature
   var first_iter = true # Can't do while loop on hashset
-  for validator_index in participants:
+  for validator_index in get_attesting_indices(
+        state,
+        attestation.data,
+        attestation.aggregation_bits,
+        cache
+      ):
     let sig = get_attestation_signature(
       state.fork, state.genesis_validators_root, attestation.data,
       MockPrivKeys[validator_index]


### PR DESCRIPTION
It's an overall 8% speed improvement in `ncli_db bench` for the first 100k slots:
```
20	237.7475	241.0585	244.9375
22	213.3625	220.535	229.2175
```
Where the columns are (count of runs, 25th percentile, mean, 75th percentile), the first row is the status quo, and the second row is this PR.

And it's averaging around a 12% improvement on "Apply block, no slot processing", specifically. Across the same samples, this PR averages 1.47ms/block and `unstable` 1.67ms/block.

Samples of corresponding per-category times are, for the current `unstable`:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4701.518,        0.000,     4701.518,     4701.518,            1, Initialize DB
       0.103,        0.520,        0.022,      151.471,        97840, Load block from database
      39.880,        0.000,       39.880,       39.880,            1, Load state from database
       0.196,        0.677,        0.028,      207.955,        96875, Advance slot, non-epoch
      13.253,        4.543,        2.296,       35.864,         3125, Advance slot, epoch
       1.680,        5.714,        0.017,       82.416,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
--
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4797.804,        0.000,     4797.804,     4797.804,            1, Initialize DB
       0.125,        0.452,        0.031,      122.513,        97840, Load block from database
      44.732,        0.000,       44.732,       44.732,            1, Load state from database
       0.195,        0.567,        0.028,      173.139,        96875, Advance slot, non-epoch
      13.211,        4.737,        1.864,       28.784,         3125, Advance slot, epoch
       1.672,        5.654,        0.014,       83.208,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
--
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4644.047,        0.000,     4644.047,     4644.047,            1, Initialize DB
       0.116,        0.491,        0.028,      136.564,        97840, Load block from database
      25.086,        0.000,       25.086,       25.086,            1, Load state from database
       0.189,        0.377,        0.028,      112.992,        96875, Advance slot, non-epoch
      12.980,        4.617,        1.331,       33.778,         3125, Advance slot, epoch
       1.632,        5.536,        0.014,       86.214,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
```

And for this PR:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4038.296,        0.000,     4038.296,     4038.296,            1, Initialize DB
       0.104,        0.578,        0.022,      172.395,        97840, Load block from database
      24.541,        0.000,       24.541,       24.541,            1, Load state from database
       0.190,        0.385,        0.028,      115.806,        96875, Advance slot, non-epoch
      12.874,        4.366,        1.294,       34.981,         3125, Advance slot, epoch
       1.382,        5.080,        0.016,       77.817,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
--
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4283.975,        0.000,     4283.975,     4283.975,            1, Initialize DB
       0.086,        0.581,        0.027,      176.299,        97840, Load block from database
      23.637,        0.000,       23.637,       23.637,            1, Load state from database
       0.193,        0.379,        0.028,      113.727,        96875, Advance slot, non-epoch
      12.897,        4.205,        1.528,       34.162,         3125, Advance slot, epoch
       1.461,        5.605,        0.016,       90.979,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
--
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4520.180,        0.000,     4520.180,     4520.180,            1, Initialize DB
       0.095,        0.374,        0.023,      104.672,        97840, Load block from database
      42.796,        0.000,       42.796,       42.796,            1, Load state from database
       0.194,        0.632,        0.028,      193.415,        96875, Advance slot, non-epoch
      12.953,        4.525,        1.985,       35.117,         3125, Advance slot, epoch
       1.452,        5.542,        0.016,       85.292,        97840, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database block store
```

Also, there were at least 4 semi-distinct `get_attesting_indices(...)` functions. This removes 3 of them.

`get_committee_assignment()` was unused because its not-totally-spec variation `get_committee_assignments()` is better-suited for a node with multiple validators.