### PR TITLE
[WIP] proof of concept of halving validator shufflings

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -237,7 +237,7 @@ proc addRawBlockKnownParent(
     # TODO: remove skipBLSValidation
 
     var sigs: seq[SignatureSet]
-    if not sigs.collectSignatureSets(signedBlock, dag.clearanceState, cache):
+    if not sigs.collectSignatureSets(signedBlock, dag, dag.clearanceState, cache):
       # A PublicKey or Signature isn't on the BLS12-381 curve
       return err((ValidationResult.Reject, Invalid))
     if not quarantine.batchVerify(sigs):

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -13,8 +13,9 @@ import
   # Status libraries
   stew/[endians2, byteutils], chronicles,
   eth/keys,
+  blscurve,
   # Internals
-  ../spec/[datatypes, crypto, digest, signatures_batch],
+  ../spec/[datatypes, crypto, digest],
   ../beacon_chain_db, ../extras
 
 export sets, tables

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -718,6 +718,7 @@ proc applyBlock(
     statePtr[] = dag.headState
 
   loadStateCache(dag, cache, blck.refs, blck.data.message.slot.epoch)
+  # for att in atts: loadsc(att)
 
   let ok = state_transition(
     dag.runtimePreset, state.data, blck.data,
@@ -846,6 +847,13 @@ proc updateStateData*(
   loadStateCache(dag, cache, bs.blck, bs.slot.epoch)
 
   # ...and make sure to process empty slots as requested
+
+  # foreach epoch_boundary_crossed, for epoch which ended:
+  # state.previous_epoch_attestations.data
+  # state.current_epoch_attestations.data
+  # do same dag.getRef(data.beacon_block_root), !isNil -> loadStateCache(data.slot.epoch)
+  # try to avoid duplicates but don't bother at first
+
   dag.advanceSlots(state, bs.slot, save, cache, rewards)
 
   let

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -12,6 +12,8 @@ import
   std/[options, math, tables],
   ./datatypes/[phase0, altair], ./digest, ./helpers
 
+import chronicles
+
 const
   SEED_SIZE = sizeof(Eth2Digest)
   ROUND_SIZE = 1
@@ -130,6 +132,12 @@ func get_shuffled_active_validator_indices*(
 
   shuffle_list(
     active_validator_indices, get_seed(state, epoch, DOMAIN_BEACON_ATTESTER))
+
+  {.noSideEffect.}:
+    debug "FOO1: POST",
+      avi = active_validator_indices.toOpenArray(0, 2),
+      stacktrace = getStackTrace()
+
 
   active_validator_indices
 


### PR DESCRIPTION
The general observation is that in three places in nbc, highlighted in this PR/branch, `loadStateCache` is only run on the block level, not for the attestations it contains. This accounts for most of the shufflings performed.