### PR TITLE
Revert "create new database in separate file (#2596)"

### DIFF
--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -86,7 +86,3 @@ template isomorphicCast*[T, U](x: var U): T =
     doAssert sizeof(T) == sizeof(U)
     doAssert getSizeofSig(T()) == getSizeofSig(U())
   cast[ref T](addr x)[]
-
-proc loadImmutableValidators*(dbSeq: var auto): seq[ImmutableValidatorData] =
-  for i in 0 ..< dbSeq.len:
-    result.add dbSeq.get(i)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -232,8 +232,7 @@ proc init*(T: type BeaconNode,
   # Doesn't use std/random directly, but dependencies might
   randomize(rng[].rand(high(int)))
 
-  info "Loading block dag from database",
-    path = config.databaseDir, hasV0 = db.hasV0
+  info "Loading block dag from database", path = config.databaseDir
 
   let
     chainDagFlags = if config.verifyFinalization: {verifyFinalization}


### PR DESCRIPTION
This reverts commit eebc828778ea4fd6ce907cfee075153173b27b8f.

Adding a separate file turns out not to be enough. This PR reverts the
separate file change.

Another theory is that the large kvstore table causes cache thrashing -
all database connections share a common page cache which would explain
the poor performance of the separate file solution.