### PR TITLE
show next attestation slot & wait time in "Slot end" log

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -151,4 +151,19 @@ type
     validators*: Table[ValidatorPubKey, AttachedValidator]
     slashingProtection*: SlashingProtectionDB
 
+  AttestationSubnets* = object
+    enabled*: bool
+    stabilitySubnets*: seq[tuple[subnet: uint8, expiration: Epoch]]
+    nextCycleEpoch*: Epoch
+
+    # These encode states in per-subnet state machines
+    subscribedSubnets*: set[uint8]
+    subscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
+    unsubscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
+
+    # Used to track the next attestation slots, using an epoch-relative
+    # coordinate system. Defaults don't need initialization.
+    attestingSlots*: array[2, uint32]
+    lastCalculatedAttestationEpoch*: Epoch
+
 func shortLog*(v: AttachedValidator): string = shortLog(v.pubKey)

--- a/beacon_chain/spec/datatypes.nim
+++ b/beacon_chain/spec/datatypes.nim
@@ -572,16 +572,6 @@ type
       Table[Epoch, seq[ValidatorIndex]]
     beacon_proposer_indices*: Table[Slot, Option[ValidatorIndex]]
 
-  AttestationSubnets* = object
-    enabled*: bool
-    stabilitySubnets*: seq[tuple[subnet: uint8, expiration: Epoch]]
-    nextCycleEpoch*: Epoch
-
-    # These encode states in per-subnet state machines
-    subscribedSubnets*: set[uint8]
-    subscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
-    unsubscribeSlot*: array[ATTESTATION_SUBNET_COUNT, Slot]
-
   # This matches the mutable state of the Solidity deposit contract
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.0/solidity_deposit_contract/deposit_contract.sol
   DepositContractState* = object

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -169,7 +169,7 @@ proc checkBitVector(sszSubType, dir: string, expectedHash: SSZHashTreeRoot) =
 
 proc checkBitList(sszSubType, dir: string, expectedHash: SSZHashTreeRoot) =
   var maxLen: int
-  let wasMatched = scanf(sszSubType, "bitlist_$i", maxLen)
+  discard scanf(sszSubType, "bitlist_$i", maxLen)
   case maxLen
   of 0: checkBasic(BitList[0], dir, expectedHash)
   of 1: checkBasic(BitList[1], dir, expectedHash)


### PR DESCRIPTION
Helps address https://github.com/status-im/nimbus-eth2/issues/2110

Less of an issue right now, but when doppelganger detection gets improved not to have to wait two epochs at gossip-startup, it'll become more immediately relevant again.