### PR TITLE
Reset cached indices when resetting cache on SSZ read

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -280,8 +280,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 ## hash
 ```diff
 + HashArray                                                                                  OK
++ HashList                                                                                   OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## state diff tests [Preset: mainnet]
 ```diff
 + random slot differences [Preset: mainnet]                                                  OK
@@ -289,4 +290,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 154/163 Fail: 0/163 Skip: 9/163
+OK: 155/164 Fail: 0/164 Skip: 9/164

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -473,10 +473,6 @@ proc getStateOnlyMutableValidators(
     let numValidators = output.validators.len
     doAssert db.immutableValidatorsMem.len >= numValidators
 
-    output.validators.hashes.setLen(0)
-    for item in output.validators.indices.mitems():
-      item = 0
-
     for i in 0 ..< numValidators:
       let
         # Bypass hash cache invalidation
@@ -487,7 +483,7 @@ proc getStateOnlyMutableValidators(
       assign(dstValidator.withdrawal_credentials,
         srcValidator.withdrawal_credentials)
 
-    output.validators.growHashes()
+    output.validators.resetCache()
 
     true
   of GetResult.notFound:

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -122,8 +122,11 @@ proc process_deposit*(preset: RuntimePreset,
     # by the deposit contract
     if skipBLSValidation in flags or verify_deposit_signature(preset, deposit.data):
       # New validator! Add validator and balance entries
-      state.validators.add(get_validator_from_deposit(deposit.data))
-      state.balances.add(amount)
+      if not state.validators.add(get_validator_from_deposit(deposit.data)):
+        return err("process_deposit: too many validators")
+      if not state.balances.add(amount):
+        static: doAssert state.balances.maxLen == state.validators.maxLen
+        raiseAssert "adding validator succeeded, so should balances"
 
       doAssert state.validators.len == state.balances.len
     else:
@@ -298,8 +301,11 @@ proc initialize_beacon_state_from_eth1*(
       if skipBlsValidation in flags or
          verify_deposit_signature(preset, deposit):
         pubkeyToIndex[pubkey] = state.validators.len
-        state.validators.add(get_validator_from_deposit(deposit))
-        state.balances.add(amount)
+        if not state.validators.add(get_validator_from_deposit(deposit)):
+          raiseAssert "too many validators"
+        if not state.balances.add(amount):
+          raiseAssert "same as validators"
+
       else:
         # Invalid deposits are perfectly possible
         trace "Skipping deposit with invalid signature",
@@ -507,7 +513,8 @@ func get_sorted_attesting_indices_list*(
     state: BeaconState, data: AttestationData, bits: CommitteeValidatorsBits,
     cache: var StateCache): List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE] =
   for index in get_sorted_attesting_indices(state, data, bits, cache):
-    result.add index.uint64
+    if not result.add index.uint64:
+      raiseAssert "same length as bits"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_indexed_attestation
 func get_indexed_attestation(state: BeaconState, attestation: Attestation,
@@ -626,6 +633,8 @@ proc process_attestation*(
     # data sadly is a processing hotspot - the business with the addDefault
     # pointer is here simply to work around the poor codegen
     var pa = attestations.addDefault()
+    if pa.isNil:
+      return err("process_attestation: too many pending attestations")
     assign(pa[].aggregation_bits, attestation.aggregation_bits)
     pa[].data = attestation.data
     pa[].inclusion_delay = state.slot - attestation.data.slot

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -514,7 +514,7 @@ func get_sorted_attesting_indices_list*(
     cache: var StateCache): List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE] =
   for index in get_sorted_attesting_indices(state, data, bits, cache):
     if not result.add index.uint64:
-      raiseAssert "same length as bits"
+      raiseAssert "The `result` list has the same max size as the sorted `bits` input"
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_indexed_attestation
 func get_indexed_attestation(state: BeaconState, attestation: Attestation,

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -726,6 +726,7 @@ proc writeValue*(writer: var JsonWriter, value: HashList)
 
 proc readValue*(reader: var JsonReader, value: var HashList)
                {.raises: [IOError, SerializationError, Defect].} =
+  value.resetCache()
   readValue(reader, value.data)
 
 template writeValue*(writer: var JsonWriter, value: Version | ForkDigest) =

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -598,8 +598,9 @@ func process_historical_roots_update(state: var BeaconState) {.nbench.} =
     # significant additional stack or heap.
     # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#historicalbatch
     # In response to https://github.com/status-im/nimbus-eth2/issues/921
-    state.historical_roots.add hash_tree_root(
-      [hash_tree_root(state.block_roots), hash_tree_root(state.state_roots)])
+    if not state.historical_roots.add hash_tree_root(
+        [hash_tree_root(state.block_roots), hash_tree_root(state.state_roots)]):
+      raiseAssert "no more room for historical roots, so long and thanks for the fish!"
 
 # https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#participation-records-rotation
 func process_participation_record_updates(state: var BeaconState) {.nbench.} =

--- a/beacon_chain/ssz/bytes_reader.nim
+++ b/beacon_chain/ssz/bytes_reader.nim
@@ -24,9 +24,8 @@ template setOutputSize[R, T](a: var array[R, T], length: int) =
     raiseIncorrectSize a.type
 
 proc setOutputSize(list: var List, length: int) {.raisesssz.} =
-  if int64(length) > list.maxLen:
+  if not list.setLen length:
     raise newException(MalformedSszError, "SSZ list maximum size exceeded")
-  list.setLen length
 
 # fromSszBytes copies the wire representation to a Nim variable,
 # assuming there's enough data in the buffer
@@ -140,15 +139,9 @@ func readSszValue*[T](input: openArray[byte],
     if resultBytesCount == maxExpectedSize:
       checkForForbiddenBits(T, input, val.maxLen + 1)
 
-  elif val is HashList:
+  elif val is HashList | HashArray:
     readSszValue(input, val.data)
-    val.hashes.setLen(0)
-    val.growHashes()
-
-  elif val is HashArray:
-    readSszValue(input, val.data)
-    for h in val.hashes.mitems():
-      clearCache(h)
+    val.resetCache()
 
   elif val is List|array:
     type E = type val[0]

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -85,13 +85,38 @@ type
   BitList*[maxLen: static Limit] = distinct BitSeq
 
   HashArray*[maxLen: static Limit; T] = object
+    ## Array implementation that caches the hash of each chunk of data - see
+    ## also HashList for more details.
     data*: array[maxLen, T]
     hashes* {.dontSerialize.}: array[maxChunkIdx(T, maxLen), Eth2Digest]
 
   HashList*[T; maxLen: static Limit] = object
+    ## List implementation that caches the hash of each chunk of data as well
+    ## as the combined hash of each level of the merkle tree using a flattened
+    ## list of hashes.
+    ##
+    ## The merkle tree of a list is formed by imagining a virtual buffer of
+    ## `maxLen` length which is zero-filled where there is no data. Then,
+    ## a merkle tree of hashes is formed as usual - at each level of the tree,
+    ## iff the hash is combined from two zero-filled chunks, the hash is not
+    ## stored in the `hashes` list - instead, `indices` keeps track of where in
+    ## the list each level starts. When the length of `data` changes, the
+    ## `hashes` and `indices` structures must be updated accordingly using
+    ## `growHashes`.
+    ##
+    ## All mutating operators (those that take `var HashList`) will
+    ## automatically invalidate the cache for the relevant chunks - the leaf and
+    ## all intermediate chunk hashes up to the root. When large changes are made
+    ## to `data`, it might be more efficient to batch the updates then reset
+    ## the cache using resetCache` instead.
+
     data*: List[T, maxLen]
-    hashes* {.dontSerialize.}: seq[Eth2Digest]
-    indices* {.dontSerialize.}: array[hashListIndicesLen(maxChunkIdx(T, maxLen)), int64]
+    hashes* {.dontSerialize.}: seq[Eth2Digest] ## \
+      ## Flattened tree store that skips "empty" branches of the tree - the
+      ## starting index in this sequence of each "level" in the tree is found
+      ## in `indices`.
+    indices* {.dontSerialize.}: array[hashListIndicesLen(maxChunkIdx(T, maxLen)), int64] ##\
+      ## Holds the starting index in the hashes list for each level of the tree
 
   # Note for readers:
   # We use `array` for `Vector` and
@@ -115,9 +140,7 @@ template init*[T, N](L: type List[T, N], x: seq[T]): auto =
   List[T, N](x)
 
 template `$`*(x: List): auto = $(distinctBase x)
-template add*(x: var List, val: auto) = add(distinctBase x, val)
 template len*(x: List): auto = len(distinctBase x)
-template setLen*(x: var List, val: auto) = setLen(distinctBase x, val)
 template low*(x: List): auto = low(distinctBase x)
 template high*(x: List): auto = high(distinctBase x)
 template `[]`*(x: List, idx: auto): untyped = distinctBase(x)[idx]
@@ -130,6 +153,20 @@ template items* (x: List): untyped = items(distinctBase x)
 template pairs* (x: List): untyped = pairs(distinctBase x)
 template mitems*(x: var List): untyped = mitems(distinctBase x)
 template mpairs*(x: var List): untyped = mpairs(distinctBase x)
+
+proc add*(x: var List, val: auto): bool =
+  if x.len < x.maxLen:
+    add(distinctBase x, val)
+    true
+  else:
+    false
+
+proc setLen*(x: var List, newLen: int): bool =
+  if newLen <= x.maxLen:
+    setLen(distinctBase x, newLen)
+    true
+  else:
+    false
 
 template init*(L: type BitList, x: seq[byte], N: static Limit): auto =
   BitList[N](data: x)
@@ -194,13 +231,16 @@ func nodesAtLayer*(layer, depth, leaves: int): int =
 
 func cacheNodes*(depth, leaves: int): int =
   ## Total number of nodes needed to cache a tree of a given depth with
-  ## `leaves` items in it (the rest zero-filled)
+  ## `leaves` items in it - chunks that are zero-filled have well-known hash
+  ## trees and don't need to be stored in the tree.
   var res = 0
   for i in 0..<depth:
     res += nodesAtLayer(i, depth, leaves)
   res
 
 proc clearCaches*(a: var HashList, dataIdx: int64) =
+  ## Clear each level of the merkle tree up to the root affected by a data
+  ## change at `dataIdx`.
   if a.hashes.len == 0:
     return
 
@@ -212,6 +252,8 @@ proc clearCaches*(a: var HashList, dataIdx: int64) =
       idxInLayer = idx - (1'i64 shl layer)
       layerIdx = idxInlayer + a.indices[layer]
     if layerIdx < a.indices[layer + 1]:
+      # Only clear cache when we're actually storing it - ie it hasn't been
+      # skipped by the "combined zero hash" optimization
       clearCache(a.hashes[layerIdx])
 
     idx = idx shr 1
@@ -225,7 +267,8 @@ proc clearCache*(a: var HashList) =
   for c in a.hashes.mitems(): clearCache(c)
 
 proc growHashes*(a: var HashList) =
-  # Ensure that the hash cache is big enough for the data in the list
+  ## Ensure that the hash cache is big enough for the data in the list - must
+  ## be called whenever `data` grows.
   let
     leaves = int(
       chunkIdx(a, a.data.len() + dataPerChunk(a.T) - 1))
@@ -250,12 +293,26 @@ proc growHashes*(a: var HashList) =
   swap(a.hashes, newHashes)
   a.indices = newIndices
 
+proc resetCache*(a: var HashList) =
+  ## Perform a full reset of the hash cache, for example after data has been
+  ## rewritten "manually" without going through the exported operators
+  a.hashes.setLen(0)
+  a.indices = default(type a.indices)
+  a.growHashes()
+
+proc resetCache*(a: var HashArray) =
+  for h in a.hashes.mitems():
+    clearCache(h)
+
 template len*(a: type HashArray): auto = int(a.maxLen)
 
-template add*(x: var HashList, val: auto) =
-  add(x.data, val)
-  x.growHashes()
-  clearCaches(x, x.data.len() - 1)
+proc add*(x: var HashList, val: auto): bool =
+  if add(x.data, val):
+    x.growHashes()
+    clearCaches(x, x.data.len() - 1)
+    true
+  else:
+    false
 
 proc addDefault*(x: var HashList): ptr x.T =
   distinctBase(x.data).setLen(x.data.len + 1)
@@ -299,7 +356,8 @@ template swap*(a, b: var HashList) =
   swap(a.indices, b.indices)
 
 template clear*(a: var HashList) =
-  a.data.setLen(0)
+  if not a.data.setLen(0):
+    raiseAssert "length 0 should always succeed"
   a.hashes.setLen(0)
   a.indices = default(type a.indices)
 

--- a/tests/official/test_fixture_rewards.nim
+++ b/tests/official/test_fixture_rewards.nim
@@ -35,8 +35,10 @@ func add(v: var Deltas, idx: int, delta: Delta) =
   v.penalties[idx] += delta.penalties
 
 func init(T: type Deltas, len: int): T =
-  result.rewards.setLen(len)
-  result.penalties.setLen(len)
+  if not result.rewards.setLen(len):
+    raiseAssert "setLen"
+  if not result.penalties.setLen(len):
+    raiseAssert "setLen"
 
 proc runTest(rewardsDir, identifier: string) =
   # We wrap the tests in a proc to avoid running out of globals


### PR DESCRIPTION
When deserializing into an existing structure, the cache should be
cleared - goes for json also