### PR TITLE
Single validator keys

### DIFF
--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -40,7 +40,7 @@ type
     db*: BeaconChainDB
     config*: BeaconNodeConf
     attachedValidators*: ref ValidatorPool
-    chainDag*: ChainDAGRef
+    dag*: ChainDAGRef
     quarantine*: QuarantineRef
     attestationPool*: ref AttestationPool
     exitPool*: ref ExitPool

--- a/beacon_chain/beacon_node_types.nim
+++ b/beacon_chain/beacon_node_types.nim
@@ -67,7 +67,7 @@ type
     ## Generally, we keep attestations only until a slot has been finalized -
     ## after that, they may no longer affect fork choice.
 
-    chainDag*: ChainDAGRef
+    dag*: ChainDAGRef
     quarantine*: QuarantineRef
 
     forkChoice*: ForkChoice
@@ -97,7 +97,7 @@ type
     prior_seen_voluntary_exit_indices*: IntSet ##\
     ## Records voluntary exit indices seen.
 
-    chainDag*: ChainDAGRef
+    dag*: ChainDAGRef
     quarantine*: QuarantineRef
 
   # #############################################
@@ -115,7 +115,7 @@ type
     pubKeyStr*: string
 
   AttachedValidator* = ref object
-    pubKey*: ValidatorPubKey
+    pubKey*: CookedPubKey
 
     case kind*: ValidatorKind
     of inProcess:

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -199,10 +199,12 @@ proc advanceClearanceState*(dag: ChainDagRef) =
     let next =
       dag.clearanceState.blck.atSlot(dag.clearanceState.blck.slot + 1)
 
-    debug "Preparing clearance state for next block", next
-
+    let startTick = Moment.now()
     var cache = StateCache()
     updateStateData(dag, dag.clearanceState, next, true, cache)
