### PR TITLE
unexport various parts of tests/ and remove unused code

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -390,10 +390,6 @@ func init(
   let
     prev_epoch = state.data.get_previous_epoch()
     cur_epoch = state.data.get_current_epoch()
-    prev_epoch_committees_per_slot = get_committee_count_per_slot(
-      state.data, prev_epoch, cache)
-    cur_epoch_committees_per_slot = get_committee_count_per_slot(
-      state.data, cur_epoch, cache)
 
   template update_attestation_pool_cache(
       epoch: Epoch, slot: Slot, participation_bitmap: untyped) =

--- a/tests/official/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/altair/test_fixture_ssz_consensus_objects.nim
@@ -38,10 +38,10 @@ type
     signing_root {.defaultVal: "".}: string
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/altair/validator.md#eth1block
-  Eth1Block* = object
-    timestamp*: uint64
-    deposit_root*: Eth2Digest
-    deposit_count*: uint64
+  Eth1Block = object
+    timestamp: uint64
+    deposit_root: Eth2Digest
+    deposit_count: uint64
     # All other eth1 block fields
 
 # Note this only tracks HashTreeRoot

--- a/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
@@ -38,10 +38,10 @@ type
     signing_root {.defaultVal: "".}: string
 
   # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/validator.md#eth1block
-  Eth1Block* = object
-    timestamp*: uint64
-    deposit_root*: Eth2Digest
-    deposit_count*: uint64
+  Eth1Block = object
+    timestamp: uint64
+    deposit_root: Eth2Digest
+    deposit_count: uint64
     # All other eth1 block fields
 
 # Note this only tracks HashTreeRoot

--- a/tests/official/test_fixture_bls.nim
+++ b/tests/official/test_fixture_bls.nim
@@ -19,28 +19,28 @@ import
   ./fixtures_utils
 
 type
-  BLSPrivToPub* = object
-    input*: ValidatorPrivKey
-    output*: ValidatorPubKey
+  BLSPrivToPub = object
+    input: ValidatorPrivKey
+    output: ValidatorPubKey
 
   BLSSignMsgInput = object
-    privkey*: ValidatorPrivKey
-    message*: seq[byte]
-    domain*: Eth2Domain
+    privkey: ValidatorPrivKey
+    message: seq[byte]
+    domain: Eth2Domain
 
-  BLSSignMsg* = object
-    input*: BLSSignMsgInput
-    output*: Signature
+  BLSSignMsg = object
+    input: BLSSignMsgInput
+    output: Signature
 
-  BLSAggSig* = object
-    input*: seq[Signature]
-    output*: Signature
+  BLSAggSig = object
+    input: seq[Signature]
+    output: Signature
 
-  BLSAggPubKey* = object
-    input*: seq[ValidatorPubKey]
-    output*: ValidatorPubKey
+  BLSAggPubKey = object
+    input: seq[ValidatorPubKey]
+    output: ValidatorPubKey
 
-proc readValue*(r: var JsonReader, a: var Eth2Domain) =
+proc readValue(r: var JsonReader, a: var Eth2Domain) =
   ## Custom deserializer for Eth2Domain
   # Furthermore Nim parseHex doesn't support uint
   # until https://github.com/nim-lang/Nim/pull/11067

--- a/tests/slashing_protection/test_official_interchange_vectors.nim
+++ b/tests/slashing_protection/test_official_interchange_vectors.nim
@@ -139,8 +139,6 @@ proc runTest(identifier: string) =
   # The tests produce a lot of log noise
   echo "\n\n===========================================\n\n"
 
-
-  let testCase = InterchangeTestsDir / identifier
   test "Slashing test: " & identifier:
     let t = parseTest(InterchangeTestsDir/identifier, Json, TestInterchange)
 

--- a/tests/slashing_protection/test_slashing_interchange.nim
+++ b/tests/slashing_protection/test_slashing_interchange.nim
@@ -26,11 +26,6 @@ func fakeRoot(index: SomeInteger): Eth2Digest =
   ## We prevent zero hash special case via a power of 2 prefix
   result.data[0 ..< 8] = (1'u64 shl 32 + index.uint64).toBytesBE()
 
-func fakeValidator(index: SomeInteger): ValidatorPubKey =
-  ## Create fake validator public key
-  result = ValidatorPubKey()
-  result.blob[0 ..< 8] = (1'u64 shl 48 + index.uint64).toBytesBE()
-
 func hexToDigest(hex: string): Eth2Digest =
   result = Eth2Digest.fromHex(hex)
 

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -8,12 +8,12 @@ import
   ../beacon_chain/networking/[eth2_network, eth2_discovery],
   ./testutil
 
-template asyncTest*(name, body: untyped) =
+template asyncTest(name, body: untyped) =
   test name:
     proc scenario {.async.} = {.gcsafe.}: body
     waitFor scenario()
 
-proc new*(T: type Eth2DiscoveryProtocol,
+proc new(T: type Eth2DiscoveryProtocol,
     pk: keys.PrivateKey,
     enrIp: Option[ValidIpAddress], enrTcpPort, enrUdpPort: Option[Port],
     bindPort: Port, bindIp: ValidIpAddress,

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,7 +18,7 @@ import
 
 from strutils import replace
 
-func isEqual*(a, b: ValidatorPrivKey): bool =
+func isEqual(a, b: ValidatorPrivKey): bool =
   # `==` on secret keys is not allowed
   let pa = cast[ptr UncheckedArray[byte]](a.unsafeAddr)
   let pb = cast[ptr UncheckedArray[byte]](b.unsafeAddr)

--- a/tests/test_ssz_merkleization.nim
+++ b/tests/test_ssz_merkleization.nim
@@ -20,7 +20,7 @@ type SparseMerkleTree[Depth: static int] = object
   # There is an extra "depth" layer to store leaf nodes
   # This stores leaves at depth = 0
   # and the root hash at the last depth
-  nnznodes*: array[Depth+1, seq[Eth2Digest]]  # nodes that leads to non-zero leaves
+  nnznodes: array[Depth+1, seq[Eth2Digest]]  # nodes that leads to non-zero leaves
 
 func merkleTreeFromLeaves(
         values: openArray[Eth2Digest],
@@ -77,7 +77,7 @@ func getMerkleProof[Depth: static int](tree: SparseMerkleTree[Depth],
     # in the next Merkle tree layer calculated
     depthLen = (depthLen + 1) div 2
 
-proc testMerkleMinimal*(): bool =
+proc testMerkleMinimal(): bool =
   proc toDigest[N: static int](x: array[N, byte]): Eth2Digest =
     result.data[0 .. N-1] = x
 

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -11,7 +11,7 @@ import ../beacon_chain/gossip_processing/block_processor,
 type
   SomeTPeer = ref object
 
-proc `$`*(peer: SomeTPeer): string =
+proc `$`(peer: SomeTPeer): string =
   "SomeTPeer"
 
 proc updateScore(peer: SomeTPeer, score: int) =

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -220,7 +220,7 @@ func makeAttestation*(
     signature: sig
   )
 
-func find_beacon_committee*(
+func find_beacon_committee(
     state: ForkedHashedBeaconState, validator_index: ValidatorIndex,
     cache: var StateCache): auto =
   let epoch = compute_epoch_at_slot(getStateField(state, slot))
@@ -285,18 +285,7 @@ func makeFullAttestations*(
     attestation.signature = agg.finish().toValidatorSig()
     result.add attestation
 
-func makeFullAttestations*(
-    state: phase0.HashedBeaconState, beacon_block_root: Eth2Digest, slot: Slot,
-    cache: var StateCache,
-    flags: UpdateFlags = {}): seq[Attestation] =
-  # TODO this only supports phase 0 currently. Either expand that to
-  # Altair here or use the ForkedHashedBeaconState version only
-  makeFullAttestations(
-    (ref ForkedHashedBeaconState)(
-      beaconStateFork: forkPhase0, hbsPhase0: state)[],
-    beacon_block_root, slot, cache, flags)
-
-iterator makeTestBlocks*(
+iterator makeTestBlocks(
   state: phase0.HashedBeaconState,
   parent_root: Eth2Digest,
   cache: var StateCache,
@@ -323,7 +312,7 @@ iterator makeTestBlocks*(state: ForkedHashedBeaconState; parent_root: Eth2Digest
   for blck in makeTestBlocks(state.hbsPhase0, parent_root, cache, blocks, attested):
     yield blck
 
-proc getAttestationsforTestBlock*(
+proc getAttestationsForTestBlock*(
     pool: var AttestationPool, stateData: StateData, cache: var StateCache):
     seq[Attestation] =
   case stateData.data.beaconStateFork:


### PR DESCRIPTION
The only part that's not in `tests/` is removing two unused variables in a function in `beacon_chain/consensus_object_pools/attestation_pool.nim`