### PR TITLE
Fix typo in book

### DIFF
--- a/docs/the_nimbus_book/src/more-keys.md
+++ b/docs/the_nimbus_book/src/more-keys.md
@@ -39,7 +39,7 @@ Copy the `validator_keys` directory to `nimbus-eth2` and then follow the instruc
 > ⚠️  If you wish to generate another validator key,  you must take great care
 to not generate a copy of your original key. Running the same key on two different validator clients will likely get you slashed.
 
-***N.B.** the commands below assume you already have one key and wish to generate a second, hence `--validator_start_index` has been set to `0`.*
+***N.B.** the commands below assume you already have one key and wish to generate a second, hence `--validator_start_index` has been set to `1` (as `0` would be the original key).*
 
 
 Run the following command from the directory which contains the `deposit` executable:


### PR DESCRIPTION
As shown in the commands below, it needs to be set to 1, not 0.