### PR TITLE
remove several IntSet usages in lieu of seq[ValidatorIndex]

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -288,7 +288,7 @@ proc validateAttestation*(
 
   # Only valid attestations go in the list, which keeps validator_index
   # in range
-  if not (pool.nextAttestationEpoch.lenu64.ValidatorIndex > validator_index):
+  if not (pool.nextAttestationEpoch.lenu64 > validator_index.uint64):
     pool.nextAttestationEpoch.setLen(validator_index.int + 1)
   pool.nextAttestationEpoch[validator_index].subnet =
     attestation.data.target.epoch + 1

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[intsets, options, sequtils],
+  std/[options, sequtils],
   chronos, chronicles,
   ./spec/[
     beaconstate, datatypes, crypto, digest, helpers, network, signatures],
@@ -163,7 +163,7 @@ proc validateAttestation*(
     pool: var AttestationPool,
     attestation: Attestation, wallTime: BeaconTime,
     topicCommitteeIndex: uint64, checksExpensive: bool):
-    Result[IntSet, (ValidationResult, cstring)] =
+    Result[seq[ValidatorIndex], (ValidationResult, cstring)] =
   # [REJECT] The attestation's epoch matches its target -- i.e.
   # attestation.data.target.epoch ==
   # compute_epoch_at_slot(attestation.data.slot)
@@ -252,7 +252,7 @@ proc validateAttestation*(
   # validator index.
   # Slightly modified to allow only newer attestations than were previously
   # seen (no point in propagating older votes)
-  if (pool.nextAttestationEpoch.len > validator_index) and
+  if (pool.nextAttestationEpoch.lenu64.ValidatorIndex > validator_index) and
       pool.nextAttestationEpoch[validator_index].subnet >
         attestation.data.target.epoch:
     return err((ValidationResult.Ignore, cstring(
@@ -286,9 +286,10 @@ proc validateAttestation*(
     return err((ValidationResult.Reject, cstring(
       "validateAttestation: attestation's target block not an ancestor of LMD vote block")))
 
-  # Only valid attestations go in the list
-  if not (pool.nextAttestationEpoch.len > validator_index):
-    pool.nextAttestationEpoch.setLen(validator_index + 1)
+  # Only valid attestations go in the list, which keeps validator_index
+  # in range
+  if not (pool.nextAttestationEpoch.lenu64.ValidatorIndex > validator_index):
+    pool.nextAttestationEpoch.setLen(validator_index.int + 1)
   pool.nextAttestationEpoch[validator_index].subnet =
     attestation.data.target.epoch + 1
 
@@ -298,7 +299,7 @@ proc validateAttestation*(
 proc validateAggregate*(
     pool: var AttestationPool,
     signedAggregateAndProof: SignedAggregateAndProof, wallTime: BeaconTime):
-    Result[IntSet, (ValidationResult, cstring)] =
+    Result[seq[ValidatorIndex], (ValidationResult, cstring)] =
   let
     aggregate_and_proof = signedAggregateAndProof.message
     aggregate = aggregate_and_proof.aggregate

--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -252,7 +252,7 @@ proc validateAttestation*(
   # validator index.
   # Slightly modified to allow only newer attestations than were previously
   # seen (no point in propagating older votes)
-  if (pool.nextAttestationEpoch.lenu64.ValidatorIndex > validator_index) and
+  if (pool.nextAttestationEpoch.lenu64 > validator_index.uint64) and
       pool.nextAttestationEpoch[validator_index].subnet >
         attestation.data.target.epoch:
     return err((ValidationResult.Ignore, cstring(

--- a/beacon_chain/attestation_pool.nim
+++ b/beacon_chain/attestation_pool.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard libraries
-  std/[deques, intsets, options, sequtils, tables],
+  std/[deques, options, sequtils, tables],
   # Status libraries
   chronicles, stew/[byteutils], json_serialization/std/sets as jsonSets,
   # Internal
@@ -19,7 +19,7 @@ import
   ./beacon_node_types,
   ./fork_choice/fork_choice
 
-export beacon_node_types, intsets
+export beacon_node_types
 
 logScope: topics = "attpool"
 
@@ -89,7 +89,7 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
   )
 
 proc addForkChoiceVotes(
-    pool: var AttestationPool, slot: Slot, participants: IntSet,
+    pool: var AttestationPool, slot: Slot, participants: seq[ValidatorIndex],
     block_root: Eth2Digest, wallSlot: Slot) =
   # Add attestation votes to fork choice
   if (let v = pool.forkChoice.on_attestation(
@@ -150,7 +150,7 @@ func addToAggregates(pool: var AttestationPool, attestation: Attestation) =
 
 proc addAttestation*(pool: var AttestationPool,
                      attestation: Attestation,
-                     participants: IntSet,
+                     participants: seq[ValidatorIndex],
                      wallSlot: Slot) =
   ## Add an attestation to the pool, assuming it's been validated already.
   ## Attestations may be either agggregated or not - we're pursuing an eager

--- a/beacon_chain/block_pools/spec_cache.nim
+++ b/beacon_chain/block_pools/spec_cache.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  std/[algorithm, intsets, sequtils],
+  std/[algorithm, sequtils],
   chronicles,
   ../spec/[
     crypto, datatypes, digest, helpers, presets, signatures,
@@ -82,11 +82,10 @@ iterator get_attesting_indices*(epochRef: EpochRef,
 func get_attesting_indices*(epochRef: EpochRef,
                             data: AttestationData,
                             bits: CommitteeValidatorsBits):
-                              IntSet =
+                              seq[ValidatorIndex] =
+  # TODO sequtils2 mapIt
   for idx in get_attesting_indices(epochRef, data, bits):
-    # Because it must have been in get_beacon_committee(...), it's a valid
-    # validator index, so the conversion is as safe as it is anywhere.
-    result.incl(idx.int)
+    result.add(idx)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#get_indexed_attestation
 func get_indexed_attestation*(epochRef: EpochRef, attestation: Attestation): IndexedAttestation =
@@ -146,7 +145,7 @@ proc is_valid_indexed_attestation*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
     fork: Fork, genesis_validators_root: Eth2Digest,
-    epochRef: EpochRef, attesting_indices: IntSet,
+    epochRef: EpochRef, attesting_indices: auto,
     attestation: SomeAttestation, flags: UpdateFlags): Result[void, cstring] =
   # This is a variation on `is_valid_indexed_attestation` that works directly
   # with an attestation instead of first constructing an `IndexedAttestation`

--- a/beacon_chain/eth2_processor.nim
+++ b/beacon_chain/eth2_processor.nim
@@ -60,7 +60,7 @@ type
 
   AttestationEntry* = object
     v*: Attestation
-    attesting_indices*: IntSet
+    attesting_indices*: seq[ValidatorIndex]
 
   AggregateEntry* = AttestationEntry
 
@@ -306,7 +306,7 @@ proc blockValidator*(
 
 proc checkForPotentialDoppelganger(
     self: var Eth2Processor, attestationData: AttestationData,
-    attesterIndices: IntSet, wallSlot: Slot) =
+    attesterIndices: openArray[ValidatorIndex], wallSlot: Slot) =
   let epoch = wallSlot.epoch
   if epoch < self.doppelgangerDetection.broadcastStartEpoch:
     let tgtBlck = self.chainDag.getRef(attestationData.target.root)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[intsets, sequtils, tables],
+  std/[sequtils, tables],
   # Status libraries
   stew/results, chronicles,
   # Internal
@@ -18,7 +18,7 @@ import
   ./fork_choice_types, ./proto_array,
   ../block_pools/[spec_cache, chain_dag]
 
-export intsets, results, fork_choice_types
+export results, fork_choice_types
 export proto_array.len
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md
@@ -174,7 +174,7 @@ proc on_attestation*(
        dag: ChainDAGRef,
        attestation_slot: Slot,
        beacon_block_root: Eth2Digest,
-       attesting_indices: IntSet,
+       attesting_indices: seq[ValidatorIndex],
        wallSlot: Slot
      ): FcResult[void] =
   ? self.update_time(dag, wallSlot)
@@ -191,7 +191,7 @@ proc on_attestation*(
   else:
     self.queuedAttestations.add(QueuedAttestation(
       slot: attestation_slot,
-      attesting_indices: toSeq(attesting_indices),
+      attesting_indices: attesting_indices,
       block_root: beacon_block_root))
   ok()
 

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -160,7 +160,7 @@ type
 
   QueuedAttestation* = object
     slot*: Slot
-    attesting_indices*: seq[int]
+    attesting_indices*: seq[ValidatorIndex]
     block_root*: Eth2Digest
     target_epoch*: Epoch
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019-2020 Status Research & Development GmbH
+# Copyright (c) 2019-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -117,7 +117,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
                 data: data,
                 aggregation_bits: aggregation_bits,
                 signature: sig
-              ), [validatorIdx.int].toIntSet(), data.slot)
+              ), @[validatorIdx], data.slot)
 
   proc proposeBlock(slot: Slot) =
     if rand(r, 1.0) > blockRatio:

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -77,7 +77,7 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, beacon_committee[0], cache)
 
     pool[].addAttestation(
-      attestation, [beacon_committee[0]].toIntSet(), attestation.data.slot)
+      attestation, @[beacon_committee[0]], attestation.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -106,10 +106,8 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, bc1[0], cache)
 
     # test reverse order
-    pool[].addAttestation(
-      attestation1, [bc1[0]].toIntSet, attestation1.data.slot)
-    pool[].addAttestation(
-      attestation0, [bc0[0]].toIntSet, attestation1.data.slot)
+    pool[].addAttestation(attestation1, @[bc1[0]], attestation1.data.slot)
+    pool[].addAttestation(attestation0, @[bc0[0]], attestation1.data.slot)
 
     discard process_slots(
       state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -130,10 +128,8 @@ suiteReport "Attestation pool processing" & preset():
       attestation1 = makeAttestation(
         state.data.data, state.blck.root, bc0[1], cache)
 
-    pool[].addAttestation(
-      attestation0, [bc0[0]].toIntSet, attestation0.data.slot)
-    pool[].addAttestation(
-      attestation1, [bc0[1]].toIntSet, attestation1.data.slot)
+    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
+    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -157,10 +153,8 @@ suiteReport "Attestation pool processing" & preset():
 
     attestation0.combine(attestation1)
 
-    pool[].addAttestation(
-      attestation0, [bc0[0]].toIntSet, attestation0.data.slot)
-    pool[].addAttestation(
-      attestation1, [bc0[1]].toIntSet, attestation1.data.slot)
+    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
+    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -183,10 +177,8 @@ suiteReport "Attestation pool processing" & preset():
 
     attestation0.combine(attestation1)
 
-    pool[].addAttestation(
-      attestation1, [bc0[1]].toIntSet, attestation1.data.slot)
-    pool[].addAttestation(
-      attestation0, [bc0[0]].toIntSet, attestation0.data.slot)
+    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
+    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -253,8 +245,7 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.data.data.slot - 1, 1.CommitteeIndex, cache)
       attestation0 = makeAttestation(state.data.data, b10.root, bc1[0], cache)
 
-    pool[].addAttestation(
-      attestation0, [bc1[0]].toIntSet, attestation0.data.slot)
+    pool[].addAttestation(attestation0, @[bc1[0]], attestation0.data.slot)
 
     let head2 = pool[].selectHead(b10Add[].slot)
 
@@ -265,8 +256,7 @@ suiteReport "Attestation pool processing" & preset():
     let
       attestation1 = makeAttestation(state.data.data, b11.root, bc1[1], cache)
       attestation2 = makeAttestation(state.data.data, b11.root, bc1[2], cache)
-    pool[].addAttestation(
-      attestation1, [bc1[1]].toIntSet, attestation1.data.slot)
+    pool[].addAttestation(attestation1, @[bc1[1]], attestation1.data.slot)
 
     let head3 = pool[].selectHead(b10Add[].slot)
     let bigger = if b11.root.data < b10.root.data: b10Add else: b11Add
@@ -275,8 +265,7 @@ suiteReport "Attestation pool processing" & preset():
       # Ties broken lexicographically in spec -> ?
       head3 == bigger[]
 
-    pool[].addAttestation(
-      attestation2, [bc1[2]].toIntSet, attestation2.data.slot)
+    pool[].addAttestation(attestation2, @[bc1[2]], attestation2.data.slot)
 
     let head4 = pool[].selectHead(b11Add[].slot)
 


### PR DESCRIPTION
- having a generic container which correctly stores the `ValidatorIndex` is better for type safety
- it does less, because `IntSet` always contains a 34-element `seq[int]`, in addition to other things
- by the same token, it avoids some stdlib stuff
- it clarifies where sets, conceptually, are actually useful. The status quo ante had been that `HashSet[ValidatorIndex]` had been the general-purpose ValidatorIndex container, because for a couple of cases, set-like behavior was desireable. But mostly, and in all the cases here, they can just be lists of validators, because they're from `get_attesting_indices()`, which is from a permuted/shuffled list of sequential integers that by construction cannot have duplicates, and comes from `get_beacon_committee()` internally, not an untrusted external source.
- avoids some imports, for compilation speed and generally fewer symbols hanging around