### PR TITLE
Import external slashing DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ TOOLS := \
 	nbench_spec_scenarios \
 	ncli \
 	ncli_db \
+	ncli_slashing \
 	process_dashboard \
 	stack_sizes \
 	nimbus_validator_client \

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -38,6 +38,7 @@ type
     wallets
     record
     web3
+    slashingdb
 
   WalletsCmd* {.pure.} = enum
     create  = "Creates a new EIP-2386 wallet"
@@ -73,6 +74,13 @@ type
   StateDbKind* {.pure.} = enum
     sql
     file
+
+  SlashProtCmd* = enum
+    exportAll = "Export the whole validator slashing protection DB to json."
+    `import` = "Import the slashing protection json to the node."
+    `export` = "Export specified validators slashing protection data to json"
+    # migrateAll = "Export and remove the whole validator slashing protection DB."
+    # migrate = "Export and remove specified validators from Nimbus."
 
   BeaconNodeConf* = object
     logLevel* {.
@@ -486,6 +494,20 @@ type
           argument
           desc: "The web3 provider URL to test"
           name: "url" }: Uri
+
+    of slashingdb:
+      # TODO: when this is not set, confutils crashes
+      interchangeFile* {.
+        desc: "Path to the slashing interchange file"
+        name: "interchange" .}: Option[string]
+
+      case slashingdbCmd* {.command.}: SlashProtCmd
+      of SlashProtCmd.exportAll, SlashProtCmd.`import`:
+        discard
+      of SlashProtCmd.`export`:
+        validators* {.
+          argument
+          desc: "One or more validators to export".}: seq[string]
 
   ValidatorClientConf* = object
     logLevel* {.

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -239,7 +239,7 @@ proc writeValue*(writer: var JsonWriter, value: PubKey0x)
 proc readValue*(reader: var JsonReader, value: var PubKey0x)
                {.raises: [SerializationError, IOError, Defect].} =
   try:
-    value = PubKey0x reader.readValue(string).hexToByteArray(RawPubKeySize)
+    value = PubKey0x hexToByteArray(reader.readValue(string), RawPubKeySize)
   except ValueError:
     raiseUnexpectedValue(reader, "Hex string expected")
 

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -9,7 +9,7 @@
 
 import
   # Stdlib
-  std/[typetraits, strutils, algorithm],
+  std/[typetraits, strutils, algorithm, sequtils],
   # Status
   eth/db/[kvstore, kvstore_sqlite3],
   stew/results,
@@ -270,6 +270,24 @@ proc exportSlashingInterchange*(
        path: string, prettify = true) {.raises: [Defect, IOError].} =
   ## Export a database to the Slashing Protection Database Interchange Format
   let spdir = db.toSPDIR()
+  Json.saveFile(path, spdir, prettify)
+  echo "Exported slashing protection DB to '", path, "'"
+
+proc exportPartialSlashingInterchange*(
+       db: SlashingProtectionDB_Concept,
+       validators: seq[string],
+       path: string, prettify = true) {.raises: [Defect, IOError].} =
+  ## Export a database to the Slashing Protection Database Interchange Format
+  # We could modify toSPDIR to do the filtering directly
+  # but this is not a performance sensitive operation.
+  # so it's better to keep it simple.
+  var spdir = db.toSPDIR()
+
+  # O(a log b) with b the number of validators to keep
+  #        and a the total number of validators in DB
+  let validators = validators.sorted()
+  spdir.data.keepItIf(validators.binarySearch("0x" & it.pubkey.PubKeyBytes.toHex()) != -1)
+
   Json.saveFile(path, spdir, prettify)
   echo "Exported slashing protection DB to '", path, "'"
 

--- a/docs/slashing_interchange.md
+++ b/docs/slashing_interchange.md
@@ -1,0 +1,75 @@
+# Slashing interchange
+
+Importing and exporting validators is available via the following commands:
+
+- `path/to/nimbus_beacon_node slashingdb import --interchange=infile.json`
+- `path/to/nimbus_beacon_node slashingdb exportAll --interchange=outfile.json`
+- `path/to/nimbus_beacon_node slashingdb export --interchange=outfile.json --validators=0xAAAA...AAA --validators=0xBBBB...BBBB --validators=0xCCCC...CCCC`
+
+## Importing new validators
+
+## Importing validators
+
+The default command for import into the database is:
+
+```
+build/nimbus_beacon_node slashingdb import --interchange=interchange.json
+```
+
+### With specified validators folder
+
+The validators folder contains the valdiators setup.
+By default it is `path/to/datadir/validators`
+
+```
+build/nimbus_beacon_node slashingdb exportAll --interchange=interchange.json --validators-dir=path/to/validatorsdir/
+```
+
+### With the data-dir folder
+
+The data-dir contains the beacon node setup.
+
+```
+build/nimbus_beacon_node slashingdb exportAll --interchange=interchange.json --data-dir=path/to/datadir/
+```
+
+## Exporting all validators
+
+The default command for exporting the database is:
+
+```
+build/nimbus_beacon_node slashingdb exportAll --interchange=interchange.json
+```
+
+On success you will have a message similar to:
+
+```
+Exported slashing protection DB to 'interchange.json'
+Export finished: '$HOME/.cache/nimbus/BeaconNode/validators/slashing_protection.sqlite3' into 'interchange.json'
+```
+
+### With specified validators folder
+
+The validators folder contains the valdiators setup.
+By default it is `path/to/datadir/validators`
+
+```
+build/nimbus_beacon_node slashingdb exportAll --interchange=interchange.json --validators-dir=path/to/validatorsdir/
+```
+
+### With the data-dir folder
+
+The data-dir contains the beacon node setup.
+
+```
+build/nimbus_beacon_node slashingdb exportAll --interchange=interchange.json --data-dir=path/to/datadir/
+```
+
+## Partial exports
+
+Partial export can be done by specifying the public keys of the relevant validators.
+The `--validators` command can be specified multiple time, once per validator.
+
+```
+build/nimbus_beacon_node slashingdb export --interchange=interchange.json --validators=0xb5da853a51d935da6f3bd46934c719fcca1bbf0b493264d3d9e7c35a1023b73c703b56d598edf0239663820af36ec615
+```

--- a/ncli/ncli_slashing.nim
+++ b/ncli/ncli_slashing.nim
@@ -10,6 +10,7 @@
 import
   std/[os, strutils],
   confutils,
+  serialization, json_serialization,
   eth/db/[kvstore, kvstore_sqlite3],
   ../beacon_chain/validators/slashing_protection,
   ../beacon_chain/spec/digest
@@ -21,24 +22,63 @@ type
 
   SlashProtConf = object
 
+    db{.desc: "The path to the database .sqlite3 file" .}: string
+
     case cmd {.
       command,
-      desc: "Dump database or restore" .}: SlashProtCmd
-    of dump, restore:
-      infile {.argument.}: string
+      desc: "Dump database to or restore from a slashing interchange file" .}: SlashProtCmd
+    of dump:
       outfile {.argument.}: string
