### PR TITLE
Remove `-d:insecure` compile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ Specific steps:
 ```bash
 # This will generate the Prometheus config on the fly, based on the number of
 # nodes (which you can control by passing something like NODES=6 to `make`).
-# The `-d:insecure` flag starts an HTTP server from which the Prometheus daemon will pull the metrics.
-make VALIDATORS=192 NODES=6 USER_NODES=0 NIMFLAGS="-d:insecure" eth2_network_simulation
+make VALIDATORS=192 NODES=6 USER_NODES=0 eth2_network_simulation
 
 # In another terminal tab, after the sim started:
 cd tests/simulation/prometheus

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1661,16 +1661,13 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
   config.createDumpDirs()
 
   if config.metricsEnabled:
-    when useInsecureFeatures:
-      let metricsAddress = config.metricsAddress
-      notice "Starting metrics HTTP server",
-        url = "http://" & $metricsAddress & ":" & $config.metricsPort & "/metrics"
-      try:
-        startMetricsHttpServer($metricsAddress, config.metricsPort)
-      except CatchableError as exc: raise exc
-      except Exception as exc: raiseAssert exc.msg # TODO fix metrics
-    else:
-      warn "Metrics support disabled, see https://status-im.github.io/nimbus-eth2/metrics-pretty-pictures.html#simple-metrics"
+    let metricsAddress = config.metricsAddress
+    notice "Starting metrics HTTP server",
+      url = "http://" & $metricsAddress & ":" & $config.metricsPort & "/metrics"
+    try:
+      startMetricsHttpServer($metricsAddress, config.metricsPort)
+    except CatchableError as exc: raise exc
+    except Exception as exc: raiseAssert exc.msg # TODO fix metrics
 
   # There are no managed event loops in here, to do a graceful shutdown, but
   # letting the default Ctrl+C handler exit is safe, since we only read from

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -20,8 +20,6 @@ const
 
   versionBlob* = "stateofus" # Single word - ends up in the default graffitti
 
-  useInsecureFeatures* = defined(insecure)
-
   gitRevision* = strip(staticExec("git rev-parse --short HEAD"))[0..5]
 
   nimBanner* = staticExec("nim --version | grep -v Compiled")

--- a/docs/the_nimbus_book/src/beacon-node-systemd.md
+++ b/docs/the_nimbus_book/src/beacon-node-systemd.md
@@ -8,9 +8,9 @@ Systemd is used in order to have a command or program run when your device boots
 
 ### 1. Create a systemd service
 
-> ⚠️  The HTTP server used for obtaining metrics is considered insecure. If you wish to run the service with metrics enabled, you'll need to compile the beacon node with the insecure flag enabled — `make NIMFLAGS="-d:insecure" nimbus_beacon_node` — and replace `--metrics:off` with `--metrics:on` in the service file below. See [here](./metrics-pretty-pictures.md) for more on metrics.
+> ⚠️  If you wish to run the service with metrics enabled, you'll need to replace `--metrics:off` with `--metrics:on` in the service file below. See [here](./metrics-pretty-pictures.md) for more on metrics.
 
-Create a `systemd` service unit file -- `nbc.service` -- and save it in `/etc/systemd/system/`.
+Create a `systemd` service unit file -- `nimbus-eth2-pyrmont.service` -- and save it in `/etc/systemd/system/`.
 
 ```txt
 [Unit]
@@ -51,6 +51,5 @@ sudo systemctl daemon-reload
 ### 3. Start the service
 
 ```console
-sudo systemctl enable nbc --now
+sudo systemctl enable nimbus-eth2-pyrmont --now
 ```
-

