### PR TITLE
Fix new altair blockpool test missing taskpool parameter

### DIFF
--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -581,7 +581,8 @@ suite "Diverging hardforks":
     var
       db = makeTestDB(SLOTS_PER_EPOCH)
       dag = init(ChainDAGRef, phase0RuntimeConfig, db, {})
-      quarantine = QuarantineRef.init(keys.newRng())
+      taskpool = Taskpool.new()
+      quarantine = QuarantineRef.init(keys.newRng(), taskpool)
       nilPhase0Callback: OnPhase0BlockAdded
       state = newClone(dag.headState.data)
       cache = StateCache()


### PR DESCRIPTION
#2718 requires to add the taskpool parameter everywhere QuarantineRef is required.

In-between the latest rebase and the merge of #2718 a new blockpool test was added.