### PR TITLE
avoid int64 -> uint64 -> int64 conversions in DbSeq

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -184,14 +184,14 @@ proc add*[T](s: var DbSeq[T], val: T) =
   s.insertStmt.exec(bytes).expect "working database (disk broken/full?)"
   inc s.recordCount
 
-template len*[T](s: DbSeq[T]): uint64 =
-  s.recordCount.uint64
+template len*[T](s: DbSeq[T]): int64 =
+  s.recordCount
 
-proc get*[T](s: DbSeq[T], idx: uint64): T =
+proc get*[T](s: DbSeq[T], idx: int64): T =
   # This is used only locally
   let resultAddr = addr result
 
-  let queryRes = s.selectStmt.exec(int64(idx) + 1) do (recordBytes: openArray[byte]):
+  let queryRes = s.selectStmt.exec(idx + 1) do (recordBytes: openArray[byte]):
     try:
       resultAddr[] = decode(SSZ, recordBytes, T)
     except SerializationError:


### PR DESCRIPTION
This is typically used in a sequence along the lines of:
```nim
for i in 0 ..< db.dbSeqObj.len:
  process(db.dbSeqObj.get(i))
```
in a hermetically sealed way, so that internal consistency's the only important thing in this choice of type.