### PR TITLE
fix replays stalling processing

### DIFF
--- a/beacon_chain/attestation_aggregation.nim
+++ b/beacon_chain/attestation_aggregation.nim
@@ -213,6 +213,7 @@ proc validateAttestation*(
   # processing once block is retrieved).
   # The block being voted for (attestation.data.beacon_block_root) passes
   # validation.
+  # [IGNORE] if block is unseen so far and enqueue it in missing blocks
   let target = ? check_beacon_and_target_block(pool, attestation.data) # [IGNORE/REJECT]
 
   # The following rule follows implicitly from that we clear out any
@@ -359,6 +360,7 @@ proc validateAggregate*(
 
   # [REJECT] The block being voted for (aggregate.data.beacon_block_root)
   # passes validation.
+  # [IGNORE] if block is unseen so far and enqueue it in missing blocks
   let target = ? check_beacon_and_target_block(pool, aggregate.data)
 
   # [REJECT] aggregate_and_proof.selection_proof selects the validator as an

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -216,7 +216,9 @@ template head*(v: ChainDagRef): BlockRef = v.headState.blck
 
 func shortLog*(v: BlockSlot): string =
   try:
-    if v.blck.slot == v.slot:
+    if v.blck == nil:
+      &"nil:0@{v.slot}"
+    elif v.blck.slot == v.slot:
       &"{v.blck.root.data.toOpenArray(0, 3).toHex()}:{v.blck.slot}"
     else: # There was a gap - log it
       &"{v.blck.root.data.toOpenArray(0, 3).toHex()}:{v.blck.slot}@{v.slot}"

--- a/beacon_chain/block_pools/block_pools_types.nim
+++ b/beacon_chain/block_pools/block_pools_types.nim
@@ -216,7 +216,7 @@ template head*(v: ChainDagRef): BlockRef = v.headState.blck
 
 func shortLog*(v: BlockSlot): string =
   try:
-    if v.blck == nil:
+    if v.blck.isNil():
       &"nil:0@{v.slot}"
     elif v.blck.slot == v.slot:
       &"{v.blck.root.data.toOpenArray(0, 3).toHex()}:{v.blck.slot}"
@@ -227,7 +227,7 @@ func shortLog*(v: BlockSlot): string =
 
 func shortLog*(v: BlockRef): string =
   try:
-    if v == nil:
+    if v.isNil():
       "BlockRef(nil)"
     else:
       &"{v.root.data.toOpenArray(0, 3).toHex()}:{v.slot}"
@@ -236,7 +236,7 @@ func shortLog*(v: BlockRef): string =
 
 func shortLog*(v: EpochRef): string =
   try:
-    if v == nil:
+    if v.isNil():
       "EpochRef(nil)"
     else:
       &"(epoch ref: {v.epoch})"

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -83,7 +83,7 @@ func parent*(bs: BlockSlot): BlockSlot =
 func parentOrSlot*(bs: BlockSlot): BlockSlot =
   ## Return a blockslot representing the previous slot, using the parent block
   ## with the current slot if the current had a block
-  if bs.blck == nil:
+  if bs.blck.isNil():
     BlockSlot(blck: nil, slot: Slot(0))
   elif bs.slot == bs.blck.slot:
     BlockSlot(blck: bs.blck.parent, slot: bs.slot)

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -495,7 +495,7 @@ proc getState(
 
   true
 
-func isStateCheckpoint*(bs: BlockSlot): bool =
+func isStateCheckpoint(bs: BlockSlot): bool =
   ## State checkpoints are the points in time for which we store full state
   ## snapshots, which later serve as rewind starting points when replaying state
   ## transitions from database, for example during reorgs.

--- a/beacon_chain/block_pools/chain_dag.nim
+++ b/beacon_chain/block_pools/chain_dag.nim
@@ -15,7 +15,8 @@ import
   ../spec/[
     crypto, datatypes, digest, helpers, validator, state_transition,
     beaconstate],
-  ./block_pools_types, ./quarantine
+  ../time,
+  "."/[block_pools_types, quarantine]
 
 export block_pools_types, helpers
 
@@ -82,7 +83,7 @@ func parent*(bs: BlockSlot): BlockSlot =
 func parentOrSlot*(bs: BlockSlot): BlockSlot =
   ## Return a blockslot representing the previous slot, using the parent block
   ## with the current slot if the current had a block
-  if bs.slot == Slot(0):
+  if bs.blck == nil:
     BlockSlot(blck: nil, slot: Slot(0))
   elif bs.slot == bs.blck.slot:
     BlockSlot(blck: bs.blck.parent, slot: bs.slot)
@@ -494,16 +495,34 @@ proc getState(
 
   true
 
+func isStateCheckpoint*(bs: BlockSlot): bool =
+  ## State checkpoints are the points in time for which we store full state
+  ## snapshots, which later serve as rewind starting points when replaying state
+  ## transitions from database, for example during reorgs.
+  ##
+  # As a policy, we only store epoch boundary states without the epoch block
+  # (if it exists) applied - the rest can be reconstructed by loading an epoch
+  # boundary state and applying the missing blocks.
+  # We also avoid states that were produced with empty slots only - as such,
+  # there is only a checkpoint for the first epoch after a block.
+
+  # The tail block also counts as a state checkpoint!
+  (bs.slot == bs.blck.slot and bs.blck.parent == nil) or
+  (bs.slot.isEpoch and bs.slot.epoch == (bs.blck.slot.epoch + 1))
+
+func stateCheckpoint*(bs: BlockSlot): BlockSlot =
+  ## The first ancestor BlockSlot that is a state checkpoint
+  var bs = bs
+  while not isStateCheckPoint(bs):
+    bs = bs.parentOrSlot
+  bs
+
 proc getState(dag: ChainDAGRef, state: var StateData, bs: BlockSlot): bool =
   ## Load a state from the database given a block and a slot - this will first
   ## lookup the state root in the state root table then load the corresponding
   ## state, if it exists
-  if not bs.slot.isEpoch:
-    return false # We only ever save epoch states - no need to hit database
-
-  # TODO earlier versions would store the epoch state with a the epoch block
-  #      applied - we generally shouldn't hit the database for such states but
-  #      will do so in a transitionary upgrade period!
+  if not bs.isStateCheckpoint():
+    return false # Only state checkpoints are stored - no need to hit DB
 
   if (let stateRoot = dag.db.getStateRoot(bs.blck.root, bs.slot);
       stateRoot.isSome()):
@@ -518,17 +537,7 @@ proc putState*(dag: ChainDAGRef, state: StateData) =
     stateSlot = shortLog(state.data.data.slot)
     stateRoot = shortLog(state.data.root)
 
-  # As a policy, we only store epoch boundary states without the epoch block
-  # (if it exists) applied - the rest can be reconstructed by loading an epoch
-  # boundary state and applying the missing blocks.
-  # We also avoid states that were produced with empty slots only - we should
-  # not call this function for states that don't have a follow-up block
-  if not state.data.data.slot.isEpoch:
-    trace "Not storing non-epoch state"
-    return
-
-  if state.data.data.slot.epoch != (state.blck.slot.epoch + 1):
-    trace "Not storing state that isn't an immediate epoch successor to its block"
+  if not isStateCheckpoint(state.blck.atSlot(state.data.data.slot)):
     return
 
   if dag.db.containsState(state.data.root):
@@ -681,6 +690,8 @@ proc updateStateData*(
   # an earlier state must be loaded since there's no way to undo the slot
   # transitions
 
+  let startTime = Moment.now()
+
   var
     ancestors: seq[BlockRef]
     cur = bs
@@ -785,15 +796,28 @@ proc updateStateData*(
   # ...and make sure to process empty slots as requested
   dag.advanceSlots(state, bs.slot, save, cache)
 
-  trace "State updated",
-    blocks = ancestors.len,
-    slots = state.data.data.slot - startSlot,
-    stateRoot = shortLog(state.data.root),
-    stateSlot = state.data.data.slot,
-    startRoot = shortLog(startRoot),
-    startSlot,
-    blck = shortLog(bs),
+  let diff = Moment.now() - startTime
+
+  logScope:
+    blocks = ancestors.len
+    slots = state.data.data.slot - startSlot
+    stateRoot = shortLog(state.data.root)
+    stateSlot = state.data.data.slot
+    startRoot = shortLog(startRoot)
+    startSlot
+    blck = shortLog(bs)
     found
+    diff = shortLog(diff)
+
+  if diff >= 1.seconds:
+    # This might indicate there's a cache that's not in order or a disk that is
+    # too slow - for now, it's here for investigative purposes and the cutoff
+    # time might need tuning
+    info "State replayed"
+  elif ancestors.len > 0:
+    debug "State replayed"
+  else:
+    trace "State advanced" # Normal case!
 
 proc delState(dag: ChainDAGRef, bs: BlockSlot) =
   # Delete state state and mapping for a particular block+slot
@@ -890,8 +914,14 @@ proc updateHead*(
 
   if finalizedHead != dag.finalizedHead:
     block: # Remove states, walking slot by slot
-      var cur = finalizedHead
-      while cur != dag.finalizedHead:
+      # We remove all state checkpoints that come _before_ the current finalized
+      # head, as we might frequently be asked to replay states from the
+      # finalized checkpoint and onwards (for example when validating blocks and
+      # attestations)
+      var
+        prev = dag.finalizedHead.stateCheckpoint.parentOrSlot
+        cur = finalizedHead.stateCheckpoint.parentOrSlot
+      while cur.blck != nil and cur != prev:
         # TODO This is a quick fix to prune some states from the database, but
         # not all, pending a smarter storage - the downside of pruning these
         # states is that certain rewinds will take longer

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -412,6 +412,14 @@ suiteReport "chain DAG finalization tests" & preset():
       let status = dag.addRawBlock(quarantine, lateBlock, nil)
       check: status.error == (ValidationResult.Ignore, Unviable)
 
+    block:
+      let
+        finalizedCheckpoint = dag.finalizedHead.stateCheckpoint
+        headCheckpoint = dag.head.atSlot(dag.head.slot).stateCheckpoint
+      check:
+        db.getStateRoot(headCheckpoint.blck.root, headCheckpoint.slot).isSome
+        db.getStateRoot(finalizedCheckpoint.blck.root, finalizedCheckpoint.slot).isSome
+
     let
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)
 

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -14,6 +14,8 @@ import
   eth/db/[kvstore, kvstore_sqlite3],
   testblockutil
 
+export beacon_chain_db
+
 type
   TestDuration = tuple[duration: float, label: string]
 


### PR DESCRIPTION
Occasionally, attestations will arrive that vote for a target derived
either from the finalized block or earlier. In these cases, Nimbus would
replay the state transition of up to 32 epochs worth of blocks because
the finalized state has been pruned, delaying other processing and
leading to poor inclusion distance.

* put cheap attestation checks before forming EpochRef
* check that attestation target is not from an unviable history with
regards to finalization
* fix overly aggressive state pruning removing the state close to the
finalized checkpoint resulting in rare long replays for valid
attestations
* log long replays
* harden logging and traversal of nil BlockSlot