### PR TITLE
add Altair support to block quarantine/clearance and block_sim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,8 +283,8 @@ endif
 		rm -rf 0000-*.json t_slashprot_migration.* *.log block_sim_db
 	for TEST_BINARY in $(TEST_BINARIES); do \
 		PARAMS=""; \
-		if [[ "$${TEST_BINARY}" == "state_sim" ]]; then PARAMS="--validators=6000 --slots=128"; \
-		elif [[ "$${TEST_BINARY}" == "block_sim" ]]; then PARAMS="--validators=6000 --slots=128"; \
+		if [[ "$${TEST_BINARY}" == "state_sim" ]]; then PARAMS="--validators=8000 --slots=160"; \
+		elif [[ "$${TEST_BINARY}" == "block_sim" ]]; then PARAMS="--validators=8000 --slots=160"; \
 		fi; \
 		echo -e "\nRunning $${TEST_BINARY} $${PARAMS}\n"; \
 		build/$${TEST_BINARY} $${PARAMS} || { echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Aborting."; exit 1; }; \

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -221,12 +221,9 @@ proc checkStateTransition(
     blck = shortLog(signedBlock.message)
     blockRoot = shortLog(signedBlock.root)
 
-  # TODO this won't transition because FAR_FUTURE_SLOT, so it's
-  # fine, for now, but in general, blockchain_dag.addBlock must
-  # match the transition here.
   if not state_transition_block(
       dag.runtimePreset, dag.clearanceState.data, signedBlock,
-      cache, dag.updateFlags, restore, FAR_FUTURE_SLOT):
+      cache, dag.updateFlags, restore, dag.altairTransitionSlot):
     info "Invalid block"
 
     return (ValidationResult.Reject, Invalid)

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -165,6 +165,9 @@ type
       ## block - we limit the number of held EpochRefs to put a cap on
       ## memory usage
 
+    altairTransitionSlot*: Slot ##\
+      ## Slot at which to upgrade from phase 0 to Altair forks
+
   EpochKey* = object
     ## The epoch key fully determines the shuffling for proposers and
     ## committees in a beacon state - the epoch level information in the state

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -559,7 +559,9 @@ proc putState(dag: ChainDAGRef, state: var StateData) =
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
-  dag.db.putState(getStateRoot(state.data), state.data.hbsPhase0.data)
+  if state.data.beaconStateFork != forkAltair:
+    # TODO re-enable for Altair
+    dag.db.putState(getStateRoot(state.data), state.data.hbsPhase0.data)
 
   dag.db.putStateRoot(
     state.blck.root, getStateField(state.data, slot), getStateRoot(state.data))

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -319,7 +319,8 @@ func isStateCheckpoint(bs: BlockSlot): bool =
 proc init*(T: type ChainDAGRef,
            preset: RuntimePreset,
            db: BeaconChainDB,
-           updateFlags: UpdateFlags = {}): ChainDAGRef =
+           updateFlags: UpdateFlags = {},
+           altairTransitionSlot: Slot = FAR_FUTURE_SLOT): ChainDAGRef =
   # TODO we require that the db contains both a head and a tail block -
   #      asserting here doesn't seem like the right way to go about it however..
 
@@ -417,6 +418,7 @@ proc init*(T: type ChainDAGRef,
     # allow skipping some validation.
     updateFlags: {verifyFinalization} * updateFlags,
     runtimePreset: preset,
+    altairTransitionSlot: altairTransitionSlot
   )
 
   doAssert dag.updateFlags in [{}, {verifyFinalization}]
@@ -664,7 +666,7 @@ proc advanceSlots(
 
     doAssert process_slots(
         state.data, getStateField(state.data, slot) + 1, cache, rewards,
-        dag.updateFlags, FAR_FUTURE_SLOT),
+        dag.updateFlags, dag.altairTransitionSlot),
       "process_slots shouldn't fail when state slot is correct"
     if save:
       dag.putState(state)
