### PR TITLE
partially integrate eth1 merge changes

### DIFF
--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/rpc/eth2_json_rest_serialization.nim
+++ b/beacon_chain/rpc/eth2_json_rest_serialization.nim
@@ -257,6 +257,28 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: Eth2Digest) {.
      raises: [IOError, Defect].} =
   writeValue(writer, hexOriginal(value.data))
 
+## BloomLogs
+proc readValue*(reader: var JsonReader[RestJson], value: var BloomLogs) {.
+     raises: [IOError, SerializationError, Defect].} =
+  try:
+    hexToByteArray(reader.readValue(string), value.data)
+  except ValueError:
+    raiseUnexpectedValue(reader,
+                         "BloomLogs value should be a valid hex string")
+
+proc writeValue*(writer: var JsonWriter[RestJson], value: BloomLogs) {.
+     raises: [IOError, Defect].} =
+  writeValue(writer, hexOriginal(value.data))
+
+## OpaqueTransaction
+proc readValue*(reader: var JsonReader[RestJson], value: var OpaqueTransaction) {.
+     raises: [IOError, SerializationError, Defect].} =
+  readValue(reader, value)
+
+proc writeValue*(writer: var JsonWriter[RestJson], value: OpaqueTransaction) {.
+     raises: [IOError, Defect].} =
+  writeValue(writer, value)
+
 ## HashArray
 proc readValue*(reader: var JsonReader[RestJson], value: var HashArray) {.
      raises: [IOError, SerializationError, Defect].} =

--- a/beacon_chain/rpc/eth2_json_rest_serialization.nim
+++ b/beacon_chain/rpc/eth2_json_rest_serialization.nim
@@ -270,15 +270,6 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: BloomLogs) {.
      raises: [IOError, Defect].} =
   writeValue(writer, hexOriginal(value.data))
 
-## OpaqueTransaction
-proc readValue*(reader: var JsonReader[RestJson], value: var OpaqueTransaction) {.
-     raises: [IOError, SerializationError, Defect].} =
-  readValue(reader, value)
-
-proc writeValue*(writer: var JsonWriter[RestJson], value: OpaqueTransaction) {.
-     raises: [IOError, Defect].} =
-  writeValue(writer, value)
-
 ## HashArray
 proc readValue*(reader: var JsonReader[RestJson], value: var HashArray) {.
      raises: [IOError, SerializationError, Defect].} =

--- a/beacon_chain/rpc/eth_merge_web3.nim
+++ b/beacon_chain/rpc/eth_merge_web3.nim
@@ -1,9 +1,9 @@
 import
   strutils,
   json_serialization/std/[sets, net], serialization/errors,
-  ./spec/[datatypes, digest, crypto, eth2_apis/beacon_rpc_client],
+  ../spec/[datatypes, digest, crypto, eth2_apis/beacon_rpc_client],
   json_rpc/[client, jsonmarshal]
 
 from os import DirSep, AltSep
 template sourceDir: string = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
-createRpcSigs(RpcClient, sourceDir & "/rpc/eth_merge_sigs.nim")
+createRpcSigs(RpcClient, sourceDir & "/eth_merge_sigs.nim")

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -40,7 +40,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     let proposer = node.chainDag.getProposer(head, slot)
     if proposer.isNone():
       raise newException(CatchableError, "could not retrieve block for slot: " & $slot)
