### PR TITLE
update gossip_processing and attestation docs

### DIFF
--- a/beacon_chain/gossip_processing/README.md
+++ b/beacon_chain/gossip_processing/README.md
@@ -1,13 +1,13 @@
 # Gossip Processing
 
-This folders hold a collection of modules to:
+This folder holds a collection of modules to:
 - validate raw gossip data before
-  - rebroadcasting them (potentially aggregated)
-  - sending it to one of the consensus object pool
+  - rebroadcasting it (potentially aggregated)
+  - sending it to one of the consensus object pools
 
 ## Validation
 
-Gossip Validation is different from consensus verification in particular for blocks.
+Gossip validation is different from consensus verification in particular for blocks.
 
 - Blocks: https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_block
 - Attestations (aggregate): https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
@@ -18,17 +18,15 @@ Gossip Validation is different from consensus verification in particular for blo
 
 There are 2 consumers of validated consensus objects:
 - a `ValidationResult.Accept` output triggers rebroadcasting in libp2p
-  - method `validate(PubSub, message)` in libp2p/protocols/pubsub/pubsub.nim in the
+  - method `validate(PubSub, Message)` in libp2p/protocols/pubsub/pubsub.nim
   - which was called by `rpcHandler(GossipSub, PubSubPeer, RPCMsg)`
-- a `xyzValidator` message enqueues the validated object in one of the processing queue in eth2_processor
-  - `blocksQueue: AsyncQueue[BlockEntry]`, (shared with request_manager and sync_manager)
-  - `attestationsQueue: AsyncQueue[AttestationEntry]`
-  - `aggregatesQueue: AsyncQueue[AggregateEntry]`
+- a `blockValidator` message enqueues the validated object to the processing queue in block_processor
+  - `blocksQueue: AsyncQueue[BlockEntry]` (shared with request_manager and sync_manager)
 
 Those queues are then regularly processed to be made available to the consensus object pools.
 
 ## Security concerns
 
-As the first line of defense in Nimbus, modules must be able to handle burst of data that may come:
+As the first line of defense in Nimbus, modules must be able to handle bursts of data that may come:
 - from malicious nodes trying to DOS us
-- from long periods of non-finality, creating lots of forks, attestations, forks
+- from long periods of non-finality, creating lots of forks, attestations

--- a/docs/attestation_flow.md
+++ b/docs/attestation_flow.md
@@ -6,33 +6,33 @@ This is a WIP document to explain the attestation flows.
 
 Important distinction:
 - We distinguish attestation `validation` which is defined in the P2P specs:
-  - single: https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
-  - aggregated: https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
-  A validated attestation or aggregate can be forwarded on gossipsub.
+  - Single: https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
+  - Aggregated: https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
+  A validated attestation or aggregate can be forwarded on GossipSub.
 - and we distinguish `verification` which is defined in consensus specs:
   https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestations
-  An attestation needs to be verified to enter fork choice, or be included in a block.
+  An attestation needs to be verified to enter fork choice, or to be included in a block.
 
-To be clarified: from the specs it seems like gossip attestation validation is a superset of consensus attestation verification.
+To be clarified: from the specs it seems like P2P attestation validation is a superset of consensus attestation verification.
 
 ### Inputs
 
 Attestations can be received from the following sources:
-- Gossipsub
-  - Aggregate: `/eth2/{$forkDigest}/beacon_aggregate_and_proof/ssz` stored `topicAggregateAndProofs` field of the beacon node
-  - Unaggregated `/eth2/{$forkDigest}/beacon_attestation_{subnetIndex}/ssz`
+- GossipSub
+  - Single `/eth2/{$forkDigest}/beacon_attestation_{subnetIndex}/ssz`
+  - Aggregated: `/eth2/{$forkDigest}/beacon_aggregate_and_proof/ssz`
 - Included in blocks received
 - the NBC database (within a block)
 - a local validator vote
 - Devtools: test suite, ncli, fuzzing
 
 The related base types are
-- Attestation
-- IndexedAttestation
+- `Attestation`
+- `IndexedAttestation`
 
 The base types are defined in the Eth2 specs.
-On top, Nimbus builds new types to represent the level of trust and validation we have with regards to each BeaconBlock.
-Those types allow the Nim compiler to help us ensure proper usage at compile-time and zero runtime cost.
+On top of these, Nimbus builds new types to represent the level of trust and validation we have with regards to each BeaconBlock.
+Those types allow the Nim compiler to help us ensure proper usage at compile-time with zero runtime cost.
 
 #### TrustedAttestation & TrustedIndexedAttestation
 
