### PR TITLE
add version metric (using labels)

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1,4 +1,3 @@
-# beacon_chain
 # Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -96,6 +95,9 @@ declareGauge ticks_delay,
 
 declareGauge next_action_wait,
   "Seconds until the next attestation will be sent"
+
+declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version", "commit"], name = "version"
+versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])
 
 logScope: topics = "beacnde"
 

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -1,4 +1,3 @@
-# beacon_chain
 # Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -22,7 +21,7 @@ const
 
   gitRevision* = strip(staticExec("git rev-parse --short HEAD"))[0..5]
 
-  nimBanner* = staticExec("nim --version | grep -v Compiled")
+  nimBanner* = staticExec("nim --version | grep Version")
 
   versionAsStr* =
     $versionMajor & "." & $versionMinor & "." & $versionBuild


### PR DESCRIPTION
One of these labels will be read by https://github.com/gobitfly/eth2-client-metrics-exporter to get our version string (a workaround for Prometheus metrics only having float values).

I also reduced the Nim compiler info included in our version string, because it was getting confusing.