### PR TITLE
Move pruning out of latency critical path

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -125,11 +125,9 @@ type
     # -----------------------------------
     # Pruning metadata
 
-    prevFinalizedHead*: BlockSlot ##\
-    ## The second to last block that was finalized.
-    ## This is used to delay DAG pruning.
-
-    needPruning*: bool
+    lastPrunePoint*: BlockSlot ##\
+    ## The last prune point
+    ## We can prune up to finalizedHead
 
     # -----------------------------------
     # Rewinder - Mutable state processing

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -123,6 +123,15 @@ type
     ## Ancestors of this block are guaranteed to have 1 child only.
 
     # -----------------------------------
+    # Pruning metadata
+
+    prevFinalizedHead*: BlockSlot ##\
+    ## The second to last block that was finalized.
+    ## This is used to delay DAG pruning.
+
+    needPruning*: bool
+
+    # -----------------------------------
     # Rewinder - Mutable state processing
 
     headState*: StateData ##\

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -923,7 +923,6 @@ proc updateHead*(
       newFinalizedHead = shortLog(finalizedHead),
       oldFinalizedHead = shortLog(dag.finalizedHead)
 
-    dag.lastPrunePoint = dag.finalizedHead
     dag.finalizedHead = finalizedHead
 
     beacon_finalized_epoch.set(

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -965,11 +965,11 @@ proc pruneFinalized*(dag: ChainDAGRef) =
     for i in 0..<hlen:
       let n = hlen - i - 1
       let head = dag.heads[n]
-      if dag.prevFinalizedHead.blck.isAncestorOf(head):
+      if dag.finalizedHead.blck.isAncestorOf(head):
         continue
 
       var cur = head.atSlot(head.slot)
-      while not cur.blck.isAncestorOf(dag.prevFinalizedHead.blck):
+      while not cur.blck.isAncestorOf(dag.finalizedHead.blck):
         # TODO there may be more empty states here: those that have a slot
         #      higher than head.slot and those near the branch point - one
         #      needs to be careful though because those close to the branch

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -136,7 +136,7 @@ proc pruneFinalized*(self: var Eth2Processor) =
   # TODO: DAG & fork choice procs are unrelated to gossip validation
 
   # Cleanup DAG & fork choice if we have a finalized head
-  if self.chainDag.needPruning:
+  if self.chainDag.needPruning():
     self.chainDag.pruneFinalized()
     self.attestationPool[].prune()
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -128,9 +128,6 @@ proc updateHead*(self: var Eth2Processor, wallSlot: Slot) =
   # justified and finalized
   self.chainDag.updateHead(newHead, self.quarantine)
 
-  # Prune the DAG eagerly (but defer pruning the fork choice, state cache checkpoints and EpochRef to onSlotEnd)
-  self.chainDag.pruneBlocksDAG()
-
   self.checkExpectedBlock()
 
 proc pruneStateCachesAndForkChoice*(self: var Eth2Processor) =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -894,6 +894,11 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
   # next slot
 
+  # Delay pruning until latency critical duties are done
+  # pruning may have already been done in `runQueueProcessingLoop`
+  # during idle time.
+  node.processor[].pruneFinalized()
+
   when declared(GC_fullCollect):
     # The slots in the beacon node work as frames in a game: we want to make
     # sure that we're ready for the next one and don't get stuck in lengthy

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -894,10 +894,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
   # next slot
 
-  # Delay pruning until latency critical duties are done
-  # pruning may have already been done in `runQueueProcessingLoop`
-  # during idle time.
-  node.processor[].pruneFinalized()
+  # Delay part of pruning until latency critical duties are done.
+  # The other part of pruning, `pruneBlocksDAG`, is done eagerly.
+  node.processor[].pruneStateCachesAndForkChoice()
 
   when declared(GC_fullCollect):
     # The slots in the beacon node work as frames in a game: we want to make

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -173,6 +173,9 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
       blck() = added[]
       chainDag.updateHead(added[], quarantine)
+      if chainDag.needPruning:
+        chainDag.pruneFinalized()
+        attPool.prune()
 
   var
     lastEth1BlockAt = genesisTime

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -173,7 +173,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
       blck() = added[]
       chainDag.updateHead(added[], quarantine)
-      if chainDag.needPruning:
+      if chainDag.needPruning():
         chainDag.pruneFinalized()
         attPool.prune()
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -174,7 +174,6 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       blck() = added[]
       chainDag.updateHead(added[], quarantine)
       if chainDag.needStateCachesAndForkChoicePruning():
-        chainDag.pruneBlocksDAG()
         chainDag.pruneStateCachesDAG()
         attPool.prune()
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -173,8 +173,9 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
       blck() = added[]
       chainDag.updateHead(added[], quarantine)
-      if chainDag.needPruning():
-        chainDag.pruneFinalized()
+      if chainDag.needStateCachesAndForkChoicePruning():
+        chainDag.pruneBlocksDAG()
+        chainDag.pruneStateCachesDAG()
         attPool.prune()
 
   var

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -54,7 +54,6 @@ template wrappedTimedTest(name: string, body: untyped) =
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
-    dag.pruneBlocksDAG()
     dag.pruneStateCachesDAG()
     # pool[].prune() # We test logic without attestation pool / fork choice pruning
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -52,6 +52,12 @@ template wrappedTimedTest(name: string, body: untyped) =
         body
     wrappedTest()
 
+proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
+  if dag.needStateCachesAndForkChoicePruning():
+    dag.pruneBlocksDAG()
+    dag.pruneStateCachesDAG()
+    # pool[].prune() # We test logic without attestation pool / fork choice pruning
+
 suiteReport "Attestation pool processing" & preset():
   ## For now just test that we can compile and execute block processing with
   ## mock data.
@@ -343,9 +349,7 @@ suiteReport "Attestation pool processing" & preset():
         let head = pool[].selectHead(blockRef[].slot)
         doassert: head == blockRef[]
         chainDag.updateHead(head, quarantine)
-        if chainDag.needPruning():
-          chainDag.pruneFinalized()
-          # pool[].prune()
+        pruneAtFinalization(chainDag, pool[])
 
         attestations.setlen(0)
         for index in 0'u64 ..< committees_per_slot:
@@ -416,9 +420,7 @@ suiteReport "Attestation validation " & preset():
 
       check: added.isOk()
       chainDag.updateHead(added[], quarantine)
-      if chainDag.needPruning():
-        chainDag.pruneFinalized()
-        # pool[].prune()
+      pruneAtFinalization(chainDag, pool[])
 
     var
       # Create an attestation for slot 1!

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -343,7 +343,7 @@ suiteReport "Attestation pool processing" & preset():
         let head = pool[].selectHead(blockRef[].slot)
         doassert: head == blockRef[]
         chainDag.updateHead(head, quarantine)
-        if chainDag.needPruning:
+        if chainDag.needPruning():
           chainDag.pruneFinalized()
           # pool[].prune()
 
@@ -416,7 +416,7 @@ suiteReport "Attestation validation " & preset():
 
       check: added.isOk()
       chainDag.updateHead(added[], quarantine)
-      if chainDag.needPruning:
+      if chainDag.needPruning():
         chainDag.pruneFinalized()
         # pool[].prune()
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -343,6 +343,9 @@ suiteReport "Attestation pool processing" & preset():
         let head = pool[].selectHead(blockRef[].slot)
         doassert: head == blockRef[]
         chainDag.updateHead(head, quarantine)
+        if chainDag.needPruning:
+          chainDag.pruneFinalized()
+          # pool[].prune()
 
         attestations.setlen(0)
         for index in 0'u64 ..< committees_per_slot:
@@ -413,6 +416,9 @@ suiteReport "Attestation validation " & preset():
 
       check: added.isOk()
       chainDag.updateHead(added[], quarantine)
+      if chainDag.needPruning:
+        chainDag.pruneFinalized()
+        # pool[].prune()
 
     var
       # Create an attestation for slot 1!

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -182,6 +182,8 @@ suiteReport "Block pool processing" & preset():
       b4Add[].parent == b2Add[]
 
     dag.updateHead(b4Add[], quarantine)
+    if dag.needPruning:
+      dag.pruneFinalized()
 
     var blocks: array[3, BlockRef]
 
@@ -245,6 +247,8 @@ suiteReport "Block pool processing" & preset():
       b2Get.get().refs.parent == b1Get.get().refs
 
     dag.updateHead(b2Get.get().refs, quarantine)
+    if dag.needPruning:
+      dag.pruneFinalized()
 
     # The heads structure should have been updated to contain only the new
     # b2 head
@@ -278,6 +282,8 @@ suiteReport "Block pool processing" & preset():
       b1Add = dag.addRawBlock(quarantine, b1, nil)
 
     dag.updateHead(b1Add[], quarantine)
+    if dag.needPruning:
+      dag.pruneFinalized()
 
     check:
       dag.head == b1Add[]
@@ -372,6 +378,8 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
+      if dag.needPruning:
+        dag.pruneFinalized()
 
     check:
       dag.heads.len() == 1
@@ -444,6 +452,8 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
+      if dag.needPruning:
+        dag.pruneFinalized()
 
     check:
       dag.heads.len() == 1
@@ -483,6 +493,8 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
+      if dag.needPruning:
+        dag.pruneFinalized()
 
     # Advance past epoch so that the epoch transition is gapped
     check:
@@ -498,6 +510,8 @@ suiteReport "chain DAG finalization tests" & preset():
     let added = dag.addRawBlock(quarantine, blck, nil)
     check: added.isOk()
     dag.updateHead(added[], quarantine)
+    if dag.needPruning:
+      dag.pruneFinalized()
 
     let
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -33,6 +33,11 @@ template wrappedTimedTest(name: string, body: untyped) =
         body
     wrappedTest()
 
+proc pruneAtFinalization(dag: ChainDAGRef) =
+  if dag.needStateCachesAndForkChoicePruning():
+    dag.pruneBlocksDAG()
+    dag.pruneStateCachesDAG()
+
 suiteReport "BlockRef and helpers" & preset():
   wrappedTimedTest "isAncestorOf sanity" & preset():
     let
@@ -182,8 +187,7 @@ suiteReport "Block pool processing" & preset():
       b4Add[].parent == b2Add[]
 
     dag.updateHead(b4Add[], quarantine)
-    if dag.needPruning():
-      dag.pruneFinalized()
+    dag.pruneAtFinalization()
 
     var blocks: array[3, BlockRef]
 
@@ -247,8 +251,7 @@ suiteReport "Block pool processing" & preset():
       b2Get.get().refs.parent == b1Get.get().refs
 
     dag.updateHead(b2Get.get().refs, quarantine)
-    if dag.needPruning():
-      dag.pruneFinalized()
+    dag.pruneAtFinalization()
 
     # The heads structure should have been updated to contain only the new
     # b2 head
@@ -282,8 +285,7 @@ suiteReport "Block pool processing" & preset():
       b1Add = dag.addRawBlock(quarantine, b1, nil)
 
     dag.updateHead(b1Add[], quarantine)
-    if dag.needPruning():
-      dag.pruneFinalized()
+    dag.pruneAtFinalization()
 
     check:
       dag.head == b1Add[]
@@ -378,8 +380,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning():
-        dag.pruneFinalized()
+      dag.pruneAtFinalization()
 
     check:
       dag.heads.len() == 1
@@ -452,8 +453,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning():
-        dag.pruneFinalized()
+      dag.pruneAtFinalization()
 
     check:
       dag.heads.len() == 1
@@ -493,8 +493,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning():
-        dag.pruneFinalized()
+      dag.pruneAtFinalization()
 
     # Advance past epoch so that the epoch transition is gapped
     check:
@@ -510,8 +509,7 @@ suiteReport "chain DAG finalization tests" & preset():
     let added = dag.addRawBlock(quarantine, blck, nil)
     check: added.isOk()
     dag.updateHead(added[], quarantine)
-    if dag.needPruning():
-      dag.pruneFinalized()
+    dag.pruneAtFinalization()
 
     let
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -35,7 +35,6 @@ template wrappedTimedTest(name: string, body: untyped) =
 
 proc pruneAtFinalization(dag: ChainDAGRef) =
   if dag.needStateCachesAndForkChoicePruning():
-    dag.pruneBlocksDAG()
     dag.pruneStateCachesDAG()
 
 suiteReport "BlockRef and helpers" & preset():

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -182,7 +182,7 @@ suiteReport "Block pool processing" & preset():
       b4Add[].parent == b2Add[]
 
     dag.updateHead(b4Add[], quarantine)
-    if dag.needPruning:
+    if dag.needPruning():
       dag.pruneFinalized()
 
     var blocks: array[3, BlockRef]
@@ -247,7 +247,7 @@ suiteReport "Block pool processing" & preset():
       b2Get.get().refs.parent == b1Get.get().refs
 
     dag.updateHead(b2Get.get().refs, quarantine)
-    if dag.needPruning:
+    if dag.needPruning():
       dag.pruneFinalized()
 
     # The heads structure should have been updated to contain only the new
@@ -282,7 +282,7 @@ suiteReport "Block pool processing" & preset():
       b1Add = dag.addRawBlock(quarantine, b1, nil)
 
     dag.updateHead(b1Add[], quarantine)
-    if dag.needPruning:
+    if dag.needPruning():
       dag.pruneFinalized()
 
     check:
@@ -378,7 +378,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning:
+      if dag.needPruning():
         dag.pruneFinalized()
 
     check:
@@ -452,7 +452,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning:
+      if dag.needPruning():
         dag.pruneFinalized()
 
     check:
@@ -493,7 +493,7 @@ suiteReport "chain DAG finalization tests" & preset():
       let added = dag.addRawBlock(quarantine, blck, nil)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
-      if dag.needPruning:
+      if dag.needPruning():
         dag.pruneFinalized()
 
     # Advance past epoch so that the epoch transition is gapped
@@ -510,7 +510,7 @@ suiteReport "chain DAG finalization tests" & preset():
     let added = dag.addRawBlock(quarantine, blck, nil)
     check: added.isOk()
     dag.updateHead(added[], quarantine)
-    if dag.needPruning:
+    if dag.needPruning():
       dag.pruneFinalized()
 
     let


### PR DESCRIPTION
This implements the main part of Lazy Pruning #23

## Summary

It moves pruning the DAG and forkchoice from inside `updateHead` to more opportune times:
- `onSlotEnd`: after all slot actions have been scheduled, in particular validator duties
- The `runQueueProcessingLoop` in eth2_processor if there is no blocks, attestations or aggregate ready for processing in the queue.

## Rationale

We had reports that we had some attestation delay after reaching new finalization points, currently in 1.0.8.
After new finalization points we trigger pruning of:
1. our blockchain DAG
2. our fork choice DAG
3. In the future we will likely also have slashing DB pruning

Even though, there is no IO involved, pruning the blockchain DAG involves walking a linked list and might incur GC delays or even ref cycles due to the data structure used.

**Old code**

https://github.com/status-im/nimbus-eth2/blob/de1060e7f397d382f2c953d6ed9304c618e4e343/beacon_chain/nimbus_beacon_node.nim#L979-L983

https://github.com/status-im/nimbus-eth2/blob/de1060e7f397d382f2c953d6ed9304c618e4e343/beacon_chain/consensus_object_pools/blockchain_dag.nim#L915-L920

As even without pruning the state is valid to produce attestations and blocks, we reorder so that `handleValidatorDuties` is done first.

## Flow analysis

`updateHead` is not only called in `onSlotStart` in nimbus_beacon_node.nim so we need to cover the implications in other places as well:

### Validator duties

`updateHead` is called in validator_duties, if the attestation cutoff is in the future. https://github.com/status-im/nimbus-eth2/blob/de1060e7f397d382f2c953d6ed9304c618e4e343/beacon_chain/validators/validator_duties.nim#L708-L710

Since the attestation cutoff cannot cross the slot end and `handleValidatorDuties` is also preceded by an `updateHead()`:
- in the past, if pruning was possible, pruning would have occurred before `handleValidatorDuties` and so within `handleValidatorDuties` no pruning would have occurred (there is no sync that can be interleaved and "fetch ancestors" requests for unknown blocks/forks in quarantine wouldn't trigger finalization when synced)
- in this PR, pruning is never done in `handleValidatorDuties`

So behavior is unchanged.

### Clearing validated blocks

`updateHead` is called in eth2_processor in processBlock https://github.com/status-im/nimbus-eth2/blob/de1060e7f397d382f2c953d6ed9304c618e4e343/beacon_chain/gossip_processing/eth2_processor.nim#L228-L247

This is called to clear the shared block queue from validated blocks coming from:
- gossip (after isValidP2PBlock)
- sync (sync_manager)
- ancestors of unknown blocks in quarantine (request_manager)

Hence:
- in the past, finalization and pruning could happen there
- in this PR, pruning is not done here, this might increase throughput during sync (though storeBlock might be a bigger bottleneck)

### Extra pruning location

The PR adds an extra pruning location when the beacon node is idle in eth2_processor:

https://github.com/status-im/nimbus-eth2/blob/161bef8a7442df67feed97186cc374ba6367d1c3/beacon_chain/gossip_processing/eth2_processor.nim#L559-L575

This way idle time can be used for maintenance. Also during fast sync if we have fast peers, pruning is deferred until either we have some leeway or slot ends.

There is a catch during steady state, due to `handleValidatorDuties` and `runQueueProcessingLoop` being async, the run queue can be scheduled before the validator duties and if no blocks/attestations/exits/slashings was received, the run queue will consider itself idle and prune even though there are validator duties pending.

There are 3 ways to solve that:
1. Activate that extra pruning location only during sync and not when validation starts
2. Remove that extra pruning location and only rely on the slot end. The impact of a leaner or fatter DAG on sync speed is unknown (storeBlock is likely the dominating factor).
3. Make `handleValidatorDuties` synchronous so that it starts ASAP ignoring floating timers, new inputs, ...

## Bound analysis

### During sync

#### Space-bounds

If we have slow peers, the DAG is pruned as soon as no blocks are enqueued.

if we have fast peers, the DAG size is bounded by how much blocks we can download between `onSlotStart` and `onSlotEnd`.

https://github.com/status-im/nimbus-eth2/blob/de1060e7f397d382f2c953d6ed9304c618e4e343/beacon_chain/nimbus_beacon_node.nim#L953-L983

#### Time-bounds

On a slow computer, there is 1 epoch to prune in normal time (and a long chain if a period of non-finality occurred)

During sync, the only processing is synced blocks (no gossip), with a conservative speed of 10 blocks/s we can process 60 blocks per slot which is roughly 2 epochs. Hence we might want to prune every 2~4 finalized epochs or when there is idle time instead of forcing pruning at slot end.

Note: `onSlotEnd` is not scheduled depending on the real slot end but when all work required within the slot is done. Hence it's very possible to have onSlotStart->onSlotEnd only giving 0.5s to accumulate new blocks from sync before pruning.

One way to achieve that would be to replace the `needPruning: bool` by a counter `delayedPruning: int` that is increased at each finalization epoch where pruning wasn't done and only do pruning when 2~4 epochs have been accumulated.

### During steady-state

#### Space-bounds

Once synced, there is 1 epoch to prune at most.

#### Time-bounds

Once synced, there is 1 epoch to prune at most.

As mentioned previously, the extra pruning in `runQueueProcessingLoop` might happen before `handleValidatorDuties` and needs to be solved.

### During periods of non-finality

Pruning might require deleting a long chain, space and time are unbounded. Note that blocks must still pass gossip validation and consensus verification and so this is made crypto-economically unviable for an attacker.

## Discussion & TODO

Is the extra pruning when the run queue is idle desirable? Do we only rely on onSlotEnd? Proposals:
1. Activate that extra pruning location only during sync and not when validation starts
2. Remove that extra pruning location and only rely on the slot end. The impact of a leaner or fatter DAG on sync speed is unknown (storeBlock is likely the dominating factor).
3. Make `handleValidatorDuties` synchronous so that it starts ASAP ignoring floating timers, new inputs, ...

During sync, do we want pruning to happen less frequently than at each finalization or when idle so that we can take full advantage of fast peers?

The original issue #23 mentions staggering pruning, doing 1 epoch each time. This complicates the code by introducing non-trivial state (instead of just a bool). It's possible that just moving pruning out of the latency critical path is enough.