### PR TITLE
introduce database support for Altair

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -83,13 +83,15 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
 + sanity check Altair blocks [Preset: mainnet]                                               OK
++ sanity check Altair states [Preset: mainnet]                                               OK
++ sanity check Altair states, reusing buffers [Preset: mainnet]                              OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
 + sanity check phase 0 blocks [Preset: mainnet]                                              OK
++ sanity check phase 0 states [Preset: mainnet]                                              OK
++ sanity check phase 0 states, reusing buffers [Preset: mainnet]                             OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
-+ sanity check states [Preset: mainnet]                                                      OK
-+ sanity check states, reusing buffers [Preset: mainnet]                                     OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
+OK: 10/10 Fail: 0/10 Skip: 0/10
 ## Beacon state [Preset: mainnet]
 ```diff
 + Smoke test initialize_beacon_state_from_eth1 [Preset: mainnet]                             OK
@@ -309,4 +311,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 175/183 Fail: 0/183 Skip: 8/183
+OK: 177/185 Fail: 0/185 Skip: 8/185

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -82,13 +82,14 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 ```diff
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
-+ sanity check blocks [Preset: mainnet]                                                      OK
++ sanity check Altair blocks [Preset: mainnet]                                               OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
++ sanity check phase 0 blocks [Preset: mainnet]                                              OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 + sanity check states [Preset: mainnet]                                                      OK
 + sanity check states, reusing buffers [Preset: mainnet]                                     OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
