### PR TITLE
More RuntimeConfig cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -178,11 +178,6 @@
 	url = https://github.com/status-im/nim-chronicles-tail.git
 	ignore = untracked
 	branch = master
-[submodule "vendor/eth2-testnets"]
-	path = vendor/eth2-testnets
-	url = https://github.com/eth2-clients/eth2-testnets.git
-	ignore = untracked
-	branch = master
 [submodule "vendor/nimbus-security-resources"]
 	path = vendor/nimbus-security-resources
 	url = https://github.com/status-im/nimbus-security-resources.git
@@ -214,3 +209,6 @@
 	ignore = untracked
 	branch = master
 
+[submodule "vendor/eth2-networks"]
+	path = vendor/eth2-networks
+	url = https://github.com/eth2-clients/eth2-networks.git

--- a/Makefile
+++ b/Makefile
@@ -345,8 +345,8 @@ define CONNECT_TO_NETWORK
 		--base-metrics-port $$(($(BASE_METRICS_PORT) + $(NODE_ID))) \
 		--config-file "build/data/shared_$(1)_$(NODE_ID)/prometheus.yml"
 
-	[ "$(3)" == "FastSync" ] && { export CHECKPOINT_PARAMS="--finalized-checkpoint-state=vendor/eth2-testnets/shared/$(1)/recent-finalized-state.ssz \
-																													--finalized-checkpoint-block=vendor/eth2-testnets/shared/$(1)/recent-finalized-block.ssz" ; }; \
+	[ "$(3)" == "FastSync" ] && { export CHECKPOINT_PARAMS="--finalized-checkpoint-state=vendor/eth2-networks/shared/$(1)/recent-finalized-state.ssz \
+																													--finalized-checkpoint-block=vendor/eth2-network/shared/$(1)/recent-finalized-block.ssz" ; }; \
 	$(CPU_LIMIT_CMD) build/$(2) \
 		--network=$(1) \
 		--log-level="$(RUNTIME_LOG_LEVEL)" \
@@ -419,7 +419,7 @@ define MAKE_DEPOSIT
 
 	build/deposit_contract sendDeposits \
 		--web3-url=$(WEB3_URL) \
-		--deposit-contract=$$(cat vendor/eth2-testnets/shared/$(1)/deposit_contract.txt) \
+		--deposit-contract=$$(cat vendor/eth2-network/shared/$(1)/deposit_contract.txt) \
 		--deposits-file=nbc-$(1)-deposits.json \
 		--min-delay=$(DEPOSITS_DELAY) \
 		--ask-for-key

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The [inspector tool](./ncli/inspector.nim) can help monitor the libp2p network a
 build/inspector_minimal --help
 
 # Connect to a network from eth2 testnet repo bootstrap file - --decode option attempts to decode the messages as well
