### PR TITLE
reduce peer pool space test iterations from 10,000 to 1,000

### DIFF
--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -885,8 +885,8 @@ suite "PeerPool testing suite":
       pool7.lenSpace({PeerType.Incoming}) == 0
       pool7.lenSpace({PeerType.Outgoing}) == high(int) - 39
 
-    # We could not check whole high(int), so we check 10_000 items
-    for i in 0 ..< 10_000:
+    # We could not check whole high(int), so we check 1_000 items
+    for i in 0 ..< 1_000:
       check:
         pool7.addPeerNoWait(PeerTest.init("idOut" & $i),
                             PeerType.Outgoing) == PeerStatus.Success
@@ -910,8 +910,8 @@ suite "PeerPool testing suite":
       pool8.lenSpace({PeerType.Outgoing}) == 0
       pool8.lenSpace({PeerType.Incoming}) == high(int) - 40
 
-    # We could not check whole high(int), so we check 10_000 items
-    for i in 0 ..< 10_000:
+    # We could not check whole high(int), so we check 1_000 items
+    for i in 0 ..< 1_000:
       check:
         pool8.addPeerNoWait(PeerTest.init("idInc" & $i),
                             PeerType.Incoming) == PeerStatus.Success
@@ -920,8 +920,8 @@ suite "PeerPool testing suite":
         pool8.lenSpace({PeerType.Incoming}) == high(int) - 40 - (i + 1)
 
     # POOL 9
-    # We could not check whole high(int), so we check 10_000 items
-    for i in 0 ..< 10_000:
+    # We could not check whole high(int), so we check 1_000 items
+    for i in 0 ..< 1_000:
       check:
         pool9.addPeerNoWait(PeerTest.init("idInc" & $i),
                             PeerType.Incoming) == PeerStatus.Success

--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -885,8 +885,8 @@ suite "PeerPool testing suite":
       pool7.lenSpace({PeerType.Incoming}) == 0
       pool7.lenSpace({PeerType.Outgoing}) == high(int) - 39
 
-    # We could not check whole high(int), so we check 1_000 items
-    for i in 0 ..< 1_000:
+    # We could not check whole high(int), so we check 2_000 items
+    for i in 0 ..< 2_000:
       check:
         pool7.addPeerNoWait(PeerTest.init("idOut" & $i),
                             PeerType.Outgoing) == PeerStatus.Success
@@ -910,8 +910,8 @@ suite "PeerPool testing suite":
       pool8.lenSpace({PeerType.Outgoing}) == 0
       pool8.lenSpace({PeerType.Incoming}) == high(int) - 40
 
-    # We could not check whole high(int), so we check 1_000 items
-    for i in 0 ..< 1_000:
+    # We could not check whole high(int), so we check 2_000 items
+    for i in 0 ..< 2_000:
       check:
         pool8.addPeerNoWait(PeerTest.init("idInc" & $i),
                             PeerType.Incoming) == PeerStatus.Success
@@ -920,8 +920,8 @@ suite "PeerPool testing suite":
         pool8.lenSpace({PeerType.Incoming}) == high(int) - 40 - (i + 1)
 
     # POOL 9
-    # We could not check whole high(int), so we check 1_000 items
-    for i in 0 ..< 1_000:
+    # We could not check whole high(int), so we check 2_000 items
+    for i in 0 ..< 2_000:
       check:
         pool9.addPeerNoWait(PeerTest.init("idInc" & $i),
                             PeerType.Incoming) == PeerStatus.Success


### PR DESCRIPTION
This follows a discussion with @cheatfate.

It addresses that the `linux-i386` GitHub Action CI runs have begun taking more than an hour, of which 45 to 50 minutes on this specific peer pool space test. Other GitHub Actions platforms seem unaffected.

For example, https://github.com/status-im/nimbus-eth2/runs/2909893404 shows, only for `linux-i386`:
```
2021-06-25T00:35:18.9657146Z [Suite] PeerPool testing suite
2021-06-25T00:35:19.0849641Z   [OK] addPeerNoWait() test
2021-06-25T00:35:20.0762389Z   [OK] addPeer() test
2021-06-25T00:35:20.1460877Z   [OK] Acquire from empty pool
2021-06-25T00:35:30.2793396Z   [OK] Acquire/Sorting and consistency test
2021-06-25T00:35:30.2965248Z   [OK] deletePeer() test
2021-06-25T00:35:30.3131526Z   [OK] Peer lifetime test
2021-06-25T00:35:30.4409992Z   [OK] Safe/Clear test
2021-06-25T00:35:30.4578208Z   [OK] Access peers by key test
2021-06-25T00:35:30.5293394Z   [OK] Iterators test
2021-06-25T00:35:30.5519283Z   [OK] Score check test
2021-06-25T00:35:30.6722250Z   [OK] Delete peer on release text
2021-06-25T01:17:42.1865029Z   [OK] Space tests
```

