### PR TITLE
allow adding Altair test blocks

### DIFF
--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -97,7 +97,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
     withTimer(timers[t]):
       signedBlock = addTestBlock(
         state[], latest_block_root, cache, attestations = blockAttestations,
-        flags = flags)
+        flags = flags).phase0Block
     latest_block_root = withTimerRet(timers[tHashBlock]):
       hash_tree_root(signedBlock.message)
     signedBlock.root = latest_block_root

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -112,7 +112,7 @@ suite "Attestation pool processing" & preset():
     let
       root1 = addTestBlock(
         state.data, state.blck.root,
-        cache, attestations = attestations, nextSlot = false).root
+        cache, attestations = attestations, nextSlot = false).phase0Block.root
       bc1 = get_beacon_committee(
         state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
       att1 = makeAttestation(state[].data, root1, bc1[0], cache)
@@ -376,7 +376,7 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns latest block with no attestations":
     var cache = StateCache()
     let
-      b1 = addTestBlock(state.data, dag.tail.root, cache)
+      b1 = addTestBlock(state.data, dag.tail.root, cache).phase0Block
       b1Add = dag.addRawBlock(quarantine, b1) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -389,7 +389,7 @@ suite "Attestation pool processing" & preset():
       head == b1Add[]
 
     let
-      b2 = addTestBlock(state.data, b1.root, cache)
+      b2 = addTestBlock(state.data, b1.root, cache).phase0Block
       b2Add = dag.addRawBlock(quarantine, b2) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -404,7 +404,7 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns block with attestation":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, dag.tail.root, cache)
+      b10 = makeTestBlock(state.data, dag.tail.root, cache).phase0Block
       b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -419,7 +419,7 @@ suite "Attestation pool processing" & preset():
     let
       b11 = makeTestBlock(state.data, dag.tail.root, cache,
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-      )
+      ).phase0Block
       b11Add = dag.addRawBlock(quarantine, b11) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -465,7 +465,7 @@ suite "Attestation pool processing" & preset():
   test "Trying to add a block twice tags the second as an error":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, dag.tail.root, cache)
+      b10 = makeTestBlock(state.data, dag.tail.root, cache).phase0Block
       b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -494,7 +494,7 @@ suite "Attestation pool processing" & preset():
     dag.updateFlags.incl {skipBLSValidation}
     var cache = StateCache()
     let
-      b10 = addTestBlock(state.data, dag.tail.root, cache)
+      b10 = addTestBlock(state.data, dag.tail.root, cache).phase0Block
       b10Add = dag.addRawBlock(quarantine, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -520,7 +520,7 @@ suite "Attestation pool processing" & preset():
         get_committee_count_per_slot(state[].data, Epoch epoch, cache)
       for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
         let new_block = addTestBlock(
-          state.data, block_root, cache, attestations = attestations)
+          state.data, block_root, cache, attestations = attestations).phase0Block
 
         block_root = new_block.root
         let blockRef = dag.addRawBlock(quarantine, new_block) do (

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -126,8 +126,8 @@ suite "Block pool processing" & preset():
       cache = StateCache()
       rewards = RewardInfo()
       att0 = makeFullAttestations(state[], dag.tail.root, 0.Slot, cache)
-      b1 = addTestBlock(state[], dag.tail.root, cache, attestations = att0)
-      b2 = addTestBlock(state[], b1.root, cache)
+      b1 = addTestBlock(state[], dag.tail.root, cache, attestations = att0).phase0Block
+      b2 = addTestBlock(state[], b1.root, cache).phase0Block
   test "getRef returns nil for missing blocks":
     check:
       dag.getRef(default Eth2Digest) == nil
@@ -180,7 +180,7 @@ suite "Block pool processing" & preset():
         rewards, {})
 
     let
-      b4 = addTestBlock(state[], b2.root, cache)
+      b4 = addTestBlock(state[], b2.root, cache).phase0Block
       b4Add = dag.addRawBlock(quarantine, b4, nilPhase0Callback)
 
     check:
@@ -354,7 +354,7 @@ suite "chain DAG finalization tests" & preset():
   test "prune heads on finalization" & preset():
     # Create a fork that will not be taken
     var
-      blck = makeTestBlock(dag.headState.data, dag.head.root, cache)
+      blck = makeTestBlock(dag.headState.data, dag.head.root, cache).phase0Block
       tmpState = assignClone(dag.headState.data)
     check:
       process_slots(
@@ -362,7 +362,7 @@ suite "chain DAG finalization tests" & preset():
         getStateField(tmpState[], slot) + (5 * SLOTS_PER_EPOCH).uint64,
         cache, rewards, {})
 
