### PR TITLE
Slashing db pruning [Merge only after v2 has been default for 1 noticeable release]

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -226,7 +226,11 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Slashing Protection DB [Preset: mainnet]
 ```diff
 + Attestation ordering #1698                                                                 OK
++ Don't prune the very last attestation(s) even by mistake                                   OK
++ Don't prune the very last block even by mistake                                            OK
 + Empty database [Preset: mainnet]                                                           OK
++ Pruning attestations works                                                                 OK
++ Pruning blocks works                                                                       OK
 + SP for block proposal - backtracking append                                                OK
 + SP for block proposal - linear append                                                      OK
 + SP for same epoch attestation target - linear append                                       OK
@@ -234,7 +238,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + SP for surrounding attestations                                                            OK
 + Test valid attestation #1699                                                               OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Spec datatypes
 ```diff
 + Graffiti bytes                                                                             OK
@@ -319,4 +323,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 176/185 Fail: 0/185 Skip: 9/185
+OK: 180/189 Fail: 0/189 Skip: 9/189

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -267,15 +267,19 @@ proc pruneAfterFinalization*(
        db: SlashingProtectionDB,
        finalizedEpoch: Epoch
      ) =
-  # TODO
-  # call sqlPruneAfterFinalizationBlocks
-  # and sqlPruneAfterFinalizationAttestations
-  # and test that wherever pruning happens, tests still pass
-  # and/or devise new tests
+  ## Prune blocks and attestations after a specified `finalizedEpoch`
+  ## The block with the highest slot
+  ## and the attestation(s) with the highest source and target epochs
+  ## are never pruned.
+  ##
+  ## This ensures that even if pruning is called with an incorrect epoch
+  ## slashing protection can fallback to the minimal / high-watermark protection mode.
+  ##
+  ## Pruning is only done if pruning is enabled (DB in kLowWatermarkV2 mode)
+  ## Pruning is only triggered on v2 database.
 
-  # {.error: "NotImplementedError".}
-  fatal "Pruning is not implemented"
-  quit 1
+  if kLowWatermarkV2 in db.modes:
+    db.db_v2.pruneAfterFinalization(finalizedEpoch)
 
 # The high-level import/export functions are
 # - importSlashingInterchange

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -626,7 +626,7 @@ suite "Slashing Protection DB" & preset():
           Epoch 20, Epoch 30
         ).isOk
 
-  wrappedTimedTest "Pruning blocks works":
+  test "Pruning blocks works":
     block:
       sqlite3db_delete(TestDir, TestDbName)
       let db = SlashingProtectionDB.init(
@@ -639,18 +639,21 @@ suite "Slashing Protection DB" & preset():
         sqlite3db_delete(TestDir, TestDbName)
 
       db.registerBlock(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 10,
         fakeRoot(10)
-      )
+      ).expect("registered block")
       db.registerBlock(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 1000,
         fakeRoot(20)
-      )
+      ).expect("registered block")
 
       # After pruning, duplicate becomes a min slot violation
       doAssert db.checkSlashableBlockProposal(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 10,
       ).error.kind == DoubleProposal
@@ -660,11 +663,12 @@ suite "Slashing Protection DB" & preset():
       )
 
       doAssert db.checkSlashableBlockProposal(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 10,
       ).error.kind == MinSlotViolation
 
-  wrappedTimedTest "Don't prune the very last block even by mistake":
+  test "Don't prune the very last block even by mistake":
     block:
       sqlite3db_delete(TestDir, TestDbName)
       let db = SlashingProtectionDB.init(
@@ -677,17 +681,20 @@ suite "Slashing Protection DB" & preset():
         sqlite3db_delete(TestDir, TestDbName)
 
       db.registerBlock(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 10,
         fakeRoot(10)
-      )
+      ).expect("registered block")
       db.registerBlock(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 1000,
         fakeRoot(20)
-      )
+      ).expect("registered block")
 
       doAssert db.checkSlashableBlockProposal(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 1000,
       ).error.kind == DoubleProposal
@@ -699,11 +706,12 @@ suite "Slashing Protection DB" & preset():
 
       # Last block is still there
       doAssert db.checkSlashableBlockProposal(
+        ValidatorIndex(100),
         fakeValidator(100),
         Slot 1000,
       ).error.kind == DoubleProposal
 
-  wrappedTimedTest "Pruning attestations works":
+  test "Pruning attestations works":
     block:
       sqlite3db_delete(TestDir, TestDbName)
       let db = SlashingProtectionDB.init(
@@ -717,34 +725,39 @@ suite "Slashing Protection DB" & preset():
 
 
       db.registerAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 10, Epoch 20,
         fakeRoot(20)
-      )
+      ).expect("registered block")
 
       db.registerAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 40, Epoch 50,
         fakeRoot(50)
-      )
+      ).expect("registered block")
 
       # After pruning, duplicate becomes a min source epoch violation
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 10, Epoch 20
       ).error.kind == DoubleVote
 
       # After pruning, surrounding vote becomes a min source epoch violation
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 9, Epoch 21
-      ).error.kind == SurroundingVote
+      ).error.kind == SurroundVote
 
       # After pruning, surrounded vote becomes a min source epoch violation
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 11, Epoch 19
-      ).error.kind == SurroundedVote
+      ).error.kind == SurroundVote
 
       # --------------------------------
       db.pruneAfterFinalization(
@@ -753,16 +766,19 @@ suite "Slashing Protection DB" & preset():
       # --------------------------------
 
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 10, Epoch 20
       ).error.kind == MinSourceViolation
 
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 9, Epoch 21
       ).error.kind == MinSourceViolation
 
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 11, Epoch 19
       ).error.kind == MinSourceViolation
@@ -770,7 +786,7 @@ suite "Slashing Protection DB" & preset():
       # TODO is it possible to actually trigger MinTargetViolation
       # given all the other constraints?
 
-  wrappedTimedTest "Don't prune the very last attestation(s) even by mistake":
+  test "Don't prune the very last attestation(s) even by mistake":
     block:
       sqlite3db_delete(TestDir, TestDbName)
       let db = SlashingProtectionDB.init(
@@ -783,16 +799,18 @@ suite "Slashing Protection DB" & preset():
         sqlite3db_delete(TestDir, TestDbName)
 
       db.registerAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 10, Epoch 20,
         fakeRoot(20)
-      )
+      ).expect("registered block")
 
       db.registerAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 40, Epoch 50,
         fakeRoot(50)
-      )
+      ).expect("registered block")
 
       # --------------------------------
       db.pruneAfterFinalization(
@@ -801,6 +819,7 @@ suite "Slashing Protection DB" & preset():
       # --------------------------------
 
       doAssert db.checkSlashableAttestation(
+        ValidatorIndex(100),
         fakeValidator(100),
         Epoch 40, Epoch 50
       ).error.kind == DoubleVote


### PR DESCRIPTION
This enables pruning of the slashing DB for the v2 DB.

As a protective measure, pruning will never removes the very last attestations/blocks so that inputting an epoch in the far future by mistake (wrong code, overflow, ...) doesn't put user funds at risks of slashing.

## Release schedule

In terms of timing, right now the default slashing protection DB formats supported are v1+v2,
I strongly suggest tagging the release that switches to `v2` format only as `1.1.0`.
Then, `1.1.x` can rely and build on the fact that `v2` is used and that users are likely not going back to `1.0.x`.

Hence the future that can be enabled on `1.1.x` are at the very least pruning (this PR), and a refactor of Doppelganger Detection to use the slashing DB v2 database.