### PR TITLE
Improve explanation of the --doppelganger-detection option in --help.

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -326,7 +326,7 @@ type
         name: "direct-peer" .}: seq[string]
 
       doppelgangerDetection* {.
-        desc: "If enabled, the beacon node prudently listens for 2 epochs for attestations from a validator with the same index (a doppelganger), before sending an attestation itself. This prevents slashing due to double-voting but means you will miss two attestations when restarting."
+        desc: "If enabled, the beacon node prudently listens for 2 epochs for attestations from a validator with the same index (a doppelganger), before sending an attestation itself. This protects against slashing (due to double-voting) but means you will miss two attestations when restarting."
         defaultValue: true
         name: "doppelganger-detection"
       }: bool

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -326,7 +326,7 @@ type
         name: "direct-peer" .}: seq[string]
 
       doppelgangerDetection* {.
-        desc: "Whether to detect whether another validator is be running the same validator keys"
+        desc: "If enabled, the beacon node prudently listens for 2 epochs for attestations from a validator with the same index (a doppelganger), before sending an attestation itself. This prevents slashing due to double-voting but means you will miss two attestations when restarting."
         defaultValue: true
         name: "doppelganger-detection"
       }: bool


### PR DESCRIPTION
The current description of `--doppelganger-detection` sounds like it was crafted after a long day of working hard on the actual feature 😉

I've changed it to be syntactically correct and also explain the feature in more detail. I condensed the explanation from [0xmiel's blog post ](https://our.status.im/nimbus-update-v1-0-7-release/#).