### PR TITLE
implement Altair attestation pool cache init

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -384,6 +384,52 @@ func init(T: type AttestationCache, state: phase0.HashedBeaconState): T =
       state.data.current_epoch_attestations[i].data,
       state.data.current_epoch_attestations[i].aggregation_bits)
 
+func init(
+    T: type AttestationCache, state: altair.HashedBeaconState,
+    cache: var StateCache): T =
+  # Load attestations that are scheduled for being given rewards for
+  let
+    prev_epoch = state.data.get_previous_epoch()
+    cur_epoch = state.data.get_current_epoch()
+    prev_epoch_committees_per_slot = get_committee_count_per_slot(
+      state.data, prev_epoch, cache)
+    cur_epoch_committees_per_slot = get_committee_count_per_slot(
+      state.data, cur_epoch, cache)
+
+  # This treats all types of rewards as equivalent, which isn't ideal
+  for slot_offset in 0 ..< SLOTS_PER_EPOCH:
+    for slot_committee_index in 0'u64 ..< get_committee_count_per_slot(
+        state.data, state.data.get_previous_epoch(), cache):
+      var
+        validator_bits: CommitteeValidatorsBits
+        i = 0
+      let slot = prev_epoch.compute_start_slot_at_epoch + slot_offset
+      for index in get_beacon_committee(
+          state.data, slot, slot_committee_index.CommitteeIndex, cache):
+        if state.data.previous_epoch_participation[index] != 0:
+          # If any flag got set, there was an attestation from this validator.
+          validator_bits[i] = true
+        i += 1
+      result.add(
+        (slot, slot_committee_index),
+        validator_bits)
+
+    for slot_committee_index in 0'u64 ..< get_committee_count_per_slot(
+        state.data, state.data.get_current_epoch(), cache):
+      var
+        validator_bits: CommitteeValidatorsBits
+        i = 0
+      let slot = cur_epoch.compute_start_slot_at_epoch + slot_offset
+      for index in get_beacon_committee(
+          state.data, slot, slot_committee_index.CommitteeIndex, cache):
+        if state.data.current_epoch_participation[index] != 0:
+          # If any flag got set, there was an attestation from this validator.
+          validator_bits[i] = true
+        i += 1
+      result.add(
+        (slot, slot_committee_index),
+        validator_bits)
+
 proc score(
     attCache: var AttestationCache, data: AttestationData,
     aggregation_bits: CommitteeValidatorsBits): int =

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -396,17 +396,16 @@ func init(
     cur_epoch_committees_per_slot = get_committee_count_per_slot(
       state.data, cur_epoch, cache)
 
-  # This treats all types of rewards as equivalent, which isn't ideal
-  for slot_offset in 0 ..< SLOTS_PER_EPOCH:
+  template update_attestation_pool_cache(
+      epoch: Epoch, slot: Slot, participation_bitmap: untyped) =
     for slot_committee_index in 0'u64 ..< get_committee_count_per_slot(
-        state.data, state.data.get_previous_epoch(), cache):
+        state.data, epoch, cache):
       var
         validator_bits: CommitteeValidatorsBits
         i = 0
-      let slot = prev_epoch.compute_start_slot_at_epoch + slot_offset
       for index in get_beacon_committee(
           state.data, slot, slot_committee_index.CommitteeIndex, cache):
-        if state.data.previous_epoch_participation[index] != 0:
+        if participation_bitmap[index] != 0:
           # If any flag got set, there was an attestation from this validator.
           validator_bits[i] = true
         i += 1
@@ -414,21 +413,17 @@ func init(
         (slot, slot_committee_index),
         validator_bits)
 
