### PR TITLE
Nim-1.2.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,9 @@ ifneq ($(USE_LIBBACKTRACE), 0)
 build/generate_makefile: | libbacktrace
 endif
 build/generate_makefile: tools/generate_makefile.nim | deps-common
-	$(ENV_SCRIPT) nim c -o:$@ $(NIM_PARAMS) tools/generate_makefile.nim
+	echo -e $(BUILD_MSG) "$@" && \
+	$(ENV_SCRIPT) nim c -o:$@ $(NIM_PARAMS) tools/generate_makefile.nim && \
+	echo -e $(BUILD_END_MSG) "$@"
 
 # GCC's LTO parallelisation is able to detect a GNU Make jobserver and get its
 # maximum number of processes from there, but only if we use the "+" prefix.

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -78,7 +78,12 @@ func toSlot*(c: BeaconClock, t: Time): tuple[afterGenesis: bool, slot: Slot] =
   c.toBeaconTime(t).toSlot()
 
 func toBeaconTime*(s: Slot, offset = Duration()): BeaconTime =
-  BeaconTime(seconds(int64(uint64(s) * SECONDS_PER_SLOT)) + offset)
+  # BeaconTime/Duration stores nanoseconds, internally
+  const maxSlot = (not 0'u64 div 2 div SECONDS_PER_SLOT div 1_000_000_000).Slot
+  var slot = s
+  if slot > maxSlot:
+    slot = maxSlot
+  BeaconTime(seconds(int64(uint64(slot) * SECONDS_PER_SLOT)) + offset)
 
 proc now*(c: BeaconClock): BeaconTime =
   ## Current time, in slots - this may end up being less than GENESIS_SLOT(!)


### PR DESCRIPTION
FAR_FUTURE_SLOT was modified to avoid an integer overflow in `Slot.toBeaconTime()`