### PR TITLE
print attestation/aggregate drop notice once per slot

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -332,10 +332,11 @@ proc init*(T: type BeaconNode,
       chainDag, attestationPool, quarantine
     )
     verifQueues = VerifQueueManager.new(
-      config, consensusManager,
+      config.dumpEnabled, config.dumpDirInvalid, config.dumpDirIncoming,
+      consensusManager,
       proc(): BeaconTime = beaconClock.now())
     processor = Eth2Processor.new(
-      config,
+      config.doppelgangerDetection,
       verifQueues,
       chainDag, attestationPool, exitPool, validatorPool,
       quarantine,


### PR DESCRIPTION
* add metrics for queue-related drops
* avoid importing beacon node conf in processor