@@ -688,7 +690,8 @@ proc applyBlock(
 
   let ok = state_transition(
     dag.runtimePreset, state.data, blck.data,
-    cache, rewards, flags + dag.updateFlags + {slotProcessed}, restore)
+    cache, rewards, flags + dag.updateFlags + {slotProcessed}, restore,
+    dag.altairTransitionSlot)
   if ok:
     state.blck = blck.refs
 

--- a/beacon_chain/rpc/beacon_rest_api.nim
+++ b/beacon_chain/rpc/beacon_rest_api.nim
@@ -12,7 +12,8 @@ import
   ../consensus_object_pools/[blockchain_dag, exit_pool],
   ../gossip_processing/gossip_validation,
   ../validators/validator_duties,
-  ../spec/[crypto, datatypes, digest, forkedbeaconstate_helpers, network],
+  ../spec/[crypto, digest, forkedbeaconstate_helpers, network],
+  ../spec/datatypes/base,
   ../ssz/merkleization,
   ./eth2_json_rest_serialization, ./rest_utils
 

--- a/beacon_chain/rpc/config_rest_api.nim
+++ b/beacon_chain/rpc/config_rest_api.nim
@@ -11,7 +11,8 @@ import
   chronicles,
   nimcrypto/utils as ncrutils,
   ../beacon_node_common, ../eth1/eth1_monitor,
-  ../spec/[datatypes, digest, forkedbeaconstate_helpers, presets],
+  ../spec/datatypes/base,
+  ../spec/[digest, forkedbeaconstate_helpers, presets],
   ./eth2_json_rest_serialization, ./rest_utils
 
 logScope: topics = "rest_config"

--- a/beacon_chain/rpc/debug_api.nim
+++ b/beacon_chain/rpc/debug_api.nim
@@ -13,7 +13,8 @@ import
   chronicles,
   ../version, ../beacon_node_common,
   ../networking/[eth2_network, peer_pool],
-  ../spec/[datatypes, digest, presets],
+  ../spec/datatypes/base,
+  ../spec/[digest, presets],
   ./rpc_utils, ./eth2_json_rpc_serialization
 
 logScope: topics = "debugapi"

--- a/beacon_chain/rpc/eth_merge_web3.nim
+++ b/beacon_chain/rpc/eth_merge_web3.nim
@@ -1,7 +1,8 @@
 import
   strutils,
   json_serialization/std/[sets, net], serialization/errors,
-  ../spec/[datatypes, digest, crypto, eth2_apis/beacon_rpc_client],
+  ../spec/datatypes/base,
+  ../spec/[crypto, digest, eth2_apis/beacon_rpc_client],
   json_rpc/[client, jsonmarshal]
 
 from os import DirSep, AltSep

--- a/beacon_chain/rpc/nimbus_api.nim
+++ b/beacon_chain/rpc/nimbus_api.nim
@@ -18,7 +18,8 @@ import
   ".."/[
     beacon_node_common, nimbus_binary_common, networking/eth2_network,
     eth1/eth1_monitor, validators/validator_duties],
-  ../spec/[digest, datatypes, forkedbeaconstate_helpers, presets]
+  ../spec/datatypes/base,
+  ../spec/[digest, forkedbeaconstate_helpers, presets]
 
 
 logScope: topics = "nimbusapi"

--- a/beacon_chain/rpc/node_api.nim
+++ b/beacon_chain/rpc/node_api.nim
@@ -17,7 +17,8 @@ import std/options,
   ../beacon_node_common, ../version,
   ../networking/[eth2_network, peer_pool],
   ../sync/sync_manager,
-  ../spec/[datatypes, digest, presets],
+  ../spec/datatypes/base,
+  ../spec/[digest, presets],
   ../spec/eth2_apis/callsigs_types
 
 logScope: topics = "nodeapi"

--- a/beacon_chain/rpc/node_rest_api.nim
+++ b/beacon_chain/rpc/node_rest_api.nim
@@ -7,7 +7,8 @@ import
   nimcrypto/utils as ncrutils,
   ../version, ../beacon_node_common, ../sync/sync_manager,
   ../networking/[eth2_network, peer_pool],
