### PR TITLE
Batch attestations

### DIFF
--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -155,8 +155,7 @@ proc schedule(batchCrypto: ref BatchCrypto, fut: Future[Result[void, cstring]], 
     # First attestation to be scheduled in the batch
     # wait for an idle time or up to 10ms before processing
     debug "batch crypto - scheduling next",
-      deadline = BatchAttAccumTime,
-      batchSize = batchCrypto.resultsBuffer.len
+      deadline = BatchAttAccumTime
     asyncSpawn(
       try:
         batchCrypto.deferCryptoProcessing(BatchAttAccumTime)

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -6,23 +6,18 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  # Standard library
-  std/[sequtils, intsets],
   # Status
   chronicles, chronos,
   stew/results,
   eth/keys,
   # Internals
   ../spec/[
-    beaconstate, state_transition_block,
-    datatypes, crypto, digest, helpers, network, signatures, signatures_batch],
+    datatypes, crypto, digest, helpers, signatures_batch],
   ../consensus_object_pools/[
-    spec_cache, blockchain_dag, block_quarantine, spec_cache,
+    blockchain_dag, block_quarantine,
     attestation_pool, exit_pool
   ],
-  ".."/[beacon_node_types, ssz, beacon_clock],
-  ../validators/attestation_aggregation,
-  ../extras
+  ".."/[beacon_node_types, ssz, beacon_clock]
 
 export BrHmacDrbgContext
 
@@ -92,7 +87,7 @@ proc processBufferedCrypto(self: ref BatchCrypto) =
   if self.pendingBuffer.len == 0:
     return
 
-  debug "batch crypto - starting",
+  trace "batch crypto - starting",
     batchSize = self.pendingBuffer.len
 
   let startTime = Moment.now()
@@ -154,7 +149,7 @@ proc schedule(batchCrypto: ref BatchCrypto, fut: Future[Result[void, cstring]], 
   if batchCrypto.resultsBuffer.len == 1:
     # First attestation to be scheduled in the batch
     # wait for an idle time or up to 10ms before processing
-    debug "batch crypto - scheduling next",
+    trace "batch crypto - scheduling next",
       deadline = BatchAttAccumTime
     asyncSpawn(
       try:

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -1,0 +1,188 @@
+# beacon_chain
+# Copyright (c) 2019-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Standard library
+  std/[sequtils, intsets],
+  # Status
+  chronicles, chronos,
+  stew/results,
+  eth/keys,
+  # Internals
+  ../spec/[
+    beaconstate, state_transition_block,
+    datatypes, crypto, digest, helpers, network, signatures, signatures_batch],
+  ../consensus_object_pools/[
+    spec_cache, blockchain_dag, block_quarantine, spec_cache,
+    attestation_pool, exit_pool
+  ],
+  ".."/[beacon_node_types, ssz, beacon_clock],
+  ../validators/attestation_aggregation,
+  ../extras
+
+export BrHmacDrbgContext
+
+logScope:
+  topics = "gossip_checks"
+
+# Batched gossip validation
+# ----------------------------------------------------------------
+{.push raises: [Defect].}
+
+type
+  BatchCrypto* = object
+    # The buffers are bounded by BatchedbatchCryptoize (16) which was chosen:
+    # - based on "nimble bench" in nim-blscurve
+    #   so that low power devices like Raspberry Pi 4 can process
+    #   that many batched verifications within 20ms
+    # - based on the accumulation rate of attestations and aggregates
+    #   in large instances which were 12000 per slot (12s)
+    #   hence 1 per ms (but the pattern is bursty around the 4s mark)
+    pendingBuffer: seq[SignatureSet]
+    resultsBuffer: seq[Future[Result[void, cstring]]]
+    sigVerifCache: BatchedBLSVerifierCache ##\
+    ## A cache for batch BLS signature verification contexts
+    rng: ref BrHmacDrbgContext  ##\
+    ## A reference to the Nimbus application-wide RNG
+
+const
+  # We cap waiting for an idle slot in case there's a lot of network traffic
+  # taking up all CPU - we don't want to _completely_ stop processing blocks
+  # in this case (attestations will get dropped) - doing so also allows us
+  # to benefit from more batching / larger network reads when under load.
+  BatchAttAccumTime = 10.milliseconds
+
+  # Attestation processing is fairly quick and therefore done in batches to
+  # avoid some of the `Future` overhead
+  BatchedbatchCryptoize = 16
+
+proc new*(T: type BatchCrypto, rng: ref BrHmacDrbgContext): ref BatchCrypto =
+  (ref BatchCrypto)(rng: rng)
+
+func clear(batchCrypto: ref BatchCrypto) =
+  ## Empty the crypto-pending attestations & aggregate queues
+  batchCrypto.pendingBuffer.setLen(0)
+  batchCrypto.resultsBuffer.setLen(0)
+
+proc done(batchCrypto: ref BatchCrypto, idx: int) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  ## that the attestation was crypto-verified (and so gossip validated)
+  ## with success
+  batchCrypto.resultsBuffer[idx].complete(Result[void, cstring].ok())
+
+proc fail(batchCrypto: ref BatchCrypto, idx: int, error: cstring) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  ## that the attestation was NOT crypto-verified (and so NOT gossip validated)
+  batchCrypto.resultsBuffer[idx].complete(Result[void, cstring].err(error))
+
+proc complete(batchCrypto: ref BatchCrypto, idx: int, res: Result[void, cstring]) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  batchCrypto.resultsBuffer[idx].complete(res)
+
+proc processBufferedCrypto(self: ref BatchCrypto) =
+  ## Drain all attestations waiting for crypto verifications
+
+  doAssert self.pendingBuffer.len ==
+             self.resultsBuffer.len
+
+  if self.pendingBuffer.len == 0:
+    return
+
+  notice "Starting batch attestations & aggregate crypto verification",
+    batchSize = self.pendingBuffer.len
+
+  var secureRandomBytes: array[32, byte]
+  self.rng[].brHmacDrbgGenerate(secureRandomBytes)
+
+  # TODO: For now only enable serial batch verification
+  let ok = batchVerifySerial(
+    self.sigVerifCache,
+    self.pendingBuffer,
+    secureRandomBytes)
+
+  notice "Finished batch attestations & aggregate crypto verification",
+    batchSize = self.pendingBuffer.len,
+    cryptoVerified = ok
+
+  if ok:
+    for i in 0 ..< self.resultsBuffer.len:
+      self.done(i)
+  else:
+    notice "Batch verification failure - falling back",
+      batchSize = self.pendingBuffer.len
+    for i in 0 ..< self.pendingBuffer.len:
+      let ok = blsVerify self.pendingBuffer[i]
+      if ok:
+        self.done(i)
+      else:
+        self.fail(i, "batch crypto verification: invalid signature")
+
+  self.clear()
+
+{.pop.} # async raising generic Exception
+
+proc deferCryptoProcessing(self: ref BatchCrypto, idleTimeout: Duration) {.async.} =
+  ## Process pending crypto check:
+  ## - if time threshold is reached
+  ## - or if networking is idle
+
+  discard await idleAsync().withTimeout(idleTimeout)
+  self.processBufferedCrypto()
+
+proc scheduleAttestationCheck*(
+      batchCrypto: ref BatchCrypto,
+      fork: Fork, genesis_validators_root: Eth2Digest,
+      epochRef: auto,
+      attestation: Attestation
+     ): Option[Future[Result[void, cstring]]] =
+  ## Schedule crypto verification of an attestation
+  ##
+  ## The buffer is processed:
+  ## - when 16 attestations are buffered (BatchedbatchCryptoize)
+  ## - when there are no network events (idleAsync)
+  ## - otherwise after 10ms (BatchAttAccumTime)
+  ##
+  ## This returns None if crypto sanity checks failed
+  ## and a future with the deferred attestation check otherwise.
+  doAssert batchCrypto.pendingBuffer.len < BatchedbatchCryptoize
+
+  # Enqueue in the buffer
+  # ------------------------------------------------------
+  let sanity = batchCrypto
+                .pendingBuffer
+                .addAttestation(
+                  fork, genesis_validators_root, epochRef,
+                  attestation
+                )
+  if not sanity:
+    return none(Future[Result[void, cstring]])
+
+  let fut = newFuture[Result[void, cstring]](
+    "batch_validation.scheduleAttestationCheck"
+  )
+  batchCrypto.resultsBuffer.add fut
+
+  # Scheduling
+  # ------------------------------------------------------
+
+  if batchCrypto.pendingBuffer.len == 1:
+    # First attestation to be scheduled in the batch
+    # wait for an idle time or up to 10ms before processing
+    asyncSpawn(
+      try:
+        batchCrypto.deferCryptoProcessing(BatchAttAccumTime)
+      except Exception as e:
+        # Chronos can in theory raise an untyped exception in `internalCheckComplete`
+        # which asyncSpawn doesn't like.
+        # Also in 1.2.6, Future and IOSelector errors don't inherit from CatchableError or Defect
+        raiseAssert e.msg
+    )
+  elif batchCrypto.pendingBuffer.len == BatchedbatchCryptoize:
+    # Reached the max buffer size, process immediately
+    batchCrypto.processBufferedCrypto()
+
+  return some(fut)

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -138,7 +138,7 @@ proc deferCryptoProcessing(self: ref BatchCrypto, idleTimeout: Duration) {.async
   # In practice this only happens when we receive a burst of attestations/aggregates.
   # Though it's possible to reach the threshold 9ms in,
   # and have only 1ms left for further accumulation.
-  discard await sleepAsync().withTimeout(idleTimeout)
+  await sleepAsync(idleTimeout)
   self[].processBufferedCrypto()
 
 proc schedule(batchCrypto: ref BatchCrypto, fut: Future[Result[void, cstring]], checkThreshold = true) =

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -138,7 +138,7 @@ proc deferCryptoProcessing(self: ref BatchCrypto, idleTimeout: Duration) {.async
   # In practice this only happens when we receive a burst of attestations/aggregates.
   # Though it's possible to reach the threshold 9ms in,
   # and have only 1ms left for further accumulation.
-  discard await idleAsync().withTimeout(idleTimeout)
+  discard await sleepAsync().withTimeout(idleTimeout)
   self[].processBufferedCrypto()
 
 proc schedule(batchCrypto: ref BatchCrypto, fut: Future[Result[void, cstring]], checkThreshold = true) =

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -11,7 +11,7 @@ import
   std/tables,
   stew/results,
   chronicles, chronos, metrics,
-  ../spec/[crypto, datatypes, digest, signatures_batch],
+  ../spec/[crypto, datatypes, digest],
   ../consensus_object_pools/[block_clearance, blockchain_dag, exit_pool, attestation_pool],
   ./gossip_validation, ./gossip_to_consensus,
   ./batch_validation,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -10,8 +10,9 @@
 import
   std/tables,
   stew/results,
+  eth/keys,
   chronicles, chronos, metrics,
-  ../spec/[crypto, datatypes, digest],
+  ../spec/[crypto, datatypes, digest, signatures_batch],
   ../consensus_object_pools/[block_clearance, blockchain_dag, exit_pool, attestation_pool],
   ./gossip_validation, ./gossip_to_consensus,
   ../validators/validator_pool,
@@ -70,6 +71,14 @@ type
     # ----------------------------------------------------------------
     exitPool: ref ExitPool
 
+    # Almost validated, pending cryptographic signature check
+    # ----------------------------------------------------------------
+    pendingAttestationCrypto: PendingAttestationsCrypto
+    sigVerifCache: BatchedBLSVerifierCache ##\
+    ## A cache for batch BLS signature verification contexts
+    rng*: ref BrHmacDrbgContext  ##\
+    ## A reference to the Nimbus application-wide RNG
+
     # Missing information
     # ----------------------------------------------------------------
     quarantine*: QuarantineRef
@@ -96,6 +105,103 @@ proc new*(T: type Eth2Processor,
     validatorPool: validatorPool,
     quarantine: quarantine
   )
+
+# Buffer for crypto checks
+# -----------------------------------------------------------------------------------
+
+func clear(atts: var PendingAttestationsCrypto) =
+  ## Empty the crypto-pending attestations & aggregate queues
+  atts.pendingBuffer.setLen(0)
+  atts.resultsBuffer.setLen(0)
+
+proc done(atts: var PendingAttestationsCrypto, idx: int) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  ## that the attestation was crypto-verified (and so gossip validated)
+  ## with success
+  atts.resultsBuffer[idx].complete(Result[void, cstring].ok())
+
+proc fail(atts: var PendingAttestationsCrypto, idx: int, error: cstring) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  ## that the attestation was NOT crypto-verified (and so NOT gossip validated)
+  atts.resultsBuffer[idx].complete(Result[void, cstring].err(error))
+
+proc complete(atts: var PendingAttestationsCrypto, idx: int, res: Result[void, cstring]) =
+  ## Send signal to [Attestation/Aggregate]Validator
+  atts.resultsBuffer[idx].complete(res)
+
+proc processPendingAttCrypto(self: var Eth2Processor) =
+  ## Drain all attestations waiting for crypto verifications
+  ##
+  ## This is called:
+  ## - every 10ms (BatchAttAccumTime)
+  ## - when 16 attestations are buffered (BatchedAttSize)
+  ##
+  ## TODO:
+  ## At the moment, draining on 16 atts doesn't extend the 10ms timer
+  ## Hence we could reach 16 atts at 9ms and then 1ms later not have enough
+  ## attestation.
+  ## In practice:
+  ## - only 2 attestations are needed to amortize the cost of batching
+  ## - verifying 16 attestations should take over 10ms
+  ## - having 16+ attestations per 10ms happens only during bursts
+
+  doAssert self.pendingAttestationCrypto.pendingBuffer.len ==
+             self.pendingAttestationCrypto.resultsBuffer.len
+
+  if self.pendingAttestationCrypto.pendingBuffer.len == 0:
+    return
+
+  var secureRandomBytes: array[32, byte]
+  self.rng[].brHmacDrbgGenerate(secureRandomBytes)
+
+  # TODO: For now only enable serial batch verification
+  let ok = batchVerifySerial(
+    self.sigVerifCache,
+    self.pendingAttestationCrypto.pendingBuffer,
+    secureRandomBytes)
+
+  trace "Batch attestations & aggregate crypto verification",
+    batchSize = buf.pendingBuffer.len,
+    cryptoVerified = ok
+
+  if ok:
+    for i in 0 ..< self.pendingAttestationCrypto.resultsBuffer.len:
+      self.pendingAttestationCrypto.done(i)
+  else:
+    trace "Batch verification failure - falling back",
+      batchSize = buf.pendingBuffer.len
+    for i in 0 ..< self.pendingAttestationCrypto.pendingBuffer.len:
+      let ok = blsVerify self.pendingAttestationCrypto.pendingBuffer[i]
+      if ok:
+        self.pendingAttestationCrypto.done(i)
+      else:
+        self.pendingAttestationCrypto.fail(i, "batch crypto verification: invalid signature")
+
+  self.pendingAttestationCrypto.clear()
+
+proc processPendingAttCryptoIf(self: var Eth2Processor, threshold: int) =
+  ## Drain all attestations waiting for crypto verifications
+  ## if a threashold is reached
+  if self.pendingAttestationCrypto.pendingBuffer.len >= threshold:
+    trace "Threshold reach - force batch verification",
+      threshold = threshold
+    self.processPendingAttCrypto()
+
+{.pop.}
+
+proc runAttQueueProcessingLoop*(self: ref Eth2Processor) {.async.} =
+  ## Drain the attestation processing buffer every 10ms
+
+  while true:
+    # Cooperative concurrency: one idle calculation step per loop - because
+    # we run both networking and CPU-heavy things like block processing
+    # on the same thread, we need to make sure that there is steady progress
+    # on the networking side or we get long lockups that lead to timeouts.
+
+    discard await idleAsync().withTimeout(BatchAttAccumTime)
+    self[].processPendingAttCrypto()
+
+{.push raises: [Defect].}
 
 # Gossip Management
 # -----------------------------------------------------------------------------------
@@ -201,7 +307,13 @@ proc attestationValidator*(
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime - attestation.data.slot.toBeaconTime
   debug "Attestation received", delay
+
+  # Empty the batch attestation crypto if needed
+  self.processPendingAttCryptoIf(threshold = BatchedAttSize)
+
+  # Now proceed to validation
   let v = self.attestationPool[].validateAttestation(
+      self.pendingAttestationCrypto,
       attestation, wallTime, committeeIndex, checksExpensive)
   if v.isErr():
     debug "Dropping attestation", err = v.error()

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -250,6 +250,7 @@ proc aggregateValidator*(
   debug "Aggregate received", delay
 
   let v = self.attestationPool[].validateAggregate(
+      self.batchCrypto,
       signedAggregateAndProof, wallTime)
   if v.isErr:
     debug "Dropping aggregate",

--- a/beacon_chain/gossip_processing/gossip_to_consensus.nim
+++ b/beacon_chain/gossip_processing/gossip_to_consensus.nim
@@ -81,17 +81,6 @@ type
 
 {.push raises: [Defect].}
 
-const
-  # We cap waiting for an idle slot in case there's a lot of network traffic
-  # taking up all CPU - we don't want to _completely_ stop processing blocks
-  # in this case (attestations will get dropped) - doing so also allows us
-  # to benefit from more batching / larger network reads when under load.
-  BatchAttAccumTime* = 10.milliseconds
-
-  # Attestation processing is fairly quick and therefore done in batches to
-  # avoid some of the `Future` overhead
-  BatchedAttSize* = 16
-
 # Initialization
 # ------------------------------------------------------------------------------
 
@@ -345,13 +334,27 @@ proc runQueueProcessingLoop*(self: ref VerifQueueManager) {.async.} =
     aggregateFut = self[].aggregatesQueue.popFirst()
     attestationFut = self[].attestationsQueue.popFirst()
 
+  # TODO:
+  #   revisit `idleTimeout`
+  #   and especially `attestationBatch` in light of batch validation
+  #   in particular we might want `attestationBatch` to drain both attestation & aggregates
   while true:
     # Cooperative concurrency: one idle calculation step per loop - because
     # we run both networking and CPU-heavy things like block processing
     # on the same thread, we need to make sure that there is steady progress
     # on the networking side or we get long lockups that lead to timeouts.
+    const
+      # We cap waiting for an idle slot in case there's a lot of network traffic
+      # taking up all CPU - we don't want to _completely_ stop processing blocks
+      # in this case (attestations will get dropped) - doing so also allows us
+      # to benefit from more batching / larger network reads when under load.
+      idleTimeout = 10.milliseconds
 
-    discard await idleAsync().withTimeout(BatchAttAccumTime)
+      # Attestation processing is fairly quick and therefore done in batches to
+      # avoid some of the `Future` overhead
+      attestationBatch = 16
+
+    discard await idleAsync().withTimeout(idleTimeout)
 
     # Avoid one more `await` when there's work to do
     if not (blockFut.finished or aggregateFut.finished or attestationFut.finished):
@@ -368,7 +371,7 @@ proc runQueueProcessingLoop*(self: ref VerifQueueManager) {.async.} =
     elif aggregateFut.finished:
       # aggregates will be dropped under heavy load on producer side
       self[].processAggregate(aggregateFut.read())
-      for i in 0..<BatchedAttSize: # process a few at a time - this is fairly fast
+      for i in 0..<attestationBatch: # process a few at a time - this is fairly fast
         if self[].aggregatesQueue.empty():
           break
         self[].processAggregate(self[].aggregatesQueue.popFirstNoWait())
@@ -378,7 +381,7 @@ proc runQueueProcessingLoop*(self: ref VerifQueueManager) {.async.} =
       # attestations will be dropped under heavy load on producer side
       self[].processAttestation(attestationFut.read())
 
-      for i in 0..<BatchedAttSize: # process a few at a time - this is fairly fast
+      for i in 0..<attestationBatch: # process a few at a time - this is fairly fast
         if self[].attestationsQueue.empty():
           break
         self[].processAttestation(self[].attestationsQueue.popFirstNoWait())

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -297,13 +297,7 @@ proc validateAttestation*(
                   cstring("validateAttestation: crypto sanity checks failure")))
 
     # Await the crypto check
-    let cryptoChecked = try:
-      await deferredCrypto.get()
-    except Exception as e:
-      # TODO
-      # https://github.com/nim-lang/Nim/issues/10288 - sigh
-      raiseAssert e.msg
-
+    let cryptoChecked = await deferredCrypto.get()
     if cryptoChecked.isErr():
       return err((ValidationResult.Reject, cryptoChecked.error))
 
@@ -440,37 +434,19 @@ proc validateAggregate*(
                   cstring("validateAttestation: crypto sanity checks failure")))
 
     # [REJECT] aggregate_and_proof.selection_proof
-    let slotChecked = try:
-      await deferredCrypto.get().slotCheck
-    except Exception as e:
-      # TODO
-      # https://github.com/nim-lang/Nim/issues/10288 - sigh
-      raiseAssert e.msg
-
+    let slotChecked = await deferredCrypto.get().slotCheck
     if slotChecked.isErr():
       return err((ValidationResult.Reject, cstring(
         "Selection_proof signature verification failed")))
 
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    let aggregatorChecked = try:
-      await deferredCrypto.get().aggregatorCheck
-    except Exception as e:
-      # TODO
-      # https://github.com/nim-lang/Nim/issues/10288 - sigh
-      raiseAssert e.msg
-
+    let aggregatorChecked = await deferredCrypto.get().aggregatorCheck
     if aggregatorChecked.isErr():
       return err((ValidationResult.Reject, cstring(
         "signed_aggregate_and_proof aggregator signature verification failed")))
 
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    let aggregateChecked = try:
-      await deferredCrypto.get().aggregateCheck
-    except Exception as e:
-      # TODO
-      # https://github.com/nim-lang/Nim/issues/10288 - sigh
-      raiseAssert e.msg
-
+    let aggregateChecked = await deferredCrypto.get().aggregateCheck
     if aggregateChecked.isErr():
       return err((ValidationResult.Reject, cstring(
         "signed_aggregate_and_proof aggregate attester signatures verification failed")))

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1704,6 +1704,36 @@ proc addValidator*[MsgType](node: Eth2Node,
     node.pubsub.addValidator(topic & "_snappy", execValidator)
   except Exception as exc: raiseAssert exc.msg # TODO fix libp2p
 
+proc addAsyncValidator*[MsgType](node: Eth2Node,
+                            topic: string,
+                            msgValidator: proc(msg: MsgType):
+                            Future[ValidationResult] {.gcsafe.} ) =
+
+  proc execValidator(
+      topic: string, message: GossipMsg): Future[ValidationResult] =
+
+    inc nbc_gossip_messages_received
+    trace "Validating incoming gossip message",
+      len = message.data.len, topic
+
+    let decompressed = snappy.decode(message.data, GOSSIP_MAX_SIZE)
+
+    if decompressed.len == 0:
+      debug "Empty gossip data after decompression",
+        topic, len = message.data.len
+      result.complete(ValidationResult.Ignore)
+      return
+
+    try:
+      return msgValidator(SSZ.decode(decompressed, MsgType))
+    except CatchableError as err:
+      debug "Gossip validation error",
+        msg = err.msg, topic, len = message.data.len
+      result.complete(ValidationResult.Ignore)
+      return
+
+  node.pubsub.addValidator(topic & "_snappy", execValidator)
+
 proc unsubscribe*(node: Eth2Node, topic: string) {.raises: [Defect, CatchableError].} =
   try:
     node.pubsub.unsubscribeAll(topic & "_snappy")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1234,7 +1234,6 @@ proc run*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
     let startTime = node.beaconClock.now()
     asyncSpawn runSlotLoop(node, startTime)
     asyncSpawn runOnSecondLoop(node)
-    asyncSpawn runAttQueueProcessingLoop(node.processor)
     asyncSpawn runQueueProcessingLoop(node.verifQueues)
 
     node.requestManager.start()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -339,6 +339,7 @@ proc init*(T: type BeaconNode,
       verifQueues,
       chainDag, attestationPool, exitPool, validatorPool,
       quarantine,
+      rng,
       proc(): BeaconTime = beaconClock.now())
 
   var res = BeaconNode(
@@ -1233,6 +1234,7 @@ proc run*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
     let startTime = node.beaconClock.now()
     asyncSpawn runSlotLoop(node, startTime)
     asyncSpawn runOnSecondLoop(node)
+    asyncSpawn runAttQueueProcessingLoop(node.processor)
     asyncSpawn runQueueProcessingLoop(node.verifQueues)
 
     node.requestManager.start()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1172,16 +1172,16 @@ proc installMessageValidators(node: BeaconNode) =
   for it in 0'u64 ..< ATTESTATION_SUBNET_COUNT.uint64:
     closureScope:
       let ci = it
-      node.network.addValidator(
+      node.network.addAsyncValidator(
         getAttestationTopic(node.forkDigest, ci),
         # This proc needs to be within closureScope; don't lift out of loop.
-        proc(attestation: Attestation): ValidationResult =
-          node.processor[].attestationValidator(attestation, ci))
+        proc(attestation: Attestation): Future[ValidationResult] =
+          node.processor.attestationValidator(attestation, ci))
 
-  node.network.addValidator(
+  node.network.addAsyncValidator(
     getAggregateAndProofsTopic(node.forkDigest),
-    proc(signedAggregateAndProof: SignedAggregateAndProof): ValidationResult =
-      node.processor[].aggregateValidator(signedAggregateAndProof))
+    proc(signedAggregateAndProof: SignedAggregateAndProof): Future[ValidationResult] =
+      node.processor.aggregateValidator(signedAggregateAndProof))
 
   node.network.addValidator(
     node.topicBeaconBlocks,

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -166,6 +166,16 @@ proc blsVerify*(
     parsedKey.isSome() and
       parsedKey.get.verify(message, parsedSig.get())
 
+proc blsVerify*(sigSet: SignatureSet): bool =
+  ## Unbatched verification
+  ## of 1 SignatureSet
+  ## tuple[pubkey: blscurve.PublicKey, message: array[32, byte], blscurve.signature: Signature]
+  verify(
+    sigSet.pubkey,
+    sigSet.message,
+    sigSet.signature
+  )
+
 func blsSign*(privkey: ValidatorPrivKey, message: openArray[byte]): ValidatorSig =
   ## Computes a signature from a secret key and a message
   let sig = SecretKey(privkey).sign(message)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -219,16 +219,14 @@ proc addAttestation*(
   var attesters{.noinit.}: blscurve.PublicKey
   attesters.finish(attestersAgg)
 
-  if not sigs.addSignatureSet(
-          attesters,
-          attestation.data,
-          attestation.signature,
-          genesis_validators_root,
-          fork,
-          attestation.data.target.epoch,
-          DOMAIN_BEACON_ATTESTER):
-    return false
-  return true
+  return sigs.addSignatureSet(
+    attesters,
+    attestation.data,
+    attestation.signature,
+    genesis_validators_root,
+    fork,
+    attestation.data.target.epoch,
+    DOMAIN_BEACON_ATTESTER)
 
 proc addIndexedAttestation*(
       sigs: var seq[SignatureSet],
@@ -255,16 +253,14 @@ proc addIndexedAttestation*(
   if not aggPK.aggregateAttesters(attestation, epochRef):
     return false
 
-  if not sigs.addSignatureSet(
-          aggPK,
-          attestation.data,
-          attestation.signature,
-          genesis_validators_root,
-          fork,
-          attestation.data.target.epoch,
-          DOMAIN_BEACON_ATTESTER):
-    return false
-  return true
+  return sigs.addSignatureSet(
+    aggPK,
+    attestation.data,
+    attestation.signature,
+    genesis_validators_root,
+    fork,
+    attestation.data.target.epoch,
+    DOMAIN_BEACON_ATTESTER)
 
 proc addSlotSignature*(
       sigs: var seq[SignatureSet],

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -266,6 +266,43 @@ proc addIndexedAttestation*(
     return false
   return true
 
+proc addSlotSignature*(
+      sigs: var seq[SignatureSet],
+      fork: Fork, genesis_validators_root: Eth2Digest,
+      slot: Slot,
+      pubkey: ValidatorPubKey,
+      signature: ValidatorSig): bool =
+
+  let epoch = compute_epoch_at_slot(slot)
+  return sigs.addSignatureSet(
+    pubkey.loadWithCacheOrExitFalse(),
+    sszObj = slot,
+    signature,
+    genesis_validators_root,
+    fork,
+    epoch,
+    DOMAIN_SELECTION_PROOF
+  )
+
+proc addAggregateAndProofSignature*(
+      sigs: var seq[SignatureSet],
+      fork: Fork, genesis_validators_root: Eth2Digest,
+      aggregate_and_proof: AggregateAndProof,
+      pubkey: ValidatorPubKey,
+      signature: ValidatorSig
+  ): bool =
+
+  let epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
+  return sigs.addSignatureSet(
+    pubkey.loadWithCacheOrExitFalse(),
+    sszObj = aggregate_and_proof,
+    signature,
+    genesis_validators_root,
+    fork,
+    epoch,
+    DOMAIN_AGGREGATE_AND_PROOF
+  )
+
 proc collectSignatureSets*(
        sigs: var seq[SignatureSet],
        signed_block: SignedBeaconBlock,

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -167,7 +167,7 @@ proc sendAttestation*(
     getAttestationTopic(node.forkDigest, subnet_index), attestation)
 
   # Ensure node's own broadcast attestations end up in its attestation pool
-  discard node.processor[].attestationValidator(
+  discard node.processor.attestationValidator(
     attestation, subnet_index, false)
 
   beacon_attestations_sent.inc()

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -440,27 +440,27 @@ suiteReport "Attestation validation " & preset():
       beaconTime = attestation.data.slot.toBeaconTime()
 
     check:
-      validateAttestation(pool[], batchCrypto, attestation, beaconTime, subnet, true).isOk
+      validateAttestation(pool, batchCrypto, attestation, beaconTime, subnet, true).waitFor().isOk
 
       # Same validator again
-      validateAttestation(pool[], batchCrypto, attestation, beaconTime, subnet, true).error()[0] ==
+      validateAttestation(pool, batchCrypto, attestation, beaconTime, subnet, true).waitFor().error()[0] ==
         ValidationResult.Ignore
 
     pool[].nextAttestationEpoch.setLen(0) # reset for test
     check:
       # Wrong subnet
-      validateAttestation(pool[], batchCrypto, attestation, beaconTime, subnet + 1, true).isErr
+      validateAttestation(pool, batchCrypto, attestation, beaconTime, subnet + 1, true).waitFor().isErr
 
     pool[].nextAttestationEpoch.setLen(0) # reset for test
     check:
       # Too far in the future
       validateAttestation(
-        pool[], batchCrypto, attestation, beaconTime - 1.seconds, subnet + 1, true).isErr
+        pool, batchCrypto, attestation, beaconTime - 1.seconds, subnet + 1, true).waitFor().isErr
 
     pool[].nextAttestationEpoch.setLen(0) # reset for test
     check:
       # Too far in the past
       validateAttestation(
-        pool[], batchCrypto, attestation,
+        pool, batchCrypto, attestation,
         beaconTime - (SECONDS_PER_SLOT * SLOTS_PER_EPOCH - 1).int.seconds,
-        subnet + 1, true).isErr
+        subnet + 1, true).waitFor().isErr


### PR DESCRIPTION
# Batch attestations

This introduces attestations and aggregate batching for gossip validation.

At a low-level:
- an unaggregated attestation requires one cryptographic check
- an aggregated attestation requires 3 checks: selection proof, aggregator signature, aggregate signatures

The batching rules are:
- on a first attestation or aggregate, a 10ms timer is started
- A batch is processed after any of the following condition is reached:
  - the timer expired
  - Chronos is idle as defined by idleAsync so no other event (?)
  - 16 or more crypto checked are batched (6 aggregates can lead to 18 crypto check batched).

A single crypto check is at about 1ms on my machine (miller loop + final exponentiation).
A batch check is at 0.5ms per check
Constant overhead:
- Secure RNG: ~1ms
- Final exponentiation: ~0.5 ms

If a batch verification fails, checks are done individually.

Worst case expected latency would be with 18 checks, and 1 failing:
- 10ms idle timer
- 10.5ms for 18 checks
- 18ms for redoing the checks 1 by 1 if one failed

So about **40ms**.
Assuming a Rpi 4 is a conservative 4x less powerful than my CPU for cryptography, the conservative worst case latency is **160ms**.
In exchange **throughput is 2x higher**.

Given that starting from 9 checks (3 aggregates) the cost of batching is already amortized, it might be sensible to set the batch threshold to 8~12. We can also augment the idle timer to 20ms:
- 20 ms idle
- 5.5 ms for 9 checks
- 9 ms for redoing the checks 1 by 1 if one failed

**34.5ms** worst case latency, but with a longer timer so better batching opportunities.

However batching is interesting to handle bursts and 10ms is already enough in burst mode.