### PR TITLE
increase block proposal speed with many validators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,8 +269,8 @@ ifeq ($(DISABLE_TEST_FIXTURES_SCRIPT), 0)
 endif
 	for TEST_BINARY in $(TEST_BINARIES); do \
 		PARAMS=""; \
-		if [[ "$${TEST_BINARY}" == "state_sim" ]]; then PARAMS="--validators=3000 --slots=128"; \
-		elif [[ "$${TEST_BINARY}" == "block_sim" ]]; then PARAMS="--validators=3000 --slots=128"; \
+		if [[ "$${TEST_BINARY}" == "state_sim" ]]; then PARAMS="--validators=6000 --slots=128"; \
+		elif [[ "$${TEST_BINARY}" == "block_sim" ]]; then PARAMS="--validators=6000 --slots=128"; \
 		fi; \
 		echo -e "\nRunning $${TEST_BINARY} $${PARAMS}\n"; \
 		build/$${TEST_BINARY} $${PARAMS} || { echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Aborting."; exit 1; }; \

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -30,7 +30,7 @@ type
     ## added to the aggregate meaning that only non-overlapping aggregates may
     ## be further combined.
     aggregation_bits*: CommitteeValidatorsBits
-    aggregate_signature*: ValidatorSig
+    aggregate_signature*: CookedSig
 
   AttestationEntry* = object
     ## Each entry holds the known signatures for a particular, distinct vote

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -68,6 +68,8 @@ type
 
   SomeSig* = TrustedSig | ValidatorSig
 
+  CookedSig* = distinct blscurve.Signature
+
 export AggregateSignature
 
 # API
@@ -116,10 +118,18 @@ func init*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
   ## This assumes that the signature is valid
   agg.init(sig.load().get())
 
-func aggregate*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
+func init*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
+  ## Initializes an aggregate signature context
+  agg.init(blscurve.Signature(sig))
+
+proc aggregate*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
   ## Aggregate two Validator Signatures
   ## Both signatures must be valid
   agg.aggregate(sig.load.get())
+
+proc aggregate*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
+  ## Aggregate two Validator Signatures
+  agg.aggregate(blscurve.Signature(sig))
 
 func finish*(agg: AggregateSignature): ValidatorSig {.inline.}=
   ## Canonicalize an AggregateSignature into a signature
@@ -225,6 +235,9 @@ template toRaw*(x: TrustedSig): auto =
 
 func toHex*(x: BlsCurveType): string =
   toHex(toRaw(x))
+
+func exportRaw*(x: CookedSig): ValidatorSig =
+  ValidatorSig(blob: blscurve.Signature(x).exportRaw())
 
 func fromRaw*(T: type ValidatorPrivKey, bytes: openArray[byte]): BlsResult[T] =
   var val: SecretKey

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -68,7 +68,10 @@ type
 
   SomeSig* = TrustedSig | ValidatorSig
 
-  CookedSig* = distinct blscurve.Signature
+  CookedSig* = distinct blscurve.Signature  ## \
+  ## Allows loading in an atttestation or other message's signature once across
+  ## all its computations, rather than repeatedly re-loading it each time it is
+  ## referenced. This primarily currently serves the attestation pool.
 
 export AggregateSignature
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -50,8 +50,8 @@ proc gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
   result = mu + sigma * (b / a)
 
 # TODO confutils is an impenetrable black box. how can a help text be added here?
-cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 200, # One per shard is minimum
+cli do(slots = SLOTS_PER_EPOCH * 5,
+       validators = SLOTS_PER_EPOCH * 400, # One per shard is minimum
        attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -33,8 +33,8 @@ proc writeJson*(fn, v: auto) =
   defer: close(f)
   Json.saveFile(fn, v, pretty = true)
 
-cli do(slots = SLOTS_PER_EPOCH * 6,
-       validators = SLOTS_PER_EPOCH * 200, # One per shard is minimum
+cli do(slots = SLOTS_PER_EPOCH * 5,
+       validators = SLOTS_PER_EPOCH * 400, # One per shard is minimum
        json_interval = SLOTS_PER_EPOCH,
        write_last_json = false,
        prefix: int = 0,


### PR DESCRIPTION
Follow-up to https://github.com/status-im/nimbus-eth2/pull/2419

In preparation for Prater, this increases block proposal speed with 220k validators from:
```
Validators: 220000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
   14962.246,     3819.300,     1201.732,    17811.739,          124, Process non-epoch slot with block
   17134.054,     1584.936,    15345.889,    19116.758,            4, Process epoch slot with block
       0.466,        0.047,        0.010,        0.541,          128, Tree-hash block
       0.511,        0.028,        0.460,        0.651,          128, Sign block
    4290.568,      172.221,     3859.790,     4739.266,          128, Have committee attest to block
       3.703,        0.000,        3.703,        3.703,            1, Replay all produced blocks

real    41m39.150s
user    41m9.303s
sys    0m7.572s
```
to
```
Validators: 220000, epoch length: 32
Validators per attestation (mean): 0.0
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
    2326.538,      437.696,      624.967,     2866.076,          124, Process non-epoch slot with block
    3088.419,      189.434,     2921.469,     3295.401,            4, Process epoch slot with block
       0.459,        0.044,        0.011,        0.527,          128, Tree-hash block
       0.498,        0.022,        0.438,        0.560,          128, Sign block
    4868.880,      183.397,     4459.721,     5448.739,          128, Have committee attest to block
       4.736,        0.000,        4.736,        4.736,            1, Replay all produced blocks

real	15m36.582s
user	15m22.210s
sys	0m5.400s
```
So, by roughly a factor of 6.