### PR TITLE
update REST API spec/documentation URLs

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -105,7 +105,7 @@ proc getBeaconBlocksTopic(node: BeaconNode, kind: BeaconBlockFork): string =
     getBeaconBlocksTopic(node.dag.forkDigests.altair)
 
 proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getGenesis
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getGenesis
   router.api(MethodGet, "/api/eth/v1/beacon/genesis") do () -> RestApiResponse:
     return RestApiResponse.jsonResponse(
       (
@@ -116,7 +116,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       )
     )
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateRoot
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateRoot
   router.api(MethodGet, "/api/eth/v1/beacon/states/{state_id}/root") do (
     state_id: StateIdent) -> RestApiResponse:
     let bslot =
@@ -133,7 +133,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonResponse((root: stateRoot))
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateFork
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateFork
   router.api(MethodGet, "/api/eth/v1/beacon/states/{state_id}/fork") do (
     state_id: StateIdent) -> RestApiResponse:
     let bslot =
@@ -159,7 +159,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       )
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateFinalityCheckpoints
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateFinalityCheckpoints
   router.api(MethodGet,
              "/api/eth/v1/beacon/states/{state_id}/finality_checkpoints") do (
     state_id: StateIdent) -> RestApiResponse:
@@ -185,7 +185,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       )
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidators
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidators
   router.api(MethodGet, "/api/eth/v1/beacon/states/{state_id}/validators") do (
     state_id: StateIdent, id: seq[ValidatorIdent],
     status: seq[ValidatorFilter]) -> RestApiResponse:
@@ -276,7 +276,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidator
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidator
   router.api(MethodGet,
           "/api/eth/v1/beacon/states/{state_id}/validators/{validator_id}") do (
     state_id: StateIdent, validator_id: ValidatorIdent) -> RestApiResponse:
@@ -353,7 +353,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            ValidatorStatusNotFoundError)
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidatorBalances
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidatorBalances
   router.api(MethodGet,
              "/api/eth/v1/beacon/states/{state_id}/validator_balances") do (
     state_id: StateIdent, id: seq[ValidatorIdent]) -> RestApiResponse:
@@ -427,7 +427,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getEpochCommittees
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getEpochCommittees
   router.api(MethodGet,
              "/api/eth/v1/beacon/states/{state_id}/committees") do (
     state_id: StateIdent, epoch: Option[Epoch], index: Option[CommitteeIndex],
@@ -511,7 +511,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     return RestApiResponse.jsonError(Http500, InternalServerError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockHeaders
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockHeaders
   router.api(MethodGet, "/api/eth/v1/beacon/headers") do (
     slot: Option[Slot], parent_root: Option[Eth2Digest]) -> RestApiResponse:
     # TODO (cheatfate): This call is incomplete, because structure
@@ -568,7 +568,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           ]
         )
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockHeader
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockHeader
   router.api(MethodGet, "/api/eth/v1/beacon/headers/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
     let bdata =
@@ -600,7 +600,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           )
         )
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/publishBlock
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
   router.api(MethodPost, "/api/eth/v1/beacon/blocks") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let blockData =
