### PR TITLE
rm std/random from beacon_chain and rm attestation timing randomness

### DIFF
--- a/beacon_chain/eth1/deposit_contract.nim
+++ b/beacon_chain/eth1/deposit_contract.nim
@@ -261,12 +261,10 @@ proc main() {.async.} =
 
     if cfg.maxDelay > 0.0:
       delayGenerator = proc (): chronos.Duration =
-        # TODO remove .int, because new rand() already returns int
         let
           minDelay = (cfg.minDelay*1000).int64
           maxDelay = (cfg.maxDelay*1000).int64
         chronos.milliseconds (rng[].rand(maxDelay - minDelay) + minDelay)
-        # (rand(cfg.minDelay..cfg.maxDelay)*1000).int
 
     await sendDeposits(deposits, cfg.web3Url, cfg.privateKey,
                        cfg.depositContractAddress, delayGenerator)

--- a/beacon_chain/eth1/deposit_contract.nim
+++ b/beacon_chain/eth1/deposit_contract.nim
@@ -1,9 +1,10 @@
 import
-  os, sequtils, strutils, options, json, terminal, random,
+  os, sequtils, strutils, options, json, terminal,
   chronos, chronicles, confutils, stint, json_serialization,
   ../filepath,
   ../networking/network_metadata,
-  web3, web3/confutils_defs, eth/keys, stew/io2,
+  web3, web3/confutils_defs, eth/keys, eth/p2p/discoveryv5/random2,
+  stew/io2,
   ../spec/[datatypes, crypto, presets], ../ssz/merkleization,
   ../validators/keystore_management
 
@@ -260,7 +261,12 @@ proc main() {.async.} =
 
     if cfg.maxDelay > 0.0:
       delayGenerator = proc (): chronos.Duration =
-        chronos.milliseconds (rand(cfg.minDelay..cfg.maxDelay)*1000).int
+        # TODO remove .int, because new rand() already returns int
+        let
+          minDelay = (cfg.minDelay*1000).int64
+          maxDelay = (cfg.maxDelay*1000).int64
+        chronos.milliseconds (rng[].rand(maxDelay - minDelay) + minDelay)
+        # (rand(cfg.minDelay..cfg.maxDelay)*1000).int
 
     await sendDeposits(deposits, cfg.web3Url, cfg.privateKey,
                        cfg.depositContractAddress, delayGenerator)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -7,8 +7,8 @@
 
 import
   # Standard library
-  std/[math, os, sequtils, strformat, strutils, tables, times,
-       terminal, osproc],
+  std/[math, os, osproc, random, sequtils, strformat, strutils,
+       tables, times, terminal],
   system/ansi_c,
 
   # Nimble packages
@@ -213,6 +213,9 @@ proc init*(T: type BeaconNode,
     except CatchableError as e:
       error "Failed to initialize database", err = e.msg
       quit 1
+
+  # Doesn't use std/random directly, but dependencies might
+  randomize()
 
   info "Loading block dag from database", path = config.databaseDir
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -215,7 +215,7 @@ proc init*(T: type BeaconNode,
       quit 1
 
   # Doesn't use std/random directly, but dependencies might
-  randomize()
+  randomize(rng[].rand(high(int)))
 
   info "Loading block dag from database", path = config.databaseDir
 

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[os, tables, random, strutils, typetraits],
+  std/[os, tables, strutils, typetraits],
 
   # Nimble packages
   chronos, confutils/defs,
@@ -46,8 +46,6 @@ proc updateLogLevel*(logLevel: string) =
         warn "Unrecognized logging topic", topic = topicName
 
 proc setupLogging*(logLevel: string, logFile: Option[OutFile]) =
-  randomize()
-
   if logFile.isSome:
     when defaultChroniclesStream.outputs.type.arity > 1:
       block openLogFile:

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -27,7 +27,8 @@ import
   ./ssz/merkleization,
   ./spec/eth2_apis/callsigs_types,
   ./validators/[attestation_aggregation, keystore_management, validator_pool, slashing_protection],
-  ./eth/db/[kvstore, kvstore_sqlite3]
+  ./eth/db/[kvstore, kvstore_sqlite3],
+  ./eth/keys, ./eth/p2p/discoveryv5/random2
 
 logScope: topics = "vc"
 
@@ -282,7 +283,11 @@ programMain:
   setupLogging(config.logLevel, config.logFile)
 
   # Doesn't use std/random directly, but dependencies might
-  randomize()
+  let rng = keys.newRng()
+  if rng.isNil:
+    randomize()
+  else:
+    randomize(rng[].rand(high(int)))
 
   case config.cmd
   of VCNoCommand:

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -7,7 +7,7 @@
 
 import
   # Standard library
-  os, strutils, json,
+  std/[os, json, random, strutils],
 
   # Nimble packages
   stew/shims/[tables, macros],
@@ -280,6 +280,9 @@ programMain:
   setupStdoutLogging(config.logLevel)
 
   setupLogging(config.logLevel, config.logFile)
+
+  # Doesn't use std/random directly, but dependencies might
+  randomize()
 
   case config.cmd
   of VCNoCommand:

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -75,10 +75,6 @@ const
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#misc
   ATTESTATION_SUBNET_COUNT* = 64
 
-  # https://github.com/ethereum/eth2.0-specs/pull/2101
-  ATTESTATION_PRODUCTION_DIVISOR* = 3
-  ATTESTATION_ENTROPY_DIVISOR* = 12
-
 template maxSize*(n: int) {.pragma.}
 
 # Block validation flow


### PR DESCRIPTION
This had been proposed for the spec, but eventually was rejected. It also removes one of the last three `std/random` imports in `beacon_chain/`.

25 randomly sampled attestation `delay`s (i.e. offset from 4 seconds after slot start) in `unstable`:
```
-3s203ms49us860ns
-3s20ms672us288ns
-3s24ms349us898ns
-3s293ms576us885ns
-3s32ms523us780ns
-3s3ms858us197ns
-3s50ms815us889ns
-2s108ms489us322ns
-2s180ms64us948ns
-2s312ms775us398ns
-2s469ms205us340ns
-2s495ms128us559ns
-2s573ms858us386ns
-2s680ms42us680ns
-2s739ms554us524ns
-2s916ms546us44ns
-2s936ms288us619ns
-1s207ms607us425ns
-1s622ms890us27ns
-1s704ms863us984ns
-956ms365us853ns
-930ms738us780ns
-336ms891us559ns
685ms466us165ns
965ms754us548ns
```
and with this PR:
```
-3s116ms631us807ns
-3s135ms439us632ns
-3s156ms318us374ns
-3s1ms59us989ns
-3s207ms769us990ns
-3s221ms888us695ns
-3s276ms681us428ns
-3s68ms544us183ns
-2s799ms941us938ns
-2s821ms491us70ns
-2s893ms96us438ns
-2s916ms672us253ns
-2s932ms439us163ns
-2s937ms764us666ns
-2s962ms458us261ns
-2s963ms125us107ns
-1s279ms524us578ns
-1s786ms780us775ns
-971ms260us49ns
13s448ms835us353ns
75ms53us444ns
100ms126us292ns
104ms20us327ns
112ms785us764ns
492ms325us227ns
```

There's generally a minor difference, because both respond to a valid block proposal, then wait at least 250ms to try reduce other nodes rejecting attestations without known blocks, rather than wait all 4 seconds.