### PR TITLE
write state diffs to separate table (and experimentally, files instead of db)

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -348,7 +348,8 @@ proc new*(T: type BeaconChainDB,
           fileStateStorage = false,
     ): BeaconChainDB =
   var sqliteStore = if inMemory:
-      SqStoreRef.init("", "test", inMemory = true).expect("working database (out of memory?)")
+      SqStoreRef.init("", "test", Keyspaces, inMemory = true).expect(
+        "working database (out of memory?)")
     else:
       let s = secureCreatePath(dir)
       doAssert s.isOk # TODO(zah) Handle this in a better way

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -19,6 +19,69 @@ import
   ./filepath
 
 type
+  # TODO when DirStoreRef and helpers are placed in a separate module, kvStore
+  #      doesn't find it.. :/
+  #      eth/db/kvstore.nim(75, 6) Error: type mismatch: got <DirStoreRef, openArray[byte], openArray[byte]>
+  DirStoreRef* = ref object of RootObj
+    root: string
+
+proc splitName(db: DirStoreRef, name: openArray[byte]): tuple[dir, file: string] =
+  # Splitting the name helps keep the number of files per directory down - up
+  # to 65536 folders will be created
+  if name.len() > 2:
+    (db.root & "/" & name.toOpenArray(0, 1).toHex(), name.toOpenArray(2, name.high()).toHex())
+  else:
+    (db.root & "/" & "0000", name.toHex())
+
+proc get*(db: DirStoreRef, key: openArray[byte], onData: DataProc): KvResult[bool] =
+  let
+    (root, name) = db.splitName(key)
+    fileName = root & "/" & name
+
+  var data: seq[byte]
+
+  if readFile(fileName, data).isOk():
+    onData(data)
+    ok(true)
+  else:
+    # Serious errors are caught when writing, so we simplify things and say
+    # the entry doesn't exist if for any reason we can't read it
+    # TODO align this with `contains` that simply checks if the file exists
+    ok(false)
+
+proc del*(db: DirStoreRef, key: openArray[byte]): KvResult[void] =
+  let
+    (root, name) = db.splitName(key)
+    fileName = root & "/" & name
+
+  removeFile(fileName).mapErr(ioErrorMsg)
+
+proc contains*(db: DirStoreRef, key: openArray[byte]): KvResult[bool] =
+  let
+    (root, name) = db.splitName(key)
+    fileName = root & "/" & name
+
+  ok(isFile(fileName))
+
+proc put*(db: DirStoreRef, key, val: openArray[byte]): KvResult[void] =
+  let
+    (root, name) = db.splitName(key)
+    fileName = root & "/" & name
+
+  ? createPath(root).mapErr(ioErrorMsg)
+  ? io2.writeFile(fileName, val).mapErr(ioErrorMsg)
+
+  ok()
+
+proc close*(db: DirStoreRef): KvResult[void] =
+  discard
+
+proc init*(T: type DirStoreRef, root: string): T =
+  T(
+    root: root,
+  )
+
+type
   DbSeq*[T] = object
     insertStmt: SqliteStmt[openArray[byte], void]
     selectStmt: SqliteStmt[int64, openArray[byte]]
@@ -61,7 +124,7 @@ type
 
     checkpoint*: proc() {.gcsafe, raises: [Defect].}
 
-    rootDir: string
+    stateStore: KvStoreRef
 
   Keyspaces* = enum
     defaultKeyspace = "kvstore"
