### PR TITLE
Slashing DB pruning: remove scalar path

### DIFF
--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -485,40 +485,86 @@ proc setupCachedQueries(db: SlashingProtectionDB_v2) =
     """, (ValidatorInternalID, int64, int64), void
   ).get()
 
+  # Important:
+  # The query plan MUST NOT involve correlated subqueries for speed concerns on 2000+ validators.
+  # use temporary tables or views instead
+
   db.sqlPruneAfterFinalizationBlocks = db.backend.prepareStmt("""
+    WITH max_proposer_slot AS (
+      SELECT
+        validator_id,
+        MAX(slot) AS max_slot
+      FROM
+        signed_blocks
+      GROUP BY
+        validator_id
+      ORDER BY
+        validator_id
+    )
     DELETE
     FROM
-      signed_blocks AS sb1
-    WHERE 1=1
-      and sb1.slot < ?
-      -- Keep the most recent slot per validator
-      and sb1.slot <> (
-        SELECT MAX(sb2.slot)
-        FROM signed_blocks AS sb2
-        WHERE sb2.validator_id = sb1.validator_id
-      )
+      signed_blocks
+    -- Delete everything except ...
+    WHERE ROWID NOT IN (
+      SELECT sb.ROWID
+      FROM
+        signed_blocks sb
+      LEFT JOIN
+        max_proposer_slot on max_proposer_slot.validator_id = sb.validator_id
+      WHERE
+        -- last finalized slot or later
+        sb.slot >= ?
+        -- also keep the most recent slot per validator
+        or sb.slot = max_proposer_slot.max_slot
+    )
     """, int64, void
   ).get()
 
   db.sqlPruneAfterFinalizationAttestations = db.backend.prepareStmt("""
+    WITH
+      max_source AS (
+        SELECT
+          validator_id,
+          MAX(source_epoch) AS max_source_epoch
+        FROM
+          signed_attestations
+        GROUP BY
+          validator_id
+        ORDER BY
+          validator_id
+      ),
+      max_target AS (
+        SELECT
+          validator_id,
+          MAX(target_epoch) AS max_target_epoch
+        FROM
+          signed_attestations
+        GROUP BY
+          validator_id
+        ORDER BY
+          validator_id
+      )
     DELETE
     FROM