-  ../spec/[datatypes, digest, presets],
+  ../spec/datatypes/base,
+  ../spec/[digest, presets],
   ../spec/eth2_apis/callsigs_types,
   ./eth2_json_rest_serialization, ./rest_utils
 

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -12,7 +12,8 @@ import
   stew/byteutils,
   ../beacon_node_common, ../validators/validator_duties,
   ../consensus_object_pools/[block_pools_types, blockchain_dag],
-  ../spec/[datatypes, digest, forkedbeaconstate_helpers, helpers]
+  ../spec/datatypes/base,
+  ../spec/[digest, forkedbeaconstate_helpers, helpers]
 
 export blockchain_dag
 

--- a/beacon_chain/rpc/validator_api.nim
+++ b/beacon_chain/rpc/validator_api.nim
@@ -9,15 +9,16 @@
 
 import
   # Standard library
-  std/[tables],
+  std/tables,
 
   # Nimble packages
-  stew/[objects],
+  stew/objects,
   json_rpc/servers/httpserver,
   chronicles,
 
   # Local modules
-  ../spec/[crypto, datatypes, digest, forkedbeaconstate_helpers, helpers, network, signatures],
+  ../spec/[crypto, digest, forkedbeaconstate_helpers, helpers, network, signatures],
+  ../spec/datatypes/base,
   ../spec/eth2_apis/callsigs_types,
   ../consensus_object_pools/[blockchain_dag, spec_cache, attestation_pool], ../ssz/merkleization,
   ../beacon_node_common, ../beacon_node_types,

--- a/beacon_chain/rpc/validator_rest_api.nim
+++ b/beacon_chain/rpc/validator_rest_api.nim
@@ -12,7 +12,8 @@ import
   ../consensus_object_pools/[blockchain_dag, spec_cache, attestation_pool],
   ../gossip_processing/gossip_validation,
   ../validators/validator_duties,
-  ../spec/[crypto, datatypes, digest, forkedbeaconstate_helpers, network],
+  ../spec/[crypto, digest, forkedbeaconstate_helpers, network],
+  ../spec/datatypes/base,
   ../ssz/merkleization,
   ./eth2_json_rest_serialization, ./rest_utils
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -306,7 +306,7 @@ proc state_transition*(
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock,
     cache: var StateCache, rewards: var RewardInfo, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc,
-    altairForkSlot: Slot = FAR_FUTURE_SLOT): bool {.nbench.} =
+    altairForkSlot: Slot): bool {.nbench.} =
   ## Apply a block to the state, advancing the slot counter as necessary. The
   ## given state must be of a lower slot, or, in case the `slotProcessed` flag
   ## is set, can be the slot state of the same slot as the block (where the

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -15,7 +15,8 @@ import
   stew/[results, byteutils],
   chronicles, chronicles/timings,
   # Internal
-  ../spec/[datatypes, digest, crypto],
+  ../spec/datatypes/base,
+  ../spec/[digest, crypto],
   ./slashing_protection_common,
   ./slashing_protection_v1,
   ./slashing_protection_v2

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -18,7 +18,8 @@ import
   json_serialization,
   chronicles,
   # Internal
-  ../spec/[datatypes, digest, crypto]
+  ../spec/datatypes/base,
+  ../spec/[digest, crypto]
 
 export serialization, json_serialization # Generic sandwich https://github.com/nim-lang/Nim/issues/11225
 

--- a/beacon_chain/validators/slashing_protection_v1.nim
+++ b/beacon_chain/validators/slashing_protection_v1.nim
@@ -17,7 +17,8 @@ import
   serialization,
   json_serialization,
   # Internal
