### PR TITLE
immutable validator database factoring

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -282,4 +282,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 152/161 Fail: 0/161 Skip: 9/161
+OK: 151/160 Fail: 0/160 Skip: 9/160

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -23,12 +23,14 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check blocks [Preset: mainnet]                                                      OK
++ sanity check full states [Preset: mainnet]                                                 OK
++ sanity check full states, reusing buffers [Preset: mainnet]                                OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states [Preset: mainnet]                                                      OK
 + sanity check states, reusing buffers [Preset: mainnet]                                     OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -280,4 +282,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 150/159 Fail: 0/159 Skip: 9/159
+OK: 152/161 Fail: 0/161 Skip: 9/161

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -26,8 +26,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states [Preset: mainnet]                                                      OK
++ sanity check states, reusing buffers [Preset: mainnet]                                     OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -279,4 +280,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 149/158 Fail: 0/158 Skip: 9/158
+OK: 150/159 Fail: 0/159 Skip: 9/159

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -24,12 +24,11 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check blocks [Preset: mainnet]                                                      OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
-+ sanity check immutable validator roundtrip [Preset: mainnet]                               OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon node
 ```diff
 + Compile                                                                                    OK

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -25,10 +25,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + sanity check blocks [Preset: mainnet]                                                      OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
-+ sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 6/6 Fail: 0/6 Skip: 0/6
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -280,4 +279,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 150/159 Fail: 0/159 Skip: 9/159
+OK: 149/158 Fail: 0/158 Skip: 9/158

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -2,33 +2,23 @@ AllTests-mainnet
 ===
 ## Attestation pool processing [Preset: mainnet]
 ```diff
-+ Attestations may arrive in any order [Preset: mainnet]                                     OK
-+ Attestations may overlap, bigger first [Preset: mainnet]                                   OK
-+ Attestations may overlap, smaller first [Preset: mainnet]                                  OK
-+ Attestations should be combined [Preset: mainnet]                                          OK
-+ Can add and retrieve simple attestation [Preset: mainnet]                                  OK
-+ Fork choice returns block with attestation                                                 OK
-+ Fork choice returns latest block with no attestations                                      OK
-+ Trying to add a block twice tags the second as an error                                    OK
-+ Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
+OK: 0/0 Fail: 0/0 Skip: 0/0
 ## Attestation validation  [Preset: mainnet]
 ```diff
-+ Validation sanity                                                                          OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 0/0 Fail: 0/0 Skip: 0/0
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check blocks [Preset: mainnet]                                                      OK
-+ sanity check genesis roundtrip [Preset: mainnet]                                           OK
+- sanity check genesis roundtrip [Preset: mainnet]                                           Fail
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 6/7 Fail: 1/7 Skip: 0/7
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -41,15 +31,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool processing [Preset: mainnet]
 ```diff
-+ Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
-+ Reverse order block add & get [Preset: mainnet]                                            OK
-+ Simple block add&get [Preset: mainnet]                                                     OK
-+ getRef returns nil for missing blocks                                                      OK
-+ loading tail block works [Preset: mainnet]                                                 OK
-+ updateHead updates head and headState [Preset: mainnet]                                    OK
-+ updateStateData sanity [Preset: mainnet]                                                   OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 0/0 Fail: 0/0 Skip: 0/0
 ## Block processing [Preset: mainnet]
 ```diff
 + Attestation gets processed at epoch [Preset: mainnet]                                      OK
@@ -74,11 +57,8 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Exit pool testing suite
 ```diff
-+ addExitMessage/getAttesterSlashingMessage                                                  OK
-+ addExitMessage/getProposerSlashingMessage                                                  OK
-+ addExitMessage/getVoluntaryExitMessage                                                     OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 0/0 Fail: 0/0 Skip: 0/0
 ## Fork Choice + Finality  [Preset: mainnet]
 ```diff
 + fork_choice - testing finality #01                                                         OK
@@ -265,9 +245,8 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 OK: 8/8 Fail: 0/8 Skip: 0/8
 ## chain DAG finalization tests [Preset: mainnet]
 ```diff
-+ init with gaps [Preset: mainnet]                                                           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 0/0 Fail: 0/0 Skip: 0/0
 ## hash
 ```diff
 + HashArray                                                                                  OK
@@ -280,4 +259,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 150/159 Fail: 0/159 Skip: 9/159
+OK: 126/136 Fail: 1/136 Skip: 9/136

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -25,9 +25,10 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + sanity check blocks [Preset: mainnet]                                                      OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
++ sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon node
 ```diff
 + Compile                                                                                    OK

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -24,11 +24,12 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check blocks [Preset: mainnet]                                                      OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
++ sanity check immutable validator roundtrip [Preset: mainnet]                               OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 8/8 Fail: 0/8 Skip: 0/8
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -280,4 +281,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 148/157 Fail: 0/157 Skip: 9/157
+OK: 150/159 Fail: 0/159 Skip: 9/159

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -2,23 +2,33 @@ AllTests-mainnet
 ===
 ## Attestation pool processing [Preset: mainnet]
 ```diff
++ Attestations may arrive in any order [Preset: mainnet]                                     OK
++ Attestations may overlap, bigger first [Preset: mainnet]                                   OK
++ Attestations may overlap, smaller first [Preset: mainnet]                                  OK
++ Attestations should be combined [Preset: mainnet]                                          OK
++ Can add and retrieve simple attestation [Preset: mainnet]                                  OK
++ Fork choice returns block with attestation                                                 OK
++ Fork choice returns latest block with no attestations                                      OK
++ Trying to add a block twice tags the second as an error                                    OK
++ Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 ```
-OK: 0/0 Fail: 0/0 Skip: 0/0
+OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Attestation validation  [Preset: mainnet]
 ```diff
++ Validation sanity                                                                          OK
 ```
-OK: 0/0 Fail: 0/0 Skip: 0/0
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check blocks [Preset: mainnet]                                                      OK
-- sanity check genesis roundtrip [Preset: mainnet]                                           Fail
++ sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states 2 [Preset: mainnet]                                                    OK
 + sanity check states [Preset: mainnet]                                                      OK
 ```
-OK: 6/7 Fail: 1/7 Skip: 0/7
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon node
 ```diff
 + Compile                                                                                    OK
@@ -31,8 +41,15 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool processing [Preset: mainnet]
 ```diff
++ Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
++ Reverse order block add & get [Preset: mainnet]                                            OK
++ Simple block add&get [Preset: mainnet]                                                     OK
++ getRef returns nil for missing blocks                                                      OK
++ loading tail block works [Preset: mainnet]                                                 OK
++ updateHead updates head and headState [Preset: mainnet]                                    OK
++ updateStateData sanity [Preset: mainnet]                                                   OK
 ```
-OK: 0/0 Fail: 0/0 Skip: 0/0
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Block processing [Preset: mainnet]
 ```diff
 + Attestation gets processed at epoch [Preset: mainnet]                                      OK
@@ -57,8 +74,11 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Exit pool testing suite
 ```diff
++ addExitMessage/getAttesterSlashingMessage                                                  OK
++ addExitMessage/getProposerSlashingMessage                                                  OK
++ addExitMessage/getVoluntaryExitMessage                                                     OK
 ```
-OK: 0/0 Fail: 0/0 Skip: 0/0
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Fork Choice + Finality  [Preset: mainnet]
 ```diff
 + fork_choice - testing finality #01                                                         OK
@@ -245,8 +265,9 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 OK: 8/8 Fail: 0/8 Skip: 0/8
 ## chain DAG finalization tests [Preset: mainnet]
 ```diff
++ init with gaps [Preset: mainnet]                                                           OK
 ```
