### PR TITLE
clean up block processing

### DIFF
--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -16,7 +16,7 @@ import
   # Local modules
   ./conf, ./beacon_clock, ./beacon_chain_db,
   ./beacon_node_types,
-  ./gossip_processing/[eth2_processor, gossip_to_consensus, consensus_manager],
+  ./gossip_processing/[eth2_processor, block_processor, consensus_manager],
   ./networking/eth2_network,
   ./eth1/eth1_monitor,
   ./consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
@@ -57,7 +57,7 @@ type
     genesisSnapshotContent*: string
     attestationSubnets*: AttestationSubnets
     processor*: ref Eth2Processor
-    verifQueues*: ref VerifQueueManager
+    blockProcessor*: ref BlockProcessor
     consensusManager*: ref ConsensusManager
     attachedValidatorBalanceTotal*: uint64
 

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -417,7 +417,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
     # Attestations produced in a particular slot are added to the block
     # at the slot where at least MIN_ATTESTATION_INCLUSION_DELAY have passed
     maxAttestationSlot = newBlockSlot - MIN_ATTESTATION_INCLUSION_DELAY
-    startPackingTime = Moment.now()
+    startPackingTick = Moment.now()
 
   var
     candidates: seq[tuple[
@@ -521,12 +521,12 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
         it.score > 0
 
   let
-    packingTime = Moment.now() - startPackingTime
+    packingDur = Moment.now() - startPackingTick
 
   debug "Packed attestations for block",
-    newBlockSlot, packingTime, totalCandidates, attestations = res.len()
+    newBlockSlot, packingDur, totalCandidates, attestations = res.len()
   attestation_pool_block_attestation_packing_time.set(
-    packingTime.toFloatSeconds())
+    packingDur.toFloatSeconds())
 
   res
 

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -90,6 +90,7 @@ proc addResolvedBlock(
     blockRoot = trustedBlock.root
     blockRef = BlockRef.init(blockRoot, trustedBlock.message)
     blockEpoch = blockRef.slot.compute_epoch_at_slot()
+    startTick = Moment.now()
 
   link(parent, blockRef)
 
@@ -100,12 +101,14 @@ proc addResolvedBlock(
 
     epochRef = EpochRef.init(state, cache, prevEpochRef)
     dag.addEpochRef(blockRef, epochRef)
+  let epochRefTick = Moment.now()
 
   dag.blocks.incl(KeyedBlockRef.init(blockRef))
   trace "Populating block dag", key = blockRoot, val = blockRef
 
   # Resolved blocks should be stored in database
   dag.putBlock(trustedBlock)
+  let putTick = Moment.now()
 
   var foundHead: BlockRef
   for head in dag.heads.mitems():
@@ -123,7 +126,9 @@ proc addResolvedBlock(
   debug "Block resolved",
     blck = shortLog(trustedBlock.message),
     blockRoot = shortLog(blockRoot),
-    heads = dag.heads.len()
+    heads = dag.heads.len(),
+    epochRefDur = epochRefTick - startTick,
+    putBlockDur = putTick - epochRefTick
 
   state.blck = blockRef
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -739,7 +739,7 @@ proc updateStateData*(
   # an earlier state must be loaded since there's no way to undo the slot
   # transitions
 
-  let startTime = Moment.now()
+  let startTick = Moment.now()
 
   var
     ancestors: seq[BlockRef]
@@ -788,10 +788,7 @@ proc updateStateData*(
       break
 
     # Moving slot by slot helps find states that were advanced with empty slots
-    cur = cur.parentOrSlot
-
-  # Let's see if we're within a few epochs of the state block - then we can
-  # simply replay blocks without loading the whole state
+    cur = cur.parentOrSlot()
 
   if not found:
     debug "UpdateStateData cache miss",
@@ -810,24 +807,27 @@ proc updateStateData*(
     while not dag.getState(state, cur):
       # There's no state saved for this particular BlockSlot combination, keep
       # looking...
-      if cur.blck.parent != nil and
-          cur.blck.slot.epoch != epoch(cur.blck.parent.slot):
-        # We store the state of the parent block with the epoch processing applied
-        # in the database - we'll need to apply the block however!
+      if cur.slot == cur.blck.slot:
+        # This is not an empty slot, so the block will need to be applied to
+        # eventually reach bs
         ancestors.add(cur.blck)
-        cur = cur.blck.parent.atEpochStart(cur.blck.slot.epoch)
-      else:
-        if cur.slot == cur.blck.slot:
-          # This is not an empty slot, so the block will need to be applied to
-          # eventually reach bs
-          ancestors.add(cur.blck)
 
-        # Moves back slot by slot, in case a state for an empty slot was saved
-        cur = cur.parent
+      if cur.slot == dag.tail.slot:
+        # If we've walked all the way to the tail and still not found a state,
+        # there's no hope finding one - the database likely has become corrupt
+        # and one will have to resync from start.
+        fatal "Cannot find state to load, the database is likely corrupt",
+          cur, bs, head = dag.head, tail = dag.tail
+        quit 1
+
+      # Move slot by slot to capture epoch boundary states
+      cur = cur.parentOrSlot()
 
     beacon_state_rewinds.inc()
 
+  # Starting state has been assigned, either from memory or database
   let
+    assignTick = Moment.now()
     startSlot {.used.} = getStateField(state, slot) # used in logs below
     startRoot {.used.} = state.data.root
   var rewards: RewardInfo
@@ -846,7 +846,9 @@ proc updateStateData*(
   # ...and make sure to process empty slots as requested
   dag.advanceSlots(state, bs.slot, save, cache, rewards)
 
-  let diff = Moment.now() - startTime
+  let
+    assignDur = assignTick - startTick
+    replayDur = Moment.now() - assignTick
 
   logScope:
     blocks = ancestors.len
@@ -857,9 +859,10 @@ proc updateStateData*(
     startSlot
     blck = shortLog(bs)
     found
-    diff = shortLog(diff)
+    assign_dur = assignDur
+    replay_dur = replayDur
 
-  if diff >= 1.seconds:
+  if (assignDur + replayDur) >= 1.seconds:
     # This might indicate there's a cache that's not in order or a disk that is
     # too slow - for now, it's here for investigative purposes and the cutoff
     # time might need tuning

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -859,8 +859,8 @@ proc updateStateData*(
     startSlot
     blck = shortLog(bs)
     found
-    assign_dur = assignDur
-    replay_dur = replayDur
+    assignDur
+    replayDur
 
   if (assignDur + replayDur) >= 1.seconds:
     # This might indicate there's a cache that's not in order or a disk that is
@@ -923,7 +923,7 @@ proc pruneBlocksDAG(dag: ChainDAGRef) =
   debug "Pruned the blockchain DAG",
     currentCandidateHeads = dag.heads.len,
     prunedHeads = hlen - dag.heads.len,
-    dagPruningDuration = dur
+    dagPruningDur = dur
 
 func needStateCachesAndForkChoicePruning*(dag: ChainDAGRef): bool =
   dag.lastPrunePoint != dag.finalizedHead

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -142,7 +142,7 @@ proc processBatch(batchCrypto: ref BatchCrypto) =
   trace "batch crypto - starting",
     batchSize
 
-  let startTime = Moment.now()
+  let startTick = Moment.now()
 
   var secureRandomBytes: array[32, byte]
   batchCrypto[].rng[].brHmacDrbgGenerate(secureRandomBytes)
@@ -153,12 +153,10 @@ proc processBatch(batchCrypto: ref BatchCrypto) =
     batch.pendingBuffer,
     secureRandomBytes)
 
-  let stopTime = Moment.now()
-
   trace "batch crypto - finished",
     batchSize,
     cryptoVerified = ok,
-    dur = stopTime - startTime
+    batchDur = Moment.now() - startTick
 
   if ok:
     for res in batch.resultsBuffer.mitems():

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -200,12 +200,12 @@ proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
     beacon_store_block_duration_seconds.observe(storeBlockDur.toFloatSeconds())
 
     debug "Block processed",
-      local_head_slot = self.consensusManager.chainDag.head.slot,
-      block_slot = entry.blck.message.slot,
-      validation_dur = entry.validationDur,
-      queue_dur = queueDur,
-      store_block_dur = storeBlockDur,
-      update_head_dur = updateHeadDur
+      localHeadSlot = self.consensusManager.chainDag.head.slot,
+      blockSlot = entry.blck.message.slot,
+      validationDur = entry.validationDur,
+      queueDur,
+      storeBlockDur,
+      updateHeadDur
 
     entry.done()
   elif res.error() in {BlockError.Duplicate, BlockError.Old}:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -183,19 +183,19 @@ proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
     quit 1
 
   let
-    start = Moment.now()
+    startTick = Moment.now()
     res = self.storeBlock(entry.blck, wallSlot)
-    storeDone = Moment.now()
+    storeTick = Moment.now()
 
   if res.isOk():
     # Eagerly update head in case the new block gets selected
     self.consensusManager[].updateHead(wallSlot)
 
     let
-      updateDone = Moment.now()
-      queueDur = entry.queueTick - start
-      storeBlockDur = storeDone - start
-      updateHeadDur = updateDone - storeDone
+      updateHeadTick = Moment.now()
+      queueDur = startTick - entry.queueTick
+      storeBlockDur = storeTick - startTick
+      updateHeadDur = updateHeadTick - storeTick
 
     beacon_store_block_duration_seconds.observe(storeBlockDur.toFloatSeconds())
 
@@ -203,9 +203,7 @@ proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
       localHeadSlot = self.consensusManager.chainDag.head.slot,
       blockSlot = entry.blck.message.slot,
       validationDur = entry.validationDur,
-      queueDur,
-      storeBlockDur,
-      updateHeadDur
+      queueDur, storeBlockDur, updateHeadDur
 
     entry.done()
   elif res.error() in {BlockError.Duplicate, BlockError.Old}:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [Defect].}
+
 import
   std/math,
   stew/results,
@@ -15,24 +17,22 @@ import
   ".."/[beacon_clock, beacon_node_types],
   ../ssz/sszdump
 
-# Gossip Queue Manager
+# Block Processor
 # ------------------------------------------------------------------------------
-# The queue manager moves blocks from "Gossip validated" to "Consensus verified"
+# The block processor moves blocks from "Incoming" to "Consensus verified"
 
 declareHistogram beacon_store_block_duration_seconds,
   "storeBlock() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
 
 type
-  SyncBlock* = object
-    blk*: SignedBeaconBlock
-    resfut*: Future[Result[void, BlockError]]
-
   BlockEntry* = object
-    # Exported for "test_sync_manager"
-    v*: SyncBlock
+    blck*: SignedBeaconBlock
+    resfut*: Future[Result[void, BlockError]]
+    queueTick*: Moment # Moment when block was enqueued
+    validationDur*: Duration # Time it took to perform gossip validation
 
-  VerifQueueManager* = object
-    ## This manages the queues of blocks and attestations.
+  BlockProcessor* = object
+    ## This manages the processing of blocks from different sources
     ## Blocks and attestations are enqueued in a gossip-validated state
     ##
     ## from:
@@ -45,9 +45,6 @@ type
     ## - database
     ## - attestation pool
     ## - fork choice
-    ##
-    ## The queue manager doesn't manage exits (voluntary, attester slashing or proposer slashing)
-    ## as don't need extra verification and can be added to the exit pool as soon as they are gossip-validated.
 
     # Config
     # ----------------------------------------------------------------
@@ -68,17 +65,15 @@ type
     consensusManager: ref ConsensusManager
       ## Blockchain DAG, AttestationPool and Quarantine
 
-{.push raises: [Defect].}
-
 # Initialization
 # ------------------------------------------------------------------------------
 
-proc new*(T: type VerifQueueManager,
+proc new*(T: type BlockProcessor,
           dumpEnabled: bool,
           dumpDirInvalid, dumpDirIncoming: string,
           consensusManager: ref ConsensusManager,
-          getWallTime: GetWallTimeFn): ref VerifQueueManager =
-  (ref VerifQueueManager)(
+          getWallTime: GetWallTimeFn): ref BlockProcessor =
+  (ref BlockProcessor)(
     dumpEnabled: dumpEnabled,
     dumpDirInvalid: dumpDirInvalid,
     dumpDirIncoming: dumpDirIncoming,
@@ -92,35 +87,32 @@ proc new*(T: type VerifQueueManager,
 # Sync callbacks
 # ------------------------------------------------------------------------------
 
-proc done*(blk: SyncBlock) =
-  ## Send signal to [Sync/Request]Manager that the block ``blk`` has passed
+proc done*(entry: BlockEntry) =
+  ## Send signal to [Sync/Request]Manager that the block ``entry`` has passed
   ## verification successfully.
-  if blk.resfut != nil:
-    blk.resfut.complete(Result[void, BlockError].ok())
+  if entry.resfut != nil:
+    entry.resfut.complete(Result[void, BlockError].ok())
 
-proc fail*(blk: SyncBlock, error: BlockError) =
+proc fail*(entry: BlockEntry, error: BlockError) =
   ## Send signal to [Sync/Request]Manager that the block ``blk`` has NOT passed
   ## verification with specific ``error``.
-  if blk.resfut != nil:
-    blk.resfut.complete(Result[void, BlockError].err(error))
+  if entry.resfut != nil:
+    entry.resfut.complete(Result[void, BlockError].err(error))
 
-proc complete*(blk: SyncBlock, res: Result[void, BlockError]) =
-  ## Send signal to [Sync/Request]Manager about result ``res`` of block ``blk``
-  ## verification.
-  if blk.resfut != nil:
-    blk.resfut.complete(res)
-
-proc hasBlocks*(self: VerifQueueManager): bool =
+proc hasBlocks*(self: BlockProcessor): bool =
   self.blocksQueue.len() > 0
 
 # Enqueue
 # ------------------------------------------------------------------------------
 
-proc addBlock*(self: var VerifQueueManager, syncBlock: SyncBlock) =
+proc addBlock*(
+    self: var BlockProcessor, blck: SignedBeaconBlock,
+    resfut: Future[Result[void, BlockError]] = nil,
+    validationDur = Duration()) =
   ## Enqueue a Gossip-validated block for consensus verification
   # Backpressure:
   #   There is no backpressure here - producers must wait for the future in the
-  #   SyncBlock to constrain their own processing
+  #   BlockEntry to constrain their own processing
   # Producers:
   # - Gossip (when synced)
   # - SyncManager (during sync)
@@ -128,13 +120,18 @@ proc addBlock*(self: var VerifQueueManager, syncBlock: SyncBlock) =
 
   # addLast doesn't fail with unbounded queues, but we'll add asyncSpawn as a
   # sanity check
-  asyncSpawn self.blocksQueue.addLast(BlockEntry(v: syncBlock))
+  try:
+    self.blocksQueue.addLastNoWait(BlockEntry(
+      blck: blck, resfut: resfut, queueTick: Moment.now(),
+      validationDur: validationDur))
+  except AsyncQueueFullError:
+    raiseAssert "unbounded queue"
 
 # Storage
 # ------------------------------------------------------------------------------
 
 proc dumpBlock*[T](
-    self: VerifQueueManager, signedBlock: SignedBeaconBlock,
+    self: BlockProcessor, signedBlock: SignedBeaconBlock,
     res: Result[T, (ValidationResult, BlockError)]) =
   if self.dumpEnabled and res.isErr:
     case res.error[1]
@@ -148,13 +145,13 @@ proc dumpBlock*[T](
       discard
 
 proc storeBlock(
-    self: var VerifQueueManager, signedBlock: SignedBeaconBlock,
+    self: var BlockProcessor, signedBlock: SignedBeaconBlock,
     wallSlot: Slot): Result[void, BlockError] =
   let
-    start = Moment.now()
     attestationPool = self.consensusManager.attestationPool
 
-  let blck = self.consensusManager.chainDag.addRawBlock(self.consensusManager.quarantine, signedBlock) do (
+  let blck = self.consensusManager.chainDag.addRawBlock(
+    self.consensusManager.quarantine, signedBlock) do (
       blckRef: BlockRef, trustedBlock: TrustedSignedBeaconBlock,
       epochRef: EpochRef, state: HashedBeaconState):
     # Callback add to fork choice if valid
@@ -168,17 +165,14 @@ proc storeBlock(
   # was pruned from the ForkChoice.
   if blck.isErr:
     return err(blck.error[1])
-
-  let duration = (Moment.now() - start).toFloatSeconds()
-  beacon_store_block_duration_seconds.observe(duration)
   ok()
 
 # Event Loop
 # ------------------------------------------------------------------------------
 
-proc processBlock(self: var VerifQueueManager, entry: BlockEntry) =
+proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
   logScope:
-    blockRoot = shortLog(entry.v.blk.root)
+    blockRoot = shortLog(entry.blck.root)
 
   let
     wallTime = self.getWallTime()
@@ -189,47 +183,39 @@ proc processBlock(self: var VerifQueueManager, entry: BlockEntry) =
     quit 1
 
   let
-    start = now(chronos.Moment)
-    res = self.storeBlock(entry.v.blk, wallSlot)
-    storeDone = now(chronos.Moment)
+    start = Moment.now()
+    res = self.storeBlock(entry.blck, wallSlot)
+    storeDone = Moment.now()
 
   if res.isOk():
     # Eagerly update head in case the new block gets selected
-    self.consensusManager[].updateHead(wallSlot)    # This also eagerly prunes the blocks DAG to prevent processing forks.
-    # self.consensusManager.pruneStateCachesDAG() # Amortized pruning, we don't prune states & fork choice here but in `onSlotEnd`()
+    self.consensusManager[].updateHead(wallSlot)
 
-    let updateDone = now(chronos.Moment)
-    let storeBlockDuration = storeDone - start
-    let updateHeadDuration = updateDone - storeDone
-    let overallDuration = updateDone - start
-    let storeSpeed =
-      block:
-        let secs = float(chronos.seconds(1).nanoseconds)
-        if not(overallDuration.isZero()):
-          let v = secs / float(overallDuration.nanoseconds)
-          round(v * 10_000) / 10_000
-        else:
-          0.0
+    let
+      updateDone = Moment.now()
+      queueDur = entry.queueTick - start
+      storeBlockDur = storeDone - start
+      updateHeadDur = updateDone - storeDone
+
+    beacon_store_block_duration_seconds.observe(storeBlockDur.toFloatSeconds())
+
     debug "Block processed",
       local_head_slot = self.consensusManager.chainDag.head.slot,
-      store_speed = storeSpeed,
-      block_slot = entry.v.blk.message.slot,
-      store_block_duration = $storeBlockDuration,
-      update_head_duration = $updateHeadDuration,
-      overall_duration = $overallDuration
+      block_slot = entry.blck.message.slot,
+      validation_dur = entry.validationDur,
+      queue_dur = queueDur,
+      store_block_dur = storeBlockDur,
+      update_head_dur = updateHeadDur
 
-    if entry.v.resFut != nil:
-      entry.v.resFut.complete(Result[void, BlockError].ok())
+    entry.done()
   elif res.error() in {BlockError.Duplicate, BlockError.Old}:
-    # These are harmless / valid outcomes - for the purpose of scoring peers,
-    # they are ok
-    if entry.v.resFut != nil:
-      entry.v.resFut.complete(Result[void, BlockError].ok())
+    # Duplicate and old blocks are ok from a sync point of view, so we mark
+    # them as successful
+    entry.done()
   else:
-    if entry.v.resFut != nil:
-      entry.v.resFut.complete(Result[void, BlockError].err(res.error()))
+    entry.fail(res.error())
 
-proc runQueueProcessingLoop*(self: ref VerifQueueManager) {.async.} =
+proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
   while true:
     # Cooperative concurrency: one block per loop iteration - because
     # we run both networking and CPU-heavy things like block processing


### PR DESCRIPTION
* gossip_to_consensus -> block_processor (it's processing only blocks,
but not only from gossip)
* measure queue and validation time for blocks
* measure assignment and state loading times for updateStateData
* avoid some unnecessary block copies in block sync
* warn that database is corrupt if we hit tail without a state