### PR TITLE
Move Jenkins workspace clearing to beginning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,9 @@ if (env.BRANCH_NAME != "stable" && env.BRANCH_NAME != "testing" && env.BRANCH_NA
 
 def runStages() {
 	try {
+		// clean the workspace
+		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+
 		stage("Clone") {
 			/* source code checkout */
 			checkout scm
@@ -69,8 +72,6 @@ def runStages() {
 			println(e.toString());
 			// we don't need to re-raise it here; it might be a PR build being cancelled by a newer one
 		}
-		// clean the workspace
-		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ if (env.BRANCH_NAME != "stable" && env.BRANCH_NAME != "testing" && env.BRANCH_NA
 def runStages() {
 	try {
 		// clean the workspace
-		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
+		preBuildCleanup(disableDeferredWipeout: true, deleteDirs: true)
 
 		stage("Clone") {
 			/* source code checkout */


### PR DESCRIPTION
This enables manual SSH post-CI diagnostics of what went wrong.

There's a `preBuildCleanup` designed for this purpose (https://github.com/jenkinsci/ws-cleanup-plugin/blob/5e34c2235dfed06406ff0793f37d79a3861463d2/src/main/java/hudson/plugins/ws_cleanup/PreBuildCleanup.java), which should be used instead of `wsClean`.