-OK: 0/0 Fail: 0/0 Skip: 0/0
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## hash
 ```diff
 + HashArray                                                                                  OK
@@ -259,4 +280,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 126/136 Fail: 1/136 Skip: 9/136
+OK: 150/159 Fail: 0/159 Skip: 9/159

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -479,8 +479,6 @@ proc getState*(
       db, key, output, rollback, immutableValidators):
     return true
 
-  # TODO both this and getStateOnlyMutableValidators can rollback. but only one
-  # really has to.
   case db.get(subkey(BeaconState, key), output)
   of GetResult.found:
     true

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -416,7 +416,7 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
   template assign[V, W](dummy: untyped, x: List[V, W], y: HashList[V, W]) =
     assign(x, y.data)
 
-  #TODO
+  # TODO workaround for https://github.com/nim-lang/Nim/issues/17253
   #template assign[V, W](dummy: untyped, x: array[V, W], y: HashArray[V, W]) =
   #  assign(x, y.data)
 
@@ -426,16 +426,16 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
   result.slot = x.slot
   result.fork = x.fork
   assign(result.latest_block_header, x.latest_block_header)
-  #assign(result.block_roots, x.block_roots)
-  #assign(result.state_roots, x.state_roots)
+  assign(result.block_roots, x.block_roots)
+  assign(result.state_roots, x.state_roots)
 
   assign(result.historical_roots, x.historical_roots)
   assign(result.eth1_data, x.eth1_data)
   assign(result.eth1_data_votes, x.eth1_data_votes)
   assign(result.eth1_deposit_index, x.eth1_deposit_index)
   assign(result.balances, x.balances)
-  #assign(result.randao_mixes, x.randao_mixes)
-  #assign(result.slashings, x.slashings)
+  assign(result.randao_mixes, x.randao_mixes)
+  assign(result.slashings, x.slashings)
   assign(
     result.previous_epoch_attestations, x.previous_epoch_attestations)
   assign(

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -237,10 +237,6 @@ proc loadImmutableValidators(db: BeaconChainDB): seq[ImmutableValidatorData] =
   for i in 0'u64 ..< db.immutableValidators.len:
     result.add db.immutableValidators.get(i)
 
-proc loadImmutableValidators(dbSeq: var auto): seq[ImmutableValidatorData] =
-  for i in 0'u64 ..< dbSeq.len:
-    result.add dbSeq.get(i)
-
 proc init*(T: type BeaconChainDB,
            preset: RuntimePreset,
            dir: string,

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -466,11 +466,20 @@ proc getStateOnlyMutableValidators(
       existingOutputValidators = output.validators.len
     doAssert db.immutableValidatorsMem.len >= numValidators
 
-    output.validators.clearCache()
+    when false:
+      # Seemingly insufficient, as is output.validators.hashes.setLen(0)
+      output.validators.clearCache()
+    else:
+      # So, instead. But this means one can't do the incremental immutable
+      # validator fill. This does not seem to have major benchmark-visible
+      # effects.
+      output.validators.clear()
+
     output.validators.data.setLen(numValidators)
 
     # If truncation occurred, skip loop
-    for i in existingOutputValidators ..< numValidators:
+    #for i in existingOutputValidators ..< numValidators:
+    for i in 0 ..< numValidators:
       let
         # Bypass hash cache invalidation
         dstValidator = addr output.validators.data[i]

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -381,8 +381,11 @@ proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
 proc putState*(db: BeaconChainDB, value: BeaconState) =
   db.putState(hash_tree_root(value), value)
 
+proc putStateFull*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
+  db.put(subkey(BeaconState, key), value)
+
 proc putStateFull*(db: BeaconChainDB, value: BeaconState) =
-  db.put(subkey(BeaconState, hash_tree_root(value)), value)
+  db.putStateFull(hash_tree_root(value), value)
 
 proc putStateRoot*(db: BeaconChainDB, root: Eth2Digest, slot: Slot,
     value: Eth2Digest) =

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -618,3 +618,7 @@ iterator getAncestorSummaries*(db: BeaconChainDB, root: Eth2Digest):
       break
 
     root = res.summary.parent_root
+
+proc loadImmutableValidators*(db: BeaconChainDB): seq[ImmutableValidatorData] =
+  for i in 0'u64 ..< db.immutableValidators.len:
+    result.add db.immutableValidators.get(i)

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.push raises: [Defect].}
 
 import
@@ -5,7 +12,7 @@ import
   stew/[assign2, endians2, io2, objects, results],
   serialization, chronicles, snappy,
   eth/db/[kvstore, kvstore_sqlite3],
-  ./networking/network_metadata,
+  ./networking/network_metadata, ./beacon_chain_db_immutable,
   ./spec/[crypto, datatypes, digest, state_transition],
   ./ssz/[ssz_serialization, merkleization],
   ./eth1/merkle_minimal,
@@ -103,64 +110,6 @@ type
   BeaconBlockSummary* = object
     slot*: Slot
     parent_root*: Eth2Digest
-
-  # TODO extract this and some other immutable validator-related items into a
-  # separate module -- they're almost only for beacon_chain_db, but overwhelm
-  # this module.
-  # TODO add HF1 compatibility; emphasize HF1 performance, but support phase 0
-  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beaconstate
-  # https://github.com/ethereum/eth2.0-specs/blob/dev/specs/lightclient/beacon-chain.md#beaconstate
-  BeaconStateNoImmutableValidators = object
-    # Versioning
-    genesis_time*: uint64
-    genesis_validators_root*: Eth2Digest
-    slot*: Slot
-    fork*: Fork
-
-    # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
-
-    block_roots*: array[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
-
-    state_roots*: array[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
-    historical_roots*: List[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
-
-    # Eth1
-    eth1_data*: Eth1Data
-    eth1_data_votes*:
-      List[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
-    eth1_deposit_index*: uint64
-
-    # Registry
-    validators*: List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
-
-    # Randomness
-    randao_mixes*: array[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
-
-    # Slashings
-    slashings*: array[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
-
-    # Attestations
-    previous_epoch_attestations*:
-      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
-    current_epoch_attestations*:
-      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
-
-    # Finality
-    justification_bits*: uint8 ##\
-    ## Bit set for every recent justified epoch
-    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
-    ## with ssz/hashing.
-
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
-
-    current_justified_checkpoint*: Checkpoint
-    finalized_checkpoint*: Checkpoint
 
 const
   # The largest object we're saving is the BeaconState, and by far, the largest
@@ -389,70 +338,6 @@ proc putBlock*(db: BeaconChainDB, value: TrustedSignedBeaconBlock) =
 proc putBlock*(db: BeaconChainDB, value: SigVerifiedSignedBeaconBlock) =
   db.put(subkey(SignedBeaconBlock, value.root), value)
   db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
-
-# TODO refactor this into immutable validator-specific module; also, figure out
-# better name, but "get" in this module generally means retrieve from database,
-# which this isn't. another argument, perhaps, for the module split.
-# TODO copy HF1 values too
-func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
-  # TODO this whole approach is a kludge; should be able to avoid copying and
-  # get SSZ to just serialize result.validators differently, concatenate from
-  # before + changed + after, or etc. also adding any additional copies, or a
-  # non-ref return type, hurts performance significantly.
-  #
-  # This copies all fields, except validators.
-  template assign[V, W](x: HashList[V, W], y: List[V, W]) =
-    # https://github.com/status-im/nimbus-eth2/blob/3f6834cce7b60581cfe3cdd9946e28bdc6d74176/beacon_chain/ssz/bytes_reader.nim#L144
-    assign(x.data, y)
-    x.hashes.setLen(0)
-    x.growHashes()
-
-  template assign[V, W](dummy, x: HashArray[V, W], y: array[V, W]) =
-    # https://github.com/status-im/nimbus-eth2/blob/3f6834cce7b60581cfe3cdd9946e28bdc6d74176/beacon_chain/ssz/bytes_reader.nim#L148
-    assign(x.data, y)
-    for h in x.hashes.mitems():
-      clearCache(h)
-
-  template assign[V, W](x: List[V, W], y: HashList[V, W]) =
-    assign(x, y.data)
-
-  template assign[V, W](
-      dummy: HashArray[V, W], x: array[V, W], y: HashArray[V, W]) =
-    assign(x, y.data)
-
-  # https://github.com/nim-lang/Nim/issues/17253 workaround
-  template type_binder(maybe_array_0, maybe_array_1: untyped): untyped =
-    when maybe_array_0 is array:
-      maybe_array_1
-    else:
-      maybe_array_0
-
-  template arrayAssign(x, y: untyped) =
-    assign(type_binder(x, y), x, y)
-
-  result = new U
-  result.genesis_time = x.genesis_time
-  result.genesis_validators_root = x.genesis_validators_root
-  result.slot = x.slot
-  result.fork = x.fork
-  assign(result.latest_block_header, x.latest_block_header)
-  arrayAssign(result.block_roots, x.block_roots)
-  arrayAssign(result.state_roots, x.state_roots)
-  assign(result.historical_roots, x.historical_roots)
-  assign(result.eth1_data, x.eth1_data)
-  assign(result.eth1_data_votes, x.eth1_data_votes)
-  assign(result.eth1_deposit_index, x.eth1_deposit_index)
-  assign(result.balances, x.balances)
-  arrayAssign(result.randao_mixes, x.randao_mixes)
-  arrayAssign(result.slashings, x.slashings)
-  assign(
-    result.previous_epoch_attestations, x.previous_epoch_attestations)
-  assign(
-    result.current_epoch_attestations, x.current_epoch_attestations)
-  result.justification_bits = x.justification_bits
-  assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
-  assign(result.current_justified_checkpoint, x.current_justified_checkpoint)
-  assign(result.finalized_checkpoint, x.finalized_checkpoint)
 
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
   # TODO prune old states - this is less easy than it seems as we never know

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -464,7 +464,7 @@ proc getStateOnlyMutableValidators(
     let numValidators = intermediateOutput[].validators.len
     doAssert db.immutableValidatorsMem.len >= numValidators
 
-    output.validators.clear()   # TODO suboptimal
+    output.validators.clearCache()
     output.validators.data.setLen(numValidators)
 
     for i in 0 ..< numValidators:

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -243,7 +243,7 @@ proc init*(T: type BeaconChainDB,
            inMemory = false): BeaconChainDB =
   var sqliteStore =
     if inMemory:
-      SqStoreRef.init("", "test", inMemory = true).expect("working database (disk broken/full?)")
+      SqStoreRef.init("", "test", inMemory = true).expect("working database (out of memory?)")
     else:
       let s = secureCreatePath(dir)
       doAssert s.isOk # TODO(zah) Handle this in a better way

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -381,6 +381,9 @@ proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
 proc putState*(db: BeaconChainDB, value: BeaconState) =
   db.putState(hash_tree_root(value), value)
 
+proc putStateFull*(db: BeaconChainDB, value: BeaconState) =
+  db.put(subkey(BeaconState, hash_tree_root(value)), value)
+
 proc putStateRoot*(db: BeaconChainDB, root: Eth2Digest, slot: Slot,
     value: Eth2Digest) =
   db.put(subkey(root, slot), value)

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -372,8 +372,8 @@ proc updateImmutableValidators(
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
   # TODO prune old states - this is less easy than it seems as we never know
   #      when or if a particular state will become finalized.
-  var mutableOnlyState = getBeaconStateNoImmutableValidators[
-    BeaconState, BeaconStateNoImmutableValidators](value)
+  var mutableOnlyState = new BeaconStateNoImmutableValidators
+  updateBeaconStateNoImmutableValidators(value, mutableOnlyState[])
   mutableOnlyState[].validators = getMutableValidatorStatuses(value)
   updateImmutableValidators(db, db.immutableValidatorsMem, value.validators)
   db.put(subkey(BeaconStateNoImmutableValidators, key), mutableOnlyState[])
@@ -459,8 +459,7 @@ proc getStateOnlyMutableValidators(
   case db.get(
     subkey(BeaconStateNoImmutableValidators, key), intermediateOutput[])
   of GetResult.found:
-    output = getBeaconStateNoImmutableValidators[
-      BeaconStateNoImmutableValidators, BeaconState](intermediateOutput[])[]
+    updateBeaconStateNoImmutableValidators(intermediateOutput[], output)
 
     let numValidators = intermediateOutput[].validators.len
     doAssert db.immutableValidatorsMem.len >= numValidators

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -2,7 +2,7 @@
 
 import
   typetraits, tables,
-  stew/[endians2, io2, objects, results],
+  stew/[assign2, endians2, io2, objects, results],
   serialization, chronicles, snappy,
   eth/db/[kvstore, kvstore_sqlite3],
   ./networking/network_metadata, ./statediff,
@@ -417,25 +417,25 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
   #
   # This copies all fields, except validators.
   result = new U
-  result.genesis_time = x.genesis_time
-  result.genesis_validators_root = x.genesis_validators_root
-  result.slot = x.slot
-  result.fork = x.fork
-  result.latest_block_header = x.latest_block_header
-  result.block_roots = x.block_roots
-  result.state_roots = x.state_roots
-  result.historical_roots = x.historical_roots
-  result.eth1_data = x.eth1_data
-  result.eth1_data_votes = x.eth1_data_votes
-  result.eth1_deposit_index = x.eth1_deposit_index
-  result.balances = x.balances
-  result.randao_mixes = x.randao_mixes
-  result.slashings = x.slashings
-  result.previous_epoch_attestations = x.previous_epoch_attestations
-  result.current_epoch_attestations = x.current_epoch_attestations
-  result.justification_bits = x.justification_bits
-  result.previous_justified_checkpoint = x.previous_justified_checkpoint
-  result.finalized_checkpoint = x.finalized_checkpoint
+  assign(result.genesis_time, x.genesis_time)
+  assign(result.genesis_validators_root, x.genesis_validators_root)
+  assign(result.slot, x.slot)
+  assign(result.fork, x.fork)
+  assign(result.latest_block_header, x.latest_block_header)
+  assign(result.block_roots, x.block_roots)
+  assign(result.state_roots, x.state_roots)
+  assign(result.historical_roots, x.historical_roots)
+  assign(result.eth1_data, x.eth1_data)
+  assign(result.eth1_data_votes, x.eth1_data_votes)
+  assign(result.eth1_deposit_index, x.eth1_deposit_index)
+  assign(result.balances, x.balances)
+  assign(result.randao_mixes, x.randao_mixes)
+  assign(result.slashings, x.slashings)
+  assign(result.previous_epoch_attestations, x.previous_epoch_attestations)
+  assign(result.current_epoch_attestations, x.current_epoch_attestations)
+  assign(result.justification_bits, x.justification_bits)
+  assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
+  assign(result.finalized_checkpoint, x.finalized_checkpoint)
 
 proc getStateOnlyMutableValidators(
     db: BeaconChainDB, key: Eth2Digest, output: var BeaconState,
@@ -466,25 +466,32 @@ proc getStateOnlyMutableValidators(
     # TODO factor out, maybe
     for i in 0 ..< intermediateOutput[].validators.len:
       # Merge immutable and mutable parts
-      debugEcho "foobar: ", i
 
       # Immutable
-      output.validators[i].pubkey = immutableValidators[i].pubkey
-      output.validators[i].withdrawal_credentials =
-        immutableValidators[i].withdrawal_credentials
+      assign(output.validators[i].pubkey, immutableValidators[i].pubkey)
+      assign(
+        output.validators[i].withdrawal_credentials,
+        immutableValidators[i].withdrawal_credentials)
 
       # Mutable
-      output.validators[i].effective_balance =
-        intermediateOutput[].validators[i].effective_balance
-      output.validators[i].slashed = intermediateOutput[].validators[i].slashed
-      output.validators[i].activation_eligibility_epoch =
-        intermediateOutput[].validators[i].activation_eligibility_epoch
-      output.validators[i].activation_epoch =
-        intermediateOutput[].validators[i].activation_epoch
-      output.validators[i].exit_epoch =
-        intermediateOutput[].validators[i].exit_epoch
-      output.validators[i].withdrawable_epoch =
-        intermediateOutput[].validators[i].withdrawable_epoch
+      assign(
+        output.validators[i].effective_balance,
+        intermediateOutput[].validators[i].effective_balance)
+      assign(
+        output.validators[i].slashed,
+        intermediateOutput[].validators[i].slashed)
+      assign(
+        output.validators[i].activation_eligibility_epoch,
+        intermediateOutput[].validators[i].activation_eligibility_epoch)
+      assign(
+        output.validators[i].activation_epoch,
+        intermediateOutput[].validators[i].activation_epoch)
+      assign(
+        output.validators[i].exit_epoch,
+        intermediateOutput[].validators[i].exit_epoch)
+      assign(
+        output.validators[i].withdrawable_epoch,
+        intermediateOutput[].validators[i].withdrawable_epoch)
 
     true
   of GetResult.notFound:

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -405,6 +405,13 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
   # non-ref return type, hurts performance significantly.
   #
   # This copies all fields, except validators.
+
+  template copyToHashList(x, y: untyped) =
+    # https://github.com/status-im/nimbus-eth2/blob/3f6834cce7b60581cfe3cdd9946e28bdc6d74176/beacon_chain/ssz/bytes_reader.nim#L144
+    assign(x.data, y)
+    x.hashes.setLen(0)
+    x.growHashes()
+
   result = new U
   result.genesis_time = x.genesis_time
   result.genesis_validators_root = x.genesis_validators_root
@@ -413,15 +420,18 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
   assign(result.latest_block_header, x.latest_block_header)
   assign(result.block_roots, x.block_roots)
   assign(result.state_roots, x.state_roots)
-  assign(result.historical_roots, x.historical_roots)
+
+  copyToHashList(result.historical_roots, x.historical_roots)
   assign(result.eth1_data, x.eth1_data)
-  assign(result.eth1_data_votes, x.eth1_data_votes)
+  copyToHashList(result.eth1_data_votes, x.eth1_data_votes)
   assign(result.eth1_deposit_index, x.eth1_deposit_index)
-  assign(result.balances, x.balances)
+  copyToHashList(result.balances, x.balances)
   assign(result.randao_mixes, x.randao_mixes)
   assign(result.slashings, x.slashings)
-  assign(result.previous_epoch_attestations, x.previous_epoch_attestations)
-  assign(result.current_epoch_attestations, x.current_epoch_attestations)
+  copyToHashList(
+    result.previous_epoch_attestations, x.previous_epoch_attestations)
+  copyToHashList(
+    result.current_epoch_attestations, x.current_epoch_attestations)
   result.justification_bits = x.justification_bits
   assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
   assign(result.finalized_checkpoint, x.finalized_checkpoint)

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -234,7 +234,7 @@ template insert*[K, V](t: var Table[K, V], key: K, value: V) =
 
 proc loadImmutableValidators(db: BeaconChainDB): seq[ImmutableValidatorData] =
   # TODO not called, but build fails otherwise
-  for i in 0'u64 ..< db.immutableValidators.len:
+  for i in 0 ..< db.immutableValidators.len:
     result.add db.immutableValidators.get(i)
 
 proc init*(T: type BeaconChainDB,
@@ -357,7 +357,7 @@ proc updateImmutableValidators(
     numValidators = validators.lenu64
     origNumImmutableValidators = immutableValidators.lenu64
 
-  doAssert immutableValidators.lenu64 == db.immutableValidators.len
+  doAssert immutableValidators.len == db.immutableValidators.len
 
   if numValidators <= origNumImmutableValidators:
     return

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -451,6 +451,7 @@ func getBeaconStateNoImmutableValidators[T, U](x: T): ref U =
     result.current_epoch_attestations, x.current_epoch_attestations)
   result.justification_bits = x.justification_bits
   assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
+  assign(result.current_justified_checkpoint, x.current_justified_checkpoint)
   assign(result.finalized_checkpoint, x.finalized_checkpoint)
 
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -466,19 +466,12 @@ proc getStateOnlyMutableValidators(
       existingOutputValidators = output.validators.len
     doAssert db.immutableValidatorsMem.len >= numValidators
 
-    when false:
-      # Seemingly insufficient, as is output.validators.hashes.setLen(0)
-      output.validators.clearCache()
-    else:
-      # So, instead. But this means one can't do the incremental immutable
-      # validator fill. This does not seem to have major benchmark-visible
-      # effects.
-      output.validators.clear()
-
+    # TODO don't clear, so enable incremental immutable validator data filling
+    # by starting loop iterations at existingOutputValidators instead of 0
+    output.validators.clear()
     output.validators.data.setLen(numValidators)
 
     # If truncation occurred, skip loop
-    #for i in existingOutputValidators ..< numValidators:
     for i in 0 ..< numValidators:
       let
         # Bypass hash cache invalidation

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -131,3 +131,7 @@ func getBeaconStateNoImmutableValidators*[T, U](x: T): ref U =
   assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
   assign(result.current_justified_checkpoint, x.current_justified_checkpoint)
   assign(result.finalized_checkpoint, x.finalized_checkpoint)
+
+proc loadImmutableValidators*(dbSeq: var auto): seq[ImmutableValidatorData] =
+  for i in 0'u64 ..< dbSeq.len:
+    result.add dbSeq.get(i)

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -1,0 +1,133 @@
+# beacon_chain
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  tables,
+  stew/[assign2, endians2, io2, objects, results],
+  serialization, chronicles,
+  eth/db/[kvstore, kvstore_sqlite3],
+  ./spec/[crypto, datatypes, digest],
+  ./ssz/[ssz_serialization, merkleization],
+  filepath
+
+type 
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beaconstate
+  BeaconStateNoImmutableValidators* = object
+    # Versioning
+    genesis_time*: uint64
+    genesis_validators_root*: Eth2Digest
+    slot*: Slot
+    fork*: Fork
+
+    # History
+    latest_block_header*: BeaconBlockHeader ##\
+    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: array[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
+    ## Needed to process attestations, older to newer
+
+    state_roots*: array[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: List[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*:
+      List[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_deposit_index*: uint64
+
+    # Registry
+    validators*: List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Randomness
+    randao_mixes*: array[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
+
+    # Slashings
+    slashings*: array[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
+    ## Per-epoch sums of slashed effective balances
+
+    # Attestations
+    previous_epoch_attestations*:
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+    current_epoch_attestations*:
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+
+    # Finality
+    justification_bits*: uint8 ##\
+    ## Bit set for every recent justified epoch
+    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
+    ## with ssz/hashing.
+
+    previous_justified_checkpoint*: Checkpoint ##\
+    ## Previous epoch snapshot
+
+    current_justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
+# TODO better name: get here generally means retrieve from database,
+# which this isn't. another argument, perhaps, for the module split.
+func getBeaconStateNoImmutableValidators*[T, U](x: T): ref U =
+  # TODO this whole approach is a kludge; should be able to avoid copying and
+  # get SSZ to just serialize result.validators differently, concatenate from
+  # before + changed + after, or etc. also adding any additional copies, or a
+  # non-ref return type, hurts performance significantly.
+  #
+  # This copies all fields, except validators.
+  template assign[V, W](x: HashList[V, W], y: List[V, W]) =
+    # https://github.com/status-im/nimbus-eth2/blob/3f6834cce7b60581cfe3cdd9946e28bdc6d74176/beacon_chain/ssz/bytes_reader.nim#L144
+    assign(x.data, y)
+    x.hashes.setLen(0)
+    x.growHashes()
+
+  template assign[V, W](dummy, x: HashArray[V, W], y: array[V, W]) =
+    # https://github.com/status-im/nimbus-eth2/blob/3f6834cce7b60581cfe3cdd9946e28bdc6d74176/beacon_chain/ssz/bytes_reader.nim#L148
+    assign(x.data, y)
+    for h in x.hashes.mitems():
+      clearCache(h)
+
+  template assign[V, W](x: List[V, W], y: HashList[V, W]) =
+    assign(x, y.data)
+
+  template assign[V, W](
+      dummy: HashArray[V, W], x: array[V, W], y: HashArray[V, W]) =
+    assign(x, y.data)
+
+  # https://github.com/nim-lang/Nim/issues/17253 workaround
+  template type_binder(maybe_array_0, maybe_array_1: untyped): untyped =
+    when maybe_array_0 is array:
+      maybe_array_1
+    else:
+      maybe_array_0
+
+  template arrayAssign(x, y: untyped) =
+    assign(type_binder(x, y), x, y)
+
+  result = new U
+  result.genesis_time = x.genesis_time
+  result.genesis_validators_root = x.genesis_validators_root
+  result.slot = x.slot
+  result.fork = x.fork
+  assign(result.latest_block_header, x.latest_block_header)
+  arrayAssign(result.block_roots, x.block_roots)
+  arrayAssign(result.state_roots, x.state_roots)
+  assign(result.historical_roots, x.historical_roots)
+  assign(result.eth1_data, x.eth1_data)
+  assign(result.eth1_data_votes, x.eth1_data_votes)
+  assign(result.eth1_deposit_index, x.eth1_deposit_index)
+  assign(result.balances, x.balances)
+  arrayAssign(result.randao_mixes, x.randao_mixes)
+  arrayAssign(result.slashings, x.slashings)
+  assign(
+    result.previous_epoch_attestations, x.previous_epoch_attestations)
+  assign(
+    result.current_epoch_attestations, x.current_epoch_attestations)
+  result.justification_bits = x.justification_bits
+  assign(result.previous_justified_checkpoint, x.previous_justified_checkpoint)
+  assign(result.current_justified_checkpoint, x.current_justified_checkpoint)
+  assign(result.finalized_checkpoint, x.finalized_checkpoint)

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -124,5 +124,5 @@ func updateBeaconStateNoImmutableValidators*[T, U](tgt: var U, src: T) =
   assign(tgt.finalized_checkpoint, src.finalized_checkpoint)
 
 proc loadImmutableValidators*(dbSeq: var auto): seq[ImmutableValidatorData] =
-  for i in 0'u64 ..< dbSeq.len:
+  for i in 0 ..< dbSeq.len:
     result.add dbSeq.get(i)

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -17,7 +17,8 @@ import
   filepath
 
 type 
-  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beaconstate
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconstate
+  # Memory-representation-equivalent to a v1.0.1 BeaconState for in-place SSZ reading and writing
   BeaconStateNoImmutableValidators* = object
     # Versioning
     genesis_time*: uint64
@@ -71,6 +72,10 @@ type
     finalized_checkpoint*: Checkpoint
 
 static:
+  # Each of these pairs of types has ABI-compatible memory representations, so
+  # that the SSZ serialization can read and write directly from an object with
+  # only mutable portions of BeaconState into a full BeaconState without using
+  # any extra copies.
   doAssert sizeof(Validator) == sizeof(ValidatorStatus)
   doAssert sizeof(BeaconState) == sizeof(BeaconStateNoImmutableValidators)
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -102,6 +102,8 @@ type
     db*: BeaconChainDB ##\
       ## ColdDB - Stores the canonical chain
 
+    iv*: seq[ImmutableValidatorData]
+
     # -----------------------------------
     # ChainDAGRef - DAG of candidate chains
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -102,8 +102,6 @@ type
     db*: BeaconChainDB ##\
       ## ColdDB - Stores the canonical chain
 
-    immutableValidators*: seq[ImmutableValidatorData]
-
     # -----------------------------------
     # ChainDAGRef - DAG of candidate chains
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -102,7 +102,7 @@ type
     db*: BeaconChainDB ##\
       ## ColdDB - Stores the canonical chain
 
-    iv*: seq[ImmutableValidatorData]
+    immutableValidators*: seq[ImmutableValidatorData]
 
     # -----------------------------------
     # ChainDAGRef - DAG of candidate chains

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -550,7 +550,10 @@ proc putState*(dag: ChainDAGRef, state: StateData) =
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
-  dag.db.putState(state.data.root, state.data.data)
+  if state.data.data.slot.epoch mod 64 != 0:
+    dag.db.putState(state.data.root, state.data.data)
+  else:
+    dag.db.putStateFull(state.data.root, state.data.data)
   dag.db.putStateRoot(state.blck.root, state.data.data.slot, state.data.root)
 
 func getRef*(dag: ChainDAGRef, root: Eth2Digest): BlockRef =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -483,7 +483,7 @@ proc getFinalizedEpochRef*(dag: ChainDAGRef): EpochRef =
 
 # TODO looking more like a beacon_chain_db/immutable-data-base-part proc
 # since it needs to be around for init stuff
-proc updateImmutableValidators(
+proc updateImmutableValidators*(
     db: BeaconChainDB, immutableValidators: var seq[ImmutableValidatorData],
     validators: auto) =
   let

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -11,7 +11,6 @@ import
   std/[options, sequtils, tables, sets],
   stew/assign2,
   metrics, snappy, chronicles,
-  ../statediff,
   ../ssz/[ssz_serialization, merkleization], ../beacon_chain_db, ../extras,
   ../spec/[
     crypto, datatypes, digest, helpers, validator, state_transition,
@@ -534,25 +533,6 @@ proc getState(dag: ChainDAGRef, state: var StateData, bs: BlockSlot): bool =
 
   false
 
-func getImmutableValidators*(state: BeaconState):
-    (ValidatorIndex, ref ImmutableValidatorList) =
-  let
-    numValidators = state.validators.lenu64
-    baseIndex = numValidators - (numValidators mod VALIDATOR_CHUNK_SIZE)
-    validatorsInChunk = numValidators - baseIndex
-
-  # TODO this can miss validators if it's not called frequently enough; might
-  # need backup mechanism or tying putState() to churn rate or tracking what,
-  # regardless of when, the last call stored immutable-validator-wise.
-  var immutableValidators = new ImmutableValidatorList
-  doAssert numValidators >= baseIndex
-  immutableValidators[].count = validatorsInChunk
-  for i in 0 ..< validatorsInChunk:
-    immutableValidators[].immutableValidators[i] =
-      getImmutableValidatorData(state.validators[baseIndex + i])
-
-  (baseIndex.ValidatorIndex, immutableValidators)
-
 proc putState*(dag: ChainDAGRef, state: StateData) =
   # Store a state and its root
   logScope:
@@ -570,10 +550,7 @@ proc putState*(dag: ChainDAGRef, state: StateData) =
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
-  let (baseIndex, immutableValidators) = getImmutableValidators(state.data.data)
-  dag.db.putImmutableValidators(baseIndex, immutableValidators[])
-  dag.db.putStateOnlyMutableValidators(
-    state.data.root, getBeaconStateNoImmutableValidators(state.data.data)[])
+  dag.db.putState(state.data.root, state.data.data)
   dag.db.putStateRoot(state.blck.root, state.data.data.slot, state.data.root)
 
 func getRef*(dag: ChainDAGRef, root: Eth2Digest): BlockRef =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -304,10 +304,6 @@ proc loadStateCache*(cache: var StateCache, blck: BlockRef, epoch: Epoch) =
   if epoch > 0:
     load(epoch - 1)
 
-proc loadImmutableValidators(db: BeaconChainDB): seq[ImmutableValidatorData] =
-  for i in 0'u64 ..< db.immutableValidators.len:
-    result.add db.immutableValidators.get(i)
-
 func init(T: type BlockRef, root: Eth2Digest, slot: Slot): BlockRef =
   BlockRef(
     root: root,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -550,10 +550,12 @@ proc putState*(dag: ChainDAGRef, state: var StateData) =
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
-  if state.data.data.slot.epoch mod 64 != 0:
-    dag.db.putState(state.data.root, state.data.data)
-  else:
+  dag.db.putState(state.data.root, state.data.data)
+
+  # Allow backwards-compatible version rollback with bounded recovery cost
+  if state.data.data.slot.epoch mod 64 == 0:
     dag.db.putStateFull(state.data.root, state.data.data)
+
   dag.db.putStateRoot(state.blck.root, state.data.data.slot, state.data.root)
 
 func getRef*(dag: ChainDAGRef, root: Eth2Digest): BlockRef =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -533,7 +533,7 @@ proc getState(dag: ChainDAGRef, state: var StateData, bs: BlockSlot): bool =
 
   false
 
-proc putState*(dag: ChainDAGRef, state: StateData) =
+proc putState*(dag: ChainDAGRef, state: var StateData) =
   # Store a state and its root
   logScope:
     blck = shortLog(state.blck)
@@ -1044,7 +1044,7 @@ proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): bool =
 
 proc preInit*(
     T: type ChainDAGRef, db: BeaconChainDB,
-    genesisState, tailState: BeaconState, tailBlock: SignedBeaconBlock) =
+    genesisState, tailState: var BeaconState, tailBlock: SignedBeaconBlock) =
   # write a genesis state, the way the ChainDAGRef expects it to be stored in
   # database
   # TODO probably should just init a block pool with the freshly written

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -582,6 +582,11 @@ type
   ValidatorStatus* = object
     # This is a validator without the expensive, immutable, append-only parts
 
+    pubkey* {.dontserialize.}: ValidatorPubKey
+
+    withdrawal_credentials* {.dontserialize.}: Eth2Digest ##\
+    ## Commitment to pubkey for withdrawals and transfers
+
     effective_balance*: uint64 ##\
     ## Balance at stake
 
@@ -650,20 +655,6 @@ func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData =
   ImmutableValidatorData(
     pubkey: validator.pubkey,
     withdrawal_credentials: validator.withdrawal_credentials)
-
-func getMutableValidatorStatuses*(state: BeaconState):
-    List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT] =
-  result.setLen(state.validators.len)
-  for i in 0 ..< state.validators.len:
-    let validator = unsafeAddr state.validators.data[i]
-    assign(result[i].effective_balance, validator.effective_balance)
-    assign(result[i].slashed, validator.slashed)
-    assign(
-      result[i].activation_eligibility_epoch,
-      validator.activation_eligibility_epoch)
-    assign(result[i].activation_epoch, validator.activation_epoch)
-    assign(result[i].exit_epoch, validator.exit_epoch)
-    assign(result[i].withdrawable_epoch, validator.withdrawable_epoch)
 
 func getDepositMessage*(depositData: DepositData): DepositMessage =
   result.pubkey = depositData.pubkey

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -651,6 +651,21 @@ func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData =
     pubkey: validator.pubkey,
     withdrawal_credentials: validator.withdrawal_credentials)
 
+func getMutableValidatorStatus(validator: Validator): ValidatorStatus =
+  ValidatorStatus(
+      effective_balance: validator.effective_balance,
+      slashed: validator.slashed,
+      activation_eligibility_epoch: validator.activation_eligibility_epoch,
+      activation_epoch: validator.activation_epoch,
+      exit_epoch: validator.exit_epoch,
+      withdrawable_epoch: validator.withdrawable_epoch)
+
+func getMutableValidatorStatuses*(state: BeaconState):
+    List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT] =
+  # use mapIt + .init(foo)?
+  for validator in state.validators:
+    result.add getMutableValidatorStatus(validator)
+
 func getDepositMessage*(depositData: DepositData): DepositMessage =
   result.pubkey = depositData.pubkey
   result.amount = depositData.amount

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -661,18 +661,17 @@ type
     ## Needed to process attestations, older to newer
 
     state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
-    historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+    historical_roots*: List[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
 
     # Eth1
     eth1_data*: Eth1Data
     eth1_data_votes*:
-      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+      List[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
     eth1_deposit_index*: uint64
 
     # Registry
-    # TODO HashList vs List? zahary likes List
     validators*: List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
@@ -683,9 +682,9 @@ type
 
     # Attestations
     previous_epoch_attestations*:
-      HashList[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
     current_epoch_attestations*:
-      HashList[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
 
     # Finality
     justification_bits*: uint8 ##\

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -581,6 +581,8 @@ type
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#validator
   ValidatorStatus* = object
     # This is a validator without the expensive, immutable, append-only parts
+    # serialized. They're represented in memory to allow in-place SSZ reading
+    # and writing compatibly with the full Validator object.
 
     pubkey* {.dontserialize.}: ValidatorPubKey
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -63,9 +63,6 @@ const
   MAX_GRAFFITI_SIZE = 32
   FAR_FUTURE_SLOT* = (not 0'u64).Slot
 
-  # Ideally align reasonably with fewish SQLite pages
-  VALIDATOR_CHUNK_SIZE* = 2048
-
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#configuration
   MAXIMUM_GOSSIP_CLOCK_DISPARITY* = 500.millis
 
@@ -701,12 +698,6 @@ type
 
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
-
-  ImmutableValidatorList* = object
-    # all but one in db at any time will be full, so optimize for that
-    # in terms of database fragmentation etc
-    count*: uint64
-    immutableValidators*: array[VALIDATOR_CHUNK_SIZE, ImmutableValidatorData]
 
   DoppelgangerProtection* = object
     broadcastStartEpoch*: Epoch

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -651,20 +651,19 @@ func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData =
     pubkey: validator.pubkey,
     withdrawal_credentials: validator.withdrawal_credentials)
 
-func getMutableValidatorStatus(validator: Validator): ValidatorStatus =
-  ValidatorStatus(
-      effective_balance: validator.effective_balance,
-      slashed: validator.slashed,
-      activation_eligibility_epoch: validator.activation_eligibility_epoch,
-      activation_epoch: validator.activation_epoch,
-      exit_epoch: validator.exit_epoch,
-      withdrawable_epoch: validator.withdrawable_epoch)
-
 func getMutableValidatorStatuses*(state: BeaconState):
     List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT] =
-  # use mapIt + .init(foo)?
-  for validator in state.validators:
-    result.add getMutableValidatorStatus(validator)
+  result.setLen(state.validators.len)
+  for i in 0 ..< state.validators.len:
+    let validator = unsafeAddr state.validators.data[i]
+    assign(result[i].effective_balance, validator.effective_balance)
+    assign(result[i].slashed, validator.slashed)
+    assign(
+      result[i].activation_eligibility_epoch,
+      validator.activation_eligibility_epoch)
+    assign(result[i].activation_epoch, validator.activation_epoch)
+    assign(result[i].exit_epoch, validator.exit_epoch)
+    assign(result[i].withdrawable_epoch, validator.withdrawable_epoch)
 
 func getDepositMessage*(depositData: DepositData): DepositMessage =
   result.pubkey = depositData.pubkey

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -643,61 +643,6 @@ type
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
 
-  # TODO BeaconStateNoImmutableValidators and getBeaconStateNoImmutableValidators should
-  # be beacon chain db creatures, and live there
-  # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/specs/phase0/beacon-chain.md#beaconstate
-  BeaconStateNoImmutableValidators* = object
-    # Versioning
-    genesis_time*: uint64
-    genesis_validators_root*: Eth2Digest
-    slot*: Slot
-    fork*: Fork
-
-    # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
-
-    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
-
-    state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
-    historical_roots*: List[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
-
-    # Eth1
-    eth1_data*: Eth1Data
-    eth1_data_votes*:
-      List[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
-    eth1_deposit_index*: uint64
-
-    # Registry
-    validators*: List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
-
-    # Randomness
-    randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
-
-    # Slashings
-    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
-
-    # Attestations
-    previous_epoch_attestations*:
-      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
-    current_epoch_attestations*:
-      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
-
-    # Finality
-    justification_bits*: uint8 ##\
-    ## Bit set for every recent justified epoch
-    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
-    ## with ssz/hashing.
-
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
-
-    current_justified_checkpoint*: Checkpoint
-    finalized_checkpoint*: Checkpoint
-
   DoppelgangerProtection* = object
     broadcastStartEpoch*: Epoch
 

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -78,6 +78,20 @@ func replaceOrAddDecodeEth1Votes[T, U](
   for item in votes1:
     votes0.add item
 
+func getMutableValidatorStatuses(state: BeaconState):
+    List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT] =
+  result.setLen(state.validators.len)
+  for i in 0 ..< state.validators.len:
+    let validator = unsafeAddr state.validators.data[i]
+    assign(result[i].effective_balance, validator.effective_balance)
+    assign(result[i].slashed, validator.slashed)
+    assign(
+      result[i].activation_eligibility_epoch,
+      validator.activation_eligibility_epoch)
+    assign(result[i].activation_epoch, validator.activation_epoch)
+    assign(result[i].exit_epoch, validator.exit_epoch)
+    assign(result[i].withdrawable_epoch, validator.withdrawable_epoch)
+
 func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
   doAssert state1.slot > state0.slot
   doAssert state0.slot.isEpoch

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -193,22 +193,3 @@ func applyDiff*(
 
   # Don't update slot until the end, because various other updates depend on it
   state.slot = stateDiff.slot
-
-func getImmutableValidators*(state: BeaconState):
-    (uint64, ref ImmutableValidatorList) =
-  let
-    numValidators = state.validators.lenu64
-    baseIndex = numValidators - (numValidators mod VALIDATOR_CHUNK_SIZE)
-    validatorsInChunk = numValidators - baseIndex
-
-  # TODO this can miss validators if it's not called frequently enough; might
-  # need backup mechanism or tying putState() to churn rate or tracking what,
-  # regardless of when, the last call stored immutable-validator-wise.
-  var immutableValidators = new ImmutableValidatorList
-  doAssert numValidators >= baseIndex
-  immutableValidators[].count = validatorsInChunk
-  for i in 0 ..< validatorsInChunk:
-    immutableValidators[].immutableValidators[i] =
-      getImmutableValidatorData(state.validators[baseIndex + i])
-
-  (baseIndex, immutableValidators)

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -193,3 +193,22 @@ func applyDiff*(
 
   # Don't update slot until the end, because various other updates depend on it
   state.slot = stateDiff.slot
+
+func getImmutableValidators*(state: BeaconState):
+    (uint64, ref ImmutableValidatorList) =
+  let
+    numValidators = state.validators.lenu64
+    baseIndex = numValidators - (numValidators mod VALIDATOR_CHUNK_SIZE)
+    validatorsInChunk = numValidators - baseIndex
+
+  # TODO this can miss validators if it's not called frequently enough; might
+  # need backup mechanism or tying putState() to churn rate or tracking what,
+  # regardless of when, the last call stored immutable-validator-wise.
+  var immutableValidators = new ImmutableValidatorList
+  doAssert numValidators >= baseIndex
+  immutableValidators[].count = validatorsInChunk
+  for i in 0 ..< validatorsInChunk:
+    immutableValidators[].immutableValidators[i] =
+      getImmutableValidatorData(state.validators[baseIndex + i])
+
+  (baseIndex, immutableValidators)

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -78,21 +78,6 @@ func replaceOrAddDecodeEth1Votes[T, U](
   for item in votes1:
     votes0.add item
 
-func getMutableValidatorStatus(validator: Validator): ValidatorStatus =
-  ValidatorStatus(
-      effective_balance: validator.effective_balance,
-      slashed: validator.slashed,
-      activation_eligibility_epoch: validator.activation_eligibility_epoch,
-      activation_epoch: validator.activation_epoch,
-      exit_epoch: validator.exit_epoch,
-      withdrawable_epoch: validator.withdrawable_epoch)
-
-func getMutableValidatorStatuses(state: BeaconState):
-    List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT] =
-  # use mapIt + .init(foo)?
-  for validator in state.validators:
-    result.add getMutableValidatorStatus(validator)
-
 func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
   doAssert state1.slot > state0.slot
   doAssert state0.slot.isEpoch

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -133,8 +133,8 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimePreset) =
 
   var foo: seq[ImmutableValidatorData]
   withTimer(timers[tLoadState]):
-    #discard db.getState(state[].root, state[].data, noRollback, ChainDAGRef.iv)
     discard db.getState(state[].root, state[].data, noRollback, foo)
+    #discard db.getState(state[].root, state[].data, noRollback, pool.iv)
 
   var
     cache = StateCache()
@@ -180,6 +180,8 @@ proc cmdDumpState(conf: DbConf, preset: RuntimePreset) =
   defer: db.close()
 
   var foo: seq[ImmutableValidatorData]
+  # TODO move the load-immutable-validators thing out of chain dag maybe, since
+  # want it here too. then use that instead of `foo`
   for stateRoot in conf.stateRoot:
     try:
       let root = Eth2Digest(data: hexToByteArray[32](stateRoot))
@@ -228,6 +230,8 @@ proc copyPrunedDatabase(
 
   # Tail states are specially addressed; no stateroot intermediary
   var foo: seq[ImmutableValidatorData]
+  # TODO move the load-immutable-validators thing out of chain dag maybe, since
+  # want it here too. then use that instead of `foo`
   if not db.getState(
       db.getBlock(tailBlock.get).get.message.state_root, beaconState[],
       noRollback, foo):

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -179,19 +179,6 @@ suiteReport "Beacon chain DB" & preset():
     check:
       hash_tree_root(state2[]) == root
 
-  wrappedTimedTest "sanity check immutable validator roundtrip" & preset():
-    var db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
-    const
-      immutableValidators = ImmutableValidatorList()
-      baseIndex = 0'u64
-
-    db.putImmutableValidators(baseIndex, immutableValidators)
-    let immutableValidators2 = db.getImmutableValidators(baseIndex)
-    db.close()
-
-    check:
-      immutableValidators == immutableValidators2[]
-
   wrappedTimedTest "sanity check states 2" & preset():
     var
       db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -8,7 +8,7 @@
 {.used.}
 
 import  options, unittest, sequtils,
-  ../beacon_chain/[beacon_chain_db, extras, interop, ssz, statediff],
+  ../beacon_chain/[beacon_chain_db, extras, interop, ssz],
   ../beacon_chain/spec/[
     beaconstate, datatypes, digest, crypto, state_transition, presets],
   eth/db/kvstore,

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -176,22 +176,3 @@ suiteReport "Beacon chain DB" & preset():
 
     check:
       hash_tree_root(state2[]) == root
-
-  wrappedTimedTest "sanity check states 2" & preset():
-    var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
-
-    let
-      state = BeaconStateRef()
-      root = hash_tree_root(state[])
-
-    # TODO make sure there's a validator
-    db.putState(state[])
-
-    check:
-      db.containsState(root)
-      hash_tree_root(db.getStateRef(root)[]) == root
-
-    # TODO check state delete
-
-    db.close()

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -7,7 +7,7 @@
 
 {.used.}
 
-import  options, unittest, sequtils,
+import  algorithm, options, sequtils, unittest,
   ../beacon_chain/[beacon_chain_db, extras, interop, ssz],
   ../beacon_chain/spec/[
     beaconstate, datatypes, digest, crypto, state_transition, presets],
@@ -76,8 +76,12 @@ suiteReport "Beacon chain DB" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
+      testStates = getTestStates(dag.headState.data)
 
-    for state in getTestStates(dag.headState.data):
+    # Ensure transitions beyond just adding validators and increasing slots
+    sort(testStates)
+
+    for state in testStates:
       db.putState(state[].data)
       let root = hash_tree_root(state[].data)
 
@@ -96,8 +100,12 @@ suiteReport "Beacon chain DB" & preset():
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
 
     let stateBuffer = BeaconStateRef()
+    var testStates = getTestStates(dag.headState.data)
 
-    for state in getTestStates(dag.headState.data):
+    # Ensure transitions beyond just adding validators and increasing slots
+    sort(testStates)
+
+    for state in testStates:
       db.putState(state[].data)
       let root = hash_tree_root(state[].data)
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -189,9 +189,6 @@ suiteReport "Beacon chain DB" & preset():
       immutableValidators: seq[ImmutableValidatorData] = @[]
 
     # TODO make sure there's a validator
-
-    # TODO it's fine, but maybe for testing purposes should be able to force a
-    # non-split-validators store. the interface isn't yet different
     db.putState(state[])
 
     check:

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -150,11 +150,8 @@ suiteReport "Beacon chain DB" & preset():
     db.putState(state[])
 
     check db.containsState(root)
-    # This just tests round-tripping for the mutable part; TODO separately test
-    # immutable validator round-tripping
-    let
-      (_, immutableValidators) = getImmutableValidators(state[])
-      state2 = db.getStateRef(root, immutableValidators[].immutableValidators)
+    let state2 = db.getStateRef(
+      root, mapIt(state[].validators, getImmutableValidatorData(it)))
     db.delState(root)
     check not db.containsState(root)
     db.close()
@@ -189,8 +186,6 @@ suiteReport "Beacon chain DB" & preset():
       baseIndex = 0'u64
 
     db.putImmutableValidators(baseIndex, immutableValidators)
-
-    check db.containsImmutableValidators(baseIndex)
     let immutableValidators2 = db.getImmutableValidators(baseIndex)
     db.close()
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -83,6 +83,8 @@ suiteReport "Beacon chain DB" & preset():
       db.containsState(root)
       hash_tree_root(db.getStateRef(root)[]) == root
 
+    # TODO check state delete
+
     db.close()
 
   wrappedTimedTest "find ancestors" & preset():
@@ -171,3 +173,23 @@ suiteReport "Beacon chain DB" & preset():
 
     check:
       hash_tree_root(state2[]) == root
+
+  wrappedTimedTest "sanity check states 2" & preset():
+    var
+      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+
+    let
+      state = BeaconStateRef()
+      root = hash_tree_root(state[])
+
+    # TODO it's fine, but maybe for testing purposes should be able to force a
+    # non-split-validators store. the interface isn't yet different
+    db.putState(state[])
+
+    check:
+      db.containsState(root)
+      hash_tree_root(db.getStateRef(root)[]) == root
+
+    # TODO check state delete
+
+    db.close()

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -9,74 +9,14 @@
 
 import
   options, sequtils, unittest,
-  ./testutil,
-  ./helpers/math_helpers,
-  ./mocking/mock_deposits,
-  ../beacon_chain/spec/[beaconstate, datatypes, digest, helpers,
-    state_transition, presets],
+  ./testutil, ./teststateutil,
+  ../beacon_chain/spec/[datatypes, digest, helpers, presets],
   ../beacon_chain/[beacon_node_types, statediff],
   ../beacon_chain/ssz,
   ../beacon_chain/consensus_object_pools/[blockchain_dag, block_quarantine, block_clearance]
 
 when isMainModule:
   import chronicles # or some random compile error happens...
-
-proc valid_deposit(state: var BeaconState) =
-  # TODO copy/pasted from foo; refactor
-  const deposit_amount = MAX_EFFECTIVE_BALANCE
-  let validator_index = state.validators.len
-  let deposit = mockUpdateStateForNewDeposit(
-                  state,
-                  uint64 validator_index,
-                  deposit_amount,
-                  flags = {}
-                )
-
-  let pre_val_count = state.validators.len
-  let pre_balance = if validator_index < pre_val_count:
-                      state.balances[validator_index]
-                    else:
-                      0
-  check:
-    process_deposit(defaultRuntimePreset(), state, deposit, {}).isOk
-    state.validators.len == pre_val_count + 1
-    state.balances.len == pre_val_count + 1
-    state.balances[validator_index] == pre_balance + deposit.data.amount
-    state.validators[validator_index].effective_balance ==
-      round_multiple_down(
-        min(MAX_EFFECTIVE_BALANCE, state.balances[validator_index]),
-        EFFECTIVE_BALANCE_INCREMENT
-      )
-
-proc getTestStates(initialState: HashedBeaconState):
-    seq[ref HashedBeaconState] =
-  # Randomly generated slot numbers, with a jump to around
-  # SLOTS_PER_HISTORICAL_ROOT to force wraparound of those
-  # slot-based mod/increment fields.
-  const stateEpochs = [
-    0, 1,
-
-    # Around minimal wraparound SLOTS_PER_HISTORICAL_ROOT wraparound
-    5, 6, 7, 8, 9,
-
-    39, 40, 97, 98, 99, 113, 114, 115, 116, 130, 131, 145, 146, 192, 193,
-    232, 233, 237, 238,
-
-    # Approaching and passing SLOTS_PER_HISTORICAL_ROOT wraparound
-    254, 255, 256, 257, 258]
-
-  var
-    tmpState = assignClone(initialState)
-    cache = StateCache()
-
-  for i, epoch in stateEpochs:
-    let slot = epoch.Epoch.compute_start_slot_at_epoch
-    if tmpState.data.slot < slot:
-      doAssert process_slots(tmpState[], slot, cache)
-    if i mod 3 == 0:
-      valid_deposit(tmpState.data)
-    doAssert tmpState.data.slot == slot
-    result.add assignClone(tmpState[])
 
 template wrappedTimedTest(name: string, body: untyped) =
   # `check` macro takes a copy of whatever it's checking, on the stack!

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -13,7 +13,7 @@ import
   ../beacon_chain/spec/[datatypes, digest, helpers, presets],
   ../beacon_chain/[beacon_node_types, statediff],
   ../beacon_chain/ssz,
-  ../beacon_chain/consensus_object_pools/[blockchain_dag, block_quarantine, block_clearance]
+  ../beacon_chain/consensus_object_pools/[blockchain_dag, block_quarantine]
 
 when isMainModule:
   import chronicles # or some random compile error happens...

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -69,4 +69,3 @@ proc getTestStates*(initialState: HashedBeaconState):
       valid_deposit(tmpState.data)
     doAssert tmpState.data.slot == slot
     result.add assignClone(tmpState[])
-

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -1,0 +1,72 @@
+# Nimbus
+# Copyright (c) 2021 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  options, stew/endians2,
+  ./mocking/mock_deposits,
+  ./helpers/math_helpers,
+  ../beacon_chain/ssz/merkleization,
+  ../beacon_chain/spec/[beaconstate, crypto, datatypes, presets,
+                        helpers, state_transition]
+
+proc valid_deposit(state: var BeaconState) =
+  const deposit_amount = MAX_EFFECTIVE_BALANCE
+  let validator_index = state.validators.len
+  let deposit = mockUpdateStateForNewDeposit(
+                  state,
+                  uint64 validator_index,
+                  deposit_amount,
+                  flags = {}
+                )
+
+  let pre_val_count = state.validators.len
+  let pre_balance = if validator_index < pre_val_count:
+                      state.balances[validator_index]
+                    else:
+                      0
+  doAssert process_deposit(defaultRuntimePreset(), state, deposit, {}).isOk
+  doAssert state.validators.len == pre_val_count + 1
+  doAssert state.balances.len == pre_val_count + 1
+  doAssert state.balances[validator_index] == pre_balance + deposit.data.amount
+  doAssert state.validators[validator_index].effective_balance ==
+    round_multiple_down(
+      min(MAX_EFFECTIVE_BALANCE, state.balances[validator_index]),
+      EFFECTIVE_BALANCE_INCREMENT
+    )
+
+proc getTestStates*(initialState: HashedBeaconState):
+    seq[ref HashedBeaconState] =
+  # Randomly generated slot numbers, with a jump to around
+  # SLOTS_PER_HISTORICAL_ROOT to force wraparound of those
+  # slot-based mod/increment fields.
+  const stateEpochs = [
+    0, 1,
+
+    # Around minimal wraparound SLOTS_PER_HISTORICAL_ROOT wraparound
+    5, 6, 7, 8, 9,
+
+    39, 40, 97, 98, 99, 113, 114, 115, 116, 130, 131, 145, 146, 192, 193,
+    232, 233, 237, 238,
+
+    # Approaching and passing SLOTS_PER_HISTORICAL_ROOT wraparound
+    254, 255, 256, 257, 258]
+
+  var
+    tmpState = assignClone(initialState)
+    cache = StateCache()
+
+  for i, epoch in stateEpochs:
+    let slot = epoch.Epoch.compute_start_slot_at_epoch
+    if tmpState.data.slot < slot:
+      doAssert process_slots(tmpState[], slot, cache)
+    if i mod 3 == 0:
+      valid_deposit(tmpState.data)
+    doAssert tmpState.data.slot == slot
+    result.add assignClone(tmpState[])
+

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -91,7 +91,7 @@ template timedTest*(name, body) =
   # TODO noto thread-safe as-is
   testTimes.add (f, name)
 
-proc makeTestDB*(tailState: BeaconState, tailBlock: SignedBeaconBlock): BeaconChainDB =
+proc makeTestDB*(tailState: var BeaconState, tailBlock: SignedBeaconBlock): BeaconChainDB =
   result = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
   ChainDAGRef.preInit(result, tailState, tailState, tailBlock)
 


### PR DESCRIPTION
Shows the approximate gains one can get though, and the general approach.

This is part of state diffs as a whole, but a prerequisite and is separately useful.

Overall `ncli_db bench --slots=150000` times with mainnet blocks, v1.0.7 (first row) vs this PR (second row):
```
8	1111	1144.7	1185.16
12	868.3	892.1	916.8
```
where columns are (n, 25th percentile, mean, 75th percentile) in seconds. It's about 20% faster overall.

For "Database block store" specifically, which here includes state storage in milliseconds, it's about 60% faster:
```
8	3.31	3.33	3.34
12	1.37	1.40	1.41
```

Typical `ncli_db` summaries look like, for v1.0.7:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    7474.769,        0.000,     7474.769,     7474.769,            1, Initialize DB
       0.459,        1.466,        0.058,      474.874,       147164, Load block from database
     512.211,        0.000,      512.211,      512.211,            1, Load state from database
       0.118,        0.224,        0.011,       75.854,       145313, Advance slot, non-epoch
      15.556,        4.353,        2.299,       47.374,         4687, Advance slot, epoch
       1.873,        7.082,        0.016,      424.647,       147164, Apply block, no slot processing
       3.334,       20.061,        0.001,     1404.539,       147164, Database block store
```
and for this branch:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    6318.330,        0.000,     6318.330,     6318.330,            1, Initialize DB
       0.526,        1.967,        0.063,      679.893,       147164, Load block from database
     549.847,        0.000,      549.847,      549.847,            1, Load state from database
       0.119,        0.246,        0.011,       87.330,       145313, Advance slot, non-epoch
      15.897,        4.659,        2.850,       51.757,         4687, Advance slot, epoch
       1.875,        7.155,        0.014,      306.680,       147164, Apply block, no slot processing
       1.354,        8.387,        0.001,     1000.602,       147164, Database block store
