### PR TITLE
remove forked message accessor

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -322,9 +322,6 @@ template root*(x: ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock): Eth
 template slot*(x: ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock): Slot =
   getForkedBlockField(x, slot)
 
-template message*(x: ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock): auto =
-  withBlck(x): blck.message
-
 template shortLog*(x: ForkedBeaconBlock): auto =
   withBlck(x): shortLog(blck)
 


### PR DESCRIPTION
The template `message` extracts fork specific data from a forked block.
However, its current implementation does not compile due to each fork
returning a different type, i.e., the generated `case` code attempts to
return different types from each branch. As the template is unused, it
is safely removed for now.