### PR TITLE
Don't execute CI builds (Github actions) when no build inputs are changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore: ['media/**', 'docs/**', '**/*.md']
+  pull_request:
+    paths-ignore: ['media/**', 'docs/**', '**/*.md']
 
 jobs:
   build:


### PR DESCRIPTION
Stolen from:
https://github.com/status-im/nimbus-eth1/pull/602

Please note that the nimbus.guide is currently deployed manually through the Makefiles.