@@ -264,6 +327,7 @@ proc init*(T: type BeaconChainDB,
       DbSeq[DepositData].init(sqliteStore, "genesis_deposits")
     immutableValidatorsSeq =
       DbSeq[ImmutableValidatorData].init(sqliteStore, "immutable_validators")
+    stateStore = DirStoreRef.init(dir & "/state")
 
   T(backend: kvStore sqliteStore,
     preset: preset,
@@ -271,46 +335,8 @@ proc init*(T: type BeaconChainDB,
     immutableValidators: immutableValidatorsSeq,
     immutableValidatorsMem: loadImmutableValidators(immutableValidatorsSeq),
     checkpoint: proc() = sqliteStore.checkpoint(),
-    rootDir: dir,
+    stateStore: kvStore stateStore,
     )
-
-proc splitName(name: openArray[byte]): tuple[dir, file: string] =
-  if name.len() > 2:
-    (name.toOpenArray(0, 1).toHex(), name.toOpenArray(2, name.high()).toHex())
-  else:
-    ("0000", name.toHex())
-
-proc filePut(db: BeaconChainDB, key: openArray[byte], value: openArray[byte]) =
-  let
-    (dir, name) = splitName(key)
-    root = db.rootDir & "/" & dir
-    fileName = root & "/" & name
-
-  createPath(root).expect("Creating directory works: " & root)
-
-  io2.writeFile(fileName, value).expect("Writing file works: " & fileName)
-
-proc fileGet(db: BeaconChainDB, key: openArray[byte], onData: DataProc): Result[bool, string] =
-  let
-    (dir, name) = splitName(key)
-    root = db.rootDir & "/" & dir
-    fileName = root & "/" & name
-
-  var data: seq[byte]
-  # We don't return error here - instead, if the file can't be loaded,
-  if readFile(fileName, data).isErr():
-    return ok(false)
-
-  onData(data)
-  ok(true)
-
-proc fileDel(db: BeaconChainDB, key: openArray[byte]) =
-  let
-    (dir, name) = splitName(key)
-    root = db.rootDir & "/" & dir
-    fileName = root & "/" & name
-
-  discard removeFile(fileName)
 
 proc snappyEncode(inp: openArray[byte]): seq[byte] =
   try:
@@ -325,15 +351,14 @@ proc sszEncode(v: auto): seq[byte] =
     # In-memory encode shouldn't fail!
     raiseAssert err.msg
 
-proc put(db: BeaconChainDB, key: openArray[byte], v: Eth2Digest) =
-  db.backend.put(key, v.data).expect("working database (disk broken/full?)")
+proc putRaw(db: KvStoreRef, key: openArray[byte], v: Eth2Digest) =
+  db.put(key, v.data).expect("working database (disk broken/full?)")
 
-proc put(db: BeaconChainDB, key: openArray[byte], v: auto) =
-  db.backend.put(key, snappyEncode(sszEncode(v))).expect("working database (disk broken/full?)")
-proc fileEncodePut(db: BeaconChainDB, key: openArray[byte], v: auto) =
-  db.filePut(key, snappyEncode(sszEncode(v)))
+proc putEncoded(db: KvStoreRef, key: openArray[byte], v: auto) =
+  db.put(key, snappyEncode(sszEncode(v))).expect(
+    "working database (disk broken/full?)")
 
-proc get(db: BeaconChainDB, key: openArray[byte], T: type Eth2Digest): Opt[T] =
+proc getRaw(db: KvStoreRef, key: openArray[byte], T: type Eth2Digest): Opt[T] =
   var res: Opt[T]
   proc decode(data: openArray[byte]) =
     if data.len == 32:
@@ -345,7 +370,7 @@ proc get(db: BeaconChainDB, key: openArray[byte], T: type Eth2Digest): Opt[T] =
        typ = name(T), dataLen = data.len
       discard
 
-  discard db.backend.get(key, decode).expect("working database (disk broken/full?)")
+  discard db.get(key, decode).expect("working database (disk broken/full?)")
 
   res
 
@@ -354,7 +379,7 @@ type GetResult = enum
   notFound = "Not found"
   corrupted = "Corrupted"
 
-proc get[T](db: BeaconChainDB, key: openArray[byte], output: var T): GetResult =
+proc getEncoded[T](db: KvStoreRef, key: openArray[byte], output: var T): GetResult =
   var status = GetResult.notFound
 
   # TODO address is needed because there's no way to express lifetimes in nim
@@ -376,33 +401,7 @@ proc get[T](db: BeaconChainDB, key: openArray[byte], output: var T): GetResult =
         err = e.msg, typ = name(T), dataLen = data.len
       status = GetResult.corrupted
 
-  discard db.backend.get(key, decode).expect("working database (disk broken/full?)")
-
-  status
-
-proc fileGet[T](db: BeaconChainDB, key: openArray[byte], output: var T): GetResult =
-  var status = GetResult.notFound
-
-  # TODO address is needed because there's no way to express lifetimes in nim
-  #      we'll use unsafeAddr to find the code later
-  var outputPtr = unsafeAddr output # callback is local, ptr wont escape
-  proc decode(data: openArray[byte]) =
-    try:
-      let decompressed = snappy.decode(data, maxDecompressedDbRecordSize)
-      if decompressed.len > 0:
-        outputPtr[] = SSZ.decode(decompressed, T, updateRoot = false)
-        status = GetResult.found
-      else:
-        warn "Corrupt snappy record found in database", typ = name(T)
-        status = GetResult.corrupted
-    except SerializationError as e:
-      # If the data can't be deserialized, it could be because it's from a
-      # version of the software that uses a different SSZ encoding
-      warn "Unable to deserialize data, old database?",
-        err = e.msg, typ = name(T), dataLen = data.len
-      status = GetResult.corrupted
-
-  discard db.fileGet(key, decode).expect("working database (disk broken/full?)")
+  discard db.get(key, decode).expect("working database (disk broken/full?)")
 
   status
 
@@ -417,14 +416,17 @@ func toBeaconBlockSummary(v: SomeBeaconBlock): BeaconBlockSummary =
 
 # TODO: we should only store TrustedSignedBeaconBlock in the DB.
 proc putBlock*(db: BeaconChainDB, value: SignedBeaconBlock) =
-  db.put(subkey(type value, value.root), value)
-  db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
+  db.backend.putEncoded(subkey(type value, value.root), value)
+  db.backend.putEncoded(
+    subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
 proc putBlock*(db: BeaconChainDB, value: TrustedSignedBeaconBlock) =
-  db.put(subkey(SignedBeaconBlock, value.root), value)
-  db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
+  db.backend.putEncoded(subkey(SignedBeaconBlock, value.root), value)
+  db.backend.putEncoded(
+    subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
 proc putBlock*(db: BeaconChainDB, value: SigVerifiedSignedBeaconBlock) =
-  db.put(subkey(SignedBeaconBlock, value.root), value)
-  db.put(subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
+  db.backend.putEncoded(subkey(SignedBeaconBlock, value.root), value)
+  db.backend.putEncoded(
+    subkey(BeaconBlockSummary, value.root), value.message.toBeaconBlockSummary())
 
 proc updateImmutableValidators(
     db: BeaconChainDB, immutableValidators: var seq[ImmutableValidatorData],
@@ -447,7 +449,7 @@ proc updateImmutableValidators(
 
 proc putState*(db: BeaconChainDB, key: Eth2Digest, value: var BeaconState) =
   updateImmutableValidators(db, db.immutableValidatorsMem, value.validators)
-  db.fileEncodePut(
+  db.stateStore.putEncoded(
     subkey(BeaconStateNoImmutableValidators, key),
     isomorphicCast[BeaconStateNoImmutableValidators](value))
 
@@ -455,17 +457,17 @@ proc putState*(db: BeaconChainDB, value: var BeaconState) =
   db.putState(hash_tree_root(value), value)
 
 proc putStateFull*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
-  db.put(subkey(BeaconState, key), value)
+  db.backend.putEncoded(subkey(BeaconState, key), value)
 
 proc putStateFull*(db: BeaconChainDB, value: BeaconState) =
   db.putStateFull(hash_tree_root(value), value)
 
 proc putStateRoot*(db: BeaconChainDB, root: Eth2Digest, slot: Slot,
     value: Eth2Digest) =
-  db.put(subkey(root, slot), value)
+  db.backend.putRaw(subkey(root, slot), value)
 
 proc putStateDiff*(db: BeaconChainDB, root: Eth2Digest, value: BeaconStateDiff) =
-  db.put(subkey(BeaconStateDiff, root), value)
+  db.backend.putEncoded(subkey(BeaconStateDiff, root), value)
 
 proc delBlock*(db: BeaconChainDB, key: Eth2Digest) =
   db.backend.del(subkey(SignedBeaconBlock, key)).expect("working database (disk broken/full?)")
@@ -473,7 +475,8 @@ proc delBlock*(db: BeaconChainDB, key: Eth2Digest) =
 
 proc delState*(db: BeaconChainDB, key: Eth2Digest) =
   db.backend.del(subkey(BeaconState, key)).expect("working database (disk broken/full?)")
-  db.fileDel(subkey(BeaconStateNoImmutableValidators, key))
+  db.stateStore.del(subkey(BeaconStateNoImmutableValidators, key)).expect(
+    "working filesystem (disk broken/full?)")
 
 proc delStateRoot*(db: BeaconChainDB, root: Eth2Digest, slot: Slot) =
   db.backend.del(subkey(root, slot)).expect("working database (disk broken/full?)")
@@ -482,30 +485,30 @@ proc delStateDiff*(db: BeaconChainDB, root: Eth2Digest) =
   db.backend.del(subkey(BeaconStateDiff, root)).expect("working database (disk broken/full?)")
 
 proc putHeadBlock*(db: BeaconChainDB, key: Eth2Digest) =
-  db.put(subkey(kHeadBlock), key)
+  db.backend.putRaw(subkey(kHeadBlock), key)
 
 proc putTailBlock*(db: BeaconChainDB, key: Eth2Digest) =
-  db.put(subkey(kTailBlock), key)
+  db.backend.putRaw(subkey(kTailBlock), key)
 
 proc putGenesisBlockRoot*(db: BeaconChainDB, key: Eth2Digest) =
-  db.put(subkey(kGenesisBlockRoot), key)
+  db.backend.putRaw(subkey(kGenesisBlockRoot), key)
 
 proc putEth1FinalizedTo*(db: BeaconChainDB,
                          eth1Checkpoint: DepositContractSnapshot) =
-  db.put(subkey(kDepositsFinalizedByEth1), eth1Checkpoint)
+  db.backend.putEncoded(subkey(kDepositsFinalizedByEth1), eth1Checkpoint)
 
 proc putEth2FinalizedTo*(db: BeaconChainDB,
                          eth1Checkpoint: DepositContractSnapshot) =
-  db.put(subkey(kDepositsFinalizedByEth2), eth1Checkpoint)
+  db.backend.putEncoded(subkey(kDepositsFinalizedByEth2), eth1Checkpoint)
 
 proc putSpeculativeDeposits*(db: BeaconChainDB,
                              eth1Checkpoint: DepositContractSnapshot) =
-  db.put(subkey(kSpeculativeDeposits), eth1Checkpoint)
+  db.backend.putEncoded(subkey(kSpeculativeDeposits), eth1Checkpoint)
 
 proc getBlock*(db: BeaconChainDB, key: Eth2Digest): Opt[TrustedSignedBeaconBlock] =
   # We only store blocks that we trust in the database
   result.ok(TrustedSignedBeaconBlock())
-  if db.get(subkey(SignedBeaconBlock, key), result.get) != GetResult.found:
+  if db.backend.getEncoded(subkey(SignedBeaconBlock, key), result.get) != GetResult.found:
     result.err()
   else:
     # set root after deserializing (so it doesn't get zeroed)
@@ -514,7 +517,7 @@ proc getBlock*(db: BeaconChainDB, key: Eth2Digest): Opt[TrustedSignedBeaconBlock
 proc getBlockSummary*(db: BeaconChainDB, key: Eth2Digest): Opt[BeaconBlockSummary] =
   # We only store blocks that we trust in the database
   result.ok(BeaconBlockSummary())
-  if db.get(subkey(BeaconBlockSummary, key), result.get) != GetResult.found:
+  if db.backend.getEncoded(subkey(BeaconBlockSummary, key), result.get) != GetResult.found:
     result.err()
 
 proc getStateOnlyMutableValidators(
@@ -531,7 +534,7 @@ proc getStateOnlyMutableValidators(
   # TODO RVO is inefficient for large objects:
   #      https://github.com/nim-lang/Nim/issues/13879
 
-  case db.fileGet(
+  case db.stateStore.getEncoded(
     subkey(
       BeaconStateNoImmutableValidators, key),
       isomorphicCast[BeaconStateNoImmutableValidators](output))
@@ -578,7 +581,7 @@ proc getState*(
   if getStateOnlyMutableValidators(db, key, output, rollback):
     return true
 
-  case db.get(subkey(BeaconState, key), output)
+  case db.backend.getEncoded(subkey(BeaconState, key), output)
   of GetResult.found:
     true
   of GetResult.notFound:
@@ -590,37 +593,37 @@ proc getState*(
 proc getStateRoot*(db: BeaconChainDB,
                    root: Eth2Digest,
                    slot: Slot): Opt[Eth2Digest] =
-  db.get(subkey(root, slot), Eth2Digest)
+  db.backend.getRaw(subkey(root, slot), Eth2Digest)
 
 proc getStateDiff*(db: BeaconChainDB,
                    root: Eth2Digest): Opt[BeaconStateDiff] =
   result.ok(BeaconStateDiff())
-  if db.get(subkey(BeaconStateDiff, root), result.get) != GetResult.found:
+  if db.backend.getEncoded(subkey(BeaconStateDiff, root), result.get) != GetResult.found:
     result.err
 
 proc getHeadBlock*(db: BeaconChainDB): Opt[Eth2Digest] =
-  db.get(subkey(kHeadBlock), Eth2Digest)
+  db.backend.getRaw(subkey(kHeadBlock), Eth2Digest)
 
 proc getTailBlock*(db: BeaconChainDB): Opt[Eth2Digest] =
-  db.get(subkey(kTailBlock), Eth2Digest)
+  db.backend.getRaw(subkey(kTailBlock), Eth2Digest)
 
 proc getGenesisBlockRoot*(db: BeaconChainDB): Eth2Digest =
-  db.get(subkey(kGenesisBlockRoot), Eth2Digest).expect(
+  db.backend.getRaw(subkey(kGenesisBlockRoot), Eth2Digest).expect(
     "The database must be seeded with the genesis state")
 
 proc getEth1FinalizedTo*(db: BeaconChainDB): Opt[DepositContractSnapshot] =
   result.ok(DepositContractSnapshot())
-  let r = db.get(subkey(kDepositsFinalizedByEth1), result.get)
+  let r = db.backend.getEncoded(subkey(kDepositsFinalizedByEth1), result.get)
   if r != found: result.err()
 
 proc getEth2FinalizedTo*(db: BeaconChainDB): Opt[DepositContractSnapshot] =
   result.ok(DepositContractSnapshot())
-  let r = db.get(subkey(kDepositsFinalizedByEth2), result.get)
+  let r = db.backend.getEncoded(subkey(kDepositsFinalizedByEth2), result.get)
   if r != found: result.err()
 
 proc getSpeculativeDeposits*(db: BeaconChainDB): Opt[DepositContractSnapshot] =
   result.ok(DepositContractSnapshot())
-  let r = db.get(subkey(kSpeculativeDeposits), result.get)
+  let r = db.backend.getEncoded(subkey(kSpeculativeDeposits), result.get)
   if r != found: result.err()
 
 proc delSpeculativeDeposits*(db: BeaconChainDB) =
@@ -630,7 +633,7 @@ proc containsBlock*(db: BeaconChainDB, key: Eth2Digest): bool =
   db.backend.contains(subkey(SignedBeaconBlock, key)).expect("working database (disk broken/full?)")
 
 proc containsState*(db: BeaconChainDB, key: Eth2Digest): bool =
-  db.backend.contains(subkey(BeaconStateNoImmutableValidators, key)).expect(
+  db.stateStore.contains(subkey(BeaconStateNoImmutableValidators, key)).expect(
       "working database  (disk broken/full?)") or
     db.backend.contains(subkey(BeaconState, key)).expect("working database (disk broken/full?)")
 
@@ -647,7 +650,7 @@ iterator getAncestors*(db: BeaconChainDB, root: Eth2Digest):
   var
     res: TrustedSignedBeaconBlock
     root = root
-  while db.get(subkey(SignedBeaconBlock, root), res) == GetResult.found:
+  while db.backend.getEncoded(subkey(SignedBeaconBlock, root), res) == GetResult.found:
     res.root = root
     yield res
     root = res.message.parent_root
@@ -665,12 +668,12 @@ iterator getAncestorSummaries*(db: BeaconChainDB, root: Eth2Digest):
     root = root
 
   while true:
-    if db.get(subkey(BeaconBlockSummary, root), res.summary) == GetResult.found:
+    if db.backend.getEncoded(subkey(BeaconBlockSummary, root), res.summary) == GetResult.found:
       res.root = root
       yield res
-    elif db.get(subkey(SignedBeaconBlock, root), tmp) == GetResult.found:
+    elif db.backend.getEncoded(subkey(SignedBeaconBlock, root), tmp) == GetResult.found:
       res.summary = tmp.message.toBeaconBlockSummary()
-      db.put(subkey(BeaconBlockSummary, root), res.summary)
+      db.backend.putEncoded(subkey(BeaconBlockSummary, root), res.summary)
       res.root = root
       yield res
     else:

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -302,10 +302,12 @@ proc loadImmutableValidators(db: BeaconChainDB): seq[ImmutableValidatorData] =
   for i in 0 ..< db.immutableValidators.len:
     result.add db.immutableValidators.get(i)
 
-proc init*(T: type BeaconChainDB,
-           preset: RuntimePreset,
-           dir: string,
-           inMemory = false): BeaconChainDB =
+proc new*(T: type BeaconChainDB,
+          preset: RuntimePreset,
+          dir: string,
+          inMemory = false,
+          fileStateStorage = false,
+    ): BeaconChainDB =
   var sqliteStore = if inMemory:
       SqStoreRef.init("", "test", inMemory = true).expect("working database (out of memory?)")
     else:
@@ -328,7 +330,8 @@ proc init*(T: type BeaconChainDB,
       DbSeq[ImmutableValidatorData].init(sqliteStore, "immutable_validators")
     backend = kvStore sqliteStore
     stateStore =
-      if inMemory: backend else: kvStore DirStoreRef.init(dir & "/state")
+      if inMemory or (not fileStateStorage): backend
+      else: kvStore DirStoreRef.init(dir & "/state")
 
   T(backend: backend,
     preset: preset,

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -70,6 +70,10 @@ type
     v2
     both
 
+  StateDbKind* {.pure.} = enum
+    sql
+    file
+
   BeaconNodeConf* = object
     logLevel* {.
       defaultValue: "INFO"
@@ -144,6 +148,12 @@ type
       defaultValue: SlashingDbKind.both
       desc: "The slashing DB flavour to use (v1, v2 or both) [=both]"
       name: "slashing-db-kind" }: SlashingDbKind
+
+    stateDbKind* {.
+      hidden
+      defaultValue: StateDbKind.sql
+      desc: "State DB kind (sql, file) [=sql]"
+      name: "state-db-kind" }: StateDbKind
 
     case cmd* {.
       command

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -99,7 +99,10 @@ proc init*(T: type BeaconNode,
            genesisDepositsSnapshotContents: string): BeaconNode {.
     raises: [Defect, CatchableError].} =
   let
-    db = BeaconChainDB.init(runtimePreset, config.databaseDir)
+    db = BeaconChainDB.new(
+      runtimePreset, config.databaseDir,
+      inMemory = false,
+      fileStateStorage = config.stateDbKind == StateDbKind.file)
 
   var
     genesisState, checkpointState: ref BeaconState

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -115,9 +115,9 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimePreset) =
   echo "Opening database..."
   let
     db = BeaconChainDB.new(
-      runtimePreset, config.databaseDir.string,
+      runtimePreset, conf.databaseDir.string,
       inMemory = false,
-      fileStateStorage = config.stateDbKind == StateDbKind.file)
+      fileStateStorage = conf.stateDbKind == StateDbKind.file)
     dbBenchmark = BeaconChainDB.new(runtimePreset, "benchmark")
   defer:
     db.close()

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -63,7 +63,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
 
   echo "Starting simulation..."
 
-  let db = BeaconChainDB.init(runtimePreset, "block_sim_db")
+  let db = BeaconChainDB.new(runtimePreset, "block_sim_db")
   defer: db.close()
 
   ChainDAGRef.preInit(db, state[].data, state[].data, genesisBlock)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -42,14 +42,14 @@ func withDigest(blck: TrustedBeaconBlock): TrustedSignedBeaconBlock =
 suiteReport "Beacon chain DB" & preset():
   wrappedTimedTest "empty database" & preset():
     var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+      db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
     check:
       db.getStateRef(Eth2Digest()).isNil
       db.getBlock(Eth2Digest()).isNone
 
   wrappedTimedTest "sanity check blocks" & preset():
     var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+      db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
 
     let
       signedBlock = withDigest(TrustedBeaconBlock())
@@ -172,7 +172,7 @@ suiteReport "Beacon chain DB" & preset():
 
   wrappedTimedTest "find ancestors" & preset():
     var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+      db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
 
     let
       a0 = withDigest(
@@ -218,7 +218,7 @@ suiteReport "Beacon chain DB" & preset():
     # serialization where an all-zero default-initialized bls signature could
     # not be deserialized because the deserialization was too strict.
     var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+      db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
 
     let
       state = initialize_beacon_state_from_eth1(
@@ -239,7 +239,7 @@ suiteReport "Beacon chain DB" & preset():
 
   wrappedTimedTest "sanity check state diff roundtrip" & preset():
     var
-      db = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+      db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
 
     # TODO htr(diff) probably not interesting/useful, but stand-in
     let

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -92,7 +92,7 @@ template timedTest*(name, body) =
   testTimes.add (f, name)
 
 proc makeTestDB*(tailState: var BeaconState, tailBlock: SignedBeaconBlock): BeaconChainDB =
-  result = BeaconChainDB.init(defaultRuntimePreset, "", inMemory = true)
+  result = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
   ChainDAGRef.preInit(result, tailState, tailState, tailBlock)
 
 proc makeTestDB*(validators: Natural): BeaconChainDB =


### PR DESCRIPTION
Here's a fun way to fix https://github.com/status-im/nimbus-eth2/issues/2440 - writing files instead of db records

On my ssd, pruning takes up to a second with sqlite - with the filesystem, I haven't been able to go beyond microseconds on pyrmont.

```
DBG 2021-03-29 15:57:09.152+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="949 nanoseconds"
DBG 2021-03-29 15:57:09.256+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="861 nanoseconds"
DBG 2021-03-29 15:57:09.383+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 688 nanoseconds"
DBG 2021-03-29 15:57:09.441+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 325 nanoseconds"
DBG 2021-03-29 15:57:09.485+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 111 nanoseconds"
DBG 2021-03-29 15:57:09.589+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 231 nanoseconds"
DBG 2021-03-29 15:57:09.694+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="19 microseconds and 696 nanoseconds"
DBG 2021-03-29 15:57:09.797+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 297 nanoseconds"
DBG 2021-03-29 15:57:09.901+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 576 nanoseconds"
DBG 2021-03-29 15:57:10.007+02:00 Pruned the blockchain DAG                  topics="chaindag" tid=140465 file=blockchain_dag.nim:920 currentCandidateHeads=1 dagPruningDuration="1 microsecond and 332 nanoseconds"
```