@@ -46,31 +46,29 @@ How the various modules interact with block is described in a diagram:
 
 ![./attestation_flow.png](./attestation_flow.png)
 
-Note: The Eth2Processor as 2 queues for attestations (before and after P2P validation) and 2 queues for aggregates. The diagram highlights that with separated `AsyncQueue[AttestationEntry]` and `AsyncQueue[AggregateEntry]`
+_TODO Note: Image is outdated, the Eth2Processor no longer has attestation queues._
 
 ### Gossip flow in
 
-Attestatios are listened to via the gossipsub topics
-- Aggregate: `/eth2/{$forkDigest}/beacon_aggregate_and_proof/ssz` stored `topicAggregateAndProofs` field of the beacon node
-- Unaggregated `/eth2/{$forkDigest}/beacon_attestation_{subnetIndex}/ssz`
+Attestatios are listened to via the GossipSub topics
+- Single: `/eth2/{$forkDigest}/beacon_attestation_{subnetIndex}/ssz`
+- Aggregate: `/eth2/{$forkDigest}/beacon_aggregate_and_proof/ssz`
 
 They are then
 - validated by `validateAttestation()` or `validateAggregate()` in either `attestationValidator()` or `aggregateValidator()`
   according to spec
   - https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
   - https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#attestation-subnets
-- It seems like P2P validation is a superset of consensus verification as in `process_attestation()`:
-  - https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestations
-- Enqueued in
-  - `attestationsQueue: AsyncQueue[AttestationEntry]`
-  - `aggregatesQueue: AsyncQueue[AggregateEntry]`
+  - It seems like P2P validation is a superset of consensus verification as in `process_attestation()`:
+    - https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#attestations
+- added to the local `attestationPool`
 - dropped in case of error
 
 ### Gossip flow out
 
-- After validation in `attestationValidator()` or `aggregateValidator()` in the Eth2Processor
+- After validation in `attestationValidator()` or `aggregateValidator()` in eth2_processor
 - Important: P2P validation is different from verification at the consensus level.
-- We jump into libp2p/protocols/pubsub/pubsub.nim in the method `validate(PubSub, message)`
+- We jump into method `validate(PubSub, Message)` in libp2p/protocols/pubsub/pubsub.nim
 - which was called by `rpcHandler(GossipSub, PubSubPeer, RPCMsg)`
 
 ### Eth2 RPC in
@@ -80,18 +78,12 @@ There is no RPC for attestations but attestations might be included in synced bl
 
 ### Sync vs Steady State
 
-During sync the only attestation we receive are within synced blocks.
-Afterwards attestations come from GossipSub
+During sync the only attestations we receive are within synced blocks.
+Afterwards attestations come from GossipSub.
 
 #### Bottlenecks during sync
 
-During sync, attestations are not a bottleneck, they are a small part of the large block processing.
-
-##### Backpressure
-
-The `attestationsQueue` to store P2P validated attestations has a max size of `TARGET_COMMITTEE_SIZE * MAX_COMMITTEES_PER_SLOT` (128 * 64 = 8192)
-
-The `aggregatesQueue` has a max size of `TARGET_AGGREGATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT` (16 * 64 = 1024)
+During sync, attestations are not a bottleneck, they are a small part of the heavy block processing.
 
 ##### Latency & Throughput sensitiveness
 
@@ -102,10 +94,10 @@ We distinguish an aggregated attestation:
 During sync attestations are included in blocks and so do not require gossip validation,
 they are also aggregated per validators and can be batched with other signatures within a block.
 
-After sync, attestations need to be rebroadcasted fast to:
+After sync, attestations need to be rebroadcasted quickly to:
 - maintain the quality of the GossipSub mesh
 - not be booted by peers
 
-Attestations need to be validated or aggregated fast to avoid delaying other networking operations, in particular they are bottleneck by cryptography.
+Attestations need to be validated or aggregated quickly to avoid delaying other networking operations, in particular their computation is bottlenecked by cryptography.
 
-The number of attestation to process grows with the number of peers. An aggregated attestation is as cheap to process as a non-aggregated one. Batching is worth it even with only 2 attestations to batch.
+The number of attestations to process grows with the number of peers. An aggregated attestation is as cheap to process as a non-aggregated one. Batching is worth it even with only 2 attestations to batch.


### PR DESCRIPTION
The README file explaining gossip_processing, and the attestation_flow
docs were no longer accurate, as attestations and aggregates no longer
go through a queue. Updated accordingly, also fixed grammar and typos.