### PR TITLE
json-rpc fixes

### DIFF
--- a/beacon_chain/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/eth2_json_rpc_serialization.nim
@@ -29,15 +29,24 @@ proc fromJson*(n: JsonNode, argName: string, result: var List) =
 proc `%`*(list: List): JsonNode = %(asSeq(list))
 
 proc fromJson*(n: JsonNode, argName: string, result: var BitList) =
-  fromJson(n, argName, seq[byte](BitSeq(result)))
+  n.kind.expect(JString, argName)
+  result = type(result)(hexToSeqByte(n.getStr()))
 
-proc `%`*(bitlist: BitList): JsonNode = %(seq[byte](BitSeq(bitlist)))
+proc `%`*(bitlist: BitList): JsonNode =
+  newJString(toJsonHex(seq[byte](BitSeq(bitlist))))
 
 proc fromJson*(n: JsonNode, argName: string, result: var ValidatorSig) =
   n.kind.expect(JString, argName)
   result = ValidatorSig.fromHex(n.getStr()).tryGet()
 
 proc `%`*(value: ValidatorSig): JsonNode =
+  newJString(toJsonHex(toRaw(value)))
+
+proc fromJson*(n: JsonNode, argName: string, result: var TrustedSig) =
+  n.kind.expect(JString, argName)
+  hexToByteArray(n.getStr(), result.data)
+
+proc `%`*(value: TrustedSig): JsonNode =
   newJString(toJsonHex(toRaw(value)))
 
 proc fromJson*(n: JsonNode, argName: string, result: var Version) =
@@ -92,3 +101,10 @@ proc `%`*(value: Eth2Digest): JsonNode =
 proc fromJson*(n: JsonNode, argName: string, result: var Eth2Digest) =
   n.kind.expect(JString, argName)
   hexToByteArray(n.getStr(), result.data)
+
+proc `%`*(value: BitSeq): JsonNode =
+  newJString(toJsonHex(value.bytes))
+
+proc fromJson*(n: JsonNode, argName: string, result: var BitSeq) =
+  n.kind.expect(JString, argName)
+  result = BitSeq(hexToSeqByte(n.getStr()))

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -17,6 +17,7 @@ import
 
   # Local modules
   spec/[datatypes, digest, crypto, helpers, network, signatures],
+  spec/eth2_apis/beacon_rpc_client,
   conf, time, version,
   eth2_network, eth2_discovery, validator_pool, beacon_node_types,
   attestation_aggregation,
@@ -31,10 +32,6 @@ import
 logScope: topics = "vc"
 
 template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
-
-## Generate client convenience marshalling wrappers from forward declarations
-createRpcSigs(RpcClient, sourceDir / "spec" / "eth2_apis" / "validator_callsigs.nim")
-createRpcSigs(RpcClient, sourceDir / "spec" / "eth2_apis" / "beacon_callsigs.nim")
 
 type
   ValidatorClient = ref object

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -102,7 +102,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
                           slot: slot))
 
   rpcServer.rpc("get_v1_validator_duties_proposer") do (
-      epoch: Epoch) -> seq[ValidatorPubkeySlotPair]:
+      epoch: Epoch) -> seq[ValidatorDutiesTuple]:
     debug "get_v1_validator_duties_proposer", epoch = epoch
     let
       head = node.doChecksAndGetCurrentHead(epoch)