-    let lateBlock = addTestBlock(tmpState[], dag.head.root, cache)
+    let lateBlock = addTestBlock(tmpState[], dag.head.root, cache).phase0Block
     block:
       let status = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: status.isOk()
@@ -378,7 +378,7 @@ suite "chain DAG finalization tests" & preset():
       blck = addTestBlock(
         tmpState[], dag.head.root, cache,
         attestations = makeFullAttestations(
-          tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {}))
+          tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {})).phase0Block
       let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
@@ -449,7 +449,7 @@ suite "chain DAG finalization tests" & preset():
       if i == SLOTS_PER_EPOCH - 1:
         assign(prestate[], dag.headState.data)
 
-      let blck = makeTestBlock(dag.headState.data, dag.head.root, cache)
+      let blck = makeTestBlock(dag.headState.data, dag.head.root, cache).phase0Block
       let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
@@ -466,7 +466,7 @@ suite "chain DAG finalization tests" & preset():
       cache, rewards, {})
 
     # create another block, orphaning the head
-    let blck = makeTestBlock(prestate[], dag.head.parent.root, cache)
+    let blck = makeTestBlock(prestate[], dag.head.parent.root, cache).phase0Block
 
     # Add block, but don't update head
     let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
@@ -483,7 +483,7 @@ suite "chain DAG finalization tests" & preset():
     for blck in makeTestBlocks(
         dag.headState.data, dag.head.root, cache, int(SLOTS_PER_EPOCH * 6 - 2),
         true):
-      let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
+      let added = dag.addRawBlock(quarantine, blck.phase0Block, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine)
       dag.pruneAtFinalization()
@@ -498,7 +498,7 @@ suite "chain DAG finalization tests" & preset():
       dag.headState.data, dag.head.root, cache,
       attestations = makeFullAttestations(
         dag.headState.data, dag.head.root, getStateField(dag.headState.data, slot),
-        cache, {}))
+        cache, {})).phase0Block
 
     let added = dag.addRawBlock(quarantine, blck, nilPhase0Callback)
     check: added.isOk()
@@ -559,7 +559,7 @@ suite "Old database versions" & preset():
       state = newClone(dag.headState.data)
       cache = StateCache()
       att0 = makeFullAttestations(state[], dag.tail.root, 0.Slot, cache)
-      b1 = addTestBlock(state[], dag.tail.root, cache, attestations = att0)
+      b1 = addTestBlock(state[], dag.tail.root, cache, attestations = att0).phase0Block
       b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     check:
@@ -595,7 +595,7 @@ suite "Diverging hardforks":
     # Because the first block is after the Altair transition, the only block in
     # common is the tail block
     var
-      b1 = addTestBlock(tmpState[], dag.tail.root, cache)
+      b1 = addTestBlock(tmpState[], dag.tail.root, cache).phase0Block
       b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     check b1Add.isOk()
@@ -613,7 +613,7 @@ suite "Diverging hardforks":
 
     # There's a block in the shared-correct phase0 hardfork, before epoch 2
     var
-      b1 = addTestBlock(tmpState[], dag.tail.root, cache)
+      b1 = addTestBlock(tmpState[], dag.tail.root, cache).phase0Block
       b1Add = dag.addRawBlock(quarantine, b1, nilPhase0Callback)
 
     check:
@@ -624,7 +624,7 @@ suite "Diverging hardforks":
         cache, rewards, {})
 
     var
-      b2 = addTestBlock(tmpState[], b1.root, cache)
+      b2 = addTestBlock(tmpState[], b1.root, cache).phase0Block
       b2Add = dag.addRawBlock(quarantine, b2, nilPhase0Callback)
 
     check b2Add.isOk()

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -73,7 +73,7 @@ suite "Gossip validation " & preset():
     for blck in makeTestBlocks(
         dag.headState.data, dag.head.root, cache,
         int(SLOTS_PER_EPOCH * 5), false):
-      let added = dag.addRawBlock(quarantine, blck) do (
+      let added = dag.addRawBlock(quarantine, blck.phase0Block) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid


### PR DESCRIPTION
testblockutil currently fails to add test blocks to Altair state because
it assumes phase0 blocks in various places. This patch corrects this
limitation by using forked types internally. Note that existing clients
so far solely operate on phase0 blocks and should eventually be updated.