### PR TITLE
Parallel attestation verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             ulimit -n 1024
           fi
-          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node nimbus_validator_client
+          make V=1 -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node nimbus_validator_client
 
       - name: Run nimbus-eth2 tests
         if: matrix.target.TEST_KIND == 'unit-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
         shell: bash
         working-directory: nimbus-eth2
         run: |
-          PS4='Line ${LINENO}: ' bash -x scripts/setup_official_tests.sh fixturesCache
+          scripts/setup_official_tests.sh fixturesCache
 
       - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
         if: matrix.target.TEST_KIND == 'unit-tests'
@@ -274,7 +274,7 @@ jobs:
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             ulimit -n 1024
           fi
-          make V=1 -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node nimbus_validator_client
+          make -j$ncpu ARCH_OVERRIDE=$PLATFORM LOG_LEVEL=TRACE NIMFLAGS="-d:testnet_servers_image" nimbus_beacon_node nimbus_validator_client
 
       - name: Run nimbus-eth2 tests
         if: matrix.target.TEST_KIND == 'unit-tests'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
         shell: bash
         working-directory: nimbus-eth2
         run: |
-          scripts/setup_official_tests.sh fixturesCache
+          PS4='Line ${LINENO}: ' bash -x scripts/setup_official_tests.sh fixturesCache
 
       - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
         if: matrix.target.TEST_KIND == 'unit-tests'

--- a/.gitmodules
+++ b/.gitmodules
@@ -203,7 +203,9 @@
 	url = https://github.com/status-im/nim-presto.git
 	ignore = untracked
 	branch = master
-
 [submodule "vendor/eth2-networks"]
 	path = vendor/eth2-networks
 	url = https://github.com/eth2-clients/eth2-networks.git
+[submodule "vendor/nim-taskpools"]
+	path = vendor/nim-taskpools
+	url = https://github.com/status-im/nim-taskpools

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  stew/[assign2, objects, results],
+  stew/[assign2, results],
   serialization,
   eth/db/kvstore,
   ./spec/datatypes/[base, altair],

--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -12,6 +12,7 @@ import
 
   # Nimble packages
   chronos, json_rpc/servers/httpserver, presto,
+  taskpools,
 
   # Local modules
   ./conf, ./beacon_clock, ./beacon_chain_db,
@@ -31,6 +32,7 @@ export
 
 type
   RpcServer* = RpcHttpServer
+  TaskPoolPtr* = TaskPool
 
   GossipState* = enum
     Disconnected
@@ -65,6 +67,7 @@ type
     attachedValidatorBalanceTotal*: uint64
     gossipState*: GossipState
     beaconClock*: BeaconClock
+    taskpool*: TaskPoolPtr
 
 const
   MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -157,8 +157,8 @@ type
       name: "slashing-db-kind" }: SlashingDbKind
 
     numThreads* {.
-      defaultValue: 0,
-      desc: "Number of threads used (0 for all logical threads)"
+      defaultValue: 1,
+      desc: "Number of threads used (0 to use all logical threads)"
       name: "num-threads" }: int
 
     case cmd* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -156,6 +156,11 @@ type
       desc: "The slashing DB flavour to use"
       name: "slashing-db-kind" }: SlashingDbKind
 
+    numThreads* {.
+      defaultValue: 0,
+      desc: "Number of threads used (0 for all logical threads)"
+      name: "num-threads" }: int
+
     case cmd* {.
       command
       defaultValue: noCommand }: BNStartUpCmd

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -12,7 +12,7 @@ import
   std/[sets, tables, hashes],
   # Status libraries
   stew/endians2, chronicles,
-  eth/keys,
+  eth/keys, taskpools,
   # Internals
   ../spec/[signatures_batch, forks],
   ../spec/datatypes/[phase0, altair],
@@ -77,6 +77,10 @@ type
     ## A reference to the Nimbus application-wide RNG
 
     inAdd*: bool
+
+    taskpool*: TaskPoolPtr
+
+  TaskPoolPtr* = TaskPool
 
   MissingBlock* = object
     tries*: int

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -21,9 +21,7 @@ logScope:
   topics = "quarant"
 
 func init*(T: type QuarantineRef, rng: ref BrHmacDrbgContext, taskpool: TaskpoolPtr): T =