--- a/docs/the_nimbus_book/src/eth2-stats.md
+++ b/docs/the_nimbus_book/src/eth2-stats.md
@@ -1,7 +1,7 @@
 # Network stats and monitoring
 
 > ⚠️  This page concerns the [Pyrmont](https://pyrmont.launchpad.ethereum.org/) testnet. eth2stats is a debugging / developer tool that's suitable for testnets. For privacy reasons, we do not recommend using it for mainnet. For a mainnet alternative, see [this guide](./metrics-pretty-pictures.md).
- 
+
 
 eth2stats is a network monitoring suite for your beacon node + validator client.
 
@@ -52,7 +52,7 @@ Click on `Compile from source` and copy the command at the bottom.
 
 From your `nimbus-eth2` repository, run:
 ```
-make NIMFLAGS="-d:insecure" nimbus_beacon_node
+make nimbus_beacon_node
 ```
 
 Followed by:
@@ -75,8 +75,3 @@ From your `eth2stats-client` repository, **run the command you copied in step 4.
 ```
 
 Your node should now be displayed on [https://pyrmont.eth2.wtf/](https://pyrmont.eth2.wtf/) :)
-
-
-
-
-

--- a/docs/the_nimbus_book/src/faq.md
+++ b/docs/the_nimbus_book/src/faq.md
@@ -4,10 +4,10 @@
 
 ### Why are metrics not working?
 
-Metrics are currently implemented using a HTTP server that hasn't been hardened sufficiently (which means it can't be exposed as a public endpoint). It must therefore be enabled specifically during build:
+The metrics server is disabled by default, enable it by passing `--metrics` to the run command:
 
 ```
-make NIMFLAGS="-d:insecure" nimbus_beacon_node --metrics ...
+./run-mainnet-beacon-node.sh --metrics ...
 ```
 
 ## Validating
@@ -40,7 +40,7 @@ Before a validator can start to secure the network, he or she needs to stake **3
 
 ### Is there any advantage to having more than 32 ETH at stake?
 
-No. There is no advantage to having more than 32 ETH staked. 
+No. There is no advantage to having more than 32 ETH staked.
 
 Limiting the maximum stake to 32 ETH encourages decentralization of power as it prevents any single validator from having an excessively large vote on the state of the chain.
 
@@ -52,7 +52,7 @@ Yes but, under normal conditions, you will lose an amount of ETH roughly equival
 
 ## I want to switch my validator keys to another machine, how long do I need to wait to avoid getting slashed?
 
-We recommend waiting 2 epochs (around 15 minutes), before restarting Nimbus on a different machine. 
+We recommend waiting 2 epochs (around 15 minutes), before restarting Nimbus on a different machine.
 
 ## When should I top up my validator's balance?
 
@@ -64,7 +64,7 @@ At the other end of the spectrum, if your balance is closer to 31 ETH, it's prob
 
 ## When can I withdraw my funds, and what's the difference between exiting and withdrawing?
 
-You can signal your intent to stop validating by signing a voluntary exit message with your validator. 
+You can signal your intent to stop validating by signing a voluntary exit message with your validator.
 
 However, bear in mind that in Phase 0, once you've exited, there's no going back.
 
@@ -133,7 +133,7 @@ It depends. In addition to [the impact of effective balance](https://www.attesta
 
 ### How great does an honest validator's uptime need to be for it to be net profitable?
 
-Overall, validators are expected to be net profitable as long as their uptime is [greater than 50%](https://blog.ethereum.org/2020/01/13/validated-staking-on-eth2-1-incentives/). 
+Overall, validators are expected to be net profitable as long as their uptime is [greater than 50%](https://blog.ethereum.org/2020/01/13/validated-staking-on-eth2-1-incentives/).
 
 This means that validators need not go to extreme lengths with backup clients or redundant internet connections as the repercussions of being offline are not so severe.
 
@@ -147,7 +147,7 @@ The idea behind this is to minimize the losses from honest mistakes, but strongl
 
 ### What exactly is slashing?
 
-Slashing has two purposes: (1) to make it prohibitively expensive to attack eth2, and (2) to stop validators from being lazy by checking that they actually perform their duties. Slashing a validator is to destroy (a portion of) the validator’s stake if they act in a provably destructive manner. 
+Slashing has two purposes: (1) to make it prohibitively expensive to attack eth2, and (2) to stop validators from being lazy by checking that they actually perform their duties. Slashing a validator is to destroy (a portion of) the validator’s stake if they act in a provably destructive manner.
 
 Validators that are slashed are prevented from participating in the protocol further and are forcibly exited.
 
@@ -174,7 +174,7 @@ As such, it's a good idea to create your keys from mnemonics which act as anothe
 
 If the withdrawal key is stolen, the thief can transfer the validator’s balance, but only once the validator has exited.
 
-If the signing key is not under the thief’s control, the thief cannot exit the validator. 
+If the signing key is not under the thief’s control, the thief cannot exit the validator.
 
 The user with the signing key could attempt to quickly exit the validator and then transfer the funds -- with the withdrawal key -- before the thief.
 

--- a/docs/the_nimbus_book/src/metrics-pretty-pictures.md
+++ b/docs/the_nimbus_book/src/metrics-pretty-pictures.md
@@ -8,20 +8,11 @@ Grafana is a tool for beautiful dashboard monitoring that works well with Promet
 
 ## Simple metrics
 
-The easiest way to see metrics concerning your validator / node is to build the beacon node with the `NIMFLAGS="-d:insecure"`:
-
-```
-make NIMFLAGS="-d:insecure" nimbus_beacon_node
-```
-
-> **Note:** Metrics are not included in the binary by default. The `NIMFLAGS="-d:insecure"` is needed because we consider the HTTP server that needs to start to serve the metrics to be insecure (without this flag it won't launch properly). As such, we recommend you make sure port 8008 is protected.
-
 Run the beacon node  with the `--metrics` flag:
 
 ```
 ./run-pyrmont-beacon-node.sh --metrics
 ```
-
 
 And visit [http://127.0.0.1:8008/metrics](http://127.0.0.1:8008/metrics) to see the raw metrics. You should see a plaintext page that looks something like this:
 
@@ -44,6 +35,8 @@ nim_gc_heap_instance_occupied_bytes{type_name="seq[TrustedAttestation]"} 29728.0
 ...
 ```
 
+> **Note:** Metrics are by default only accessible from the same machine as the beacon node is running on - to fetch metrics from a remote machine, an SSH tunnel is recommended.
+
 Unfortunately, this simple method only offers one snapshot in time (you'll need to keep refreshing to see the data update) which means it's impossible to see a useful history of the metrics. In short, it's far from optimal from an information design point of view.
 
 In order to settle on a better solution, we'll need the help of two external projects -- Prometheus and Grafana.
@@ -59,7 +52,7 @@ The following steps will take you through how to use Prometheus and Grafana to s
 Use your favourite package manager to download Prometheus -- for example `apt-get install prometheus` on Ubuntu, or `brew install prometheus` on MacOS, should do the trick.
 
 > If you don't use a package manager, you can download the [latest release](https://prometheus.io/download/) of directly from Prometheus website. To extract it, run:
-> 
+>
 > ```
 > tar xvfz prometheus-*.tar.gz
 > cd prometheus-*

--- a/docs/the_nimbus_book/src/pyrmont.md
+++ b/docs/the_nimbus_book/src/pyrmont.md
@@ -59,8 +59,8 @@ INF 2020-08-03 16:24:17.951+02:00 Local validators attached                  top
 INF 2020-08-03 16:24:17.958+02:00 Starting beacon node                       topics="beacnde" tid=11677993 file=nimbus_beacon_node.nim:875 version="0.5.0 (31b33907)" nim="Nim Compiler Version 1.2.6 [MacOSX: amd64] (bf320ed1)" timeSinceFinalization=81350 head=ebe49843:0 finalizedHead=ebe49843:0 SLOTS_PER_EPOCH=32 SECONDS_PER_SLOT=12 SPEC_VERSION=0.12.2 dataDir=build/data/shared_pyrmont_0 pcs=start_beacon_node
 ```
 
- > **Note:** when you run `./run-pyrmont-beacon-node.sh`, the beacon node launches with an Infura endpoint supplied by us. This endpoint is passed through the `web3-url` option (which takes as input the url of the web3 server from which you'd like to observe the eth1 chain). 
-> 
+ > **Note:** when you run `./run-pyrmont-beacon-node.sh`, the beacon node launches with an Infura endpoint supplied by us. This endpoint is passed through the `web3-url` option (which takes as input the url of the web3 server from which you'd like to observe the eth1 chain).
+>
 > Because Infura caps the requests per endpoint per day to 100k, and all Nimbus nodes use the same Infura endpoint by default, it can happen that our Infura endpoint is overloaded (i.e the requests on a given day reach the 100k limit). If this happens, all requests to Infura using the default endpoint will fail, which means your node will stop processing new deposits.
 >
 > To pass in your own Infura endpoint, you'll need to run:
@@ -70,7 +70,7 @@ INF 2020-08-03 16:24:17.958+02:00 Starting beacon node                       top
 > Importantly, the endpoint must be a websocket (`wss`) endpoint, not `https`. If you're not familiar with Infura, we recommend reading through our [Infura guide](./infura-guide), first.
 >
 > P.S. We are well aware that Infura is less than ideal from a decentralisation perspective. As such we are in the process of changing our default to [Geth](https://geth.ethereum.org/docs/install-and-build/installing-geth) (with Infura as a fallback). For some rough notes on how to use Geth with Nimbus, see [here](https://gist.github.com/onqtam/aaf883d46f4dab1311ca9c160df12fe4) (we will be adding more complete instructions very soon).
- 
+
 
 > **Tip:** to 🎨 on the [graffitwall](https://pyrmont.beaconcha.in/graffitiwall), pass the graffiti parameter like this:
 >```
@@ -143,10 +143,10 @@ The `validators` folder contains your keystores (encrypted keys). Keystores are 
 
 ## Metrics
 
-Metrics are not included in the binary by default - to enable them, use the following options when building the client:
+Metrics are not enabled by default - to enable, run with the `--metrics` flag
 
 ```
-make NIMFLAGS="-d:insecure" nimbus_beacon_node
+./run-pyrmont-beacon-node.sh --metrics
 ```
 
 You can then browse the metrics by connecting to:

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -204,7 +204,7 @@ if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
   BINARIES="${BINARIES} logtrace"
 fi
 NETWORK_NIM_FLAGS=$(scripts/load-testnet-nim-flags.sh "${NETWORK}")
-$MAKE -j ${NPROC} LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:insecure -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" ${BINARIES}
+$MAKE -j ${NPROC} LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:testnet_servers_image -d:local_testnet ${NETWORK_NIM_FLAGS}" ${BINARIES}
 
 PIDS=""
 WEB3_ARG=""

--- a/scripts/reset_testnet.sh
+++ b/scripts/reset_testnet.sh
@@ -66,7 +66,7 @@ if [ "$ETH1_PRIVATE_KEY" != "" ]; then
 fi
 
 echo "Building a local nimbus_beacon_node instance for 'deposits create' and 'createTestnet'"
-make -j2 NIMFLAGS="-d:insecure -d:testnet_servers_image ${NETWORK_NIM_FLAGS}" nimbus_beacon_node nimbus_signing_process process_dashboard
+make -j2 NIMFLAGS="-d:testnet_servers_image ${NETWORK_NIM_FLAGS}" nimbus_beacon_node nimbus_signing_process process_dashboard
 
 echo "Generating Grafana dashboards for remote testnet servers"
 for testnet in 0 1; do

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -49,7 +49,7 @@ mkdir -p "$SECRETS_DIR"
 
 cd "$GIT_ROOT"
 
-CUSTOM_NIMFLAGS="${NIMFLAGS} -d:useSysAsserts -d:chronicles_sinks:textlines,json[file] -d:const_preset=mainnet -d:insecure -d:local_testnet"
+CUSTOM_NIMFLAGS="${NIMFLAGS} -d:useSysAsserts -d:chronicles_sinks:textlines,json[file] -d:const_preset=mainnet -d:local_testnet"
 GANACHE_BLOCK_TIME=5
 
 # Run with "SLOTS_PER_EPOCH=8 ./start.sh" to change these


### PR DESCRIPTION
With metrics running on top of chronos, the metrics server no longer
needs to be compiled in conditionally - it remains disabled by default.