### PR TITLE
remove some BeaconState use and abstract over other uses

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -36,10 +36,6 @@ type
   GetWallTimeFn* = proc(): BeaconTime {.gcsafe, raises: [Defect].}
 
 proc init*(T: type BeaconClock, genesis_time: uint64): T =
-  ## Initialize time from a beacon state. The genesis time of a beacon state is
-  ## constant throughout its lifetime, so the state from any slot will do,
-  ## including the genesis state.
-
   # ~290 billion years into the future
   doAssert genesis_time <= high(int64).uint64
 

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -36,6 +36,10 @@ type
   GetWallTimeFn* = proc(): BeaconTime {.gcsafe, raises: [Defect].}
 
 proc init*(T: type BeaconClock, genesis_time: uint64): T =
+  ## Initialize time from a beacon state. The genesis time of a beacon state is
+  ## constant throughout its lifetime, so the state from any slot will do,
+  ## including the genesis state.
+
   # ~290 billion years into the future
   doAssert genesis_time <= high(int64).uint64
 
@@ -46,12 +50,6 @@ proc init*(T: type BeaconClock, genesis_time: uint64): T =
     unixGenesisOffset = times.seconds(int(GENESIS_SLOT * SECONDS_PER_SLOT))
 
   T(genesis: unixGenesis - unixGenesisOffset)
