### PR TITLE
Fix #2595 recompute wallslot across async calls

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -206,9 +206,8 @@ proc attestationValidator*(
     attestation = shortLog(attestation)
     subnet_id
 
-  let
-    wallTime = self.getWallTime()
-    (afterGenesis, wallSlot) = wallTime.toSlot()
+  let wallTime = self.getWallTime()
+  var (afterGenesis, wallSlot) = wallTime.toSlot()
 
   if not afterGenesis:
     notice "Attestation before genesis"
@@ -225,8 +224,10 @@ proc attestationValidator*(
       self.batchCrypto, attestation, wallTime, subnet_id, checkSignature)
   if v.isErr():
     debug "Dropping attestation", validationError = v.error
-
     return v.error[0]
+
+  # Due to async validation the wallSlot here might have changed
+  (afterGenesis, wallSlot) = self.getWallTime().toSlot()
 
   beacon_attestations_received.inc()
   beacon_attestation_delay.observe(delay.toFloatSeconds())
@@ -248,9 +249,8 @@ proc aggregateValidator*(
     aggregate = shortLog(signedAggregateAndProof.message.aggregate)
     signature = shortLog(signedAggregateAndProof.signature)
 
-  let
-    wallTime = self.getWallTime()
-    (afterGenesis, wallSlot) = wallTime.toSlot()
+  let wallTime = self.getWallTime()
+  var (afterGenesis, wallSlot) = wallTime.toSlot()
 
   if not afterGenesis:
     notice "Aggregate before genesis"
@@ -274,6 +274,9 @@ proc aggregateValidator*(
       wallSlot
     return v.error[0]
 
+  # Due to async validation the wallSlot here might have changed
+  (afterGenesis, wallSlot) = self.getWallTime().toSlot()
+
   beacon_aggregates_received.inc()
   beacon_aggregate_delay.observe(delay.toFloatSeconds())
 
@@ -284,8 +287,7 @@ proc aggregateValidator*(
 
   trace "Aggregate validated",
     aggregator_index = signedAggregateAndProof.message.aggregator_index,
-    selection_proof = signedAggregateAndProof.message.selection_proof,
-    wallSlot
+    selection_proof = signedAggregateAndProof.message.selection_proof
 
   self.attestationPool[].addAttestation(
     signedAggregateAndProof.message.aggregate, attesting_indices, sig, wallSlot)


### PR DESCRIPTION
Fix #2595.

Draft, I'm unsure how reliant the Doppelganger protection is on the correct wallSlot and if there are failure scenarios.