### PR TITLE
Slashing protection updates

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -120,6 +120,13 @@ type
       desc: "Subscribe to all attestation subnet topics when gossiping"
       name: "subscribe-all-subnets" }: bool
 
+    # Can we use a set[enum]?
+    testDualSlashingProtectionDBs* {.
+      hidden
+      defaultValue: false
+      desc: "Use the the 2 slashing protection implementation at the same time to ensure no regression."
+      name: "slashing-test-dual-db" }: bool
+
     case cmd* {.
       command
       defaultValue: noCommand }: BNStartUpCmd
@@ -664,4 +671,3 @@ func defaultAdminListenAddress*(conf: BeaconNodeConf|ValidatorClientConf): Valid
 template writeValue*(writer: var JsonWriter,
                      value: TypedInputFile|InputFile|InputDir|OutPath|OutDir|OutFile) =
   writer.writeValue(string value)
-

--- a/beacon_chain/validator_protection/slashing_protection.nim
+++ b/beacon_chain/validator_protection/slashing_protection.nim
@@ -409,10 +409,4 @@ proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
 # Sanity check
 # --------------------------------------------------------------
 
-proc foo(db: SlashingProtectionDB_Concept) =
-  discard
-
-var x: SlashingProtectionDB
-foo(x) {.explain.}
-
 static: doAssert SlashingProtectionDB is SlashingProtectionDB_Concept

--- a/beacon_chain/validator_protection/slashing_protection_v2.nim
+++ b/beacon_chain/validator_protection/slashing_protection_v2.nim
@@ -594,24 +594,29 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Option[Eth2Digest] =
 proc initCompatV1*(T: type SlashingProtectionDB_v2,
            genesis_validators_root: Eth2Digest,
            basePath: string,
-           dbname: string): T =
+           dbname: string): tuple[db: T, requiresMigration: bool] =
   ## Initialize a new slashing protection database
   ## or load an existing one with matching genesis root
   ## `dbname` MUST not be ending with .sqlite3
 
   let alreadyExists = fileExists(basepath/dbname&".sqlite3")
 
-  result = T(backend: SqStoreRef.init(
+  result.db = T(backend: SqStoreRef.init(
       basePath, dbname,
       keyspaces = ["kvstore"] # The key compat part
     ).get())
   if alreadyExists and result.getMetadataTable_DbV2().isSome():
-    result.checkDB(genesis_validators_root)
+    result.db.checkDB(genesis_validators_root)
+    result.requiresMigration = false
+  elif alreadyExists:
+    result.db.setupDB(genesis_validators_root)
+    result.requiresMigration = true
   else:
-    result.setupDB(genesis_validators_root)
+    result.db.setupDB(genesis_validators_root)
+    result.requiresMigration = false
 
   # Cached queries
-  result.setupCachedQueries()
+  result.db.setupCachedQueries()
 
 # Resource Management
 # -------------------------------------------------------------

--- a/beacon_chain/validator_protection/slashing_protection_v2.nim
+++ b/beacon_chain/validator_protection/slashing_protection_v2.nim
@@ -594,7 +594,8 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Option[Eth2Digest] =
 proc initCompatV1*(T: type SlashingProtectionDB_v2,
            genesis_validators_root: Eth2Digest,
            basePath: string,
-           dbname: string): tuple[db: T, requiresMigration: bool] =
+           dbname: string
+     ): tuple[db: SlashingProtectionDB_v2, requiresMigration: bool] =
   ## Initialize a new slashing protection database
   ## or load an existing one with matching genesis root
   ## `dbname` MUST not be ending with .sqlite3
@@ -605,7 +606,7 @@ proc initCompatV1*(T: type SlashingProtectionDB_v2,
       basePath, dbname,
       keyspaces = ["kvstore"] # The key compat part
     ).get())
-  if alreadyExists and result.getMetadataTable_DbV2().isSome():
+  if alreadyExists and result.db.getMetadataTable_DbV2().isSome():
     result.db.checkDB(genesis_validators_root)
     result.requiresMigration = false
   elif alreadyExists:


### PR DESCRIPTION
Small updates to slashing protection.

- [x] Fix the Slashing Protection trying to migrate already migrated DBs:
  - `requiresMigrationFromDB_v1 ended with a return false instead of `return true` 
  - That test should be done before the DBv2 is setup on fresh start.
- [x] expose dual DB mode as a (hidden?) CLI  option for some of our less IO-bound fleet node.

The flag for dual DB mode is `--slashing-test-dual-db`

As mentioned by @kdeme if 1.0.8 needs to be rollbacked we need to document a way to safely rollback if some attestations were sent and stored in the new DB and not the old ones. Options include:

- Ship the updated slashing protection alone, so that we have a safe rollback point if any other changes has issues.
And ship another release a couple days after.
- Communicate don't turn off doppelganger detection after rollback.
- export from DBv2 and reimport into DBv1 via a CLI tool. (The DBv2 doesn't have pruning yet due to rollback concerns which means with reimport no history would be lost).