### PR TITLE
[RFC] cache attestation signatures for attestions for block_sim speedup 

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -133,7 +133,7 @@ proc updateCurrent(pool: var AttestationPool, wallSlot: Slot) =
   for k in keysToRemove:
     pool.attestationAggregates.del k
 
-func addToAggregates(pool: var AttestationPool, attestation: Attestation) =
+proc addToAggregates(pool: var AttestationPool, attestation: Attestation) =
   # do a lookup for the current slot and get it's associated htrs/attestations
   var aggregated_attestation = pool.attestationAggregates.mgetOrPut(
     attestation.data.slot, Table[Eth2Digest, Attestation]()).

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -135,7 +135,7 @@ func init*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
   ## This assumes that the signature is valid
   agg.init(sig.load().get())
 
-proc aggregate*(agg: var AggregateSignature, sig: ValidatorSig) {.deprecated, inline.}=
+proc aggregate*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
   ## Aggregate two Validator Signatures
   ## Both signatures must be valid
   agg.aggregate(sig.loadWithCache.get())

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -24,7 +24,7 @@ import
   # Test utilities
   ./testutil, ./testblockutil
 
-func combine(tgt: var Attestation, src: Attestation) =
+proc combine(tgt: var Attestation, src: Attestation) =
   ## Combine the signature and participation bitfield, with the assumption that
   ## the same data is being signed - if the signatures overlap, they are not
   ## combined.


### PR DESCRIPTION
For the moment, it shouldn't be merged. Unlike the similar validator public key cache, it's not intrinsically bounded without more explicit cache management, and there are other approaches to modifying attestation pool to be smarter about accessing attestations.

But it highlights a real scaling issue with block proposals, that currently, `block_sim` at Prater testnet numbers is quite slow:
```
Validators: 220000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
   14962.246,     3819.300,     1201.732,    17811.739,          124, Process non-epoch slot with block
   17134.054,     1584.936,    15345.889,    19116.758,            4, Process epoch slot with block
       0.466,        0.047,        0.010,        0.541,          128, Tree-hash block
       0.511,        0.028,        0.460,        0.651,          128, Sign block
    4290.568,      172.221,     3859.790,     4739.266,          128, Have committee attest to block
       3.703,        0.000,        3.703,        3.703,            1, Replay all produced blocks

real    41m39.150s
user    41m9.303s
sys    0m7.572s
```

This PR makes it 2x faster overall, with `proposeBlock` being around 5x faster (taking ratios of non-epoch slots, since epochs add other unrelated overhead):
```
Validators: 220000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    2751.016,      715.339,      835.691,     3841.966,          124, Process non-epoch slot with block
    3544.882,      702.460,     2931.228,     4178.623,            4, Process epoch slot with block
       0.487,        0.098,        0.015,        0.611,          128, Tree-hash block
       0.528,        0.089,        0.397,        0.648,          128, Sign block
    4556.319,      719.713,     3637.329,     5446.093,          128, Have committee attest to block
       4.665,        0.000,        4.665,        4.665,            1, Replay all produced blocks

real	18m34.447s
user	15m40.182s
sys	0m2.172s
```

`Process non-epoch slot with block` and `Process epoch slot with block` both basically just `proposeBlock`. `unstable` spends 70% of its time at 220k validators just loading in the attestation signatures. This PR reduces that to 12% or less.

In particular, it almost removes
https://github.com/status-im/nimbus-eth2/blob/f3fc551ea7ff31ff743a18c3c33fd035559c9caa/beacon_chain/consensus_object_pools/attestation_pool.nim#L397-L401
from the profile, getting it to 5% or so.