### PR TITLE
remove non-implemented mock genesis arg

### DIFF
--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -17,7 +17,7 @@ import
   # Mocking procs
   ./mock_deposits
 
-proc initGenesisState*(num_validators: uint64, genesis_time: uint64 = 0): phase0.HashedBeaconState =
+proc initGenesisState*(num_validators: uint64): phase0.HashedBeaconState =
   let deposits = mockGenesisBalancedDeposits(
       validatorCount = num_validators,
       amountInEth = 32, # We create canonical validators with 32 Eth


### PR DESCRIPTION
The `initGenesisState` function to mock genesis states for testing was
originally introduced with a `genesis_time` parameter in #326. However,
this parameter was never respected and genesis state was always mocked
with `genesis_time` assumed to be 0. Since there is no test overriding
`genesis_time`, the parameter is removed until needed.