-      signed_attestations AS sa1
-    WHERE 1=1
-      and source_epoch < ?
-      and target_epoch < ?
-      -- Keep the most recent source_epoch per validator
-      and sa1.source_epoch <> (
-          SELECT MAX(sas.source_epoch)
-          FROM signed_attestations AS sas
-          WHERE sa1.validator_id = sas.validator_id
-      )
-      -- And the most recent target_epoch per validator
-      and sa1.target_epoch <> (
-          SELECT MAX(sat.target_epoch)
-          FROM signed_attestations AS sat
-          WHERE sa1.validator_id = sat.validator_id
-      )
+      signed_attestations
+    -- Delete everything except ...
+    WHERE ROWID NOT IN (
+      SELECT sa.ROWID
+      FROM
+        signed_attestations sa
+      LEFT JOIN
+        max_source on max_source.validator_id = sa.validator_id
+      LEFT JOIN
+        max_target on max_target.validator_id = sa.validator_id
+      WHERE
+        -- last finalized epochs or later
+        source_epoch >= ?
+        or target_epoch >= ?
+        -- Keep the most recent source_epoch per validator
+        or sa.source_epoch = max_source.max_source_epoch
+        -- And the most recent target_epoch per validator
+        or sa.target_epoch = max_target.max_target_epoch
+    )
      """, (int64, int64), void
   ).get()
 


### PR DESCRIPTION
This removes scalar scans and searches that impact Pyrmont nodes

![image](https://user-images.githubusercontent.com/22738317/117780775-3a423280-b240-11eb-860a-97e50c4793b9.png)

Ergo **correlated subqueries must be avoided at all cost**.

Question: we require the temp table from the WITH clause to be sorted by validator_id. This shouldn't have perf implication as validator_id is an index and so already sorted.

# Blocks

## Before

issue: CORRELATED SUBQUERY to remove

```sql
EXPLAIN QUERY PLAN
DELETE
FROM
  signed_blocks AS sb1
WHERE 1=1
  and sb1.slot < ?
  -- Keep the most recent slot per validator
  and sb1.slot <> (
    SELECT MAX(sb2.slot)
    FROM signed_blocks AS sb2
    WHERE sb2.validator_id = sb1.validator_id
  )
```
![image](https://user-images.githubusercontent.com/22738317/117782037-8e014b80-b241-11eb-8cb4-864eedb69ecb.png)


## Intermediate attempt with EXISTS

issue: SCAN SUBQUERY 1 does not use an index

```
EXPLAIN QUERY PLAN
WITH max_proposer_slot AS (
  SELECT
    validator_id,
    MAX(slot) AS max_slot
  FROM
    signed_blocks
  GROUP BY
    validator_id
  ORDER BY
    validator_id
)
DELETE
FROM
  signed_blocks
WHERE EXISTS (
  SELECT 1
  FROM
    signed_blocks sb
  LEFT JOIN
    max_proposer_slot on max_proposer_slot.validator_id = sb.validator_id 
  WHERE 1=1
    and sb.slot < ?
    -- Keep the most recent slot per validator
    and sb.slot <> max_proposer_slot.max_slot
)
```

![image](https://user-images.githubusercontent.com/22738317/117782204-b2f5be80-b241-11eb-8153-69e0b2682b12.png)


## PR with rowid

Note: we reframe the outer list/scan deletion subquery as "delete everything except ..." (NOT IN) as we expect the list of items to keep is small and constant in size while the list of items to delete can grow if pruning was never done or in period of non-finality

```sql
EXPLAIN QUERY PLAN
WITH max_proposer_slot AS (
  SELECT
    validator_id,
    MAX(slot) AS max_slot
  FROM
    signed_blocks
  GROUP BY
    validator_id
  ORDER BY
    validator_id
)
DELETE
FROM
  signed_blocks
-- Delete everything except ...
WHERE ROWID NOT IN (
  SELECT sb.ROWID 
  FROM
    signed_blocks sb
  LEFT JOIN
    max_proposer_slot on max_proposer_slot.validator_id = sb.validator_id 
  WHERE
    sb.slot >= 4000
    -- also keep the most recent slot per validator
    or sb.slot = max_proposer_slot.max_slot
)
```

![image](https://user-images.githubusercontent.com/22738317/117782276-c1dc7100-b241-11eb-8844-09920646b303.png)


# Attestations

## Before:

![image](https://user-images.githubusercontent.com/22738317/117780672-226aae80-b240-11eb-9828-8a734c40db88.png)

## Intermediate attempt with EXISTS

issue: There is still an inner scan subquery

```sql
EXPLAIN QUERY PLAN
WITH
  max_source AS (
      SELECT
        validator_id,
        MAX(source_epoch) AS max_source_epoch
      from
        signed_attestations
      GROUP BY
        validator_id
      ORDER BY
        validator_id
    ),
  max_target AS (
      SELECT
        validator_id,
        MAX(target_epoch) AS max_target_epoch
      from
        signed_attestations
      GROUP BY
        validator_id
      ORDER BY
        validator_id
    )
DELETE
FROM
  signed_attestations
WHERE EXISTS (
    SELECT 1
    FROM
      signed_attestations sa1
    LEFT JOIN
      max_source on max_source.validator_id = sa1.validator_id
    LEFT JOIN
      max_target on max_target.validator_id = sa1.validator_id
    WHERE 1=1
      and source_epoch < 4000
      and target_epoch < 4000
      -- Keep the most recent source_epoch per validator
      and sa1.source_epoch <> max_source.max_source_epoch
      -- And the most recent target_epoch per validator
      and sa1.target_epoch <> max_target.max_target_epoch
)
```

![image](https://user-images.githubusercontent.com/22738317/117781445-f6036200-b240-11eb-82fa-3f0852a4111c.png)


## PR with rowid

Unlike for blocks it doesn't seem like we can easily remove the inner scan subquery.
However the result of it is ordered so hopefully the search is still fast.

Note that we frame the subquery as negative (NOT IN) as we expect there are very few rowid to retain compared to rowid to delete which means the list will be smaller.

```sql
EXPLAIN QUERY PLAN
    WITH
      max_source AS (
        SELECT
          validator_id,
          MAX(source_epoch) AS max_source_epoch
        FROM
          signed_attestations
        GROUP BY
          validator_id
        ORDER BY
          validator_id
      ),
      max_target AS (
        SELECT
          validator_id,
          MAX(target_epoch) AS max_target_epoch
        FROM
          signed_attestations
        GROUP BY
          validator_id
        ORDER BY
          validator_id
      )
    DELETE
    FROM
      signed_attestations
    -- Delete everything except ...
    WHERE ROWID NOT IN (
      SELECT sa.ROWID 
      FROM
        signed_attestations sa
      LEFT JOIN
        max_source on max_source.validator_id = sa.validator_id
      LEFT JOIN
        max_target on max_target.validator_id = sa.validator_id
      WHERE 1=1
        -- last finalized epochs or later
        and source_epoch >= ?
        and target_epoch >= ?
        -- Keep the most recent source_epoch per validator
        and sa.source_epoch = max_source.max_source_epoch
        -- And the most recent target_epoch per validator
        and sa.target_epoch = max_target.max_target_epoch
    )
```

![image](https://user-images.githubusercontent.com/22738317/117781140-9c029c80-b240-11eb-82e1-efbb6e67f640.png)

