### PR TITLE
store full state 4x less frequently

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -588,7 +588,7 @@ proc putState*(dag: ChainDAGRef, state: var StateData) =
   dag.db.putState(state.data.root, state.data.data)
 
   # Allow backwards-compatible version rollback with bounded recovery cost
-  if getStateField(state, slot).epoch mod 64 == 0:
+  if getStateField(state, slot).epoch mod 256 == 0:
     dag.db.putStateFull(state.data.root, state.data.data)
 
   dag.db.putStateRoot(


### PR DESCRIPTION
Less disruptive alternative to https://github.com/status-im/nimbus-eth2/pull/2514

Currently:
- every epoch (or so) at least one state is stored;
- every 32 epochs, that stored state survives state pruning;
- every 64 epochs, a full state with validators is stored, for backwards compatibility with version 1.0.x.

This means that the steady state will be that one has:
1. {state with validators, state without validators}
2. {state without validators}
3. {state without validators}
4. {state without validators}
5. {state without validators}
6. {state without validators}
7. {state without validators}
8. {state without validators}
9. {state with validators, state without validators}
10. {state without validators}
11. {state without validators}
12. {state without validators}
13. {state without validators}
14. {state without validators}
15. {state without validators}
16. {state without validators}
17. {state with validators, state without validators}
18. ...

Where the states without validators are around 2MB stored blobs, while those with validators are 9 or 10MB and increasing at the 120k+ validator counts of Mainnet/Pyrmont, with Prater (210k+) being even more acutely different.

https://github.com/status-im/nimbus-eth2/pull/2297 and https://github.com/status-im/nimbus-eth2/issues/2440#issuecomment-804707165 have benchmarks and measurements of this.

Cutting out {64, 128, 192} mod 256 states with validators decreases the average sustained marginal per-epoch cost of state storage approximately from (8 x 2MB + 4 x 10MB) to (8 x 2MB + 10MB), or from 56MB to 26MB, or by a factor of two for the smaller networks and more for Prater.