### PR TITLE
Revamp attestation pool

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -6,13 +6,15 @@ AllTests-mainnet
 + Attestations may overlap, bigger first [Preset: mainnet]                                   OK
 + Attestations may overlap, smaller first [Preset: mainnet]                                  OK
 + Attestations should be combined [Preset: mainnet]                                          OK
-+ Can add and retrieve simple attestation [Preset: mainnet]                                  OK
++ Can add and retrieve simple attestations [Preset: mainnet]                                 OK
++ Everyone voting for something different [Preset: mainnet]                                  OK
 + Fork choice returns block with attestation                                                 OK
 + Fork choice returns latest block with no attestations                                      OK
 + Trying to add a block twice tags the second as an error                                    OK
 + Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
++ Working with aggregates [Preset: mainnet]                                                  OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## Attestation validation  [Preset: mainnet]
 ```diff
 + Validation sanity                                                                          OK
@@ -290,4 +292,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 155/164 Fail: 0/164 Skip: 9/164
+OK: 157/166 Fail: 0/166 Skip: 9/166

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -16,7 +16,9 @@ import
   ../spec/[crypto, datatypes, digest, helpers, signatures, signatures_batch, state_transition],
   ./block_pools_types, ./blockchain_dag, ./block_quarantine
 
-export results
+from libp2p/protocols/pubsub/pubsub import ValidationResult
+
+export results, ValidationResult
 
 # Clearance
 # ---------------------------------------------

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -17,9 +17,7 @@ import
   ../spec/[datatypes, crypto, digest, signatures_batch],
   ../beacon_chain_db, ../extras
 
-from libp2p/protocols/pubsub/pubsub import ValidationResult
-export ValidationResult, sets, tables
-
+export sets, tables
 
 # #############################################
 #

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -125,6 +125,9 @@ func init*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
   ## Initializes an aggregate signature context
   agg.init(blscurve.Signature(sig))
 
+func init*(T: type AggregateSignature, sig: CookedSig | ValidatorSig): T =
+  result.init(sig)
+
 proc aggregate*(agg: var AggregateSignature, sig: ValidatorSig) {.inline.}=
   ## Aggregate two Validator Signatures
   ## Both signatures must be valid
@@ -134,11 +137,11 @@ proc aggregate*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
   ## Aggregate two Validator Signatures
   agg.aggregate(blscurve.Signature(sig))
 
-func finish*(agg: AggregateSignature): ValidatorSig {.inline.}=
+func finish*(agg: AggregateSignature): CookedSig {.inline.}=
   ## Canonicalize an AggregateSignature into a signature
   var sig: blscurve.Signature
   sig.finish(agg)
-  ValidatorSig(blob: sig.exportRaw())
+  CookedSig(sig)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#bls-signatures
 proc blsVerify*(

--- a/beacon_chain/ssz/bitseqs.nim
+++ b/beacon_chain/ssz/bitseqs.nim
@@ -235,7 +235,8 @@ func `$`*(a: BitSeq): string =
   for i in countdown(length - 1, 0):
     result.add if a[i]: '1' else: '0'
 
-func combine*(tgt: var BitSeq, src: BitSeq) =
+func incl*(tgt: var BitSeq, src: BitSeq) =
+  # Update `tgt` to include the bits of `src`, as if applying `or` to each bit
   doAssert tgt.len == src.len
   for tgtWord, srcWord in words(tgt, src):
     tgtWord = tgtWord or srcWord
@@ -245,6 +246,12 @@ func overlaps*(a, b: BitSeq): bool =
     if (wa and wb) != 0:
       return true
 
+func countOverlap*(a, b: BitSeq): int =
+  var res = 0
+  for wa, wb in words(a, b):
+    res += countOnes(wa and wb)
+  res
+
 func isSubsetOf*(a, b: BitSeq): bool =
   let alen = a.len
   doAssert b.len == alen
@@ -253,10 +260,24 @@ func isSubsetOf*(a, b: BitSeq): bool =
       return false
   true
 
-proc isZeros*(x: BitSeq): bool =
+func isZeros*(x: BitSeq): bool =
   for w in words(x):
     if w != 0: return false
   return true
+
+func countOnes*(x: BitSeq): int =
+  # Count the number of set bits
+  var res = 0
+  for w in words(x):
+    res += w.countOnes()
+  res
+
+func clear*(x: var BitSeq) =
+  for w in words(x):
+    w = 0
+
+func countZeros*(x: BitSeq): int =
+  x.len() - x.countOnes()
 
 template bytes*(x: BitSeq): untyped =
   seq[byte](x)

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -183,9 +183,12 @@ template `==`*(a, b: BitList): bool = BitSeq(a) == BitSeq(b)
 template setBit*(x: var BitList, idx: Natural) = setBit(BitSeq(x), idx)
 template clearBit*(x: var BitList, idx: Natural) = clearBit(BitSeq(x), idx)
 template overlaps*(a, b: BitList): bool = overlaps(BitSeq(a), BitSeq(b))
-template combine*(a: var BitList, b: BitList) = combine(BitSeq(a), BitSeq(b))
+template incl*(a: var BitList, b: BitList) = incl(BitSeq(a), BitSeq(b))
 template isSubsetOf*(a, b: BitList): bool = isSubsetOf(BitSeq(a), BitSeq(b))
 template isZeros*(x: BitList): bool = isZeros(BitSeq(x))
+template countOnes*(x: BitList): int = countOnes(BitSeq(x))
+template countZeros*(x: BitList): int = countZeros(BitSeq(x))
+template countOverlap*(x, y: BitList): int = countOverlap(BitSeq(x), BitSeq(y))
 template `$`*(a: BitList): string = $(BitSeq(a))
 
 iterator items*(x: BitList): bool =

--- a/beacon_chain/validators/attestation_aggregation.nim
+++ b/beacon_chain/validators/attestation_aggregation.nim
@@ -26,7 +26,7 @@ func is_aggregator*(epochRef: EpochRef, slot: Slot, index: CommitteeIndex,
   return is_aggregator(committee_len, slot_signature)
 
 proc aggregate_attestations*(
-    pool: AttestationPool, epochRef: EpochRef, slot: Slot, index: CommitteeIndex,
+    pool: var AttestationPool, epochRef: EpochRef, slot: Slot, index: CommitteeIndex,
     validatorIndex: ValidatorIndex, slot_signature: ValidatorSig): Option[AggregateAndProof] =
   doAssert validatorIndex in get_beacon_committee(epochRef, slot, index)
   doAssert index.uint64 < get_committee_count_per_slot(epochRef)

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -138,10 +138,10 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
                   makeAttestation(state[].data, latest_block_root, scas, target_slot,
                     i.CommitteeIndex, v, cache, flags)
                 if not att2.aggregation_bits.overlaps(attestation.aggregation_bits):
-                  attestation.aggregation_bits.combine(att2.aggregation_bits)
+                  attestation.aggregation_bits.incl(att2.aggregation_bits)
                   if skipBlsValidation notin flags:
                     agg.aggregate(att2.signature)
-          attestation.signature = agg.finish()
+          attestation.signature = agg.finish().exportRaw()
 
         if not first:
           # add the attestation if any of the validators attested, as given

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -78,7 +78,7 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
       agg.aggregate(sig)
 
   if first_iter != true:
-    attestation.signature = agg.finish()
+    attestation.signature = agg.finish().exportRaw()
     # Otherwise no participants so zero sig
 
 proc mockAttestationImpl(

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,19 +8,21 @@
 {.used.}
 
 import
-  # Standard library
-  std/unittest,
+  std/sequtils,
   # Status lib
+  unittest2,
   chronicles, chronos,
   stew/byteutils,
   eth/keys,
   # Internal
-  ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
-                        helpers, beaconstate, presets, network],
   ../beacon_chain/[beacon_node_types, extras, beacon_clock],
   ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
   ../beacon_chain/fork_choice/[fork_choice_types, fork_choice],
-  ../beacon_chain/consensus_object_pools/[block_quarantine, blockchain_dag, block_clearance, attestation_pool],
+  ../beacon_chain/consensus_object_pools/[
+    block_quarantine, blockchain_dag, block_clearance, attestation_pool],
+  ../beacon_chain/ssz/merkleization,
+  ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
+                        helpers, beaconstate, presets, network],
   # Test utilities
   ./testutil, ./testblockutil
 
@@ -34,26 +36,17 @@ func combine(tgt: var Attestation, src: Attestation) =
   # In a BLS aggregate signature, one needs to count how many times a
   # particular public key has been added - since we use a single bit per key, we
   # can only it once, thus we can never combine signatures that overlap already!
-  if not tgt.aggregation_bits.overlaps(src.aggregation_bits):
-    tgt.aggregation_bits.combine(src.aggregation_bits)
+  doAssert not tgt.aggregation_bits.overlaps(src.aggregation_bits)
 
-    var agg {.noInit.}: AggregateSignature
-    agg.init(tgt.signature)
-    agg.aggregate(src.signature)
-    tgt.signature = agg.finish()
+  tgt.aggregation_bits.incl(src.aggregation_bits)
+
+  var agg {.noInit.}: AggregateSignature
+  agg.init(tgt.signature)
+  agg.aggregate(src.signature)
+  tgt.signature = agg.finish().exportRaw()
 
 func loadSig(a: Attestation): CookedSig =
   a.signature.load.get().CookedSig
-
-template wrappedTimedTest(name: string, body: untyped) =
-  # `check` macro takes a copy of whatever it's checking, on the stack!
-  # This leads to stack overflow
-  # We can mitigate that by wrapping checks in proc
-  block: # Symbol namespacing
-    proc wrappedTest() =
-      timedTest name:
-        body
-    wrappedTest()
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
@@ -65,9 +58,9 @@ suiteReport "Attestation pool processing" & preset():
   ## mock data.
 
   setup:
-    # Genesis state that results in 3 members per committee
+    # Genesis state that results in 6 members per committee
     var
-      chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
+      chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 6))
       quarantine = QuarantineRef.init(keys.newRng())
       pool = newClone(AttestationPool.init(chainDag, quarantine))
       state = newClone(chainDag.headState)
@@ -76,27 +69,187 @@ suiteReport "Attestation pool processing" & preset():
     check:
       process_slots(state.data, state.data.data.slot + 1, cache)
 
-  wrappedTimedTest "Can add and retrieve simple attestation" & preset():
+  timedTest "Can add and retrieve simple attestations" & preset():
     let
       # Create an attestation for slot 1!
-      beacon_committee = get_beacon_committee(
+      bc0 = get_beacon_committee(
         state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
       attestation = makeAttestation(
-        state.data.data, state.blck.root, beacon_committee[0], cache)
+        state.data.data, state.blck.root, bc0[0], cache)
 
     pool[].addAttestation(
-      attestation, @[beacon_committee[0]], attestation.loadSig,
+      attestation, @[bc0[0]], attestation.loadSig,
       attestation.data.slot)
 
     check:
-      process_slots(state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
+      # Added attestation, should get it back
+      toSeq(pool[].attestations(none(Slot), none(CommitteeIndex))) ==
+        @[attestation]
+      toSeq(pool[].attestations(
+        some(attestation.data.slot), none(CommitteeIndex))) == @[attestation]
+      toSeq(pool[].attestations(
+        some(attestation.data.slot), some(attestation.data.index.CommitteeIndex))) ==
+        @[attestation]
+      toSeq(pool[].attestations(none(Slot), some(attestation.data.index.CommitteeIndex))) ==
+        @[attestation]
+      toSeq(pool[].attestations(some(
+        attestation.data.slot + 1), none(CommitteeIndex))) == []
+      toSeq(pool[].attestations(
+        none(Slot), some(CommitteeIndex(attestation.data.index + 1)))) == []
+
+      process_slots(
+        state.data, state.data.data.slot + MIN_ATTESTATION_INCLUSION_DELAY, cache)
 
     let attestations = pool[].getAttestationsForBlock(state.data.data, cache)
 
     check:
       attestations.len == 1
+      pool[].getAggregatedAttestation(1.Slot, 0.CommitteeIndex).isSome()
 
-  wrappedTimedTest "Attestations may arrive in any order" & preset():
+    let
+      root1 = addTestBlock(
+        state.data, state.blck.root,
+        cache, attestations = attestations, nextSlot = false).root
+      bc1 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+      att1 = makeAttestation(
+        state.data.data, root1, bc1[0], cache)
+
+    check:
+      process_slots(
+        state.data, state.data.data.slot + MIN_ATTESTATION_INCLUSION_DELAY, cache)
+
+    check:
+      # shouldn't include already-included attestations
+      pool[].getAttestationsForBlock(state.data.data, cache) == []
+
+    pool[].addAttestation(
+      att1, @[bc1[0]], att1.loadSig, att1.data.slot)
+
+    check:
+      # but new ones should go in
+      pool[].getAttestationsForBlock(state.data.data, cache).len() == 1
+
+    let
+      att2 = makeAttestation(
+        state.data.data, root1, bc1[1], cache)
+    pool[].addAttestation(
+      att2, @[bc1[1]], att2.loadSig, att2.data.slot)
+
+    let
+      combined = pool[].getAttestationsForBlock(state.data.data, cache)
+
+    check:
+      # New attestations should be combined with old attestations
+      combined.len() == 1
+      combined[0].aggregation_bits.countOnes() == 2
+
+    pool[].addAttestation(
+      combined[0], @[bc1[1], bc1[0]], combined[0].loadSig, combined[0].data.slot)
+
+    check:
+      # readding the combined attestation shouldn't have an effect
+      pool[].getAttestationsForBlock(state.data.data, cache).len() == 1
+
+    let
+      # Someone votes for a different root
+      att3 = makeAttestation(state.data.data, Eth2Digest(), bc1[2], cache)
+    pool[].addAttestation(
+      att3, @[bc1[2]], att3.loadSig, att3.data.slot)
+
+    check:
+      # We should now get both attestations for the block, but the aggregate
+      # should be the one with the most votes
+      pool[].getAttestationsForBlock(state.data.data, cache).len() == 2
+      pool[].getAggregatedAttestation(2.Slot, 0.CommitteeIndex).
+        get().aggregation_bits.countOnes() == 2
+      pool[].getAggregatedAttestation(2.Slot, hash_tree_root(att2.data)).
+        get().aggregation_bits.countOnes() == 2
+
+    let
+      # Someone votes for a different root
+      att4 = makeAttestation(state.data.data, Eth2Digest(), bc1[2], cache)
+    pool[].addAttestation(
+      att4, @[bc1[2]], att3.loadSig, att3.data.slot)
+
+  timedTest "Working with aggregates" & preset():
+    let
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(
+        state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+
+    var
+      att0 = makeAttestation(state.data.data, state.blck.root, bc0[0], cache)
+      att0x = att0
+      att1 = makeAttestation(state.data.data, state.blck.root, bc0[1], cache)
+      att2 = makeAttestation(state.data.data, state.blck.root, bc0[2], cache)
+      att3 = makeAttestation(state.data.data, state.blck.root, bc0[3], cache)
+
+    # Both attestations include member 2 but neither is a subset of the other
+    att0.combine(att2)
+    att1.combine(att2)
+
+    pool[].addAttestation(att0, @[bc0[0], bc0[2]], att0.loadSig, att0.data.slot)
+    pool[].addAttestation(att1, @[bc0[1], bc0[2]], att1.loadSig, att1.data.slot)
+
+    check:
+      process_slots(
+        state.data, state.data.data.slot + MIN_ATTESTATION_INCLUSION_DELAY, cache)
+
+    check:
+      pool[].getAttestationsForBlock(state.data.data, cache).len() == 2
+      # Can get either aggregate here, random!
+      pool[].getAggregatedAttestation(1.Slot, 0.CommitteeIndex).isSome()
+
+    # Add in attestation 3 - both aggregates should now have it added
+    pool[].addAttestation(att3, @[bc0[3]], att3.loadSig, att3.data.slot)
+
+    block:
+      let attestations = pool[].getAttestationsForBlock(state.data.data, cache)
+      check:
+        attestations.len() == 2
+        attestations[0].aggregation_bits.countOnes() == 3
+        # Can get either aggregate here, random!
+        pool[].getAggregatedAttestation(1.Slot, 0.CommitteeIndex).isSome()
+
+    # Add in attestation 0 as single - attestation 1 is now a superset of the
+    # aggregates in the pool, so everything else should be removed
+    pool[].addAttestation(att0x, @[bc0[0]], att0x.loadSig, att0x.data.slot)
+
+    block:
+      let attestations = pool[].getAttestationsForBlock(state.data.data, cache)
+      check:
+        attestations.len() == 1
+        attestations[0].aggregation_bits.countOnes() == 4
+        pool[].getAggregatedAttestation(1.Slot, 0.CommitteeIndex).isSome()
+
+  timedTest "Everyone voting for something different" & preset():
+    var attestations: int
+    for i in 0..<SLOTS_PER_EPOCH:
+      var root: Eth2Digest
+      root.data[0..<8] = toBytesBE(i.uint64)
+      let
+        bc0 = get_beacon_committee(
+          state.data.data, state.data.data.slot, 0.CommitteeIndex, cache)
+
+      for j in 0..<bc0.len():
+        root.data[8..<16] = toBytesBE(j.uint64)
+        var att = makeAttestation(state.data.data, root, bc0[j], cache)
+        pool[].addAttestation(att, @[bc0[j]], att.loadSig, att.data.slot)
+        inc attestations
+
+      check:
+        process_slots(state.data, state.data.data.slot + 1, cache)
+
+    doAssert attestations.uint64 > MAX_ATTESTATIONS,
+      "6*SLOTS_PER_EPOCH validators > 128 mainnet MAX_ATTESTATIONS"
+    check:
+      # Fill block with attestations
+      pool[].getAttestationsForBlock(state.data.data, cache).lenu64() ==
+        MAX_ATTESTATIONS
+      pool[].getAggregatedAttestation(state.data.data.slot - 1, 0.CommitteeIndex).isSome()
+
+  timedTest "Attestations may arrive in any order" & preset():
     var cache = StateCache()
     let
       # Create an attestation for slot 1!
@@ -118,7 +271,7 @@ suiteReport "Attestation pool processing" & preset():
     pool[].addAttestation(
       attestation1, @[bc1[0]], attestation1.loadSig, attestation1.data.slot)
     pool[].addAttestation(
-      attestation0, @[bc0[0]], attestation0.loadSig, attestation1.data.slot)
+      attestation0, @[bc0[0]], attestation0.loadSig, attestation0.data.slot)
 
     discard process_slots(
       state.data, MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache)
@@ -128,7 +281,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       attestations.len == 1
 
-  wrappedTimedTest "Attestations should be combined" & preset():
+  timedTest "Attestations should be combined" & preset():
     var cache = StateCache()
     let
       # Create an attestation for slot 1!
@@ -152,7 +305,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       attestations.len == 1
 
-  wrappedTimedTest "Attestations may overlap, bigger first" & preset():
+  timedTest "Attestations may overlap, bigger first" & preset():
     var cache = StateCache()
 
     var
@@ -179,7 +332,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       attestations.len == 1
 
-  wrappedTimedTest "Attestations may overlap, smaller first" & preset():
+  timedTest "Attestations may overlap, smaller first" & preset():
     var cache = StateCache()
     var
       # Create an attestation for slot 1!
@@ -205,7 +358,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       attestations.len == 1
 
-  wrappedTimedTest "Fork choice returns latest block with no attestations":
+  timedTest "Fork choice returns latest block with no attestations":
     var cache = StateCache()
     let
       b1 = addTestBlock(state.data, chainDag.tail.root, cache)
@@ -233,7 +386,7 @@ suiteReport "Attestation pool processing" & preset():
     check:
       head2 == b2Add[]
 
-  wrappedTimedTest "Fork choice returns block with attestation":
+  timedTest "Fork choice returns block with attestation":
     var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
@@ -293,7 +446,7 @@ suiteReport "Attestation pool processing" & preset():
       # Two votes for b11
       head4 == b11Add[]
 
-  wrappedTimedTest "Trying to add a block twice tags the second as an error":
+  timedTest "Trying to add a block twice tags the second as an error":
     var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
@@ -319,7 +472,7 @@ suiteReport "Attestation pool processing" & preset():
 
     doAssert: b10Add_clone.error == (ValidationResult.Ignore, Duplicate)
 
-  wrappedTimedTest "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
+  timedTest "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
     # Note: very sensitive to stack usage
 
     chainDag.updateFlags.incl {skipBLSValidation}
@@ -361,7 +514,7 @@ suiteReport "Attestation pool processing" & preset():
           pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
 
         let head = pool[].selectHead(blockRef[].slot)
-        doassert: head == blockRef[]
+        doAssert: head == blockRef[]
         chainDag.updateHead(head, quarantine)
         pruneAtFinalization(chainDag, pool[])
 
@@ -418,7 +571,7 @@ suiteReport "Attestation validation " & preset():
     check:
       process_slots(state.data, state.data.data.slot + 1, cache)
 
-  wrappedTimedTest "Validation sanity":
+  timedTest "Validation sanity":
     # TODO: refactor tests to avoid skipping BLS validation
     chainDag.updateFlags.incl {skipBLSValidation}
 

--- a/tests/test_bitseqs.nim
+++ b/tests/test_bitseqs.nim
@@ -12,21 +12,33 @@ suite "Bit fields":
 
     check:
       not a[0]
+      a.isZeros()
 
     a.setBit 1
 
     check:
       not a[0]
       a[1]
+      a.countOnes() == 1
+      a.countZeros() == 99
+      not a.isZeros()
+      a.countOverlap(a) == 1
 
     b.setBit 2
 
-    a.combine(b)
+    a.incl(b)
 
     check:
       not a[0]
       a[1]
       a[2]
+      a.countOverlap(a) == 2
+      a.countOverlap(b) == 1
+      b.countOverlap(a) == 1
+      b.countOverlap(b) == 1
+    a.clear()
+    check:
+      not a[1]
 
   test "iterating words":
     for bitCount in [8, 3, 7, 8, 14, 15, 16, 19, 260]:
@@ -73,4 +85,4 @@ suite "Bit fields":
       check:
         not a.overlaps(b)
         not b.overlaps(a)
-
+        a.countOverlap(b) == 0

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -133,9 +133,7 @@ suiteReport "Block pool processing" & preset():
       stateData = newClone(dag.headState)
       cache = StateCache()
       b1 = addTestBlock(stateData.data, dag.tail.root, cache)
-      b1Root = hash_tree_root(b1.message)
-      b2 = addTestBlock(stateData.data, b1Root, cache)
-      b2Root {.used.} = hash_tree_root(b2.message)
+      b2 = addTestBlock(stateData.data, b1.root, cache)
   wrappedTimedTest "getRef returns nil for missing blocks":
     check:
       dag.getRef(default Eth2Digest) == nil
@@ -154,7 +152,7 @@ suiteReport "Block pool processing" & preset():
 
     check:
       b1Get.isSome()
-      b1Get.get().refs.root == b1Root
+      b1Get.get().refs.root == b1.root
       b1Add[].root == b1Get.get().refs.root
       dag.heads.len == 1
       dag.heads[0] == b1Add[]
@@ -263,12 +261,12 @@ suiteReport "Block pool processing" & preset():
 
     check:
       # ensure we loaded the correct head state
-      dag2.head.root == b2Root
+      dag2.head.root == b2.root
       hash_tree_root(dag2.headState.data.data) == b2.message.state_root
-      dag2.get(b1Root).isSome()
-      dag2.get(b2Root).isSome()
+      dag2.get(b1.root).isSome()
+      dag2.get(b2.root).isSome()
       dag2.heads.len == 1
-      dag2.heads[0].root == b2Root
+      dag2.heads[0].root == b2.root
 
   wrappedTimedTest "Adding the same block twice returns a Duplicate error" & preset():
     let

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -81,9 +81,11 @@ proc addTestBlock*(
     attestations = newSeq[Attestation](),
     deposits = newSeq[Deposit](),
     graffiti = default(GraffitiBytes),
-    flags: set[UpdateFlag] = {}): SignedBeaconBlock =
+    flags: set[UpdateFlag] = {},
+    nextSlot = true): SignedBeaconBlock =
   # Create and add a block to state - state will advance by one slot!
-  doAssert process_slots(state, state.data.slot + 1, cache, flags)
+  if nextSlot:
+    doAssert process_slots(state, state.data.slot + 1, cache, flags)
 
   let
     proposer_index = get_beacon_proposer_index(state.data, cache)
@@ -235,7 +237,7 @@ proc makeFullAttestations*(
           hackPrivKey(state.validators[committee[j]])
         ))
 
-    attestation.signature = agg.finish()
+    attestation.signature = agg.finish().exportRaw()
     result.add attestation
 
 iterator makeTestBlocks*(


### PR DESCRIPTION
This is a revamp of the attestation pool that cleans up several aspects
of attestation processing as the network grows larger and block space
becomes more precious.

The aim is to better exploit the divide between attestation subnets and
aggregations by keeping the two kinds separate until it's time to either
produce a block or aggregate. This means we're no longer eagerly
combining single-vote attestations, but rather wait until the last
moment, and then try to add singles to all aggregates, including those
coming from the network.

Importantly, the branch improves on poor aggregate quality and poor
attestation packing in cases where block space is running out.

A basic greed scoring mechanism is used to select attestations for
blocks - attestations are added based on how much many new votes they
bring to the table.

* Collect single-vote attestations separately and store these until it's
time to make aggregates
* Create aggregates based on single-vote attestations
* Select _best_ aggregate rather than _first_ aggregate when on
aggregation duty
* Top up all aggregates with singles when it's time make the attestation
cut, thus improving the chances of grabbing the best aggregates out
there
* Improve aggregation test coverage
* Improve bitseq operations
* Simplify aggregate signature creation
* Make attestation cache temporary instead of storing it in attestation
pool - most of the time, blocks are not being produced, no need to keep
the data around
* Remove redundant aggregate storage that was used only for RPC
* Use tables to avoid some linear seeks when looking up attestation data
* Fix long cleanup on large slot jumps
* Avoid some pointers
* Speed up iterating all attestations for a slot