### PR TITLE
don't store full states with validators

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -502,11 +502,8 @@ proc putState*(db: BeaconChainDB, key: Eth2Digest, value: var BeaconState) =
 proc putState*(db: BeaconChainDB, value: var BeaconState) =
   db.putState(hash_tree_root(value), value)
 
-proc putStateFull*(db: BeaconChainDB, key: Eth2Digest, value: BeaconState) =
-  db.backend.putEncoded(subkey(BeaconState, key), value)
-
 proc putStateFull*(db: BeaconChainDB, value: BeaconState) =
-  db.putStateFull(hash_tree_root(value), value)
+  db.backend.putEncoded(subkey(BeaconState, hash_tree_root(value)), value)
 
 proc putStateRoot*(db: BeaconChainDB, root: Eth2Digest, slot: Slot,
     value: Eth2Digest) =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -587,10 +587,6 @@ proc putState*(dag: ChainDAGRef, state: var StateData) =
   # is resilient against one or the other going missing
   dag.db.putState(state.data.root, state.data.data)
 
-  # Allow backwards-compatible version rollback with bounded recovery cost
-  if getStateField(state, slot).epoch mod 256 == 0:
-    dag.db.putStateFull(state.data.root, state.data.data)
-
   dag.db.putStateRoot(
     state.blck.root, getStateField(state, slot), state.data.root)
 


### PR DESCRIPTION
This PR should not land in v1.2.x, only v1.3.x or later. It's okay if it's in `unstable` whenever.

Currently:
- every epoch (or so) at least one state is stored;
- every 32 epochs, that stored state survives state pruning;
- every 256 epochs, a full state with validators is stored, for backwards compatibility with version 1.0.x.

This means that the steady state is that one has:
1. {state with validators, state without validators}
2. {state without validators}
3. {state without validators}
4. {state without validators}
5. {state without validators}
6. {state without validators}
7. {state without validators}
8. {state without validators}
9. {state with validators, state without validators}
10. {state without validators}
11. {state without validators}
12. {state without validators}
13. {state without validators}
14. {state without validators}
15. {state without validators}
16. {state without validators}
17. {state with validators, state without validators}
18. ...

Where the states without validators are around 2MB stored blobs, while those with validators are 9 or 10MB and increasing at the 100k/120k+ validator counts of Mainnet/Pyrmont, with Prater (210k+) being even more acutely different.

https://github.com/status-im/nimbus-eth2/pull/2297 and https://github.com/status-im/nimbus-eth2/issues/2440#issuecomment-804707165 have benchmarks and measurements of this.

Cutting out the states with validators from this pattern decreases the average sustained marginal per-epoch cost of state storage approximately from (8 x 2MB + 10MB) to (8 x 2MB), or from 26MB to 16MB, or by a factor of a bit less than 2 for the smaller networks and more for Prater.