### PR TITLE
Improve peer cycling

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1005,7 +1005,7 @@ proc trimConnections(node: Eth2Node, count: int) {.async.} =
   for peerId in scores.keys:
     #TODO kill a single connection instead of the whole peer
     # Not possible with the current libp2p's conn management
-    debug "kicking peer", peerId
+    debug "kicking peer", peerId, score=scores[peerId]
     await node.switch.disconnect(peerId)
     dec toKick
     inc(nbc_cycling_kicked_peers)

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -82,7 +82,6 @@ type
     peerPingerHeartbeatFut: Future[void]
     cfg: RuntimeConfig
     getBeaconTime: GetBeaconTimeFn
-    unhealthySubnetsCount*: int
 
   EthereumNode = Eth2Node # needed for the definitions in p2p_backends_helpers
 
@@ -1065,9 +1064,6 @@ proc runDiscoveryLoop*(node: Eth2Node) {.async.} =
       (wantedAttnets, wantedSyncnets) = node.getLowSubnets()
       wantedAttnetsCount = wantedAttnets.countOnes()
       wantedSyncnetsCount = wantedSyncnets.countOnes()
-
-    # Just take attnets into account for UX simplicity
-    node.unhealthySubnetsCount = wantedAttnetsCount
 
     if wantedAttnetsCount > 0 or wantedSyncnetsCount > 0:
       let discoveredNodes = await node.discovery.queryRandom(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1110,7 +1110,6 @@ proc onSlotStart(
     delay = shortLog(delay),
     peers = len(node.network.peerPool),
     head = shortLog(node.dag.head),
-    unhealthySubnetCount = node.network.unhealthySubnetsCount,
     headEpoch = shortLog(node.dag.head.slot.compute_epoch_at_slot()),
     finalized = shortLog(node.dag.finalizedHead.blck),
     finalizedEpoch = shortLog(finalizedEpoch),

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1110,6 +1110,7 @@ proc onSlotStart(
     delay = shortLog(delay),
     peers = len(node.network.peerPool),
     head = shortLog(node.dag.head),
+    unhealthySubnetCount = node.network.unhealthySubnetsCount,
     headEpoch = shortLog(node.dag.head.slot.compute_epoch_at_slot()),
     finalized = shortLog(node.dag.finalizedHead.blck),
     finalizedEpoch = shortLog(finalizedEpoch),


### PR DESCRIPTION
Follow up #2668

Some peer cycling improvements:
- Add the number of unhealthy topics in the Slot start log
- Add a metrics for the number of kicked peers
- Sort discovered peers correctly
- Smarter peer kicker
- Slightly increase the maximum metadata request ping failure time (30s -> 45s)

The new peer kicker will kick enough peer to make room for every discovered peer (with an upper limit of `peer_count / 5`)
This gives better performance on big server, since they can kick bad peers quicker, while maintaining a reasonable number of peers on smaller servers

This also fix a dial issue when the semaphore count was <0 and dialing previously stopped. Though the semaphore count should not be <0, so there must be a bug in libp2p, at least the case is handled correctly here.