-  result = T()
-  result.rng = rng
-  result.taskpool = taskpool
+  T(rng: rng, taskpool: taskpool)
 
 func checkMissing*(quarantine: QuarantineRef): seq[FetchRecord] =
   ## Return a list of blocks that we should try to resolve from other client -

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -20,9 +20,10 @@ export options, block_pools_types
 logScope:
   topics = "quarant"
 
-func init*(T: type QuarantineRef, rng: ref BrHmacDrbgContext): T =
+func init*(T: type QuarantineRef, rng: ref BrHmacDrbgContext, taskpool: TaskpoolPtr): T =
   result = T()
   result.rng = rng
+  result.taskpool = taskpool
 
 func checkMissing*(quarantine: QuarantineRef): seq[FetchRecord] =
   ## Return a list of blocks that we should try to resolve from other client -

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -11,7 +11,7 @@ import
   # Status
   chronicles, chronos,
   stew/results,
-  eth/keys,
+  eth/keys, taskpools,
   # Internals
   ../spec/[helpers, signatures_batch],
   ../spec/datatypes/base,
@@ -67,6 +67,10 @@ type
     rng: ref BrHmacDrbgContext  ##\
     ## A reference to the Nimbus application-wide RNG
     pruneTime: Moment ## :ast time we had to prune something
+    ## A pointer to the Nimbus application-wide threadpool
+    taskpool: TaskPoolPtr
+
+  TaskPoolPtr* = TaskPool
 
 const
   # We cap waiting for an idle slot in case there's a lot of network traffic
@@ -84,8 +88,9 @@ const
   BatchedCryptoSize = 16
 
 proc new*(
-    T: type BatchCrypto, rng: ref BrHmacDrbgContext, eager: Eager): ref BatchCrypto =
-  (ref BatchCrypto)(rng: rng, eager: eager, pruneTime: Moment.now())
+    T: type BatchCrypto, rng: ref BrHmacDrbgContext,
+    eager: Eager, taskpool: TaskPoolPtr): ref BatchCrypto =
+  (ref BatchCrypto)(rng: rng, eager: eager, pruneTime: Moment.now(), taskpool: taskpool)
 
 func len(batch: Batch): int =
   doAssert batch.resultsBuffer.len() == batch.pendingBuffer.len()
@@ -146,11 +151,13 @@ proc processBatch(batchCrypto: ref BatchCrypto) =
   var secureRandomBytes: array[32, byte]
   batchCrypto[].rng[].brHmacDrbgGenerate(secureRandomBytes)
 
-  # TODO: For now only enable serial batch verification
-  let ok = batchVerifySerial(
-    batchCrypto.sigVerifCache,
-    batch.pendingBuffer,
-    secureRandomBytes)
+  let ok = try:
+    batchCrypto.taskpool.batchVerify(
+      batchCrypto.sigVerifCache,
+      batch.pendingBuffer,
+      secureRandomBytes)
+  except Exception as exc:
+    raise newException(Defect, "Unexpected exception in batchVerify.")
 
   trace "batch crypto - finished",
     batchSize,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -102,7 +102,9 @@ proc new*(T: type Eth2Processor,
           syncCommitteeMsgPool: SyncCommitteeMsgPoolRef,
           quarantine: QuarantineRef,
           rng: ref BrHmacDrbgContext,
-          getBeaconTime: GetBeaconTimeFn): ref Eth2Processor =
+          getBeaconTime: GetBeaconTimeFn,
+          taskpool: batch_validation.TaskPoolPtr
+         ): ref Eth2Processor =
   (ref Eth2Processor)(
     doppelGangerDetectionEnabled: doppelGangerDetectionEnabled,
     doppelgangerDetection: DoppelgangerProtection(
@@ -119,7 +121,8 @@ proc new*(T: type Eth2Processor,
       rng = rng,
       # Only run eager attestation signature verification if we're not
       # processing blocks in order to give priority to block processing
-      eager = proc(): bool = not blockProcessor[].hasBlocks())
+      eager = proc(): bool = not blockProcessor[].hasBlocks(),
+      taskpool)
   )
 
 # Gossip Management

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -16,6 +16,7 @@ import
   chronos, confutils, metrics, metrics/chronos_httpserver,
   chronicles, bearssl, blscurve, presto,
   json_serialization/std/[options, sets, net], serialization/errors,
