### PR TITLE
ensure ValidatorIndex safely, losslessly 32-bit-system-int-convertible

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -137,7 +137,7 @@ type
   # instances are not invalid _per se_ when they hold an out-of-bounds index -
   # that is part of consensus.
   # VALIDATOR_REGISTRY_LIMIT is 1^40 in spec 1.0, but if the number of
-  # validators ever grows near 1^32 that we support here, we'll have bigger
+  # validators ever grows near 1^31 that we support here, we'll have bigger
   # issues than the size of this type to take care of. Until then, we'll use
   # int32 as it halves memory requirements for active validator sets,
   # improves consistency on 32-vs-64-bit platforms and works better with

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -139,10 +139,10 @@ type
   # VALIDATOR_REGISTRY_LIMIT is 1^40 in spec 1.0, but if the number of
   # validators ever grows near 1^32 that we support here, we'll have bigger
   # issues than the size of this type to take care of. Until then, we'll use
-  # uint32 as it halves memory requirements for active validator sets,
+  # int32 as it halves memory requirements for active validator sets,
   # improves consistency on 32-vs-64-bit platforms and works better with
   # Nim seq constraints.
-  ValidatorIndex* = distinct uint32
+  ValidatorIndex* = distinct int32
 
   # Though in theory the committee index would fit in a uint8, it is not used
   # in a way that would significantly benefit from the smaller type, thus we


### PR DESCRIPTION
By switching it from `uint32` to `int32`. The important constraint here is that it be able to function as an array and `seq[ValidatorIndex]` index on both 32-bit and 64-bit systems.

https://github.com/status-im/nimbus-eth2/pull/2459#discussion_r610464541 contains further discussion.