-  ../spec/[datatypes, digest, crypto],
+  ../spec/datatypes/base,
+  ../spec/[digest, crypto],
   ../ssz,
   ./slashing_protection_common
 

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -164,7 +164,7 @@ proc runFullTransition*(dir, preState, blocksPrefix: string, blocksQty: int, ski
                 else: {}
     let success = state_transition(
       defaultRuntimePreset, state[], signedBlock, cache, rewards, flags,
-      noRollback)
+      noRollback, FAR_FUTURE_SLOT)
     echo "State transition status: ", if success: "SUCCESS ✓" else: "FAILURE ⚠️"
 
 proc runProcessSlots*(dir, preState: string, numSlots: uint64) =

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -90,7 +90,8 @@ proc doTransition(conf: NcliConf) =
     cache = StateCache()
     rewards = RewardInfo()
   if not state_transition(getRuntimePresetForNetwork(conf.eth2Network),
-                          stateY[], blckX, cache, rewards, flags, noRollback):
+                          stateY[], blckX, cache, rewards, flags, noRollback,
+                          FAR_FUTURE_SLOT):
     error "State transition failed"
     quit 1
   else:

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -122,7 +122,8 @@ proc nfuzz_block(input: openArray[byte], xoutput: ptr byte,
       rewards = RewardInfo()
     result =
       state_transition(
-        preset, fhState[], blck, cache, rewards, flags, rollback)
+        preset, fhState[], blck, cache, rewards, flags, rollback,
+        FAR_FUTURE_SLOT)
     data.state = fhState.hbsPhase0.data
 
   decodeAndProcess(BlockInput):

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -20,9 +20,10 @@ import
   confutils, chronicles, eth/db/kvstore_sqlite3,
   eth/keys,
   ../tests/testblockutil,
