### PR TITLE
Make it clear that the default port for ETH2 is 9000 udp/tcp

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -154,12 +154,12 @@ type
 
       tcpPort* {.
         defaultValue: defaultEth2TcpPort
-        desc: "Listening TCP port for Ethereum LibP2P traffic"
+        desc: "Listening TCP port for Ethereum LibP2P traffic, the default is 9000"
         name: "tcp-port" }: Port
 
       udpPort* {.
         defaultValue: defaultEth2TcpPort
-        desc: "Listening UDP port for node discovery"
+        desc: "Listening UDP port for node discovery, default is 9000"
         name: "udp-port" }: Port
 
       maxPeers* {.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -1,6 +1,6 @@
 # Command line options
 
-You can pass any `nimbus_beacon_node` options to the `pyrmont` and `mainnet` scripts. For example, if you wanted to launch Nimbus on mainnet with a different base port, say `9100`, you would run:
+You can pass any `nimbus_beacon_node` options to the `pyrmont` and `mainnet` scripts. For example, if you wanted to launch Nimbus on mainnet with different base ports than the default `9000/udp` and `9000/tcp`, say `9100/udp` and `9100/tcp`, you would run:
 
 ```
 ./run-mainnet-beacon-node.sh --tcp-port=9100 --udp-port=9100
@@ -44,8 +44,8 @@ The following options are available:
                                addresses.
      --listen-address          Listening address for the Ethereum LibP2P and Discovery v5
                                traffic.
-     --tcp-port                Listening TCP port for Ethereum LibP2P traffic.
-     --udp-port                Listening UDP port for node discovery.
+     --tcp-port                Override default listening TCP port 9000 TCP port for Ethereum LibP2P traffic.
+     --udp-port                Override default listening UDP port 9000 UDP port for node discovery.
      --max-peers               The maximum number of peers to connect to.
      --nat                     Specify method to use for determining public address. Must be
                                one of: any, none, upnp, pmp, extip:<IP>.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -44,7 +44,7 @@ The following options are available:
                                addresses.
      --listen-address          Listening address for the Ethereum LibP2P and Discovery v5
                                traffic.
-     --tcp-port                Override default listening TCP port 9000 TCP port for Ethereum LibP2P traffic.
+     --tcp-port                Listening UDP port for node discovery, default is 9000
      --udp-port                Override default listening UDP port 9000 UDP port for node discovery.
      --max-peers               The maximum number of peers to connect to.
      --nat                     Specify method to use for determining public address. Must be

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -44,8 +44,8 @@ The following options are available:
                                addresses.
      --listen-address          Listening address for the Ethereum LibP2P and Discovery v5
                                traffic.
-     --tcp-port                Listening UDP port for node discovery, default is 9000
-     --udp-port                Override default listening UDP port 9000 UDP port for node discovery.
+     --tcp-port                Listening TCP port for Ethereum LibP2P traffic, the default is 9000
+     --udp-port                Listening UDP port for node discovery, default is 9000
      --max-peers               The maximum number of peers to connect to.
      --nat                     Specify method to use for determining public address. Must be
                                one of: any, none, upnp, pmp, extip:<IP>.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -87,4 +87,3 @@ Available sub-commands:
 
 ...
 ```
-							   


### PR DESCRIPTION
Hello team!

The only place where the default port is explicitly mentioned is in a [troubleshooting section](https://nimbus.guide/troubleshooting.html?highlight=port#address-already-in-use-error) which is suboptimal for people trying to find the right ports for firewall configuration.

Please confirm that `9000` on both `udp/tcp` is the default, right now I am only going on that troubleshooting section.