### PR TITLE
Revert "Nim-1.2.10"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,9 +282,7 @@ ifneq ($(USE_LIBBACKTRACE), 0)
 build/generate_makefile: | libbacktrace
 endif
 build/generate_makefile: tools/generate_makefile.nim | deps-common
-	echo -e $(BUILD_MSG) "$@" && \
-	$(ENV_SCRIPT) nim c -o:$@ $(NIM_PARAMS) tools/generate_makefile.nim && \
-	echo -e $(BUILD_END_MSG) "$@"
+	$(ENV_SCRIPT) nim c -o:$@ $(NIM_PARAMS) tools/generate_makefile.nim
 
 # GCC's LTO parallelisation is able to detect a GNU Make jobserver and get its
 # maximum number of processes from there, but only if we use the "+" prefix.

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -78,12 +78,7 @@ func toSlot*(c: BeaconClock, t: Time): tuple[afterGenesis: bool, slot: Slot] =
   c.toBeaconTime(t).toSlot()
 
 func toBeaconTime*(s: Slot, offset = Duration()): BeaconTime =
-  # BeaconTime/Duration stores nanoseconds, internally
-  const maxSlot = (not 0'u64 div 2 div SECONDS_PER_SLOT div 1_000_000_000).Slot
-  var slot = s
-  if slot > maxSlot:
-    slot = maxSlot
-  BeaconTime(seconds(int64(uint64(slot) * SECONDS_PER_SLOT)) + offset)
+  BeaconTime(seconds(int64(uint64(s) * SECONDS_PER_SLOT)) + offset)
 
 proc now*(c: BeaconClock): BeaconTime =
   ## Current time, in slots - this may end up being less than GENESIS_SLOT(!)


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#2353

this breaks the json rpc interface, in part because of https://github.com/nim-lang/Nim/issues/17383 and in part because for reasons unknown, the `BiggestUInt` overload of `%` is being used for `Epoch` - it shouldn't because it's a `distinct` type.

repro:
```
curl -d '{"jsonrpc":"2.0","method":"get_v1_beacon_states_stateId_validators","params":["head"],"id":1}' -H 'Content-Type: application/json' localhost:8190
```

```
#0  raiseRangeErrorNoArgs () at /home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/system/chcks.nim:42
#1  0x00000000005918c1 in percent___uWOueivRHEiYocdYDq1ILQ (n_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/pure/json.nim:294
#2  percent___fq8CoYV6OIE7gsPrIyF0qA (o=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/pure/json.nim:352
#3  0x00000000009f97f9 in percent___qqwFOJTvVcK59bOX7KDo5GQ (o=0x7fffffff5df0) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/jsonmarshal.nim:63
#4  percent___GC9bdgxRLsamx2ohBbQ9czCg (elementsLen_0=110089, elements=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nimbus-build-system/vendor/Nim/lib/pure/json.nim:319
#5  getv1beaconstatesstateIdvalidators__5e44OfU0ifpBpz89ahJSpCg_9 (ClE_0=0x7ffff78824c0) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/router.nim:170
#6  0x00000000009fbe08 in getv1beaconstatesstateIdvalidators_continue__eeIPlibv3mjCpc5bMwQJdw (udataX60gensym323245244_=udataX60gensym323245244_@entry=0x0, ClE_0=ClE_0@entry=0x7fffeb828558) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:39
#7  0x00000000009fc2e9 in getv1beaconstatesstateIdvalidators__1TbT4tFzUD1gAubtxx4aeQ_5 (params=0x7fffefe39358, ClE_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:63
#8  0x0000000000628adf in route__q63p9cugo9cZqJBuXMkSlYIg_2 (ClE_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/router.nim:84
#9  0x0000000000629d61 in route_continue__ExP9cNWcTxJZSQyuQM5gBpQ (udataX60gensym50865839_=udataX60gensym50865839_@entry=0x0, ClE_0=ClE_0@entry=0x7fffd58e2b38) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:36
#10 0x000000000062a6be in route__0KXvOjjsBJs9cjOcAIfHzeA (node=<optimized out>, router=...) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:63
#11 route__q63p9cugo9cZqJBuXMkSlYIg (ClE_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/router.nim:94
#12 0x000000000062a9b1 in route_continue__20VZRV15gCavPUhVv4781w (udataX60gensym51165244_=udataX60gensym51165244_@entry=0x0, ClE_0=ClE_0@entry=0x7fffd58e4ea8) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:36
#13 0x000000000062af6c in route__zk6QEQxZjJhsidamKwJT7Q (router=..., data_0=data_0@entry=0x7fffebdcf030) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:63
#14 0x0000000000ca2aef in route__o6tYbpAGosAeJHIlpkpsyQ (server=0x7ffff7c23978, line=0x7fffebdcf030) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/server.nim:27
#15 0x00000000006353d6 in processClient__FrsS18ysIhHL8b2nnXU9aOA (ClE_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-json-rpc/json_rpc/servers/httpserver.nim:173
#16 0x0000000000632ba8 in processClient_continue__FqAtM4SroX3AJaN9coL9aBgw (udataX60gensym52745244_=<optimized out>, ClE_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncmacro2.nim:39
#17 0x00000000004f50f7 in poll__YNjd8fE6xG8CRNwfLnrx0g_2 () at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-chronos/chronos/asyncloop.nim:279
#18 0x0000000000aac755 in run__9bEhTo426QdYcdwLMojXkaQ_3 (node=node@entry=0x7fffee0e7048) at /home/arnetheduck/status/nim-beacon-chain/beacon_chain/nimbus_beacon_node.nim:1239
#19 0x0000000000aacd64 in start__9bEhTo426QdYcdwLMojXkaQ_2 (node=node@entry=0x7fffee0e7048) at /home/arnetheduck/status/nim-beacon-chain/beacon_chain/nimbus_beacon_node.nim:1294
#20 0x0000000000ab0505 in doRunBeaconNode__dPnR39aKQK1GZWUAnBb7zDw (config=<optimized out>, rng_0=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/beacon_chain/nimbus_beacon_node.nim:1660
#21 0x0000000000abdc67 in main__m5ggDac9cjg6y6sta9aZc5Jw () at /home/arnetheduck/status/nim-beacon-chain/beacon_chain/nimbus_beacon_node.nim:1937
#22 0x0000000000abe028 in NimMainModule () at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-testutils/testutils/moduletests.nim:21
#23 NimMainInner () at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-libp2p/libp2p/stream/bufferstream.nim:352
#24 0x0000000000421ba3 in NimMain () at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-libp2p/libp2p/stream/bufferstream.nim:360
#25 main (argc=<optimized out>, args=<optimized out>, env=<optimized out>) at /home/arnetheduck/status/nim-beacon-chain/vendor/nim-libp2p/libp2p/stream/bufferstream.nim:367
```