### PR TITLE
avoid some slashing protection queries

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -145,7 +145,7 @@ type
     slashingDbKind* {.
       hidden
       defaultValue: SlashingDbKind.v2
-      desc: "The slashing DB flavour to use (v1, v2 or both) [=both]"
+      desc: "The slashing DB flavour to use (v2) [=v2]"
       name: "slashing-db-kind" }: SlashingDbKind
 
     stateDbKind* {.

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -20,6 +20,7 @@ import
   ./slashing_protection_v2
 
 export slashing_protection_common
+
 # Generic sandwich
 export chronicles
 
@@ -51,7 +52,7 @@ type
     ## Database storing the blocks attested
     ## by validators attached to a beacon node
     ## or validator client.
-    db_v2: SlashingProtectionDB_v2
+    db_v2*: SlashingProtectionDB_v2
     modes: set[SlashProtDBMode]
     disagreementBehavior: DisagreementBehavior
 
@@ -283,3 +284,7 @@ proc pruneAfterFinalization*(
 #
 # That builds on a DB backend inclSPDIR and toSPDIR
 # SPDIR being a common Intermediate Representation
+
+proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
+             {.raises: [SerializationError, IOError, Defect].} =
+  db.db_v2.inclSPDIR(spdir)

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -288,3 +288,7 @@ proc pruneAfterFinalization*(
 proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
              {.raises: [SerializationError, IOError, Defect].} =
   db.db_v2.inclSPDIR(spdir)
+
+proc toSPDIR*(db: SlashingProtectionDB): SPDIR
+             {.raises: [IOError, Defect].} =
+  db.db_v2.toSPDIR()

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -5,8 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# TODO doesn't work with concepts (sigh)
-# {.push raises: [Defect].}
+{.push raises: [Defect].}
 
 import
   # stdlib
@@ -52,7 +51,6 @@ type
     ## Database storing the blocks attested
     ## by validators attached to a beacon node
     ## or validator client.
-    db_v1: SlashingProtectionDB_v1
     db_v2: SlashingProtectionDB_v2
     modes: set[SlashProtDBMode]
     disagreementBehavior: DisagreementBehavior
@@ -99,17 +97,27 @@ proc init*(
   )
   result.db_v2 = db
 
+  var db_v1: SlashingProtectionDB_v1
+
   let rawdb = kvstore result.db_v2.getRawDBHandle()
   if not rawdb.checkOrPutGenesis_DbV1(genesis_validators_root):
     fatal "The slashing database refers to another chain/mainnet/testnet",
       path = basePath/dbname,
       genesis_validators_root = genesis_validators_root
-  result.db_v1.fromRawDB(rawdb)
+  db_v1.fromRawDB(rawdb)
 
   if requiresMigration:
     info "Migrating local validators slashing DB from v1 to v2"
-    let spdir = result.db_v1.toSPDIR_lowWatermark()
-    let status = result.db_v2.inclSPDIR(spdir)
+    let spdir = try: db_v1.toSPDIR_lowWatermark()
+    except IOError as exc:
+      fatal "Cannot migrate v1 database", err = exc.msg
+      quit 1
+
+    let status = try: result.db_v2.inclSPDIR(spdir)
+    except CatchableError as exc:
+      fatal "Writing DB v2 failed", err = exc.msg
+      quit 1
+
     case status
     of siSuccess:
       info "Slashing DB migration successful."
@@ -163,77 +171,9 @@ proc close*(db: SlashingProtectionDB) =
 # DB Queries
 # --------------------------------------------
 
-proc useV1(db: SlashingProtectionDB): bool =
-  kCompleteArchiveV1 in db.modes
-
-proc useV2(db: SlashingProtectionDB): bool =
-  kCompleteArchiveV2 in db.modes or
-    kLowWatermarkV2 in db.modes
-
-template queryVersions(
-          db: SlashingProtectionDB,
-          queryExpr: untyped
-         ): auto =
-  ## Query multiple DB versions
-  ## Query should be in the form
-  ## myQuery(db_version, args...)
-  ##
-  ## Resolve conflicts according to
-  ## `db.disagreementBehavior`
-  ##
-  ## For example
-  ## checkSlashableBlockProposal(db_version, validator, slot)
-  ##
-  ## db_version will be replaced by db_v1 and db_v2 accordingly
-  type T = typeof(block:
-    template db_version: untyped = db.db_v1
-    queryExpr
-  )
-
-  var res1, res2: T
-  let useV1 = db.useV1()
-  let useV2 = db.useV2()
-
-  if useV1:
-    template db_version: untyped = db.db_v1
-    res1 = queryExpr
-  if useV2:
-    template db_version: untyped = db.db_v2
-    res2 = queryExpr
-
-  if useV1 and useV2:
-    if res1 == res2:
-      res1
-    else:
-      # TODO: Chronicles doesn't work with astToStr.
-      const queryStr = astToStr(queryExpr)
-      case db.disagreementBehavior
-      of kCrash:
-        fatal "Slashing protection DB has an internal error",
-          query = queryStr,
-          dbV1_result = res1,
-          dbV2_result = res2
-        doAssert false, "Slashing DB internal error"
-        res1 # For proper type deduction
-      of kChooseV1:
-        error "Slashing protection DB has an internal error, using v1 result",
-          query = queryStr,
-          dbV1_result = res1,
-          dbV2_result = res2
-        res1
-      of kChooseV2:
-        error "Slashing protection DB has an internal error, using v2 result",
-          query = queryStr,
-          dbV1_result = res1,
-          dbV2_result = res2
-        res2
-  elif useV1:
-    res1
-  else:
-    res2
-
 proc checkSlashableBlockProposal*(
        db: SlashingProtectionDB,
+       index: ValidatorIndex,
        validator: ValidatorPubKey,
        slot: Slot
      ): Result[void, BadProposal] =
@@ -243,12 +183,11 @@ proc checkSlashableBlockProposal*(
   ## The error contains the blockroot that was already proposed
   ##
   ## Returns success otherwise
-  db.queryVersions(
-    checkSlashableBlockProposal(db_version, validator, slot)
-  )
+  checkSlashableBlockProposal(db.db_v2, some(index), validator, slot)
 
 proc checkSlashableAttestation*(
        db: SlashingProtectionDB,
+       index: ValidatorIndex,
        validator: ValidatorPubKey,
        source: Epoch,
        target: Epoch
@@ -259,65 +198,36 @@ proc checkSlashableAttestation*(
   ## (surrounding vote or surrounded vote).
   ##
   ## Returns success otherwise
-  db.queryVersions(
-    checkSlashableAttestation(db_version, validator, source, target)
-  )
+  checkSlashableAttestation(db.db_v2, some(index), validator, source, target)
 
-# DB Updates
+# DB Updates - only v2 supported here
 # --------------------------------------------
-
-template updateVersions(
-          db: SlashingProtectionDB,
-          query: untyped
-         ) {.dirty.} =
-  ## Update multiple DB versions
-  ## Query should be in the form
-  ## myQuery(db_version, args...)
-  ##
-  ## Resolve conflicts according to
-  ## `db.disagreementBehavior`
-  ##
-  ## For example
-  ## registerBlock(db_version, validator, slot, block_root)
-  ##
-  ## db_version will be replaced by db_v1 and db_v2 accordingly
-
-  if db.useV1():
-    template db_version: untyped = db.db_v1
-    query
-  if db.useV2():
-    template db_version: untyped = db.db_v2
-    query
 
 proc registerBlock*(
        db: SlashingProtectionDB,
+       index: ValidatorIndex,
        validator: ValidatorPubKey,
-       slot: Slot, block_signing_root: Eth2Digest) =
-  ## Add a block to the slashing protection DB
-  ## `checkSlashableBlockProposal` MUST be run
-  ## before to ensure no overwrite.
+       slot: Slot, block_signing_root: Eth2Digest): Result[void, BadProposal] =
+  ## Add a block to the slashing protection DB - the registration will
+  ## fail if it would violate a slashing protection rule.
   ##
   ## block_signing_root is the output of
   ## compute_signing_root(block, domain)
-  db.updateVersions(
-    registerBlock(db_version, validator, slot, block_signing_root)
-  )
+  registerBlock(db.db_v2, some(index), validator, slot, block_signing_root)
 
 proc registerAttestation*(
        db: SlashingProtectionDB,
+       index: ValidatorIndex,
        validator: ValidatorPubKey,
        source, target: Epoch,
-       attestation_signing_root: Eth2Digest) =
-  ## Add an attestation to the slashing protection DB
-  ## `checkSlashableAttestation` MUST be run
-  ## before to ensure no overwrite.
+       attestation_signing_root: Eth2Digest): Result[void, BadVote] =
+  ## Add an attestation to the slashing protection DB - the registration will
+  ## fail if it would violate a slashing protection rule.
   ##
   ## attestation_signing_root is the output of
   ## compute_signing_root(attestation, domain)
-  db.updateVersions(
-    registerAttestation(db_version, validator,
-        source, target, attestation_signing_root)
-  )
+  registerAttestation(db.db_v2, some(index), validator,
+      source, target, attestation_signing_root)
 
 # DB maintenance
 # --------------------------------------------
@@ -366,41 +276,6 @@ proc pruneAfterFinalization*(
   fatal "Pruning is not implemented"
   quit 1
 
-# Interchange
-# --------------------------------------------
-
-proc toSPDIR*(db: SlashingProtectionDB): SPDIR
-             {.raises: [IOError, Defect].} =
-  ## Assumes that if the db uses both v1 and v2
-  ## the v2 has the latest information and includes the v1 DB
-  if db.useV2():
-    return db.db_v2.toSPDIR()
-  else:
-    doAssert db.useV1()
-    return db.db_v1.toSPDIR()
-
-proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
-             {.raises: [SerializationError, IOError, Defect].} =
-  let useV1 = db.useV1()
-  let useV2 = db.useV2()
-
-  if useV2 and useV1:
-    let resultV2 = db.db_v2.inclSPDIR(spdir)
-    let resultV1 = db.db_v1.inclSPDIR(spdir)
-    if resultV1 == resultV2:
-      return resultV2
-    else:
-      error "The legacy and new slashing protection DB have imported the file with different level of success",
-        resultV1 = resultV1,
-        resultV2 = resultV2
-      return resultV2
-
-  if useV2 and not useV1:
-    return db.db_v2.inclSPDIR(spdir)
-  else:
-    doAssert useV1
-    return db.db_v1.inclSPDIR(spdir)
-
 # The high-level import/export functions are
 # - importSlashingInterchange
 # - exportSlashingInterchange
@@ -408,8 +283,3 @@ proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
 #
 # That builds on a DB backend inclSPDIR and toSPDIR
 # SPDIR being a common Intermediate Representation
-
-# Sanity check
-# --------------------------------------------------------------
-
-static: doAssert SlashingProtectionDB is SlashingProtectionDB_Concept

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -149,24 +149,26 @@ func `==`*(a, b: BadVote): bool =
   ## result of multiple DB versions
   if a.kind != b.kind:
     false
-  elif a.kind == DoubleVote:
-    a.existingAttestation == b.existingAttestation
-  elif a.kind in {SurroundVote, SurroundVote}:
-    (a.existingAttestationRoot == b.existingAttestationRoot) and
-      (a.sourceExisting == b.sourceExisting) and
-      (a.targetExisting == b.targetExisting) and
-      (a.sourceSlashable == b.sourceSlashable) and
-      (a.targetSlashable == b.targetSlashable)
-  elif a.kind == TargetPrecedesSource:
-    true
-  elif a.kind == MinSourceViolation:
-    (a.minSource == b.minSource) and
-      (a.candidateSource == b.candidateSource)
-  elif a.kind == MinTargetViolation:
-    (a.minTarget == b.minTarget) and
-      (a.candidateTarget == b.candidateTarget)
-  else: # Unreachable
-    false
+  else:
+    case a.kind
+    of DoubleVote:
+      a.existingAttestation == b.existingAttestation
+    of SurroundVote:
+      (a.existingAttestationRoot == b.existingAttestationRoot) and
+        (a.sourceExisting == b.sourceExisting) and
+        (a.targetExisting == b.targetExisting) and
+        (a.sourceSlashable == b.sourceSlashable) and
+        (a.targetSlashable == b.targetSlashable)
+    of TargetPrecedesSource:
+      true
+    of MinSourceViolation:
+      (a.minSource == b.minSource) and
+        (a.candidateSource == b.candidateSource)
+    of MinTargetViolation:
+      (a.minTarget == b.minTarget) and
+        (a.candidateTarget == b.candidateTarget)
+    of BadVoteKind.DatabaseError:
+      true
 
 func `==`*(a, b: BadProposal): bool =
   ## Comparison operator.

--- a/beacon_chain/validators/slashing_protection_v1.nim
+++ b/beacon_chain/validators/slashing_protection_v1.nim
@@ -531,7 +531,7 @@ proc checkSlashableAttestation*(
       # s2 < s1 < t1 < t2
       # Logged by caller
       return err(BadVote(
-        kind: SurroundingVote,
+        kind: SurroundVote,
         existingAttestationRoot: ar1,
         sourceExisting: s1,
         targetExisting: t1,
@@ -542,7 +542,7 @@ proc checkSlashableAttestation*(
       # s1 < s2 < t2 < t1
       # Logged by caller
       return err(BadVote(
-        kind: SurroundedVote,
+        kind: SurroundVote,
         existingAttestationRoot: ar1,
         sourceExisting: s1,
         targetExisting: t1,
@@ -587,10 +587,10 @@ proc registerValidator(db: SlashingProtectionDB_v1, validator: ValidatorPubKey) 
 proc registerBlock*(
        db: SlashingProtectionDB_v1,
        validator: ValidatorPubKey,
-       slot: Slot, block_root: Eth2Digest) =
+       slot: Slot, block_root: Eth2Digest): Result[void, BadProposal] =
   ## Add a block to the slashing protection DB
-  ## `checkSlashableBlockProposal` MUST be run
-  ## before to ensure no overwrite.
+
+  ? checkSlashableBlockProposal(db, validator, slot)
 
   let valID = validator.toRaw()
 
@@ -724,10 +724,12 @@ proc registerAttestation*(
        db: SlashingProtectionDB_v1,
        validator: ValidatorPubKey,
        source, target: Epoch,
-       attestation_root: Eth2Digest) =
+       attestation_root: Eth2Digest): Result[void, BadVote] =
   ## Add an attestation to the slashing protection DB
   ## `checkSlashableAttestation` MUST be run
   ## before to ensure no overwrite.
+
+  ? checkSlashableAttestation(db, validator, source, target)
 
   let valID = validator.toRaw()
 
@@ -1141,8 +1143,3 @@ proc inclSPDIR*(db: SlashingProtectionDB_v1, spdir: SPDIR): SlashingImportStatus
   # Create a mutable copy for sorting
   var spdir = spdir
   return db.importInterchangeV5Impl(spdir)
-
-# Sanity check
-# --------------------------------------------------------------
-
-static: doAssert SlashingProtectionDB_v1 is SlashingProtectionDB_Concept

--- a/beacon_chain/validators/slashing_protection_v1.nim
+++ b/beacon_chain/validators/slashing_protection_v1.nim
@@ -620,7 +620,7 @@ proc registerBlock*(
         # targetEpochs.isInit will be false
       )
     )
-    return
+    return ok()
 
   var ll = maybeLL.unsafeGet()
   var cur = ll.blockSlots.stop
@@ -632,7 +632,7 @@ proc registerBlock*(
     db.put(subkey(kBlock, valID, slot), node)
     # TODO: what if crash here?
     db.put(subkey(kLinkedListMeta, valID), ll)
-    return
+    return ok()
 
   if cur < slot:
     # Adding a block later than all known blocks
@@ -652,7 +652,7 @@ proc registerBlock*(
     db.put(subkey(kBlock, valID, cur), prevNode)
     # TODO: what if crash here?
     db.put(subkey(kLinkedListMeta, valID), ll)
-    return
+    return ok()
 
   # TODO: we likely want a proper DB or better KV-store high-level API
   #       in the future.
@@ -687,7 +687,7 @@ proc registerBlock*(
       # TODO: what if crash here?
       db.put(subkey(kBlock, valID, cur), curNode)
       db.put(subkey(kLinkedListMeta, valID), ll)
-      return
+      return ok()
     elif slot > curNode.prev:
       # Reached: prev < slot < cur
       # Change: prev <-> cur
@@ -709,7 +709,7 @@ proc registerBlock*(
       # TODO: what if crash here?
       db.put(subkey(kBlock, valID, cur), curNode)
       db.put(subkey(kBlock, valID, prev), prevNode)
-      return
+      return ok()
 
     # Previous
     cur = curNode.prev
@@ -719,6 +719,8 @@ proc registerBlock*(
       # bug in Nim results, ".e" field inaccessible
       # ).expect("Consistent linked-list in DB")
     ).unsafeGet()
+
+  ok()
 
 proc registerAttestation*(
        db: SlashingProtectionDB_v1,
@@ -761,7 +763,7 @@ proc registerAttestation*(
         targetEpochs: EpochDesc(start: target, stop: target, isInit: true)
       )
     )
-    return
+    return ok()
 
   var ll = maybeLL.unsafeGet()
   var cur = ll.targetEpochs.stop
@@ -775,7 +777,7 @@ proc registerAttestation*(
     db.put(subkey(kTargetEpoch, valID, target), node)
     # TODO: what if crash here?
     db.put(subkey(kLinkedListMeta, valID), ll)
-    return
+    return ok()
 
   block: # Update source epoch
     if ll.sourceEpochs.stop < source:
@@ -802,7 +804,7 @@ proc registerAttestation*(
     db.put(subkey(kTargetEpoch, valID, cur), prevNode)
     # TODO: what if crash here?
     db.put(subkey(kLinkedListMeta, valID), ll)
-    return
+    return ok()
 
   # TODO: we likely want a proper DB or better KV-store high-level API
   #       in the future.
@@ -837,7 +839,7 @@ proc registerAttestation*(
       # TODO: what if crash here?
       db.put(subkey(kTargetEpoch, valID, cur), curNode)
       db.put(subkey(kLinkedListMeta, valID), ll)
-      return
+      return ok()
     elif target > curNode.prev:
       # Reached: prev < target < cur
       # Change: prev <-> cur
@@ -860,7 +862,7 @@ proc registerAttestation*(
       # TODO: what if crash here?
       db.put(subkey(kTargetEpoch, valID, cur), curNode)
       db.put(subkey(kTargetEpoch, valID, prev), prevNode)
-      return
+      return ok()
 
     # Previous
     cur = curNode.prev
@@ -870,6 +872,8 @@ proc registerAttestation*(
       # bug in Nim results, ".e" field inaccessible
       # ).expect("Consistent linked-list in DB")
     ).unsafeGet()
+
+  ok()
 
 # Debug tools
 # --------------------------------------------

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[os, options, typetraits, decls],
+  std/[os, options, typetraits, decls, tables],
   # Status
   stew/byteutils,
   eth/db/[kvstore, kvstore_sqlite3],
@@ -211,11 +211,12 @@ type
     # Cached queries - read
     sqlGetValidatorInternalID: SqliteStmt[PubKeyBytes, ValidatorInternalID]
     sqlAttForSameTargetEpoch: SqliteStmt[(ValidatorInternalID, int64), Hash32]
-    sqlAttSurrounded: SqliteStmt[(ValidatorInternalID, int64, int64), (int64, int64, Hash32)]
-    sqlAttSurrounding: SqliteStmt[(ValidatorInternalID, int64, int64), (int64, int64, Hash32)]
+    sqlAttSurrounds: SqliteStmt[(ValidatorInternalID, int64, int64, int64, int64), (int64, int64, Hash32)]
     sqlAttMinSourceTargetEpochs: SqliteStmt[ValidatorInternalID, (int64, int64)]
     sqlBlockForSameSlot: SqliteStmt[(ValidatorInternalID, int64), Hash32]
     sqlBlockMinSlot: SqliteStmt[ValidatorInternalID, int64]
+
+    internalIds: Table[ValidatorIndex, ValidatorInternalID]
 
   ValidatorInternalID = int32
     ## Validator internal ID in the DB
@@ -382,30 +383,17 @@ proc setupCachedQueries(db: SlashingProtectionDB_v2) =
     """, (ValidatorInternalID, int64), Hash32
   ).get()
 
-  db.sqlAttSurrounded = db.backend.prepareStmt("""
+  db.sqlAttSurrounds = db.backend.prepareStmt("""
     SELECT
       source_epoch, target_epoch, signing_root
     FROM
       signed_attestations
     WHERE 1=1
       and validator_id = ?
-      and source_epoch < ?
-      and ? < target_epoch
+      and ((source_epoch < ? and ? < target_epoch) OR
+           (? < source_epoch and target_epoch < ?))
     LIMIT 1
-    """, (ValidatorInternalID, int64, int64), (int64, int64, Hash32)
-  ).get()
-
-  db.sqlAttSurrounding = db.backend.prepareStmt("""
-    SELECT
-      source_epoch, target_epoch, signing_root
-    FROM
-      signed_attestations
-    WHERE 1=1
-      and validator_id = ?
-      and ? < source_epoch
-      and target_epoch < ?
-    LIMIT 1
-    """, (ValidatorInternalID, int64, int64), (int64, int64, Hash32)
+    """, (ValidatorInternalID, int64, int64, int64, int64), (int64, int64, Hash32)
   ).get()
 
   # By default an aggregate always return a value
@@ -680,8 +668,21 @@ proc foundAnyResult(status: KVResult[bool]): bool {.inline.}=
 
 proc getValidatorInternalID(
        db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
        validator: ValidatorPubKey): Option[ValidatorInternalID] =
   ## Retrieve a validator internal ID
+  if index.isSome():
+    # An unfortunate aspect of the v2 format is that the validator public key
+    # is mapped to an internal id instead of using the validator index - this
+    # slows down access to the table due to the extra lookup as well as
+    # insertions that now must do a foreign key validation. We can at least
+    # avoid the extra lookup by using a cache here.
+    # Future work could get rid of the whole thing by simply using
+    # the validator index directly, but this would require an (incompatible)
+    # database upgrade.
+    db.internalIds.withValue(index.get(), internal) do:
+      return some(internal[])
+
   let serializedPubkey = validator.toRaw() # Miracl/BLST to bytes
   var valID: ValidatorInternalID
   let status = db.sqlGetValidatorInternalID.exec(serializedPubkey) do (res: ValidatorInternalID):
@@ -689,13 +690,15 @@ proc getValidatorInternalID(
 
   # Note: we enforce at the DB level that if the pubkey exists it is unique.
   if status.foundAnyResult():
+    if index.isSome():
+      db.internalIds[index.get()] = valID
     some(valID)
   else:
     none(ValidatorInternalID)
 
-proc checkSlashableBlockProposal*(
+proc checkSlashableBlockProposalOther(
        db: SlashingProtectionDB_v2,
-       validator: ValidatorPubKey,
+       valID: ValidatorInternalID,
        slot: Slot
      ): Result[void, BadProposal] =
   ## Returns an error if the specified validator
@@ -705,49 +708,6 @@ proc checkSlashableBlockProposal*(
   ##
   ## Returns success otherwise
   # TODO distinct type for the result block root
-
-  let valID = block:
-    let id = db.getValidatorInternalID(validator)
-    if id.isNone():
-      notice "No slashing protection data - first block proposal?",
-        validator = validator,
-        slot = slot
-      return ok()
-    else:
-      id.unsafeGet()
-
-  # Casper FFG 1st slashing condition
-  # Detect h(t1) = h(t2)
-  # ---------------------------------
-  block:
-    # Condition 1 at https://eips.ethereum.org/EIPS/eip-3076
-    var root: ETH2Digest
-
-    # 6 second (minimal preset) slots => overflow at ~1.75 trillion years under
-    # minimal preset, and twice that with mainnet preset
-    doAssert slot <= high(int64).uint64
-
-    let status = db.sqlBlockForSameSlot.exec(
-          (valID, int64 slot)
-        ) do (res: Hash32):
-      root.data = res
-
-    # Note: we enforce at the DB level that if (pubkey, slot) exists it maps to a unique block root.
-    #
-    # It's possible to allow republishing an already signed block here (Lighthouse does it)
-    # AFAIK repeat signing only happens if the node crashes after saving to the DB and
-    # there is still time to redo the validator work but:
-    # - will the validator have reconstructed the same state in memory?
-    #   for example if the validator has different attestations
-    #   it can't reconstruct the previous signed block anyway.
-    # - it is useful if the validator couldn't gossip.
-    # Rather than adding Result "Ok" and Result "OkRepeatSigning"
-    # and an extra Eth2Digest comparison for that case, we just refuse repeat signing.
-    if status.foundAnyResult():
-      # Conflicting block exist
-      return err(BadProposal(
-        kind: DoubleProposal,
-        existing_block: root))
 
   # EIP-3067 - Low-watermark
   # Detect h(t1) <= h(t2)
@@ -778,37 +738,87 @@ proc checkSlashableBlockProposal*(
 
   ok()
 
-proc checkSlashableAttestation*(
+proc checkSlashableBlockProposalDoubleProposal(
        db: SlashingProtectionDB_v2,
-       validator: ValidatorPubKey,
-       source: Epoch,
-       target: Epoch
-     ): Result[void, BadVote] =
+       valID: ValidatorInternalID,
+       slot: Slot
+     ): Result[void, BadProposal] =
   ## Returns an error if the specified validator
-  ## already voted for the specified slot
-  ## or would vote in a contradiction to previous votes
-  ## (surrounding vote or surrounded vote).
+  ## already proposed a block for the specified slot.
+  ## This would lead to slashing.
+  ## The error contains the blockroot that was already proposed
   ##
   ## Returns success otherwise
-  # TODO distinct type for the result attestation root
+  # TODO distinct type for the result block root
 
+  # Casper FFG 1st slashing condition
+  # Detect h(t1) = h(t2)
+  # ---------------------------------
+  block:
+    # Condition 1 at https://eips.ethereum.org/EIPS/eip-3076
+    var root: ETH2Digest
+    let status = db.sqlBlockForSameSlot.exec(
+          (valID, int64 slot)
+        ) do (res: Hash32):
+      root.data = res
+
+    # Note: we enforce at the DB level that if (pubkey, slot) exists it maps to a unique block root.
+    #
+    # It's possible to allow republishing an already signed block here (Lighthouse does it)
+    # AFAIK repeat signing only happens if the node crashes after saving to the DB and
+    # there is still time to redo the validator work but:
+    # - will the validator have reconstructed the same state in memory?
+    #   for example if the validator has different attestations
+    #   it can't reconstruct the previous signed block anyway.
+    # - it is useful if the validator couldn't gossip.
+    # Rather than adding Result "Ok" and Result "OkRepeatSigning"
+    # and an extra Eth2Digest comparison for that case, we just refuse repeat signing.
+    if status.foundAnyResult():
+      # Conflicting block exist
+      return err(BadProposal(
+        kind: DoubleProposal,
+        existing_block: root))
+
+  ok()
+
+proc checkSlashableBlockProposal*(
+       db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
+       validator: ValidatorPubKey,
+       slot: Slot
+     ): Result[void, BadProposal] =
+  ## Returns an error if the specified validator
+  ## already proposed a block for the specified slot.
+  ## This would lead to slashing.
+  ## The error contains the blockroot that was already proposed
+  ##
+  ## Returns success otherwise
+  # TODO distinct type for the result block root
+
+  let valID = block:
+    let id = db.getValidatorInternalID(index, validator)
+    if id.isNone():
+      notice "No slashing protection data - first block proposal?",
+        validator = validator,
+        slot = slot
+      return ok()
+    else:
+      id.unsafeGet()
+
+  ? checkSlashableBlockProposalDoubleProposal(db, valID, slot)
+  ? checkSlashableBlockProposalOther(db, valID, slot)
+
+  ok()
+
+proc checkSlashableAttestationDoubleVote(
+       db: SlashingProtectionDB_v2,
+       valID: ValidatorInternalID,
+       source: Epoch,
+       target: Epoch): Result[void, BadVote] =
   # Sanity
   # ---------------------------------
   if source > target:
     return err(BadVote(kind: TargetPrecedesSource))
-
-  # Internal metadata
-  # ---------------------------------
-  let valID = block:
-    let id = db.getValidatorInternalID(validator)
-    if id.isNone():
-      notice "No slashing protection data - first attestation?",
-        validator = validator,
-        attSource = source,
-        attTarget = target
-      return ok()
-    else:
-      id.unsafeGet()
 
   # Casper FFG 1st slashing condition
   # Detect h(t1) = h(t2)
@@ -833,12 +843,38 @@ proc checkSlashableAttestation*(
         existingAttestation: root
       ))
 
+  ok()
+
+proc checkSlashableAttestationOther(
+       db: SlashingProtectionDB_v2,
+       valID: ValidatorInternalID,
+       source: Epoch,
+       target: Epoch): Result[void, BadVote] =
+  # Simple double votes are protected by the unique index on the database table
+  # - this function checks everything else!
+
+  ## Returns an error if the specified validator
+  ## already voted for the specified slot
+  ## or would vote in a contradiction to previous votes
+  ## (surrounding vote or surrounded vote).
+  ##
+  ## Returns success otherwise
+  # TODO distinct type for the result attestation root
+
+  # Sanity
+  # ---------------------------------
+  if source > target:
+    return err(BadVote(kind: TargetPrecedesSource))
+
   # Casper FFG 2nd slashing condition
   # -> Surrounded vote
   # Detect h(s1) < h(s2) < h(t2) < h(t1)
+  # -> Surrounding vote
+  # Detect h(s2) < h(s1) < h(t1) < h(t2)
   # ---------------------------------
   block:
     # Condition 3 part 2/3 at https://eips.ethereum.org/EIPS/eip-3076
+    # Condition 3 part 3/3 at https://eips.ethereum.org/EIPS/eip-3076
     var root: ETH2Digest
     var db_source, db_target: Epoch
 
@@ -846,8 +882,8 @@ proc checkSlashableAttestation*(
     doAssert source <= high(int64).uint64
     doAssert target <= high(int64).uint64
 
-    let status = db.sqlAttSurrounded.exec(
-          (valID, int64 source, int64 target)
+    let status = db.sqlAttSurrounds.exec(
+          (valID, int64 source, int64 target, int64 source, int64 target)
         ) do (res: tuple[source, target: int64, root: Hash32]):
       db_source = Epoch res.source
       db_target = Epoch res.target
@@ -858,35 +894,7 @@ proc checkSlashableAttestation*(
       # Conflicting attestation exist, log by caller
       # s1 < s2 < t2 < t1
       return err(BadVote(
-        kind: SurroundedVote,
-        existingAttestationRoot: root,
-        sourceExisting: db_source,
-        targetExisting: db_target,
-        sourceSlashable: source,
-        targetSlashable: target
-      ))
-
-  # Casper FFG 2nd slashing condition
-  # -> Surrounding vote
-  # Detect h(s2) < h(s1) < h(t1) < h(t2)
-  # ---------------------------------
-  block:
-    # Condition 3 part 3/3 at https://eips.ethereum.org/EIPS/eip-3076
-    var root: ETH2Digest
-    var db_source, db_target: Epoch
-    let status = db.sqlAttSurrounding.exec(
-          (valID, int64 source, int64 target)
-        ) do (res: tuple[source, target: int64, root: Hash32]):
-      db_source = Epoch res.source
-      db_target = Epoch res.target
-      root.data = res.root
-
-    # Note: we enforce at the DB level that if (pubkey, target) exists it maps to a unique block root.
-    if status.foundAnyResult():
-      # Conflicting attestation exist, log by caller
-      # s1 < s2 < t2 < t1
-      return err(BadVote(
-        kind: SurroundingVote,
+        kind: SurroundVote,
         existingAttestationRoot: root,
         sourceExisting: db_source,
         targetExisting: db_target,
@@ -933,7 +941,31 @@ proc checkSlashableAttestation*(
           candidateTarget: target
         ))
 
-  return ok()
+  ok()
+
+proc checkSlashableAttestation*(
+       db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
+       validator: ValidatorPubKey,
+       source: Epoch,
+       target: Epoch
+     ): Result[void, BadVote] =
+  if source > target:
+    return err(BadVote(kind: TargetPrecedesSource))
+
+  let valID = block:
+    let id = db.getValidatorInternalID(index, validator)
+    if id.isNone():
+      notice "No slashing protection data - first attestation?",
+        validator, source, target
+      return ok()
+    else:
+      id.unsafeGet()
+
+  ? checkSlashableAttestationDoubleVote(db, valID, source, target)
+  ? checkSlashableAttestationOther(db, valID, source, target)
+
+  ok()
 
 # DB update
 # --------------------------------------------
@@ -948,16 +980,17 @@ proc registerValidator(db: SlashingProtectionDB_v2, validator: ValidatorPubKey) 
 
 proc getOrRegisterValidator(
        db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
        validator: ValidatorPubKey): ValidatorInternalID =
   ## Get validator from the database
   ## or register it and then return it
-  let id = db.getValidatorInternalID(validator)
+  let id = db.getValidatorInternalID(index, validator)
   if id.isNone():
     info "No slashing protection data for validator - initiating",
       validator = validator
 
     db.registerValidator(validator)
-    let id = db.getValidatorInternalID(validator)
+    let id = db.getValidatorInternalID(index, validator)
     doAssert id.isSome()
     id.unsafeGet()
   else:
@@ -965,33 +998,65 @@ proc getOrRegisterValidator(
 
 proc registerBlock*(
        db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
        validator: ValidatorPubKey,
-       slot: Slot, block_root: Eth2Digest) =
+       slot: Slot, block_root: Eth2Digest): Result[void, BadProposal] =
   ## Add a block to the slashing protection DB
   ## `checkSlashableBlockProposal` MUST be run
   ## before to ensure no overwrite.
-  let valID = db.getOrRegisterValidator(validator)
+  let valID = db.getOrRegisterValidator(index, validator)
 
   # 6 second (minimal preset) slots => overflow at ~1.75 trillion years under
   # minimal preset, and twice that with mainnet preset
   doAssert slot <= high(int64).uint64
 
+  let check = checkSlashableBlockProposalOther(db, valID, slot)
+  if check.isErr():
+    # Check for double vote to get more accurate error information
+    ? checkSlashableBlockProposalDoubleProposal(db, valID, slot)
+    return check
+
   let status = db.sqlInsertBlock.exec(
-    (valID, int64 slot,
-    block_root.data))
-  doAssert status.isOk(),
-    "SQLite error when registering block: " & $status.error & "\n" &
-    "for validator: 0x" & validator.toHex() & ", slot: " & $slot
+    (valID, int64 slot, block_root.data))
+  if status.isErr():
+    # Inserting primarily fails when the constraint for double proposals is
+    # violated but may also happen due to disk full and other storage issues -
+    # in any case, we'll return an error so that production is halted
+    ? checkSlashableBlockProposalDoubleProposal(db, valID, slot)
+    # If this was not a slashing error, it must have been a database error
+    return err(BadProposal(
+      kind: BadProposalKind.DatabaseError,
+      message: status.error))
+
+  ok()
+
+proc registerBlock*(
+       db: SlashingProtectionDB_v2,
+       validator: ValidatorPubKey,
+       slot: Slot, block_root: Eth2Digest): Result[void, BadProposal] =
+  registerBlock(db, none(ValidatorIndex), validator, slot, block_root)
 
 proc registerAttestation*(
        db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
        validator: ValidatorPubKey,
        source, target: Epoch,
-       attestation_root: Eth2Digest) =
+       attestation_root: Eth2Digest): Result[void, BadVote] =
   ## Add an attestation to the slashing protection DB
   ## `checkSlashableAttestation` MUST be run
   ## before to ensure no overwrite.
-  let valID = db.getOrRegisterValidator(validator)
+  if source > target:
+    return err(BadVote(kind: TargetPrecedesSource))
+
+  let valID = db.getOrRegisterValidator(index, validator)
+
+  # Double votes caught by database index!
+  let check = checkSlashableAttestationOther(db, valID, source, target)
+
+  if check.isErr():
+    # Check for double vote to get more accurate error information
+    ? checkSlashableAttestationDoubleVote(db, valID, source, target)
+    return check
 
   # Overflows in 14 trillion years (minimal) or 112 trillion years (mainnet)
   doAssert source <= high(int64).uint64
@@ -1000,27 +1065,49 @@ proc registerAttestation*(
   let status = db.sqlInsertAtt.exec(
     (valID, int64 source, int64 target,
     attestation_root.data))
-  doAssert status.isOk(),
-    "SQLite error when registering attestation: " & $status.error & "\n" &
-    "for validator: 0x" & validator.toHex() &
-    ", sourceEpoch: " & $source &
-    ", targetEpoch: " & $target
+  if status.isErr():
+    # Inserting primarily fails when the constraint for double votes is
+    # violated but may also happen due to disk full and other storage issues -
+    # in any case, we'll return an error so that production is halted
+    ? checkSlashableAttestationDoubleVote(db, valID, source, target)
+    # If this was not a slashing error, it must have been a database error
+    return err(BadVote(
+      kind: BadVoteKind.DatabaseError,
+      message: status.error))
 
+  ok()
+
+proc registerAttestation*(
+       db: SlashingProtectionDB_v2,
+       validator: ValidatorPubKey,
+       source, target: Epoch,
+       attestation_root: Eth2Digest): Result[void, BadVote] =
+  registerAttestation(
+    db, none(ValidatorIndex), validator, source, target, attestation_root)
 # DB maintenance
 # --------------------------------------------
-proc pruneBlocks*(db: SlashingProtectionDB_v2, validator: ValidatorPubkey, newMinSlot: Slot) =
+proc pruneBlocks*(
+    db: SlashingProtectionDB_v2,
+    index: Option[ValidatorIndex],
+    validator: ValidatorPubkey, newMinSlot: Slot) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import to ensure
   ## that in case of a gap, we don't allow signing in that gap.
-  let valID = db.getOrRegisterValidator(validator)
+  let valID = db.getOrRegisterValidator(index, validator)
   let status = db.sqlPruneValidatorBlocks.exec(
     (valID, int64 newMinSlot))
   doAssert status.isOk(),
     "SQLite error when pruning validator blocks: " & $status.error & "\n" &
     "for validator: 0x" & validator.toHex() & ", newMinSlot: " & $newMinSlot
 
+proc pruneBlocks*(
+    db: SlashingProtectionDB_v2,
+    validator: ValidatorPubkey, newMinSlot: Slot) =
+  pruneBlocks(db, none(ValidatorIndex), validator, newMinSlot)
+
 proc pruneAttestations*(
        db: SlashingProtectionDB_v2,
+       index: Option[ValidatorIndex],
        validator: ValidatorPubkey,
        newMinSourceEpoch: int64,
        newMinTargetEpoch: int64) =
@@ -1028,7 +1115,7 @@ proc pruneAttestations*(
   ## This is intended for interchange import.
   ## Negative source/target epoch of -1 can be received if no attestation was imported
   ## In that case nothing is done (since we used signed int in SQLite)
-  let valID = db.getOrRegisterValidator(validator)
+  let valID = db.getOrRegisterValidator(index, validator)
 
   let status = db.sqlPruneValidatorAttestations.exec(
     (valID, newMinSourceEpoch, newMinTargetEpoch))
@@ -1037,6 +1124,14 @@ proc pruneAttestations*(
     "for validator: 0x" & validator.toHex() &
     ", newSourceEpoch: " & $newMinSourceEpoch &
     ", newTargetEpoch: " & $newMinTargetEpoch
+
+proc pruneAttestations*(
+       db: SlashingProtectionDB_v2,
+       validator: ValidatorPubkey,
+       newMinSourceEpoch: int64,
+       newMinTargetEpoch: int64) =
+  pruneAttestations(
+    db, none(ValidatorIndex), validator, newMinSourceEpoch, newMinTargetEpoch)
 
 proc pruneAfterFinalization*(
        db: SlashingProtectionDB_v2,
@@ -1205,8 +1300,3 @@ proc inclSPDIR*(db: SlashingProtectionDB_v2, spdir: SPDIR): SlashingImportStatus
   # Create a mutable copy for sorting
   var spdir = spdir
   return db.importInterchangeV5Impl(spdir)
-
-# Sanity check
-# --------------------------------------------------------------
-
-static: doAssert SlashingProtectionDB_v2 is SlashingProtectionDB_Concept

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -672,14 +672,13 @@ proc getValidatorInternalID(
        validator: ValidatorPubKey): Option[ValidatorInternalID] =
   ## Retrieve a validator internal ID
   if index.isSome():
-    # An unfortunate aspect of the v2 format is that the validator public key
-    # is mapped to an internal id instead of using the validator index - this
-    # slows down access to the table due to the extra lookup as well as
-    # insertions that now must do a foreign key validation. We can at least
-    # avoid the extra lookup by using a cache here.
-    # Future work could get rid of the whole thing by simply using
-    # the validator index directly, but this would require an (incompatible)
-    # database upgrade.
+    # Validator keys are mapped to internal id:s instead of using the
+    # validator index - this allows importing keys without knowing the
+    # state but has the unfortunate consequence of introducing an indirection
+    # that must be kept updated at some cost. In a future version of the
+    # database, one could consider a simplified design that directly uses the
+    # validator index. In the meantime, this cache avoids some of the
+    # unnecessary read traffic when checking and registering entries.
     db.internalIds.withValue(index.get(), internal) do:
       return some(internal[])
 

--- a/tests/slashing_protection/test_migration.nim
+++ b/tests/slashing_protection/test_migration.nim
@@ -25,14 +25,6 @@ import
   # Test utilies
   ../testutil
 
-template wrappedTimedTest(name: string, body: untyped) =
-  # `check` macro takes a copy of whatever it's checking, on the stack!
-  block: # Symbol namespacing
-    proc wrappedTest() =
-      test name:
-        body
-    wrappedTest()
-
 func fakeRoot(index: SomeInteger): Eth2Digest =
   ## Create fake roots
   ## Those are just the value serialized in big-endian
@@ -59,7 +51,7 @@ suite "Slashing Protection DB - v1 and v2 migration" & preset():
   # https://eips.ethereum.org/EIPS/eip-3076
   sqlite3db_delete(TestDir, TestDbName)
 
-  wrappedTimedTest "Minimal format migration" & preset():
+  test "Minimal format migration" & preset():
     let genesis_validators_root = hexToDigest"0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
     block: # export from a v1 DB
       let db = SlashingProtectionDB_v1.init(

--- a/tests/slashing_protection/test_official_interchange_vectors.nim
+++ b/tests/slashing_protection/test_official_interchange_vectors.nim
@@ -13,7 +13,7 @@ import
   nimcrypto/utils,
   chronicles,
   # Internal
-  ../../beacon_chain/validators/slashing_protection,
+  ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],
   ../../beacon_chain/spec/[datatypes, digest, crypto, presets],
   # Test utilies
   ../testutil, ../testdbutil,

--- a/tests/slashing_protection/test_official_interchange_vectors.nim
+++ b/tests/slashing_protection/test_official_interchange_vectors.nim
@@ -174,7 +174,7 @@ proc runTest(identifier: string) =
           "    " & $status & "\n"
 
       for blck in step.blocks:
-        let status = db.checkSlashableBlockProposal(
+        let status = db.db_v2.checkSlashableBlockProposal(none(ValidatorIndex),
           ValidatorPubKey.fromRaw(blck.pubkey.PubKeyBytes).get(),
           Slot blck.slot
         )
@@ -190,7 +190,7 @@ proc runTest(identifier: string) =
             "    for " & $toHexLogs(blck)
 
       for att in step.attestations:
-        let status = db.checkSlashableAttestation(
+        let status = db.db_v2.checkSlashableAttestation(none(ValidatorIndex),
           ValidatorPubKey.fromRaw(att.pubkey.PubKeyBytes).get(),
           Epoch att.source_epoch,
           Epoch att.target_epoch

--- a/tests/slashing_protection/test_slashing_interchange.nim
+++ b/tests/slashing_protection/test_slashing_interchange.nim
@@ -11,11 +11,11 @@ import
   # Standard library
   std/[os],
   # Status lib
-  eth/db/kvstore,
+  eth/db/[kvstore, kvstore_sqlite3],
   stew/results,
   nimcrypto/utils,
   # Internal
-  ../../beacon_chain/validators/slashing_protection,
+  ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],
   ../../beacon_chain/spec/[datatypes, digest, crypto, presets],
   # Test utilies
   ../testutil
@@ -62,29 +62,30 @@ suite "Slashing Protection DB - Interchange" & preset():
       let pubkey = ValidatorPubKey
                     .fromHex"0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed"
                     .get()
-      db.registerBlock(
-        pubkey,
-        Slot 81952,
-        hexToDigest"0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b"
-      )
-      # db.registerBlock(
-      #   pubkey,
-      #   Slot 81951,
-      #   fakeRoot(65535)
-      # )
+      check:
+        db.db_v2.registerBlock(
+          pubkey,
+          Slot 81952,
+          hexToDigest"0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b"
+        ).isOk()
+        # db.registerBlock(
+        #   pubkey,
+        #   Slot 81951,
+        #   fakeRoot(65535)
+        # )
 
-      db.registerAttestation(
-        pubkey,
-        source = Epoch 2290,
-        target = Epoch 3007,
-        hexToDigest"0x587d6a4f59a58fe24f406e0502413e77fe1babddee641fda30034ed37ecc884d"
-      )
-      db.registerAttestation(
-        pubkey,
-        source = Epoch 2290,
-        target = Epoch 3008,
-        fakeRoot(65535)
-      )
+        db.db_v2.registerAttestation(
+          pubkey,
+          source = Epoch 2290,
+          target = Epoch 3007,
+          hexToDigest"0x587d6a4f59a58fe24f406e0502413e77fe1babddee641fda30034ed37ecc884d"
+        ).isOk()
+        db.db_v2.registerAttestation(
+          pubkey,
+          source = Epoch 2290,
+          target = Epoch 3008,
+          fakeRoot(65535)
+        ).isOk()
 
       db.exportSlashingInterchange(currentSourcePath.parentDir/"test_complete_export_slashing_protection.json")
 


### PR DESCRIPTION
This PR reduces the number of database queries for slashing protection
from 5 reads and 1 write to 2 reads and 1 write in the optimistic case.

In the process, it removes user-level support for writing the database
in the version 1 format in order to simplify the code flow, and prevent
code rot. In particular, the v1 format was not covered by any unit tests
and has no advantages over v2. The concrete code to read and write it
remains for now, in particular to support upgrades from v1 to v2.

The branch also removes the use of concepts which doesn't work with
checked exceptions - in particular, this highlights code that both
raises exceptions and returns error codes, which could be cleaned up in
the future.

* Cache internal validator ID
* Rely on unique index to check for trivial duplicate votes
* Combine two surround vote queries into one
* Combine API for checking and registering slashing into single function

The slashing DB is normally not a bottleneck, but may become one with
high attached validator counts.