+  taskpools,
 
   eth/[keys, async_utils], eth/net/nat,
   eth/db/[kvstore, kvstore_sqlite3],
@@ -109,6 +110,22 @@ proc init*(T: type BeaconNode,
            genesisStateContents: string,
            genesisDepositsSnapshotContents: string): BeaconNode {.
     raises: [Defect, CatchableError].} =
+
+  var taskpool: TaskpoolPtr
+
+  try:
+    if config.numThreads < 0:
+      fatal "The number of threads --numThreads cannot be negative."
+      quit 1
+    elif config.numThreads == 0:
+      taskpool = TaskpoolPtr.new()
+    else:
+      taskpool = TaskpoolPtr.new(numThreads = config.numThreads)
+
+    info "Threadpool started", numThreads = taskpool.numThreads
+  except Exception as exc:
+    raise newException(Defect, "Failure in taskpool initialization.")
+
   let
     db = BeaconChainDB.new(config.databaseDir, inMemory = false)
 
@@ -239,7 +256,7 @@ proc init*(T: type BeaconNode,
     chainDagFlags = if config.verifyFinalization: {verifyFinalization}
                      else: {}
     dag = ChainDAGRef.init(cfg, db, chainDagFlags)
-    quarantine = QuarantineRef.init(rng)
+    quarantine = QuarantineRef.init(rng, taskpool)
     databaseGenesisValidatorsRoot =
       getStateField(dag.headState.data, genesis_validators_root)
 
@@ -345,7 +362,7 @@ proc init*(T: type BeaconNode,
     processor = Eth2Processor.new(
       config.doppelgangerDetection,
       blockProcessor, dag, attestationPool, exitPool, validatorPool,
-      syncCommitteeMsgPool, quarantine, rng, getBeaconTime)
+      syncCommitteeMsgPool, quarantine, rng, getBeaconTime, taskpool)
 
   var node = BeaconNode(
     nickname: nickname,
@@ -369,7 +386,8 @@ proc init*(T: type BeaconNode,
     blockProcessor: blockProcessor,
     consensusManager: consensusManager,
     requestManager: RequestManager.init(network, blockProcessor),
-    beaconClock: beaconClock
+    beaconClock: beaconClock,
+    taskpool: taskpool
   )
 
   # set topic validation routine

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -18,7 +18,7 @@ import
   math, stats, times, strformat,
   tables, options, random, tables, os,
   confutils, chronicles, eth/db/kvstore_sqlite3,
-  chronos/timer, eth/keys,
+  chronos/timer, eth/keys, taskpools,
   ../tests/testblockutil,
   ../beacon_chain/spec/[
     beaconstate, forks, helpers, signatures, state_transition],
@@ -89,7 +89,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     dag = ChainDAGRef.init(cfg, db, {})
     eth1Chain = Eth1Chain.init(cfg, db)
     merkleizer = depositContractSnapshot.createMerkleizer
-    quarantine = QuarantineRef.init(keys.newRng())
+    taskpool = Taskpool.new()
+    quarantine = QuarantineRef.init(keys.newRng(), taskpool)
     attPool = AttestationPool.init(dag, quarantine)
     syncCommitteePool = newClone SyncCommitteeMsgPool.init()
     timers: array[Timers, RunningStat]

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -13,7 +13,7 @@ import
   unittest2,
   chronicles, chronos,
   stew/byteutils,
-  eth/keys,
+  eth/keys, taskpools,
   # Internal
   ../beacon_chain/[beacon_node_types],
   ../beacon_chain/gossip_processing/[gossip_validation],
@@ -60,7 +60,8 @@ suite "Attestation pool processing" & preset():
     # Genesis state that results in 6 members per committee
     var
       dag = init(ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 6), {})
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -542,7 +542,8 @@ suite "Old database versions" & preset():
         makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation})
       genBlock = get_initial_beacon_block(genState[])
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
 
   test "pre-1.1.0":
     # only kvstore, no immutable validator keys

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -12,7 +12,7 @@ import
   std/[options, sequtils],
   unittest2,
   stew/assign2,
