### PR TITLE
altair-capable beacon block creation

### DIFF
--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -411,7 +411,9 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       # It was not integrated into the beacon node's database.
       return 202
     else:
-      let res = await proposeSignedBlock(node, head, AttachedValidator(), blck)
+      let res = await proposeSignedBlock(
+        node, head, AttachedValidator(),
+        ForkedSignedBeaconBlock.init(blck))
       if res == head:
         # TODO altair-transition, but not immediate testnet-priority
         node.network.broadcastBeaconBlock(ForkedSignedBeaconBlock.init(blck))

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -406,6 +406,7 @@ proc makeBeaconBlock*(
     proposerSlashings: seq[ProposerSlashing],
     attesterSlashings: seq[AttesterSlashing],
     voluntaryExits: seq[SignedVoluntaryExit],
+    sync_aggregate: SyncAggregate,
     executionPayload: ExecutionPayload,
     rollback: RollbackAltairHashedProc,
     cache: var StateCache): Result[altair.BeaconBlock, string] =
@@ -432,10 +433,7 @@ proc makeBeaconBlock*(
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
       voluntary_exits:
         List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS](voluntaryExits),
-      sync_aggregate: SyncAggregate(sync_committee_signature:
-        default(CookedSig).toValidatorSig)))
-
-  # TODO sync committees
+      sync_aggregate: sync_aggregate))
 
   let res = process_block(cfg, state.data, blck, {skipBlsValidation}, cache)
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -14,7 +14,7 @@ import
   ../beacon_chain/spec/[helpers, signatures, state_transition, forks],
   ../beacon_chain/consensus_object_pools/attestation_pool
 
-func makeFakeValidatorPrivKey(i: int): ValidatorPrivKey =
+func makeFakeValidatorPrivKey*(i: int): ValidatorPrivKey =
   # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
   # lighthouse.
   # TODO: switch to https://github.com/ethereum/eth2.0-pm/issues/60


### PR DESCRIPTION
In general, it just duplicates the phase 0 and Altair codepaths. This needs to be fixed, especially in terms of scaling to the merge, but not in this PR.

The only general difference is that the Altair codepaths track the sync committees, e.g.,
```nim
node.sync_committee_msg_pool[].produceSyncAggregate(head),
```
The other dozen-plus parameters are identical.

The upside is that it allows simplification of several aspects of JSON-RPC and REST code.