### PR TITLE
allow mocking blocks at any slot

### DIFF
--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -36,7 +36,7 @@ proc signMockBlockImpl(
 proc signMockBlock*(state: phase0.BeaconState, signedBlock: var phase0.SignedBeaconBlock) =
   signMockBlockImpl(state, signedBlock)
 
-proc mockBlock(
+proc mockBlock*(
     state: phase0.BeaconState,
     slot: Slot): phase0.SignedBeaconBlock =
   ## TODO don't do this gradual construction, for exception safety


### PR DESCRIPTION
Currently, only the function to mock a block at next slot is exported.
A more generic function that allows specifying any slot is available but
not exported. This patch marks that function to also be exported.