### PR TITLE
add checkDir = true to walkDir() across tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,8 +73,6 @@ def runStages() {
 			println(e.toString());
 			// we don't need to re-raise it here; it might be a PR build being cancelled by a newer one
 		}
-		// clean the workspace
-		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,6 +73,8 @@ def runStages() {
 			println(e.toString());
 			// we don't need to re-raise it here; it might be a PR build being cancelled by a newer one
 		}
+		// clean the workspace
+		cleanWs(disableDeferredWipeout: true, deleteDirs: true)
 	}
 }
 

--- a/tests/official/altair/test_fixture_fork.nim
+++ b/tests/official/altair/test_fixture_fork.nim
@@ -43,5 +43,5 @@ proc runTest(identifier: string) =
   `testImpl _ fork _ identifier`()
 
 suite "Official - Altair - Fork " & preset():
-  for kind, path in walkDir(OpForkDir, true):
+  for kind, path in walkDir(OpForkDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_attestations.nim
+++ b/tests/official/altair/test_fixture_operations_attestations.nim
@@ -62,5 +62,6 @@ proc runTest(identifier: string) =
   `testImpl _ operations_attestations _ identifier`()
 
 suite "Official - Altair - Operations - Attestations " & preset():
-  for kind, path in walkDir(OperationsAttestationsDir, true):
+  for kind, path in walkDir(
+      OperationsAttestationsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_attester_slashings.nim
@@ -64,5 +64,5 @@ proc runTest(identifier: string) =
   `testImpl _ operations_attester_slashing _ identifier`()
 
 suite "Official - Altair - Operations - Attester slashing " & preset():
-  for kind, path in walkDir(OpAttSlashingDir, true):
+  for kind, path in walkDir(OpAttSlashingDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_block_header.nim
+++ b/tests/official/altair/test_fixture_operations_block_header.nim
@@ -61,5 +61,5 @@ proc runTest(identifier: string) =
   `testImpl _ blockheader _ identifier`()
 
 suite "Official - Altair - Operations - Block header " & preset():
-  for kind, path in walkDir(OpBlockHeaderDir, true):
+  for kind, path in walkDir(OpBlockHeaderDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_deposits.nim
+++ b/tests/official/altair/test_fixture_operations_deposits.nim
@@ -55,5 +55,6 @@ proc runTest(identifier: string) =
   `testImpl _ operations_deposits _ identifier`()
 
 suite "Official - Altair - Operations - Deposits " & preset():
-  for kind, path in walkDir(OperationsDepositsDir, true):
+  for kind, path in walkDir(
+      OperationsDepositsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_proposer_slashings.nim
@@ -66,5 +66,6 @@ proc runTest(identifier: string) =
   `testImpl_proposer_slashing _ identifier`()
 
 suite "Official - Altair - Operations - Proposer slashing " & preset():
-  for kind, path in walkDir(OpProposerSlashingDir, true):
+  for kind, path in walkDir(
+      OpProposerSlashingDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_operations_sync_aggregate.nim
+++ b/tests/official/altair/test_fixture_operations_sync_aggregate.nim
@@ -66,5 +66,6 @@ proc runTest(dir, identifier: string) =
   `testImpl_sync_committee _ identifier`()
 
 suite "Official - Altair - Operations - Sync Aggregate" & preset():
-  for kind, path in walkDir(OpSyncAggregateDir, true):
+  for kind, path in walkDir(
+      OpSyncAggregateDir, relative = true, checkDir = true):
     runTest(OpSyncAggregateDir, path)

--- a/tests/official/altair/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/altair/test_fixture_operations_voluntary_exit.nim
@@ -64,5 +64,6 @@ proc runTest(identifier: string) =
   `testImpl _ voluntary_exit _ identifier`()
 
 suite "Official - Altair - Operations - Voluntary exit " & preset():
-  for kind, path in walkDir(OpVoluntaryExitDir, true):
+  for kind, path in walkDir(
+      OpVoluntaryExitDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_sanity_blocks.nim
+++ b/tests/official/altair/test_fixture_sanity_blocks.nim
@@ -71,9 +71,9 @@ proc runTest(testName, testDir, unitTestName: string) =
   `testImpl _ blck _ testName`()
 
 suite "Official - Altair - Sanity - Blocks " & preset():
-  for kind, path in walkDir(SanityBlocksDir, true):
+  for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
     runTest("Official - Altair - Sanity - Blocks", SanityBlocksDir, path)
 
 suite "Official - Altair - Finality " & preset():
-  for kind, path in walkDir(FinalityDir, true):
+  for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
     runTest("Official - Altair - Finality", FinalityDir, path)

--- a/tests/official/altair/test_fixture_sanity_slots.nim
+++ b/tests/official/altair/test_fixture_sanity_slots.nim
@@ -50,5 +50,5 @@ proc runTest(identifier: string) =
   `testImpl _ slots _ identifier`()
 
 suite "Official - Altair - Sanity - Slots " & preset():
-  for kind, path in walkDir(SanitySlotsDir, true):
+  for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/altair/test_fixture_ssz_consensus_objects.nim
@@ -89,15 +89,17 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 
 suite "Official - Altair - SSZ consensus objects " & preset():
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the official test vectors."
-  for pathKind, sszType in walkDir(SSZDir, relative = true):
+  for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 
     test &"  Testing    {sszType}":
       let path = SSZDir/sszType
-      for pathKind, sszTestKind in walkDir(path, relative = true):
+      for pathKind, sszTestKind in walkDir(
+          path, relative = true, checkDir = true):
         doAssert pathKind == pcDir
         let path = SSZDir/sszType/sszTestKind
-        for pathKind, sszTestCase in walkDir(path, relative = true):
+        for pathKind, sszTestCase in walkDir(
+            path, relative = true, checkDir = true):
           let path = SSZDir/sszType/sszTestKind/sszTestCase
           let hash = loadExpectedHashTreeRoot(path)
 

--- a/tests/official/altair/test_fixture_transition.nim
+++ b/tests/official/altair/test_fixture_transition.nim
@@ -86,5 +86,5 @@ proc runTest(testName, testDir, unitTestName: string) =
   `testImpl _ blck _ testName`()
 
 suite "Official - Altair - Transition " & preset():
-  for kind, path in walkDir(TransitionDir, true):
+  for kind, path in walkDir(TransitionDir, relative = true, checkDir = true):
     runTest("Official - Altair - Transition", TransitionDir, path)

--- a/tests/official/phase0/test_fixture_operations_attestations.nim
+++ b/tests/official/phase0/test_fixture_operations_attestations.nim
@@ -62,5 +62,6 @@ proc runTest(identifier: string) =
   `testImpl _ operations_attestations _ identifier`()
 
 suite "Official - Phase 0 - Operations - Attestations " & preset():
-  for kind, path in walkDir(OperationsAttestationsDir, true):
+  for kind, path in walkDir(
+      OperationsAttestationsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_attester_slashings.nim
@@ -64,5 +64,5 @@ proc runTest(identifier: string) =
   `testImpl _ operations_attester_slashing _ identifier`()
 
 suite "Official - Phase 0 - Operations - Attester slashing " & preset():
-  for kind, path in walkDir(OpAttSlashingDir, true):
+  for kind, path in walkDir(OpAttSlashingDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_operations_block_header.nim
+++ b/tests/official/phase0/test_fixture_operations_block_header.nim
@@ -61,5 +61,5 @@ proc runTest(identifier: string) =
   `testImpl _ blockheader _ identifier`()
 
 suite "Official - Phase 0 - Operations - Block header " & preset():
-  for kind, path in walkDir(OpBlockHeaderDir, true):
+  for kind, path in walkDir(OpBlockHeaderDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_operations_deposits.nim
+++ b/tests/official/phase0/test_fixture_operations_deposits.nim
@@ -55,5 +55,6 @@ proc runTest(identifier: string) =
   `testImpl _ operations_deposits _ identifier`()
 
 suite "Official - Phase 0 - Operations - Deposits " & preset():
-  for kind, path in walkDir(OperationsDepositsDir, true):
+  for kind, path in walkDir(
+      OperationsDepositsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
@@ -66,5 +66,6 @@ proc runTest(identifier: string) =
   `testImpl_proposer_slashing _ identifier`()
 
 suite "Official - Phase 0 - Operations - Proposer slashing " & preset():
-  for kind, path in walkDir(OpProposerSlashingDir, true):
+  for kind, path in walkDir(
+      OpProposerSlashingDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
@@ -64,5 +64,6 @@ proc runTest(identifier: string) =
   `testImpl _ voluntary_exit _ identifier`()
 
 suite "Official - Phase 0 - Operations - Voluntary exit " & preset():
-  for kind, path in walkDir(OpVoluntaryExitDir, true):
+  for kind, path in walkDir(
+      OpVoluntaryExitDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/official/phase0/test_fixture_sanity_blocks.nim
@@ -71,9 +71,9 @@ proc runTest(testName, testDir, unitTestName: string) =
   `testImpl _ blck _ testName`()
 
 suite "Official - Phase 0 - Sanity - Blocks " & preset():
-  for kind, path in walkDir(SanityBlocksDir, true):
+  for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
     runTest("Official - Phase 0 - Sanity - Blocks", SanityBlocksDir, path)
 
 suite "Official - Phase 0 - Finality " & preset():
-  for kind, path in walkDir(FinalityDir, true):
+  for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
     runTest("Official - Phase 0 - Finality", FinalityDir, path)

--- a/tests/official/phase0/test_fixture_sanity_slots.nim
+++ b/tests/official/phase0/test_fixture_sanity_slots.nim
@@ -47,5 +47,5 @@ proc runTest(identifier: string) =
   `testImpl _ slots _ identifier`()
 
 suite "Official - Phase 0 - Sanity - Slots " & preset():
-  for kind, path in walkDir(SanitySlotsDir, true):
+  for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
@@ -89,15 +89,17 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 
 suite "Official - Phase 0 - SSZ consensus objects " & preset():
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the official test vectors."
-  for pathKind, sszType in walkDir(SSZDir, relative = true):
+  for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 
     test &"  Testing    {sszType}":
       let path = SSZDir/sszType
-      for pathKind, sszTestKind in walkDir(path, relative = true):
+      for pathKind, sszTestKind in walkDir(
+          path, relative = true, checkDir = true):
         doAssert pathKind == pcDir
         let path = SSZDir/sszType/sszTestKind
-        for pathKind, sszTestCase in walkDir(path, relative = true):
+        for pathKind, sszTestCase in walkDir(
+            path, relative = true, checkDir = true):
           let path = SSZDir/sszType/sszTestKind/sszTestCase
           let hash = loadExpectedHashTreeRoot(path)
 

--- a/tests/official/test_fixture_rewards.nim
+++ b/tests/official/test_fixture_rewards.nim
@@ -128,5 +128,5 @@ proc runTest(rewardsDir, identifier: string) =
 
 suite "Official - Rewards " & preset():
   for rewardsDir in [RewardsDirBasic, RewardsDirLeak, RewardsDirRandom]:
-    for kind, path in walkDir(rewardsDir, true):
+    for kind, path in walkDir(rewardsDir, relative = true, checkDir = true):
       runTest(rewardsDir, path)

--- a/tests/official/test_fixture_ssz_generic_types.nim
+++ b/tests/official/test_fixture_ssz_generic_types.nim
@@ -248,7 +248,7 @@ proc sszCheck(baseDir, sszType, sszSubType: string) =
 
 suite "Official - SSZ generic types":
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the official test vectors."
-  for pathKind, sszType in walkDir(SSZDir, relative = true):
+  for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 
     var skipped: string
@@ -262,13 +262,15 @@ suite "Official - SSZ generic types":
 
     test &"Testing {sszType:12} inputs - valid" & skipped:
       let path = SSZDir/sszType/"valid"
-      for pathKind, sszSubType in walkDir(path, relative = true):
+      for pathKind, sszSubType in walkDir(
+          path, relative = true, checkDir = true):
         if pathKind != pcDir: continue
         sszCheck(path, sszType, sszSubType)
 
     test &"Testing {sszType:12} inputs - invalid" & skipped:
       let path = SSZDir/sszType/"invalid"
-      for pathKind, sszSubType in walkDir(path, relative = true):
+      for pathKind, sszSubType in walkDir(
+          path, relative = true, checkDir = true):
         if pathKind != pcDir: continue
         try:
           sszCheck(path, sszType, sszSubType)

--- a/tests/slashing_protection/test_official_interchange_vectors.nim
+++ b/tests/slashing_protection/test_official_interchange_vectors.nim
@@ -211,7 +211,7 @@ proc runTest(identifier: string) =
     db.close()
     sqlite3db_delete(TestDir, dbname)
 
-
 suite "Slashing Interchange tests " & preset():
-  for kind, path in walkDir(InterchangeTestsDir, true):
+  for kind, path in walkDir(
+      InterchangeTestsDir, relative = true, checkDir = true):
     runTest(path)


### PR DESCRIPTION
Otherwise, tests can go missing across test fixture versions without explicit `make test` errors.