-    let message = makeBeaconBlockForHeadAndSlot(
+    let message = await makeBeaconBlockForHeadAndSlot(
       node, randao_reveal, proposer.get()[0], graffiti, head, slot)
     if message.isNone():
       raise newException(CatchableError, "could not retrieve block for slot: " & $slot)

--- a/beacon_chain/rpc/validator_rest_api.nim
+++ b/beacon_chain/rpc/validator_rest_api.nim
@@ -220,7 +220,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         let proposer = node.chainDag.getProposer(qhead, qslot)
         if proposer.isNone():
           return RestApiResponse.jsonError(Http400, ProposerNotFoundError)
-        let res = makeBeaconBlockForHeadAndSlot(
+        let res = await makeBeaconBlockForHeadAndSlot(
           node, qrandao, proposer.get()[0], qgraffiti, qhead, qslot)
         if res.isNone():
           return RestApiResponse.jsonError(Http400, BlockProduceError)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -28,10 +28,11 @@ import
   std/[macros, hashes, intsets, strutils, tables, typetraits],
   stew/[assign2, byteutils], chronicles,
   json_serialization,
-  ../../version, ../../ssz/types as sszTypes, ../crypto, ../digest, ../presets
+  ../../version, ../../ssz/types as sszTypes, ../crypto, ../digest, ../presets,
+  ./merge
 
 export
-  sszTypes, presets, json_serialization
+  sszTypes, merge, presets, json_serialization
 
 # Presently, we're reusing the data types from the serialization (uint64) in the
 # objects we pass around to the beacon chain logic, thus keeping the two

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -30,13 +30,11 @@ const
   EVM_BLOCK_ROOTS_SIZE* = 8
 
 type
-  # https://github.com/ethereum/eth2.0-specs/blob/eca6bd7d622a0cfb7343bff742da046ed25b3825/specs/merge/beacon-chain.md#custom-types
-  # TODO is this maneuver sizeof()/memcpy()/SSZ-equivalent? Pretty sure, but not 100% certain
-  OpaqueTransaction* = object
-    data*: List[byte, MAX_BYTES_PER_OPAQUE_TRANSACTION]
+  # https://github.com/ethereum/eth2.0-specs/blob/dev/specs/merge/beacon-chain.md#custom-types
+  OpaqueTransaction* = List[byte, Limit MAX_BYTES_PER_OPAQUE_TRANSACTION]
 
   EthAddress* = object
-    data*: array[20, byte]  # TODO there's a network_metadata type, but the import hierarchy's inconvenient without splitting out aspects of this module
+    data*: array[20, byte]  # TODO there's a network_metadata type, but the import hierarchy's inconvenient
 
   BloomLogs* = object
     data*: array[BYTES_PER_LOGS_BLOOM, byte]
@@ -54,6 +52,20 @@ type
     receipt_root*: Eth2Digest
     logs_bloom*: BloomLogs
     transactions*: List[OpaqueTransaction, MAX_EXECUTION_TRANSACTIONS]
+
+  # https://github.com/ethereum/eth2.0-specs/blob/dev/specs/merge/beacon-chain.md#executionpayloadheader
+  ExecutionPayloadHeader* = object
+    block_hash*: Eth2Digest  # Hash of execution block
+    parent_hash*: Eth2Digest
+    coinbase*: EthAddress
+    state_root*: Eth2Digest
+    number*: uint64
+    gas_limit*: uint64
+    gas_used*: uint64
+    timestamp*: uint64
+    receipt_root*: Eth2Digest
+    logs_bloom*: BloomLogs
+    transactions_root*: Eth2Digest
 
   # Empirically derived from Catalyst responses; doesn't seem to match merge
   # spec per commit 1fb9a6dd32b581c912d672634882d7e2eb2775cd from 2021-04-22
@@ -80,6 +92,9 @@ type
 
   BoolReturnSuccessRPC* = object
     success*: bool
+
+func encodeQuantityHex*(x: auto): string =
+  "0x" & x.toHex
 
 proc fromHex*(T: typedesc[BloomLogs], s: string): T =
   hexToBytes(s, result.data)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -265,6 +265,7 @@ proc makeBeaconBlock*(
     proposerSlashings: seq[ProposerSlashing],
     attesterSlashings: seq[AttesterSlashing],
     voluntaryExits: seq[SignedVoluntaryExit],
+    executionPayload: ExecutionPayload,
     rollback: RollbackHashedProc,
     cache: var StateCache): Option[BeaconBlock] =
   ## Create a block for the given state. The last block applied to it must be
@@ -306,4 +307,4 @@ proc makeBeaconBlock*(
   state.root = hash_tree_root(state.data)
   blck.state_root = state.root
 
-  some(blck)
+  return some(blck)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -150,6 +150,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
           @[],
           @[],
           @[],
+          ExecutionPayload(),
           noRollback,
           cache)
 

--- a/scripts/run-catalyst.sh
+++ b/scripts/run-catalyst.sh
@@ -2,8 +2,8 @@
 # set -Eeuo pipefail
 # https://github.com/prysmaticlabs/bazel-go-ethereum/blob/catalyst/run-catalyst.sh
 
-# To increase verbosity: debug.verbosity(5) or debug.verbosity(6)
-# MetaMask seed phrase for account with balance is
+# To increase verbosity: debug.verbosity(4)
+# MetaMask seed phrase for account with balance is:
 # lecture manual soon title cloth uncle gesture cereal common fruit tooth crater
 
 echo \{ \

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -117,6 +117,7 @@ proc addTestBlock*(
       @[],
       @[],
       @[],
+      default(ExecutionPayload),
       noRollback,
       cache)
 


### PR DESCRIPTION
This still maintains compatibility with current networks, but includes not just new files, but safe changes to existing files/modules:
- implementation of `consensus_{setHead,assembleBlock,newBlock}` in Eth1Monitor
- REST serialization support for merge data type `BloomLogs`
- async `makeBeaconBlockForHeadAndSlot()` to allow it to RPC to `consensus_assembleBlock` (actual call not included here)
- merkelization fixes for merge SSZ types