@@ -110,6 +110,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) =
     for i in 0 ..< SLOTS_PER_EPOCH:
       if epochRef.beacon_proposers[i].isSome():
         result.add((public_key: epochRef.beacon_proposers[i].get()[1],
+                    validator_index: epochRef.beacon_proposers[i].get()[0],
                     slot: compute_start_slot_at_epoch(epoch) + i))
 
   rpcServer.rpc("post_v1_validator_beacon_committee_subscriptions") do (

--- a/beacon_chain/spec/eth2_apis/beacon_rpc_client.nim
+++ b/beacon_chain/spec/eth2_apis/beacon_rpc_client.nim
@@ -1,9 +1,16 @@
 import
-  os, json,
+  std/[os, json],
   json_rpc/[rpcclient, jsonmarshal],
   ../../eth2_json_rpc_serialization,
-  ../digest, ../datatypes,
+  ../crypto, ../digest, ../datatypes,
   callsigs_types
 
-createRpcSigs(RpcClient, currentSourcePath.parentDir / "beacon_callsigs.nim")
+export
+  rpcclient,
+  crypto, digest, datatypes,
+  callsigs_types,
+  eth2_json_rpc_serialization
 
+createRpcSigs(RpcClient, currentSourcePath.parentDir / "beacon_callsigs.nim")
+createRpcSigs(RpcClient, currentSourcePath.parentDir / "node_callsigs.nim")
+createRpcSigs(RpcClient, currentSourcePath.parentDir / "validator_callsigs.nim")

--- a/beacon_chain/spec/eth2_apis/callsigs_types.nim
+++ b/beacon_chain/spec/eth2_apis/callsigs_types.nim
@@ -16,7 +16,10 @@ type
     validator_committee_index: uint64
     slot: Slot
 
-  ValidatorPubkeySlotPair* = tuple[public_key: ValidatorPubKey, slot: Slot]
+  ValidatorDutiesTuple* = tuple
+    public_key: ValidatorPubKey
+    validator_index: ValidatorIndex
+    slot: Slot
 
   BeaconGenesisTuple* = tuple
     genesis_time: uint64
@@ -74,3 +77,7 @@ type
   BalanceTuple* = tuple
     index: uint64
     balance: uint64
+
+  SyncInfo* = object
+    head_slot*: Slot
+    sync_distance*: int64

--- a/beacon_chain/spec/eth2_apis/node_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/node_callsigs.nim
@@ -1,0 +1,12 @@
+import
+  options,
+  ../[datatypes, digest, crypto],
+  json_rpc/jsonmarshal,
+  callsigs_types
+
+proc get_v1_node_version(): JsonNode
+proc get_v1_node_syncing(): SyncInfo
+proc get_v1_node_health(): JsonNode
+
+proc get_v1_node_peers(state: Option[seq[string]],
+                       direction: Option[seq[string]]): seq[NodePeerTuple]

--- a/beacon_chain/spec/eth2_apis/validator_callsigs.nim
+++ b/beacon_chain/spec/eth2_apis/validator_callsigs.nim
@@ -24,7 +24,7 @@ proc post_v1_validator_aggregate_and_proofs(payload: SignedAggregateAndProof): b
 proc get_v1_validator_duties_attester(epoch: Epoch, public_keys: seq[ValidatorPubKey]): seq[AttesterDuties]
 
 # TODO epoch is part of the REST path
-proc get_v1_validator_duties_proposer(epoch: Epoch): seq[ValidatorPubkeySlotPair]
+proc get_v1_validator_duties_proposer(epoch: Epoch): seq[ValidatorDutiesTuple]
 
 proc post_v1_validator_beacon_committee_subscriptions(committee_index: CommitteeIndex,
                                                       slot: Slot,

--- a/beacon_chain/sync_manager.nim
+++ b/beacon_chain/sync_manager.nim
@@ -1,7 +1,7 @@
 import chronicles
 import options, deques, heapqueue, tables, strutils, sequtils, math, algorithm
 import stew/results, chronos, chronicles
-import spec/[datatypes, digest, helpers], peer_pool, eth2_network
+import spec/[datatypes, digest, helpers, eth2_apis/callsigs_types], peer_pool, eth2_network
 
 import ./eth2_processor
 import block_pools/block_pools_types
@@ -128,10 +128,6 @@ type
     kind*: SyncFailureKind
     peer*: T
     stamp*: chronos.Moment
-
-  SyncInfo* = object
-    head_slot*: Slot
-    sync_distance*: int64
 
   SyncManagerError* = object of CatchableError
   BeaconBlocksRes* = NetRes[seq[SignedBeaconBlock]]


### PR DESCRIPTION
* expose node signatures
* format bitseqs as hex strings
* format trusted sigs as hex strings (same as untrusted)
* reuse rpc client sigs
* include validator index in duties
* move SyncInfo to spec