### PR TITLE
remove too-aggressive assertion

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -863,7 +863,6 @@ func getNextAttestation(node: BeaconNode, slot: Slot): Slot =
     let bitmapEpoch = slot.epoch + i
 
     if bitmapEpoch > node.attestationSubnets.lastCalculatedAttestationEpoch:
-      doAssert i == 0 or orderedAttestingSlots[0] == 0
       return FAR_FUTURE_SLOT
 
     for slotOffset in 0 ..< SLOTS_PER_EPOCH:


### PR DESCRIPTION
This can incorrectly fire if:

- there aren't any validators (then both bitmaps are just always empty); or
- one has just attested the last attestation assigned in the current epoch, in which the next attestation found has i = 1 (it's the next epoch) and the current-epoch bitmap isn't empty (`orderedAttestingSlots[0] == 0` doesn't hold either).