### PR TITLE
allow testing with custom cfg

### DIFF
--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -45,14 +45,17 @@ proc signMockBlock*(state: ForkedHashedBeaconState, b: var ForkedSignedBeaconBlo
         privkey).toValidatorSig()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/tests/core/pyspec/eth2spec/test/helpers/block.py#L75-L105
-proc mockBlock*(state: ForkedHashedBeaconState, slot: Slot): ForkedSignedBeaconBlock =
+proc mockBlock*(
+    state: ForkedHashedBeaconState, 
+    slot: Slot, 
+    cfg = defaultRuntimeConfig): ForkedSignedBeaconBlock =
   ## TODO don't do this gradual construction, for exception safety
   ## Mock a BeaconBlock for the specific slot
 
   var cache = StateCache()
   var rewards = RewardInfo()
   var tmpState = assignClone(state)
-  doAssert process_slots(defaultRuntimeConfig, tmpState[], slot, cache, rewards, flags = {})
+  doAssert process_slots(cfg, tmpState[], slot, cache, rewards, flags = {})
   
   var previous_block_header = getStateField(tmpState[], latest_block_header)
   if previous_block_header.state_root == ZERO_HASH:

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -17,17 +17,13 @@ import
   ./mock_deposits
 
 proc initGenesisState*(
-    num_validators: uint64 = 8'u64 * SLOTS_PER_EPOCH,
-    beaconStateFork: BeaconStateFork = forkPhase0): ref ForkedHashedBeaconState =
+    num_validators = 8'u64 * SLOTS_PER_EPOCH,
+    cfg = defaultRuntimeConfig): ref ForkedHashedBeaconState =
   let deposits = mockGenesisBalancedDeposits(
       validatorCount = num_validators,
       amountInEth = 32, # We create canonical validators with 32 Eth
       flags = {}
     )
-
-  var cfg = defaultRuntimeConfig
-  if beaconStateFork >= forkAltair:
-    cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
 
   result = (ref ForkedHashedBeaconState)(
     beaconStateFork: forkPhase0,
@@ -35,8 +31,6 @@ proc initGenesisState*(
       cfg, eth1BlockHash, 0, deposits, {}))
 
   maybeUpgradeStateToAltair(cfg, result[])
-
-  doAssert result.beaconStateFork == beaconStateFork
 
 when isMainModule:
   # Smoke test


### PR DESCRIPTION
This extends some test utilities to allow simulating states that use
a custom RuntimeConfig, e.g., to test with an earlier ALTAIR_FORK_EPOCH.