### PR TITLE
space is printable

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -870,7 +870,7 @@ chronicles.formatIt Checkpoint: it.shortLog
 
 const
   # http://facweb.cs.depaul.edu/sjost/it212/documents/ascii-pr.htm
-  PrintableAsciiChars = {'!'..'~'}
+  PrintableAsciiChars = {' '..'~'}
 
 func `$`*(value: GraffitiBytes): string =
   result = strip(string.fromBytes(distinctBase value),


### PR DESCRIPTION
Printing space as a string in graffiti makes a few more graffitis
visible