### PR TITLE
roll back putative blocks from invalid hardforks

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -69,6 +69,12 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + parent sanity [Preset: mainnet]                                                            OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## Diverging hardforks
+```diff
++ Non-tail block in common                                                                   OK
++ Tail block only in common                                                                  OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Eth1 monitor
 ```diff
 + Rewrite HTTPS Infura URLs                                                                  OK
@@ -348,4 +354,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 36/48 Fail: 0/48 Skip: 12/48
 
 ---TOTAL---
-OK: 190/202 Fail: 0/202 Skip: 12/202
+OK: 192/204 Fail: 0/204 Skip: 12/204

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -789,10 +789,15 @@ proc getEth2FinalizedTo*(db: BeaconChainDB): Opt[DepositContractSnapshot] =
 proc containsBlock*(db: BeaconChainDBV0, key: Eth2Digest): bool =
   db.backend.contains(subkey(phase0.SignedBeaconBlock, key)).expectDb()
 
-proc containsBlock*(db: BeaconChainDB, key: Eth2Digest): bool =
-  db.altairBlocks.contains(key.data).expectDb() or
-    db.blocks.contains(key.data).expectDb() or
+proc containsBlockPhase0*(db: BeaconChainDB, key: Eth2Digest): bool =
+  db.blocks.contains(key.data).expectDb() or
     db.v0.containsBlock(key)
+
+proc containsBlockAltair*(db: BeaconChainDB, key: Eth2Digest): bool =
+  db.altairBlocks.contains(key.data).expectDb()
+
+proc containsBlock*(db: BeaconChainDB, key: Eth2Digest): bool =
+  db.containsBlockPhase0(key) or db.containsBlockAltair(key)
 
 proc containsState*(db: BeaconChainDBV0, key: Eth2Digest): bool =
   let sk = subkey(BeaconStateNoImmutableValidators, key)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -68,11 +68,15 @@ suite "Beacon chain DB" & preset():
 
     check:
       db.containsBlock(root)
+      db.containsBlockPhase0(root)
+      not db.containsBlockAltair(root)
       db.getBlock(root).get() == signedBlock
 
     db.delBlock(root)
     check:
       not db.containsBlock(root)
+      not db.containsBlockPhase0(root)
+      not db.containsBlockAltair(root)
       db.getBlock(root).isErr()
 
     db.putStateRoot(root, signedBlock.message.slot, root)
@@ -97,11 +101,15 @@ suite "Beacon chain DB" & preset():
 
     check:
       db.containsBlock(root)
+      not db.containsBlockPhase0(root)
+      db.containsBlockAltair(root)
       db.getAltairBlock(root).get() == signedBlock
 
     db.delBlock(root)
     check:
       not db.containsBlock(root)
+      not db.containsBlockPhase0(root)
+      not db.containsBlockAltair(root)
       db.getAltairBlock(root).isErr()
 
     db.putStateRoot(root, signedBlock.message.slot, root)


### PR DESCRIPTION
Addresses https://github.com/status-im/nimbus-eth2/issues/2810

It removes the invalid blocks up-front, before anything else in the processing pipeline knows they exist.

Once the next head update occurs, the transition period naturally ends.