### PR TITLE
increase block attestation wait time

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -693,14 +693,18 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
       # An opposite case is that we received (or produced) a block that has
       # not yet reached our neighbours. To protect against our attestations
       # being dropped (because the others have not yet seen the block), we'll
-      # impose a minimum delay of 250ms. The delay is enforced only when we're
+      # impose a minimum delay of 1000ms. The delay is enforced only when we're
       # not hitting the "normal" cutoff time for sending out attestations.
+      # An earlier delay of 250ms has proven to be not enough, increasing the
+      # risk of losing attestations.
+      # Regardless, because we "just" received the block, we'll impose the
+      # delay.
 
-      const afterBlockDelay = 250
+      const afterBlockDelay = 1000
       let
         afterBlockTime = node.beaconClock.now() + millis(afterBlockDelay)
         afterBlockCutoff = node.beaconClock.fromNow(
-          min(afterBlockTime, attestationCutoffTime))
+          min(afterBlockTime, attestationCutoffTime + millis(afterBlockDelay)))
 
       if afterBlockCutoff.inFuture:
         debug "Got block, waiting to send attestations",


### PR DESCRIPTION
We generally send out attestations 250 ms after the block arrives.
Recent efficiency improvements have led to a slightly increased
incidence of "slot 0" issues  where attestations are dropped by other
nodes because they have not yet had time to process the block due to
epoch processing taking time.

This PR mitigates the problem by increasing the window between receiving
the block and sending out attestations.