https://github.com/status-im/nimbus-eth2/runs/2907770936 shows:
```
2021-06-24T19:08:30.3021116Z [Suite] PeerPool testing suite
2021-06-24T19:08:30.4236918Z   [OK] addPeerNoWait() test
2021-06-24T19:08:31.4144413Z   [OK] addPeer() test
2021-06-24T19:08:31.4879622Z   [OK] Acquire from empty pool
2021-06-24T19:08:43.2248729Z   [OK] Acquire/Sorting and consistency test
2021-06-24T19:08:43.2428382Z   [OK] deletePeer() test
2021-06-24T19:08:43.2609313Z   [OK] Peer lifetime test
2021-06-24T19:08:43.3890016Z   [OK] Safe/Clear test
2021-06-24T19:08:43.4092526Z   [OK] Access peers by key test
2021-06-24T19:08:43.4861777Z   [OK] Iterators test
2021-06-24T19:08:43.5100535Z   [OK] Score check test
2021-06-24T19:08:43.6295063Z   [OK] Delete peer on release text
2021-06-24T19:54:48.9572082Z   [OK] Space tests
```

and https://github.com/status-im/nimbus-eth2/runs/2902343755 shows:
```
2021-06-24T07:42:23.1050667Z [Suite] PeerPool testing suite
2021-06-24T07:42:23.2323588Z   [OK] addPeerNoWait() test
2021-06-24T07:42:24.2260764Z   [OK] addPeer() test
2021-06-24T07:42:24.2961032Z   [OK] Acquire from empty pool
2021-06-24T07:42:35.6206103Z   [OK] Acquire/Sorting and consistency test
2021-06-24T07:42:35.6407631Z   [OK] deletePeer() test
2021-06-24T07:42:35.6602924Z   [OK] Peer lifetime test
2021-06-24T07:42:35.7916790Z   [OK] Safe/Clear test
2021-06-24T07:42:35.8084043Z   [OK] Access peers by key test
2021-06-24T07:42:35.8922487Z   [OK] Iterators test
2021-06-24T07:42:35.9175915Z   [OK] Score check test
2021-06-24T07:42:36.0390872Z   [OK] Delete peer on release text
2021-06-24T08:25:45.6502595Z   [OK] Space tests
```

It does look like something that particular commit brought in, e.g., https://github.com/status-im/nimbus-eth2/runs/2873839135 shows a `linux-i386` GitHub Actions build more in line with the other platforms, without this long delay:
```
2021-06-21T10:04:55.1884509Z [Suite] PeerPool testing suite
2021-06-21T10:04:55.1884986Z   [OK] addPeerNoWait() test
2021-06-21T10:04:56.1369973Z   [OK] addPeer() test
2021-06-21T10:04:56.1371827Z   [OK] Acquire from empty pool
2021-06-21T10:04:56.1373598Z   [OK] Acquire/Sorting and consistency test
2021-06-21T10:04:56.1374953Z   [OK] deletePeer() test
2021-06-21T10:04:56.1376148Z   [OK] Peer lifetime test
2021-06-21T10:04:56.2004107Z   [OK] Safe/Clear test
2021-06-21T10:04:56.2005605Z   [OK] Access peers by key test
2021-06-21T10:04:56.2006535Z   [OK] Iterators test
2021-06-21T10:04:56.2010851Z   [OK] Score check test
2021-06-21T10:04:56.3018039Z   [OK] Delete peer on release text
2021-06-21T10:04:56.4719120Z   [OK] Space tests
```

Likewise, https://github.com/status-im/nimbus-eth2/runs/2896108562 from two days ago shows:
```
2021-06-23T15:08:49.6408562Z [Suite] PeerPool testing suite
2021-06-23T15:08:49.6409565Z   [OK] addPeerNoWait() test
2021-06-23T15:08:50.5467767Z   [OK] addPeer() test
2021-06-23T15:08:50.5469200Z   [OK] Acquire from empty pool
2021-06-23T15:08:50.5470322Z   [OK] Acquire/Sorting and consistency test
2021-06-23T15:08:50.5470872Z   [OK] deletePeer() test
2021-06-23T15:08:50.5490452Z   [OK] Peer lifetime test
2021-06-23T15:08:50.6497270Z   [OK] Safe/Clear test
2021-06-23T15:08:50.6497823Z   [OK] Access peers by key test
2021-06-23T15:08:50.6498562Z   [OK] Iterators test
2021-06-23T15:08:50.6498982Z   [OK] Score check test
2021-06-23T15:08:50.7500040Z   [OK] Delete peer on release text
2021-06-23T15:08:50.9066211Z   [OK] Space tests
```

Something about https://github.com/status-im/nimbus-eth2/pull/2667 increases the peer pool space test time for linux-i386 specifically by a factor of hundreds. This works around that, pending finding a more root cause.