### PR TITLE
Restore the deposit creation tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ if possible.
 
 * The metrics support is now compiled by default thanks to a new and more secure HTTP back-end.
 
-* Command-line tools for generating keystores and JSON deposit files suitable for use with the
-  official network launchpads.
+* Command-line tools for generating testnet keystores and JSON deposit files suitable for use
+  with the official network launchpads.
 
 * `setGraffiti` JSON-RPC call for modifying the graffiti bytes of the client at run-time.
 

--- a/Makefile
+++ b/Makefile
@@ -394,7 +394,7 @@ define CONNECT_TO_NETWORK_WITH_VALIDATOR_CLIENT
 endef
 
 define MAKE_DEPOSIT_DATA
-	build/nimbus_beacon_node deposits create \
+	build/nimbus_beacon_node deposits createTestnetDeposits \
 		--network=$(1) \
 		--new-wallet-file=build/data/shared_$(1)_$(NODE_ID)/wallet.json \
 		--out-validators-dir=build/data/shared_$(1)_$(NODE_ID)/validators \
@@ -404,7 +404,7 @@ define MAKE_DEPOSIT_DATA
 endef
 
 define MAKE_DEPOSIT
-	build/nimbus_beacon_node deposits create \
+	build/nimbus_beacon_node deposits createTestnetDeposits \
 		--network=$(1) \
 		--out-deposits-file=nbc-$(1)-deposits.json \
 		--new-wallet-file=build/data/shared_$(1)_$(NODE_ID)/wallet.json \

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -45,7 +45,7 @@ type
     list    = "Lists details about all wallets"
 
   DepositsCmd* {.pure.} = enum
-    # create   = "Creates validator keystores and deposits"
+    create   = "Creates validator keystores and deposits"
     `import` = "Imports password-protected keystores interactively"
     # status   = "Displays status information about all deposits"
     exit     = "Submits a validator voluntary exit"
@@ -379,7 +379,6 @@ type
 
     of deposits:
       case depositsCmd* {.command.}: DepositsCmd
-      #[
       of DepositsCmd.create:
         totalDeposits* {.
           defaultValue: 1
@@ -412,9 +411,10 @@ type
           desc: "Output wallet file"
           name: "new-wallet-file" }: Option[OutFile]
 
+      #[
       of DepositsCmd.status:
         discard
