### PR TITLE
only deserialize attestation and aggregation gossiped signatures once

### DIFF
--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -38,6 +38,7 @@ type
     ## be further combined.
     aggregation_bits*: CommitteeValidatorsBits
     aggregate_signature*: CookedSig
+    aggregate_signature_raw*: ValidatorSig
 
   AttestationEntry* = object
     ## Each entry holds the known signatures for a particular, distinct vote

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -182,9 +182,11 @@ proc addAttestation*(pool: var AttestationPool,
     # Only attestestions with valid signatures get here
 
   template getValidation(): auto =
+    doAssert attestation.signature == signature.exportRaw
     Validation(
       aggregation_bits: attestation.aggregation_bits,
-      aggregate_signature: signature)
+      aggregate_signature: signature,
+      aggregate_signature_raw: attestation.signature)
 
   var found = false
   for a in attestationsSeen.attestations.mitems():
@@ -287,7 +289,7 @@ iterator attestations*(pool: AttestationPool, slot: Option[Slot],
           yield Attestation(
             aggregation_bits: validation.aggregation_bits,
             data: entry.data,
-            signature: validation.aggregate_signature.exportRaw
+            signature: validation.aggregate_signature_raw
           )
 
 func getAttestationDataKey(ad: AttestationData): AttestationDataKey =
@@ -383,7 +385,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
       attestation = Attestation(
         aggregation_bits: a.validations[0].aggregation_bits,
         data: a.data,
-        signature: a.validations[0].aggregate_signature.exportRaw
+        signature: a.validations[0].aggregate_signature_raw
       )
 
       agg {.noInit.}: AggregateSignature
@@ -454,7 +456,7 @@ proc getAggregatedAttestation*(pool: AttestationPool,
       attestation = Attestation(
         aggregation_bits: a.validations[0].aggregation_bits,
         data: a.data,
-        signature: a.validations[0].aggregate_signature.exportRaw
+        signature: a.validations[0].aggregate_signature_raw
       )
 
       agg {.noInit.}: AggregateSignature

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -153,6 +153,7 @@ func addToAggregates(pool: var AttestationPool, attestation: Attestation) =
 proc addAttestation*(pool: var AttestationPool,
                      attestation: Attestation,
                      participants: seq[ValidatorIndex],
+                     signature: CookedSig,
                      wallSlot: Slot) =
   ## Add an attestation to the pool, assuming it's been validated already.
   ## Attestations may be either agggregated or not - we're pursuing an eager
@@ -179,15 +180,18 @@ proc addAttestation*(pool: var AttestationPool,
   let
     attestationsSeen = addr pool.candidates[candidateIdx.get]
     # Only attestestions with valid signatures get here
-    validation = Validation(
+
+  template getValidation(): auto =
+    doAssert attestation.signature == signature.exportRaw
+    Validation(
       aggregation_bits: attestation.aggregation_bits,
-      aggregate_signature: load(attestation.signature).get.CookedSig)
+      aggregate_signature: signature)
 
   var found = false
   for a in attestationsSeen.attestations.mitems():
     if a.data == attestation.data:
       for v in a.validations:
-        if validation.aggregation_bits.isSubsetOf(v.aggregation_bits):
+        if attestation.aggregation_bits.isSubsetOf(v.aggregation_bits):
           # The validations in the new attestation are a subset of one of the
           # attestations that we already have on file - no need to add this
           # attestation to the database
@@ -202,9 +206,9 @@ proc addAttestation*(pool: var AttestationPool,
         trace "Removing subset attestations", newParticipants = participants
 
         a.validations.keepItIf(
-          not it.aggregation_bits.isSubsetOf(validation.aggregation_bits))
+          not it.aggregation_bits.isSubsetOf(attestation.aggregation_bits))
 
-        a.validations.add(validation)
+        a.validations.add(getValidation())
         pool.addForkChoiceVotes(
           attestation.data.slot, participants, attestation.data.beacon_block_root,
           wallSlot)
@@ -220,7 +224,7 @@ proc addAttestation*(pool: var AttestationPool,
   if not found:
     attestationsSeen.attestations.add(AttestationEntry(
       data: attestation.data,
-      validations: @[validation],
+      validations: @[getValidation()],
       aggregation_bits: attestation.aggregation_bits
     ))
     pool.addForkChoiceVotes(

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -182,7 +182,6 @@ proc addAttestation*(pool: var AttestationPool,
     # Only attestestions with valid signatures get here
 
   template getValidation(): auto =
-    doAssert attestation.signature == signature.exportRaw
     Validation(
       aggregation_bits: attestation.aggregation_bits,
       aggregate_signature: signature)

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -222,10 +222,12 @@ proc attestationValidator*(
   beacon_attestations_received.inc()
   beacon_attestation_delay.observe(delay.toFloatSeconds())
 
-  self[].checkForPotentialDoppelganger(attestation.data, v.value, wallSlot)
+  self[].checkForPotentialDoppelganger(
+    attestation.data, v.value.attestingIndices, wallSlot)
 
   trace "Attestation validated"
-  self.verifQueues[].addAttestation(attestation, v.get())
+  let (attestingIndices, sig) = v.get()
+  self.verifQueues[].addAttestation(attestation, attestingIndices, sig)
 
   return ValidationResult.Accept
 
@@ -266,14 +268,17 @@ proc aggregateValidator*(
   beacon_aggregate_delay.observe(delay.toFloatSeconds())
 
   self[].checkForPotentialDoppelganger(
-    signedAggregateAndProof.message.aggregate.data, v.value, wallSlot)
+    signedAggregateAndProof.message.aggregate.data, v.value.attestingIndices,
+    wallSlot)
 
   trace "Aggregate validated",
     aggregator_index = signedAggregateAndProof.message.aggregator_index,
     selection_proof = signedAggregateAndProof.message.selection_proof,
     wallSlot
 
-  self.verifQueues[].addAggregate(signedAggregateAndProof, v.get())
+  let (attestingIndices, sig) = v.get()
+  self.verifQueues[].addAggregate(
+    signedAggregateAndProof, attestingIndices, sig)
 
   return ValidationResult.Accept
 

--- a/beacon_chain/gossip_processing/gossip_to_consensus.nim
+++ b/beacon_chain/gossip_processing/gossip_to_consensus.nim
@@ -286,7 +286,6 @@ proc processAttestation(
     quit 1
 
   trace "Processing attestation"
-  doAssert entry.sig.exportRaw == entry.v.signature
   self.consensusManager.attestationPool[].addAttestation(
     entry.v, entry.attesting_indices, entry.sig, wallSlot)
 
@@ -304,7 +303,6 @@ proc processAggregate(
     quit 1
 
   trace "Processing aggregate"
-  doAssert entry.sig.exportRaw == entry.v.signature
   self.consensusManager.attestationPool[].addAttestation(
     entry.v, entry.attesting_indices, entry.sig, wallSlot)
 

--- a/beacon_chain/gossip_processing/gossip_to_consensus.nim
+++ b/beacon_chain/gossip_processing/gossip_to_consensus.nim
@@ -40,6 +40,7 @@ type
   AttestationEntry = object
     v: Attestation
     attesting_indices: seq[ValidatorIndex]
+    sig: CookedSig
 
   AggregateEntry = AttestationEntry
 
@@ -160,7 +161,9 @@ proc addBlock*(self: var VerifQueueManager, syncBlock: SyncBlock) =
   # addLast doesn't fail
   asyncSpawn(self.blocksQueue.addLast(BlockEntry(v: syncBlock)))
 
-proc addAttestation*(self: var VerifQueueManager, att: Attestation, att_indices: seq[ValidatorIndex]) =
+proc addAttestation*(
+    self: var VerifQueueManager, att: Attestation,
+    att_indices: seq[ValidatorIndex], sig: CookedSig) =
   ## Enqueue a Gossip-validated attestation for consensus verification
   # Backpressure:
   #   If buffer is full, the oldest attestation is dropped and the newest is enqueued
@@ -185,11 +188,13 @@ proc addAttestation*(self: var VerifQueueManager, att: Attestation, att_indices:
 
   try:
     self.attestationsQueue.addLastNoWait(
-      AttestationEntry(v: att, attesting_indices: att_indices))
+      AttestationEntry(v: att, attesting_indices: att_indices, sig: sig))
   except AsyncQueueFullError as exc:
     raiseAssert "We just checked that queue is not full! " & exc.msg
 
-proc addAggregate*(self: var VerifQueueManager, agg: SignedAggregateAndProof, att_indices: seq[ValidatorIndex]) =
+proc addAggregate*(
+    self: var VerifQueueManager, agg: SignedAggregateAndProof,
+    att_indices: seq[ValidatorIndex], sig: CookedSig) =
   ## Enqueue a Gossip-validated aggregate attestation for consensus verification
   # Backpressure:
   #   If buffer is full, the oldest aggregate is dropped and the newest is enqueued
@@ -216,7 +221,8 @@ proc addAggregate*(self: var VerifQueueManager, agg: SignedAggregateAndProof, at
   try:
     self.aggregatesQueue.addLastNoWait(AggregateEntry(
       v: agg.message.aggregate,
-      attesting_indices: att_indices))
+      attesting_indices: att_indices,
+      sig: sig))
   except AsyncQueueFullError as exc:
     raiseAssert "We just checked that queue is not full! " & exc.msg
 
@@ -280,8 +286,9 @@ proc processAttestation(
     quit 1
 
   trace "Processing attestation"
+  doAssert entry.sig.exportRaw == entry.v.signature
   self.consensusManager.attestationPool[].addAttestation(
-    entry.v, entry.attesting_indices, wallSlot)
+    entry.v, entry.attesting_indices, entry.sig, wallSlot)
 
 proc processAggregate(
     self: var VerifQueueManager, entry: AggregateEntry) =
@@ -297,8 +304,9 @@ proc processAggregate(
     quit 1
 
   trace "Processing aggregate"
+  doAssert entry.sig.exportRaw == entry.v.signature
   self.consensusManager.attestationPool[].addAttestation(
-    entry.v, entry.attesting_indices, wallSlot)
+    entry.v, entry.attesting_indices, entry.sig, wallSlot)
 
 proc processBlock(self: var VerifQueueManager, entry: BlockEntry) =
   logScope:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -449,17 +449,18 @@ proc validateAggregate*(
     return err((ValidationResult.Reject, cstring(
       "Selection_proof signature verification failed")))
 
-  # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-  let aggregatorChecked = await cryptoFuts.aggregatorCheck
-  if aggregatorChecked.isErr():
-    return err((ValidationResult.Reject, cstring(
-      "signed_aggregate_and_proof aggregator signature verification failed")))
+  block:
+    # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+    let aggregatorChecked = await cryptoFuts.aggregatorCheck
+    if aggregatorChecked.isErr():
+      return err((ValidationResult.Reject, cstring(
+        "signed_aggregate_and_proof aggregator signature verification failed")))
 
-  # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-  let aggregateChecked = await cryptoFuts.aggregateCheck
-  if aggregateChecked.isErr():
-    return err((ValidationResult.Reject, cstring(
-      "signed_aggregate_and_proof aggregate attester signatures verification failed")))
+    # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+    let aggregateChecked = await cryptoFuts.aggregateCheck
+    if aggregateChecked.isErr():
+      return err((ValidationResult.Reject, cstring(
+        "signed_aggregate_and_proof aggregate attester signatures verification failed")))
 
   # The following rule follows implicitly from that we clear out any
   # unviable blocks from the chain dag:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -305,7 +305,6 @@ proc validateAttestation*(
   let
     (cryptoFut, sig) = deferredCrypto.get()
     cryptoChecked = await cryptoFut
-  doAssert attestation.signature == sig.exportRaw
   if cryptoChecked.isErr():
     return err((ValidationResult.Reject, cryptoChecked.error))
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -418,14 +418,15 @@ proc validateAggregate*(
     return err((ValidationResult.Reject, cstring(
       "Aggregator's validator index not in committee")))
 
-  # 1. [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the
-  #    aggregate.data.slot by the validator with index
-  #    aggregate_and_proof.aggregator_index.
-  #    get_slot_signature(state, aggregate.data.slot, privkey)
-  # 2. [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-  # 3. [REJECT] The signature of aggregate is valid.
-  if aggregate_and_proof.aggregator_index >= epochRef.validator_keys.lenu64:
-    return err((ValidationResult.Reject, cstring("Invalid aggregator_index")))
+  block:
+    # 1. [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the
+    #    aggregate.data.slot by the validator with index
+    #    aggregate_and_proof.aggregator_index.
+    #    get_slot_signature(state, aggregate.data.slot, privkey)
+    # 2. [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+    # 3. [REJECT] The signature of aggregate is valid.
+    if aggregate_and_proof.aggregator_index >= epochRef.validator_keys.lenu64:
+      return err((ValidationResult.Reject, cstring("Invalid aggregator_index")))
 
   let
     fork = getStateField(pool.chainDag.headState, fork)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -42,7 +42,7 @@ template loadOrExit(signature: ValidatorSig, failReturn: auto):
 template loadWithCacheOrExit(pubkey: ValidatorPubKey, failReturn: auto):
     blscurve.PublicKey =
   ## Load a BLS signature from a raw public key
-  ## Exists the **caller** with false if the public key is invalid
+  ## Exits the **caller** with false if the public key is invalid
   let pk = pubkey.loadWithCache()
   if pk.isNone:
     return failReturn # this exits the calling scope, as templates are inlined.

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -35,7 +35,6 @@ template loadOrExit(signature: ValidatorSig, failReturn: auto):
   ## Exits the **caller** with false if the signature is invalid
   let sig = signature.load()
   if sig.isNone:
-    doAssert false
     return failReturn # this exits the calling scope, as templates are inlined.
   sig.unsafeGet()
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -118,7 +118,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
                 data: data,
                 aggregation_bits: aggregation_bits,
                 signature: sig
-              ), @[validatorIdx], data.slot)
+              ), @[validatorIdx], sig.load.get().CookedSig, data.slot)
 
   proc proposeBlock(slot: Slot) =
     if rand(r, 1.0) > blockRatio:

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -42,7 +42,7 @@ func combine(tgt: var Attestation, src: Attestation) =
     agg.aggregate(src.signature)
     tgt.signature = agg.finish()
 
-func unsafeLoadSig(a: Attestation): CookedSig =
+func loadSig(a: Attestation): CookedSig =
   a.signature.load.get().CookedSig
 
 template wrappedTimedTest(name: string, body: untyped) =
@@ -85,7 +85,7 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, beacon_committee[0], cache)
 
     pool[].addAttestation(
-      attestation, @[beacon_committee[0]], attestation.unsafeLoadSig,
+      attestation, @[beacon_committee[0]], attestation.loadSig,
       attestation.data.slot)
 
     check:
@@ -116,11 +116,9 @@ suiteReport "Attestation pool processing" & preset():
 
     # test reverse order
     pool[].addAttestation(
-      attestation1, @[bc1[0]], attestation1.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation1, @[bc1[0]], attestation1.loadSig, attestation1.data.slot)
     pool[].addAttestation(
-      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation0, @[bc0[0]], attestation0.loadSig, attestation1.data.slot)
 
     discard process_slots(
       state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -142,11 +140,9 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, bc0[1], cache)
 
     pool[].addAttestation(
-      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
-      attestation0.data.slot)
+      attestation0, @[bc0[0]], attestation0.loadSig, attestation0.data.slot)
     pool[].addAttestation(
-      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation1, @[bc0[1]], attestation1.loadSig, attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -171,11 +167,9 @@ suiteReport "Attestation pool processing" & preset():
     attestation0.combine(attestation1)
 
     pool[].addAttestation(
-      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
-      attestation0.data.slot)
+      attestation0, @[bc0[0]], attestation0.loadSig, attestation0.data.slot)
     pool[].addAttestation(
-      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation1, @[bc0[1]], attestation1.loadSig, attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -199,11 +193,9 @@ suiteReport "Attestation pool processing" & preset():
     attestation0.combine(attestation1)
 
     pool[].addAttestation(
-      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation1, @[bc0[1]], attestation1.loadSig, attestation1.data.slot)
     pool[].addAttestation(
-      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
-      attestation0.data.slot)
+      attestation0, @[bc0[0]], attestation0.loadSig, attestation0.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -271,8 +263,7 @@ suiteReport "Attestation pool processing" & preset():
       attestation0 = makeAttestation(state.data.data, b10.root, bc1[0], cache)
 
     pool[].addAttestation(
-      attestation0, @[bc1[0]], attestation0.unsafeLoadSig,
-      attestation0.data.slot)
+      attestation0, @[bc1[0]], attestation0.loadSig, attestation0.data.slot)
 
     let head2 = pool[].selectHead(b10Add[].slot)
 
@@ -284,8 +275,7 @@ suiteReport "Attestation pool processing" & preset():
       attestation1 = makeAttestation(state.data.data, b11.root, bc1[1], cache)
       attestation2 = makeAttestation(state.data.data, b11.root, bc1[2], cache)
     pool[].addAttestation(
-      attestation1, @[bc1[1]], attestation1.unsafeLoadSig,
-      attestation1.data.slot)
+      attestation1, @[bc1[1]], attestation1.loadSig, attestation1.data.slot)
 
     let head3 = pool[].selectHead(b10Add[].slot)
     let bigger = if b11.root.data < b10.root.data: b10Add else: b11Add
@@ -295,8 +285,7 @@ suiteReport "Attestation pool processing" & preset():
       head3 == bigger[]
 
     pool[].addAttestation(
-      attestation2, @[bc1[2]], attestation2.unsafeLoadSig,
-      attestation2.data.slot)
+      attestation2, @[bc1[2]], attestation2.loadSig, attestation2.data.slot)
 
     let head4 = pool[].selectHead(b11Add[].slot)
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -42,6 +42,9 @@ func combine(tgt: var Attestation, src: Attestation) =
     agg.aggregate(src.signature)
     tgt.signature = agg.finish()
 
+func unsafeLoadSig(a: Attestation): CookedSig =
+  a.signature.load.get().CookedSig
+
 template wrappedTimedTest(name: string, body: untyped) =
   # `check` macro takes a copy of whatever it's checking, on the stack!
   # This leads to stack overflow
@@ -82,7 +85,8 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, beacon_committee[0], cache)
 
     pool[].addAttestation(
-      attestation, @[beacon_committee[0]], attestation.data.slot)
+      attestation, @[beacon_committee[0]], attestation.unsafeLoadSig,
+      attestation.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -111,8 +115,12 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.blck.root, bc1[0], cache)
 
     # test reverse order