-  eth/keys,
+  eth/keys, taskpools,
   ../beacon_chain/spec/datatypes/base,
   ../beacon_chain/spec/[beaconstate, forks, helpers, state_transition],
   ../beacon_chain/beacon_node_types,
@@ -120,7 +120,8 @@ suite "Block pool processing" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, {})
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
       nilPhase0Callback: OnPhase0BlockAdded
       state = newClone(dag.headState.data)
       cache = StateCache()
@@ -347,7 +348,9 @@ suite "chain DAG finalization tests" & preset():
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, {})
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
+      nilPhase0Callback: OnPhase0BlockAdded
       cache = StateCache()
       rewards = RewardInfo()
 

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -16,8 +16,7 @@ import "."/[testutil, testdbutil]
 proc getExitPool(): auto =
   let dag =
     init(ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3), {})
-  let taskpool = Taskpool.new()
-  newClone(ExitPool.init(dag, QuarantineRef.init(keys.newRng(), taskpool)))
+  newClone(ExitPool.init(dag))
 
 suite "Exit pool testing suite":
   setup:

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -7,16 +7,17 @@
 
 {.used.}
 
-import chronicles
-import eth/keys
-import ../beacon_chain/spec/datatypes/base
-import ../beacon_chain/consensus_object_pools/[blockchain_dag, exit_pool]
+import chronicles, chronos
+import eth/keys, taskpools
+import ../beacon_chain/spec/[datatypes/base, presets]
+import ../beacon_chain/consensus_object_pools/[block_quarantine, blockchain_dag, exit_pool]
 import "."/[testutil, testdbutil]
 
 proc getExitPool(): auto =
   let dag =
     init(ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3), {})
-  newClone(ExitPool.init(dag))
+  let taskpool = Taskpool.new()
+  newClone(ExitPool.init(dag, QuarantineRef.init(keys.newRng(), taskpool)))
 
 suite "Exit pool testing suite":
   setup:

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -11,7 +11,7 @@ import
   # Status lib
   unittest2,
   chronicles, chronos,
-  eth/keys,
+  eth/keys, taskpools
   # Internal
   ../beacon_chain/[beacon_node_types, beacon_clock],
   ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
@@ -38,7 +38,8 @@ suite "Gossip validation " & preset():
       state = newClone(dag.headState)
       cache = StateCache()
       rewards = RewardInfo()
-      batchCrypto = BatchCrypto.new(keys.newRng(), eager = proc(): bool = false)
+      taskpool = TaskPool.new()
+      batchCrypto = BatchCrypto.new(keys.newRng(), eager = proc(): bool = false, taskpool)
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:
       process_slots(

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -11,7 +11,7 @@ import
   # Status lib
   unittest2,
   chronicles, chronos,
-  eth/keys, taskpools
+  eth/keys, taskpools,
   # Internal
   ../beacon_chain/[beacon_node_types, beacon_clock],
   ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
@@ -33,12 +33,12 @@ suite "Gossip validation " & preset():
     # Genesis state that results in 3 members per committee
     var
       dag = init(ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3), {})
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()
       rewards = RewardInfo()
-      taskpool = TaskPool.new()
       batchCrypto = BatchCrypto.new(keys.newRng(), eager = proc(): bool = false, taskpool)
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:


### PR DESCRIPTION
This adds parallel attestation verification using [nim-taskpools](https://github.com/status-im/nim-taskpools).

First tests on mainnet show (on a 36 cores CPU) that unlike my first experiment with OpenMP, the extra cores are turned off very fast which help reduce power consumption to the strict minimum. That said the scalability isn't as good as openMP at the moment maybe because of some latency but the speed up is still significant (see last remark in https://github.com/status-im/nim-blscurve/pull/116#issue-686145100)

Example ratio of time used per core on mainnet in after 10 min launch (node already synced)

![image](https://user-images.githubusercontent.com/22738317/125518587-a905a04c-76bf-435e-acae-3535ffc651a6.png)

Unused cores are never started, minimizing power consumption. And the time spent on the extra cores is less than 5 seconds per core. I'm unsure why the main process time count is only 4min though so this needs less coarse grained energy consumption evaluation.