### PR TITLE
treat gossip decoding errors more strictly

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -161,7 +161,7 @@ template errReject(msg: cstring): untyped =
     # This doesn't depend on the wall clock or the exact state of the DAG; it's
     # an internal consistency/correctness check only, and effectively never has
     # false positives. These don't, for example, arise from timeouts.
-    doAssert false
+    raiseAssert $msg
   err((ValidationResult.Reject, msg))
 
 template errReject(error: (ValidationResult, cstring)): untyped =
@@ -170,7 +170,7 @@ template errReject(error: (ValidationResult, cstring)): untyped =
     # This doesn't depend on the wall clock or the exact state of the DAG; it's
     # an internal consistency/correctness check only, and effectively never has
     # false positives. These don't, for example, arise from timeouts.
-    doAssert false
+    raiseAssert $error[1]
   err(error)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -655,8 +655,7 @@ proc getInitialAggregateSubnets(node: BeaconNode): Table[SubnetId, Slot] =
   mergeAggregateSubnets(wallEpoch + 1)
 
 proc subscribeAttestationSubnetHandlers(node: BeaconNode,
-                                        forkDigest: ForkDigest) {.
-  raises: [Defect, CatchableError].} =
+                                        forkDigest: ForkDigest) =
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#phase-0-attestation-subnet-stability
   # TODO:
   # We might want to reuse the previous stability subnet if not expired when:
@@ -755,8 +754,7 @@ static:
   aggregateTopicParams.validateParameters().tryGet()
   basicParams.validateParameters.tryGet()
 
-proc addPhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest)
-                             {.raises: [Defect, CatchableError].} =
+proc addPhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.network.subscribe(getBeaconBlocksTopic(forkDigest), blocksTopicParams, enableTopicMetrics = true)
   node.network.subscribe(getAttesterSlashingsTopic(forkDigest), basicParams)
   node.network.subscribe(getProposerSlashingsTopic(forkDigest), basicParams)
@@ -765,12 +763,10 @@ proc addPhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest)
 
   node.subscribeAttestationSubnetHandlers(forkDigest)
 
-proc addPhase0MessageHandlers(node: BeaconNode)
-                             {.raises: [Defect, CatchableError].} =
+proc addPhase0MessageHandlers(node: BeaconNode) =
   addPhase0MessageHandlers(node, node.dag.forkDigests.phase0)
 
-proc removePhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest)
-                                {.raises: [Defect, CatchableError].} =
+proc removePhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.network.unsubscribe(getBeaconBlocksTopic(forkDigest))
   node.network.unsubscribe(getVoluntaryExitsTopic(forkDigest))
   node.network.unsubscribe(getProposerSlashingsTopic(forkDigest))
@@ -781,22 +777,19 @@ proc removePhase0MessageHandlers(node: BeaconNode, forkDigest: ForkDigest)
     node.network.unsubscribe(
       getAttestationTopic(forkDigest, SubnetId(subnet_id)))
 
-proc removePhase0MessageHandlers(node: BeaconNode)
-                                {.raises: [Defect, CatchableError].} =
+proc removePhase0MessageHandlers(node: BeaconNode) =
   removePhase0MessageHandlers(node, node.dag.forkDigests.phase0)
 
-proc addAltairMessageHandlers(node: BeaconNode, slot: Slot)
-                             {.raises: [Defect, CatchableError].} =
+proc addAltairMessageHandlers(node: BeaconNode, slot: Slot) =
   node.addPhase0MessageHandlers(node.dag.forkDigests.altair)
 
-proc removeAltairMessageHandlers(node: BeaconNode)
-                                {.raises: [Defect, CatchableError].} =
+proc removeAltairMessageHandlers(node: BeaconNode) =
   node.removePhase0MessageHandlers(node.dag.forkDigests.altair)
 
 func getTopicSubscriptionEnabled(node: BeaconNode): bool =
   node.attestationSubnets.enabled
 
-proc removeAllMessageHandlers(node: BeaconNode) {.raises: [Defect, CatchableError].} =
+proc removeAllMessageHandlers(node: BeaconNode) =
   node.removePhase0MessageHandlers()
   node.removeAltairMessageHandlers()
 
@@ -817,7 +810,7 @@ proc setupDoppelgangerDetection(node: BeaconNode, slot: Slot) =
     broadcastStartEpoch =
       node.processor.doppelgangerDetection.broadcastStartEpoch
 
-proc updateGossipStatus(node: BeaconNode, slot: Slot) {.raises: [Defect, CatchableError].} =
+proc updateGossipStatus(node: BeaconNode, slot: Slot) =
   # Syncing tends to be ~1 block/s, and allow for an epoch of time for libp2p
   # subscribing to spin up. The faster the sync, the more wallSlot - headSlot
   # lead time is required


### PR DESCRIPTION
* penalize peers for sending gossip messages that fail decoding
* add metrics for decoding/decompression errors
* clean up obsolete exception handlers