### PR TITLE
Zero sig checks

### DIFF
--- a/beacon_chain/rpc/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/rpc/eth2_json_rpc_serialization.nim
@@ -67,6 +67,13 @@ proc fromJson*(n: JsonNode, argName: string, result: var ValidatorSig) {.raises:
 proc `%`*(value: ValidatorSig): JsonNode =
   newJString(toJsonHex(toRaw(value)))
 
+proc fromJson*(n: JsonNode, argName: string, result: var NullableValidatorSig) {.raises: [Defect, ValueError].} =
+  n.kind.expect(JString, argName)
+  result = NullableValidatorSig.fromHex(n.getStr()).tryGet()
+
+proc `%`*(value: NullableValidatorSig): JsonNode =
+  newJString(toJsonHex(toRaw(value)))
+
 proc fromJson*(n: JsonNode, argName: string, result: var TrustedSig) {.raises: [Defect, ValueError].} =
   n.kind.expect(JString, argName)
   hexToByteArray(n.getStr(), result.data)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -357,7 +357,7 @@ type
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#signedbeaconblockheader
   SignedBeaconBlockHeader* = object
     message*: BeaconBlockHeader
-    signature*: ValidatorSig
+    signature*: NullableValidatorSig # Genesis block has zero signature (different from infinity sig)
 
   TrustedSignedBeaconBlockHeader* = object
     message*: BeaconBlockHeader

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -34,7 +34,7 @@ func `$`*(s: SignatureSet): string =
 #     there is no guarantee that pubkeys and signatures received are valid
 #     unlike when Nimbus did eager loading which ensured they were correct beforehand
 
-template loadOrExit(signature: ValidatorSig, error: cstring):
+template loadOrExit(signature: ValidatorSig|NullableValidatorSig, error: cstring):
     untyped =
   ## Load a BLS signature from a raw signature
   ## Exits the **caller** with false if the signature is invalid

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -8,6 +8,7 @@
 {.used.}
 
 import
+  std/strutils,
   unittest2,
   ../beacon_chain/spec/crypto,
   ../beacon_chain/spec/datatypes/base,
@@ -53,3 +54,12 @@ suite "Zero signature sanity checks":
       SSZ.decode(sszDefaultBlockHeader, SignedBeaconBlockHeader)
 
     check(defaultBlockHeader == deserBlockHeader)
+
+  test "default initialization of signatures":
+    block:
+      let sig = default(CookedSig)
+      doAssert sig.toValidatorSig().toHex() == "c" & '0'.repeat(191)
+
+    block:
+      let sig = AggregateSignature()
+      doAssert sig.toHex() == "c" & '0'.repeat(191)

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -63,3 +63,7 @@ suite "Zero signature sanity checks":
     block:
       let sig = AggregateSignature()
       doAssert sig.toHex() == "c" & '0'.repeat(191)
+
+    block:
+      let sig = ValidatorSig()
+      doAssert sig.toHex() == "c" & '0'.repeat(191)


### PR DESCRIPTION
We sent blocks with a zero signature instead of an infinity signature in Altair.

This adds checks to ensure that on serialization of signatures, in particular empty aggregates or defautl init ones we send `0xc000...0000` which is the infinity point serialized.

-----

Source of the bug:

By delaying the deserialization of signatures up until they are needed (https://github.com/status-im/nimbus-eth2/pull/2259)

https://github.com/status-im/nimbus-eth2/blob/07a1c5716b707e7244eb312bed68c92c1fb9508d/beacon_chain/spec/crypto.nim#L64-L65, sometimes they are never needed.
In that case empty signatures will be hex-serialized as 0x0000...0000.

Solution, we need to check for a full zero byte array in a custom `toHex` function.