### PR TITLE
remove delta-encoding from state diff balances

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -274,10 +274,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## state diff tests [Preset: mainnet]
 ```diff
-+ delta-encoding/decoding roundtrip sanity [Preset: mainnet]                                 OK
 + random slot differences [Preset: mainnet]                                                  OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 149/158 Fail: 0/158 Skip: 9/158
+OK: 148/157 Fail: 0/157 Skip: 9/157

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1,6 +1,6 @@
 import
   # Std lib
-  std/[typetraits, strutils, sequtils, os, algorithm, math, sets],
+  std/[typetraits, sequtils, os, algorithm, math, sets],
   std/options as stdOptions,
 
   # Status libs

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -626,7 +626,7 @@ type
       List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Represent in full
-    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Mod-increment
     randao_mix*: Eth2Digest

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -626,7 +626,7 @@ type
       List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Represent in full
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Mod-increment
     randao_mix*: Eth2Digest
@@ -634,9 +634,9 @@ type
 
     # To start with, always overwrite, not append
     previous_epoch_attestations*:
-      HashList[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
     current_epoch_attestations*:
-      HashList[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
+      List[PendingAttestation, Limit(MAX_ATTESTATIONS * SLOTS_PER_EPOCH)]
 
     justification_bits*: uint8
     previous_justified_checkpoint*: Checkpoint

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -128,7 +128,7 @@ func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
     eth1_deposit_index: state1.eth1_deposit_index,
 
     validatorStatuses: getMutableValidatorStatuses(state1),
-    balances: state1.balances,
+    balances: state1.balances.data,
 
     # RANDAO mixes gets updated every block, in place
     randao_mix: state1.randao_mixes[state0.slot.compute_epoch_at_slot.uint64 mod
@@ -136,8 +136,8 @@ func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
     slashing: state1.slashings[state0.slot.compute_epoch_at_slot.uint64 mod
       EPOCHS_PER_HISTORICAL_VECTOR.uint64],
 
-    previous_epoch_attestations: state1.previous_epoch_attestations,
-    current_epoch_attestations: state1.current_epoch_attestations,
+    previous_epoch_attestations: state1.previous_epoch_attestations.data,
+    current_epoch_attestations: state1.current_epoch_attestations.data,
 
     justification_bits: state1.justification_bits,
     previous_justified_checkpoint: state1.previous_justified_checkpoint,
@@ -149,6 +149,11 @@ func applyDiff*(
     state: var BeaconState,
     immutableValidators: openArray[ImmutableValidatorData],
     stateDiff: BeaconStateDiff) =
+  template assign[T, U](tgt: var HashList[T, U], src: List[T, U]) =
+    tgt.clear()
+    assign(tgt.data, src)
+    tgt.growHashes()
+
   # Carry over unchanged genesis_time, genesis_validators_root, and fork.
   assign(state.latest_block_header, stateDiff.latest_block_header)
 

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -8,6 +8,7 @@
 {.push raises: [Defect].}
 
 import
+  stew/assign2,
   ./ssz/types,
   ./spec/[datatypes, digest, helpers]
 
@@ -48,25 +49,6 @@ func setValidatorStatuses(
     validators[i].activation_epoch = hl[i].activation_epoch
     validators[i].exit_epoch = hl[i].exit_epoch
     validators[i].withdrawable_epoch = hl[i].withdrawable_epoch
-
-func deltaEncodeBalances*[T, U](balances: HashList[T, U]): List[T, U] =
-  if balances.len == 0:
-    return
-
-  result.add balances[0]
-
-  for i in 1 ..< balances.len:
-    result.add balances[i] - balances[i - 1]
-
-  doAssert balances.len == result.len
-
-func deltaDecodeBalances*[T, U](encodedBalances: List[T, U]): HashList[T, U] =
-  var accum = 0'u64
-  for i in 0 ..< encodedBalances.len:
-    accum += encodedBalances[i]
-    result.add accum
-
-  doAssert encodedBalances.len == result.len
 
 func replaceOrAddEncodeEth1Votes[T, U](votes0, votes1: HashList[T, U]):
     (bool, List[T, U]) =
@@ -146,7 +128,7 @@ func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
     eth1_deposit_index: state1.eth1_deposit_index,
 
     validatorStatuses: getMutableValidatorStatuses(state1),
-    balances: deltaEncodeBalances(state1.balances),
+    balances: state1.balances,
 
     # RANDAO mixes gets updated every block, in place
     randao_mix: state1.randao_mixes[state0.slot.compute_epoch_at_slot.uint64 mod
@@ -168,37 +150,41 @@ func applyDiff*(
     immutableValidators: openArray[ImmutableValidatorData],
     stateDiff: BeaconStateDiff) =
   # Carry over unchanged genesis_time, genesis_validators_root, and fork.
-  state.latest_block_header = stateDiff.latest_block_header
+  assign(state.latest_block_header, stateDiff.latest_block_header)
 
   applyModIncrement(state.block_roots, stateDiff.block_roots, state.slot.uint64)
   applyModIncrement(state.state_roots, stateDiff.state_roots, state.slot.uint64)
   if stateDiff.historical_root_added:
     state.historical_roots.add stateDiff.historical_root
 
-  state.eth1_data = stateDiff.eth1_data
+  assign(state.eth1_data, stateDiff.eth1_data)
   replaceOrAddDecodeEth1Votes(
     state.eth1_data_votes, stateDiff.eth1_data_votes_replaced,
     stateDiff.eth1_data_votes)
-  state.eth1_deposit_index = stateDiff.eth1_deposit_index
+  assign(state.eth1_deposit_index, stateDiff.eth1_deposit_index)
 
   applyValidatorIdentities(state.validators, immutableValidators)
   setValidatorStatuses(state.validators, stateDiff.validator_statuses)
-  state.balances = deltaDecodeBalances(stateDiff.balances)
+  assign(state.balances, stateDiff.balances)
 
   # RANDAO mixes gets updated every block, in place, so ensure there's always
   # >=1 value from it
   let epochIndex =
     state.slot.epoch.uint64 mod EPOCHS_PER_HISTORICAL_VECTOR.uint64
-  state.randao_mixes[epochIndex] = stateDiff.randao_mix
-  state.slashings[epochIndex] = stateDiff.slashing
+  assign(state.randao_mixes[epochIndex], stateDiff.randao_mix)
+  assign(state.slashings[epochIndex], stateDiff.slashing)
 
-  state.previous_epoch_attestations = stateDiff.previous_epoch_attestations
-  state.current_epoch_attestations = stateDiff.current_epoch_attestations
+  assign(
+    state.previous_epoch_attestations, stateDiff.previous_epoch_attestations)
+  assign(
+    state.current_epoch_attestations, stateDiff.current_epoch_attestations)
 
   state.justification_bits = stateDiff.justification_bits
-  state.previous_justified_checkpoint = stateDiff.previous_justified_checkpoint
-  state.current_justified_checkpoint = stateDiff.current_justified_checkpoint
-  state.finalized_checkpoint = stateDiff.finalized_checkpoint
+  assign(
+    state.previous_justified_checkpoint, stateDiff.previous_justified_checkpoint)
+  assign(
+    state.current_justified_checkpoint, stateDiff.current_justified_checkpoint)
+  assign(state.finalized_checkpoint, stateDiff.finalized_checkpoint)
 
   # Don't update slot until the end, because various other updates depend on it
   state.slot = stateDiff.slot

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -115,60 +115,3 @@ suiteReport "state diff tests" & preset():
           diff)
         check hash_tree_root(testStates[j].data) ==
           hash_tree_root(tmpStateApplyBase[])
-
-  wrappedTimedTest "delta-encoding/decoding roundtrip sanity" & preset():
-    const
-      balances0 = [
-        18441870559'u64, 33446800397'u64, 11147100626'u64, 42603154274'u64,
-        35932339237'u64, 59867680015'u64, 19647051219'u64, 63570367156'u64,
-        43824455480'u64, 47579598334'u64, 22175553574'u64, 13601246675'u64,
-        40046565997'u64, 19862192832'u64, 14541260920'u64, 25776220537'u64,
-        53093805050'u64, 47082111792'u64, 24773067164'u64, 25673826779'u64,
-        45827636611'u64, 31759878136'u64, 58103054360'u64, 50512782241'u64,
-        31182839614'u64]
-
-      balances1 = [
-        42080447134'u64,  9723866886'u64, 21528919469'u64, 60580554318'u64,
-        37463193877'u64, 18143243334'u64, 32030042150'u64, 51881718936'u64,
-        17259308484'u64, 18169637307'u64, 48769712906'u64, 51088432822'u64,
-        52895655180'u64, 26116017983'u64, 39305430230'u64, 24222097345'u64,
-        39462882494'u64, 39596015040'u64, 37160795641'u64, 35339479924'u64,
-        33636108383'u64, 15242724015'u64, 60815628681'u64, 32706350007'u64,
-         8978429438'u64, 21322048864'u64, 22997808541'u64, 37068275007'u64,
-        50938101702'u64, 14620153832'u64, 55162721187'u64, 26298968647'u64,
-        17648055143'u64, 59996602297'u64, 30878159440'u64, 22415848926'u64,
-        20768842475'u64]
-
-      balances2 = [
-        21675589964'u64, 13993227022'u64, 26438767944'u64, 41440196317'u64,
-        41766461882'u64, 52661505859'u64, 42126387709'u64, 54445893868'u64,
-        41509802863'u64, 36976355380'u64, 46813612650'u64, 41196532827'u64,
-        23300952618'u64, 39031444988'u64, 37599530900'u64, 51850708563'u64,
-        42648477675'u64, 48123583384'u64, 17001259539'u64, 41801119284'u64,
-        44028789526'u64, 18179258736'u64, 50904978474'u64, 61199002779'u64,
-        24333838181'u64, 39569287366'u64, 37714257632'u64, 27622624307'u64,
-        63524818041'u64,  9470549646'u64, 41890932546'u64, 35929754455'u64,
-        18073815159'u64, 61164677670'u64, 46599755663'u64, 39969979788'u64,
-        19044350776'u64, 54818254044'u64, 48961544925'u64, 32004978192'u64,
-        26380608851'u64, 31055862486'u64, 16774301884'u64, 34387075525'u64,
-        30929489373'u64, 59224634642'u64, 39883929054'u64, 46052767920'u64,
-        53119984525'u64]
-
-      balances_empty: array[0, uint64] = []
-
-      balances_single = [26971116287'u64]
-
-    template test_roundtrip_balances(state_balances: untyped) =
-      var balances = HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]()
-      for balance in state_balances:
-        balances.add balance
-
-      check deltaDecodeBalances[uint64, Limit VALIDATOR_REGISTRY_LIMIT](
-        deltaEncodeBalances[uint64, Limit VALIDATOR_REGISTRY_LIMIT](
-          balances)) == balances
-
-    test_roundtrip_balances(balances_empty)
-    test_roundtrip_balances(balances_single)
-    test_roundtrip_balances(balances0)
-    test_roundtrip_balances(balances1)
-    test_roundtrip_balances(balances2)


### PR DESCRIPTION
It's slow and ineffective, according to https://github.com/status-im/nimbus-eth2/pull/2297#issuecomment-793621492:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    4358.981,        0.000,     4358.981,     4358.981,            1, Initialize DB
       0.142,        0.312,        0.032,       91.416,       147164, Load block from database
      38.200,        0.000,       38.200,       38.200,            1, Load state from database
       0.175,        0.302,        0.025,      111.499,       145313, Advance slot, non-epoch
      13.289,        3.378,        1.374,       22.325,         4687, Advance slot, epoch
       1.245,        4.354,        0.013,       56.232,       147164, Apply block, no slot processing
     129.136,       42.731,       35.840,      248.019,         4294, Database load
      20.424,        6.497,        7.970,      293.087,         4294, Database store
```
where it's in the database load path in that benchmark.

By contrast, a similar commit without it:
```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    5133.605,        0.000,     5133.605,     5133.605,            1, Initialize DB
       0.315,        0.458,        0.044,       77.542,        97840, Load block from database
      43.990,        0.000,       43.990,       43.990,            1, Load state from database
       0.146,        0.343,        0.025,      105.164,        96875, Advance slot, non-epoch
      10.618,        1.991,        1.319,       17.071,         3125, Advance slot, epoch
       1.119,        4.029,        0.015,       54.087,        97840, Apply block, no slot processing
      12.544,        7.062,        4.491,       45.720,         2862, Database load
      16.945,        6.674,        7.785,      309.739,         2862, Database 
```

It alone was making the load 10x slower for no discernible compression efficiency gains when using Snappy.