### PR TITLE
enable trace-level networking logging in local simulation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,12 +57,12 @@ def runStages() {
 			// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
 			sh """#!/bin/bash
 			set -e
-			./scripts/launch_local_testnet.sh --preset minimal --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace \
+			./scripts/launch_local_testnet.sh --preset minimal --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
 				--data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port \
 				\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 600 \
 				--kill-old-processes \
 				-- --verify-finalization --discv5:no
-			./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace \
+			./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
 				--data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port \
 				\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 2400 \
 				--kill-old-processes \

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -40,7 +40,7 @@ DATA_DIR="local_testnet_data"
 USE_HTOP="1"
 USE_VC="1"
 USE_GANACHE="0"
-LOG_LEVEL="DEBUG"
+LOG_LEVEL="DEBUG; TRACE:networking"
 BASE_PORT="9000"
 BASE_METRICS_PORT="8008"
 BASE_RPC_PORT="7000"
@@ -228,7 +228,7 @@ if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
   BINARIES="${BINARIES} logtrace"
 fi
 
-$MAKE -j ${NPROC} LOG_LEVEL="${LOG_LEVEL}" NIMFLAGS="${NIMFLAGS} -d:testnet_servers_image -d:local_testnet -d:const_preset=${CONST_PRESET}" ${BINARIES}
+$MAKE -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:testnet_servers_image -d:local_testnet -d:const_preset=${CONST_PRESET}" ${BINARIES}
 
 # Kill child processes on Ctrl-C/SIGTERM/exit, passing the PID of this shell
 # instance as the parent and the target process name as a pattern to the


### PR DESCRIPTION
It enables the following two logging messages:
```
nimbus-eth2/local_testnet_data$ grep -rh TRC . | jq .msg | sort | uniq
"Number of peers has been changed"
"Outgoing pubsub message sent"
```