-  ../beacon_chain/spec/[beaconstate, crypto, datatypes, digest,
+  ../beacon_chain/spec/[beaconstate, crypto, digest,
                         forkedbeaconstate_helpers, presets,
                         helpers, signatures, state_transition],
+  ../beacon_chain/spec/datatypes/[phase0, altair],
   ../beacon_chain/[beacon_node_types, beacon_chain_db, extras],
   ../beacon_chain/eth1/eth1_monitor,
   ../beacon_chain/validators/validator_pool,
@@ -52,7 +53,7 @@ proc gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
   result = mu + sigma * (b / a)
 
 # TODO confutils is an impenetrable black box. how can a help text be added here?
-cli do(slots = SLOTS_PER_EPOCH * 5,
+cli do(slots = SLOTS_PER_EPOCH * 6,
        validators = SLOTS_PER_EPOCH * 400, # One per shard is minimum
        attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
@@ -63,6 +64,8 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
     runtimePreset = defaultRuntimePreset
     genesisTime = float state[].data.genesis_time
 
+  const altairTransitionSlot = 96.Slot
+
   echo "Starting simulation..."
 
   let db = BeaconChainDB.new(runtimePreset, "block_sim_db")
@@ -72,7 +75,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
   putInitialDepositContractSnapshot(db, depositContractSnapshot)
 
   var
-    dag = ChainDAGRef.init(runtimePreset, db)
+    dag = ChainDAGRef.init(runtimePreset, db, {}, altairTransitionSlot)
     eth1Chain = Eth1Chain.init(runtimePreset, db)
     merkleizer = depositContractSnapshot.createMerkleizer
     quarantine = QuarantineRef.init(keys.newRng())
@@ -123,65 +126,96 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
                 signature: sig.toValidatorSig()
               ), [validatorIdx], sig, data.slot)
 
-  proc proposeBlock(slot: Slot) =
+  proc getNewBlock[T](
+      stateData: var StateData, slot: Slot, cache: var StateCache): T =
+    let
+      finalizedEpochRef = dag.getFinalizedEpochRef()
+      proposerIdx = get_beacon_proposer_index(
+        stateData.data, cache, getStateField(stateData.data, slot)).get()
+      privKey = hackPrivKey(
+        getStateField(stateData.data, validators)[proposerIdx])
+      eth1ProposalData = eth1Chain.getBlockProposalData(
+        stateData.data,
+        finalizedEpochRef.eth1_data,
+        finalizedEpochRef.eth1_deposit_index)
+      hashedState =
+        when T is phase0.SignedBeaconBlock:
+          addr stateData.data.hbsPhase0
+        elif T is altair.SignedBeaconBlock:
+          addr stateData.data.hbsAltair
+        else:
+          static: doAssert false
+      message = makeBeaconBlock(
+        runtimePreset,
+        hashedState[],
+        proposerIdx,
+        dag.head.root,
+        privKey.genRandaoReveal(
+          getStateField(stateData.data, fork),
+          getStateField(stateData.data, genesis_validators_root),
+          slot).toValidatorSig(),
+        eth1ProposalData.vote,
+        default(GraffitiBytes),
+        attPool.getAttestationsForTestBlock(stateData, cache),
+        eth1ProposalData.deposits,
+        @[],
+        @[],
+        @[],
+        ExecutionPayload(),
+        noRollback,
+        cache)
+
+    var
+      newBlock = T(
+        message: message.get()
+      )
+
+    let blockRoot = withTimerRet(timers[tHashBlock]):
+      hash_tree_root(newBlock.message)
+    newBlock.root = blockRoot
+    # Careful, state no longer valid after here because of the await..
+    newBlock.signature = withTimerRet(timers[tSignBlock]):
+      get_block_signature(
+        getStateField(stateData.data, fork),
+        getStateField(stateData.data, genesis_validators_root),
+        newBlock.message.slot,
+        blockRoot, privKey).toValidatorSig()
+
+    newBlock
+
+  proc proposePhase0Block(slot: Slot) =
     if rand(r, 1.0) > blockRatio:
       return
 
-    let
-      head = dag.head
-
-    dag.withState(tmpState[], head.atSlot(slot)):
+    dag.withState(tmpState[], dag.head.atSlot(slot)):
       let
-        finalizedEpochRef = dag.getFinalizedEpochRef()
-        proposerIdx = get_beacon_proposer_index(
-          stateData.data, cache, getStateField(stateData.data, slot)).get()
-        privKey = hackPrivKey(
-          getStateField(stateData.data, validators)[proposerIdx])
-        eth1ProposalData = eth1Chain.getBlockProposalData(
-          stateData.data,
-          finalizedEpochRef.eth1_data,
-          finalizedEpochRef.eth1_deposit_index)
-        message = makeBeaconBlock(
-          runtimePreset,
-          stateData.data.hbsPhase0,
-          proposerIdx,
-          head.root,
-          privKey.genRandaoReveal(
-            getStateField(stateData.data, fork),
-            getStateField(stateData.data, genesis_validators_root),
-            slot).toValidatorSig(),
-          eth1ProposalData.vote,
-          default(GraffitiBytes),
-          attPool.getAttestationsForTestBlock(stateData, cache),
-          eth1ProposalData.deposits,
-          @[],
-          @[],
-          @[],
-          ExecutionPayload(),
-          noRollback,
-          cache)
+        newBlock = getNewBlock[phase0.SignedBeaconBlock](stateData, slot, cache)
+        added = dag.addRawBlock(quarantine, newBlock) do (
+            blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
+            epochRef: EpochRef):
+          # Callback add to fork choice if valid
+          attPool.addForkChoice(
+            epochRef, blckRef, signedBlock.message, blckRef.slot)
 
-      var
-        newBlock = SignedBeaconBlock(
-          message: message.get()
-        )
+      blck() = added[]
+      dag.updateHead(added[], quarantine)
+      if dag.needStateCachesAndForkChoicePruning():
+        dag.pruneStateCachesDAG()
+        attPool.prune()
 
-      let blockRoot = withTimerRet(timers[tHashBlock]):
-        hash_tree_root(newBlock.message)
-      newBlock.root = blockRoot
-      # Careful, state no longer valid after here because of the await..
-      newBlock.signature = withTimerRet(timers[tSignBlock]):
-        get_block_signature(
-          getStateField(stateData.data, fork),
-          getStateField(stateData.data, genesis_validators_root),
-          newBlock.message.slot,
-          blockRoot, privKey).toValidatorSig()
+  proc proposeAltairBlock(slot: Slot) =
+    if rand(r, 1.0) > blockRatio:
+      return
 
-      let added = dag.addRawBlock(quarantine, newBlock) do (
-          blckRef: BlockRef, signedBlock: TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
-        # Callback add to fork choice if valid
-        attPool.addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
+    dag.withState(tmpState[], dag.head.atSlot(slot)):
+      let
+        newBlock = getNewBlock[altair.SignedBeaconBlock](stateData, slot, cache)
+        added = dag.addRawBlock(quarantine, newBlock) do (
+            blckRef: BlockRef, signedBlock: altair.TrustedSignedBeaconBlock,
+            epochRef: EpochRef):
+          # Callback add to fork choice if valid
+          attPool.addForkChoice(
+            epochRef, blckRef, signedBlock.message, blckRef.slot)
 
       blck() = added[]
       dag.updateHead(added[], quarantine)
@@ -228,7 +262,10 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
 
     if blockRatio > 0.0:
       withTimer(timers[t]):
-        proposeBlock(slot)
+        if slot < altairTransitionSlot:
+          proposePhase0Block(slot)
+        else:
+          proposeAltairBlock(slot)
     if attesterRatio > 0.0:
       withTimer(timers[tAttest]):
         handleAttestations(slot)

--- a/tests/official/altair/test_fixture_sanity_blocks.nim
+++ b/tests/official/altair/test_fixture_sanity_blocks.nim
@@ -53,12 +53,12 @@ proc runTest(testName, testDir, unitTestName: string) =
         if hasPostState:
           let success = state_transition(
             defaultRuntimePreset, fhPreState[], blck, cache, rewards, flags = {},
-            noRollback)
+            noRollback, FAR_FUTURE_SLOT)
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
             defaultRuntimePreset, fhPreState[], blck, cache, rewards, flags = {},
-            noRollback)
+            noRollback, FAR_FUTURE_SLOT)
           doAssert (i + 1 < numBlocks) or not success,
             "We didn't expect these invalid blocks to be processed"
 

