### PR TITLE
attestation processing speedups

### DIFF
--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -145,24 +145,29 @@ proc is_valid_indexed_attestation*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
     fork: Fork, genesis_validators_root: Eth2Digest,
-    epochRef: EpochRef, attesting_indices: auto,
+    epochRef: EpochRef,
     attestation: SomeAttestation, flags: UpdateFlags): Result[void, cstring] =
   # This is a variation on `is_valid_indexed_attestation` that works directly
   # with an attestation instead of first constructing an `IndexedAttestation`
   # and then validating it - for the purpose of validating the signature, the
   # order doesn't matter and we can proceed straight to validating the
   # signature instead
-  if attesting_indices.len == 0:
-    return err("indexed_attestation: no attesting indices")
+  let sigs = attestation.aggregation_bits.countOnes()
+  if sigs == 0:
+    return err("is_valid_indexed_attestation: no attesting indices")
 
   # Verify aggregate signature
   if not (skipBLSValidation in flags or attestation.signature is TrustedSig):
-    let pubkeys = mapIt(
-      attesting_indices, epochRef.validator_keys[it])
+    var
+      pubkeys = newSeqOfCap[ValidatorPubKey](sigs)
+    for index in get_attesting_indices(
+        epochRef, attestation.data, attestation.aggregation_bits):
+      pubkeys.add(epochRef.validator_keys[index])
+
     if not verify_attestation_signature(
         fork, genesis_validators_root, attestation.data,
         pubkeys, attestation.signature):
-      return err("indexed attestation: signature verification failure")
+      return err("is_valid_indexed_attestation: signature verification failure")
 
   ok()
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -277,8 +277,7 @@ proc validateAttestation*(
   block:
     # First pass - without cryptography
     let v = is_valid_indexed_attestation(
-        fork, genesis_validators_root, epochRef, attesting_indices,
-        attestation,
+        fork, genesis_validators_root, epochRef, attestation,
         {skipBLSValidation})
     if v.isErr():
       return err((ValidationResult.Reject, v.error))

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -218,7 +218,7 @@ proc createAndSendAttestation(node: BeaconNode,
   let deadline = attestationData.slot.toBeaconTime() +
                  seconds(int(SECONDS_PER_SLOT div 3))
 
-  let (delayStr, delayMillis) =
+  let (delayStr, delaySecs) =
     if wallTime < deadline:
       ("-" & $(deadline - wallTime), -toFloatSeconds(deadline - wallTime))
     else:
@@ -228,7 +228,7 @@ proc createAndSendAttestation(node: BeaconNode,
                              validator = shortLog(validator), delay = delayStr,
                              indexInCommittee = indexInCommittee
 
-  beacon_attestation_sent_delay.observe(delayMillis)
+  beacon_attestation_sent_delay.observe(delaySecs)
 
 proc getBlockProposalEth1Data*(node: BeaconNode,
                                stateData: StateData): BlockProposalEth1Data =


### PR DESCRIPTION
* avoid creating indexed attestation just to check signatures - above
all, don't create it when not checking signatures ;)
* avoid pointer op when adding attestation to pool
* better iterator for yielding attestations
* add metric / log for attestation packing time