### PR TITLE
ncli_db pruneDatabase checkpointing; remove onSlotEnd lookaheadTime

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -928,12 +928,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   node.db.checkpoint()
 
   let
-    horizonSlot = compute_start_slot_at_epoch(
-      node.attestationSubnets.lastCalculatedAttestationEpoch + 1) - 1
     nextAttestationSlot = node.getNextAttestation(slot)
     nextActionWaitTime =
       saturate(fromNow(node.beaconClock, nextAttestationSlot))
-    horizonDistance = saturate(fromNow(node.beaconClock, horizonSlot))
 
   info "Slot end",
     slot = shortLog(slot),
@@ -948,8 +945,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
       if nextAttestationSlot == FAR_FUTURE_SLOT:
         "n/a"
       else:
-        shortLog(nextActionWaitTime),
-    lookaheadTime = shortLog(horizonDistance)
+        shortLog(nextActionWaitTime)
 
   if nextAttestationSlot != FAR_FUTURE_SLOT:
     next_action_wait.set(nextActionWaitTime.toFloatSeconds)

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -234,6 +234,7 @@ proc copyPrunedDatabase(
   for signedBlock in getAncestors(db, headBlock.get):
     if not dry_run:
       copyDb.putBlock(signedBlock)
+      copyDb.checkpoint()
     if verbose:
       echo "copied block at slot ", signedBlock.message.slot
 

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -2,7 +2,7 @@
 
 import unittest
 import chronos
-import ../beacon_chain/gossip_processing/[eth2_processor, gossip_to_consensus],
+import ../beacon_chain/gossip_processing/gossip_to_consensus,
        ../beacon_chain/sync/sync_manager
 
 type


### PR DESCRIPTION
Otherwise `ncli_db pruneDatabase` just accumulates a huge WAL file until the end. At some point manual checkpointing was introduced and automatic checkpointing disabled.

`lookaheadTime` isn't particularly useful, and potentially confusing.