--- a/tests/official/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/official/phase0/test_fixture_sanity_blocks.nim
@@ -53,12 +53,12 @@ proc runTest(testName, testDir, unitTestName: string) =
         if hasPostState:
           let success = state_transition(
             defaultRuntimePreset, fhPreState[], blck, cache, rewards, flags = {},
-            noRollback)
+            noRollback, FAR_FUTURE_SLOT)
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
             defaultRuntimePreset, fhPreState[], blck, cache, rewards, flags = {},
-            noRollback)
+            noRollback, FAR_FUTURE_SLOT)
           doAssert (i + 1 < numBlocks) or not success,
             "We didn't expect these invalid blocks to be processed"
 

--- a/tests/official/test_fixture_const_sanity_check.nim
+++ b/tests/official/test_fixture_const_sanity_check.nim
@@ -13,7 +13,8 @@ import
   unittest2,
   stew/[byteutils, endians2],
   # Internals
-  ../../beacon_chain/spec/[datatypes, presets],
+  ../../beacon_chain/spec/datatypes/base,
+  ../../beacon_chain/spec/presets,
   # Test utilities
   ../testutil, ./fixtures_utils
 

--- a/tests/slashing_protection/test_migration.nim
+++ b/tests/slashing_protection/test_migration.nim
@@ -21,7 +21,8 @@ import
     slashing_protection,
     slashing_protection_v1
   ],
-  ../../beacon_chain/spec/[datatypes, digest, crypto, presets],
+  ../../beacon_chain/spec/datatypes/base,
+  ../../beacon_chain/spec/[digest, crypto, presets],
   # Test utilies
   ../testutil
 

--- a/tests/slashing_protection/test_official_interchange_vectors.nim
+++ b/tests/slashing_protection/test_official_interchange_vectors.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -14,7 +14,8 @@ import
   chronicles,
   # Internal
   ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],
-  ../../beacon_chain/spec/[datatypes, digest, crypto, presets],
+  ../../beacon_chain/spec/datatypes/base,
+  ../../beacon_chain/spec/[digest, crypto, presets],
   # Test utilies
   ../testutil, ../testdbutil,
   ../official/fixtures_utils