-    pool[].addAttestation(attestation1, @[bc1[0]], attestation1.data.slot)
-    pool[].addAttestation(attestation0, @[bc0[0]], attestation1.data.slot)
+    pool[].addAttestation(
+      attestation1, @[bc1[0]], attestation1.unsafeLoadSig,
+      attestation1.data.slot)
+    pool[].addAttestation(
+      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
+      attestation1.data.slot)
 
     discard process_slots(
       state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -133,8 +141,12 @@ suiteReport "Attestation pool processing" & preset():
       attestation1 = makeAttestation(
         state.data.data, state.blck.root, bc0[1], cache)
 
-    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
-    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
+    pool[].addAttestation(
+      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
+      attestation0.data.slot)
+    pool[].addAttestation(
+      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
+      attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -158,8 +170,12 @@ suiteReport "Attestation pool processing" & preset():
 
     attestation0.combine(attestation1)
 
-    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
-    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
+    pool[].addAttestation(
+      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
+      attestation0.data.slot)
+    pool[].addAttestation(
+      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
+      attestation1.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -182,8 +198,12 @@ suiteReport "Attestation pool processing" & preset():
 
     attestation0.combine(attestation1)
 
-    pool[].addAttestation(attestation1, @[bc0[1]], attestation1.data.slot)
-    pool[].addAttestation(attestation0, @[bc0[0]], attestation0.data.slot)
+    pool[].addAttestation(
+      attestation1, @[bc0[1]], attestation1.unsafeLoadSig,
+      attestation1.data.slot)
+    pool[].addAttestation(
+      attestation0, @[bc0[0]], attestation0.unsafeLoadSig,
+      attestation0.data.slot)
 
     check:
       process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -250,7 +270,9 @@ suiteReport "Attestation pool processing" & preset():
         state.data.data, state.data.data.slot - 1, 1.CommitteeIndex, cache)
       attestation0 = makeAttestation(state.data.data, b10.root, bc1[0], cache)
 
-    pool[].addAttestation(attestation0, @[bc1[0]], attestation0.data.slot)
+    pool[].addAttestation(
+      attestation0, @[bc1[0]], attestation0.unsafeLoadSig,
+      attestation0.data.slot)
 
     let head2 = pool[].selectHead(b10Add[].slot)
 
@@ -261,7 +283,9 @@ suiteReport "Attestation pool processing" & preset():
     let
       attestation1 = makeAttestation(state.data.data, b11.root, bc1[1], cache)
       attestation2 = makeAttestation(state.data.data, b11.root, bc1[2], cache)
-    pool[].addAttestation(attestation1, @[bc1[1]], attestation1.data.slot)
+    pool[].addAttestation(
+      attestation1, @[bc1[1]], attestation1.unsafeLoadSig,
+      attestation1.data.slot)
 
     let head3 = pool[].selectHead(b10Add[].slot)
     let bigger = if b11.root.data < b10.root.data: b10Add else: b11Add
@@ -270,7 +294,9 @@ suiteReport "Attestation pool processing" & preset():
       # Ties broken lexicographically in spec -> ?
       head3 == bigger[]
 
-    pool[].addAttestation(attestation2, @[bc1[2]], attestation2.data.slot)
+    pool[].addAttestation(
+      attestation2, @[bc1[2]], attestation2.unsafeLoadSig,
+      attestation2.data.slot)
 
     let head4 = pool[].selectHead(b11Add[].slot)
 


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/2423 does what it advertises, but also adds a lot of slow `ValidatorSig` deserialization to the common paths each slot with attestations. I noticed some regressions in attesting in v1.0.12 versus v1.0.10, where the only relevant difference is that PR being merged.

This PR eliminates those repeated deserializations, and instead reuses the gossip layer's deserializations in the attestation/aggregation processing queues and attestation pool.

The main exception is that `sendAttestation` disables `checksExpensive` in `validateAttestation()`, which therefore must deserialize what had just been serialized. This is still much better than the status quo, since it's only for sent attestations.

It is possible to eliminate much/most of this extra work with the following, much more minimal PR, but it doesn't address the duplicate deserialization between the gossip layer and attestation pool (`trace` to `debug` to get statistics of which branches followed):
```nim
diff --git a/beacon_chain/consensus_object_pools/attestation_pool.nim b/beacon_chain/consensus_object_pools/attestation_pool.nim
index 689c527d..e350a2cb 100644
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -177,7 +177,9 @@ proc addAttestation*(pool: var AttestationPool,
   let
     attestationsSeen = addr pool.candidates[candidateIdx.get]
     # Only attestestions with valid signatures get here
-    validation = Validation(
+
+  template getValidation(): auto =
+    Validation(
       aggregation_bits: attestation.aggregation_bits,
       aggregate_signature: load(attestation.signature).get.CookedSig)
 
@@ -185,11 +187,11 @@ proc addAttestation*(pool: var AttestationPool,
   for a in attestationsSeen.attestations.mitems():
     if a.data == attestation.data:
       for v in a.validations:
-        if validation.aggregation_bits.isSubsetOf(v.aggregation_bits):
+        if attestation.aggregation_bits.isSubsetOf(v.aggregation_bits):
           # The validations in the new attestation are a subset of one of the
           # attestations that we already have on file - no need to add this
           # attestation to the database
-          trace "Ignoring subset attestation", newParticipants = participants
+          debug "Ignoring subset attestation", newParticipants = participants
           found = true
           break
 
@@ -200,8 +202,10 @@ proc addAttestation*(pool: var AttestationPool,
         trace "Removing subset attestations", newParticipants = participants
 
         a.validations.keepItIf(
-          not it.aggregation_bits.isSubsetOf(validation.aggregation_bits))
+          not it.aggregation_bits.isSubsetOf(attestation.aggregation_bits))
 
+        let validation = getValidation()
+        doAssert validation.aggregate_signature.exportRaw == attestation.signature
         a.validations.add(validation)
         pool.addForkChoiceVotes(
           attestation.data.slot, participants, attestation.data.beacon_block_root,
@@ -216,6 +220,8 @@ proc addAttestation*(pool: var AttestationPool,
       break
 
   if not found:
+    let validation = getValidation()
+    doAssert validation.aggregate_signature.exportRaw == attestation.signature
     attestationsSeen.attestations.add(AttestationEntry(
       data: attestation.data,
       validations: @[validation],
```
It just avoids deserializing signatures for attestations which aren't resolved due to already being known/present in the attestation pool.

A few hours running Prater resolved 3.4M attestations and triggered "Ignoring subset attestations" 1.8M times, so that patch might still be a useful middle ground. However, many of those attestations resolved are from beacon blocks, which skew the statistics in ways that aren't trivial to correct for, which hinders knowing exactly how much it accounts for.

I did look for whether a `GossipValidatedAttestation` or similar type would be worthwhile, and while it could be used, in general this part of the processing pipeline splits out the `Attestation` from some cached/post-processed portions, such as attesting indices.

`self.verifQueues[].addAttestation(attestation, attestingIndices, sig)` and similar lines could use such a data type, and maybe even incorporate attesting indices into it, if that fits through the whole pipeline. One could argue, though, that those types already effectively exist, in the form of `AttestationEntry` and the like, and it'd be redundant to add one more nesting layer:
https://github.com/status-im/nimbus-eth2/blob/0aef88e0ccd68432c302bc722530c73c2cad2a9e/beacon_chain/gossip_processing/gossip_to_consensus.nim#L34-L39

It also uses both `blscurve.Signature` and `CookedSig`, the former where it's already used as a more raw BLS type, and the latter as a distinct alias for it meant for higher-level code. Therefore, it tends to covert at the interfaces/thresholds/boundaries between those realms.