### PR TITLE
rename initialize_beacon_state to initialize_beacon_state_from_eth1

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -94,7 +94,7 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Beacon state [Preset: mainnet]
 ```diff
-+ Smoke test initialize_beacon_state [Preset: mainnet]                                       OK
++ Smoke test initialize_beacon_state_from_eth1 [Preset: mainnet]                             OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Bit fields

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -195,7 +195,7 @@ when hasGenesisDetection:
 
     var deposits = m.allGenesisDepositsUpTo(eth1Block.voteData.deposit_count)
 
-    result = initialize_beacon_state(
+    result = initialize_beacon_state_from_eth1(
       m.preset,
       eth1Block.voteData.block_hash,
       eth1Block.timestamp.uint64,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1748,7 +1748,7 @@ proc doCreateTestnet(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.raise
                else: (waitFor getEth1BlockHash(config.web3Urls[0], blockId("latest"))).asEth2Digest
     runtimePreset = getRuntimePresetForNetwork(config.eth2Network)
   var
-    initialState = initialize_beacon_state(
+    initialState = initialize_beacon_state_from_eth1(
       runtimePreset, eth1Hash, startTime, deposits, {skipBlsValidation})
 
   # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -240,7 +240,7 @@ func genesis_time_from_eth1_timestamp*(preset: RuntimePreset, eth1_timestamp: ui
   eth1_timestamp + preset.GENESIS_DELAY
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#genesis
-proc initialize_beacon_state*(
+proc initialize_beacon_state_from_eth1*(
     preset: RuntimePreset,
     eth1_block_hash: Eth2Digest,
     eth1_timestamp: uint64,
@@ -335,7 +335,7 @@ proc initialize_hashed_beacon_state_from_eth1*(
     eth1_timestamp: uint64,
     deposits: openArray[DepositData],
     flags: UpdateFlags = {}): HashedBeaconState =
-  let genesisState = initialize_beacon_state(
+  let genesisState = initialize_beacon_state_from_eth1(
     preset, eth1_block_hash, eth1_timestamp, deposits, flags)
   HashedBeaconState(data: genesisState[], root: hash_tree_root(genesisState[]))
 

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -102,7 +102,7 @@ proc loadGenesis*(validators: Natural, validate: bool):
     let contractSnapshot = DepositContractSnapshot(
       depositContractState: merkleizer.toDepositContractState)
 
-    res.data = initialize_beacon_state(
+    res.data = initialize_beacon_state_from_eth1(
       defaultRuntimePreset,
       Eth2Digest(),
       0,

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -215,7 +215,7 @@ suite "Beacon chain DB" & preset():
       db = BeaconChainDB.new(defaultRuntimePreset, "", inMemory = true)
 
     let
-      state = initialize_beacon_state(
+      state = initialize_beacon_state_from_eth1(
         defaultRuntimePreset, eth1BlockHash, 0,
         makeInitialDeposits(SLOTS_PER_EPOCH), {skipBlsValidation})
       root = hash_tree_root(state[])

--- a/tests/test_beaconstate.nim
+++ b/tests/test_beaconstate.nim
@@ -13,7 +13,7 @@ import
   ./testutil, ./testblockutil
 
 suite "Beacon state" & preset():
-  test "Smoke test initialize_beacon_state" & preset():
-    let state = initialize_beacon_state(
+  test "Smoke test initialize_beacon_state_from_eth1" & preset():
+    let state = initialize_beacon_state_from_eth1(
       defaultRuntimePreset, Eth2Digest(), 0, makeInitialDeposits(SLOTS_PER_EPOCH, {}), {})
     check: state.validators.lenu64 == SLOTS_PER_EPOCH

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -150,7 +150,7 @@ suite "Interop":
 
     const genesis_time = 1570500000
     var
-      initialState = initialize_beacon_state(
+      initialState = initialize_beacon_state_from_eth1(
         defaultRuntimePreset, eth1BlockHash, genesis_time, deposits, {})
 
     # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2019 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -21,7 +21,7 @@ proc makeTestDB*(tailState: var BeaconState, tailBlock: SignedBeaconBlock): Beac
 
 proc makeTestDB*(validators: Natural): BeaconChainDB =
   let
-    genState = initialize_beacon_state(
+    genState = initialize_beacon_state_from_eth1(
       defaultRuntimePreset,
       Eth2Digest(),
       0,


### PR DESCRIPTION
Undoes the erroneous portion of https://github.com/status-im/nimbus-eth2/pull/2520

As noted, `initialize_beacon_state_from_eth1` is the spec name of this function.