### PR TITLE
use correct proposer when mocking blocks

### DIFF
--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -43,7 +43,7 @@ proc mockBlock(
   ## Mock a BeaconBlock for the specific slot
 
   var emptyCache = StateCache()
-  let proposer_index = get_beacon_proposer_index(state, emptyCache)
+  let proposer_index = get_beacon_proposer_index(state, emptyCache, slot)
   result.message.slot = slot
   result.message.proposer_index = proposer_index.get.uint64
   result.message.body.eth1_data.deposit_count = state.eth1_deposit_index


### PR DESCRIPTION
When creating beacon blocks, the state needs to be advanced to the new
slot to determine the correct proposer index. In #875 a regression got
introduced that removed this logic when mocking blocks. Existing tests
failed to detect this, as they do not make use of the proposer index.
This patch re-introduces the state advancement, fixing the problem.