### PR TITLE
fix assertion in beacon block creation rollback/restore

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -316,7 +316,7 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       # TODO address this ugly workaround - there should probably be a
       #      `state_transition` that takes a `StateData` instead and updates
       #      the block as well
-      doAssert v.addr == addr proposalStateAddr.data
+      doAssert v.addr == addr proposalStateAddr.data.hbsPhase0
       assign(proposalStateAddr[], poolPtr.headState)
 
     return makeBeaconBlock(


### PR DESCRIPTION
This was overlooked in the big `ForkedHashedBeaconState` merge, and still never has come up for me in testing -- beacon block creation just doesn't tend to create invalid states, evidently, since it's completely under the control of the node itself, not evaluating outside/untrusted states.