### PR TITLE
allow testing genesis with Altair

### DIFF
--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -23,8 +23,7 @@ import
 suite "[Unit - Spec - Block processing] Attestations " & preset():
 
   const NumValidators = uint64(8) * SLOTS_PER_EPOCH
-  let genesisState = (ref ForkedHashedBeaconState)(
-    hbsPhase0: initGenesisState(NumValidators), beaconStateFork: forkPhase0)
+  let genesisState = initGenesisState(NumValidators)
 
   doAssert getStateField(genesisState[], validators).lenu64 == NumValidators
 

--- a/tests/spec_block_processing/test_process_deposits.nim
+++ b/tests/spec_block_processing/test_process_deposits.nim
@@ -16,7 +16,7 @@ import
   # Standard library
   std/math,
   # Specs
-  ../../beacon_chain/spec/[state_transition_block],
+  ../../beacon_chain/spec/[forks, state_transition_block],
   ../../beacon_chain/spec/datatypes/base,
   # Internals
   # Mock helpers
@@ -26,7 +26,7 @@ import
 suite "[Unit - Spec - Block processing] Deposits " & preset():
 
   const NumValidators = uint64 5 * SLOTS_PER_EPOCH
-  let genesisState = newClone(initGenesisState(NumValidators))
+  let genesisState = newClone(initGenesisState(NumValidators).hbsPhase0)
   doAssert genesisState.data.validators.lenu64 == NumValidators
 
   template valid_deposit(deposit_amount: uint64, name: string): untyped =

--- a/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
+++ b/tests/spec_epoch_processing/test_process_justification_and_finalization.nim
@@ -218,8 +218,7 @@ proc payload =
     echo "   Finalization rules are detailed at https://github.com/protolambda/eth2-docs#justification-and-finalization"
 
     const NumValidators = uint64(8) * SLOTS_PER_EPOCH
-    let genesisState = (ref ForkedHashedBeaconState)(
-      hbsPhase0: initGenesisState(NumValidators), beaconStateFork: forkPhase0)
+    let genesisState = initGenesisState(NumValidators)
     doAssert getStateField(genesisState[], validators).lenu64 == NumValidators
 
     setup:


### PR DESCRIPTION
The mocking framework was limited to chain configurations that do not
include Altair at genesis. This patch extends it so that genesis states
can be generated that are already upgraded to Altair. This is useful for
tests such as eth2spec/test/altair/unittests/test_sync_protocol.py.