+    of restore:
+      infile {.argument.}: string
 
 proc doDump(conf: SlashProtConf) =
-  let (dir, file) = splitPath(conf.infile)
+  let (dir, file) = splitPath(conf.db)
   # TODO: Make it read-only https://github.com/status-im/nim-eth/issues/312
   # TODO: why is sqlite3 always appending .sqlite3 ?
   let filetrunc = file.changeFileExt("")
   let db = SlashingProtectionDB.loadUnchecked(dir, filetrunc, readOnly = false)
   db.exportSlashingInterchange(conf.outfile)
+  echo "Export finished: '", conf.db, "' into '", conf.outfile, "'"
+
+proc doRestore(conf: SlashProtConf) =
+  let (dir, file) = splitPath(conf.db)
+  # TODO: Make it read-only https://github.com/status-im/nim-eth/issues/312
+  # TODO: why is sqlite3 always appending .sqlite3 ?
+  let filetrunc = file.changeFileExt("")
+
+  var spdir: SPDIR
+  try:
+    spdir = JSON.loadFile(conf.infile, SPDIR)
+  except SerializationError as err:
+    writeStackTrace()
+    stderr.write $JSON & " load issue for file \"", conf.infile, "\"\n"
+    stderr.write err.formatMsg(conf.infile), "\n"
+    quit 1
+
+  # Open DB and handle migration from v1 to v2 if needed
+  let db = SlashingProtectionDB.init(
+    genesis_validators_root = Eth2Digest spdir.metadata.genesis_validators_root,
+    basePath = dir,
+    dbname = filetrunc,
+    modes = {kCompleteArchiveV2},
+    disagreementBehavior = kChooseV2
+  )
+
+  # Now import the slashing interchange file
+  # Failures mode:
+  # - siError can only happen with invalid genesis_validators_root which would be caught above
+  # - siPartial can happen for invalid public keys, slashable blocks, slashable votes
+  let status = db.inclSPDIR(spdir)
+  doAssert status in {siSuccess, siPartial}
+
+  echo "Import finished: '", conf.infile, "' into '", conf.db, "'"
+  # TODO: do we mention that v2 MUST be used?
+  #       normally this has always been a hidden option.
 
 when isMainModule:
   let conf = SlashProtConf.load()
 
   case conf.cmd:
   of dump: conf.doDump()
-  of restore: doAssert false, "unimplemented"
+  of restore: conf.doRestore()

--- a/ncli/ncli_slashing.nim
+++ b/ncli/ncli_slashing.nim
@@ -20,7 +20,7 @@ type
     dump = "Dump the validator slashing protection DB to json"
     restore = "Restore the validator slashing protection DB from json"
 
-  SlashProtConf = object
+  SlashProtConf* = object
 
     db{.desc: "The path to the database .sqlite3 file" .}: string
 


### PR DESCRIPTION
This PR:
- implements the command to import external slashing DB
- builds `ncli_slashing` to dump/import slashing DB

API:

**export**

```
build/ncli_slashing dump --db=path/to/data/shared_pyrmont_0/validators/slashing_protection.sqlite3 path/to/test_interchange.json
```

**import**

```
build/ncli_slashing restore --db=path/to/data/shared_pyrmont_0/validators/slashing_protection.sqlite3 path/to/test_interchange.json
```

------

Pending:

Better handling of only v1 or only v2 DBs detection, currently detection is done when we prepare cached queries that refers to non-existing tables.
