### PR TITLE
avoid recomputing base_reward_per_increment() across attestations

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -310,12 +310,23 @@ proc process_operations(preset: RuntimePreset,
                         cache: var StateCache): Result[void, cstring] {.nbench.} =
   # Verify that outstanding deposits are processed up to the maximum number of
   # deposits
+  template base_reward_per_increment(state: phase0.BeaconState): Gwei = 0.Gwei
+  template base_reward_per_increment(state: altair.BeaconState): Gwei =
+    get_base_reward_per_increment(state, cache)
+
   let
     req_deposits = min(MAX_DEPOSITS,
                        state.eth1_data.deposit_count - state.eth1_deposit_index)
+    generalized_base_reward_per_increment = base_reward_per_increment(state)
+
   if state.eth1_data.deposit_count < state.eth1_deposit_index or
       body.deposits.lenu64 != req_deposits:
     return err("incorrect number of deposits")
+
+  template do_process_attestation(state, operation, flags, cache: untyped):
+      untyped =
+    process_attestation(
+      state, operation, flags, generalized_base_reward_per_increment, cache)
 
   template for_ops(operations: auto, fn: auto) =
     for operation in operations:
@@ -325,7 +336,7 @@ proc process_operations(preset: RuntimePreset,
 
   for_ops(body.proposer_slashings, process_proposer_slashing)
   for_ops(body.attester_slashings, process_attester_slashing)
-  for_ops(body.attestations, process_attestation)
+  for_ops(body.attestations, do_process_attestation)
 
   for deposit in body.deposits:
     let res = process_deposit(preset, state, deposit, flags)

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -286,8 +286,11 @@ genProcessBlockScenario(runProcessProposerSlashing,
                         needFlags = true,
                         needCache = true)
 
+template do_process_attestation(state, operation, flags, cache: untyped):
+    untyped =
+  process_attestation(state, operation, flags, 0.Gwei, cache)
 genProcessBlockScenario(runProcessAttestation,
-                        process_attestation,
+                        do_process_attestation,
                         attestation,
                         Attestation,
                         needFlags = true,

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -98,7 +98,7 @@ template decodeAndProcess(typ, process: untyped): bool =
 proc nfuzz_attestation(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =
   decodeAndProcess(AttestationInput):
-    process_attestation(data.state, data.attestation, flags, cache).isOk
+    process_attestation(data.state, data.attestation, flags, 0.Gwei, cache).isOk
 
 proc nfuzz_attester_slashing(input: openArray[byte], xoutput: ptr byte,
     xoutput_size: ptr uint, disable_bls: bool): bool {.exportc, raises: [FuzzCrashError, Defect].} =

--- a/tests/official/altair/test_fixture_operations_attestations.nim
+++ b/tests/official/altair/test_fixture_operations_attestations.nim
@@ -51,12 +51,16 @@ proc runTest(identifier: string) =
       if existsFile(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(testDir/"post.ssz_snappy", SSZ, BeaconState))
-        let done = process_attestation(preState[], attestation, {}, cache).isOk
+        let done = process_attestation(
+          preState[], attestation, {},
+          get_base_reward_per_increment(preState[], cache), cache).isOk
         doAssert done, "Valid attestation not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_attestation(preState[], attestation, {}, cache).isOk
+        let done = process_attestation(
+          preState[], attestation, {},
+          get_base_reward_per_increment(preState[], cache), cache).isOk
         doAssert done == false, "We didn't expect this invalid attestation to be processed."
 
   `testImpl _ operations_attestations _ identifier`()

--- a/tests/official/phase0/test_fixture_operations_attestations.nim
+++ b/tests/official/phase0/test_fixture_operations_attestations.nim
@@ -51,12 +51,14 @@ proc runTest(identifier: string) =
       if existsFile(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(testDir/"post.ssz_snappy", SSZ, BeaconState))
-        let done = process_attestation(preState[], attestation, {}, cache).isOk
+        let done = process_attestation(
+          preState[], attestation, {}, 0.Gwei, cache).isOk
         doAssert done, "Valid attestation not processed"
         check: preState[].hash_tree_root() == postState[].hash_tree_root()
         reportDiff(preState, postState)
       else:
-        let done = process_attestation(preState[], attestation, {}, cache).isOk
+        let done = process_attestation(
+          preState[], attestation, {}, 0.Gwei, cache).isOk
         doAssert done == false, "We didn't expect this invalid attestation to be processed."
 
   `testImpl _ operations_attestations _ identifier`()

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -53,7 +53,7 @@ suite "[Unit - Spec - Block processing] Attestations " & preset():
       # ----------------------------------------
       var cache = StateCache()
       check process_attestation(
-        state.hbsPhase0.data, attestation, flags = {}, cache
+        state.hbsPhase0.data, attestation, flags = {}, 0.Gwei, cache
       ).isOk
 
       # Check that the attestation was processed


### PR DESCRIPTION
It decreases the portion of time that `block_sim --validators=100000` spends doing `process_attestations()` during block processing from 1.5% to 0.25%. It doesn't register much in the overall `block_sim` benchmarks, because at this point, it's predominantly (as with phase 0 for a long time) BLS cryptography, especially, signing all those attestations, but it'll matter more for a real network where one node isn't the entire network.