-build/inspector_minimal --decode -b:$(curl -s https://raw.githubusercontent.com/eth2-clients/eth2-testnets/master/nimbus/testnet0/bootstrap_nodes.txt | head -n1)
+build/inspector_minimal --decode -b:$(curl -s https://raw.githubusercontent.com/eth2-clients/eth2-networks/master/nimbus/testnet0/bootstrap_nodes.txt | head -n1)
 ```
 
 ### CI setup

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -78,7 +78,6 @@ type
     db: SqStoreRef
 
     v0: BeaconChainDBV0
-    preset*: RuntimeConfig
     genesisDeposits*: DepositsSeq
 
     # immutableValidatorsDb only stores the total count; it's a proxy for SQL
@@ -264,7 +263,6 @@ proc loadImmutableValidators(vals: DbSeq[ImmutableValidatorData2]): seq[Immutabl
     result.add vals.get(i)
 
 proc new*(T: type BeaconChainDB,
-          preset: RuntimeConfig,
           dir: string,
           inMemory = false,
     ): BeaconChainDB =
@@ -334,7 +332,6 @@ proc new*(T: type BeaconChainDB,
       backend: backend,
       stateStore: stateStore,
     ),
-    preset: preset,
     genesisDeposits: genesisDepositsSeq,
     immutableValidatorsDb: immutableValidatorsDb,
     immutableValidators: loadImmutableValidators(immutableValidatorsDb),

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -76,6 +76,3 @@ template beaconClock*(node: BeaconNode): BeaconClock =
 
 proc currentSlot*(node: BeaconNode): Slot =
   node.beaconClock.now.slotOrZero
-
-template runtimePreset*(node: BeaconNode): RuntimeConfig =
-  node.db.preset

--- a/beacon_chain/eth1/deposit_contract.nim
+++ b/beacon_chain/eth1/deposit_contract.nim
@@ -183,54 +183,54 @@ proc sendDeposits*(deposits: seq[LaunchPadDeposit],
 
 {.pop.} # TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 proc main() {.async.} =
-  var cfg = CliConfig.load()
+  var conf = CliConfig.load()
   let rng = keys.newRng()
 
-  if cfg.cmd == StartUpCommand.generateSimulationDeposits:
+  if conf.cmd == StartUpCommand.generateSimulationDeposits:
     let
       mnemonic = generateMnemonic(rng[])
       seed = getSeed(mnemonic, KeyStorePass.init "")
-      runtimePreset = getRuntimePresetForNetwork(cfg.eth2Network)
+      cfg = getRuntimeConfig(conf.eth2Network)
 
-    let vres = secureCreatePath(string cfg.outValidatorsDir)
+    let vres = secureCreatePath(string conf.outValidatorsDir)
     if vres.isErr():
       warn "Could not create validators folder",
-           path = string cfg.outValidatorsDir, err = ioErrorMsg(vres.error)
+           path = string conf.outValidatorsDir, err = ioErrorMsg(vres.error)
 
-    let sres = secureCreatePath(string cfg.outSecretsDir)
+    let sres = secureCreatePath(string conf.outSecretsDir)
     if sres.isErr():
       warn "Could not create secrets folder",
-           path = string cfg.outSecretsDir, err = ioErrorMsg(sres.error)
+           path = string conf.outSecretsDir, err = ioErrorMsg(sres.error)
 
     let deposits = generateDeposits(
-      runtimePreset,
+      cfg,
       rng[],
       seed,
-      0, cfg.simulationDepositsCount,
-      string cfg.outValidatorsDir,
-      string cfg.outSecretsDir)
+      0, conf.simulationDepositsCount,
+      string conf.outValidatorsDir,
+      string conf.outSecretsDir)
 
     if deposits.isErr:
       fatal "Failed to generate deposits", err = deposits.error
       quit 1
 
     let launchPadDeposits =
-      mapIt(deposits.value, LaunchPadDeposit.init(runtimePreset, it))
+      mapIt(deposits.value, LaunchPadDeposit.init(cfg, it))
 
-    Json.saveFile(string cfg.outDepositsFile, launchPadDeposits)
-    notice "Deposit data written", filename = cfg.outDepositsFile
+    Json.saveFile(string conf.outDepositsFile, launchPadDeposits)
+    notice "Deposit data written", filename = conf.outDepositsFile
     quit 0
 
   var deposits: seq[LaunchPadDeposit]
-  if cfg.cmd == StartUpCommand.sendDeposits:
-    deposits = Json.loadFile(string cfg.depositsFile, seq[LaunchPadDeposit])
+  if conf.cmd == StartUpCommand.sendDeposits:
+    deposits = Json.loadFile(string conf.depositsFile, seq[LaunchPadDeposit])
 
-  if cfg.askForKey:
+  if conf.askForKey:
     var
       privateKey: TaintedString
       reasonForKey = ""
 
-    if cfg.cmd == StartUpCommand.sendDeposits:
+    if conf.cmd == StartUpCommand.sendDeposits:
       let
         depositsWord = if deposits.len > 1: "deposits" else: "deposit"
         totalEthNeeded = 32 * deposits.len
@@ -244,40 +244,40 @@ proc main() {.async.} =
       error "Failed to read an Eth1 private key from standard input"
 
     if privateKey.len > 0:
-      cfg.privateKey = privateKey.string
+      conf.privateKey = privateKey.string
 
-  let web3 = await initWeb3(cfg.web3Url, cfg.privateKey)
+  let web3 = await initWeb3(conf.web3Url, conf.privateKey)
 
-  case cfg.cmd
+  case conf.cmd
   of StartUpCommand.deploy:
     let receipt = await web3.deployContract(contractCode)
     echo receipt.contractAddress.get, ";", receipt.blockHash
 
   of StartUpCommand.drain:
     let sender = web3.contractSender(DepositContract,
-                                     cfg.drainedContractAddress)
+                                     conf.drainedContractAddress)
     discard await sender.drain().send(gasPrice = 1)
 
   of StartUpCommand.sendEth:
-    echo await sendEth(web3, cfg.toAddress, cfg.valueEth.parseInt)
+    echo await sendEth(web3, conf.toAddress, conf.valueEth.parseInt)
 
   of StartUpCommand.sendDeposits:
     var delayGenerator: DelayGenerator
-    if not (cfg.maxDelay > 0.0):
-      cfg.maxDelay = cfg.minDelay
-    elif cfg.minDelay > cfg.maxDelay:
+    if not (conf.maxDelay > 0.0):
+      conf.maxDelay = conf.minDelay
+    elif conf.minDelay > conf.maxDelay:
       echo "The minimum delay should not be larger than the maximum delay"
       quit 1
 
-    if cfg.maxDelay > 0.0:
+    if conf.maxDelay > 0.0:
       delayGenerator = proc (): chronos.Duration =
         let
-          minDelay = (cfg.minDelay*1000).int64
-          maxDelay = (cfg.maxDelay*1000).int64
+          minDelay = (conf.minDelay*1000).int64
+          maxDelay = (conf.maxDelay*1000).int64
         chronos.milliseconds (rng[].rand(maxDelay - minDelay) + minDelay)
 
-    await sendDeposits(deposits, cfg.web3Url, cfg.privateKey,
-                       cfg.depositContractAddress, delayGenerator)
+    await sendDeposits(deposits, conf.web3Url, conf.privateKey,
+                       conf.depositContractAddress, delayGenerator)
 
   of StartUpCommand.generateSimulationDeposits:
     # This is handled above before the case statement

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -72,7 +72,7 @@ type
       incompatibilityDesc*: string
 
 const
-  eth2testnetsDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/eth2-testnets"
+  eth2NetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/eth2-networks"
 
 proc readBootstrapNodes*(path: string): seq[string] {.raises: [IOError, Defect].} =
   # Read a list of ENR values from a YAML file containing a flat list of entries
@@ -156,7 +156,7 @@ proc loadEth2NetworkMetadata*(path: string): Eth2NetworkMetadata
                         incompatibilityDesc: err.msg)
 
 template eth2Network(path: string): Eth2NetworkMetadata =
-  loadEth2NetworkMetadata(eth2testnetsDir & "/" & path)
+  loadEth2NetworkMetadata(eth2NetworksDir & "/" & path)
 
 const
   mainnetMetadata* = eth2Network "shared/mainnet"
@@ -192,7 +192,7 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata {.raises: 
     quit 1
   return metadata
 
-proc getRuntimePresetForNetwork*(
+proc getRuntimeConfig*(
     eth2Network: Option[string]): RuntimeConfig {.raises: [Defect, IOError].} =
   if eth2Network.isSome:
     return getMetadataForNetwork(eth2Network.get).cfg

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -114,8 +114,7 @@ proc init*(T: type BeaconNode,
            genesisDepositsSnapshotContents: string): BeaconNode {.
     raises: [Defect, CatchableError].} =
   let
-    db = BeaconChainDB.new(
-      cfg, config.databaseDir, inMemory = false)
+    db = BeaconChainDB.new(config.databaseDir, inMemory = false)
 
   var
     genesisState, checkpointState: ref BeaconState
@@ -1651,10 +1650,10 @@ proc doCreateTestnet(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.raise
     outGenesis = config.outputGenesis.string
     eth1Hash = if config.web3Urls.len == 0: eth1BlockHash
                else: (waitFor getEth1BlockHash(config.web3Urls[0], blockId("latest"))).asEth2Digest
-    runtimePreset = getRuntimePresetForNetwork(config.eth2Network)
+    cfg = getRuntimeConfig(config.eth2Network)
   var
     initialState = initialize_beacon_state_from_eth1(
-      runtimePreset, eth1Hash, startTime, deposits, {skipBlsValidation})
+      cfg, eth1Hash, startTime, deposits, {skipBlsValidation})
 
   # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state
   initialState.genesis_time = startTime

--- a/beacon_chain/rpc/beacon_api.nim
+++ b/beacon_chain/rpc/beacon_api.nim
@@ -185,7 +185,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       genesis_time: getStateField(node.dag.headState.data, genesis_time),
       genesis_validators_root:
         getStateField(node.dag.headState.data, genesis_validators_root),
-      genesis_fork_version: node.runtimePreset.GENESIS_FORK_VERSION
+      genesis_fork_version: node.dag.cfg.GENESIS_FORK_VERSION
     )
 
   rpcServer.rpc("get_v1_beacon_states_root") do (stateId: string) -> Eth2Digest:

--- a/beacon_chain/rpc/beacon_rest_api.nim
+++ b/beacon_chain/rpc/beacon_rest_api.nim
@@ -111,7 +111,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         genesis_time: getStateField(node.dag.headState.data, genesis_time),
         genesis_validators_root:
           getStateField(node.dag.headState.data, genesis_validators_root),
-        genesis_fork_version: node.runtimePreset.GENESIS_FORK_VERSION
+        genesis_fork_version: node.dag.cfg.GENESIS_FORK_VERSION
       )
     )
 

--- a/beacon_chain/rpc/config_api.nim
+++ b/beacon_chain/rpc/config_api.nim
@@ -24,13 +24,6 @@ type
 template unimplemented() =
   raise (ref CatchableError)(msg: "Unimplemented")
 
-func getDepositAddress(node: BeaconNode): string =
-  if isNil(node.eth1Monitor):
-    ""
-  else:
-    $node.runtimePreset.DEPOSIT_CONTRACT_ADDRESS
-
-
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Exception].} = # TODO fix json-rpc
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:
@@ -41,33 +34,33 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "MAX_COMMITTEES_PER_SLOT": $MAX_COMMITTEES_PER_SLOT,
       "TARGET_COMMITTEE_SIZE": $TARGET_COMMITTEE_SIZE,
       "MAX_VALIDATORS_PER_COMMITTEE": $MAX_VALIDATORS_PER_COMMITTEE,
-      "MIN_PER_EPOCH_CHURN_LIMIT": $node.runtimePreset.MIN_PER_EPOCH_CHURN_LIMIT,
-      "CHURN_LIMIT_QUOTIENT": $node.runtimePreset.CHURN_LIMIT_QUOTIENT,
+      "MIN_PER_EPOCH_CHURN_LIMIT": $node.dag.cfg.MIN_PER_EPOCH_CHURN_LIMIT,
+      "CHURN_LIMIT_QUOTIENT": $node.dag.cfg.CHURN_LIMIT_QUOTIENT,
       "SHUFFLE_ROUND_COUNT": $SHUFFLE_ROUND_COUNT,
       "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT":
-        $node.runtimePreset.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
-      "MIN_GENESIS_TIME": $node.runtimePreset.MIN_GENESIS_TIME,
+        $node.dag.cfg.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
+      "MIN_GENESIS_TIME": $node.dag.cfg.MIN_GENESIS_TIME,
       "HYSTERESIS_QUOTIENT": $HYSTERESIS_QUOTIENT,
       "HYSTERESIS_DOWNWARD_MULTIPLIER": $HYSTERESIS_DOWNWARD_MULTIPLIER,
       "HYSTERESIS_UPWARD_MULTIPLIER": $HYSTERESIS_UPWARD_MULTIPLIER,
       "SAFE_SLOTS_TO_UPDATE_JUSTIFIED": $SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
-      "ETH1_FOLLOW_DISTANCE": $node.runtimePreset.ETH1_FOLLOW_DISTANCE,
+      "ETH1_FOLLOW_DISTANCE": $node.dag.cfg.ETH1_FOLLOW_DISTANCE,
       "TARGET_AGGREGATORS_PER_COMMITTEE": $TARGET_AGGREGATORS_PER_COMMITTEE,
       "RANDOM_SUBNETS_PER_VALIDATOR": $RANDOM_SUBNETS_PER_VALIDATOR,
       "EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION":
         $EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION,
-      "SECONDS_PER_ETH1_BLOCK": $node.runtimePreset.SECONDS_PER_ETH1_BLOCK,
-      "DEPOSIT_CHAIN_ID": $node.runtimePreset.DEPOSIT_CHAIN_ID,
-      "DEPOSIT_NETWORK_ID": $node.runtimePreset.DEPOSIT_NETWORK_ID,
-      "DEPOSIT_CONTRACT_ADDRESS": node.getDepositAddress,
+      "SECONDS_PER_ETH1_BLOCK": $node.dag.cfg.SECONDS_PER_ETH1_BLOCK,
+      "DEPOSIT_CHAIN_ID": $node.dag.cfg.DEPOSIT_CHAIN_ID,
+      "DEPOSIT_NETWORK_ID": $node.dag.cfg.DEPOSIT_NETWORK_ID,
+      "DEPOSIT_CONTRACT_ADDRESS": $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS,
       "MIN_DEPOSIT_AMOUNT": $MIN_DEPOSIT_AMOUNT,
       "MAX_EFFECTIVE_BALANCE": $MAX_EFFECTIVE_BALANCE,
-      "EJECTION_BALANCE": $node.runtimePreset.EJECTION_BALANCE,
+      "EJECTION_BALANCE": $node.dag.cfg.EJECTION_BALANCE,
       "EFFECTIVE_BALANCE_INCREMENT": $EFFECTIVE_BALANCE_INCREMENT,
       "GENESIS_FORK_VERSION":
-        "0x" & $node.runtimePreset.GENESIS_FORK_VERSION,
+        "0x" & $node.dag.cfg.GENESIS_FORK_VERSION,
       "BLS_WITHDRAWAL_PREFIX": "0x" & ncrutils.toHex([BLS_WITHDRAWAL_PREFIX]),
-      "GENESIS_DELAY": $node.runtimePreset.GENESIS_DELAY,
+      "GENESIS_DELAY": $node.dag.cfg.GENESIS_DELAY,
       "SECONDS_PER_SLOT": $SECONDS_PER_SLOT,
       "MIN_ATTESTATION_INCLUSION_DELAY": $MIN_ATTESTATION_INCLUSION_DELAY,
       "SLOTS_PER_EPOCH": $SLOTS_PER_EPOCH,
@@ -76,8 +69,8 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "EPOCHS_PER_ETH1_VOTING_PERIOD": $EPOCHS_PER_ETH1_VOTING_PERIOD,
       "SLOTS_PER_HISTORICAL_ROOT": $SLOTS_PER_HISTORICAL_ROOT,
       "MIN_VALIDATOR_WITHDRAWABILITY_DELAY":
-        $node.runtimePreset.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
-      "SHARD_COMMITTEE_PERIOD": $node.runtimePreset.SHARD_COMMITTEE_PERIOD,
+        $node.dag.cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+      "SHARD_COMMITTEE_PERIOD": $node.dag.cfg.SHARD_COMMITTEE_PERIOD,
       "MIN_EPOCHS_TO_INACTIVITY_PENALTY": $MIN_EPOCHS_TO_INACTIVITY_PENALTY,
       "EPOCHS_PER_HISTORICAL_VECTOR": $EPOCHS_PER_HISTORICAL_VECTOR,
       "EPOCHS_PER_SLASHINGS_VECTOR": $EPOCHS_PER_SLASHINGS_VECTOR,
@@ -112,6 +105,6 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
   rpcServer.rpc("get_v1_config_deposit_contract") do () -> JsonNode:
     return %*{
-      "chain_id": $node.runtimePreset.DEPOSIT_CHAIN_ID,
-      "address": node.getDepositAddress
+      "chain_id": $node.dag.cfg.DEPOSIT_CHAIN_ID,
+      "address": node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS
     }

--- a/beacon_chain/rpc/config_rest_api.nim
+++ b/beacon_chain/rpc/config_rest_api.nim
@@ -17,12 +17,6 @@ import
 
 logScope: topics = "rest_config"
 
-func getDepositAddress(node: BeaconNode): string =
-  if isNil(node.eth1Monitor):
-    "0x0000000000000000000000000000000000000000"
-  else:
-    $node.eth1Monitor.depositContractAddress
-
 proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/api/eth/v1/config/fork_schedule") do () -> RestApiResponse:
@@ -45,17 +39,17 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
         MAX_VALIDATORS_PER_COMMITTEE:
           Base10.toString(MAX_VALIDATORS_PER_COMMITTEE),
         MIN_PER_EPOCH_CHURN_LIMIT:
-          Base10.toString(node.runtimePreset.MIN_PER_EPOCH_CHURN_LIMIT),
+          Base10.toString(node.dag.cfg.MIN_PER_EPOCH_CHURN_LIMIT),
         CHURN_LIMIT_QUOTIENT:
-          Base10.toString(node.runtimePreset.CHURN_LIMIT_QUOTIENT),
+          Base10.toString(node.dag.cfg.CHURN_LIMIT_QUOTIENT),
         SHUFFLE_ROUND_COUNT:
           Base10.toString(SHUFFLE_ROUND_COUNT),
         MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:
           Base10.toString(
-            node.runtimePreset.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+            node.dag.cfg.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
           ),
         MIN_GENESIS_TIME:
-          Base10.toString(node.runtimePreset.MIN_GENESIS_TIME),
+          Base10.toString(node.dag.cfg.MIN_GENESIS_TIME),
         HYSTERESIS_QUOTIENT:
           Base10.toString(HYSTERESIS_QUOTIENT),
         HYSTERESIS_DOWNWARD_MULTIPLIER:
@@ -65,7 +59,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
         SAFE_SLOTS_TO_UPDATE_JUSTIFIED:
           Base10.toString(SAFE_SLOTS_TO_UPDATE_JUSTIFIED),
         ETH1_FOLLOW_DISTANCE:
-          Base10.toString(node.runtimePreset.ETH1_FOLLOW_DISTANCE),
+          Base10.toString(node.dag.cfg.ETH1_FOLLOW_DISTANCE),
         TARGET_AGGREGATORS_PER_COMMITTEE:
           Base10.toString(TARGET_AGGREGATORS_PER_COMMITTEE),
         RANDOM_SUBNETS_PER_VALIDATOR:
@@ -73,27 +67,27 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
         EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION:
           Base10.toString(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION),
         SECONDS_PER_ETH1_BLOCK:
-          Base10.toString(node.runtimePreset.SECONDS_PER_ETH1_BLOCK),
+          Base10.toString(node.dag.cfg.SECONDS_PER_ETH1_BLOCK),
         DEPOSIT_CHAIN_ID:
-          Base10.toString(uint64(node.runtimePreset.DEPOSIT_CHAIN_ID)),
+          Base10.toString(uint64(node.dag.cfg.DEPOSIT_CHAIN_ID)),
         DEPOSIT_NETWORK_ID:
-          Base10.toString(uint64(node.runtimePreset.DEPOSIT_NETWORK_ID)),
+          Base10.toString(uint64(node.dag.cfg.DEPOSIT_NETWORK_ID)),
         DEPOSIT_CONTRACT_ADDRESS:
-          node.getDepositAddress(),
+          $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS,
         MIN_DEPOSIT_AMOUNT:
           Base10.toString(MIN_DEPOSIT_AMOUNT),
         MAX_EFFECTIVE_BALANCE:
           Base10.toString(MAX_EFFECTIVE_BALANCE),
         EJECTION_BALANCE:
-          Base10.toString(node.runtimePreset.EJECTION_BALANCE),
+          Base10.toString(node.dag.cfg.EJECTION_BALANCE),
         EFFECTIVE_BALANCE_INCREMENT:
           Base10.toString(EFFECTIVE_BALANCE_INCREMENT),
         GENESIS_FORK_VERSION:
-          "0x" & $node.runtimePreset.GENESIS_FORK_VERSION,
+          "0x" & $node.dag.cfg.GENESIS_FORK_VERSION,
         BLS_WITHDRAWAL_PREFIX:
           "0x" & ncrutils.toHex([BLS_WITHDRAWAL_PREFIX]),
         GENESIS_DELAY:
-          Base10.toString(node.runtimePreset.GENESIS_DELAY),
+          Base10.toString(node.dag.cfg.GENESIS_DELAY),
         SECONDS_PER_SLOT:
           Base10.toString(uint64(SECONDS_PER_SLOT)),
         MIN_ATTESTATION_INCLUSION_DELAY:
@@ -110,9 +104,9 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           Base10.toString(SLOTS_PER_HISTORICAL_ROOT),
         MIN_VALIDATOR_WITHDRAWABILITY_DELAY:
           Base10.toString(
-            node.runtimePreset.MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
+            node.dag.cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
         SHARD_COMMITTEE_PERIOD:
-          Base10.toString(node.runtimePreset.SHARD_COMMITTEE_PERIOD),
+          Base10.toString(node.dag.cfg.SHARD_COMMITTEE_PERIOD),
         MIN_EPOCHS_TO_INACTIVITY_PENALTY:
           Base10.toString(MIN_EPOCHS_TO_INACTIVITY_PENALTY),
         EPOCHS_PER_HISTORICAL_VECTOR:
@@ -165,7 +159,10 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/api/eth/v1/config/deposit_contract") do () -> RestApiResponse:
     return RestApiResponse.jsonResponse(
-      (chain_id: $node.runtimePreset.DEPOSIT_CHAIN_ID, address: node.getDepositAddress())
+      (
+        chain_id: $node.dag.cfg.DEPOSIT_CHAIN_ID,
+        address: $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS
+      )
     )
 
   router.redirect(

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -30,7 +30,7 @@ type
   Eth1Address* = ethtypes.Address
 
   RuntimeConfig* = object
-    ## https://github.com/ethereum/eth2.0-specs/tree/1d5c4ecffbadc70b62189cb4219be055b8efa2e9/configs
+    ## https://github.com/ethereum/eth2.0-specs/tree/v1.1.0-alpha.8/configs
 
     PRESET_BASE*: string
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -322,7 +322,7 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
       assign(proposalStateAddr[], poolPtr.headState)
 
     return makeBeaconBlock(
-      node.runtimePreset,
+      node.dag.cfg,
       stateData.data.hbsPhase0,
       validator_index,
       head.root,

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -95,7 +95,7 @@ proc doTransition(conf: NcliConf) =
   var
     cache = StateCache()
     rewards = RewardInfo()
-  if not state_transition(getRuntimePresetForNetwork(conf.eth2Network),
+  if not state_transition(getRuntimeConfig(conf.eth2Network),
                           stateY[], blckX, cache, rewards, flags, noRollback):
     error "State transition failed"
     quit 1

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -154,14 +154,13 @@ proc getBlockRange(dag: ChainDAGRef, start, ends: Slot): seq[BlockRef] =
     cur = cur.parent
   blockRefs
 
-proc cmdBench(conf: DbConf, runtimePreset: RuntimeConfig) =
+proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
   var timers: array[Timers, RunningStat]
 
   echo "Opening database..."
   let
-    db = BeaconChainDB.new(
-      runtimePreset, conf.databaseDir.string,)
-    dbBenchmark = BeaconChainDB.new(runtimePreset, "benchmark")
+    db = BeaconChainDB.new(conf.databaseDir.string,)
+    dbBenchmark = BeaconChainDB.new("benchmark")
   defer:
     db.close()
     dbBenchmark.close()
@@ -172,7 +171,7 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimeConfig) =
 
   echo "Initializing block pool..."
   let dag = withTimerRet(timers[tInit]):
-    ChainDAGRef.init(runtimePreset, db, {})
+    ChainDAGRef.init(cfg, db, {})
 
   var
     (start, ends) = dag.getSlotRange(conf.benchSlot, conf.benchSlots)
@@ -238,8 +237,8 @@ proc cmdBench(conf: DbConf, runtimePreset: RuntimeConfig) =
 
   printTimers(false, timers)
 
-proc cmdDumpState(conf: DbConf, preset: RuntimeConfig) =
-  let db = BeaconChainDB.new(preset, conf.databaseDir.string)
+proc cmdDumpState(conf: DbConf) =
+  let db = BeaconChainDB.new(conf.databaseDir.string)
   defer: db.close()
 
   for stateRoot in conf.stateRoot:
@@ -253,8 +252,8 @@ proc cmdDumpState(conf: DbConf, preset: RuntimeConfig) =
     except CatchableError as e:
       echo "Couldn't load ", stateRoot, ": ", e.msg
 
-proc cmdDumpBlock(conf: DbConf, preset: RuntimeConfig) =
-  let db = BeaconChainDB.new(preset, conf.databaseDir.string)
+proc cmdDumpBlock(conf: DbConf) =
+  let db = BeaconChainDB.new(conf.databaseDir.string)
   defer: db.close()
 
   for blockRoot in conf.blockRootx:
@@ -339,11 +338,11 @@ proc copyPrunedDatabase(
     copyDb.putHeadBlock(headBlock.get)
     copyDb.putTailBlock(tailBlock.get)
 
-proc cmdPrune(conf: DbConf, preset: RuntimeConfig) =
+proc cmdPrune(conf: DbConf) =
   let
-    db = BeaconChainDB.new(preset, conf.databaseDir.string)
+    db = BeaconChainDB.new(conf.databaseDir.string)
     # TODO: add the destination as CLI paramter
-    copyDb = BeaconChainDB.new(preset, "pruned_db")
+    copyDb = BeaconChainDB.new("pruned_db")
 
   defer:
     db.close()
@@ -351,9 +350,9 @@ proc cmdPrune(conf: DbConf, preset: RuntimeConfig) =
 
   db.copyPrunedDatabase(copyDb, conf.dryRun, conf.verbose, conf.keepOldStates)
 
-proc cmdRewindState(conf: DbConf, preset: RuntimeConfig) =
+proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
   echo "Opening database..."
-  let db = BeaconChainDB.new(preset, conf.databaseDir.string)
+  let db = BeaconChainDB.new(conf.databaseDir.string)
   defer: db.close()
 
   if not ChainDAGRef.isInitialized(db):
@@ -361,7 +360,7 @@ proc cmdRewindState(conf: DbConf, preset: RuntimeConfig) =
     quit 1
 
   echo "Initializing block pool..."
-  let dag = init(ChainDAGRef, preset, db, {})
+  let dag = init(ChainDAGRef, cfg, db, {})
 
   let blckRef = dag.getRef(fromHex(Eth2Digest, conf.blockRoot))
   if blckRef == nil:
@@ -379,8 +378,8 @@ proc atCanonicalSlot(blck: BlockRef, slot: Slot): BlockSlot =
   else:
     blck.atSlot(slot - 1).blck.atSlot(slot)
 
-proc cmdExportEra(conf: DbConf, preset: RuntimeConfig) =
-  let db = BeaconChainDB.new(preset, conf.databaseDir.string)
+proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
+  let db = BeaconChainDB.new(conf.databaseDir.string)
   defer: db.close()
 
   if not ChainDAGRef.isInitialized(db):
@@ -389,7 +388,7 @@ proc cmdExportEra(conf: DbConf, preset: RuntimeConfig) =
 
   echo "Initializing block pool..."
   let
-    dag = init(ChainDAGRef, preset, db, {})
+    dag = init(ChainDAGRef, cfg, db, {})
 
   let tmpState = assignClone(dag.headState)
 
@@ -439,11 +438,10 @@ type
     first_slot_head_attester_when_first_slot_not_empty: uint64
     delays: Table[uint64, uint64]
 
-proc cmdValidatorPerf(conf: DbConf, runtimePreset: RuntimeConfig) =
+proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
   echo "Opening database..."
   let
-    db = BeaconChainDB.new(
-      runtimePreset, conf.databaseDir.string,)
+    db = BeaconChainDB.new(conf.databaseDir.string,)
   defer:
     db.close()
 
@@ -452,7 +450,7 @@ proc cmdValidatorPerf(conf: DbConf, runtimePreset: RuntimeConfig) =
     quit 1
 
   echo "# Initializing block pool..."
-  let dag = ChainDAGRef.init(runtimePreset, db, {})
+  let dag = ChainDAGRef.init(cfg, db, {})
 
   var
     (start, ends) = dag.getSlotRange(conf.perfSlot, conf.perfSlots)
@@ -569,12 +567,11 @@ proc cmdValidatorPerf(conf: DbConf, runtimePreset: RuntimeConfig) =
       perf.first_slot_head_attester_when_first_slot_empty,",",
       perf.first_slot_head_attester_when_first_slot_not_empty
 
-proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
+proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
   # Create a database with performance information for every epoch
   echo "Opening database..."
   let
-    db = BeaconChainDB.new(
-      runtimePreset, conf.databaseDir.string,)
+    db = BeaconChainDB.new(conf.databaseDir.string,)
   defer:
     db.close()
 
@@ -583,7 +580,7 @@ proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
     quit 1
 
   echo "Initializing block pool..."
-  let dag = ChainDAGRef.init(runtimePreset, db, {})
+  let dag = ChainDAGRef.init(cfg, db, {})
 
   let outDb = SqStoreRef.init(conf.outDir, "validatorDb").expect("DB")
   defer: outDb.close()
@@ -755,7 +752,7 @@ proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
     blck = db.getBlock(blockRefs[blockRefs.len - bi - 1].root).get()
     while getStateField(state[].data, slot) < blck.message.slot:
       let ok = process_slots(
-        runtimePreset, state[].data, getStateField(state[].data, slot) + 1, cache, rewards,
+        cfg, state[].data, getStateField(state[].data, slot) + 1, cache, rewards,
         {})
       doAssert ok, "Slot processing can't fail with correct inputs"
 
@@ -763,7 +760,7 @@ proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
         processEpoch()
 
     if not state_transition_block(
-        runtimePreset, state[].data, blck, cache, {}, noRollback):
+        cfg, state[].data, blck, cache, {}, noRollback):
       echo "State transition failed (!)"
       quit 1
 
@@ -771,7 +768,7 @@ proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
   # finalized
   while getStateField(state[].data, slot) <= ends:
     let ok = process_slots(
-      runtimePreset, state[].data, getStateField(state[].data, slot) + 1, cache,
+      cfg, state[].data, getStateField(state[].data, slot) + 1, cache,
       rewards, {})
     doAssert ok, "Slot processing can't fail with correct inputs"
 
@@ -781,22 +778,22 @@ proc cmdValidatorDb(conf: DbConf, runtimePreset: RuntimeConfig) =
 when isMainModule:
   var
     conf = DbConf.load()
-    runtimePreset = getRuntimePresetForNetwork(conf.eth2Network)
+    cfg = getRuntimeConfig(conf.eth2Network)
 
   case conf.cmd
   of bench:
-    cmdBench(conf, runtimePreset)
+    cmdBench(conf, cfg)
   of dumpState:
-    cmdDumpState(conf, runtimePreset)
+    cmdDumpState(conf)
   of dumpBlock:
-    cmdDumpBlock(conf, runtimePreset)
+    cmdDumpBlock(conf)
   of pruneDatabase:
-    cmdPrune(conf, runtimePreset)
+    cmdPrune(conf)
   of rewindState:
-    cmdRewindState(conf, runtimePreset)
+    cmdRewindState(conf, cfg)
   of exportEra:
-    cmdExportEra(conf, runtimePreset)
+    cmdExportEra(conf, cfg)
   of validatorPerf:
-    cmdValidatorPerf(conf, runtimePreset)
+    cmdValidatorPerf(conf, cfg)
   of validatorDb:
-    cmdValidatorDb(conf, runtimePreset)
+    cmdValidatorDb(conf, cfg)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -63,21 +63,21 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     genesisBlock = get_initial_beacon_block(state[].data)
     genesisTime = float state[].data.genesis_time
 
-  var runtimePreset = defaultRuntimeConfig
+  var cfg = defaultRuntimeConfig
 
-  runtimePreset.ALTAIR_FORK_EPOCH = 96.Slot.epoch
+  cfg.ALTAIR_FORK_EPOCH = 96.Slot.epoch
 
   echo "Starting simulation..."
 
-  let db = BeaconChainDB.new(runtimePreset, "block_sim_db")
+  let db = BeaconChainDB.new("block_sim_db")
   defer: db.close()
 
   ChainDAGRef.preInit(db, state[].data, state[].data, genesisBlock)
   putInitialDepositContractSnapshot(db, depositContractSnapshot)
 
   var
-    dag = ChainDAGRef.init(runtimePreset, db, {})
-    eth1Chain = Eth1Chain.init(runtimePreset, db)
+    dag = ChainDAGRef.init(cfg, db, {})
+    eth1Chain = Eth1Chain.init(cfg, db)
     merkleizer = depositContractSnapshot.createMerkleizer
     quarantine = QuarantineRef.init(keys.newRng())
     attPool = AttestationPool.init(dag, quarantine)
@@ -147,7 +147,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         else:
           static: doAssert false
       message = makeBeaconBlock(
-        runtimePreset,
+        cfg,
         hashedState[],
         proposerIdx,
         dag.head.root,

--- a/scripts/reset_testnet.sh
+++ b/scripts/reset_testnet.sh
@@ -26,8 +26,8 @@ echo "Bootstrap node hostname : ${BOOTSTRAP_HOST:="master-01.aws-eu-central-1a.n
 echo "Bootstrap node ip       : ${BOOTSTRAP_IP:="$(dig +short $BOOTSTRAP_HOST)"}"
 echo "Bootstrap node port     : ${BOOTSTRAP_PORT:=9000}"
 echo "Reset testnet at end    : ${PUBLISH_TESTNET_RESETS:="1"}"
-echo "Testnet metadata repo   : ${ETH2_TESTNETS_GIT_URL:="git@github.com:${ETH2_TESTNETS_ORG:=eth2-clients}/eth2-testnets"}"
-echo "Testnet metadata dir    : ${ETH2_TESTNETS:="build/eth2-testnets"}"
+echo "Testnet metadata repo   : ${ETH2_TESTNETS_GIT_URL:="git@github.com:${ETH2_TESTNETS_ORG:=eth2-clients}/eth2-networks"}"
+echo "Testnet metadata dir    : ${ETH2_TESTNETS:="build/eth2-networks"}"
 echo "Beacon node data dir    : ${DATA_DIR:="build/testnet-reset-data/$NETWORK"}"
 echo "Nim build flags         : $NETWORK_NIM_FLAGS"
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -54,13 +54,13 @@ func withDigest(blck: altair.TrustedBeaconBlock):
 suite "Beacon chain DB" & preset():
   test "empty database" & preset():
     var
-      db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+      db = BeaconChainDB.new("", inMemory = true)
     check:
       db.getPhase0StateRef(Eth2Digest()).isNil
       db.getBlock(Eth2Digest()).isNone
 
   test "sanity check phase 0 blocks" & preset():
-    var db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+    var db = BeaconChainDB.new("", inMemory = true)
 
     let
       signedBlock = withDigest((phase0.TrustedBeaconBlock)())
@@ -89,7 +89,7 @@ suite "Beacon chain DB" & preset():
     db.close()
 
   test "sanity check Altair blocks" & preset():
-    var db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+    var db = BeaconChainDB.new("", inMemory = true)
 
     let
       signedBlock = withDigest((altair.TrustedBeaconBlock)())
@@ -272,7 +272,7 @@ suite "Beacon chain DB" & preset():
 
   test "find ancestors" & preset():
     var
-      db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+      db = BeaconChainDB.new("", inMemory = true)
 
     let
       a0 = withDigest(
@@ -318,7 +318,7 @@ suite "Beacon chain DB" & preset():
     # serialization where an all-zero default-initialized bls signature could
     # not be deserialized because the deserialization was too strict.
     var
-      db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+      db = BeaconChainDB.new("", inMemory = true)
 
     let
       state = initialize_beacon_state_from_eth1(
@@ -339,7 +339,7 @@ suite "Beacon chain DB" & preset():
 
   test "sanity check state diff roundtrip" & preset():
     var
-      db = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+      db = BeaconChainDB.new("", inMemory = true)
 
     # TODO htr(diff) probably not interesting/useful, but stand-in
     let

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -16,7 +16,7 @@ import
 export beacon_chain_db, testblockutil, kvstore, kvstore_sqlite3
 
 proc makeTestDB*(tailState: var BeaconState, tailBlock: TrustedSignedBeaconBlock): BeaconChainDB =
-  result = BeaconChainDB.new(defaultRuntimeConfig, "", inMemory = true)
+  result = BeaconChainDB.new("", inMemory = true)
   ChainDAGRef.preInit(result, tailState, tailState, tailBlock)
 
 proc makeTestDB*(validators: Natural): BeaconChainDB =


### PR DESCRIPTION
* remove from BeaconChainDB (doesn't depend on runtime config)
* eth2-testnets -> eth2-networks
* use `cfg` name throughout