### PR TITLE
remove attestation/aggregate queue

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -15,11 +15,6 @@ AllTests-mainnet
 + Working with aggregates [Preset: mainnet]                                                  OK
 ```
 OK: 11/11 Fail: 0/11 Skip: 0/11
-## Attestation validation  [Preset: mainnet]
-```diff
-+ Validation sanity                                                                          OK
-```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -98,6 +93,11 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + fork_choice - testing with votes                                                           OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
+## Gossip validation  [Preset: mainnet]
+```diff
++ Validation sanity                                                                          OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Honest validator
 ```diff
 + General pubsub topics                                                                      OK

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -78,6 +78,27 @@ iterator get_attesting_indices*(epochRef: EpochRef,
         yield index
       inc i
 
+func get_attesting_indices_one*(epochRef: EpochRef,
+                                data: AttestationData,
+                                bits: CommitteeValidatorsBits):
+                                  Option[ValidatorIndex] =
+  # A variation on get_attesting_indices that returns the validator index only
+  # if only one validator index is set
+  if bits.lenu64 != get_beacon_committee_len(epochRef, data.slot, data.index.CommitteeIndex):
+    trace "get_attesting_indices: inconsistent aggregation and committee length"
+    none(ValidatorIndex)
+  else:
+    var res = none(ValidatorIndex)
+    var i = 0
+    for index in get_beacon_committee(epochRef, data.slot, data.index.CommitteeIndex):
+      if bits[i]:
+        if res.isNone():
+          res = some(index)
+        else:
+          return none(ValidatorIndex)
+      inc i
+    res
+
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_attesting_indices
 func get_attesting_indices*(epochRef: EpochRef,
                             data: AttestationData,

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -34,39 +34,17 @@ type
     ## Fork Choice Error Kinds
     fcFinalizedNodeUnknown
     fcJustifiedNodeUnknown
-    fcInvalidFinalizedRootChange
     fcInvalidNodeIndex
-    fcInvalidParentIndex
-    fcInvalidBestChildIndex
     fcInvalidJustifiedIndex
     fcInvalidBestDescendant
     fcInvalidParentDelta
     fcInvalidNodeDelta
     fcDeltaUnderflow
-    fcIndexUnderflow
     fcInvalidDeltaLen
-    fcRevertedFinalizedEpoch
     fcInvalidBestNode
     fcInconsistentTick
-    # -------------------------
-    # TODO: Extra error modes beyond Proto/Lighthouse to be reviewed
     fcUnknownParent
     fcPruningFromOutdatedFinalizedRoot
-
-  AttErrorKind* = enum
-    attFromFuture
-    attFromPast
-    attBadTargetEpoch
-    attUnkownTarget
-    attUnknownBlock
-    attWrongTarget
-    attFutureSlot
-
-  FcUnderflowKind* = enum
-    ## Fork Choice Overflow Kinds
-     fcUnderflowIndices = "Indices Overflow"
-     fcUnderflowBestChild = "Best Child Overflow"
-     fcUnderflowBestDescendant = "Best Descendant Overflow"
 
   Index* = int
   Delta* = int64
@@ -77,26 +55,18 @@ type
     of fcFinalizedNodeUnknown,
        fcJustifiedNodeUnknown:
          blockRoot*: Eth2Digest
-    of fcInvalidFinalizedRootChange,
-       fcInconsistentTick:
+    of fcInconsistentTick:
       discard
     of fcInvalidNodeIndex,
-       fcInvalidParentIndex,
-       fcInvalidBestChildIndex,
        fcInvalidJustifiedIndex,
        fcInvalidBestDescendant,
        fcInvalidParentDelta,
        fcInvalidNodeDelta,
        fcDeltaUnderflow:
          index*: Index
-    of fcIndexUnderflow:
-      underflowKind*: FcUnderflowKind
     of fcInvalidDeltaLen:
       deltasLen*: int
       indicesLen*: int
-    of fcRevertedFinalizedEpoch:
-      currentFinalizedEpoch*: Epoch
-      new_finalized_epoch*: Epoch
     of fcInvalidBestNode:
       startRoot*: Eth2Digest
       justifiedEpoch*: Epoch

--- a/beacon_chain/gossip_processing/gossip_to_consensus.nim
+++ b/beacon_chain/gossip_processing/gossip_to_consensus.nim
@@ -22,12 +22,6 @@ import
 declareHistogram beacon_store_block_duration_seconds,
   "storeBlock() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
 
-declareCounter beacon_attestations_dropped_queue_full,
-  "Number of attestations dropped because queue is full"
-
-declareCounter beacon_aggregates_dropped_queue_full,
-  "Number of aggregates dropped because queue is full"
-
 type
   SyncBlock* = object
     blk*: SignedBeaconBlock

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[sequtils, intsets, deques],
+  std/[intsets, deques],
   # Status
   chronicles, chronos,
   stew/results,
@@ -149,7 +149,6 @@ func check_attestation_subnet(
 
 # Gossip Validation
 # ----------------------------------------------------------------
-{.pop.} # async can raises anything
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
 proc validateAttestation*(
@@ -158,7 +157,7 @@ proc validateAttestation*(
     attestation: Attestation,
     wallTime: BeaconTime,
     attestation_subnet: uint64, checksExpensive: bool):
-    Future[Result[tuple[attestingIndices: seq[ValidatorIndex], sig: CookedSig],
+    Future[Result[tuple[attesting_index: ValidatorIndex, sig: CookedSig],
       (ValidationResult, cstring)]] {.async.} =
   # Some of the checks below have been reordered compared to the spec, to
   # perform the cheap checks first - in particular, we want to avoid loading
@@ -247,13 +246,13 @@ proc validateAttestation*(
     fork = getStateField(pool.chainDag.headState, fork)
     genesis_validators_root =
       getStateField(pool.chainDag.headState, genesis_validators_root)
-    attesting_indices = get_attesting_indices(
+    attesting_index = get_attesting_indices_one(
       epochRef, attestation.data, attestation.aggregation_bits)
 
   # The number of aggregation bits matches the committee size, which ensures
   # this condition holds.
-  doAssert attesting_indices.len == 1, "Per bits check above"
-  let validator_index = toSeq(attesting_indices)[0]
+  doAssert attesting_index.isSome(), "We've checked bits length and one count already"
+  let validator_index = attesting_index.get()
 
   # There has been no other valid attestation seen on an attestation subnet
   # that has an identical `attestation.data.target.epoch` and participating
@@ -271,7 +270,7 @@ proc validateAttestation*(
     # TODO this means that (a) this becomes an "expensive" check and (b) it is
     # doing in-principle unnecessary work, since this should be known from the
     # attestation creation.
-    return ok((attesting_indices, attestation.signature.load.get().CookedSig))
+    return ok((validator_index, attestation.signature.load.get().CookedSig))
 
   # The signature of attestation is valid.
   block:
@@ -295,9 +294,15 @@ proc validateAttestation*(
   # Await the crypto check
   let
     (cryptoFut, sig) = deferredCrypto.get()
-    cryptoChecked = await cryptoFut
-  if cryptoChecked.isErr():
-    return err((ValidationResult.Reject, cryptoChecked.error))
+
+  var x = (await cryptoFut)
+  case x
+  of BatchResult.Invalid:
+    return err((ValidationResult.Reject, cstring("validateAttestation: invalid signature")))
+  of BatchResult.Timeout:
+    return err((ValidationResult.Ignore, cstring("validateAttestation: timeout checking signature")))
+  of BatchResult.Valid:
+    discard # keep going only in this case
 
   # Only valid attestations go in the list, which keeps validator_index
   # in range
@@ -306,7 +311,7 @@ proc validateAttestation*(
   pool.nextAttestationEpoch[validator_index].subnet =
     attestation.data.target.epoch + 1
 
-  return ok((attesting_indices, sig))
+  return ok((validator_index, sig))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
 proc validateAggregate*(
@@ -430,28 +435,43 @@ proc validateAggregate*(
                 )
   if deferredCrypto.isNone():
     return err((ValidationResult.Reject,
-                cstring("validateAttestation: crypto sanity checks failure")))
+                cstring("validateAggregate: crypto sanity checks failure")))
 
-  # [REJECT] aggregate_and_proof.selection_proof
   let
     (cryptoFuts, sig) = deferredCrypto.get()
-    slotChecked = await cryptoFuts.slotCheck
-  if slotChecked.isErr():
-    return err((ValidationResult.Reject, cstring(
-      "Selection_proof signature verification failed")))
+
+  block:
+    # [REJECT] aggregate_and_proof.selection_proof
+    var x = await cryptoFuts.slotCheck
+    case x
+    of BatchResult.Invalid:
+      return err((ValidationResult.Reject, cstring("validateAggregate: invalid slot signature")))
+    of BatchResult.Timeout:
+      return err((ValidationResult.Reject, cstring("validateAggregate: timeout checking slot signature")))
+    of BatchResult.Valid:
+      discard
 
   block:
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    let aggregatorChecked = await cryptoFuts.aggregatorCheck
-    if aggregatorChecked.isErr():
-      return err((ValidationResult.Reject, cstring(
-        "signed_aggregate_and_proof aggregator signature verification failed")))
+    var x = await cryptoFuts.aggregatorCheck
+    case x
+    of BatchResult.Invalid:
+      return err((ValidationResult.Reject, cstring("validateAggregate: invalid aggregator signature")))
+    of BatchResult.Timeout:
+      return err((ValidationResult.Reject, cstring("validateAggregate: timeout checking aggregator signature")))
+    of BatchResult.Valid:
+      discard
 
+  block:
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    let aggregateChecked = await cryptoFuts.aggregateCheck
-    if aggregateChecked.isErr():
-      return err((ValidationResult.Reject, cstring(
-        "signed_aggregate_and_proof aggregate attester signatures verification failed")))
+    var x = await cryptoFuts.aggregateCheck
+    case x
+    of BatchResult.Invalid:
+      return err((ValidationResult.Reject, cstring("validateAggregate: invalid aggregate signature")))
+    of BatchResult.Timeout:
+      return err((ValidationResult.Reject, cstring("validateAggregate: timeout checking aggregate signature")))
+    of BatchResult.Valid:
+      discard
 
   # The following rule follows implicitly from that we clear out any
   # unviable blocks from the chain dag:
@@ -473,8 +493,6 @@ proc validateAggregate*(
     epochRef, aggregate.data, aggregate.aggregation_bits)
 
   return ok((attesting_indices, sig))
-
-{.push raises: [Defect].}
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_block
 proc isValidBeaconBlock*(

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -53,5 +53,5 @@ func makeDeposit*(
     withdrawal_credentials: makeWithdrawalCredentials(pubkey))
 
   if skipBLSValidation notin flags:
-    result.signature = preset.get_deposit_signature(result, privkey)
+    result.signature = preset.get_deposit_signature(result, privkey).toValidatorSig()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1598,7 +1598,7 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
       validator_index: validatorIdx))
 
   signedExit.signature = get_voluntary_exit_signature(
-    fork, genesisValidatorsRoot, signedExit.message, signingKey.get)
+    fork, genesisValidatorsRoot, signedExit.message, signingKey.get).toValidatorSig()
 
   template ask(prompt: string): string =
     try:

--- a/beacon_chain/nimbus_signing_process.nim
+++ b/beacon_chain/nimbus_signing_process.nim
@@ -33,4 +33,4 @@ programMain:
 
     let privKey = validators[ValidatorPubKey.fromHex(args[0]).get()]
 
-    echo blsSign(privKey, Eth2Digest.fromHex(args[1]).data)
+    echo blsSign(privKey, Eth2Digest.fromHex(args[1]).data).toValidatorSig()

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -761,5 +761,5 @@ proc prepareDeposit*(preset: RuntimePreset,
     pubkey: signingPubKey,
     withdrawal_credentials: makeWithdrawalCredentials(withdrawalPubKey))
 
-  res.signature = preset.get_deposit_signature(res, signingKey)
+  res.signature = preset.get_deposit_signature(res, signingKey).toValidatorSig()
   return res

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -35,7 +35,7 @@ func compute_slot_root*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#aggregation-selection
 func get_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    privkey: ValidatorPrivKey): ValidatorSig =
+    privkey: ValidatorPrivKey): CookedSig =
   blsSign(privKey, compute_slot_root(fork, genesis_validators_root, slot).data)
 
 proc verify_slot_signature*(
@@ -60,7 +60,7 @@ func compute_epoch_root*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#randao-reveal
 func get_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
-    privkey: ValidatorPrivKey): ValidatorSig =
+    privkey: ValidatorPrivKey): CookedSig =
   blsSign(privKey, compute_epoch_root(fork, genesis_validators_root, epoch).data)
 
 proc verify_epoch_signature*(
@@ -85,7 +85,7 @@ func compute_block_root*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#signature
 func get_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    root: Eth2Digest, privkey: ValidatorPrivKey): ValidatorSig =
+    root: Eth2Digest, privkey: ValidatorPrivKey): CookedSig =
   blsSign(privKey, compute_block_root(fork, genesis_validators_root, slot, root).data)
 
 proc verify_block_signature*(
@@ -114,7 +114,7 @@ func compute_aggregate_and_proof_root*(fork: Fork, genesis_validators_root: Eth2
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#broadcast-aggregate
 func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
                                         aggregate_and_proof: AggregateAndProof,
-                                        privKey: ValidatorPrivKey): ValidatorSig =
+                                        privKey: ValidatorPrivKey): CookedSig =
   blsSign(privKey, compute_aggregate_and_proof_root(fork, genesis_validators_root,
                                                     aggregate_and_proof).data)
 
@@ -144,7 +144,7 @@ func compute_attestation_root*(
 func get_attestation_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     attestation_data: AttestationData,
-    privkey: ValidatorPrivKey): ValidatorSig =
+    privkey: ValidatorPrivKey): CookedSig =
   blsSign(privKey, compute_attestation_root(fork, genesis_validators_root,
                                             attestation_data).data)
 
@@ -165,7 +165,7 @@ proc verify_attestation_signature*(
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#deposits
 func get_deposit_signature*(preset: RuntimePreset,
                             deposit: DepositData,
-                            privkey: ValidatorPrivKey): ValidatorSig =
+                            privkey: ValidatorPrivKey): CookedSig =
   let
     deposit_message = deposit.getDepositMessage()
     # Fork-agnostic domain since deposits are valid across forks
@@ -188,7 +188,7 @@ func get_voluntary_exit_signature*(
     fork: Fork,
     genesis_validators_root: Eth2Digest,
     voluntary_exit: VoluntaryExit,
-    privkey: ValidatorPrivKey): ValidatorSig =
+    privkey: ValidatorPrivKey): CookedSig =
   let
     domain = get_domain(
       fork, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch, genesis_validators_root)

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -25,8 +25,9 @@ func init*(T: type ValidatorPool,
   ## `genesis_validators_root` is used as an unique ID for the
   ## blockchain
   ## `backend` is the KeyValue Store backend
-  result.validators = initTable[ValidatorPubKey, AttachedValidator]()
-  result.slashingProtection = slashingProtectionDB
+  T(
+    slashingProtection: slashingProtectionDB
+  )
 
 template count*(pool: ValidatorPool): int =
   pool.validators.len
@@ -72,23 +73,23 @@ proc signWithRemoteValidator(v: AttachedValidator, data: Eth2Digest):
 proc signBlockProposal*(v: AttachedValidator, fork: Fork,
                         genesis_validators_root: Eth2Digest, slot: Slot,
                         blockRoot: Eth2Digest): Future[ValidatorSig] {.async.} =
-  if v.kind == inProcess:
-    result = get_block_signature(
-      fork, genesis_validators_root, slot, blockRoot, v.privKey)
+  return if v.kind == inProcess:
+    get_block_signature(
+      fork, genesis_validators_root, slot, blockRoot, v.privKey).toValidatorSig()
   else:
     let root = compute_block_root(fork, genesis_validators_root, slot, blockRoot)
-    result = await signWithRemoteValidator(v, root)
+    await signWithRemoteValidator(v, root)
 
 proc signAttestation*(v: AttachedValidator,
                       attestation: AttestationData,
                       fork: Fork, genesis_validators_root: Eth2Digest):
                       Future[ValidatorSig] {.async.} =
-  if v.kind == inProcess:
-    result = get_attestation_signature(
-      fork, genesis_validators_root, attestation, v.privKey)
+  return if v.kind == inProcess:
+    get_attestation_signature(
+      fork, genesis_validators_root, attestation, v.privKey).toValidatorSig()
   else:
     let root = compute_attestation_root(fork, genesis_validators_root, attestation)
-    result = await signWithRemoteValidator(v, root)
+    await signWithRemoteValidator(v, root)
 
 proc produceAndSignAttestation*(validator: AttachedValidator,
                                 attestationData: AttestationData,
@@ -107,36 +108,36 @@ proc signAggregateAndProof*(v: AttachedValidator,
                             aggregate_and_proof: AggregateAndProof,
                             fork: Fork, genesis_validators_root: Eth2Digest):
                             Future[ValidatorSig] {.async.} =
-  if v.kind == inProcess:
-    result = get_aggregate_and_proof_signature(
-      fork, genesis_validators_root, aggregate_and_proof, v.privKey)
+  return if v.kind == inProcess:
+    get_aggregate_and_proof_signature(
+      fork, genesis_validators_root, aggregate_and_proof, v.privKey).toValidatorSig()
   else:
     let root = compute_aggregate_and_proof_root(
       fork, genesis_validators_root, aggregate_and_proof)
-    result = await signWithRemoteValidator(v, root)
+    await signWithRemoteValidator(v, root)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#randao-reveal
 func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork,
-    genesis_validators_root: Eth2Digest, slot: Slot): ValidatorSig =
+    genesis_validators_root: Eth2Digest, slot: Slot): CookedSig =
   get_epoch_signature(
     fork, genesis_validators_root, slot.compute_epoch_at_slot, k)
 
 proc genRandaoReveal*(v: AttachedValidator, fork: Fork,
                       genesis_validators_root: Eth2Digest, slot: Slot):
                       Future[ValidatorSig] {.async.} =
-  if v.kind == inProcess:
-    return genRandaoReveal(v.privKey, fork, genesis_validators_root, slot)
+  return if v.kind == inProcess:
+    genRandaoReveal(v.privKey, fork, genesis_validators_root, slot).toValidatorSig()
   else:
     let root = compute_epoch_root(
       fork, genesis_validators_root, slot.compute_epoch_at_slot)
-    result = await signWithRemoteValidator(v, root)
+    await signWithRemoteValidator(v, root)
 
 proc getSlotSig*(v: AttachedValidator, fork: Fork,
                  genesis_validators_root: Eth2Digest, slot: Slot
                  ): Future[ValidatorSig] {.async.} =
-  if v.kind == inProcess:
-    result = get_slot_signature(
-      fork, genesis_validators_root, slot, v.privKey)
+  return if v.kind == inProcess:
+    get_slot_signature(
+      fork, genesis_validators_root, slot, v.privKey).toValidatorSig()
   else:
     let root = compute_slot_root(fork, genesis_validators_root, slot)
-    result = await signWithRemoteValidator(v, root)
+    await signWithRemoteValidator(v, root)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -117,8 +117,8 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
               Attestation(
                 data: data,
                 aggregation_bits: aggregation_bits,
-                signature: sig
-              ), @[validatorIdx], sig.load.get().CookedSig, data.slot)
+                signature: sig.toValidatorSig()
+              ), [validatorIdx], sig, data.slot)
 
   proc proposeBlock(slot: Slot) =
     if rand(r, 1.0) > blockRatio:
@@ -141,7 +141,8 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
           hashedState,
           proposerIdx,
           head.root,
-          privKey.genRandaoReveal(state.fork, state.genesis_validators_root, slot),
+          privKey.genRandaoReveal(state.fork, state.genesis_validators_root,
+            slot).toValidatorSig(),
           eth1ProposalData.vote,
           default(GraffitiBytes),
           attPool.getAttestationsForBlock(state, cache),
@@ -164,7 +165,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
       newBlock.signature = withTimerRet(timers[tSignBlock]):
         get_block_signature(
           state.fork, state.genesis_validators_root, newBlock.message.slot,
-          blockRoot, privKey)
+          blockRoot, privKey).toValidatorSig()
 
       let added = chainDag.addRawBlock(quarantine, newBlock) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -131,7 +131,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
                 attestation =
                   makeAttestation(state[].data, latest_block_root, scas, target_slot,
                     i.CommitteeIndex, v, cache, flags)
-                agg.init(attestation.signature)
+                agg.init(attestation.signature.load.get())
                 first = false
               else:
                 let att2 =
@@ -140,8 +140,8 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
                 if not att2.aggregation_bits.overlaps(attestation.aggregation_bits):
                   attestation.aggregation_bits.incl(att2.aggregation_bits)
                   if skipBlsValidation notin flags:
-                    agg.aggregate(att2.signature)
-          attestation.signature = agg.finish().exportRaw()
+                    agg.aggregate(att2.signature.load.get())
+          attestation.signature = agg.finish().toValidatorSig()
 
         if not first:
           # add the attestation if any of the validators attested, as given

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -21,6 +21,7 @@ import # Unit test
   ./test_discovery,
   ./test_eth1_monitor,
   ./test_exit_pool,
+  ./test_gossip_validation,
   ./test_helpers,
   ./test_honest_validator,
   ./test_interop,

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -78,7 +78,7 @@ proc signMockAttestation*(state: BeaconState, attestation: var Attestation) =
       agg.aggregate(sig)
 
   if first_iter != true:
-    attestation.signature = agg.finish().exportRaw()
+    attestation.signature = agg.finish().toValidatorSig()
     # Otherwise no participants so zero sig
 
 proc mockAttestationImpl(

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -8,7 +8,7 @@
 import
   options,
   # Specs
-  ../../beacon_chain/spec/[datatypes, helpers, signatures, validator],
+  ../../beacon_chain/spec/[crypto, datatypes, helpers, signatures, validator],
   # Internals
   ../../beacon_chain/ssz,
   # Mock helpers
@@ -28,11 +28,11 @@ proc signMockBlockImpl(
 
   signedBlock.message.body.randao_reveal = get_epoch_signature(
     state.fork, state.genesis_validators_root, block_slot.compute_epoch_at_slot,
-    privkey)
+    privkey).toValidatorSig()
   signedBlock.root = hash_tree_root(signedBlock.message)
   signedBlock.signature = get_block_signature(
     state.fork, state.genesis_validators_root, block_slot,
-    signedBlock.root, privkey)
+    signedBlock.root, privkey).toValidatorSig()
 
 proc signMockBlock*(state: BeaconState, signedBlock: var SignedBeaconBlock) =
   signMockBlockImpl(state, signedBlock)

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -44,7 +44,7 @@ func mockDepositData(
       ): DepositData =
   var ret = mockDepositData(pubkey, amount)
   if skipBlsValidation notin flags:
-    ret.signature = defaultRuntimePreset.get_deposit_signature(ret, privkey)
+    ret.signature = defaultRuntimePreset.get_deposit_signature(ret, privkey).toValidatorSig()
   ret
 
 template mockGenesisDepositsImpl(

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -1,0 +1,149 @@
+# beacon_chain
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Status lib
+  unittest2,
+  chronicles, chronos,
+  eth/keys,
+  # Internal
+  ../beacon_chain/[beacon_node_types, extras, beacon_clock],
+  ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
+  ../beacon_chain/fork_choice/[fork_choice_types, fork_choice],
+  ../beacon_chain/consensus_object_pools/[
+    block_quarantine, blockchain_dag, block_clearance, attestation_pool],
+  ../beacon_chain/ssz/merkleization,
+  ../beacon_chain/spec/[crypto, datatypes, digest, validator, state_transition,
+                        helpers, presets, network],
+  # Test utilities
+  ./testutil, ./testblockutil
+
+proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
+  if dag.needStateCachesAndForkChoicePruning():
+    dag.pruneStateCachesDAG()
+    # pool[].prune() # We test logic without att_1_0 pool / fork choice pruning
+
+suiteReport "Gossip validation " & preset():
+  setup:
+    # Genesis state that results in 3 members per committee
+    var
+      chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
+      quarantine = QuarantineRef.init(keys.newRng())
+      pool = newClone(AttestationPool.init(chainDag, quarantine))
+      state = newClone(chainDag.headState)
+      cache = StateCache()
+      batchCrypto = BatchCrypto.new(keys.newRng(), eager = proc(): bool = false)
+    # Slot 0 is a finalized slot - won't be making attestations for it..
+    check:
+      process_slots(state.data, getStateField(state, slot) + 1, cache)
+
+  timedTest "Validation sanity":
+    # TODO: refactor tests to avoid skipping BLS validation
+    chainDag.updateFlags.incl {skipBLSValidation}
+
+    var
+      cache: StateCache
+    for blck in makeTestBlocks(
+        chainDag.headState.data, chainDag.head.root, cache,
+        int(SLOTS_PER_EPOCH * 5), false):
+      let added = chainDag.addRawBlock(quarantine, blck) do (
+          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
+          epochRef: EpochRef, state: HashedBeaconState):
+        # Callback add to fork choice if valid
+        pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
+
+      check: added.isOk()
+      chainDag.updateHead(added[], quarantine)
+      pruneAtFinalization(chainDag, pool[])
+
+    var
+      # Create attestations for slot 1
+      beacon_committee = get_beacon_committee(
+        chainDag.headState.data.data, chainDag.head.slot, 0.CommitteeIndex, cache)
+      att_1_0 = makeAttestation(
+        chainDag.headState.data.data, chainDag.head.root, beacon_committee[0], cache)
+      att_1_1 = makeAttestation(
+        chainDag.headState.data.data, chainDag.head.root, beacon_committee[1], cache)
+
+      committees_per_slot =
+        get_committee_count_per_slot(chainDag.headState.data.data,
+        att_1_0.data.slot.epoch, cache)
+
+      subnet = compute_subnet_for_attestation(
+        committees_per_slot,
+        att_1_0.data.slot, att_1_0.data.index.CommitteeIndex)
+
+      beaconTime = att_1_0.data.slot.toBeaconTime()
+
+    check:
+      validateAttestation(pool, batchCrypto, att_1_0, beaconTime, subnet, true).waitFor().isOk
+
+      # Same validator again
+      validateAttestation(pool, batchCrypto, att_1_0, beaconTime, subnet, true).waitFor().error()[0] ==
+        ValidationResult.Ignore
+
+    pool[].nextAttestationEpoch.setLen(0) # reset for test
+    check:
+      # Wrong subnet
+      validateAttestation(pool, batchCrypto, att_1_0, beaconTime, subnet + 1, true).waitFor().isErr
+
+    pool[].nextAttestationEpoch.setLen(0) # reset for test
+    check:
+      # Too far in the future
+      validateAttestation(
+        pool, batchCrypto, att_1_0, beaconTime - 1.seconds, subnet + 1, true).waitFor().isErr
+
+    pool[].nextAttestationEpoch.setLen(0) # reset for test
+    check:
+      # Too far in the past
+      validateAttestation(
+        pool, batchCrypto, att_1_0,
+        beaconTime - (SECONDS_PER_SLOT * SLOTS_PER_EPOCH - 1).int.seconds,
+        subnet + 1, true).waitFor().isErr
+
+    block:
+      var broken = att_1_0
+      broken.signature.blob[0] += 1
+      pool[].nextAttestationEpoch.setLen(0) # reset for test
+      check:
+        # Invalid signature
+        validateAttestation(
+          pool, batchCrypto, broken, beaconTime, subnet, true).waitFor().
+            error()[0] == ValidationResult.Reject
+
+    block:
+      var broken = att_1_0
+      broken.signature.blob[5] += 1
+      pool[].nextAttestationEpoch.setLen(0) # reset for test
+      # One invalid, one valid (batched)
+      let
+        fut_1_0 = validateAttestation(
+          pool, batchCrypto, broken, beaconTime, subnet, true)
+        fut_1_1 = validateAttestation(
+          pool, batchCrypto, att_1_1, beaconTime, subnet, true)
+
+      check:
+        fut_1_0.waitFor().error()[0] == ValidationResult.Reject
+        fut_1_1.waitFor().isOk()
+
+    block:
+      var broken = att_1_0
+      # This shouldn't deserialize, which is a different way to break it
+      broken.signature.blob = default(type broken.signature.blob)
+      pool[].nextAttestationEpoch.setLen(0) # reset for test
+      # One invalid, one valid (batched)
+      let
+        fut_1_0 = validateAttestation(
+          pool, batchCrypto, broken, beaconTime, subnet, true)
+        fut_1_1 = validateAttestation(
+          pool, batchCrypto, att_1_1, beaconTime, subnet, true)
+
+      check:
+        fut_1_0.waitFor().error()[0] == ValidationResult.Reject
+        fut_1_1.waitFor().isOk()

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -136,7 +136,7 @@ suiteReport "Interop":
 
       check:
         # TODO re-enable
-        true or dep.sig == computed_sig
+        true or dep.sig == computed_sig.toValidatorSig()
 
   timedTest "Interop genesis":
     # Check against https://github.com/protolambda/zcli:


### PR DESCRIPTION
With the introduction of batching and lazy attestation aggregation, it
no longer makes sense to enqueue attestations between the signature
check and adding them to the attestation pool - this only takes up
valuable CPU without any real benefit.

* add successfully validated attestations to attestion pool directly
* avoid copying participant list around for single-vote attestations,
pass single validator index instead
* release decompressed gossip memory earlier, specially during async
message validation
* use cooked signatures in a few more places to avoid reloads and errors
* remove some Defect-raising versions of signature-loading
* release decompressed data memory before validating message