### PR TITLE
Remove raises Exception and bump nim-eth

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -645,7 +645,7 @@ proc setEventHandlers(p: ProtocolInfo,
   p.onPeerConnected = onPeerConnected
   p.onPeerDisconnected = onPeerDisconnected
 
-proc implementSendProcBody(sendProc: SendProc) {.raises: [Exception].} =
+proc implementSendProcBody(sendProc: SendProc) =
   let
     msg = sendProc.msg
     UntypedResponse = bindSym "UntypedResponse"

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -122,7 +122,7 @@ suite "Eth2 specific discovery tests":
       check node2.updateRecord(
         {"eth2": SSZ.encode(enrForkId), "attnets": SSZ.encode(attnets)}).isOk()
 
-      let nodes = await node1.findNode(node2.localNode, @[0'u32])
+      let nodes = await node1.findNode(node2.localNode, @[0'u16])
       check nodes.isOk() and nodes[].len > 0
       discard node1.addNode(nodes[][0])
 


### PR DESCRIPTION
Is there a reason why there is a `{.raises: [Exception].}` there? Or is it an accidental leftover?

When removed https://github.com/status-im/nim-eth/pull/374 works.