### PR TITLE
update research VCS ignores

### DIFF
--- a/research/.gitignore
+++ b/research/.gitignore
@@ -1,3 +1,5 @@
+*.dSYM/
 *.json
+block_sim
+stack_sizes
 state_sim
-serialized_sizes


### PR DESCRIPTION
In edd9826464720f21f99d69e7859f565154ec2aa0, VCS ignores were introduced
to ignore the output from building and running the research tools from
their directory. Over time, new research tools got introduced, but the
ignore list did not get updated. Updating now for current set of tools.