--- a/tests/slashing_protection/test_slashing_interchange.nim
+++ b/tests/slashing_protection/test_slashing_interchange.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -16,7 +16,8 @@ import
   nimcrypto/utils,
   # Internal
   ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],
-  ../../beacon_chain/spec/[datatypes, digest, crypto, presets],
+  ../../beacon_chain/spec/datatypes/base,
+  ../../beacon_chain/spec/[digest, crypto, presets],
   # Test utilies
   ../testutil
 

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -15,7 +15,8 @@ import
   stew/results,
   # Internal
   ../../beacon_chain/validators/slashing_protection,
-  ../../beacon_chain/spec/[datatypes, digest, crypto, presets, helpers],
+  ../../beacon_chain/spec/[crypto, digest, helpers, presets],
+  ../../beacon_chain/spec/datatypes/base,
   # Test utilies
   ../testutil
 

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -8,6 +8,7 @@
 {.used.}
 
 import
+  chronicles,
   std/[options, sequtils],
   unittest2,
   stew/assign2,
@@ -20,9 +21,6 @@ import
   ../beacon_chain/consensus_object_pools/[
     blockchain_dag, block_quarantine, block_clearance],
   ./testutil, ./testdbutil, ./testblockutil
-
-when isMainModule:
-  import chronicles # or some random compile error happens...
 
 proc `$`(x: BlockRef): string =
   $x.root
@@ -124,6 +122,7 @@ suite "Block pool processing" & preset():
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
       quarantine = QuarantineRef.init(keys.newRng())
+      nilPhase0Callback: OnPhase0BlockAdded
       state = newClone(dag.headState.data)
       cache = StateCache()
       rewards = RewardInfo()
@@ -143,7 +142,7 @@ suite "Block pool processing" & preset():
 
   test "Simple block add&get" & preset():
     let
-      b1Add = dag.addRawBlock(quarantine, b1, nil)
+      b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
       b1Get = dag.get(b1.root)
 
     check:
@@ -154,7 +153,7 @@ suite "Block pool processing" & preset():
       dag.heads[0] == b1Add[]
 
     let
-      b2Add = dag.addRawBlock(quarantine, b2, nil)
+      b2Add = dag.addRawBlock(quarantine, b2, nilPhase0Callback)
       b2Get = dag.get(b2.root)
       er = dag.findEpochRef(b1Add[], b1Add[].slot.epoch)
       validators = getStateField(dag.headState.data, validators).lenu64()
@@ -183,7 +182,7 @@ suite "Block pool processing" & preset():
 
     let
       b4 = addTestBlock(state[], b2.root, cache)
-      b4Add = dag.addRawBlock(quarantine, b4, nil)
+      b4Add = dag.addRawBlock(quarantine, b4, nilPhase0Callback)
 
     check:
       b4Add[].parent == b2Add[]
@@ -231,14 +230,14 @@ suite "Block pool processing" & preset():
       blocks[2..<2].len == 0
 
   test "Reverse order block add & get" & preset():
-    let missing = dag.addRawBlock(quarantine, b2, nil)
+    let missing = dag.addRawBlock(quarantine, b2, nilPhase0Callback)
     check: missing.error == (ValidationResult.Ignore, MissingParent)
 
     check:
       dag.get(b2.root).isNone() # Unresolved, shouldn't show up
       FetchRecord(root: b1.root) in quarantine.checkMissing()
 
-    let status = dag.addRawBlock(quarantine, b1, nil)
+    let status = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     check: status.isOk
 
@@ -275,8 +274,8 @@ suite "Block pool processing" & preset():
 
   test "Adding the same block twice returns a Duplicate error" & preset():
     let
-      b10 = dag.addRawBlock(quarantine, b1, nil)
-      b11 = dag.addRawBlock(quarantine, b1, nil)
+      b10 = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
+      b11 = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     check:
       b11.error == (ValidationResult.Ignore, Duplicate)
@@ -284,7 +283,7 @@ suite "Block pool processing" & preset():
 
   test "updateHead updates head and headState" & preset():
     let