+
+    debug "Prepared clearance state for next block",
+      next, updateStateDur = Moment.now() - startTick
 
 proc addRawBlockKnownParent(
        dag: ChainDAGRef, quarantine: QuarantineRef,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -60,7 +60,7 @@ template asTrusted(x: SignedBeaconBlock or SigVerifiedBeaconBlock): TrustedSigne
 
   cast[ptr TrustedSignedBeaconBlock](signedBlock.unsafeAddr)[]
 
-func getOrResolve*(dag: ChainDAGRef, quarantine: var QuarantineRef, root: Eth2Digest): BlockRef =
+func getOrResolve*(dag: ChainDAGRef, quarantine: QuarantineRef, root: Eth2Digest): BlockRef =
   ## Fetch a block ref, or nil if not found (will be added to list of
   ## blocks-to-resolve)
   result = dag.getRef(root)
@@ -68,7 +68,7 @@ func getOrResolve*(dag: ChainDAGRef, quarantine: var QuarantineRef, root: Eth2Di
   if result.isNil:
     quarantine.addMissing(root)
 
-proc batchVerify(quarantine: var QuarantineRef, sigs: openArray[SignatureSet]): bool =
+proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool =
   var secureRandomBytes: array[32, byte]
   quarantine.rng[].brHmacDrbgGenerate(secureRandomBytes)
 
@@ -76,12 +76,12 @@ proc batchVerify(quarantine: var QuarantineRef, sigs: openArray[SignatureSet]): 
   return batchVerifySerial(quarantine.sigVerifCache, sigs, secureRandomBytes)
 
 proc addRawBlock*(
-      dag: var ChainDAGRef, quarantine: var QuarantineRef,
+      dag: ChainDAGRef, quarantine: QuarantineRef,
       signedBlock: SignedBeaconBlock, onBlockAdded: OnBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] {.gcsafe.}
 
 proc addResolvedBlock(
-       dag: var ChainDAGRef, quarantine: var QuarantineRef,
+       dag: ChainDAGRef, quarantine: QuarantineRef,
        state: var StateData, trustedBlock: TrustedSignedBeaconBlock,
        parent: BlockRef, cache: var StateCache,
        onBlockAdded: OnBlockAdded, stateDataDur, sigVerifyDur,
@@ -119,6 +119,12 @@ proc addResolvedBlock(
   # Up to here, state.data was referring to the new state after the block had
   # been applied but the `blck` field was still set to the parent
   state.blck = blockRef
+
+  # Regardless of the chain we're on, the deposits come in the same order so
+  # as soon as we import a block, we'll also update the shared public key
+  # cache
+
+  dag.updateValidatorKeys(getStateField(state, validators).asSeq())
 
   # Getting epochRef with the state will potentially create a new EpochRef
   let
@@ -159,11 +165,10 @@ proc addResolvedBlock(
       for v in resolved:
         discard addRawBlock(dag, quarantine, v, onBlockAdded)
 
-proc addRawBlockCheckStateTransition(
-       dag: ChainDAGRef, quarantine: var QuarantineRef,
-       signedBlock: SomeSignedBeaconBlock, cache: var StateCache
-     ): (ValidationResult, BlockError) =
-  ## addRawBlock - Ensure block can be applied on a state
+proc checkStateTransition(
+       dag: ChainDAGRef, signedBlock: SomeSignedBeaconBlock,
+       cache: var StateCache): (ValidationResult, BlockError) =
+  ## Ensure block can be applied on a state
   func restore(v: var HashedBeaconState) =
     # TODO address this ugly workaround - there should probably be a
     #      `state_transition` that takes a `StateData` instead and updates
@@ -183,7 +188,7 @@ proc addRawBlockCheckStateTransition(
     return (ValidationResult.Reject, Invalid)
   return (ValidationResult.Accept, default(BlockError))
 
-proc advanceClearanceState*(dag: var ChainDagRef) =
+proc advanceClearanceState*(dag: ChainDagRef) =
   # When the chain is synced, the most likely block to be produced is the block
   # right after head - we can exploit this assumption and advance the state
   # to that slot before the block arrives, thus allowing us to do the expensive
@@ -191,20 +196,21 @@ proc advanceClearanceState*(dag: var ChainDagRef) =
   # Notably, we use the clearance state here because that's where the block will
   # first be seen - later, this state will be copied to the head state!
   if dag.clearanceState.blck.slot == getStateField(dag.clearanceState, slot):
-    let next =  dag.clearanceState.blck.atSlot(
-      getStateField(dag.clearanceState, slot) + 1)
+    let next =
+      dag.clearanceState.blck.atSlot(dag.clearanceState.blck.slot + 1)
+
     debug "Preparing clearance state for next block", next
 
     var cache = StateCache()
-    updateStateData(dag, dag.clearanceState,next, true, cache)
+    updateStateData(dag, dag.clearanceState, next, true, cache)
 
 proc addRawBlockKnownParent(
-       dag: var ChainDAGRef, quarantine: var QuarantineRef,
+       dag: ChainDAGRef, quarantine: QuarantineRef,
        signedBlock: SignedBeaconBlock,
        parent: BlockRef,
        onBlockAdded: OnBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =
-  ## addRawBlock - Block has a parent
+  ## Add a block whose parent is known, after performing validity checks
 
   if parent.slot >= signedBlock.message.slot:
     # A block whose parent is newer than the block itself is clearly invalid -
@@ -239,27 +245,26 @@ proc addRawBlockKnownParent(
   # blocks we add to the database are clean for the given state
   let startTick = Moment.now()
 
-  # TODO if the block is from the future, we should not be resolving it (yet),
-  #      but maybe we should use it as a hint that our clock is wrong?
   var cache = StateCache()
   updateStateData(
     dag, dag.clearanceState, parent.atSlot(signedBlock.message.slot), true, cache)
   let stateDataTick = Moment.now()
 
-  # First batch verify crypto
+  # First, batch-verify all signatures in block
   if skipBLSValidation notin dag.updateFlags:
     # TODO: remove skipBLSValidation
 
     var sigs: seq[SignatureSet]
-    if not sigs.collectSignatureSets(signedBlock, dag.clearanceState, cache):
+    if sigs.collectSignatureSets(
+        signedBlock, dag.validatorKeys, dag.clearanceState, cache).isErr():
       # A PublicKey or Signature isn't on the BLS12-381 curve
       return err((ValidationResult.Reject, Invalid))
     if not quarantine.batchVerify(sigs):
       return err((ValidationResult.Reject, Invalid))
 
   let sigVerifyTick = Moment.now()
-  let (valRes, blockErr) = addRawBlockCheckStateTransition(
-    dag, quarantine, signedBlock.asSigVerified(), cache)
+  let (valRes, blockErr) = checkStateTransition(
+    dag, signedBlock.asSigVerified(), cache)
   if valRes != ValidationResult.Accept:
     return err((valRes, blockErr))
 
@@ -278,8 +283,8 @@ proc addRawBlockKnownParent(
   return ok dag.clearanceState.blck
 
 proc addRawBlockUnresolved(
-       dag: var ChainDAGRef,
-       quarantine: var QuarantineRef,
+       dag: ChainDAGRef,
+       quarantine: QuarantineRef,
        signedBlock: SignedBeaconBlock
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## addRawBlock - Block is unresolved / has no parent
@@ -317,7 +322,7 @@ proc addRawBlockUnresolved(
   return err((ValidationResult.Ignore, MissingParent))
 
 proc addRawBlock*(
-       dag: var ChainDAGRef, quarantine: var QuarantineRef,
+       dag: ChainDAGRef, quarantine: QuarantineRef,
        signedBlock: SignedBeaconBlock,
        onBlockAdded: OnBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -24,7 +24,7 @@ func init*(T: type QuarantineRef, rng: ref BrHmacDrbgContext): T =
   result = T()
   result.rng = rng
 
-func checkMissing*(quarantine: var QuarantineRef): seq[FetchRecord] =
+func checkMissing*(quarantine: QuarantineRef): seq[FetchRecord] =
   ## Return a list of blocks that we should try to resolve from other client -
   ## to be called periodically but not too often (once per slot?)
   var done: seq[Eth2Digest]
@@ -58,7 +58,7 @@ func containsOrphan*(
     quarantine: QuarantineRef, signedBlock: SignedBeaconBlock): bool =
   (signedBlock.root, signedBlock.signature) in quarantine.orphans
 
-func addMissing*(quarantine: var QuarantineRef, root: Eth2Digest) =
+func addMissing*(quarantine: QuarantineRef, root: Eth2Digest) =
   ## Schedule the download a the given block
   # Can only request by root, not by signature, so partial match suffices
   if not anyIt(quarantine.orphans.keys, it[0] == root):
@@ -66,7 +66,7 @@ func addMissing*(quarantine: var QuarantineRef, root: Eth2Digest) =
     discard quarantine.missing.hasKeyOrPut(root, MissingBlock())
 
 func removeOrphan*(
-    quarantine: var QuarantineRef, signedBlock: SignedBeaconBlock) =
+    quarantine: QuarantineRef, signedBlock: SignedBeaconBlock) =
   quarantine.orphans.del((signedBlock.root, signedBlock.signature))
 
 func isViableOrphan(dag: ChainDAGRef, signedBlock: SignedBeaconBlock): bool =
@@ -74,7 +74,7 @@ func isViableOrphan(dag: ChainDAGRef, signedBlock: SignedBeaconBlock): bool =
   # either is the finalized block or more recent
   signedBlock.message.slot > dag.finalizedHead.slot
 
-func removeOldBlocks(quarantine: var QuarantineRef, dag: ChainDAGRef) =
+func removeOldBlocks(quarantine: QuarantineRef, dag: ChainDAGRef) =
   var oldBlocks: seq[(Eth2Digest, ValidatorSig)]
 
   for k, v in quarantine.orphans.pairs():
@@ -84,11 +84,11 @@ func removeOldBlocks(quarantine: var QuarantineRef, dag: ChainDAGRef) =
   for k in oldBlocks:
     quarantine.orphans.del k
 
-func clearQuarantine*(quarantine: var QuarantineRef) =
+func clearQuarantine*(quarantine: QuarantineRef) =
   quarantine.orphans.clear()
   quarantine.missing.clear()
 
-func add*(quarantine: var QuarantineRef, dag: ChainDAGRef,
+func add*(quarantine: QuarantineRef, dag: ChainDAGRef,
           signedBlock: SignedBeaconBlock): bool =
   ## Adds block to quarantine's `orphans` and `missing` lists.
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -855,7 +855,7 @@ proc updateStateData*(
     assignDur
     replayDur
 
-  if (assignDur + replayDur) >= 1.seconds:
+  if (assignDur + replayDur) >= 250.millis:
     # This might indicate there's a cache that's not in order or a disk that is
     # too slow - for now, it's here for investigative purposes and the cutoff
     # time might need tuning

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -27,8 +27,8 @@ const
   VOLUNTARY_EXITS_BOUND* = MAX_VOLUNTARY_EXITS * 2
 
 proc init*(
-    T: type ExitPool, chainDag: ChainDAGRef, quarantine: QuarantineRef): T =
-  ## Initialize an ExitPool from the chainDag `headState`
+    T: type ExitPool, dag: ChainDAGRef, quarantine: QuarantineRef): T =
+  ## Initialize an ExitPool from the dag `headState`
   T(
     # Allow for filtering out some exit messages during block production
     attester_slashings:
@@ -37,7 +37,7 @@ proc init*(
       initDeque[ProposerSlashing](initialSize = PROPOSER_SLASHINGS_BOUND.int),
     voluntary_exits:
       initDeque[SignedVoluntaryExit](initialSize = VOLUNTARY_EXITS_BOUND.int),
-    chainDag: chainDag,
+    dag: dag,
     quarantine: quarantine
    )
 
@@ -111,7 +111,7 @@ func getExitMessagesForBlock[T](
 
     if allIt(
         getValidatorIndices(exit_message),
-        getStateField(pool.chainDag.headState, validators)[it].exit_epoch !=
+        getStateField(pool.dag.headState, validators)[it].exit_epoch !=
           FAR_FUTURE_EPOCH):
       # A beacon block exit message already targeted all these validators
       continue

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -150,7 +150,7 @@ proc storeBlock(
   let
     attestationPool = self.consensusManager.attestationPool
 
-  let blck = self.consensusManager.chainDag.addRawBlock(
+  let blck = self.consensusManager.dag.addRawBlock(
     self.consensusManager.quarantine, signedBlock) do (
       blckRef: BlockRef, trustedBlock: TrustedSignedBeaconBlock,
       epochRef: EpochRef, state: HashedBeaconState):
@@ -200,7 +200,7 @@ proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
     beacon_store_block_duration_seconds.observe(storeBlockDur.toFloatSeconds())
 
     debug "Block processed",
-      localHeadSlot = self.consensusManager.chainDag.head.slot,
+      localHeadSlot = self.consensusManager.dag.head.slot,
       blockSlot = entry.blck.message.slot,
       validationDur = entry.validationDur,
       queueDur, storeBlockDur, updateHeadDur

--- a/beacon_chain/nimbus_signing_process.nim
+++ b/beacon_chain/nimbus_signing_process.nim
@@ -22,7 +22,7 @@ programMain:
   # load and send all public keys so the BN knows for which ones to ping us
   doAssert paramCount() == 2
   for curr in validatorKeysFromDirs(paramStr(1), paramStr(2)):
-    validators[curr.toPubKey] = curr
+    validators[curr.toPubKey.toPubKey()] = curr
     echo curr.toPubKey
   echo "end"
 

--- a/beacon_chain/rpc/config_api.nim
+++ b/beacon_chain/rpc/config_api.nim
@@ -33,7 +33,7 @@ func getDepositAddress(node: BeaconNode): string =
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Exception].} = # TODO fix json-rpc
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:
-    return @[getStateField(node.chainDag.headState, fork)]
+    return @[getStateField(node.dag.headState, fork)]
 
   rpcServer.rpc("get_v1_config_spec") do () -> JsonNode:
     return %*{

--- a/beacon_chain/rpc/config_rest_api.nim
+++ b/beacon_chain/rpc/config_rest_api.nim
@@ -28,7 +28,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
     # TODO: Implemenation needs a fix, when forks infrastructure will be
     # established.
     return RestApiResponse.jsonResponse(
-      [getStateField(node.chainDag.headState, fork)]
+      [getStateField(node.dag.headState, fork)]
     )
 
   router.api(MethodGet,

--- a/beacon_chain/rpc/debug_api.nim
+++ b/beacon_chain/rpc/debug_api.nim
@@ -29,4 +29,4 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       return stateData.data.data
 
   rpcServer.rpc("get_v1_debug_beacon_heads") do () -> seq[tuple[root: Eth2Digest, slot: Slot]]:
-    return node.chainDag.heads.mapIt((it.root, it.slot))
+    return node.dag.heads.mapIt((it.root, it.slot))

--- a/beacon_chain/rpc/debug_rest_api.nim
+++ b/beacon_chain/rpc/debug_rest_api.nim
@@ -29,7 +29,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/api/eth/v1/debug/beacon/heads") do () -> RestApiResponse:
     return RestApiResponse.jsonResponse(
-      node.chainDag.heads.mapIt((root: it.root, slot: it.slot))
+      node.dag.heads.mapIt((root: it.root, slot: it.slot))
     )
 
   router.redirect(

--- a/beacon_chain/rpc/nimbus_api.nim
+++ b/beacon_chain/rpc/nimbus_api.nim
@@ -38,14 +38,14 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
   ## Install non-standard api handlers - some of these are used by 3rd-parties
   ## such as eth2stats, pending a full REST api
   rpcServer.rpc("getBeaconHead") do () -> Slot:
-    return node.chainDag.head.slot
+    return node.dag.head.slot
 
   rpcServer.rpc("getChainHead") do () -> JsonNode:
     let
-      head = node.chainDag.head
-      finalized = getStateField(node.chainDag.headState, finalized_checkpoint)
+      head = node.dag.head
+      finalized = getStateField(node.dag.headState, finalized_checkpoint)
       justified =
-        getStateField(node.chainDag.headState, current_justified_checkpoint)
+        getStateField(node.dag.headState, current_justified_checkpoint)
     return %* {
       "head_slot": head.slot,
       "head_block_root": head.root.data.toHex(),
@@ -103,8 +103,8 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       wallSlot = node.beaconClock.now.slotOrZero
       head = node.doChecksAndGetCurrentHead(wallSlot)
 
-    let proposalState = assignClone(node.chainDag.headState)
-    node.chainDag.withState(proposalState[], head.atSlot(wallSlot)):
+    let proposalState = assignClone(node.dag.headState)
+    node.dag.withState(proposalState[], head.atSlot(wallSlot)):
       return node.getBlockProposalEth1Data(stateData)
 
   rpcServer.rpc("debug_getChronosFutures") do () -> seq[FutureInfo]:

--- a/beacon_chain/rpc/nimbus_rest_api.nim
+++ b/beacon_chain/rpc/nimbus_rest_api.nim
@@ -107,14 +107,14 @@ proc toNode(v: PubSubPeer, backoff: Moment): RestPubSubPeer =
 
 proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet, "/api/nimbus/v1/beacon/head") do () -> RestApiResponse:
-    return RestApiResponse.jsonResponse(node.chainDag.head.slot)
+    return RestApiResponse.jsonResponse(node.dag.head.slot)
 
   router.api(MethodGet, "/api/nimbus/v1/chain/head") do() -> RestApiResponse:
     let
-      head = node.chainDag.head
-      finalized = getStateField(node.chainDag.headState, finalized_checkpoint)
+      head = node.dag.head
+      finalized = getStateField(node.dag.headState, finalized_checkpoint)
       justified =
-        getStateField(node.chainDag.headState, current_justified_checkpoint)
+        getStateField(node.dag.headState, current_justified_checkpoint)
     return RestApiResponse.jsonResponse(
       (
         head_slot: head.slot,
@@ -202,8 +202,8 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if res.isErr():
           return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
         res.get()
-    let proposalState = assignClone(node.chainDag.headState)
-    node.chainDag.withState(proposalState[], head.atSlot(wallSlot)):
+    let proposalState = assignClone(node.dag.headState)
+    node.dag.withState(proposalState[], head.atSlot(wallSlot)):
       return RestApiResponse.jsonResponse(
         node.getBlockProposalEth1Data(stateData))
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -820,15 +820,13 @@ proc get_next_sync_committee*(state: altair.BeaconState): SyncCommittee =
   # see signatures_batch, TODO shouldn't be here
   # Deposit processing ensures all keys are valid
   var
-    aggregate_pubkey: blscurve.PublicKey
     attestersAgg: AggregatePublicKey
   attestersAgg.init(pubkeys[0].loadWithCache().get)
   for i in 1 ..< pubkeys.len:
     attestersAgg.aggregate(pubkeys[i].loadWithCache().get)
-  aggregate_pubkey.finish(attestersAgg)
+  let aggregate_pubkey = finish(attestersAgg)
 
-  var res = SyncCommittee(aggregate_pubkey:
-    ValidatorPubKey(blob: aggregate_pubkey.exportRaw()))
+  var res = SyncCommittee(aggregate_pubkey: aggregate_pubkey.toPubKey())
   for i in 0 ..< SYNC_COMMITTEE_SIZE:
     # obviously ineffecient
     res.pubkeys[i] = pubkeys[i]

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -718,7 +718,7 @@ proc createKeystore*(kdfKind: KdfKind,
 
   Keystore(
     crypto: cryptoField,
-    pubkey: pubkey,
+    pubkey: pubkey.toPubKey(),
     path: path,
     description: newClone(description),
     uuid: $uuid,
@@ -747,18 +747,22 @@ proc createWallet*(kdfKind: KdfKind,
     nextAccount: nextAccount.get(0))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/deposit-contract.md#withdrawal-credentials
-proc makeWithdrawalCredentials*(k: ValidatorPubKey): Eth2Digest =
+func makeWithdrawalCredentials*(k: ValidatorPubKey): Eth2Digest =
   var bytes = eth2digest(k.toRaw())
   bytes.data[0] = BLS_WITHDRAWAL_PREFIX.uint8
   bytes
 
+# https://github.com/ethereum/eth2.0-specs/blob/v0.12.2/specs/phase0/deposit-contract.md#withdrawal-credentials
+proc makeWithdrawalCredentials*(k: CookedPubKey): Eth2Digest =
+  makeWithdrawalCredentials(k.toPubKey())
+
 proc prepareDeposit*(preset: RuntimePreset,
-                     withdrawalPubKey: ValidatorPubKey,
-                     signingKey: ValidatorPrivKey, signingPubKey: ValidatorPubKey,
+                     withdrawalPubKey: CookedPubKey,
+                     signingKey: ValidatorPrivKey, signingPubKey: CookedPubKey,
                      amount = MAX_EFFECTIVE_BALANCE.Gwei): DepositData =
   var res = DepositData(
     amount: amount,
-    pubkey: signingPubKey,
+    pubkey: signingPubKey.toPubKey(),
     withdrawal_credentials: makeWithdrawalCredentials(withdrawalPubKey))
 
   res.signature = preset.get_deposit_signature(res, signingKey).toValidatorSig()

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -40,7 +40,7 @@ func get_slot_signature*(
 
 proc verify_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    pubkey: ValidatorPubKey, signature: SomeSig): bool =
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
     let
       epoch = compute_epoch_at_slot(slot)
@@ -65,7 +65,7 @@ func get_epoch_signature*(
 
 proc verify_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
-    pubkey: ValidatorPubKey, signature: SomeSig): bool =
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
     let
       domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
@@ -91,8 +91,7 @@ func get_block_signature*(
 proc verify_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     blck: Eth2Digest | SomeSomeBeaconBlock | BeaconBlockHeader,
-    pubkey: ValidatorPubKey,
-    signature: SomeSig): bool =
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
     let
       epoch = compute_epoch_at_slot(slot)
@@ -118,9 +117,10 @@ func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth
   blsSign(privKey, compute_aggregate_and_proof_root(fork, genesis_validators_root,
                                                     aggregate_and_proof).data)
 
-proc verify_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
-                                           aggregate_and_proof: AggregateAndProof,
-                                           pubkey: ValidatorPubKey, signature: SomeSig): bool =
+proc verify_aggregate_and_proof_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    aggregate_and_proof: AggregateAndProof,
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
     let
       epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
@@ -151,7 +151,7 @@ func get_attestation_signature*(
 proc verify_attestation_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     attestation_data: AttestationData,
-    pubkeys: openArray[ValidatorPubKey],
+    pubkeys: auto,
     signature: SomeSig): bool =
   withTrust(signature):
     let

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -158,7 +158,8 @@ proc check_proposer_slashing*(
         proposer_slashing.signed_header_2]:
       if not verify_block_signature(
           state.fork, state.genesis_validators_root, signed_header.message.slot,
-          signed_header.message, proposer[].pubkey, signed_header.signature):
+          signed_header.message, proposer[].pubkey,
+          signed_header.signature):
         return err("check_proposer_slashing: invalid signature")
 
   ok()

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -100,7 +100,7 @@ func diffStates*(state0, state1: BeaconState): BeaconStateDiff =
   doAssert state1.slot > state0.slot
   doAssert state0.slot.isEpoch
   doAssert state1.slot == state0.slot + SLOTS_PER_EPOCH
-  # TODO not here, but in chainDag, an isancestorof check
+  # TODO not here, but in dag, an isancestorof check
 
   doAssert state0.genesis_time == state1.genesis_time
   doAssert state0.genesis_validators_root == state1.genesis_validators_root

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -389,7 +389,7 @@ proc saveNetKeystore*(rng: var BrHmacDrbgContext, keyStorePath: string,
 
 proc saveKeystore(rng: var BrHmacDrbgContext,
                   validatorsDir, secretsDir: string,
-                  signingKey: ValidatorPrivKey, signingPubKey: ValidatorPubKey,
+                  signingKey: ValidatorPrivKey, signingPubKey: CookedPubKey,
                   signingKeyPath: KeyPath): Result[void, KeystoreGenerationError] =
   let
     keyName = "0x" & $signingPubKey
@@ -462,7 +462,8 @@ proc generateDeposits*(preset: RuntimePreset,
                    derivedKey, signingPubKey,
                    makeKeyPath(validatorIdx, signingKeyKind))
 
-    deposits.add preset.prepareDeposit(withdrawalPubKey, derivedKey, signingPubKey)
+    deposits.add preset.prepareDeposit(
+      withdrawalPubKey, derivedKey, signingPubKey)
 
   ok deposits
 

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -285,7 +285,7 @@ proc importInterchangeV5Impl*(
 
         result = siPartial
         continue
-      if key.get().loadWithCache().isNone():
+      if key.get().load().isNone():
         # The bytes don't deserialize to a valid BLS G1 elliptic curve point.
         # Deserialization is costly but done only once per validator.
         # and SlashingDB import is a very rare event.

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -33,22 +33,22 @@ template count*(pool: ValidatorPool): int =
   pool.validators.len
 
 proc addLocalValidator*(pool: var ValidatorPool,
-                        pubKey: ValidatorPubKey,
+                        pubKey: CookedPubKey,
                         privKey: ValidatorPrivKey,
                         index: Option[ValidatorIndex]) =
   let v = AttachedValidator(pubKey: pubKey,
                             index: index,
                             kind: inProcess,
                             privKey: privKey)
-  pool.validators[pubKey] = v
+  pool.validators[pubKey.toPubKey()] = v
   notice "Local validator attached", pubKey, validator = shortLog(v)
 
   validators.set(pool.count().int64)
 
 proc addRemoteValidator*(pool: var ValidatorPool,
-                         pubKey: ValidatorPubKey,
+                         pubKey: CookedPubKey,
                          v: AttachedValidator) =
-  pool.validators[pubKey] = v
+  pool.validators[pubKey.toPubKey()] = v
   notice "Remote validator attached", pubKey, validator = shortLog(v)
 
   validators.set(pool.count().int64)

--- a/tests/mocking/mock_validator_keys.nim
+++ b/tests/mocking/mock_validator_keys.nim
@@ -42,7 +42,7 @@ proc genMockPrivKeys(privkeys: var openArray[ValidatorPrivKey]) =
 func genMockPubKeys(pubkeys: var openArray[ValidatorPubKey],
                     privkeys: openArray[ValidatorPrivKey]) =
   for i in 0 ..< privkeys.len:
-    pubkeys[i] = toPubKey(privkeys[i])
+    pubkeys[i] = toPubKey(privkeys[i]).toPubKey()
 
 # Ref array necessary to limit stack usage / binary size
 var MockPrivKeys* = newSeq[ValidatorPrivKey](defaultRuntimePreset.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -61,10 +61,10 @@ suite "Attestation pool processing" & preset():
   setup:
     # Genesis state that results in 6 members per committee
     var
-      chainDag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 6))
+      dag = init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 6))
       quarantine = QuarantineRef.init(keys.newRng())
-      pool = newClone(AttestationPool.init(chainDag, quarantine))
-      state = newClone(chainDag.headState)
+      pool = newClone(AttestationPool.init(dag, quarantine))
+      state = newClone(dag.headState)
       cache = StateCache()
       rewards: RewardInfo
     # Slot 0 is a finalized slot - won't be making attestations for it..
@@ -363,8 +363,8 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns latest block with no attestations":
     var cache = StateCache()
     let
-      b1 = addTestBlock(state.data, chainDag.tail.root, cache)
-      b1Add = chainDag.addRawBlock(quarantine, b1) do (
+      b1 = addTestBlock(state.data, dag.tail.root, cache)
+      b1Add = dag.addRawBlock(quarantine, b1) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -377,7 +377,7 @@ suite "Attestation pool processing" & preset():
 
     let
       b2 = addTestBlock(state.data, b1.root, cache)
-      b2Add = chainDag.addRawBlock(quarantine, b2) do (
+      b2Add = dag.addRawBlock(quarantine, b2) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -391,8 +391,8 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns block with attestation":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
-      b10Add = chainDag.addRawBlock(quarantine, b10) do (
+      b10 = makeTestBlock(state.data, dag.tail.root, cache)
+      b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -404,10 +404,10 @@ suite "Attestation pool processing" & preset():
       head == b10Add[]
 
     let
-      b11 = makeTestBlock(state.data, chainDag.tail.root, cache,
+      b11 = makeTestBlock(state.data, dag.tail.root, cache,
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       )
-      b11Add = chainDag.addRawBlock(quarantine, b11) do (
+      b11Add = dag.addRawBlock(quarantine, b11) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -451,8 +451,8 @@ suite "Attestation pool processing" & preset():
   test "Trying to add a block twice tags the second as an error":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, chainDag.tail.root, cache)
-      b10Add = chainDag.addRawBlock(quarantine, b10) do (
+      b10 = makeTestBlock(state.data, dag.tail.root, cache)
+      b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -466,7 +466,7 @@ suite "Attestation pool processing" & preset():
     # -------------------------------------------------------------
     # Add back the old block to ensure we have a duplicate error
     let b10_clone = b10 # Assumes deep copy
-    let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
+    let b10Add_clone = dag.addRawBlock(quarantine, b10_clone) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -477,11 +477,11 @@ suite "Attestation pool processing" & preset():
   test "Trying to add a duplicate block from an old pruned epoch is tagged as an error":
     # Note: very sensitive to stack usage
 
-    chainDag.updateFlags.incl {skipBLSValidation}
+    dag.updateFlags.incl {skipBLSValidation}
     var cache = StateCache()
     let
-      b10 = addTestBlock(state.data, chainDag.tail.root, cache)
-      b10Add = chainDag.addRawBlock(quarantine, b10) do (
+      b10 = addTestBlock(state.data, dag.tail.root, cache)
+      b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid
@@ -509,7 +509,7 @@ suite "Attestation pool processing" & preset():
           state.data, block_root, cache, attestations = attestations)
 
         block_root = new_block.root
-        let blockRef = chainDag.addRawBlock(quarantine, new_block) do (
+        let blockRef = dag.addRawBlock(quarantine, new_block) do (
             blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
             epochRef: EpochRef, state: HashedBeaconState):
           # Callback add to fork choice if valid
@@ -517,8 +517,8 @@ suite "Attestation pool processing" & preset():
 
         let head = pool[].selectHead(blockRef[].slot)
         doAssert: head == blockRef[]
-        chainDag.updateHead(head, quarantine)
-        pruneAtFinalization(chainDag, pool[])
+        dag.updateHead(head, quarantine)
+        pruneAtFinalization(dag, pool[])
 
         attestations.setlen(0)
         for index in 0'u64 ..< committees_per_slot:
@@ -545,13 +545,13 @@ suite "Attestation pool processing" & preset():
     # -------------------------------------------------------------
     # Prune
 
-    doAssert: chainDag.finalizedHead.slot != 0
+    doAssert: dag.finalizedHead.slot != 0
 
     pool[].prune()
     doAssert: b10.root notin pool.forkChoice.backend
 
     # Add back the old block to ensure we have a duplicate error
-    let b10Add_clone = chainDag.addRawBlock(quarantine, b10_clone) do (
+    let b10Add_clone = dag.addRawBlock(quarantine, b10_clone) do (
           blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
           epochRef: EpochRef, state: HashedBeaconState):
         # Callback add to fork choice if valid

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -14,9 +14,9 @@ import ../beacon_chain/consensus_object_pools/[block_quarantine, blockchain_dag,
 import "."/[testutil, testdbutil]
 
 proc getExitPool(): auto =
-  let chainDag =
+  let dag =
     init(ChainDAGRef, defaultRuntimePreset, makeTestDB(SLOTS_PER_EPOCH * 3))
-  newClone(ExitPool.init(chainDag, QuarantineRef.init(keys.newRng())))
+  newClone(ExitPool.init(dag, QuarantineRef.init(keys.newRng())))
 
 suite "Exit pool testing suite":
   setup:

--- a/tests/test_interop.nim
+++ b/tests/test_interop.nim
@@ -146,7 +146,8 @@ suite "Interop":
 
     for i in 0..<64:
       let privKey = makeInteropPrivKey(i)
-      deposits.add makeDeposit(defaultRuntimePreset, privKey.toPubKey(), privKey)
+      deposits.add makeDeposit(
+        defaultRuntimePreset, privKey.toPubKey().toPubKey(), privKey)
 
     const genesis_time = 1570500000
     var

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -47,7 +47,7 @@ func makeDeposit*(i: int, flags: UpdateFlags = {}): DepositData =
     withdrawal_credentials = makeFakeHash(i)
 
   result = DepositData(
-    pubkey: pubkey,
+    pubkey: pubkey.toPubKey(),
     withdrawal_credentials: withdrawal_credentials,
     amount: MAX_EFFECTIVE_BALANCE)
 


### PR DESCRIPTION
Instead of keeping a validator key list per EpochRef, this PR introduces
a single shared validator key list in ChainDAG, and cleans up some other
ChainDAG and key-related issues.

The PR does not introduce the validator key list in the state transition
- this is because we batch-check all signatures before entering the spec
code, thus the spec code never hits the cache.

A future refactor should _probably_ remove the threadvar altogether.

There's a few other small fixes in here that make the flow easier to
read:

* fix `var ChainDAGRef` -> `ChainDAGRef`
* fix `var QuarantineRef` -> `QuarantineRef`
* consistent `dag` variable name
* avoid using threadvar pubkey cache in most cases
* better error messages in batch signature checking