-      #]#
+      ]#
 
       of DepositsCmd.`import`:
         importedDepositsDir* {.
@@ -654,11 +654,9 @@ func outWalletName*(config: BeaconNodeConf): Option[WalletName] =
     of WalletsCmd.restore: config.restoredWalletNameFlag
     of WalletsCmd.list: fail()
   of deposits:
-    # TODO: Uncomment when the deposits create command is restored
-    #case config.depositsCmd
-    #of DepositsCmd.create: config.newWalletNameFlag
-    #else: fail()
-    fail()
+    case config.depositsCmd
+    of DepositsCmd.create: config.newWalletNameFlag
+    else: fail()
   else:
     fail()
 
@@ -673,11 +671,9 @@ func outWalletFile*(config: BeaconNodeConf): Option[OutFile] =
     of WalletsCmd.restore: config.restoredWalletFileFlag
     of WalletsCmd.list: fail()
   of deposits:
-    # TODO: Uncomment when the deposits create command is restored
-    #case config.depositsCmd
-    #of DepositsCmd.create: config.newWalletFileFlag
-    #else: fail()
-    fail()
+    case config.depositsCmd
+    of DepositsCmd.create: config.newWalletFileFlag
+    else: fail()
   else:
     fail()
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -45,7 +45,7 @@ type
     list    = "Lists details about all wallets"
 
   DepositsCmd* {.pure.} = enum
-    create   = "Creates validator keystores and deposits"
+    createTestnetDeposits = "Creates validator keystores and deposits for testnet usage"
     `import` = "Imports password-protected keystores interactively"
     # status   = "Displays status information about all deposits"
     exit     = "Submits a validator voluntary exit"
@@ -379,7 +379,7 @@ type
 
     of deposits:
       case depositsCmd* {.command.}: DepositsCmd
-      of DepositsCmd.create:
+      of DepositsCmd.createTestnetDeposits:
         totalDeposits* {.
           defaultValue: 1
           desc: "Number of deposits to generate"
@@ -655,7 +655,7 @@ func outWalletName*(config: BeaconNodeConf): Option[WalletName] =
     of WalletsCmd.list: fail()
   of deposits:
     case config.depositsCmd
-    of DepositsCmd.create: config.newWalletNameFlag
+    of DepositsCmd.createTestnetDeposits: config.newWalletNameFlag
     else: fail()
   else:
     fail()
@@ -672,7 +672,7 @@ func outWalletFile*(config: BeaconNodeConf): Option[OutFile] =
     of WalletsCmd.list: fail()
   of deposits:
     case config.depositsCmd
-    of DepositsCmd.create: config.newWalletFileFlag
+    of DepositsCmd.createTestnetDeposits: config.newWalletFileFlag
     else: fail()
   else:
     fail()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1751,7 +1751,10 @@ proc findWalletWithoutErrors(config: BeaconNodeConf,
 proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
     raises: [Defect, CatchableError].} =
   case config.depositsCmd
-  of DepositsCmd.create:
+  of DepositsCmd.createTestnetDeposits:
+    if config.eth2Network.isNone:
+      fatal "Please specify the intended testnet for the deposits"
+      quit 1
     let metadata = config.loadEth2Network()
     var seed: KeySeed
     defer: burnMem(seed)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1740,11 +1740,19 @@ proc doCreateTestnet(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.raise
     writeFile(bootstrapFile, bootstrapEnr.tryGet().toURI)
     echo "Wrote ", bootstrapFile
 
+proc findWalletWithoutErrors(config: BeaconNodeConf,
+                             name: WalletName): Option[WalletPathPair] =
+  let res = findWallet(config, name)
+  if res.isErr:
+    fatal "Failed to locate wallet", error = res.error
+    quit 1
+  res.get
+
 proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
     raises: [Defect, CatchableError].} =
   case config.depositsCmd
-  #[
   of DepositsCmd.create:
+    let metadata = config.loadEth2Network()
     var seed: KeySeed
     defer: burnMem(seed)
     var walletPath: WalletPathPair
@@ -1752,7 +1760,7 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
     if config.existingWalletId.isSome:
       let
         id = config.existingWalletId.get
-        found = findWalletWithoutErrors(id)
+        found = findWalletWithoutErrors(config, id)
 
       if found.isSome:
         walletPath = found.get
@@ -1767,7 +1775,7 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
         # The failure will be reported in `unlockWalletInteractively`.
         quit 1
     else:
-      var walletRes = createWalletInteractively(rng[], config)
+      var walletRes = createWalletInteractively(rng, config)
       if walletRes.isErr:
         fatal "Unable to create wallet", err = walletRes.error
         quit 1
@@ -1786,8 +1794,8 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
       quit QuitFailure
 
     let deposits = generateDeposits(
-      runtimePreset,
-      rng[],
+      metadata.runtimePreset,
+      rng,
       seed,
       walletPath.wallet.nextAccount,
       config.totalDeposits,
@@ -1805,7 +1813,7 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
         config.outValidatorsDir / "deposit_data-" & $epochTime() & ".json"
 
       let launchPadDeposits =
-        mapIt(deposits.value, LaunchPadDeposit.init(runtimePreset, it))
+        mapIt(deposits.value, LaunchPadDeposit.init(metadata.runtimePreset, it))
 
       Json.saveFile(depositDataPath, launchPadDeposits)
       echo "Deposit data written to \"", depositDataPath, "\""
@@ -1820,12 +1828,12 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
     except CatchableError as err:
       fatal "Failed to create launchpad deposit data file", err = err.msg
       quit 1
-
+  #[
   of DepositsCmd.status:
     echo "The status command is not implemented yet"
     quit 1
+  ]#
 
-  #]#
   of DepositsCmd.`import`:
     let validatorKeysDir = if config.importedDepositsDir.isSome:
       config.importedDepositsDir.get
@@ -1850,19 +1858,12 @@ proc doDeposits(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
 
 proc doWallets(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
     raises: [Defect, CatchableError].} =
-  template findWalletWithoutErrors(name: WalletName): auto =
-    let res = keystore_management.findWallet(config, name)
-    if res.isErr:
-      fatal "Failed to locate wallet", error = res.error
-      quit 1
-    res.get
-
   case config.walletsCmd:
   of WalletsCmd.create:
     if config.createdWalletNameFlag.isSome:
       let
         name = config.createdWalletNameFlag.get
-        existingWallet = findWalletWithoutErrors(name)
+        existingWallet = findWalletWithoutErrors(config, name)
       if existingWallet.isSome:
         echo "The Wallet '" & name.string & "' already exists."
         quit 1

--- a/scripts/reset_testnet.sh
+++ b/scripts/reset_testnet.sh
@@ -65,7 +65,7 @@ if [ "$ETH1_PRIVATE_KEY" != "" ]; then
   echo "Done: $DEPOSIT_CONTRACT_ADDRESS"
 fi
 
-echo "Building a local nimbus_beacon_node instance for 'deposits create' and 'createTestnet'"
+echo "Building a local nimbus_beacon_node instance for 'deposits createTestnetDeposits' and 'createTestnet'"
 make -j2 NIMFLAGS="-d:testnet_servers_image ${NETWORK_NIM_FLAGS}" nimbus_beacon_node nimbus_signing_process process_dashboard
 
 echo "Generating Grafana dashboards for remote testnet servers"
@@ -83,7 +83,7 @@ echo "Building Docker image..."
 # in docker/Makefile, and are enabled by default.
 make build
 
-../build/nimbus_beacon_node deposits create \
+../build/nimbus_beacon_node deposits createTestnetDeposits \
   --count=$TOTAL_VALIDATORS \
   --out-validators-dir="$VALIDATORS_DIR_ABS" \
   --out-secrets-dir="$SECRETS_DIR_ABS" \

--- a/tests/fuzzing/beacon_node_cli/corpus/spadina-deposits-data.txt
+++ b/tests/fuzzing/beacon_node_cli/corpus/spadina-deposits-data.txt
@@ -1,1 +1,1 @@
-deposits create --network=spadina --new-wallet-file=build/data/shared_spadina_0/wallet.json --out-validators-dir=build/data/shared_spadina_0/validators --out-secrets-dir=build/data/shared_spadina_0/secrets --out-deposits-file=spadina-deposits_data-20201001212925.json --count=1
+deposits createTestnetDeposits --network=spadina --new-wallet-file=build/data/shared_spadina_0/wallet.json --out-validators-dir=build/data/shared_spadina_0/validators --out-secrets-dir=build/data/shared_spadina_0/secrets --out-deposits-file=spadina-deposits_data-20201001212925.json --count=1


### PR DESCRIPTION
Rationale:

* This code has been audited and it's eventually going to be used in production once the Status desktop app is integrated with Nimbus.
* We needed it during the creation of the Prater testnet.
* The strategy of commenting it out has resulted in unnecessary bit rot.