-      b1Add = dag.addRawBlock(quarantine, b1, nil)
+      b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     dag.updateHead(b1Add[], quarantine)
     dag.pruneAtFinalization()
@@ -295,8 +294,8 @@ suite "Block pool processing" & preset():
 
   test "updateStateData sanity" & preset():
     let
-      b1Add = dag.addRawBlock(quarantine, b1, nil)
-      b2Add = dag.addRawBlock(quarantine, b2, nil)
+      b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
+      b2Add = dag.addRawBlock(quarantine, b2, nilPhase0Callback)
       bs1 = BlockSlot(blck: b1Add[], slot: b1.message.slot)
       bs1_3 = b1Add[].atSlot(3.Slot)
       bs2_3 = b2Add[].atSlot(3.Slot)
@@ -348,6 +347,7 @@ suite "chain DAG finalization tests" & preset():
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimePreset, db)
       quarantine = QuarantineRef.init(keys.newRng())
+      nilPhase0Callback: OnPhase0BlockAdded
       cache = StateCache()
       rewards = RewardInfo()
 
@@ -363,7 +363,7 @@ suite "chain DAG finalization tests" & preset():
 
     let lateBlock = addTestBlock(tmpState[], dag.head.root, cache)
     block:
-      let status = dag.addRawBlock(quarantine, blck, nil)
+      let status = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: status.isOk()
 
     assign(tmpState[], dag.headState.data)
@@ -378,7 +378,7 @@ suite "chain DAG finalization tests" & preset():
         tmpState[], dag.head.root, cache,
         attestations = makeFullAttestations(
           tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {}))
-      let added = dag.addRawBlock(quarantine, blck, nil)
+      let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
       dag.pruneAtFinalization()
@@ -420,7 +420,7 @@ suite "chain DAG finalization tests" & preset():
     block:
       # The late block is a block whose parent was finalized long ago and thus
       # is no longer a viable head candidate
-      let status = dag.addRawBlock(quarantine, lateBlock, nil)
+      let status = dag.addRawBlock(quarantine, lateBlock, nilPhase0Callback)
       check: status.error == (ValidationResult.Ignore, Unviable)
 
     block:
@@ -449,7 +449,7 @@ suite "chain DAG finalization tests" & preset():
         assign(prestate[], dag.headState.data)
 
       let blck = makeTestBlock(dag.headState.data, dag.head.root, cache)
-      let added = dag.addRawBlock(quarantine, blck, nil)
+      let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
       dag.pruneAtFinalization()
@@ -468,21 +468,21 @@ suite "chain DAG finalization tests" & preset():
     let blck = makeTestBlock(prestate[], dag.head.parent.root, cache)
 
     # Add block, but don't update head
-    let added = dag.addRawBlock(quarantine, blck, nil)
+    let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
     check: added.isOk()
 
     var
       dag2 = init(ChainDAGRef, defaultRuntimePreset, db)
 
     # check that we can apply the block after the orphaning
-    let added2 = dag2.addRawBlock(quarantine, blck, nil)
+    let added2 = dag2.addRawBlock(quarantine, blck, nilPhase0Callback)
     check: added2.isOk()
 
   test "init with gaps" & preset():
     for blck in makeTestBlocks(
         dag.headState.data, dag.head.root, cache, int(SLOTS_PER_EPOCH * 6 - 2),
         true):
-      let added = dag.addRawBlock(quarantine, blck, nil)
+      let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
       dag.pruneAtFinalization()
@@ -499,7 +499,7 @@ suite "chain DAG finalization tests" & preset():
         dag.headState.data, dag.head.root, getStateField(dag.headState.data, slot),
         cache, {}))
 
-    let added = dag.addRawBlock(quarantine, blck, nil)
+    let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
     check: added.isOk()
     dag.updateHead(added[], quarantine)
     dag.pruneAtFinalization()


### PR DESCRIPTION
- add Altair support to block quarantine/clearance and `block_sim`
- switch some `spec/datatypes` imports to `spec/datatypes/base`, to add compile-time checking for dependencies on fork-specific data structures such as states and blocks
- add runtime DAG configuration of Altair transition slot