### PR TITLE
Use the ValidatorIndex type in VoluntaryExit

### DIFF
--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -67,7 +67,7 @@ iterator getValidatorIndices(proposer_slashing: ProposerSlashing): uint64 =
   yield proposer_slashing.signed_header_1.message.proposer_index
 
 iterator getValidatorIndices(voluntary_exit: SignedVoluntaryExit): uint64 =
-  yield voluntary_exit.message.validator_index
+  yield voluntary_exit.message.validator_index.uint64
 
 # TODO stew/sequtils2
 template allIt(s, pred: untyped): bool =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1472,12 +1472,13 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
     fatal "Failed to connect to the beacon node RPC service", err = err.msg
     quit 1
 
-  let (validator, validatorIdx, _, _) = try:
+  let (validator, validatorIdxUint64, _, _) = try:
     await rpcClient.get_v1_beacon_states_stateId_validators_validatorId(
       "head", config.exitedValidator)
   except CatchableError as err:
     fatal "Failed to obtain information for validator", err = err.msg
     quit 1
+  let validatorIdx = validatorIdxUint64 as ValidatorIndex
 
   let exitAtEpoch = if config.exitAtEpoch.isSome:
     Epoch config.exitAtEpoch.get

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -254,7 +254,7 @@ type
     epoch*: Epoch ##\
     ## Earliest epoch when voluntary exit can be processed
 
-    validator_index*: uint64
+    validator_index*: ValidatorIndex
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock
   BeaconBlock* = object
@@ -765,6 +765,24 @@ func `[]`*[T](a: var seq[T], b: ValidatorIndex): var T =
 
 func `[]`*[T](a: seq[T], b: ValidatorIndex): auto =
   a[b.int]
+
+template `as`*(val: uint64, T: type ValidatorIndex): ValidatorIndex =
+  ValidatorIndex(val)
+
+template `<`*(x: ValidatorIndex, y: uint64): bool =
+  uint64(x) < y
+
+template `<=`*(x: ValidatorIndex, y: uint64): bool =
+  uint64(x) <= y
+
+template `==`*(x: ValidatorIndex, y: uint64): bool =
+  uint64(x) == y
+
+template `>=`*(x: ValidatorIndex, y: uint64): bool =
+  uint64(x) >= y
+
+template `>`*(x: ValidatorIndex, y: uint64): bool =
+  uint64(x) > y
 
 # `ValidatorIndex` Nim integration
 proc `==`*(x, y: ValidatorIndex) : bool {.borrow, noSideEffect.}

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -248,10 +248,10 @@ proc check_voluntary_exit*(
   let voluntary_exit = signed_voluntary_exit.message
 
   # Not in spec. Check that validator_index is in range
-  if voluntary_exit.validator_index >= state.validators.lenu64:
+  if voluntary_exit.validator_index.uint64 >= state.validators.lenu64:
     return err("Exit: invalid validator index")
 
-  let validator = unsafeAddr state.validators.asSeq()[voluntary_exit.validator_index]
+  let validator = unsafeAddr state.validators.asSeq()[voluntary_exit.validator_index.uint64]
 
   # Verify the validator is active
   if not is_active_validator(validator[], get_current_epoch(state)):

--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -60,6 +60,9 @@ template fromSszBytes*(T: type Slot, bytes: openArray[byte]): T =
 template fromSszBytes*(T: type Epoch, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
+template fromSszBytes*(T: type ValidatorIndex, bytes: openArray[byte]): T =
+  T fromSszBytes(uint64, bytes)
+
 func fromSszBytes*(T: type ForkDigest, bytes: openArray[byte]): T {.raisesssz.} =
   if bytes.len != sizeof(result):
     raiseIncorrectSize T


### PR DESCRIPTION
Using the `ValidatorIndex` consistently in the spec datatypes can improve type safety in theory and it simplifies the implementation of the REST API modules where the numeric types need special treatment. This is a draft PR exploring the cost of such a refactoring.