### PR TITLE
Fix #2393

### DIFF
--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -337,8 +337,8 @@ proc pruneBlocks*(
 proc pruneAttestations*(
        db: SlashingProtectionDB,
        validator: ValidatorPubkey,
-       newMinSourceEpoch: Epoch,
-       newMinTargetEpoch: Epoch) =
+       newMinSourceEpoch: int64,
+       newMinTargetEpoch: int64) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import to ensure
   ## that in case of a gap, we don't allow signing in that gap.

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -446,4 +446,8 @@ proc importInterchangeV5Impl*(
 
     # Now prune everything that predates
     # this interchange file max slot
-    db.pruneAttestations(parsedKey, Epoch maxValidSourceEpochSeen, Epoch maxValidTargetEpochSeen)
+    if maxValidSourceEpochSeen < 0:
+      doAssert maxValidSourceEpochSeen == -1 and maxValidTargetEpochSeen == -1
+      notice "No attestation found in slashing interchange file"
+      return
+    db.pruneAttestations(parsedKey, maxValidSourceEpochSeen, maxValidTargetEpochSeen)

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -117,7 +117,7 @@ type
     # Pruning
     # --------------------------------------------
     db.pruneBlocks(ValidatorPubKey, Slot)
-    db.pruneAttestations(ValidatorPubKey, Epoch, Epoch)
+    db.pruneAttestations(ValidatorPubKey, int64, int64)
     db.pruneAfterFinalization(Epoch)
 
     # Interchange

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -446,7 +446,7 @@ proc importInterchangeV5Impl*(
 
     # Now prune everything that predates
     # this interchange file max slot
-    if maxValidSourceEpochSeen < 0:
+    if maxValidSourceEpochSeen < 0 or maxValidTargetEpochSeen < 0:
       doAssert maxValidSourceEpochSeen == -1 and maxValidTargetEpochSeen == -1
       notice "No attestation found in slashing interchange file"
       return

--- a/beacon_chain/validators/slashing_protection_v1.nim
+++ b/beacon_chain/validators/slashing_protection_v1.nim
@@ -961,13 +961,13 @@ proc pruneAttestations*(
   ## This is intended for interchange import.
   ##
   ## Note: the Database v1 does not support pruning.
-  ## 
+  ##
   ## Negative source/target epoch of -1 can be received if no attestation was imported
   ## In that case nothing is done
   warn "Slashing DB pruning is not supported on the v1 of our database. Request ignored.",
     validator = shortLog(validator),
-    newMinSourceEpoch = shortLog(newMinSourceEpoch),
-    newMinTargetEpoch = shortLog(newMinTargetEpoch)
+    newMinSourceEpoch = newMinSourceEpoch,
+    newMinTargetEpoch = newMinTargetEpoch
 
 proc pruneAfterFinalization*(
        db: SlashingProtectionDB_v1,

--- a/beacon_chain/validators/slashing_protection_v1.nim
+++ b/beacon_chain/validators/slashing_protection_v1.nim
@@ -955,12 +955,15 @@ proc pruneBlocks*(db: SlashingProtectionDB_v1, validator: ValidatorPubkey, newMi
 proc pruneAttestations*(
        db: SlashingProtectionDB_v1,
        validator: ValidatorPubkey,
-       newMinSourceEpoch: Epoch,
-       newMinTargetEpoch: Epoch) =
+       newMinSourceEpoch: int64,
+       newMinTargetEpoch: int64) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import.
   ##
   ## Note: the Database v1 does not support pruning.
+  ## 
+  ## Negative source/target epoch of -1 can be received if no attestation was imported
+  ## In that case nothing is done
   warn "Slashing DB pruning is not supported on the v1 of our database. Request ignored.",
     validator = shortLog(validator),
     newMinSourceEpoch = shortLog(newMinSourceEpoch),

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1020,14 +1020,16 @@ proc pruneBlocks*(db: SlashingProtectionDB_v2, validator: ValidatorPubkey, newMi
 proc pruneAttestations*(
        db: SlashingProtectionDB_v2,
        validator: ValidatorPubkey,
-       newMinSourceEpoch: Epoch,
-       newMinTargetEpoch: Epoch) =
+       newMinSourceEpoch: int64,
+       newMinTargetEpoch: int64) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import.
+  ## Negative source/target epoch of -1 can be received if no attestation was imported
+  ## In that case nothing is done (since we used signed int in SQLite)
   let valID = db.getOrRegisterValidator(validator)
 
   let status = db.sqlPruneValidatorAttestations.exec(
-    (valID, int64 newMinSourceEpoch, int64 newMinTargetEpoch))
+    (valID, newMinSourceEpoch, newMinTargetEpoch))
   doAssert status.isOk(),
     "SQLite error when pruning validator attestations: " & $status.error & "\n" &
     "for validator: 0x" & validator.toHex() &


### PR DESCRIPTION
This fixes #2393 (blocker for 1.2.10) by removing int64 -> uint64 -> int64 conversion before pruneAttestations when importing a slashing protection DB.

A special value of -1 is used to track the max source and target epochs and this -1 is converted to uint64 if no attestation is found.
It is then converted back to int64 to be passed to sqlite.

We remove that conversion, and also don't call pruneAttestation at all with negative epochs.