-
-proc init*(T: type BeaconClock, state: BeaconState): T =
-  ## Initialize time from a beacon state. The genesis time of a beacon state is
-  ## constant throughout its lifetime, so the state from any slot will do,
-  ## including the genesis state.
-  BeaconClock.init(state.genesis_time)
 
 template `<`*(a, b: BeaconTime): bool =
   Duration(a) < Duration(b)

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -78,8 +78,10 @@ proc init*(T: type AttestationPool, chainDag: ChainDAGRef, quarantine: Quarantin
     doAssert status.isOk(), "Error in preloading the fork choice: " & $status.error
 
   info "Fork choice initialized",
-    justified_epoch = chainDag.headState.data.data.current_justified_checkpoint.epoch,
-    finalized_epoch = chainDag.headState.data.data.finalized_checkpoint.epoch,
+    justified_epoch = getStateField(
+      chainDag.headState, current_justified_checkpoint).epoch,
+    finalized_epoch = getStateField(
+      chainDag.headState, finalized_checkpoint).epoch,
     finalized_root = shortlog(chainDag.finalizedHead.blck.root)
 
   T(

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -79,7 +79,7 @@ proc addResolvedBlock(
        onBlockAdded: OnBlockAdded
      ) =
   # TODO move quarantine processing out of here
-  doAssert state.data.data.slot == trustedBlock.message.slot,
+  doAssert getStateField(state, slot) == trustedBlock.message.slot,
     "state must match block"
   doAssert state.blck.root == trustedBlock.message.parent_root,
     "the StateData passed into the addResolved function not yet updated!"

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -111,7 +111,7 @@ func getExitMessagesForBlock[T](
 
     if allIt(
         getValidatorIndices(exit_message),
-        pool.chainDag.headState.data.data.validators[it].exit_epoch !=
+        getStateField(pool.chainDag.headState, validators)[it].exit_epoch !=
           FAR_FUTURE_EPOCH):
       # A beacon block exit message already targeted all these validators
       continue

--- a/beacon_chain/rpc/beacon_api.nim
+++ b/beacon_chain/rpc/beacon_api.nim
@@ -182,9 +182,9 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Exception].} = # TODO fix json-rpc
   rpcServer.rpc("get_v1_beacon_genesis") do () -> BeaconGenesisTuple:
     return (
-      genesis_time: node.chainDag.headState.data.data.genesis_time,
+      genesis_time: getStateField(node.chainDag.headState, genesis_time),
       genesis_validators_root:
-        node.chainDag.headState.data.data.genesis_validators_root,
+        getStateField(node.chainDag.headState, genesis_validators_root),
       genesis_fork_version: node.runtimePreset.GENESIS_FORK_VERSION
     )
 

--- a/beacon_chain/rpc/config_api.nim
+++ b/beacon_chain/rpc/config_api.nim
@@ -33,7 +33,7 @@ func getDepositAddress(node: BeaconNode): string =
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Exception].} = # TODO fix json-rpc
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:
-    return @[node.chainDag.headState.data.data.fork]
+    return @[getStateField(node.chainDag.headState, fork)]
 
   rpcServer.rpc("get_v1_config_spec") do () -> JsonNode:
     return %*{

--- a/beacon_chain/rpc/nimbus_api.nim
+++ b/beacon_chain/rpc/nimbus_api.nim
@@ -43,8 +43,9 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
   rpcServer.rpc("getChainHead") do () -> JsonNode:
     let
       head = node.chainDag.head
-      finalized = node.chainDag.headState.data.data.finalized_checkpoint
-      justified = node.chainDag.headState.data.data.current_justified_checkpoint
+      finalized = getStateField(node.chainDag.headState, finalized_checkpoint)
+      justified =
+        getStateField(node.chainDag.headState, current_justified_checkpoint)
     return %* {
       "head_slot": head.slot,
       "head_block_root": head.root.data.toHex(),

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -21,7 +21,7 @@ template withStateForStateId*(stateId: string, body: untyped): untyped =
     bs = node.stateIdToBlockSlot(stateId)
 
   template isState(state: StateData): bool =
-    state.blck.atSlot(state.data.data.slot) == bs
+    state.blck.atSlot(getStateField(state, slot)) == bs
 
   if isState(node.chainDag.headState):
     withStateVars(node.chainDag.headState):
@@ -75,7 +75,7 @@ proc stateIdToBlockSlot*(node: BeaconNode, stateId: string): BlockSlot {.raises:
     node.chainDag.finalizedHead
   of "justified":
     node.chainDag.head.atEpochStart(
-      node.chainDag.headState.data.data.current_justified_checkpoint.epoch)
+      getStateField(node.chainDag.headState, current_justified_checkpoint).epoch)
   else:
     if stateId.startsWith("0x"):
       let blckRoot = parseRoot(stateId)

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -141,8 +141,8 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         "Slot requested not in current or next wall-slot epoch")
 
     if not verify_slot_signature(
-        node.chainDag.headState.data.data.fork,
-        node.chainDag.headState.data.data.genesis_validators_root,
+        getStateField(node.chainDag.headState, fork),
+        getStateField(node.chainDag.headState, genesis_validators_root),
         slot, validator_pubkey, slot_signature):
       raise newException(CatchableError,
         "Invalid slot signature")

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -84,8 +84,10 @@ proc getCurrentStatus*(state: BeaconSyncNetworkState): StatusMsg {.gcsafe.} =
 
   StatusMsg(
     forkDigest: state.forkDigest,
-    finalizedRoot: chainDag.headState.data.data.finalized_checkpoint.root,
-    finalizedEpoch: chainDag.headState.data.data.finalized_checkpoint.epoch,
+    finalizedRoot:
+      getStateField(chainDag.headState, finalized_checkpoint).root,
+    finalizedEpoch:
+      getStateField(chainDag.headState, finalized_checkpoint).epoch,
     headRoot: headBlock.root,
     headSlot: headBlock.slot)
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -345,9 +345,9 @@ proc proposeBlock(node: BeaconNode,
     return head
 
   let
-    fork = node.chainDag.headState.data.data.fork
+    fork = getStateField(node.chainDag.headState, fork)
     genesis_validators_root =
-      node.chainDag.headState.data.data.genesis_validators_root
+      getStateField(node.chainDag.headState, genesis_validators_root)
   let
     randao = await validator.genRandaoReveal(
       fork, genesis_validators_root, slot)
@@ -417,9 +417,9 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     committees_per_slot =
       get_committee_count_per_slot(epochRef)
     num_active_validators = count_active_validators(epochRef)
-    fork = node.chainDag.headState.data.data.fork
+    fork = getStateField(node.chainDag.headState, fork)
     genesis_validators_root =
-      node.chainDag.headState.data.data.genesis_validators_root
+      getStateField(node.chainDag.headState, genesis_validators_root)
 
   for committee_index in 0'u64..<committees_per_slot:
     let committee = get_beacon_committee(
@@ -498,9 +498,9 @@ proc broadcastAggregatedAttestations(
 
   let
     epochRef = node.chainDag.getEpochRef(aggregationHead, aggregationSlot.epoch)
-    fork = node.chainDag.headState.data.data.fork
+    fork = getStateField(node.chainDag.headState, fork)
     genesis_validators_root =
-      node.chainDag.headState.data.data.genesis_validators_root
+      getStateField(node.chainDag.headState, genesis_validators_root)
     committees_per_slot = get_committee_count_per_slot(epochRef)
 
   var


### PR DESCRIPTION
Semi-mechanical: `'<,'>s/\(chainDag.headState\).data.data.\([a-zA-Z_0-9]\+\)/getStateField(\1, \2)` in vim (with variations for a few ways to refer to `StateData`).