### PR TITLE
Validator index reform

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -392,22 +392,21 @@ func init(
 
   template update_attestation_pool_cache(
       epoch: Epoch, slot: Slot, participation_bitmap: untyped) =
-    for slot_committee_index in 0'u64 ..< get_committee_count_per_slot(
-        state.data, epoch, cache):
+    for slot_committee_index in committee_indices_per_slot(state.data, epoch, cache):
       var
         validator_bits =
           CommitteeValidatorsBits.init(
             get_beacon_committee_len(
-              state.data, slot, slot_committee_index.CommitteeIndex, cache).int)
+              state.data, slot, slot_committee_index, cache).int)
         i = 0
       for index in get_beacon_committee(
-          state.data, slot, slot_committee_index.CommitteeIndex, cache):
+          state.data, slot, slot_committee_index, cache):
         if participation_bitmap[index] != 0:
           # If any flag got set, there was an attestation from this validator.
           validator_bits[i] = true
         i += 1
       result.add(
-        (slot, slot_committee_index),
+        (slot, slot_committee_index.uint64),
         validator_bits)
 
   # This treats all types of rewards as equivalent, which isn't ideal

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -284,7 +284,7 @@ proc addRawBlockKnownParent(
     # TODO: remove skipBLSValidation
     var sigs: seq[SignatureSet]
     if (let e = sigs.collectSignatureSets(
-        signedBlock, dag.db.immutableValidators,
+        signedBlock, dag.db.immutableValidators.byIndex,
         dag.clearanceState.data, cache); e.isErr()):
       info "Unable to load signature sets",
         err = e.error()

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -65,16 +65,14 @@ func get_beacon_committee_len*(
 
   compute_committee_len(
     count_active_validators(epochRef),
-    (slot mod SLOTS_PER_EPOCH) * committees_per_slot +
-      index.uint64,
+    (slot mod SLOTS_PER_EPOCH) * committees_per_slot + index.uint64,
     committees_per_slot * SLOTS_PER_EPOCH
   )
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_attesting_indices
 iterator get_attesting_indices*(epochRef: EpochRef,
                                 data: AttestationData,
-                                bits: CommitteeValidatorsBits):
-                                  ValidatorIndex =
+                                bits: CommitteeValidatorsBits): ValidatorIndex =
   if bits.lenu64 != get_beacon_committee_len(epochRef, data.slot, data.index.CommitteeIndex):
     trace "get_attesting_indices: inconsistent aggregation and committee length"
   else:
@@ -86,8 +84,7 @@ iterator get_attesting_indices*(epochRef: EpochRef,
 
 func get_attesting_indices_one*(epochRef: EpochRef,
                                 data: AttestationData,
-                                bits: CommitteeValidatorsBits):
-                                  Option[ValidatorIndex] =
+                                bits: CommitteeValidatorsBits): Option[ValidatorIndex] =
   # A variation on get_attesting_indices that returns the validator index only
   # if only one validator index is set
   if bits.lenu64 != get_beacon_committee_len(epochRef, data.slot, data.index.CommitteeIndex):
@@ -108,9 +105,7 @@ func get_attesting_indices_one*(epochRef: EpochRef,
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_attesting_indices
 func get_attesting_indices*(epochRef: EpochRef,
                             data: AttestationData,
-                            bits: CommitteeValidatorsBits):
-                              seq[ValidatorIndex] =
-  # TODO sequtils2 mapIt
+                            bits: CommitteeValidatorsBits): seq[ValidatorIndex] =
   for idx in get_attesting_indices(epochRef, data, bits):
     result.add(idx)
 
@@ -134,7 +129,7 @@ proc is_valid_indexed_attestation*(
       pubkeys = newSeqOfCap[CookedPubKey](sigs)
     for index in get_attesting_indices(
         epochRef, attestation.data, attestation.aggregation_bits):
-      pubkeys.add(epochRef.validatorKey(index).get())
+      pubkeys.add epochRef.validatorKey(index)
 
     if not verify_attestation_signature(
         fork, genesis_validators_root, attestation.data,

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -215,11 +215,11 @@ when hasGenesisDetection:
     if verify_deposit_signature(m.cfg, deposit):
       let pubkey = deposit.pubkey
       if pubkey notin m.genesisValidatorKeyToIndex:
-        let idx = ValidatorIndex m.genesisValidators.len
+        let idx = m.genesisValidators.len
         m.genesisValidators.add ImmutableValidatorData(
           pubkey: pubkey,
           withdrawal_credentials: deposit.withdrawal_credentials)
-        m.genesisValidatorKeyToIndex[pubkey] = idx
+        m.genesisValidatorKeyToIndex[pubkey] = ValidatorIndex.verifiedValue(idx)
 
   proc processGenesisDeposit*(m: Eth1Monitor, newDeposit: DepositData) =
     m.db.genesisDeposits.add newDeposit

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -191,7 +191,7 @@ proc checkForPotentialDoppelganger(
     let epochRef = self.dag.getEpochRef(
       tgtBlck, attestation.data.target.epoch)
     for validatorIndex in attesterIndices:
-      let validatorPubkey = epochRef.validatorKey(validatorIndex).get().toPubKey()
+      let validatorPubkey = self.dag.validatorKey(validatorIndex).toPubKey()
       if  self.doppelgangerDetectionEnabled and
           self.validatorPool[].getValidator(validatorPubkey) !=
             default(AttachedValidator):

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -436,12 +436,11 @@ proc getAttachedValidators(node: BeaconNode):
     Table[ValidatorIndex, AttachedValidator] =
   for validatorIndex in 0 ..<
       getStateField(node.dag.headState.data, validators).len:
-    let attachedValidator = node.getAttachedValidator(
-      getStateField(node.dag.headState.data, validators),
-      validatorIndex.ValidatorIndex)
-    if attachedValidator.isNil:
-      continue
-    result[validatorIndex.ValidatorIndex] = attachedValidator
+    let
+      validatorIndex = ValidatorIndex.verifiedValue(validatorIndex)
+      attachedValidator = node.getAttachedValidator(validatorIndex)
+    if not attachedValidator.isNil:
+      result[validatorIndex] = attachedValidator
 
 proc updateSubscriptionSchedule(node: BeaconNode, epoch: Epoch) {.async.} =
   doAssert epoch >= 1

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -218,7 +218,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     let (keySet, indexSet) =
       block:
         var res1: HashSet[ValidatorPubKey]
-        var res2: HashSet[ValidatorIndex]
+        var res2: HashSet[RestValidatorIndex]
         for item in validatorIds:
           case item.kind
           of ValidatorQueryKind.Key:
@@ -242,7 +242,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             if vitem in res2:
               return RestApiResponse.jsonError(Http400,
                                                UniqueValidatorIndexError)
-            res2.incl(vitem)
+            res2.incl(item.index)
         (res1, res2)
 
     node.withStateForBlockSlot(bslot):
@@ -251,7 +251,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       for index, validator in getStateField(stateData.data, validators).pairs():
         let includeFlag =
           (len(keySet) == 0) and (len(indexSet) == 0) or
-          (len(indexSet) > 0 and (ValidatorIndex(index) in indexSet)) or
+          (len(indexSet) > 0 and RestValidatorIndex(index) in indexSet) or
           (len(keySet) > 0 and (validator.pubkey in keySet))
         let sres = validator.getStatus(current_epoch)
         if sres.isOk():
@@ -259,7 +259,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           let statusFlag = vstatus in validatorsMask
           if includeFlag and statusFlag:
             res.add(RestValidator(
-              index: ValidatorIndex(index),
+              index: RestValidatorIndex(index),
               balance:
                 Base10.toString(getStateField(stateData.data, balances)[index]),
               status: toString(vstatus),
@@ -298,7 +298,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             if sres.isOk():
               return RestApiResponse.jsonResponse(
                 (
-                  index: ValidatorIndex(index),
+                  index: index,
                   balance:
                     Base10.toString(
                       getStateField(stateData.data, balances)[index]
@@ -325,17 +325,16 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                             UnsupportedValidatorIndexValueError)
             vres.get()
 
-        if uint64(vindex) >=
-          uint64(len(getStateField(stateData.data, validators))):
+        if uint64(vindex) >= getStateField(stateData.data, validators).lenu64:
           return RestApiResponse.jsonError(Http404, ValidatorNotFoundError)
-        let validator = getStateField(stateData.data, validators)[vindex]
+        let validator = getStateField(stateData.data, validators)[uint64(vindex)]
         let sres = validator.getStatus(current_epoch)
         if sres.isOk():
           return RestApiResponse.jsonResponse(
             (
               index: vindex,
               balance: Base10.toString(
-                         getStateField(stateData.data, balances)[vindex]
+                         getStateField(stateData.data, balances)[uint64(vindex)]
                        ),
               status: toString(sres.get()),
               validator: validator
@@ -373,7 +372,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     let (keySet, indexSet) =
       block:
         var res1: HashSet[ValidatorPubKey]
-        var res2: HashSet[ValidatorIndex]
+        var res2: HashSet[RestValidatorIndex]
         for item in validatorIds:
           case item.kind
           of ValidatorQueryKind.Key:
@@ -405,14 +404,14 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       for index, validator in getStateField(stateData.data, validators).pairs():
         let includeFlag =
           (len(keySet) == 0) and (len(indexSet) == 0) or
-          (len(indexSet) > 0 and (ValidatorIndex(index) in indexSet)) or
+          (len(indexSet) > 0 and (RestValidatorIndex(index) in indexSet)) or
           (len(keySet) > 0 and (validator.pubkey in keySet))
         let sres = validator.getStatus(current_epoch)
         if sres.isOk():
           let vstatus = sres.get()
           if includeFlag:
             res.add(RestValidatorBalance(
-              index: ValidatorIndex(index),
+              index: RestValidatorIndex(index),
               balance:
                 Base10.toString(getStateField(stateData.data, balances)[index]),
             ))
@@ -469,8 +468,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     node.withStateForBlockSlot(bslot):
       proc getCommittee(slot: Slot,
                        index: CommitteeIndex): RestBeaconStatesCommittees =
-        let validators = get_beacon_committee(stateData.data, slot, index,
-                                              cache).mapIt(it)
+        let validators = get_beacon_committee(stateData.data, slot, index, cache)
+                        .mapIt(it.toRestType)
         RestBeaconStatesCommittees(index: index, slot: slot,
                                    validators: validators)
 

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -150,6 +150,11 @@ func match(data: openarray[char], charset: set[char]): int =
       return 1
   0
 
+proc `==`*(lhs, rhs: RestValidatorIndex): bool {.borrow, noSideEffect.}
+
+template toRestType*(x: ValidatorIndex): RestValidatorIndex =
+  RestValidatorIndex(asUInt64(x))
+
 proc validate(key: string, value: string): int =
   ## This is rough validation procedure which should be simple and fast,
   ## because it will be used for query routing.
@@ -250,21 +255,21 @@ template withStateForBlockSlot*(node: BeaconNode,
     node.dag.withState(rpcState[], blockSlot):
       body
 
-proc toValidatorIndex*(value: RestValidatorIndex): Result[ValidatorIndex,
+proc toValidatorIndex*(value: RestValidatorIndex): Result[RestValidatorIndex,
                                                           ValidatorIndexError] =
   when sizeof(ValidatorIndex) == 4:
     if uint64(value) < VALIDATOR_REGISTRY_LIMIT:
       # On x86 platform Nim allows only `int32` indexes, so all the indexes in
       # range `2^31 <= x < 2^32` are not supported.
       if uint64(value) <= uint64(high(int32)):
-        ok(ValidatorIndex(value))
+        ok(value)
       else:
         err(ValidatorIndexError.UnsupportedValue)
     else:
       err(ValidatorIndexError.TooHighValue)
   elif sizeof(ValidatorIndex) == 8:
     if uint64(value) < VALIDATOR_REGISTRY_LIMIT:
-      ok(ValidatorIndex(value))
+      ok(value)
     else:
       err(ValidatorIndexError.TooHighValue)
   else:

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -97,9 +97,8 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
           epochRef, slot, committee_index.CommitteeIndex)
         for index_in_committee, validatorIdx in committee:
           let curr_val_pubkey = epochRef.validatorKey(validatorIdx)
-          if curr_val_pubkey.isSome():
-            if public_keys.findIt(it == curr_val_pubkey.get().toPubKey()) != -1:
-              result.add((public_key: curr_val_pubkey.get().toPubKey(),
+          if public_keys.findIt(it == curr_val_pubkey.toPubKey()) != -1:
+            result.add((public_key: curr_val_pubkey.toPubKey(),
                           validator_index: validatorIdx,
                           committee_index: committee_index.CommitteeIndex,
                           committee_length: committee.lenu64,
@@ -114,7 +113,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       epochRef = node.dag.getEpochRef(head, epoch)
     for i, bp in epochRef.beacon_proposers:
       if bp.isSome():
-        result.add((public_key: epochRef.validatorKey(bp.get()).get().toPubKey(),
+        result.add((public_key: epochRef.validatorKey(bp.get).toPubKey,
                     validator_index: bp.get(),
                     slot: compute_start_slot_at_epoch(epoch) + i))
 

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -52,6 +52,10 @@ type
     ## cases, like the database state)
     blob*: array[RawPubKeySize, byte]
 
+  ValidCompressedPubKeyBytes* = object
+    ## Compressed raw serialized key bytes - it's guaranteed that the key is valid
+    blob*: array[RawPubKeySize, byte]
+
   UncompressedPubKey* = object
     ## Uncompressed variation of ValidatorPubKey - this type is faster to
     ## deserialize but doubles the storage footprint
@@ -77,7 +81,9 @@ type
     ## Cooked signatures are those that have been loaded successfully from a
     ## ValidatorSig and are used to avoid expensive reloading as well as error
     ## checking
-export AggregateSignature
+
+export
+  AggregateSignature
 
 # API
 # ----------------------------------------------------------------------
@@ -94,6 +100,7 @@ func toPubKey*(privkey: ValidatorPrivKey): CookedPubKey =
 
 template toRaw*(x: CookedPubKey): auto =
   PublicKey(x).exportRaw()
+
 template toUncompressed*(x: CookedPubKey): auto =
   UncompressedPubKey(blob: PublicKey(x).exportUncompressed())
 
@@ -153,6 +160,9 @@ proc load*(v: ValidatorSig): Option[CookedSig] =
     some(CookedSig(parsed))
   else:
     none(CookedSig)
+
+template hash*(x: ValidCompressedPubKeyBytes): Hash =
+  hash(x.blob)
 
 func init*(agg: var AggregatePublicKey, pubkey: CookedPubKey) {.inline.}=
   ## Initializes an aggregate signature context

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -692,6 +692,12 @@ template `==`*(x: uint64, y: ValidatorIndex): bool =
 template `==`*(x: ValidatorIndex, y: uint64): bool =
   uint64(x) == y
 
+template asUInt64*(x: ValidatorIndex): uint64 =
+  uint64 distinctBase(x)
+
+template verifiedValue*(T: type ValidatorIndex, x: untyped): ValidatorIndex =
+  ValidatorIndex(x)
+
 # TODO Nim 1.4, but not Nim 1.2, defines a function by this name, which works
 # only on openArray[int]. They do the same thing, so either's fine, when both
 # overloads match. The Nim 1.4 stdlib doesn't int-convert but it's a no-op in
@@ -712,6 +718,9 @@ template hash*(x: CommitteeIndex): Hash =
 
 template `$`*(x: CommitteeIndex): auto =
   $ distinctBase(x)
+
+template verifiedValue*(T: type CommitteeIndex, x: untyped): CommitteeIndex =
+  CommitteeIndex(x)
 
 template `==`*(x, y: SubnetId): bool =
   distinctBase(x) == distinctBase(y)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -328,21 +328,16 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndex) {.
      raises: [IOError, Defect].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
-proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex) {.
-     raises: [IOError, SerializationError, Defect].} =
-  let svalue = reader.readValue(string)
-  let res = Base10.decode(uint64, svalue)
-  if res.isOk():
-    let v = res.get()
-    if v < VALIDATOR_REGISTRY_LIMIT:
-      value = ValidatorIndex(v)
-    else:
-      reader.raiseUnexpectedValue(
-        "Validator index is bigger then VALIDATOR_REGISTRY_LIMIT")
-  else:
-    reader.raiseUnexpectedValue($res.error())
+proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex)
+               {.error: "Types such as `ValidatorIndex` have to be subjected to validation." &
+                        "For this reason, they cannot appear in REST API input structures".}
 
 ## RestValidatorIndex
+
+proc writeValue*(writer: var JsonWriter, value: RestValidatorIndex)
+                {.raises: [IOError, Defect].} = # Used for logging
+  writeValue(writer, uint64(value))
+
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: RestValidatorIndex) {.
      raises: [IOError, Defect].} =

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -87,20 +87,20 @@ type
 
   RestAttesterDuty* = object
     pubkey*: ValidatorPubKey
-    validator_index*: ValidatorIndex
+    validator_index*: RestValidatorIndex
     committee_index*: CommitteeIndex
     committee_length*: uint64
     committees_at_slot*: uint64
-    validator_committee_index*: ValidatorIndex
+    validator_committee_index*: RestValidatorIndex
     slot*: Slot
 
   RestProposerDuty* = object
     pubkey*: ValidatorPubKey
-    validator_index*: ValidatorIndex
+    validator_index*: RestValidatorIndex
     slot*: Slot
 
   RestCommitteeSubscription* = object
-    validator_index*: ValidatorIndex
+    validator_index*: RestValidatorIndex
     committee_index*: CommitteeIndex
     committees_at_slot*: uint64
     slot*: Slot
@@ -117,27 +117,27 @@ type
     genesis_fork_version*: Version
 
   RestValidatorBalance* = object
-    index*: ValidatorIndex
+    index*: RestValidatorIndex
     balance*: string
 
   RestBeaconStatesCommittees* = object
     index*: CommitteeIndex
     slot*: Slot
-    validators*: seq[ValidatorIndex]
+    validators*: seq[RestValidatorIndex]
 
   RestAttestationsFailure* = object
     index*: uint64
     message*: string
 
   RestValidator* = object
-    index*: ValidatorIndex
+    index*: RestValidatorIndex
     balance*: string
     status*: string
     validator*: Validator
 
   RestBlockHeader* = object
     slot*: Slot
-    proposer_index*: ValidatorIndex
+    proposer_index*: RestValidatorIndex
     parent_root*: Eth2Digest
     state_root*: Eth2Digest
     body_root*: Eth2Digest
@@ -300,6 +300,9 @@ type
   GetVersionResponse* = DataEnclosedObject[RestNodeVersion]
   ProduceAttestationDataResponse* = DataEnclosedObject[AttestationData]
   ProduceBlockResponse* = DataEnclosedObject[phase0.BeaconBlock]
+
+template `$`*(x: RestValidatorIndex): auto =
+  $ distinctBase(x)
 
 func init*(t: typedesc[StateIdent], v: StateIdentType): StateIdent =
   StateIdent(kind: StateQueryKind.Named, value: v)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -183,10 +183,10 @@ proc addAttestation*(
                     attestation.data,
                     attestation.aggregation_bits):
     if not inited: # first iteration
-      attestersAgg.init(epochRef.validatorKey(valIndex).get())
+      attestersAgg.init(epochRef.validatorKey(valIndex))
       inited = true
     else:
-      attestersAgg.aggregate(epochRef.validatorKey(valIndex).get())
+      attestersAgg.aggregate(epochRef.validatorKey(valIndex))
 
   if not inited:
     # There were no attesters

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -46,7 +46,7 @@ func process_block_header*(
   if proposer_index.isNone:
     return err("process_block_header: proposer missing")
 
-  if not (blck.proposer_index.ValidatorIndex == proposer_index.get):
+  if not (blck.proposer_index == proposer_index.get):
     return err("process_block_header: proposer index incorrect")
 
   # Verify that the parent matches

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -634,27 +634,26 @@ iterator get_flag_index_deltas(
       unslashed_participating_balance div EFFECTIVE_BALANCE_INCREMENT
     active_increments = total_active_balance div EFFECTIVE_BALANCE_INCREMENT
 
-  for index in 0 ..< state.validators.len:
+  for index in state.validatorIndices:
     # TODO Obviously not great
     let v = state.validators[index]
     if  not (is_active_validator(v, previous_epoch) or
         (v.slashed and previous_epoch + 1 < v.withdrawable_epoch)):
       continue
 
-    template vidx: ValidatorIndex = index.ValidatorIndex
-    let base_reward = get_base_reward(state, vidx, total_active_balance_sqrt)
+    let base_reward = get_base_reward(state, index, total_active_balance_sqrt)
     yield
-      if vidx in unslashed_participating_indices:
+      if index in unslashed_participating_indices:
         if not is_in_inactivity_leak(state):
           let reward_numerator =
             base_reward * weight * unslashed_participating_increments
-          (vidx, reward_numerator div (active_increments * WEIGHT_DENOMINATOR), 0.Gwei)
+          (index, reward_numerator div (active_increments * WEIGHT_DENOMINATOR), 0.Gwei)
         else:
-          (vidx, 0.Gwei, 0.Gwei)
+          (index, 0.Gwei, 0.Gwei)
       elif flag_index != TIMELY_HEAD_FLAG_INDEX:
-        (vidx, 0.Gwei, base_reward * weight div WEIGHT_DENOMINATOR)
+        (index, 0.Gwei, base_reward * weight div WEIGHT_DENOMINATOR)
       else:
-        (vidx, 0.Gwei, 0.Gwei)
+        (index, 0.Gwei, 0.Gwei)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.2/specs/altair/beacon-chain.md#modified-get_inactivity_penalty_deltas
 iterator get_inactivity_penalty_deltas(cfg: RuntimeConfig, state: altair.BeaconState):

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -171,6 +171,12 @@ func get_committee_count_per_slot*(state: SomeBeaconState,
   # Otherwise, get_beacon_committee(...) cannot access some committees.
   doAssert (SLOTS_PER_EPOCH * MAX_COMMITTEES_PER_SLOT) >= uint64(result)
 
+iterator committee_indices_per_slot*(state: SomeBeaconState,
+                                     epoch: Epoch,
+                                     cache: var StateCache): CommitteeIndex =
+  for idx in 0'u64 ..< get_committee_count_per_slot(state, epoch, cache):
+    yield CommitteeIndex.verifiedValue(idx)
+
 func get_committee_count_per_slot*(state: SomeBeaconState,
                                    slot: Slot,
                                    cache: var StateCache): uint64 =

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -68,8 +68,11 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
     else:
       debug "Local validator updated with index",
             pubKey = item.validator.pubkey, index = item.index
-      vc.attachedValidators.updateValidator(item.validator.pubkey,
-                                            item.index)
+      let idx = ValidatorIndex.verifiedValue(item.index.uint64)
+        # We are operating under the assumption that our beacon node is not
+        # lying to us. If we had a trusted BeaconState instead, we could have
+        # found the indices of the attached validators by ourselves.
+      vc.attachedValidators.updateValidator(item.validator.pubkey, idx)
 
 proc pollForAttesterDuties*(vc: ValidatorClientRef,
                             epoch: Epoch): Future[int] {.async.} =


### PR DESCRIPTION
This is a work-in-progress  from the altair branch to reform validator
indices - in review, the changes have been found wanting due to the
difficulty of using type to communicate lifetime when the lifetime is
tied to state and not a static property of the type.

A more accurate change would be to introduce a `CachedValidatorIndex`
that sits at a `dag` level, but that would require refactoring the
current changes to not touch the state, whose validator index validity
works in a different way than the cache preventing these changes from
beeing merged in their current state, so as not to introduce confusion
in the spec code.

The changes also need to be reviewed for tree hash cache performance
regressions (calling the right `[]` etc).

The other change discussed in this context has been to harden the code
against silly values of CommitteeIndex and ValidatorIndex using their
natural / static range limits from the spec constants - this would be a
separate change to the reform in this branch. In particular, the notion
of a "valid" `CommitteeIndex` in this branch needs to be revisited (as
the validity depends on the state, not the lifetime of a program).

See also
https://github.com/status-im/nimbus-eth2/pull/2709#discussion_r686246957