### PR TITLE
Allow the custom testnet metadata to specify a path to the genesis file

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -361,11 +361,6 @@ type
         desc: "Output file where to write the initial state snapshot"
         name: "output-genesis" }: OutFile
 
-      withGenesisRoot* {.
-        desc: "Include a genesis root in 'network.json'"
-        defaultValue: false
-        name: "with-genesis-root" }: bool
-
       outputBootstrapFile* {.
         desc: "Output file with list of bootstrap nodes for the network"
         name: "output-bootstrap-file" }: OutFile

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -71,6 +71,7 @@ type
       # `genesisData` will have `len == 0` for networks with a still
       # unknown genesis state.
       genesisData*: string
+      genesisDataPath*: string
       genesisDepositsSnapshot*: string
     else:
       incompatibilityDesc*: string
@@ -201,7 +202,7 @@ const
 {.pop.} # the following pocedures raise more than just `Defect`
 
 proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
-  let
+  var
     metadata = case toLowerAscii(networkName)
       of "mainnet":
         mainnetMetadata
@@ -224,6 +225,8 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
     fatal "The selected network is not compatible with the current build",
             reason = metadata.incompatibilityDesc
     quit 1
+  if metadata.genesisData.len == 0 and metadata.genesisDataPath.len > 0:
+    metadata.genesisData = readFile(metadata.genesisDataPath)
   return metadata
 
 proc getRuntimePresetForNetwork*(eth2Network: Option[string]): RuntimePreset =

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -208,7 +208,7 @@ $MAKE -j ${NPROC} LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:testnet_serv
 
 PIDS=""
 WEB3_ARG=""
-STATE_SNAPSHOT_ARG=""
+GENESIS_DATA_PATH=""
 BOOTSTRAP_TIMEOUT=30 # in seconds
 DEPOSIT_CONTRACT_ADDRESS="0x0000000000000000000000000000000000000000"
 DEPOSIT_CONTRACT_BLOCK="0x0000000000000000000000000000000000000000000000000000000000000000"
@@ -239,7 +239,7 @@ if [[ $USE_GANACHE == "0" ]]; then
     --insecure-netkey-password=true \
     --genesis-offset=${GENESIS_OFFSET} # Delay in seconds
 
-  STATE_SNAPSHOT_ARG="--finalized-checkpoint-state=${NETWORK_DIR}/genesis.ssz"
+  GENESIS_DATA_PATH="\"genesisDataPath\": \"${NETWORK_DIR}/genesis.ssz\","
 else
   echo "Launching ganache"
   ganache-cli --blockTime 17 --gasLimit 100000000 -e 100000 --verbose > "${DATA_DIR}/log_ganache.txt" 2>&1 &
@@ -279,6 +279,7 @@ fi
 echo Wrote $NETWORK_METADATA_FILE:
 tee "$NETWORK_METADATA_FILE" <<EOF
 {
+  $GENESIS_DATA_PATH
   "runtimePreset": {
     "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": ${TOTAL_VALIDATORS},
     "MIN_GENESIS_TIME": 0,
@@ -388,7 +389,6 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --max-peers=$(( NUM_NODES - 1 )) \
     --data-dir="${NODE_DATA_DIR}" \
     ${BOOTSTRAP_ARG} \
-    ${STATE_SNAPSHOT_ARG} \
     ${WEB3_ARG} \
     ${STOP_AT_EPOCH_FLAG} \
     --rpc \

--- a/tests/simulation/run_node.sh
+++ b/tests/simulation/run_node.sh
@@ -80,11 +80,6 @@ fi
 rm -rf "$NODE_DATA_DIR/dump"
 "$MAKEDIR" "$NODE_DATA_DIR/dump"
 
-SNAPSHOT_ARG=""
-if [ -f "${SNAPSHOT_FILE}" ]; then
-  SNAPSHOT_ARG="--finalized-checkpoint-state=${SNAPSHOT_FILE}"
-fi
-
 cd "$NODE_DATA_DIR"
 
 $BEACON_NODE_BIN \
@@ -96,7 +91,6 @@ $BEACON_NODE_BIN \
   --node-name=$NODE_ID \
   --tcp-port=$PORT \
   --udp-port=$PORT \
-  $SNAPSHOT_ARG \
   $NAT_ARG \
   $WEB3_ARG \
   --rpc \

--- a/tests/simulation/start.sh
+++ b/tests/simulation/start.sh
@@ -195,9 +195,15 @@ if [ "$USE_GANACHE" != "no" ]; then
   fi
 fi
 
+GENESIS_DATA_PATH=""
+if [ -f "${SNAPSHOT_FILE}" ]; then
+  GENESIS_DATA_PATH="\"genesisDataPath\": \"${SNAPSHOT_FILE}\","
+fi
+
 echo Wrote $NETWORK_METADATA_FILE:
 tee "$NETWORK_METADATA_FILE" <<EOF
 {
+  $GENESIS_DATA_PATH
   "runtimePreset": {
     "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT": ${NUM_VALIDATORS},
     "MIN_GENESIS_TIME": 0,


### PR DESCRIPTION
Requested for easier setup of short-lived attacknets.