@@ -671,7 +671,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       else:
         return RestApiResponse.jsonMsgResponse(BlockValidationSuccess)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlock
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlock
   router.api(MethodGet, "/api/eth/v1/beacon/blocks/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
     let bdata =
@@ -690,7 +690,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       of BeaconBlockFork.Altair:
         RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockV2
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockV2
   router.api(MethodGet, "/api/eth/v2/beacon/blocks/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
     let bdata =
@@ -713,7 +713,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           (version: "altair", data: bdata.data.altairBlock)
         )
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockRoot
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockRoot
   router.api(MethodGet, "/api/eth/v1/beacon/blocks/{block_id}/root") do (
     block_id: BlockIdent) -> RestApiResponse:
     let bdata =
@@ -729,7 +729,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       withBlck(bdata.data):
         RestApiResponse.jsonResponse((root: blck.root))
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockAttestations
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockAttestations
   router.api(MethodGet,
              "/api/eth/v1/beacon/blocks/{block_id}/attestations") do (
     block_id: BlockIdent) -> RestApiResponse:
@@ -746,7 +746,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       withBlck(bdata.data):
         RestApiResponse.jsonResponse(blck.message.body.attestations.asSeq())
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolAttestations
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttestations
   router.api(MethodGet, "/api/eth/v1/beacon/pool/attestations") do (
     slot: Option[Slot],
     committee_index: Option[CommitteeIndex]) -> RestApiResponse:
@@ -774,7 +774,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       res.add(item)
     return RestApiResponse.jsonResponse(res)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolAttestations
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttestations
   router.api(MethodPost, "/api/eth/v1/beacon/pool/attestations") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let attestations =
@@ -802,7 +802,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     else:
       return RestApiResponse.jsonMsgResponse(AttestationValidationSuccess)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolAttesterSlashings
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttesterSlashings
   router.api(MethodGet, "/api/eth/v1/beacon/pool/attester_slashings") do (
     ) -> RestApiResponse:
     var res: seq[AttesterSlashing]
@@ -814,7 +814,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       res.add(item)
     return RestApiResponse.jsonResponse(res)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolAttesterSlashings
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashings
   router.api(MethodPost, "/api/eth/v1/beacon/pool/attester_slashings") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let slashing =
@@ -836,7 +836,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     node.network.sendAttesterSlashing(slashing)
     return RestApiResponse.jsonMsgResponse(AttesterSlashingValidationSuccess)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolProposerSlashings
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolProposerSlashings
   router.api(MethodGet, "/api/eth/v1/beacon/pool/proposer_slashings") do (
     ) -> RestApiResponse:
     var res: seq[ProposerSlashing]
@@ -848,7 +848,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       res.add(item)
     return RestApiResponse.jsonResponse(res)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolProposerSlashings
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolProposerSlashings
   router.api(MethodPost, "/api/eth/v1/beacon/pool/proposer_slashings") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let slashing =
@@ -870,7 +870,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     node.network.sendProposerSlashing(slashing)
     return RestApiResponse.jsonMsgResponse(ProposerSlashingValidationSuccess)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolVoluntaryExits
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolVoluntaryExits
   router.api(MethodGet, "/api/eth/v1/beacon/pool/voluntary_exits") do (
     ) -> RestApiResponse:
     var res: seq[SignedVoluntaryExit]
@@ -882,7 +882,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       res.add(item)
     return RestApiResponse.jsonResponse(res)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolVoluntaryExit
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolVoluntaryExit
   router.api(MethodPost, "/api/eth/v1/beacon/pool/voluntary_exits") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let exit =

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -45,4 +45,4 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
 proc getDebugChainHeads*(): RestResponse[GetDebugChainHeadsResponse] {.
      rest, endpoint: "/eth/v1/debug/beacon/heads",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getDebugChainHeads
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getDebugChainHeads

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -19,7 +19,7 @@ import
 logScope: topics = "rest_validatorapi"
 
 proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/getAttesterDuties
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getAttesterDuties
   router.api(MethodPost, "/api/eth/v1/validator/duties/attester/{epoch}") do (
     epoch: Epoch, contentBody: Option[ContentBody]) -> RestApiResponse:
     let indexList =
@@ -98,7 +98,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res
     return RestApiResponse.jsonResponseWRoot(duties, droot)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/getProposerDuties
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getProposerDuties
   router.api(MethodGet, "/api/eth/v1/validator/duties/proposer/{epoch}") do (
     epoch: Epoch) -> RestApiResponse:
     let qepoch =
@@ -142,7 +142,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res
     return RestApiResponse.jsonResponseWRoot(duties, droot)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/produceBlock
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlock
   router.api(MethodGet, "/api/eth/v1/validator/blocks/{slot}") do (
     slot: Slot, randao_reveal: Option[ValidatorSig],
     graffiti: Option[GraffitiBytes]) -> RestApiResponse:
@@ -271,7 +271,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             (version: "altair", data: message.altairBlock.message)
           )
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/produceAttestationData
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceAttestationData
   router.api(MethodGet, "/api/eth/v1/validator/attestation_data") do (
     slot: Option[Slot],
     committee_index: Option[CommitteeIndex]) -> RestApiResponse:
@@ -307,7 +307,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         makeAttestationData(epochRef, qhead.atSlot(qslot), qindex)
     return RestApiResponse.jsonResponse(adata)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/getAggregatedAttestation
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getAggregatedAttestation
   router.api(MethodGet, "/api/eth/v1/validator/aggregate_attestation") do (
     attestation_data_root: Option[Eth2Digest],
     slot: Option[Slot]) -> RestApiResponse:
@@ -339,7 +339,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res.get()
     return RestApiResponse.jsonResponse(attestation)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/publishAggregateAndProofs
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofs
   router.api(MethodPost, "/api/eth/v1/validator/aggregate_and_proofs") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
     let proofs =
@@ -370,7 +370,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     return RestApiResponse.jsonMsgResponse(AggregateAndProofValidationSuccess)
 
-  # https://ethereum.github.io/eth2.0-APIs/#/Validator/prepareBeaconCommitteeSubnet
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/prepareBeaconCommitteeSubnet
   router.api(MethodPost,
              "/api/eth/v1/validator/beacon_committee_subscriptions") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:

--- a/beacon_chain/spec/eth2_apis/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_json_rpc_serialization.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 # The serializations in this file are approximations of
-# https://ethereum.github.io/eth2.0-APIs/#/ but where written before the standard
+# https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/ but where written before the standard
 # had materialized - they've now made it out to releases which means the easiest
 # thing to do is to maintain them as-is, even if there are mismatches. In
 # particular, numbers are serialized as strings in the eth2 API - here, they

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -16,17 +16,17 @@ export client, rest_types, eth2_rest_serialization
 proc getGenesis*(): RestResponse[GetGenesisResponse] {.
      rest, endpoint: "/eth/v1/beacon/genesis",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getGenesis
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getGenesis
 
 proc getStateRoot*(state_id: StateIdent): RestResponse[GetStateRootResponse] {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/root",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateRoot
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateRoot
 
 proc getStateFork*(state_id: StateIdent): RestResponse[GetStateForkResponse] {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/fork",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateFork
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateFork
 
 proc getStateFinalityCheckpoints*(state_id: StateIdent
           ): RestResponse[GetStateFinalityCheckpointsResponse] {.
@@ -38,7 +38,7 @@ proc getStateValidators*(state_id: StateIdent,
                         ): RestResponse[GetStateValidatorsResponse] {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/validators",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidators
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidators
 
 proc getStateValidator*(state_id: StateIdent,
                         validator_id: ValidatorIdent
@@ -46,64 +46,64 @@ proc getStateValidator*(state_id: StateIdent,
      rest,
      endpoint: "/eth/v1/beacon/states/{state_id}/validators/{validator_id}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidator
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidator
 
 proc getStateValidatorBalances*(state_id: StateIdent
                         ): RestResponse[GetStateValidatorBalancesResponse] {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/validator_balances",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateValidators
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getStateValidators
 
 proc getEpochCommittees*(state_id: StateIdent
                         ): RestResponse[GetEpochCommitteesResponse] {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/committees",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getEpochCommittees
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getEpochCommittees
 
 # TODO altair
 # proc getEpochSyncCommittees*(state_id: StateIdent
 #                         ): RestResponse[GetEpochSyncCommitteesResponse] {.
 #      rest, endpoint: "/eth/v1/beacon/states/{state_id}/sync_committees",
 #      meth: MethodGet.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getEpochSyncCommittees
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getEpochSyncCommittees
 
 proc getBlockHeaders*(slot: Option[Slot], parent_root: Option[Eth2Digest]
                         ): RestResponse[GetBlockHeadersResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/headers",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockHeaders
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockHeaders
 
 proc getBlockHeader*(block_id: BlockIdent): RestResponse[GetBlockHeaderResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/headers/{block_id}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockHeader
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockHeader
 
 proc publishBlock*(body: phase0.SignedBeaconBlock): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/blocks",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/publishBlock
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishBlock
 
 proc getBlock*(block_id: BlockIdent): RestResponse[GetBlockResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/blocks/{block_id}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlock
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlock
 
 # TODO altair
 # proc getBlockV2*(block_id: BlockIdent): RestResponse[GetBlockV2Response] {.
 #      rest, endpoint: "/api/eth/v2/beacon/blocks/{block_id}",
 #      meth: MethodGet.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockV2
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockV2
 
 proc getBlockRoot*(block_id: BlockIdent): RestResponse[GetBlockRootResponse] {.
      rest, endpoint: "/eth/v1/beacon/blocks/{block_id}/root",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockRoot
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockRoot
 
 proc getBlockAttestations*(block_id: BlockIdent
                         ): RestResponse[GetBlockAttestationsResponse] {.
      rest, endpoint: "/eth/v1/beacon/blocks/{block_id}/attestations",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockAttestations
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getBlockAttestations
 
 proc getPoolAttestations*(
     slot: Option[Slot],
@@ -111,45 +111,45 @@ proc getPoolAttestations*(
               ): RestResponse[GetPoolAttestationsResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/pool/attestations",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolAttestations
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttestations
 
 proc submitPoolAttestations*(body: seq[Attestation]): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/pool/attestations",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolAttestations
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttestations
 
 proc getPoolAttesterSlashings*(): RestResponse[GetPoolAttesterSlashingsResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/pool/attester_slashings",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolAttesterSlashings
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttesterSlashings
 
 proc submitPoolAttesterSlashings*(body: AttesterSlashing): RestPlainResponse {.
      rest, endpoint: "/api/eth/v1/beacon/pool/attester_slashings",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolAttesterSlashings
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashings
 
 proc getPoolProposerSlashings*(): RestResponse[GetPoolProposerSlashingsResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/pool/proposer_slashings",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolProposerSlashings
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolProposerSlashings
 
 proc submitPoolProposerSlashings*(body: ProposerSlashing): RestPlainResponse {.
      rest, endpoint: "/api/eth/v1/beacon/pool/proposer_slashings",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolProposerSlashings
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolProposerSlashings
 
 # TODO Altair
 # proc submitPoolSyncCommitteeSignatures*(body: seq[RestSyncCommitteeSignature]): RestPlainResponse {.
 #      rest, endpoint: "/eth/v1/beacon/pool/sync_committees",
 #      meth: MethodPost.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolSyncCommitteeSignatures
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolSyncCommitteeSignatures
 
 proc getPoolVoluntaryExits*(): RestResponse[GetPoolVoluntaryExitsResponse] {.
      rest, endpoint: "/api/eth/v1/beacon/pool/voluntary_exits",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getPoolVoluntaryExits
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolVoluntaryExits
 
 proc submitPoolVoluntaryExit*(body: SignedVoluntaryExit): RestPlainResponse {.
      rest, endpoint: "/api/eth/v1/beacon/pool/voluntary_exits",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolVoluntaryExit
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolVoluntaryExit

--- a/beacon_chain/spec/eth2_apis/rest_config_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_config_calls.nim
@@ -14,12 +14,12 @@ export client, rest_types, eth2_rest_serialization
 
 proc getForkSchedule*(): RestResponse[GetForkScheduleResponse] {.
      rest, endpoint: "/eth/v1/config/fork_schedule", meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Config/getForkSchedule
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Config/getForkSchedule
 
 proc getSpec*(): RestResponse[GetSpecResponse] {.
      rest, endpoint: "/eth/v1/config/spec", meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Config/getSpec
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Config/getSpec
 
 proc getDepositContract*(): RestResponse[GetDepositContractResponse] {.
      rest, endpoint: "/eth/v1/config/deposit_contract", meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Config/getDepositContract
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Config/getDepositContract

--- a/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
@@ -15,15 +15,15 @@ export client, rest_types, eth2_rest_serialization
 proc getState*(state_id: StateIdent): RestResponse[GetStateResponse] {.
      rest, endpoint: "/eth/v1/debug/beacon/states/{state_id}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getState
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getState
 
 # TODO altair
 # proc getStateV2*(state_id: StateIdent): RestResponse[GetStateV2Response] {.
 #      rest, endpoint: "/eth/v2/debug/beacon/states/{state_id}",
 #      meth: MethodGet.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getState
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getState
 
 proc getDebugChainHeads*(): RestResponse[GetDebugChainHeadsResponse] {.
      rest, endpoint: "/eth/v1/debug/beacon/heads",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Beacon/getDebugChainHeads
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getDebugChainHeads

--- a/beacon_chain/spec/eth2_apis/rest_node_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_node_calls.nim
@@ -15,36 +15,36 @@ export client, rest_types, eth2_rest_serialization
 proc getNetworkIdentity*(): RestResponse[GetNetworkIdentityResponse] {.
      rest, endpoint: "/eth/v1/node/identity",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getNetworkIdentity
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getNetworkIdentity
 
 proc getPeers*(
     state: seq[PeerStateKind],
     direction: seq[PeerDirectKind]): RestResponse[GetPeersResponse] {.
      rest, endpoint: "/eth/v1/node/peers",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getPeers
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getPeers
 
 proc getPeer*(peer_id: PeerId): RestResponse[GetPeerResponse] {.
      rest, endpoint: "/eth/v1/node/peers/{peer_id}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getPeer
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getPeer
 
 proc getPeerCount*(): RestResponse[GetPeerCountResponse] {.
      rest, endpoint: "/eth/v1/node/peer_count",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getPeerCount
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getPeerCount
 
 proc getNodeVersion*(): RestResponse[GetVersionResponse] {.
      rest, endpoint: "/eth/v1/node/version",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getNodeVersion
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getNodeVersion
 
 proc getSyncingStatus*(): RestResponse[GetSyncingStatusResponse] {.
      rest, endpoint: "/eth/v1/node/syncing",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getSyncingStatus
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getSyncingStatus
 
 proc getHealth*(): RestPlainResponse {.
      rest, endpoint: "/eth/v1/node/health",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Node/getHealth
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Node/getHealth

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Types used by both client and server in the common REST API:
-# https://ethereum.github.io/eth2.0-APIs/#/
+# https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/
 # Be mindful that changing these changes the serialization and deserialization
 # in the API which may lead to incompatibilities between clients - tread
 # carefully!

--- a/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
@@ -17,25 +17,25 @@ proc getAttesterDuties*(epoch: Epoch,
                        ): RestResponse[GetAttesterDutiesResponse] {.
      rest, endpoint: "/eth/v1/validator/duties/attester/{epoch}",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/getAttesterDuties
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getAttesterDuties
 
 proc getProposerDuties*(epoch: Epoch): RestResponse[GetProposerDutiesResponse] {.
      rest, endpoint: "/eth/v1/validator/duties/proposer/{epoch}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/getProposerDuties
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getProposerDuties
 
 # TODO altair
 # proc getSyncCommitteeDuties*(epoch: Epoch): RestResponse[DataRestSyncCommitteeDuties] {.
 #      rest, endpoint: "/eth/v1/validator/duties/sync/{epoch}",
 #      meth: MethodPost.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Validator/getSyncCommitteeDuties
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getSyncCommitteeDuties
 
 proc produceBlock*(slot: Slot, randao_reveal: ValidatorSig,
                    graffiti: GraffitiBytes
                   ): RestResponse[ProduceBlockResponse] {.
      rest, endpoint: "/eth/v1/validator/blocks/{slot}",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/produceBlock
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlock
 
 # TODO altair
 # proc produceBlockV2*(slot: Slot, randao_reveal: ValidatorSig,
@@ -43,47 +43,47 @@ proc produceBlock*(slot: Slot, randao_reveal: ValidatorSig,
 #                   ): RestResponse[DataRestBlockV2] {.
 #      rest, endpoint: "/eth/v2/validator/blocks/{slot}",
 #      meth: MethodGet.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Validator/produceBlockV2
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlockV2
 
 proc produceAttestationData*(slot: Slot,
                              committee_index: CommitteeIndex
                             ): RestResponse[ProduceAttestationDataResponse] {.
      rest, endpoint: "/eth/v1/validator/attestation_data",
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/produceAttestationData
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceAttestationData
 
 proc getAggregatedAttestation*(attestation_data_root: Eth2Digest,
                                slot: Slot): RestResponse[GetAggregatedAttestationResponse] {.
      rest, endpoint: "/eth/v1/validator/aggregate_attestation"
      meth: MethodGet.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/getAggregatedAttestation
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getAggregatedAttestation
 
 proc publishAggregateAndProofs*(body: seq[SignedAggregateAndProof]
                                ): RestPlainResponse {.
      rest, endpoint: "/eth/v1/validator/aggregate_and_proofs",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/publishAggregateAndProofs
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofs
 
 proc prepareBeaconCommitteeSubnet*(body: seq[RestCommitteeSubscription]): RestPlainResponse {.
      rest, endpoint: "/eth/v1/validator/beacon_committee_subscriptions",
      meth: MethodPost.}
-  ## https://ethereum.github.io/eth2.0-APIs/#/Validator/prepareBeaconCommitteeSubnet
+  ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/prepareBeaconCommitteeSubnet
 
 # TODO altair
 # proc prepareSyncCommitteeSubnets*(body: seq[int]
 #                                   ): RestPlainResponse {.
 #      rest, endpoint: "/eth/v1/validator/sync_committee_subscriptions",
 #      meth: MethodPost.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Validator/prepareSyncCommitteeSubnets
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/prepareSyncCommitteeSubnets
 
 # proc produceSyncCommitteeContribution*(body: seq[int]
 #                                   ): RestPlainResponse {.
 #      rest, endpoint: "/eth/v1/validator/sync_committee_contribution",
 #      meth: MethodPost.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Validator/produceSyncCommitteeContribution
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceSyncCommitteeContribution
 
 # proc publishContributionAndProofs*(body: seq[RestCommitteeSubscription]
 #                                   ): RestPlainResponse {.
 #      rest, endpoint: "/eth/v1/validator/contribution_and_proofs",
 #      meth: MethodPost.}
-#   ## https://ethereum.github.io/eth2.0-APIs/#/Validator/publishContributionAndProofs
+#   ## https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishContributionAndProofs

--- a/beacon_chain/spec/eth2_apis/rpc_types.nim
+++ b/beacon_chain/spec/eth2_apis/rpc_types.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Types used in the JSON-RPC (legacy) API - these are generally derived from
-# the common REST API, https://ethereum.github.io/eth2.0-APIs/#/
+# the common REST API, https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/
 
 {.push raises: [Defect].}
 


### PR DESCRIPTION
The previous/current URLs don't work. This is a mass search and replace from
> `# https://ethereum.github.io/eth2.0-APIs/#/`

to

> `# https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/`

In theory, it might be interesting to specifically target https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.0.0 or https://ethereum.github.io/beacon-APIs/?urls.primaryName=v1 but those both yield
> Failed to load API definition.