### PR TITLE
database state storage benchmarking via ncli_db

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -2,11 +2,11 @@
 
 import
   typetraits, tables,
-  stew/[results, objects, endians2, io2],
+  stew/[endians2, io2, objects, results],
   serialization, chronicles, snappy,
   eth/db/[kvstore, kvstore_sqlite3],
   ./network_metadata,
-  ./spec/[datatypes, digest, crypto, state_transition],
+  ./spec/[crypto, datatypes, digest, state_transition],
   ./ssz/[ssz_serialization, merkleization],
   merkle_minimal, filepath
 

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -235,10 +235,8 @@ proc init*(T: type BeaconChainDB,
     if sqliteStore.exec("DROP TABLE IF EXISTS deposits;").isErr:
       debug "Failed to drop the deposits table"
 
-    var
-      validatorKeyToIndex = initTable[ValidatorPubKey, ValidatorIndex]()
-      genesisDepositsSeq = DbSeq[DepositData].init(sqliteStore, "genesis_deposits")
-
+    var genesisDepositsSeq =
+      DbSeq[DepositData].init(sqliteStore, "genesis_deposits")
 
     T(backend: kvStore sqliteStore,
       preset: preset,

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -210,13 +210,13 @@ const
   clientId* = "Nimbus beacon node " & fullVersionStr
   nodeMetadataFilename = "node-metadata.json"
 
-  NewPeerScore = 200
+  NewPeerScore* = 200
     ## Score which will be assigned to new connected Peer
   PeerScoreLowLimit* = 0
     ## Score after which peer will be kicked
   PeerScoreHighLimit* = 1000
     ## Max value of peer's score
-  PeerScoreInvalidRequest = -500
+  PeerScoreInvalidRequest* = -500
     ## This peer is sending malformed or nonsensical data
 
   ConcurrentConnections = 10

--- a/beacon_chain/eth2_network.nim
+++ b/beacon_chain/eth2_network.nim
@@ -210,44 +210,36 @@ const
   clientId* = "Nimbus beacon node " & fullVersionStr
   nodeMetadataFilename = "node-metadata.json"
 
-  TCP = net.Protocol.IPPROTO_TCP
-  HandshakeTimeout = FaultOrError
-
-  NewPeerScore* = 200
+  NewPeerScore = 200
     ## Score which will be assigned to new connected Peer
   PeerScoreLowLimit* = 0
     ## Score after which peer will be kicked
   PeerScoreHighLimit* = 1000
     ## Max value of peer's score
-  PeerScoreInvalidRequest* = -500
+  PeerScoreInvalidRequest = -500
     ## This peer is sending malformed or nonsensical data
-  PeerScoreFlooder* = -250
-    ## This peer is sending too many expensive requests
 
-  ConcurrentConnections* = 10
+  ConcurrentConnections = 10
     ## Maximum number of active concurrent connection requests.
 
-  SeenTableTimeTimeout* =
+  SeenTableTimeTimeout =
     when not defined(local_testnet): 5.minutes else: 10.seconds
 
     ## Seen period of time for timeout connections
-  SeenTableTimeDeadPeer* =
+  SeenTableTimeDeadPeer =
     when not defined(local_testnet): 5.minutes else: 10.seconds
 
     ## Period of time for dead peers.
-  SeenTableTimeIrrelevantNetwork* = 24.hours
+  SeenTableTimeIrrelevantNetwork = 24.hours
     ## Period of time for `IrrelevantNetwork` error reason.
-  SeenTableTimeClientShutDown* = 10.minutes
+  SeenTableTimeClientShutDown = 10.minutes
     ## Period of time for `ClientShutDown` error reason.
-  SeenTableTimeFaultOrError* = 10.minutes
+  SeenTableTimeFaultOrError = 10.minutes
     ## Period of time for `FaultOnError` error reason.
-  SeenTablePenaltyError* = 60.minutes
+  SeenTablePenaltyError = 60.minutes
     ## Period of time for peers which score below or equal to zero.
-  SeenTableTimeReconnect* = 1.minutes
+  SeenTableTimeReconnect = 1.minutes
     ## Minimal time between disconnection and reconnection attempt
-
-  ResolvePeerTimeout* = 1.minutes
-    ## Maximum time allowed for peer resolve process.
 
 template neterr(kindParam: Eth2NetworkingErrorKind): auto =
   err(type(result), Eth2NetworkingError(kind: kindParam))

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1368,7 +1368,7 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
     fatal "Failed to connect to the beacon node RPC service", err = err.msg
     quit 1
 
-  let (validator, validatorIdx, status, balance) = try:
+  let (validator, validatorIdx, _, _) = try:
     await rpcClient.get_v1_beacon_states_stateId_validators_validatorId(
       "head", config.exitedValidator)
   except CatchableError as err:
@@ -1431,7 +1431,7 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
     try:
       stdout.write prompt, ": "
       stdin.readLine()
-    except IOError as err:
+    except IOError:
       fatal "Failed to read user input from stdin"
       quit 1
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -30,8 +30,6 @@ import
   eth/db/[kvstore, kvstore_sqlite3]
 
 logScope: topics = "vc"
-
-template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
 
 type
   ValidatorClient = ref object

--- a/beacon_chain/rpc/nimbus_api.nim
+++ b/beacon_chain/rpc/nimbus_api.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -16,7 +16,7 @@ import
   ../eth1_monitor, ../validator_duties,
   ../spec/[digest, datatypes, presets],
 
-  libp2p/protocols/pubsub/[gossipsub, pubsubpeer]
+  libp2p/protocols/pubsub/pubsubpeer
 
 
 logScope: topics = "nimbusapi"

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -656,6 +656,11 @@ type
   DoppelgangerProtection* = object
     broadcastStartEpoch*: Epoch
 
+func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData =
+  ImmutableValidatorData(
+    pubkey: validator.pubkey,
+    withdrawal_credentials: validator.withdrawal_credentials)
+
 func getDepositMessage*(depositData: DepositData): DepositMessage =
   result.pubkey = depositData.pubkey
   result.amount = depositData.amount

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019-2020 Status Research & Development GmbH
+# Copyright (c) 2019-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -42,7 +42,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
        validate = true):
   let
     flags = if validate: {} else: {skipBlsValidation}
-    (state, depositContractState) = loadGenesis(validators, validate)
+    (state, _) = loadGenesis(validators, validate)
     genesisBlock = get_initial_beacon_block(state.data)
 
   echo "Starting simulation..."


### PR DESCRIPTION
This extracts one of the parts of https://github.com/status-im/nimbus-eth2/pull/2297 which already should be in nbc. It enables useful benchmarking of an operation which is soon going to require such benchmarking, using a comparable baseline with the status-quo state storage mechanisms and alternative ones (immutable validator-based states and/or statediffs, for example).

It necessarily approximates the the database operations nbc performs, but it does the basics -- checkpointing every slot and actually closing the benchmark database when it's done.

It also removes unused variables and cleans up the global namespace somewhat, from some eth2_networking constants needlessly exported.