### PR TITLE
Gossip peers management

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1001,7 +1001,8 @@ proc runGossipBalanceLoop*(node: Eth2Node) {.async.} =
                 meta = fres.get()
               info "Got metadata", meta, peer=data.id
               var noSubnets = true
-              for subnet in 0'u8 ..<ATTESTATION_SUBNET_COUNT:
+              for subnet in 0'u8..(ATTESTATION_SUBNET_COUNT - 1'u8):
+              # for subnet in 0'u8 ..<ATTESTATION_SUBNET_COUNT: # compilation failed...
                 if meta.attnets[subnet]:
                   noSubnets = false
                   break


### PR DESCRIPTION
This is the work in progress on connecting gossip and nimbus in terms of peer management

@cheatfate @kdeme You guys might be interested and I would be happy if you took over as the work is mostly nimbus side really.

Gossip `pubsubpeer` scores can help take decisions and as well knowledge of which peers are currently in what topic should be taken into account. That's the "gossip" part of this.

What should be achieved first is to have more outgoing connections, currently we loose every single outgoing connection after a while.