```

For database size, v1.0.7 (with noted ncli_db patch) creates a 17GiB `benchmark/nbc.sqlite3` file snapshotting every epoch, while this branch creates a 3.9GiB `benchmark/nbc.sqlite3` file under the same conditions, for a 75% reduction in size, and, presumably, disk I/O. The gap increases with slot number.

For v1.0.7 benchmarking, I first applied:
```nim
diff --git a/ncli/ncli_db.nim b/ncli/ncli_db.nim
index 04b9d58d..3aa77a41 100644
--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -93,7 +93,9 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimePreset) =
   let
     db = BeaconChainDB.init(runtimePreset, conf.databaseDir.string)
     dbBenchmark = BeaconChainDB.init(runtimePreset, "benchmark")
-  defer: db.close()
+  defer:
+    db.close()
+    dbBenchmark.close()
 
   if not ChainDAGRef.isInitialized(db):
     echo "Database not initialized"
@@ -151,6 +153,10 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimePreset) =
     if conf.storeBlocks:
       withTimer(timers[tDbStore]):
         dbBenchmark.putBlock(b)
+    withTimer(timers[tDbStore]):
+      if state[].data.slot mod SLOTS_PER_EPOCH == 0:
+        dbBenchmark.putState(state[].root, state[].data)
+      dbBenchmark.checkpoint()
 
   printTimers(false, timers)

```
To simulate the basic operation of state storage by chain_dag. It doesn't account for some of the finalization pruning, but that only shifts the total amounts, not the ratios/proportions here. Similarly, without checkpointing, it just builds up the WAL file, so it checkpoints exactly as often as nbc.