-    for slot_committee_index in 0'u64 ..< get_committee_count_per_slot(
-        state.data, state.data.get_current_epoch(), cache):
-      var
-        validator_bits: CommitteeValidatorsBits
-        i = 0
-      let slot = cur_epoch.compute_start_slot_at_epoch + slot_offset
-      for index in get_beacon_committee(
-          state.data, slot, slot_committee_index.CommitteeIndex, cache):
-        if state.data.current_epoch_participation[index] != 0:
-          # If any flag got set, there was an attestation from this validator.
-          validator_bits[i] = true
-        i += 1
-      result.add(
-        (slot, slot_committee_index),
-        validator_bits)
+  # This treats all types of rewards as equivalent, which isn't ideal
+  for slot_offset in 0 ..< SLOTS_PER_EPOCH:
+    update_attestation_pool_cache(
+      state.data.get_previous_epoch(),
+      prev_epoch.compute_start_slot_at_epoch + slot_offset,
+      state.data.previous_epoch_participation)
+
+    update_attestation_pool_cache(
+      state.data.get_current_epoch(),
+      cur_epoch.compute_start_slot_at_epoch + slot_offset,
+      state.data.current_epoch_participation)
 
 proc score(
     attCache: var AttestationCache, data: AttestationData,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -391,7 +391,7 @@ proc init*(T: type ChainDAGRef,
       let root = db.getStateRoot(cur.blck.root, cur.slot)
       if root.isSome():
         if db.getState(root.get(), tmpState.data.hbsPhase0.data, noRollback):
-          tmpState.data.hbsPhase0.root = root.get()
+          setStateRoot(tmpState.data, root.get())
           tmpState.blck = cur.blck
 
           break
@@ -514,7 +514,7 @@ proc getState(
     return false
 
   state.blck = blck
-  state.data.hbsPhase0.root = stateRoot
+  setStateRoot(state.data, stateRoot)
 
   true
 

--- a/beacon_chain/spec/forkedbeaconstate_helpers.nim
+++ b/beacon_chain/spec/forkedbeaconstate_helpers.nim
@@ -53,6 +53,11 @@ template getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
   of forkPhase0: x.hbsPhase0.root
   of forkAltair: x.hbsAltair.root
 
+func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
+  case x.beaconStateFork:
+  of forkPhase0: x.hbsPhase0.root = root
+  of forkAltair: x.hbsAltair.root = root
+
 template hash_tree_root*(x: ForkedHashedBeaconState): Eth2Digest =
   case x.beaconStateFork:
   of forkPhase0: hash_tree_root(x.hbsPhase0.data)

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -153,7 +153,7 @@ proc runFullTransition*(dir, preState, blocksPrefix: string, blocksQty: int, ski
     hbsPhase0: HashedBeaconState(data: parseSSZ(prePath, BeaconState)),
     beaconStateFork: forkPhase0
   )
-  state.hbsPhase0.root = hash_tree_root(state[])
+  setStateRoot(state[], hash_tree_root(state[]))
 
   for i in 0 ..< blocksQty:
     let blockPath = dir / blocksPrefix & $i & ".ssz"
@@ -177,7 +177,7 @@ proc runProcessSlots*(dir, preState: string, numSlots: uint64) =
   let state = (ref ForkedHashedBeaconState)(
     hbsPhase0: HashedBeaconState(data: parseSSZ(prePath, BeaconState)),
     beaconStateFork: forkPhase0)
-  state.hbsPhase0.root = hash_tree_root(state[])
+  setStateRoot(state[], hash_tree_root(state[]))
 
   # Shouldn't necessarily assert, because nbench can run test suite
   discard process_slots(

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -84,7 +84,7 @@ proc doTransition(conf: NcliConf) =
     blckX = SSZ.loadFile(conf.blck, SignedBeaconBlock)
     flags = if not conf.verifyStateRoot: {skipStateRootValidation} else: {}
 
-  stateY.hbsPhase0.root = hash_tree_root(stateY[])
+  setStateRoot(stateY[], hash_tree_root(stateY[]))
 
   var
     cache = StateCache()
@@ -112,7 +112,7 @@ proc doSlots(conf: NcliConf) =
       beaconStateFork: forkPhase0
     )
 
-  stateY.hbsPhase0.root = hash_tree_root(stateY[])
+  setStateRoot(stateY[], hash_tree_root(stateY[]))
 
   var
     cache = StateCache()

--- a/tests/official/altair/test_fixture_transition.nim
+++ b/tests/official/altair/test_fixture_transition.nim
@@ -8,7 +8,7 @@
 {.used.}
 
 import
-  chronicles, yaml,
+  yaml,
   # Standard library
   os, sequtils,
   # Status internal

--- a/tests/official/phase0/test_fixture_sanity_slots.nim
+++ b/tests/official/phase0/test_fixture_sanity_slots.nim
@@ -8,7 +8,6 @@
 {.used.}
 
 import
-  chronicles,
   # Standard library
   os, strutils,
   # Beacon chain internals


### PR DESCRIPTION
This provides a drop-in-equivalent replacement of the Attestation pool cache init, used for `getAttestationsForBlock()`, for Altair. It's beneficial to emulate/reconstruct the phase 0 structure here, because it has roughly the same cost at init time while remaining compatible with the generally attestation-oriented updates which `getAttestationsForBlock()` does later, whether it's for phase 0 or Altair. Therefore, while it's at some level a compatibility shim, it's one which converts the epoch-processing-optimized Altair `{current,previous}_epoch_participation` representation into the block-processing-optimized `{current,previous}_epoch_attestations` phase 0-representation.

It's mostly suboptimal for basically the same reason that the phase0 version already is, that it treats inferred attestations as either completely there or not as a greedy profit optimization heuristic. Partly, this is to enable an expedient and relatively low-risk Altair transition, from which one can more fully exploit the kind of structure which https://kb.beaconcha.in/rewards-and-penalties illustrates both from phase 0 and Altair, while avoiding too much tech debt and enabling progress on one of the primary remaining issues for the Altair transition, beacon block creation.

It also replaces some `foo.hbsPhase0.root = bar` updates with versions which work across phase 0 and Altair.