+OK: 8/8 Fail: 0/8 Skip: 0/8
 ## Beacon state [Preset: mainnet]
 ```diff
 + Smoke test initialize_beacon_state_from_eth1 [Preset: mainnet]                             OK
@@ -308,4 +309,4 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 174/182 Fail: 0/182 Skip: 8/182
+OK: 175/183 Fail: 0/183 Skip: 8/183

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -584,6 +584,8 @@ proc getAltairBlock*(db: BeaconChainDB, key: Eth2Digest):
   if db.altairBlocks.getSnappySSZ(key.data, result.get) == GetResult.found:
     # set root after deserializing (so it doesn't get zeroed)
     result.get().root = key
+  else:
+    result.err()
 
 proc getStateOnlyMutableValidators(
     immutableValidators: openArray[ImmutableValidatorData2],

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -717,7 +717,7 @@ proc getState*(
   else:
     true
 
-proc getState*(
+proc getAltairState*(
     db: BeaconChainDB, key: Eth2Digest, output: var altair.BeaconState,
     rollback: AltairRollbackProc): bool =
   ## Load state into `output` - BeaconState is large so we want to avoid

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -12,13 +12,14 @@ import
   stew/[assign2, io2, objects, results],
   serialization,
   eth/db/[kvstore, kvstore_sqlite3],
-  ./spec/[crypto, datatypes, digest],
+  ./spec/[crypto, digest],
+  ./spec/datatypes/[base, altair],
   ./ssz/[ssz_serialization, merkleization],
   filepath
 
 type
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconstate
-  # Memory-representation-equivalent to a v1.0.1 BeaconState for in-place SSZ reading and writing
+  # Memory-representation-equivalent to a phase0 BeaconState for in-place SSZ reading and writing
   BeaconStateNoImmutableValidators* = object
     # Versioning
     genesis_time*: uint64
@@ -70,6 +71,68 @@ type
 
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.7/specs/altair/beacon-chain.md#beaconstate
+  # Memory-representation-equivalent to an Altair BeaconState for in-place SSZ
+  # reading and writing
+  AltairBeaconStateNoImmutableValidators* = object
+    # Versioning
+    genesis_time*: uint64
+    genesis_validators_root*: Eth2Digest
+    slot*: Slot
+    fork*: Fork
+
+    # History
+    latest_block_header*: BeaconBlockHeader ##\
+    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
+    ## Needed to process attestations, older to newer
+
+    state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*:
+      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_deposit_index*: uint64
+
+    # Registry
+    validators*: HashList[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Randomness
+    randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
+
+    # Slashings
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
+    ## Per-epoch sums of slashed effective balances
+
+    # Participation
+    previous_epoch_participation*:
+      HashList[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+    current_epoch_participation*:
+      HashList[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Finality
+    justification_bits*: uint8 ##\
+    ## Bit set for every recent justified epoch
+    ## Model a Bitvector[4] as a one-byte uint, which should remain consistent
+    ## with ssz/hashing.
+
+    previous_justified_checkpoint*: Checkpoint ##\
+    ## Previous epoch snapshot
+
+    current_justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
+    # Inactivity
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]  # [New in Altair]
+
+    # Light client sync committees
+    current_sync_committee*: SyncCommittee     # [New in Altair]
+    next_sync_committee*: SyncCommittee        # [New in Altair]
 
 func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
   for name, value in x.fieldPairs:

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -559,9 +559,11 @@ proc putState(dag: ChainDAGRef, state: var StateData) =
   # Ideally we would save the state and the root lookup cache in a single
   # transaction to prevent database inconsistencies, but the state loading code
   # is resilient against one or the other going missing
-  if state.data.beaconStateFork != forkAltair:
-    # TODO re-enable for Altair
+  case state.data.beaconStateFork:
+  of forkPhase0:
     dag.db.putState(getStateRoot(state.data), state.data.hbsPhase0.data)
+  of forkAltair:
+    dag.db.putState(getStateRoot(state.data), state.data.hbsAltair.data)
 
   dag.db.putStateRoot(
     state.blck.root, getStateField(state.data, slot), getStateRoot(state.data))

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -105,6 +105,7 @@ func verifyStateRoot(state: phase0.BeaconState, blck: altair.TrustedBeaconBlock)
 
 type
   RollbackProc* = proc(v: var phase0.BeaconState) {.gcsafe, raises: [Defect].}
+  AltairRollbackProc* = proc(v: var altair.BeaconState) {.gcsafe, raises: [Defect].}
 
 func noRollback*(state: var phase0.BeaconState) =
   trace "Skipping rollback of broken state"

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -108,7 +108,10 @@ type
   AltairRollbackProc* = proc(v: var altair.BeaconState) {.gcsafe, raises: [Defect].}
 
 func noRollback*(state: var phase0.BeaconState) =
-  trace "Skipping rollback of broken state"
+  trace "Skipping rollback of broken phase 0 state"
+
+func noRollback*(state: var altair.BeaconState) =
+  trace "Skipping rollback of broken Altair state"
 
 type
   RollbackHashedProc* = proc(state: var phase0.HashedBeaconState) {.gcsafe, raises: [Defect].}
@@ -171,7 +174,7 @@ func noRollback*(state: var phase0.HashedBeaconState) =
 func noRollback*(state: var altair.HashedBeaconState) =
   trace "Skipping rollback of broken Altair state"
 
-proc maybeUpgradeStateToAltair(
+proc maybeUpgradeStateToAltair*(
     state: var ForkedHashedBeaconState, altairForkSlot: Slot) =
   # Both process_slots() and state_transition_block() call this, so only run it
   # once by checking for existing fork.

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,8 +13,8 @@ import
   math,
 
   # Specs
-  ../../beacon_chain/spec/[datatypes, crypto, digest,
-                           keystore, signatures, presets],
+  ../../beacon_chain/spec/[crypto, digest, keystore, signatures, presets],
+  ../../beacon_chain/spec/datatypes/base,
 
   # Internals
   ../../beacon_chain/extras,
@@ -103,8 +103,8 @@ proc mockGenesisBalancedDeposits*(
   mockGenesisDepositsImpl(result, validatorCount,amount,flags):
     discard
 
-proc mockUpdateStateForNewDeposit*(
-       state: var BeaconState,
+proc mockUpdateStateForNewDeposit*[T](
+       state: var T,
        validator_index: uint64,
        amount: uint64,
        # withdrawal_credentials: Eth2Digest

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -76,6 +76,7 @@ suite "Beacon chain DB" & preset():
     db.delBlock(root)
     check:
       not db.containsBlock(root)
+      db.getBlock(root).isErr()
 
     db.putStateRoot(root, signedBlock.message.slot, root)
     var root2 = root
@@ -105,6 +106,7 @@ suite "Beacon chain DB" & preset():
     db.delBlock(root)
     check:
       not db.containsBlock(root)
+      db.getAltairBlock(root).isErr()
 
     db.putStateRoot(root, signedBlock.message.slot, root)
     var root2 = root
@@ -136,7 +138,9 @@ suite "Beacon chain DB" & preset():
         hash_tree_root(db.getPhase0StateRef(root)[]) == root
 
       db.delState(root)
-      check: not db.containsState(root)
+      check:
+        not db.containsState(root)
+        db.getPhase0StateRef(root).isNil
 
     db.close()
 
@@ -159,7 +163,9 @@ suite "Beacon chain DB" & preset():
         hash_tree_root(db.getAltairStateRef(root)[]) == root
 
       db.delState(root)
-      check: not db.containsState(root)
+      check:
+        not db.containsState(root)
+        db.getAltairStateRef(root).isNil
 
     db.close()
 
@@ -185,7 +191,9 @@ suite "Beacon chain DB" & preset():
         hash_tree_root(stateBuffer[]) == root
 
       db.delState(root)
-      check: not db.containsState(root)
+      check:
+        not db.containsState(root)
+        not db.getState(root, stateBuffer[], noRollback)
 
     db.close()
 
@@ -211,7 +219,9 @@ suite "Beacon chain DB" & preset():
         hash_tree_root(stateBuffer[]) == root
 
       db.delState(root)
-      check: not db.containsState(root)
+      check:
+        not db.containsState(root)
+        not db.getAltairState(root, stateBuffer[], noRollback)
 
     db.close()
 


### PR DESCRIPTION
- introduce immutable Altair BeaconState
- put/get/contains/delete Altair blocks and states
- tests for all of this

It generally combines `delState`/`delBlock` and `containsState`/`containsBlock` into single functions which check both Altair and phase 0 database for the relevant roots. This is a bit simpler, more robust API, but does tradeoff an additional database query. It should be indexed, so fast enough not to be a major IOPS driver.