### PR TITLE
switch result = foo to expression return; unexport rest of logtrace symbols

### DIFF
--- a/beacon_chain/statusbar.nim
+++ b/beacon_chain/statusbar.nim
@@ -41,7 +41,7 @@ const
 
 func loadFragmentsLayout(contentLayout: string): ContentFragments {.
     raises: [Defect, ValueError].} =
-  result = toSeq(interpolatedFragments(strip contentLayout))
+  toSeq(interpolatedFragments(strip contentLayout))
 
 func loadCellsLayout(cellsLayout: string): seq[StatusBarCell] {.
     raises: [Defect, ValueError].} =

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -173,14 +173,14 @@ proc getShortMap*[T](req: SyncRequest[T],
     else:
       res.add('.')
     slider = slider + req.step
-  result = res
+  res
 
 proc contains*[T](req: SyncRequest[T], slot: Slot): bool {.inline.} =
   slot >= req.slot and slot < req.slot + req.count * req.step and
     ((slot - req.slot) mod req.step == 0)
 
 proc cmp*[T](a, b: SyncRequest[T]): int =
-  result = cmp(uint64(a.slot), uint64(b.slot))
+  cmp(uint64(a.slot), uint64(b.slot))
 
 proc checkResponse*[T](req: SyncRequest[T],
                        data: openArray[ForkedSignedBeaconBlock]): bool =
@@ -215,39 +215,39 @@ proc checkResponse*[T](req: SyncRequest[T],
 proc getFullMap*[T](req: SyncRequest[T],
                     data: openArray[ForkedSignedBeaconBlock]): string =
   # Returns all slot numbers in ``data`` as comma-delimeted string.
-  result = mapIt(data, $it.message.slot).join(", ")
+  mapIt(data, $it.message.slot).join(", ")
 
 proc init*[T](t1: typedesc[SyncRequest], t2: typedesc[T], slot: Slot,
               count: uint64): SyncRequest[T] =
-  result = SyncRequest[T](slot: slot, count: count, step: 1'u64)
+  SyncRequest[T](slot: slot, count: count, step: 1'u64)
 
 proc init*[T](t1: typedesc[SyncRequest], t2: typedesc[T], start: Slot,
               finish: Slot): SyncRequest[T] =
   let count = finish - start + 1'u64
-  result = SyncRequest[T](slot: start, count: count, step: 1'u64)
+  SyncRequest[T](slot: start, count: count, step: 1'u64)
 
 proc init*[T](t1: typedesc[SyncRequest], t2: typedesc[T], slot: Slot,
               count: uint64, item: T): SyncRequest[T] =
-  result = SyncRequest[T](slot: slot, count: count, item: item, step: 1'u64)
+  SyncRequest[T](slot: slot, count: count, item: item, step: 1'u64)
 
 proc init*[T](t1: typedesc[SyncRequest], t2: typedesc[T], start: Slot,
               finish: Slot, item: T): SyncRequest[T] =
   let count = finish - start + 1'u64
-  result = SyncRequest[T](slot: start, count: count, step: 1'u64, item: item)
+  SyncRequest[T](slot: start, count: count, step: 1'u64, item: item)
 
 proc init*[T](t1: typedesc[SyncFailure], kind: SyncFailureKind,
               peer: T): SyncFailure[T] =
-  result = SyncFailure[T](kind: kind, peer: peer, stamp: now(chronos.Moment))
+  SyncFailure[T](kind: kind, peer: peer, stamp: now(chronos.Moment))
 
 proc empty*[T](t: typedesc[SyncRequest],
                t2: typedesc[T]): SyncRequest[T] {.inline.} =
-  result = SyncRequest[T](step: 0'u64, count: 0'u64)
+  SyncRequest[T](step: 0'u64, count: 0'u64)
 
 proc setItem*[T](sr: var SyncRequest[T], item: T) =
   sr.item = item
 
 proc isEmpty*[T](sr: SyncRequest[T]): bool {.inline.} =
-  result = (sr.step == 0'u64) and (sr.count == 0'u64)
+  (sr.step == 0'u64) and (sr.count == 0'u64)
 
 proc init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
               start, last: Slot, chunkSize: uint64,
@@ -322,10 +322,10 @@ proc init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
   )
 
 proc `<`*[T](a, b: SyncRequest[T]): bool {.inline.} =
-  result = (a.slot < b.slot)
+  a.slot < b.slot
 
 proc `<`*[T](a, b: SyncResult[T]): bool {.inline.} =
-  result = (a.request.slot < b.request.slot)
+  a.request.slot < b.request.slot
 
 proc `==`*[T](a, b: SyncRequest[T]): bool {.inline.} =
   result = ((a.slot == b.slot) and (a.count == b.count) and
@@ -333,7 +333,7 @@ proc `==`*[T](a, b: SyncRequest[T]): bool {.inline.} =
 
 proc lastSlot*[T](req: SyncRequest[T]): Slot {.inline.} =
   ## Returns last slot for request ``req``.
-  result = req.slot + req.count - 1'u64
+  req.slot + req.count - 1'u64
 
 proc makePending*[T](sq: SyncQueue[T], req: var SyncRequest[T]) =
   req.index = sq.counter
@@ -698,15 +698,15 @@ proc len*[T](sq: SyncQueue[T]): uint64 {.inline.} =
 
 proc total*[T](sq: SyncQueue[T]): uint64 {.inline.} =
   ## Returns total number of slots in queue ``sq``.
-  result = sq.lastSlot - sq.startSlot + 1'u64
+  sq.lastSlot - sq.startSlot + 1'u64
 
 proc progress*[T](sq: SyncQueue[T]): uint64 =
   ## Returns queue's ``sq`` progress string.
   let curSlot = sq.outSlot - sq.startSlot
-  result = (curSlot * 100'u64) div sq.total()
+  (curSlot * 100'u64) div sq.total()
 
 proc now*(sm: typedesc[SyncMoment], slot: Slot): SyncMoment {.inline.} =
-  result = SyncMoment(stamp: now(chronos.Moment), slot: slot)
+  SyncMoment(stamp: now(chronos.Moment), slot: slot)
 
 proc speed*(start, finish: SyncMoment): float {.inline.} =
   ## Returns number of slots per second.

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -390,7 +390,7 @@ proc updateStatus*(peer: Peer): Future[bool] {.async.} =
 
 proc getHeadSlot*(peer: Peer): Slot =
   ## Returns head slot for specific peer ``peer``.
-  result = peer.state(BeaconSync).statusMsg.headSlot
+  peer.state(BeaconSync).statusMsg.headSlot
 
 proc handleStatus(peer: Peer,
                   state: BeaconSyncNetworkState,

--- a/ncli/logtrace.nim
+++ b/ncli/logtrace.nim
@@ -163,7 +163,7 @@ type
     aggSends: seq[AggregatedAttestationSentMessage]
     aggRecvs: TableRef[string, AggregatedAttestationReceivedMessage]
 
-proc readValue*(reader: var JsonReader, value: var DateTime) =
+proc readValue(reader: var JsonReader, value: var DateTime) =
   let s = reader.readValue(string)
   try:
     value = parse(s, "YYYY-MM-dd HH:mm:ss'.'fffzzz", utc())
@@ -178,8 +178,8 @@ proc init(t: typedesc[GossipMessage], kind: GossipDirection, id,
     datetime: parse(datestr, "YYYY-MM-dd HH:mm:ss'.'fffzzz")
   )
 
-proc `$`*(msg: GossipMessage): string =
-  result = msg.id
+func `$`(msg: GossipMessage): string =
+  msg.id
 
 proc readLogFile(file: string): seq[JsonNode] =
   var res = newSeq[JsonNode]()
@@ -351,7 +351,7 @@ proc filterGossipMessages(log: seq[JsonNode]): seq[GossipMessage] =
                                      node["ts"].getStr())
         result.add(msg)
 
-iterator simDirectoryLogFiles*(simdir: string): string =
+iterator simDirectoryLogFiles(simdir: string): string =
   let absPath = absolutePath(simdir)
   let dataPath = absPath & DirSep & "data"
   if not dirExists(dataPath):
@@ -371,8 +371,8 @@ iterator simDirectoryLogFiles*(simdir: string): string =
       break
     inc(index)
 
-proc getDirectoryLogFiles*(builddir: string,
-                           filter: seq[string]): seq[NodeDirectory] =
+proc getDirectoryLogFiles(builddir: string,
+                          filter: seq[string]): seq[NodeDirectory] =
   var res = newSeq[NodeDirectory]()
   let absPath = absolutePath(builddir)
   let dataPath = absPath & DirSep & "data"
@@ -392,8 +392,8 @@ proc getDirectoryLogFiles*(builddir: string,
         res.add(nodeDir)
   return res
 
-proc getLogFiles*(builddir: string,
-                  filter: seq[string]): seq[NodeDirectory] =
+proc getLogFiles(builddir: string,
+                 filter: seq[string]): seq[NodeDirectory] =
   var res = newSeq[NodeDirectory]()
   let dataPath = absolutePath(builddir)
   if not dirExists(dataPath):
@@ -408,7 +408,7 @@ proc getLogFiles*(builddir: string,
       res.add(nodeDir)
   return res
 
-proc getMessage(logs: seq[GossipMessage],
+func getMessage(logs: seq[GossipMessage],
                 msg: GossipMessage): Option[GossipMessage] =
   {.push warning[ProveInit]: off.}
   result = none[GossipMessage]()
@@ -500,8 +500,8 @@ proc runAttSend(logConf: LogTraceConf, logFiles: seq[string]) =
                          slot_messages = slotMessagesCount,
                          late_attestation_messages = lateAttsMessagesCount
 
-proc toSimple*(s: seq[string]): string =
-  result = "[" & s.mapIt("'" & it & "'").join(", ") & "]"
+func toSimple(s: seq[string]): string =
+  "[" & s.mapIt("'" & it & "'").join(", ") & "]"
 
 proc runAttSendReceive(logConf: LogTraceConf, nodes: seq[NodeDirectory]) =
   info "Check for attestation sent/received messages"

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -39,7 +39,7 @@ type Timers = enum
   tAttest = "Have committee attest to block"
   tReplay = "Replay all produced blocks"
 
-proc gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
+func gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
   # TODO This is present in Nim 1.4
   const K = sqrt(2 / E)
   var
@@ -49,7 +49,7 @@ proc gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
     a = rand(r, 1.0)
     b = (2.0 * rand(r, 1.0) - 1.0) * K
     if  b * b <= -4.0 * a * a * ln(a): break
-  result = mu + sigma * (b / a)
+  mu + sigma * (b / a)
 
 # TODO confutils is an impenetrable black box. how can a help text be added here?
 cli do(slots = SLOTS_PER_EPOCH * 6,

--- a/tests/test_peer_pool.nim
+++ b/tests/test_peer_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019 Status Research & Development GmbH
+# Copyright (c) 2019-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -19,18 +19,18 @@ type
     weight: int
     future: Future[void]
 
-proc getKey*(peer: PeerTest): PeerTestID =
-  result = peer.id
+func getKey*(peer: PeerTest): PeerTestID =
+  peer.id
 
-proc getFuture*(peer: PeerTest): Future[void] =
-  result = peer.future
+func getFuture*(peer: PeerTest): Future[void] =
+  peer.future
 
-proc `<`*(a, b: PeerTest): bool =
-  result = `<`(a.weight, b.weight)
+func `<`*(a, b: PeerTest): bool =
+  `<`(a.weight, b.weight)
 
 proc init*(t: typedesc[PeerTest], id: string = "",
            weight: int = 0): PeerTest =
-  result = PeerTest(id: id, weight: weight, future: newFuture[void]())
+  PeerTest(id: id, weight: weight, future: newFuture[void]())
 
 proc close*(peer: PeerTest) =
   peer.future.complete()


### PR DESCRIPTION
- `result = foo` was removed where all conditions were met: (a) non-async function; (b) at end of function both execution and spatially, with its being only reference to `result`; and (c) in `beacon_chain/`, `ncli/`, `research/`, or `tests/`.
- `logtrace` isn't imported by anything, so has no reason to export symbols. Meanwhile, exporting symbols inhibits Nim's unused symbol check.