### PR TITLE
implement forked merge state/block support

### DIFF
--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -80,6 +80,20 @@ FixtureAll-mainnet
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: mainnet OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_same_proposer_slashings_s OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_similar_proposer_slashing OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_validator_exit_same_block OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - duplicate_attester_slashing [Pre OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - expected_deposit_in_block [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_block_sig [Preset: mainn OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_state_root [Preset: main OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - parent_from_same_slot [Preset: m OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - prev_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - same_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_same_index [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - zero_block_sig [Preset: mainnet] OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
@@ -220,6 +234,34 @@ FixtureAll-mainnet
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: mainnet] OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: mainnet OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_no_updates_at_genesis [Preset: OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_1 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_2 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_3 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_4 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attestation [Preset: mainnet]    OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attester_slashing [Preset: mainn OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - balance_driven_status_transition OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_in_block [Preset: mainne OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_top_up [Preset: mainnet] OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_0 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_1 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_2 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_3 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - high_proposer_index [Preset: mai OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: mainne OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_validator_exi OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_after_inactive_index [P OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_self_slashing [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_slashing [Preset: mainn OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - skipped_slots [Preset: mainnet]  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_diff_index [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - voluntary_exit [Preset: mainnet] OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: mainnet]     OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: mainnet]     OK
@@ -323,7 +365,7 @@ FixtureAll-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 320/320 Fail: 0/320 Skip: 0/320
+OK: 362/362 Fail: 0/362 Skip: 0/362
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -707,4 +749,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 573/573 Fail: 0/573 Skip: 0/573
+OK: 615/615 Fail: 0/615 Skip: 0/615

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -123,7 +123,16 @@ FixtureAll-mainnet
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_empty_indices                                                               OK
 + [Invalid] att2_high_index                                                                  OK
++ [Invalid] bad_everything_regular_payload                                                   OK
++ [Invalid] bad_execution_first_payload                                                      OK
++ [Invalid] bad_execution_regular_payload                                                    OK
++ [Invalid] bad_number_regular_payload                                                       OK
++ [Invalid] bad_parent_hash_regular_payload                                                  OK
++ [Invalid] bad_random_first_payload                                                         OK
++ [Invalid] bad_random_regular_payload                                                       OK
 + [Invalid] bad_source_root                                                                  OK
++ [Invalid] bad_timestamp_first_payload                                                      OK
++ [Invalid] bad_timestamp_regular_payload                                                    OK
 + [Invalid] before_inclusion_delay                                                           OK
 + [Invalid] correct_after_epoch_delay                                                        OK
 + [Invalid] empty_participants_seemingly_valid_sig                                           OK
@@ -333,11 +342,15 @@ FixtureAll-mainnet
 + [Valid]   success_block_header_from_future                                                 OK
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_exit_queue__min_churn                                                    OK
++ [Valid]   success_first_payload                                                            OK
++ [Valid]   success_first_payload_with_gap_slot                                              OK
 + [Valid]   success_low_balances                                                             OK
 + [Valid]   success_misc_balances                                                            OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK
 + [Valid]   success_proposer_index_slashed                                                   OK
++ [Valid]   success_regular_payload                                                          OK
++ [Valid]   success_regular_payload_with_gap_slot                                            OK
 + [Valid]   success_slashed_and_proposer_index_the_same                                      OK
 + [Valid]   success_surround                                                                 OK
 + [Valid]   success_with_effective_balance_disparity                                         OK
@@ -365,7 +378,7 @@ FixtureAll-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 362/362 Fail: 0/362 Skip: 0/362
+OK: 375/375 Fail: 0/375 Skip: 0/375
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -749,4 +762,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 615/615 Fail: 0/615 Skip: 0/615
+OK: 628/628 Fail: 0/628 Skip: 0/628

--- a/FixtureAll-mainnet.md
+++ b/FixtureAll-mainnet.md
@@ -464,6 +464,106 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 36/36 Fail: 0/36 Skip: 0/36
+## Ethereum Foundation - Merge - Epoch Processing - Effective balance updates [Preset: mainnet]
+```diff
++ Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Eth1 data reset [Preset: mainnet]
+```diff
++ Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
++ Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Ethereum Foundation - Merge - Epoch Processing - Historical roots update [Preset: mainnet]
+```diff
++ Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Inactivity [Preset: mainnet]
+```diff
++ Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
++ Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: mainnet]      OK
++ Inactivity - all_zero_inactivity_scores_full_participation [Preset: mainnet]               OK
++ Inactivity - all_zero_inactivity_scores_full_participation_leaking [Preset: mainnet]       OK
++ Inactivity - all_zero_inactivity_scores_random_participation [Preset: mainnet]             OK
++ Inactivity - all_zero_inactivity_scores_random_participation_leaking [Preset: mainnet]     OK
++ Inactivity - genesis [Preset: mainnet]                                                     OK
++ Inactivity - genesis_random_scores [Preset: mainnet]                                       OK
++ Inactivity - random_inactivity_scores_empty_participation [Preset: mainnet]                OK
++ Inactivity - random_inactivity_scores_empty_participation_leaking [Preset: mainnet]        OK
++ Inactivity - random_inactivity_scores_full_participation [Preset: mainnet]                 OK
++ Inactivity - random_inactivity_scores_full_participation_leaking [Preset: mainnet]         OK
++ Inactivity - random_inactivity_scores_random_participation [Preset: mainnet]               OK
++ Inactivity - random_inactivity_scores_random_participation_leaking [Preset: mainnet]       OK
++ Inactivity - some_exited_full_random_leaking [Preset: mainnet]                             OK
++ Inactivity - some_slashed_full_random [Preset: mainnet]                                    OK
++ Inactivity - some_slashed_full_random_leaking [Preset: mainnet]                            OK
++ Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
++ Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
+```
+OK: 19/19 Fail: 0/19 Skip: 0/19
+## Ethereum Foundation - Merge - Epoch Processing - Justification & Finalization [Preset: mainnet]
+```diff
++ Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
++ Justification & Finalization - 123_poor_support [Preset: mainnet]                          OK
++ Justification & Finalization - 12_ok_support [Preset: mainnet]                             OK
++ Justification & Finalization - 12_ok_support_messed_target [Preset: mainnet]               OK
++ Justification & Finalization - 12_poor_support [Preset: mainnet]                           OK
++ Justification & Finalization - 234_ok_support [Preset: mainnet]                            OK
++ Justification & Finalization - 234_poor_support [Preset: mainnet]                          OK
++ Justification & Finalization - 23_ok_support [Preset: mainnet]                             OK
++ Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
++ Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Ethereum Foundation - Merge - Epoch Processing - Participation flag updates [Preset: mainnet]
+```diff
++ Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
++ Participation flag updates - current_epoch_zeroed [Preset: mainnet]                        OK
++ Participation flag updates - current_filled [Preset: mainnet]                              OK
++ Participation flag updates - filled [Preset: mainnet]                                      OK
++ Participation flag updates - previous_epoch_zeroed [Preset: mainnet]                       OK
++ Participation flag updates - previous_filled [Preset: mainnet]                             OK
++ Participation flag updates - random_0 [Preset: mainnet]                                    OK
++ Participation flag updates - random_1 [Preset: mainnet]                                    OK
++ Participation flag updates - random_2 [Preset: mainnet]                                    OK
++ Participation flag updates - random_genesis [Preset: mainnet]                              OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Ethereum Foundation - Merge - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
+```diff
++ RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Registry updates [Preset: mainnet]
+```diff
++ Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
++ Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: mainnet] OK
++ Registry updates - activation_queue_activation_and_ejection__exceed_churn_limit [Preset: m OK
++ Registry updates - activation_queue_efficiency_min [Preset: mainnet]                       OK
++ Registry updates - activation_queue_no_activation_no_finality [Preset: mainnet]            OK
++ Registry updates - activation_queue_sorting [Preset: mainnet]                              OK
++ Registry updates - activation_queue_to_activated_if_finalized [Preset: mainnet]            OK
++ Registry updates - add_to_activation_queue [Preset: mainnet]                               OK
++ Registry updates - ejection [Preset: mainnet]                                              OK
++ Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Ethereum Foundation - Merge - Epoch Processing - Slashings [Preset: mainnet]
+```diff
++ Slashings - low_penalty [Preset: mainnet]                                                  OK
++ Slashings - max_penalties [Preset: mainnet]                                                OK
++ Slashings - minimal_penalty [Preset: mainnet]                                              OK
++ Slashings - scaled_penalties [Preset: mainnet]                                             OK
++ Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## Ethereum Foundation - Merge - Epoch Processing - Slashings reset [Preset: mainnet]
+```diff
++ Slashings reset - flush_slashings [Preset: mainnet]                                        OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Ethereum Foundation - Merge - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -607,4 +707,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 513/513 Fail: 0/513 Skip: 0/513
+OK: 573/573 Fail: 0/573 Skip: 0/573

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -115,7 +115,16 @@ FixtureAll-minimal
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_empty_indices                                                               OK
 + [Invalid] att2_high_index                                                                  OK
++ [Invalid] bad_everything_regular_payload                                                   OK
++ [Invalid] bad_execution_first_payload                                                      OK
++ [Invalid] bad_execution_regular_payload                                                    OK
++ [Invalid] bad_number_regular_payload                                                       OK
++ [Invalid] bad_parent_hash_regular_payload                                                  OK
++ [Invalid] bad_random_first_payload                                                         OK
++ [Invalid] bad_random_regular_payload                                                       OK
 + [Invalid] bad_source_root                                                                  OK
++ [Invalid] bad_timestamp_first_payload                                                      OK
++ [Invalid] bad_timestamp_regular_payload                                                    OK
 + [Invalid] before_inclusion_delay                                                           OK
 + [Invalid] correct_after_epoch_delay                                                        OK
 + [Invalid] empty_participants_seemingly_valid_sig                                           OK
@@ -344,11 +353,15 @@ FixtureAll-minimal
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_exit_queue__min_churn                                                    OK
 + [Valid]   success_exit_queue__scaled_churn                                                 OK
++ [Valid]   success_first_payload                                                            OK
++ [Valid]   success_first_payload_with_gap_slot                                              OK
 + [Valid]   success_low_balances                                                             OK
 + [Valid]   success_misc_balances                                                            OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK
 + [Valid]   success_proposer_index_slashed                                                   OK
++ [Valid]   success_regular_payload                                                          OK
++ [Valid]   success_regular_payload_with_gap_slot                                            OK
 + [Valid]   success_slashed_and_proposer_index_the_same                                      OK
 + [Valid]   success_surround                                                                 OK
 + [Valid]   success_with_effective_balance_disparity                                         OK
@@ -361,7 +374,7 @@ FixtureAll-minimal
 + [Valid]   sync_committee_with_participating_withdrawable_member                            OK
 + [Valid]   valid_signature_future_committee                                                 OK
 ```
-OK: 358/358 Fail: 0/358 Skip: 0/358
+OK: 371/371 Fail: 0/371 Skip: 0/371
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -779,4 +792,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 637/637 Fail: 0/637 Skip: 0/637
+OK: 650/650 Fail: 0/650 Skip: 0/650

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -470,6 +470,121 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 36/36 Fail: 0/36 Skip: 0/36
+## Ethereum Foundation - Merge - Epoch Processing - Effective balance updates [Preset: minimal]
+```diff
++ Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Eth1 data reset [Preset: minimal]
+```diff
++ Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
++ Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Ethereum Foundation - Merge - Epoch Processing - Historical roots update [Preset: minimal]
+```diff
++ Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Inactivity [Preset: minimal]
+```diff
++ Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
++ Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: minimal]      OK
++ Inactivity - all_zero_inactivity_scores_full_participation [Preset: minimal]               OK
++ Inactivity - all_zero_inactivity_scores_full_participation_leaking [Preset: minimal]       OK
++ Inactivity - all_zero_inactivity_scores_random_participation [Preset: minimal]             OK
++ Inactivity - all_zero_inactivity_scores_random_participation_leaking [Preset: minimal]     OK
++ Inactivity - genesis [Preset: minimal]                                                     OK
++ Inactivity - genesis_random_scores [Preset: minimal]                                       OK
++ Inactivity - random_inactivity_scores_empty_participation [Preset: minimal]                OK
++ Inactivity - random_inactivity_scores_empty_participation_leaking [Preset: minimal]        OK
++ Inactivity - random_inactivity_scores_full_participation [Preset: minimal]                 OK
++ Inactivity - random_inactivity_scores_full_participation_leaking [Preset: minimal]         OK
++ Inactivity - random_inactivity_scores_random_participation [Preset: minimal]               OK
++ Inactivity - random_inactivity_scores_random_participation_leaking [Preset: minimal]       OK
++ Inactivity - some_exited_full_random_leaking [Preset: minimal]                             OK
++ Inactivity - some_slashed_full_random [Preset: minimal]                                    OK
++ Inactivity - some_slashed_full_random_leaking [Preset: minimal]                            OK
++ Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
++ Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
+```
+OK: 19/19 Fail: 0/19 Skip: 0/19
+## Ethereum Foundation - Merge - Epoch Processing - Justification & Finalization [Preset: minimal]
+```diff
++ Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
++ Justification & Finalization - 123_poor_support [Preset: minimal]                          OK
++ Justification & Finalization - 12_ok_support [Preset: minimal]                             OK
++ Justification & Finalization - 12_ok_support_messed_target [Preset: minimal]               OK
++ Justification & Finalization - 12_poor_support [Preset: minimal]                           OK
++ Justification & Finalization - 234_ok_support [Preset: minimal]                            OK
++ Justification & Finalization - 234_poor_support [Preset: minimal]                          OK
++ Justification & Finalization - 23_ok_support [Preset: minimal]                             OK
++ Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
++ Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
+```
+OK: 10/10 Fail: 0/10 Skip: 0/10
+## Ethereum Foundation - Merge - Epoch Processing - Participation flag updates [Preset: minimal]
+```diff
++ Participation flag updates - all_zeroed [Preset: minimal]                                  OK
++ Participation flag updates - current_epoch_zeroed [Preset: minimal]                        OK
++ Participation flag updates - current_filled [Preset: minimal]                              OK
++ Participation flag updates - filled [Preset: minimal]                                      OK
++ Participation flag updates - large_random [Preset: minimal]                                OK
++ Participation flag updates - previous_epoch_zeroed [Preset: minimal]                       OK
++ Participation flag updates - previous_filled [Preset: minimal]                             OK
++ Participation flag updates - random_0 [Preset: minimal]                                    OK
++ Participation flag updates - random_1 [Preset: minimal]                                    OK
++ Participation flag updates - random_2 [Preset: minimal]                                    OK
++ Participation flag updates - random_genesis [Preset: minimal]                              OK
++ Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
+```
+OK: 12/12 Fail: 0/12 Skip: 0/12
+## Ethereum Foundation - Merge - Epoch Processing - RANDAO mixes reset [Preset: minimal]
+```diff
++ RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Registry updates [Preset: minimal]
+```diff
++ Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
++ Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: minimal] OK
++ Registry updates - activation_queue_activation_and_ejection__exceed_churn_limit [Preset: m OK
++ Registry updates - activation_queue_activation_and_ejection__exceed_scaled_churn_limit [Pr OK
++ Registry updates - activation_queue_activation_and_ejection__scaled_churn_limit [Preset: m OK
++ Registry updates - activation_queue_efficiency_min [Preset: minimal]                       OK
++ Registry updates - activation_queue_efficiency_scaled [Preset: minimal]                    OK
++ Registry updates - activation_queue_no_activation_no_finality [Preset: minimal]            OK
++ Registry updates - activation_queue_sorting [Preset: minimal]                              OK
++ Registry updates - activation_queue_to_activated_if_finalized [Preset: minimal]            OK
++ Registry updates - add_to_activation_queue [Preset: minimal]                               OK
++ Registry updates - ejection [Preset: minimal]                                              OK
++ Registry updates - ejection_past_churn_limit_min [Preset: minimal]                         OK
++ Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
+```
+OK: 14/14 Fail: 0/14 Skip: 0/14
+## Ethereum Foundation - Merge - Epoch Processing - Slashings [Preset: minimal]
+```diff
++ Slashings - low_penalty [Preset: minimal]                                                  OK
++ Slashings - max_penalties [Preset: minimal]                                                OK
++ Slashings - minimal_penalty [Preset: minimal]                                              OK
++ Slashings - scaled_penalties [Preset: minimal]                                             OK
++ Slashings - slashings_with_random_state [Preset: minimal]                                  OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## Ethereum Foundation - Merge - Epoch Processing - Slashings reset [Preset: minimal]
+```diff
++ Slashings reset - flush_slashings [Preset: minimal]                                        OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
+## Ethereum Foundation - Merge - Epoch Processing - Sync committee updates [Preset: minimal]
+```diff
++ Sync committee updates - sync_committees_no_progress_not_boundary [Preset: minimal]        OK
++ Sync committee updates - sync_committees_progress_genesis [Preset: minimal]                OK
++ Sync committee updates - sync_committees_progress_misc_balances_genesis [Preset: minimal]  OK
++ Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
++ Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Ethereum Foundation - Merge - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -617,4 +732,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 519/519 Fail: 0/519 Skip: 0/519
+OK: 590/590 Fail: 0/590 Skip: 0/590

--- a/FixtureAll-minimal.md
+++ b/FixtureAll-minimal.md
@@ -72,6 +72,20 @@ FixtureAll-minimal
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: minimal OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_same_proposer_slashings_s OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_similar_proposer_slashing OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_validator_exit_same_block OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - duplicate_attester_slashing [Pre OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - expected_deposit_in_block [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_block_sig [Preset: minim OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_state_root [Preset: mini OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - parent_from_same_slot [Preset: m OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - prev_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - same_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_same_index [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - zero_block_sig [Preset: minimal] OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
@@ -218,6 +232,39 @@ FixtureAll-minimal
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: minimal] OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: minimal OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_no_updates_at_genesis [Preset: OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_1 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_2 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_3 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_4 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attestation [Preset: minimal]    OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attester_slashing [Preset: minim OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - balance_driven_status_transition OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_in_block [Preset: minima OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_top_up [Preset: minimal] OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition_large_val OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition_large_val OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition_not_final OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - eth1_data_votes_consensus [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - eth1_data_votes_no_consensus [Pr OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_0 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_1 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_2 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_3 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - high_proposer_index [Preset: min OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: minima OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_validator_exi OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_after_inactive_index [P OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_self_slashing [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_slashing [Preset: minim OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - skipped_slots [Preset: minimal]  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_diff_index [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - voluntary_exit [Preset: minimal] OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: minimal]     OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: minimal]     OK
@@ -314,7 +361,7 @@ FixtureAll-minimal
 + [Valid]   sync_committee_with_participating_withdrawable_member                            OK
 + [Valid]   valid_signature_future_committee                                                 OK
 ```
-OK: 311/311 Fail: 0/311 Skip: 0/311
+OK: 358/358 Fail: 0/358 Skip: 0/358
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -732,4 +779,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 590/590 Fail: 0/590 Skip: 0/590
+OK: 637/637 Fail: 0/637 Skip: 0/637

--- a/FixtureSSZConsensus-mainnet.md
+++ b/FixtureSSZConsensus-mainnet.md
@@ -123,7 +123,16 @@ FixtureSSZConsensus-mainnet
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_empty_indices                                                               OK
 + [Invalid] att2_high_index                                                                  OK
++ [Invalid] bad_everything_regular_payload                                                   OK
++ [Invalid] bad_execution_first_payload                                                      OK
++ [Invalid] bad_execution_regular_payload                                                    OK
++ [Invalid] bad_number_regular_payload                                                       OK
++ [Invalid] bad_parent_hash_regular_payload                                                  OK
++ [Invalid] bad_random_first_payload                                                         OK
++ [Invalid] bad_random_regular_payload                                                       OK
 + [Invalid] bad_source_root                                                                  OK
++ [Invalid] bad_timestamp_first_payload                                                      OK
++ [Invalid] bad_timestamp_regular_payload                                                    OK
 + [Invalid] before_inclusion_delay                                                           OK
 + [Invalid] correct_after_epoch_delay                                                        OK
 + [Invalid] empty_participants_seemingly_valid_sig                                           OK
@@ -333,11 +342,15 @@ FixtureSSZConsensus-mainnet
 + [Valid]   success_block_header_from_future                                                 OK
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_exit_queue__min_churn                                                    OK
++ [Valid]   success_first_payload                                                            OK
++ [Valid]   success_first_payload_with_gap_slot                                              OK
 + [Valid]   success_low_balances                                                             OK
 + [Valid]   success_misc_balances                                                            OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK
 + [Valid]   success_proposer_index_slashed                                                   OK
++ [Valid]   success_regular_payload                                                          OK
++ [Valid]   success_regular_payload_with_gap_slot                                            OK
 + [Valid]   success_slashed_and_proposer_index_the_same                                      OK
 + [Valid]   success_surround                                                                 OK
 + [Valid]   success_with_effective_balance_disparity                                         OK
@@ -365,7 +378,7 @@ FixtureSSZConsensus-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 362/362 Fail: 0/362 Skip: 0/362
+OK: 375/375 Fail: 0/375 Skip: 0/375
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -649,4 +662,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 555/555 Fail: 0/555 Skip: 0/555
+OK: 568/568 Fail: 0/568 Skip: 0/568

--- a/FixtureSSZConsensus-mainnet.md
+++ b/FixtureSSZConsensus-mainnet.md
@@ -80,6 +80,20 @@ FixtureSSZConsensus-mainnet
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: mainnet OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_same_proposer_slashings_s OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_similar_proposer_slashing OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_validator_exit_same_block OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - duplicate_attester_slashing [Pre OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - expected_deposit_in_block [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_block_sig [Preset: mainn OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_state_root [Preset: main OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - parent_from_same_slot [Preset: m OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - prev_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - same_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_same_index [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - zero_block_sig [Preset: mainnet] OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
@@ -220,6 +234,34 @@ FixtureSSZConsensus-mainnet
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: mainnet] OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: mainnet OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_no_updates_at_genesis [Preset: OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_1 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_2 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_3 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_4 [Preset: mainnet]       OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attestation [Preset: mainnet]    OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attester_slashing [Preset: mainn OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - balance_driven_status_transition OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_in_block [Preset: mainne OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_top_up [Preset: mainnet] OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_0 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_1 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_2 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_3 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - high_proposer_index [Preset: mai OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: mainne OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_validator_exi OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_after_inactive_index [P OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_self_slashing [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_slashing [Preset: mainn OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - skipped_slots [Preset: mainnet]  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_diff_index [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - voluntary_exit [Preset: mainnet] OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: mainnet]     OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: mainnet]     OK
@@ -323,7 +365,7 @@ FixtureSSZConsensus-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 320/320 Fail: 0/320 Skip: 0/320
+OK: 362/362 Fail: 0/362 Skip: 0/362
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -607,4 +649,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 513/513 Fail: 0/513 Skip: 0/513
+OK: 555/555 Fail: 0/555 Skip: 0/555

--- a/FixtureSSZConsensus-minimal.md
+++ b/FixtureSSZConsensus-minimal.md
@@ -72,6 +72,20 @@ FixtureSSZConsensus-minimal
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
 + [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: minimal OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_same_proposer_slashings_s OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_similar_proposer_slashing OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - double_validator_exit_same_block OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - duplicate_attester_slashing [Pre OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - expected_deposit_in_block [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_block_sig [Preset: minim OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_proposer_index_sig_from_ OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - invalid_state_root [Preset: mini OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - parent_from_same_slot [Preset: m OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - prev_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - same_slot_block_transition [Pres OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_same_index [Prese OK
++ [Invalid] Ethereum Foundation - Merge - Sanity - Blocks - zero_block_sig [Preset: minimal] OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
 + [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
@@ -218,6 +232,39 @@ FixtureSSZConsensus-minimal
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: minimal] OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
 + [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: minimal OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_no_updates_at_genesis [Preset: OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_1 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_2 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_3 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Finality - finality_rule_4 [Preset: minimal]       OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attestation [Preset: minimal]    OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - attester_slashing [Preset: minim OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - balance_driven_status_transition OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_in_block [Preset: minima OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - deposit_top_up [Preset: minimal] OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_block_transition_large_val OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition_large_val OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - empty_epoch_transition_not_final OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - eth1_data_votes_consensus [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - eth1_data_votes_no_consensus [Pr OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_0 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_1 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_2 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - full_random_operations_3 [Preset OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - high_proposer_index [Preset: min OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: minima OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_validator_exi OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_after_inactive_index [P OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_self_slashing [Preset:  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - proposer_slashing [Preset: minim OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - skipped_slots [Preset: minimal]  OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - slash_and_exit_diff_index [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - voluntary_exit [Preset: minimal] OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: minimal]     OK
 + [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: minimal]     OK
@@ -314,7 +361,7 @@ FixtureSSZConsensus-minimal
 + [Valid]   sync_committee_with_participating_withdrawable_member                            OK
 + [Valid]   valid_signature_future_committee                                                 OK
 ```
-OK: 311/311 Fail: 0/311 Skip: 0/311
+OK: 358/358 Fail: 0/358 Skip: 0/358
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -617,4 +664,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 519/519 Fail: 0/519 Skip: 0/519
+OK: 566/566 Fail: 0/566 Skip: 0/566

--- a/FixtureSSZConsensus-minimal.md
+++ b/FixtureSSZConsensus-minimal.md
@@ -115,7 +115,16 @@ FixtureSSZConsensus-minimal
 + [Invalid] att2_duplicate_index_normal_signed                                               OK
 + [Invalid] att2_empty_indices                                                               OK
 + [Invalid] att2_high_index                                                                  OK
++ [Invalid] bad_everything_regular_payload                                                   OK
++ [Invalid] bad_execution_first_payload                                                      OK
++ [Invalid] bad_execution_regular_payload                                                    OK
++ [Invalid] bad_number_regular_payload                                                       OK
++ [Invalid] bad_parent_hash_regular_payload                                                  OK
++ [Invalid] bad_random_first_payload                                                         OK
++ [Invalid] bad_random_regular_payload                                                       OK
 + [Invalid] bad_source_root                                                                  OK
++ [Invalid] bad_timestamp_first_payload                                                      OK
++ [Invalid] bad_timestamp_regular_payload                                                    OK
 + [Invalid] before_inclusion_delay                                                           OK
 + [Invalid] correct_after_epoch_delay                                                        OK
 + [Invalid] empty_participants_seemingly_valid_sig                                           OK
@@ -344,11 +353,15 @@ FixtureSSZConsensus-minimal
 + [Valid]   success_double                                                                   OK
 + [Valid]   success_exit_queue__min_churn                                                    OK
 + [Valid]   success_exit_queue__scaled_churn                                                 OK
++ [Valid]   success_first_payload                                                            OK
++ [Valid]   success_first_payload_with_gap_slot                                              OK
 + [Valid]   success_low_balances                                                             OK
 + [Valid]   success_misc_balances                                                            OK
 + [Valid]   success_multi_proposer_index_iterations                                          OK
 + [Valid]   success_previous_epoch                                                           OK
 + [Valid]   success_proposer_index_slashed                                                   OK
++ [Valid]   success_regular_payload                                                          OK
++ [Valid]   success_regular_payload_with_gap_slot                                            OK
 + [Valid]   success_slashed_and_proposer_index_the_same                                      OK
 + [Valid]   success_surround                                                                 OK
 + [Valid]   success_with_effective_balance_disparity                                         OK
@@ -361,7 +374,7 @@ FixtureSSZConsensus-minimal
 + [Valid]   sync_committee_with_participating_withdrawable_member                            OK
 + [Valid]   valid_signature_future_committee                                                 OK
 ```
-OK: 358/358 Fail: 0/358 Skip: 0/358
+OK: 371/371 Fail: 0/371 Skip: 0/371
 ## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -664,4 +677,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 566/566 Fail: 0/566 Skip: 0/566
+OK: 579/579 Fail: 0/579 Skip: 0/579

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -14,7 +14,7 @@ import
   eth/db/[kvstore, kvstore_sqlite3],
   ./networking/network_metadata, ./beacon_chain_db_immutable,
   ./spec/[eth2_ssz_serialization, eth2_merkleization, state_transition],
-  ./spec/datatypes/[phase0, altair],
+  ./spec/datatypes/[phase0, altair, merge],
   ./filepath
 
 export
@@ -484,6 +484,9 @@ proc putBlock*(db: BeaconChainDB, value: phase0.TrustedSignedBeaconBlock) =
 proc putBlock*(db: BeaconChainDB, value: altair.TrustedSignedBeaconBlock) =
   db.altairBlocks.putSnappySSZ(value.root.data, value)
   db.putBeaconBlockSummary(value.root, value.message.toBeaconBlockSummary())
+
+proc putBlock*(db: BeaconChainDB, value: merge.TrustedSignedBeaconBlock) =
+  doAssert false # TODO Deliberate -- put impl in separately
 
 proc updateImmutableValidators*(
     db: BeaconChainDB, validators: openArray[Validator]) =

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -317,7 +317,8 @@ proc addAttestation*(pool: var AttestationPool,
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
                     blckRef: BlockRef,
-                    blck: phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock | merge.TrustedBeaconBlock,
+                    blck: phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock |
+                          merge.TrustedBeaconBlock,
                     wallSlot: Slot) =
   ## Add a verified block to the fork choice context
   let state = pool.forkChoice.process_block(
@@ -390,7 +391,8 @@ func init(T: type AttestationCache, state: phase0.HashedBeaconState): T =
       state.data.current_epoch_attestations[i].aggregation_bits)
 
 func init(
-    T: type AttestationCache, state: altair.HashedBeaconState | merge.HashedBeaconState,
+    T: type AttestationCache,
+    state: altair.HashedBeaconState | merge.HashedBeaconState,
     cache: var StateCache): T =
   # Load attestations that are scheduled for being given rewards for
   let

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -15,7 +15,7 @@ import
   chronicles, stew/byteutils, json_serialization/std/sets as jsonSets,
   # Internal
   ../spec/[beaconstate, eth2_merkleization, forks, helpers, validator],
-  ../spec/datatypes/[phase0, altair],
+  ../spec/datatypes/[phase0, altair, merge],
   "."/[spec_cache, blockchain_dag, block_quarantine],
   ".."/[beacon_clock, beacon_node_types],
   ../fork_choice/fork_choice
@@ -317,7 +317,7 @@ proc addAttestation*(pool: var AttestationPool,
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
                     blckRef: BlockRef,
-                    blck: phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock,
+                    blck: phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock | merge.TrustedBeaconBlock,
                     wallSlot: Slot) =
   ## Add a verified block to the fork choice context
   let state = pool.forkChoice.process_block(
@@ -390,7 +390,7 @@ func init(T: type AttestationCache, state: phase0.HashedBeaconState): T =
       state.data.current_epoch_attestations[i].aggregation_bits)
 
 func init(
-    T: type AttestationCache, state: altair.HashedBeaconState,
+    T: type AttestationCache, state: altair.HashedBeaconState | merge.HashedBeaconState,
     cache: var StateCache): T =
   # Load attestations that are scheduled for being given rewards for
   let
@@ -473,7 +473,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
     attCache =
       when state is phase0.HashedBeaconState:
         AttestationCache.init(state)
-      elif state is altair.HashedBeaconState:
+      elif state is altair.HashedBeaconState or state is merge.HashedBeaconState:
         AttestationCache.init(state, cache)
       else:
         static: doAssert false
@@ -528,11 +528,13 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
   var
     prevEpoch = state.data.get_previous_epoch()
     prevEpochSpace =
-      when state is altair.HashedBeaconState:
+      when state is altair.HashedBeaconState or state is merge.HashedBeaconState:
         MAX_ATTESTATIONS
-      else:
+      elif state is phase0.HashedBeaconState:
         state.data.previous_epoch_attestations.maxLen -
           state.data.previous_epoch_attestations.len()
+      else:
+        raiseAssert "invalid HashedBeaconState fork"
 
   var res: seq[Attestation]
   let totalCandidates = candidates.len()

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -40,32 +40,32 @@ logScope:
 template asSigVerified(x: phase0.SignedBeaconBlock):
     phase0.SigVerifiedSignedBeaconBlock =
   ## This converts a signed beacon block to a sig verified beacon clock.
-  ## This assumes that their bytes representation is the same.
+  ## This verifies that their bytes representation is the same.
   isomorphicCast[phase0.SigVerifiedSignedBeaconBlock](x)
 
 template asSigVerified(x: altair.SignedBeaconBlock):
     altair.SigVerifiedSignedBeaconBlock =
   ## This converts a signed beacon block to a sig verified beacon clock.
-  ## This assumes that their bytes representation is the same.
+  ## This verifies that their bytes representation is the same.
   isomorphicCast[altair.SigVerifiedSignedBeaconBlock](x)
 
 template asSigVerified(x: merge.SignedBeaconBlock):
     merge.SigVerifiedSignedBeaconBlock =
   ## This converts a signed beacon block to a sig verified beacon clock.
-  ## This assumes that their bytes representation is the same.
+  ## This verifies that their bytes representation is the same.
   isomorphicCast[merge.SigVerifiedSignedBeaconBlock](x)
 
 # TODO aren't these in forks.nim?
 template asTrusted(x: phase0.SignedBeaconBlock or phase0.SigVerifiedBeaconBlock):
     phase0.TrustedSignedBeaconBlock =
   ## This converts a sigverified beacon block to a trusted beacon clock.
-  ## This assumes that their bytes representation is the same.
+  ## This verifies that their bytes representation is the same.
   isomorphicCast[phase0.TrustedSignedBeaconBlock](x)
 
 template asTrusted(x: altair.SignedBeaconBlock or altair.SigVerifiedBeaconBlock):
     altair.TrustedSignedBeaconBlock =
   ## This converts a sigverified beacon block to a trusted beacon clock.
-  ## This assumes that their bytes representation is the same.
+  ## This verifies that their bytes representation is the same.
   isomorphicCast[altair.TrustedSignedBeaconBlock](x)
 
 proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool =
@@ -78,7 +78,8 @@ proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool
 
 proc addRawBlock*(
       dag: ChainDAGRef, quarantine: QuarantineRef,
-      signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+      signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                   merge.SignedBeaconBlock,
       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] {.gcsafe.}
 
@@ -143,7 +144,8 @@ proc resolveQuarantinedBlocks(
 proc addResolvedBlock(
        dag: ChainDAGRef, quarantine: QuarantineRef,
        state: var StateData,
-       trustedBlock: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock,
+       trustedBlock: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock |
+                     merge.TrustedSignedBeaconBlock,
        parent: BlockRef, cache: var StateCache,
        onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded,
        stateDataDur, sigVerifyDur,
@@ -260,7 +262,8 @@ proc advanceClearanceState*(dag: ChainDAGRef) =
 
 proc addRawBlockKnownParent(
        dag: ChainDAGRef, quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                    merge.SignedBeaconBlock,
        parent: BlockRef,
        onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =
@@ -347,7 +350,8 @@ proc addRawBlockKnownParent(
 proc addRawBlockUnresolved(
        dag: ChainDAGRef,
        quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                    merge.SignedBeaconBlock,
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## addRawBlock - Block is unresolved / has no parent
 
@@ -387,7 +391,8 @@ proc addRawBlockUnresolved(
 
 proc addRawBlock(
        dag: ChainDAGRef, quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                    merge.SignedBeaconBlock,
        onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## Try adding a block to the chain, verifying first that it passes the state

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -14,7 +14,7 @@ import
   eth/keys,
   ".."/[beacon_clock],
   ../spec/[eth2_merkleization, forks, helpers, signatures, signatures_batch, state_transition],
-  ../spec/datatypes/[phase0, altair],
+  ../spec/datatypes/[phase0, altair, merge],
   "."/[blockchain_dag, block_quarantine]
 
 from libp2p/protocols/pubsub/pubsub import ValidationResult
@@ -49,6 +49,13 @@ template asSigVerified(x: altair.SignedBeaconBlock):
   ## This assumes that their bytes representation is the same.
   isomorphicCast[altair.SigVerifiedSignedBeaconBlock](x)
 
+template asSigVerified(x: merge.SignedBeaconBlock):
+    merge.SigVerifiedSignedBeaconBlock =
+  ## This converts a signed beacon block to a sig verified beacon clock.
+  ## This assumes that their bytes representation is the same.
+  isomorphicCast[merge.SigVerifiedSignedBeaconBlock](x)
+
+# TODO aren't these in forks.nim?
 template asTrusted(x: phase0.SignedBeaconBlock or phase0.SigVerifiedBeaconBlock):
     phase0.TrustedSignedBeaconBlock =
   ## This converts a sigverified beacon block to a trusted beacon clock.
@@ -71,8 +78,8 @@ proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool
 
 proc addRawBlock*(
       dag: ChainDAGRef, quarantine: QuarantineRef,
-      signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
-      onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded
+      signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+      onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] {.gcsafe.}
 
 # Now that we have the new block, we should see if any of the previously
@@ -116,12 +123,29 @@ proc resolveQuarantinedBlocks(
       for v in resolved:
         discard addRawBlock(dag, quarantine, v, onBlockAdded)
 
+proc resolveQuarantinedBlocks(
+    dag: ChainDAGRef, quarantine: QuarantineRef,
+    onBlockAdded: OnMergeBlockAdded) =
+  if not quarantine.inAdd:
+    quarantine.inAdd = true
+    defer: quarantine.inAdd = false
+    var entries = 0
+    while entries != quarantine.orphansMerge.len:
+      entries = quarantine.orphansMerge.len # keep going while quarantine is shrinking
+      var resolved: seq[merge.SignedBeaconBlock]
+      for _, v in quarantine.orphansMerge:
+        if v.message.parent_root in dag:
+          resolved.add(v)
+
+      for v in resolved:
+        discard addRawBlock(dag, quarantine, v, onBlockAdded)
+
 proc addResolvedBlock(
        dag: ChainDAGRef, quarantine: QuarantineRef,
        state: var StateData,
-       trustedBlock: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock,
+       trustedBlock: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock,
        parent: BlockRef, cache: var StateCache,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded,
+       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded,
        stateDataDur, sigVerifyDur,
        stateVerifyDur: Duration
      ) =
@@ -190,7 +214,9 @@ type SomeSignedBlock =
   phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
   phase0.TrustedSignedBeaconBlock |
   altair.SignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock |
-  altair.TrustedSignedBeaconBlock
+  altair.TrustedSignedBeaconBlock |
+  merge.SignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock |
+  merge.TrustedSignedBeaconBlock
 proc checkStateTransition(
        dag: ChainDAGRef, signedBlock: SomeSignedBlock,
        cache: var StateCache): (ValidationResult, BlockError) =
@@ -234,9 +260,9 @@ proc advanceClearanceState*(dag: ChainDAGRef) =
 
 proc addRawBlockKnownParent(
        dag: ChainDAGRef, quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
        parent: BlockRef,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded
+       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## Add a block whose parent is known, after performing validity checks
   logScope:
@@ -321,7 +347,7 @@ proc addRawBlockKnownParent(
 proc addRawBlockUnresolved(
        dag: ChainDAGRef,
        quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## addRawBlock - Block is unresolved / has no parent
 
@@ -361,8 +387,8 @@ proc addRawBlockUnresolved(
 
 proc addRawBlock(
        dag: ChainDAGRef, quarantine: QuarantineRef,
-       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded
+       signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded
      ): Result[BlockRef, (ValidationResult, BlockError)] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -15,7 +15,7 @@ import
   eth/keys, taskpools,
   # Internals
   ../spec/[signatures_batch, forks],
-  ../spec/datatypes/[phase0, altair],
+  ../spec/datatypes/[phase0, altair, merge],
   ".."/beacon_chain_db
 
 export sets, tables
@@ -73,6 +73,11 @@ type
 
     orphansAltair*: Table[(Eth2Digest, ValidatorSig), altair.SignedBeaconBlock] ##\
     ## Altair Blocks that have passed validation, but that we lack a link back
+    ## to tail for - when we receive a "missing link", we can use this data to
+    ## build an entire branch
+
+    orphansMerge*:  Table[(Eth2Digest, ValidatorSig), merge.SignedBeaconBlock] ##\
+    ## Merge Blocks which have passed validation, but that we lack a link back
     ## to tail for - when we receive a "missing link", we can use this data to
     ## build an entire branch
 
@@ -258,6 +263,11 @@ type
   OnAltairBlockAdded* = proc(
     blckRef: BlockRef,
     blck: altair.TrustedSignedBeaconBlock,
+    epochRef: EpochRef) {.gcsafe, raises: [Defect].}
+
+  OnMergeBlockAdded* = proc(
+    blckRef: BlockRef,
+    blck: merge.TrustedSignedBeaconBlock,
     epochRef: EpochRef) {.gcsafe, raises: [Defect].}
 
   HeadChangeInfoObject* = object

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -68,8 +68,9 @@ func containsOrphan*(
 func addMissing*(quarantine: QuarantineRef, root: Eth2Digest) =
   ## Schedule the download a the given block
   # Can only request by root, not by signature, so partial match suffices
-  if (not anyIt(quarantine.orphansPhase0.keys, it[0] == root)) and
-     (not anyIt(quarantine.orphansAltair.keys, it[0] == root)):
+  if (not anyIt(quarantine.orphansMerge.keys,  it[0] == root)) and
+     (not anyIt(quarantine.orphansAltair.keys, it[0] == root)) and
+     (not anyIt(quarantine.orphansPhase0.keys, it[0] == root)):
     # If the block is in orphans, we no longer need it
     discard quarantine.missing.hasKeyOrPut(root, MissingBlock())
 
@@ -102,7 +103,8 @@ func removeOrphan*(
 
 func isViableOrphan(
     dag: ChainDAGRef,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock): bool =
+    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                 merge.SignedBeaconBlock): bool =
   # The orphan must be newer than the finalization point so that its parent
   # either is the finalized block or more recent
   signedBlock.message.slot > dag.finalizedHead.slot

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -44,8 +44,9 @@ declareGauge beacon_processed_deposits_total, "Number of total deposits included
 logScope: topics = "chaindag"
 
 proc putBlock*(
-    dag: ChainDAGRef, signedBlock:
-      phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock) =
+    dag: ChainDAGRef,
+    signedBlock: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock |
+                 merge.TrustedSignedBeaconBlock) =
   dag.db.putBlock(signedBlock)
 
 proc updateStateData*(

--- a/beacon_chain/consensus_object_pools/forkedbeaconstate_dbhelpers.nim
+++ b/beacon_chain/consensus_object_pools/forkedbeaconstate_dbhelpers.nim
@@ -15,3 +15,4 @@ proc putState*(db: BeaconChainDB, state: ForkedHashedBeaconState) =
   case state.beaconStateFork:
   of forkPhase0: db.putState(getStateRoot(state), state.hbsPhase0.data)
   of forkAltair: db.putState(getStateRoot(state), state.hbsAltair.data)
+  of forkMerge:  raiseAssert "TODO implement this"

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -14,7 +14,7 @@ import
   stew/results, chronicles,
   # Internal
   ../spec/[beaconstate, helpers],
-  ../spec/datatypes/[phase0, altair],
+  ../spec/datatypes/[phase0, altair, merge],
   # Fork choice
   ./fork_choice_types, ./proto_array,
   ../consensus_object_pools/[spec_cache, blockchain_dag]
@@ -289,8 +289,9 @@ proc process_block*(self: var ForkChoiceBackend,
 # blck: SomeSomeBeaconBlock
 # as comes up. Other types can be added as needed.
 type ReallyAnyBeaconBlock =
-  phase0.BeaconBlock | altair.BeaconBlock |
-  phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock
+  phase0.BeaconBlock | altair.BeaconBlock | merge.BeaconBlock |
+  phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock |
+  merge.TrustedBeaconBlock
 proc process_block*(self: var ForkChoice,
                     dag: ChainDAGRef,
                     epochRef: EpochRef,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -130,7 +130,8 @@ proc addBlock*(
 
 proc dumpBlock*[T](
     self: BlockProcessor,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                 merge.SignedBeaconBlock,
     res: Result[T, (ValidationResult, BlockError)]) =
   if self.dumpEnabled and res.isErr:
     case res.error[1]

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -11,7 +11,7 @@ import
   std/math,
   stew/results,
   chronicles, chronos, metrics,
-  ../spec/datatypes/[phase0, altair],
+  ../spec/datatypes/[phase0, altair, merge],
   ../spec/[forks],
   ../consensus_object_pools/[block_clearance, blockchain_dag, attestation_pool],
   ./consensus_manager,
@@ -130,7 +130,7 @@ proc addBlock*(
 
 proc dumpBlock*[T](
     self: BlockProcessor,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
     res: Result[T, (ValidationResult, BlockError)]) =
   if self.dumpEnabled and res.isErr:
     case res.error[1]
@@ -145,7 +145,8 @@ proc dumpBlock*[T](
 
 proc storeBlock(
     self: var BlockProcessor,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                 merge.SignedBeaconBlock,
     wallSlot: Slot): Result[void, BlockError] =
   let
     attestationPool = self.consensusManager.attestationPool

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2130,6 +2130,9 @@ proc broadcastBeaconBlock*(node: Eth2Node, forked: ForkedSignedBeaconBlock) =
   of BeaconBlockFork.Altair:
     let topic = getBeaconBlocksTopic(node.forkDigests.altair)
     node.broadcast(topic, forked.altairBlock)
+  of BeaconBlockFork.Merge:
+    let topic = getBeaconBlocksTopic(node.forkDigests.merge)
+    node.broadcast(topic, forked.mergeBlock)
 
 proc broadcastSyncCommitteeMessage*(
     node: Eth2Node, msg: SyncCommitteeMessage, committeeIdx: SyncCommitteeIndex) =

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -114,6 +114,18 @@ func syncCommitteeParticipants*(forkedState: ForkedHashedBeaconState,
       ok(@(forkedState.hbsAltair.data.next_sync_committee.pubkeys.data))
     else:
       err("Epoch is outside the sync committee period of the state")
+  of BeaconStateFork.forkMerge:
+    let
+      headSlot = forkedState.hbsMerge.data.slot
+      epochPeriod = syncCommitteePeriod(epoch.compute_start_slot_at_epoch())
+      currentPeriod = syncCommitteePeriod(headSlot)
+      nextPeriod = currentPeriod + 1'u64
+    if epochPeriod == currentPeriod:
+      ok(@(forkedState.hbsMerge.data.current_sync_committee.pubkeys.data))
+    elif epochPeriod == nextPeriod:
+      ok(@(forkedState.hbsMerge.data.next_sync_committee.pubkeys.data))
+    else:
+      err("Epoch is outside the sync committee period of the state")
 
 proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getGenesis

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -767,7 +767,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           RestApiResponse.jsonResponse(bdata.data.phase0Block)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)
-      of BeaconBlockFork.Altair:
+      of BeaconBlockFork.Altair, BeaconBlockFork.Merge:
         RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
@@ -797,6 +797,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           RestApiResponse.sszResponse(bdata.data.phase0Block)
         of BeaconBlockFork.Altair:
           RestApiResponse.sszResponse(bdata.data.altairBlock)
+        of BeaconBlockFork.Merge:
+          RestApiResponse.sszResponse(bdata.data.mergeBlock)
       of "application/json":
         RestApiResponse.jsonResponsePlain(bdata.data.asSigned())
       else:

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -39,7 +39,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
               RestApiResponse.jsonResponse(stateData.data.hbsPhase0.data)
             else:
               RestApiResponse.jsonError(Http500, InvalidAcceptError)
-        of BeaconStateFork.forkAltair:
+        of BeaconStateFork.forkAltair, BeaconStateFork.forkMerge:
           RestApiResponse.jsonError(Http404, StateNotFoundError)
     return RestApiResponse.jsonError(Http404, StateNotFoundError)
 
@@ -76,6 +76,8 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
             RestApiResponse.sszResponse(stateData.data.hbsPhase0.data)
           of BeaconStateFork.forkAltair:
             RestApiResponse.sszResponse(stateData.data.hbsAltair.data)
+          of BeaconStateFork.forkMerge:
+            RestApiResponse.sszResponse(stateData.data.hbsMerge.data)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)
     return RestApiResponse.jsonError(Http404, StateNotFoundError)

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -50,9 +50,9 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     case blck.kind
     of BeaconBlockFork.Phase0:
       return blck.phase0Block
-    of BeaconBlockFork.Altair:
+    of BeaconBlockFork.Altair, BeaconBlockFork.Merge:
       raise newException(CatchableError,
-                         "could not retrieve block for altair blocks")
+                         "could not retrieve block for altair or merge blocks")
 
   rpcServer.rpc("post_v1_validator_block") do (body: phase0.SignedBeaconBlock) -> bool:
     debug "post_v1_validator_block",

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -740,7 +740,8 @@ func get_next_sync_committee_indices(state: altair.BeaconState | merge.BeaconSta
   sync_committee_indices
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.7/specs/altair/beacon-chain.md#get_next_sync_committee
-proc get_next_sync_committee*(state: altair.BeaconState | merge.BeaconState): SyncCommittee =
+proc get_next_sync_committee*(state: altair.BeaconState | merge.BeaconState):
+    SyncCommittee =
   ## Return the *next* sync committee for a given ``state``.
   let indices = get_next_sync_committee_indices(state)
   # TODO not robust

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -196,6 +196,14 @@ func altairFork*(cfg: RuntimeConfig): Fork =
     current_version: cfg.ALTAIR_FORK_VERSION,
     epoch: cfg.ALTAIR_FORK_EPOCH)
 
+func mergeFork*(cfg: RuntimeConfig): Fork =
+  # TODO in theory, the altair + merge forks could be in same epoch, so the
+  # previous fork version would be the GENESIS_FORK_VERSION
+  Fork(
+    previous_version: cfg.ALTAIR_FORK_VERSION,
+    current_version: cfg.MERGE_FORK_VERSION,
+    epoch: cfg.MERGE_FORK_EPOCH)
+
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#genesis
 proc initialize_beacon_state_from_eth1*(
     cfg: RuntimeConfig,
@@ -700,7 +708,7 @@ proc process_attestation*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#get_next_sync_committee_indices
-func get_next_sync_committee_indices(state: altair.BeaconState):
+func get_next_sync_committee_indices(state: altair.BeaconState | merge.BeaconState):
     seq[ValidatorIndex] =
   ## Return the sequence of sync committee indices (which may include
   ## duplicate indices) for the next sync committee, given a ``state`` at a
@@ -732,7 +740,7 @@ func get_next_sync_committee_indices(state: altair.BeaconState):
   sync_committee_indices
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.7/specs/altair/beacon-chain.md#get_next_sync_committee
-proc get_next_sync_committee*(state: altair.BeaconState): SyncCommittee =
+proc get_next_sync_committee*(state: altair.BeaconState | merge.BeaconState): SyncCommittee =
   ## Return the *next* sync committee for a given ``state``.
   let indices = get_next_sync_committee_indices(state)
   # TODO not robust

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -250,15 +250,6 @@ type
     data*: BeaconState
     root*: Eth2Digest # hash_tree_root(data)
 
-  # Altair implies phase 0 knowledge, and this saves creating some other
-  # module to merge such knowledge. Another approach is to have imported
-  # set of phase 0/HF1 symbols be independently combined by each module,
-  # when necessary, but that spreads such detailed abstraction knowledge
-  # more widely through codebase than strictly required. Do not export a
-  # phase 0 version of symbols; anywhere which specially handles it will
-  # have to do so itself.
-  SomeHashedBeaconState* = HashedBeaconState | phase0.HashedBeaconState
-
   # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock
   BeaconBlock* = object
     ## For each slot, a proposer is chosen from the validator pool to propose
@@ -417,22 +408,6 @@ type
   SomeSignedBeaconBlock* = SignedBeaconBlock | SigVerifiedSignedBeaconBlock | TrustedSignedBeaconBlock
   SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
-
-  # TODO rename
-
-  # TODO why does this fail?
-  #SomeSomeBeaconBlock* = SomeBeaconBlock | phase0.SomeBeaconBlock
-  SomeSomeBeaconBlock* =
-    BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock |
-    phase0.BeaconBlock | phase0.SigVerifiedBeaconBlock | phase0.TrustedBeaconBlock
-
-  # TODO see above, re why does it fail
-  SomeSomeBeaconBlockBody* =
-    BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody |
-    phase0.BeaconBlockBody | phase0.SigVerifiedBeaconBlockBody | phase0.TrustedBeaconBlockBody
-  #SomeSomeBeaconBlockBody* = SomeBeaconBlockBody | phase0.SomeBeaconBlockBody
-
-  SomeSomeSignedBeaconBlock* = SomeSignedBeaconBlock | phase0.SomeSignedBeaconBlock
 
   SyncCommitteeIndex* = distinct uint8
 

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -76,9 +76,8 @@ type
     transactions_root*: Eth2Digest
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#execution-engine
-  ExecutionEngine* = object
-    # TODO
-    discard
+  ExecutePayload* = proc(
+    execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#beaconstate
   BeaconState* = object

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -22,8 +22,8 @@ const
   MAX_BYTES_PER_OPAQUE_TRANSACTION* = 1048576
   MAX_TRANSACTIONS_PER_PAYLOAD* = 16384
   BYTES_PER_LOGS_BLOOM = 256
-  GAS_LIMIT_DENOMINATOR = 1024
-  MIN_GAS_LIMIT = 5000
+  GAS_LIMIT_DENOMINATOR* = 1024
+  MIN_GAS_LIMIT* = 5000
   MAX_EXTRA_DATA_BYTES = 32
 
 type
@@ -366,10 +366,6 @@ proc readValue*(r: var JsonReader, a: var EthAddress) {.raises: [Defect, IOError
     a = fromHex(type(a), r.readValue(string))
   except ValueError:
     raiseUnexpectedValue(r, "Hex string expected")
-
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_complete
-func is_merge_complete(state: merge.BeaconState): bool =
-  state.latest_execution_payload_header != default(ExecutionPayloadHeader)
 
 func shortLog*(v: SomeBeaconBlock): auto =
   (

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -75,6 +75,11 @@ type
     block_hash*: Eth2Digest  # Hash of execution block
     transactions_root*: Eth2Digest
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#execution-engine
+  ExecutionEngine* = object
+    # TODO
+    discard
+
   # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#beaconstate
   BeaconState* = object
     # Versioning

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -138,7 +138,12 @@ type
     # Execution
     latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Merge]
 
+  HashedBeaconState* = object
+    data*: BeaconState
+    root*: Eth2Digest # hash_tree_root(data)
+
   SomeBeaconState* = BeaconState | altair.BeaconState | phase0.BeaconState
+  SomeHashedBeaconState* = HashedBeaconState | altair.HashedBeaconState | phase0.HashedBeaconState
 
   # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock
   BeaconBlock* = object
@@ -302,6 +307,22 @@ type
   SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
+  # TODO why does this fail?
+  #SomeSomeBeaconBlock* = SomeBeaconBlock | phase0.SomeBeaconBlock
+  SomeSomeBeaconBlock* =
+    BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock |
+    altair.BeaconBlock | altair.SigVerifiedBeaconBlock | altair.TrustedBeaconBlock |
+    phase0.BeaconBlock | phase0.SigVerifiedBeaconBlock | phase0.TrustedBeaconBlock
+
+  # TODO see above, re why does it fail
+  SomeSomeBeaconBlockBody* =
+    BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody |
+    altair.BeaconBlockBody | altair.SigVerifiedBeaconBlockBody | altair.TrustedBeaconBlockBody |
+    phase0.BeaconBlockBody | phase0.SigVerifiedBeaconBlockBody | phase0.TrustedBeaconBlockBody
+  #SomeSomeBeaconBlockBody* = SomeBeaconBlockBody | phase0.SomeBeaconBlockBody
+
+  SomeSomeSignedBeaconBlock* = SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock | phase0.SomeSignedBeaconBlock
+
   # Empirically derived from Catalyst responses; doesn't seem to match merge
   # spec per commit 1fb9a6dd32b581c912d672634882d7e2eb2775cd from 2021-04-22
   # {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x35139e42d930c640eee446944f7f8b345771b69dfa10120895057f48680ea27d","parentHash":"0x3a3fdfc9ab6e17ff530b57bc21494da3848ebbeaf9343545fded7a18d221ffec","miner":"0x1000000000000000000000000000000000000000","stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","number":"0x1","gasLimit":"0x2fefd8","gasUsed":"0x0","timestamp":"0x6087e796","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactions":[]}}
@@ -349,3 +370,25 @@ proc readValue*(r: var JsonReader, a: var EthAddress) {.raises: [Defect, IOError
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_complete
 func is_merge_complete(state: merge.BeaconState): bool =
   state.latest_execution_payload_header != default(ExecutionPayloadHeader)
+
+func shortLog*(v: SomeBeaconBlock): auto =
+  (
+    slot: shortLog(v.slot),
+    proposer_index: v.proposer_index,
+    parent_root: shortLog(v.parent_root),
+    state_root: shortLog(v.state_root),
+    eth1data: v.body.eth1_data,
+    graffiti: $v.body.graffiti,
+    proposer_slashings_len: v.body.proposer_slashings.len(),
+    attester_slashings_len: v.body.attester_slashings.len(),
+    attestations_len: v.body.attestations.len(),
+    deposits_len: v.body.deposits.len(),
+    voluntary_exits_len: v.body.voluntary_exits.len(),
+    sync_committee_participants: countOnes(v.body.sync_aggregate.sync_committee_bits)
+  )
+
+func shortLog*(v: SomeSignedBeaconBlock): auto =
+  (
+    blck: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -655,9 +655,19 @@ proc readValue*(reader: var JsonReader[RestJson],
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect altair block format")
     value = ForkedBeaconBlock.init(res.get())
+  of BeaconBlockFork.Merge:
+    let res =
+      try:
+        some(RestJson.decode(string(data.get()), merge.BeaconBlock,
+                             requireAllFields = true))
+      except SerializationError:
+        none[merge.BeaconBlock]()
+    if res.isNone():
+      reader.raiseUnexpectedValue("Incorrect merge block format")
+    value = ForkedBeaconBlock.init(res.get())
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconBlock) {.
-     raises: [IOError, Defect].} =
+     raises: [IOError, SerializationError, Defect].} =
   writer.beginRecord()
   case value.kind
   of BeaconBlockFork.Phase0:
@@ -666,6 +676,9 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconBlock) {.
   of BeaconBlockFork.Altair:
     writer.writeField("version", "altair")
     writer.writeField("data", value.altairBlock)
+  of BeaconBlockFork.Merge:
+    writer.writeField("version", "merge")
+    writer.writeField("data", value.mergeBlock)
   writer.endRecord()
 
 ## ForkedSignedBeaconBlock
@@ -724,10 +737,20 @@ proc readValue*(reader: var JsonReader[RestJson],
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect altair block format")
     value = ForkedSignedBeaconBlock.init(res.get())
+  of BeaconBlockFork.Merge:
+    let res =
+      try:
+        some(RestJson.decode(string(data.get()), merge.SignedBeaconBlock,
+                             requireAllFields = true))
+      except SerializationError:
+        none[merge.SignedBeaconBlock]()
+    if res.isNone():
+      reader.raiseUnexpectedValue("Incorrect merge block format")
+    value = ForkedSignedBeaconBlock.init(res.get())
 
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: ForkedSignedBeaconBlock) {.
-     raises: [IOError, Defect].} =
+     raises: [IOError, SerializationError, Defect].} =
   writer.beginRecord()
   case value.kind
   of BeaconBlockFork.Phase0:
@@ -736,6 +759,9 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   of BeaconBlockFork.Altair:
     writer.writeField("version", "altair")
     writer.writeField("data", value.altairBlock)
+  of BeaconBlockFork.Merge:
+    writer.writeField("version", "merge")
+    writer.writeField("data", value.mergeBlock)
   writer.endRecord()
 
 # ForkedBeaconState
@@ -794,9 +820,19 @@ proc readValue*(reader: var JsonReader[RestJson],
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect altair beacon state format")
     value = ForkedBeaconState.init(res.get())
+  of BeaconStateFork.forkMerge:
+    let res =
+      try:
+        some(RestJson.decode(string(data.get()), merge.BeaconState,
+                             requireAllFields = true))
+      except SerializationError:
+        none[merge.BeaconState]()
+    if res.isNone():
+      reader.raiseUnexpectedValue("Incorrect merge beacon state format")
+    value = ForkedBeaconState.init(res.get())
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconState) {.
-     raises: [IOError, Defect].} =
+     raises: [IOError, SerializationError, Defect].} =
   writer.beginRecord()
   case value.beaconStateFork
   of BeaconStateFork.forkPhase0:
@@ -805,6 +841,9 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconState) {.
   of BeaconStateFork.forkAltair:
     writer.writeField("version", "altair")
     writer.writeField("data", value.bsAltair)
+  of BeaconStateFork.forkMerge:
+    writer.writeField("version", "merge")
+    writer.writeField("data", value.bsMerge)
   writer.endRecord()
 
 template toSszType*(v: BeaconBlockFork): auto =

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -619,6 +619,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         version = some(BeaconBlockFork.Phase0)
       of "altair":
         version = some(BeaconBlockFork.Altair)
+      of "merge":
+        version = some(BeaconBlockFork.Merge)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
@@ -667,7 +669,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     value = ForkedBeaconBlock.init(res.get())
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconBlock) {.
-     raises: [IOError, SerializationError, Defect].} =
+     raises: [IOError, Defect].} =
   writer.beginRecord()
   case value.kind
   of BeaconBlockFork.Phase0:
@@ -678,7 +680,9 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconBlock) {.
     writer.writeField("data", value.altairBlock)
   of BeaconBlockFork.Merge:
     writer.writeField("version", "merge")
-    writer.writeField("data", value.mergeBlock)
+    when false:
+      # TODO SerializationError
+      writer.writeField("data", value.mergeBlock)
   writer.endRecord()
 
 ## ForkedSignedBeaconBlock
@@ -701,6 +705,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         version = some(BeaconBlockFork.Phase0)
       of "altair":
         version = some(BeaconBlockFork.Altair)
+      of "merge":
+        version = some(BeaconBlockFork.Merge)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
@@ -750,7 +756,7 @@ proc readValue*(reader: var JsonReader[RestJson],
 
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: ForkedSignedBeaconBlock) {.
-     raises: [IOError, SerializationError, Defect].} =
+     raises: [IOError, Defect].} =
   writer.beginRecord()
   case value.kind
   of BeaconBlockFork.Phase0:
@@ -761,7 +767,9 @@ proc writeValue*(writer: var JsonWriter[RestJson],
     writer.writeField("data", value.altairBlock)
   of BeaconBlockFork.Merge:
     writer.writeField("version", "merge")
-    writer.writeField("data", value.mergeBlock)
+    when false:
+      # TODO SerializationError
+      writer.writeField("data", value.mergeBlock)
   writer.endRecord()
 
 # ForkedBeaconState
@@ -784,6 +792,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         version = some(BeaconStateFork.forkPhase0)
       of "altair":
         version = some(BeaconStateFork.forkAltair)
+      of "merge":
+        version = some(BeaconStateFork.forkMerge)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
@@ -832,7 +842,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     value = ForkedBeaconState.init(res.get())
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconState) {.
-     raises: [IOError, SerializationError, Defect].} =
+     raises: [IOError, Defect].} =
   writer.beginRecord()
   case value.beaconStateFork
   of BeaconStateFork.forkPhase0:
@@ -843,7 +853,9 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconState) {.
     writer.writeField("data", value.bsAltair)
   of BeaconStateFork.forkMerge:
     writer.writeField("version", "merge")
-    writer.writeField("data", value.bsMerge)
+    when false:
+      # TODO SerializationError
+      writer.writeField("data", value.bsMerge)
   writer.endRecord()
 
 template toSszType*(v: BeaconBlockFork): auto =

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -8,7 +8,7 @@
 
 import
   chronos, presto/client,
-  ../datatypes/[phase0, altair],
+  ../datatypes/[phase0, altair, merge],
   "."/[rest_types, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -13,28 +13,32 @@ import
   stew/[assign2, results],
   ../extras,
   ../spec/[beaconstate, helpers, state_transition_block, validator],
-  ./datatypes/[phase0, altair]
+  ./datatypes/[phase0, altair, merge]
 
 export extras, phase0, altair
 
 type
   BeaconStateFork* = enum
     forkPhase0,
-    forkAltair
+    forkAltair,
+    forkMerge
 
   ForkedHashedBeaconState* = object
     case beaconStateFork*: BeaconStateFork
     of forkPhase0: hbsPhase0*: phase0.HashedBeaconState
     of forkAltair: hbsAltair*: altair.HashedBeaconState
+    of forkMerge:  hbsMerge*:  merge.HashedBeaconState
 
   ForkedBeaconState* = object
     case beaconStateFork*: BeaconStateFork
     of forkPhase0: bsPhase0*: phase0.BeaconState
     of forkAltair: bsAltair*: altair.BeaconState
+    of forkMerge:  bsMerge*:  merge.BeaconState
 
   BeaconBlockFork* {.pure.} = enum
     Phase0
     Altair
+    Merge
 
   ForkedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -42,6 +46,8 @@ type
       phase0Block*: phase0.BeaconBlock
     of BeaconBlockFork.Altair:
       altairBlock*: altair.BeaconBlock
+    of BeaconBlockFork.Merge:
+      mergeBlock*:  merge.BeaconBlock
 
   ForkedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -49,6 +55,8 @@ type
       phase0Block*: phase0.SignedBeaconBlock
     of BeaconBlockFork.Altair:
       altairBlock*: altair.SignedBeaconBlock
+    of BeaconBlockFork.Merge:
+      mergeBlock*:  merge.SignedBeaconBlock
 
   ForkedTrustedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -56,10 +64,13 @@ type
       phase0Block*: phase0.TrustedSignedBeaconBlock
     of BeaconBlockFork.Altair:
       altairBlock*: altair.TrustedSignedBeaconBlock
+    of BeaconBlockFork.Merge:
+      mergeBlock*:  merge.TrustedSignedBeaconBlock
 
   ForkDigests* = object
     phase0*: ForkDigest
     altair*: ForkDigest
+    merge*:  ForkDigest  # TODO where does this get filled
     altairTopicPrefix*: string # Used by isAltairTopic
 
   ForkDigestsRef* = ref ForkDigests
@@ -68,16 +79,22 @@ template init*(T: type ForkedBeaconBlock, blck: phase0.BeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Block: blck)
 template init*(T: type ForkedBeaconBlock, blck: altair.BeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairBlock: blck)
+template init*(T: type ForkedBeaconBlock, blck: merge.BeaconBlock): T =
+  T(kind: BeaconBlockFork.Merge, mergeBlock: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, blck: phase0.SignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Block: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: altair.SignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairBlock: blck)
+template init*(T: type ForkedSignedBeaconBlock, blck: merge.SignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Merge, mergeBlock: blck)
 
 template init*(T: type ForkedBeaconState, state: phase0.BeaconState): T =
   T(beaconStateFork: BeaconStateFork.forkPhase0, bsPhase0: state)
 template init*(T: type ForkedBeaconState, state: altair.BeaconState): T =
   T(beaconStateFork: BeaconStateFork.forkAltair, bsAltair: state)
+template init*(T: type ForkedBeaconState, state: merge.BeaconState): T =
+  T(beaconStateFork: BeaconStateFork.forkMerge, bsMerge: state)
 template init*(T: type ForkedBeaconState, state: ForkedHashedBeaconState): T =
   case state.beaconStateFork
   of BeaconStateFork.forkPhase0:
@@ -86,6 +103,9 @@ template init*(T: type ForkedBeaconState, state: ForkedHashedBeaconState): T =
   of BeaconStateFork.forkAltair:
     T(beaconStateFork: BeaconStateFork.forkAltair,
       bsAltair: state.hbsAltair.data)
+  of BeaconStateFork.forkMerge:
+    T(beaconStateFork: BeaconStateFork.forkMerge,
+      bsMerge: state.hbsMerge.data)
 
 template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
                blockRoot: Eth2Digest, signature: ValidatorSig): T =
@@ -100,11 +120,18 @@ template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
       altairBlock: altair.SignedBeaconBlock(message: forked.altairBlock,
                                             root: blockRoot,
                                             signature: signature))
+  of BeaconBlockFork.Merge:
+    T(kind: BeaconBlockFork.Merge,
+      mergeBlock: merge.SignedBeaconBlock(message: forked.mergeBlock,
+                                          root: blockRoot,
+                                          signature: signature))
 
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: phase0.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Block: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: altair.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairBlock: blck)
+template init*(T: type ForkedTrustedSignedBeaconBlock, blck: merge.TrustedSignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Merge,  mergeBlock: blck)
 
 # State-related functionality based on ForkedHashedBeaconState instead of BeaconState
 
@@ -136,16 +163,19 @@ template getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
   case x.beaconStateFork:
   of forkPhase0: x.hbsPhase0.root
   of forkAltair: x.hbsAltair.root
+  of forkMerge:  x.hbsAltair.root
 
 func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
   case x.beaconStateFork:
   of forkPhase0: x.hbsPhase0.root = root
   of forkAltair: x.hbsAltair.root = root
+  of forkMerge:  x.hbsMerge.root  = root
 
 template hash_tree_root*(x: ForkedHashedBeaconState): Eth2Digest =
   case x.beaconStateFork:
   of forkPhase0: hash_tree_root(x.hbsPhase0.data)
   of forkAltair: hash_tree_root(x.hbsAltair.data)
+  of forkMerge:  hash_tree_root(x.hbsMerge.data)
 
 template hash_tree_root*(blk: ForkedBeaconBlock): Eth2Digest =
   case blk.kind
@@ -153,6 +183,8 @@ template hash_tree_root*(blk: ForkedBeaconBlock): Eth2Digest =
     hash_tree_root(blk.phase0Block)
   of BeaconBlockFork.Altair:
     hash_tree_root(blk.altairBlock)
+  of BeaconBlockFork.Merge:
+    hash_tree_root(blk.mergeBlock)
 
 template proposer_index*(blk: ForkedBeaconBlock): uint64 =
   case blk.kind
@@ -160,6 +192,8 @@ template proposer_index*(blk: ForkedBeaconBlock): uint64 =
     blk.phase0Block.proposer_index
   of BeaconBlockFork.Altair:
     blk.altairBlock.proposer_index
+  of BeaconBlockFork.Merge:
+    blk.mergeBlock.proposer_index
 
 func get_active_validator_indices_len*(
     state: ForkedHashedBeaconState; epoch: Epoch): uint64 =
@@ -168,6 +202,8 @@ func get_active_validator_indices_len*(
     get_active_validator_indices_len(state.hbsPhase0.data, epoch)
   of forkAltair:
     get_active_validator_indices_len(state.hbsAltair.data, epoch)
+  of forkMerge:
+    get_active_validator_indices_len(state.hbsMerge.data, epoch)
 
 func get_beacon_committee*(
     state: ForkedHashedBeaconState, slot: Slot, index: CommitteeIndex,
@@ -180,6 +216,7 @@ func get_beacon_committee*(
   case state.beaconStateFork:
   of forkPhase0: get_beacon_committee(state.hbsPhase0.data, slot, index, cache)
   of forkAltair: get_beacon_committee(state.hbsAltair.data, slot, index, cache)
+  of forkMerge:  get_beacon_committee(state.hbsMerge.data,  slot, index, cache)
 
 func get_beacon_committee_len*(
     state: ForkedHashedBeaconState, slot: Slot, index: CommitteeIndex,
@@ -188,6 +225,7 @@ func get_beacon_committee_len*(
   case state.beaconStateFork:
   of forkPhase0: get_beacon_committee_len(state.hbsPhase0.data, slot, index, cache)
   of forkAltair: get_beacon_committee_len(state.hbsAltair.data, slot, index, cache)
+  of forkMerge:  get_beacon_committee_len(state.hbsMerge.data,  slot, index, cache)
 
 func get_committee_count_per_slot*(state: ForkedHashedBeaconState,
                                    epoch: Epoch,
@@ -196,6 +234,7 @@ func get_committee_count_per_slot*(state: ForkedHashedBeaconState,
   case state.beaconStateFork:
   of forkPhase0: get_committee_count_per_slot(state.hbsPhase0.data, epoch, cache)
   of forkAltair: get_committee_count_per_slot(state.hbsAltair.data, epoch, cache)
+  of forkMerge:  get_committee_count_per_slot(state.hbsMerge.data,  epoch, cache)
 
 func get_beacon_proposer_index*(state: ForkedHashedBeaconState,
                                 cache: var StateCache, slot: Slot):
@@ -203,6 +242,7 @@ func get_beacon_proposer_index*(state: ForkedHashedBeaconState,
   case state.beaconStateFork:
   of forkPhase0: get_beacon_proposer_index(state.hbsPhase0.data, cache, slot)
   of forkAltair: get_beacon_proposer_index(state.hbsAltair.data, cache, slot)
+  of forkMerge:  get_beacon_proposer_index(state.hbsMerge.data,  cache, slot)
 
 func get_shuffled_active_validator_indices*(
     cache: var StateCache, state: ForkedHashedBeaconState, epoch: Epoch):
@@ -212,6 +252,8 @@ func get_shuffled_active_validator_indices*(
     cache.get_shuffled_active_validator_indices(state.hbsPhase0.data, epoch)
   of forkAltair:
     cache.get_shuffled_active_validator_indices(state.hbsAltair.data, epoch)
+  of forkMerge:
+    cache.get_shuffled_active_validator_indices(state.hbsMerge.data,  epoch)
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#get_block_root_at_slot
 func get_block_root_at_slot*(state: ForkedHashedBeaconState,
@@ -220,6 +262,7 @@ func get_block_root_at_slot*(state: ForkedHashedBeaconState,
   case state.beaconStateFork:
   of forkPhase0: get_block_root_at_slot(state.hbsPhase0.data, slot)
   of forkAltair: get_block_root_at_slot(state.hbsAltair.data, slot)
+  of forkMerge:  get_block_root_at_slot(state.hbsMerge.data,  slot)
 
 proc get_attesting_indices*(state: ForkedHashedBeaconState;
                             data: AttestationData;
@@ -249,6 +292,8 @@ proc check_attester_slashing*(
     check_attester_slashing(state.hbsPhase0.data, attester_slashing, flags)
   of forkAltair:
     check_attester_slashing(state.hbsAltair.data, attester_slashing, flags)
+  of forkMerge:
+    check_attester_slashing(state.hbsMerge.data,  attester_slashing, flags)
 
 proc check_proposer_slashing*(
     state: var ForkedHashedBeaconState; proposer_slashing: SomeProposerSlashing;
@@ -258,6 +303,8 @@ proc check_proposer_slashing*(
     check_proposer_slashing(state.hbsPhase0.data, proposer_slashing, flags)
   of forkAltair:
     check_proposer_slashing(state.hbsAltair.data, proposer_slashing, flags)
+  of forkMerge:
+    check_proposer_slashing(state.hbsMerge.data,  proposer_slashing, flags)
 
 proc check_voluntary_exit*(
     cfg: RuntimeConfig, state: ForkedHashedBeaconState;
@@ -268,6 +315,8 @@ proc check_voluntary_exit*(
     check_voluntary_exit(cfg, state.hbsPhase0.data, signed_voluntary_exit, flags)
   of forkAltair:
     check_voluntary_exit(cfg, state.hbsAltair.data, signed_voluntary_exit, flags)
+  of forkMerge:
+    check_voluntary_exit(cfg, state.hbsMerge.data,  signed_voluntary_exit, flags)
 
 # Derived utilities
 
@@ -317,6 +366,10 @@ template asTrusted*(x: altair.SignedBeaconBlock or altair.SigVerifiedBeaconBlock
     altair.TrustedSignedBeaconBlock =
   isomorphicCast[altair.TrustedSignedBeaconBlock](x)
 
+template asTrusted*(x: merge.SignedBeaconBlock or merge.SigVerifiedBeaconBlock):
+    merge.TrustedSignedBeaconBlock =
+  isomorphicCast[merge.TrustedSignedBeaconBlock](x)
+
 template asTrusted*(x: ForkedSignedBeaconBlock): ForkedTrustedSignedBeaconBlock =
   isomorphicCast[ForkedTrustedSignedBeaconBlock](x)
 
@@ -327,6 +380,9 @@ template withBlck*(x: ForkedBeaconBlock | ForkedSignedBeaconBlock | ForkedTruste
     body
   of BeaconBlockFork.Altair:
     template blck: untyped {.inject.} = x.altairBlock
+    body
+  of BeaconBlockFork.Merge:
+    template blck: untyped {.inject.} = x.mergeBlock
     body
 
 template getForkedBlockField*(x: ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock, y: untyped): untyped =
@@ -355,18 +411,21 @@ chronicles.formatIt ForkedSignedBeaconBlock: it.shortLog
 chronicles.formatIt ForkedTrustedSignedBeaconBlock: it.shortLog
 
 proc forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
+  # TODO MERGE_FORK_EPOCH
   if epoch < cfg.ALTAIR_FORK_EPOCH:
     genesisFork(cfg)
   else:
     altairFork(cfg)
 
 proc forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
+  # TODO MERGE_FORK_EPOCH
   if epoch < cfg.ALTAIR_FORK_EPOCH:
     cfg.GENESIS_FORK_VERSION
   else:
     cfg.ALTAIR_FORK_VERSION
 
 proc nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
+  # TODO MERGE_FORK_EPOCH
   if epoch < cfg.ALTAIR_FORK_EPOCH:
     cfg.ALTAIR_FORK_EPOCH
   else:

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -157,13 +157,14 @@ template getStateField*(x, y: untyped): untyped =
   # Without `unsafeAddr`, the `validators` list would be copied to a temporary variable.
   (case x.beaconStateFork
    of forkPhase0: unsafeAddr (x.hbsPhase0.data.y)
-   of forkAltair: unsafeAddr (x.hbsAltair.data.y))[]
+   of forkAltair: unsafeAddr (x.hbsAltair.data.y)
+   of forkMerge:  unsafeAddr (x.hbsMerge.data.y))[]
 
 template getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
   case x.beaconStateFork:
   of forkPhase0: x.hbsPhase0.root
   of forkAltair: x.hbsAltair.root
-  of forkMerge:  x.hbsAltair.root
+  of forkMerge:  x.hbsMerge.root
 
 func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
   case x.beaconStateFork:

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -234,7 +234,27 @@ func has_flag*(flags: ParticipationFlags, flag_index: int): bool =
   let flag = ParticipationFlags(1'u8 shl flag_index)
   (flags and flag) == flag
 
-# https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-beta.3/specs/altair/sync-protocol.md#get_subtree_index
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/sync-protocol.md#get_subtree_index
 func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   doAssert idx > 0
   uint64(idx mod (type(idx)(1) shl log2trunc(idx)))
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_complete
+func is_merge_complete(state: merge.BeaconState): bool =
+  state.latest_execution_payload_header != default(ExecutionPayloadHeader)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_block
+func is_merge_block(
+    state: merge.BeaconState, body: merge.BeaconBlockBody): bool =
+  not is_merge_complete(state) and body.execution_payload != ExecutionPayload()
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_execution_enabled
+func is_execution_enabled(
+    state: merge.BeaconState, body: merge.BeaconBlockBody): bool =
+  is_merge_block(state, body) or is_merge_complete(state)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#compute_timestamp_at_slot
+func compute_timestamp_at_slot(state: SomeBeaconState, slot: Slot): uint64 =
+  # Note: This function is unsafe with respect to overflows and underflows.
+  let slots_since_genesis = slot - GENESIS_SLOT
+  state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -245,12 +245,16 @@ func is_merge_complete*(state: merge.BeaconState): bool =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_block
 func is_merge_block(
-    state: merge.BeaconState, body: merge.BeaconBlockBody): bool =
+    state: merge.BeaconState,
+    body: merge.BeaconBlockBody | merge.TrustedBeaconBlockBody |
+          merge.SigVerifiedBeaconBlockBody): bool =
   not is_merge_complete(state) and body.execution_payload != ExecutionPayload()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_execution_enabled
-func is_execution_enabled(
-    state: merge.BeaconState, body: merge.BeaconBlockBody): bool =
+func is_execution_enabled*(
+    state: merge.BeaconState,
+    body: merge.BeaconBlockBody | merge.TrustedBeaconBlockBody |
+          merge.SigVerifiedBeaconBlockBody): bool =
   is_merge_block(state, body) or is_merge_complete(state)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#compute_timestamp_at_slot

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -240,7 +240,7 @@ func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   uint64(idx mod (type(idx)(1) shl log2trunc(idx)))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_complete
-func is_merge_complete(state: merge.BeaconState): bool =
+func is_merge_complete*(state: merge.BeaconState): bool =
   state.latest_execution_payload_header != default(ExecutionPayloadHeader)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_merge_block
@@ -254,7 +254,7 @@ func is_execution_enabled(
   is_merge_block(state, body) or is_merge_complete(state)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#compute_timestamp_at_slot
-func compute_timestamp_at_slot(state: SomeBeaconState, slot: Slot): uint64 =
+func compute_timestamp_at_slot*(state: SomeBeaconState, slot: Slot): uint64 =
   # Note: This function is unsafe with respect to overflows and underflows.
   let slots_since_genesis = slot - GENESIS_SLOT
   state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -8,7 +8,7 @@
 {.push raises: [Defect].}
 
 import
-  ./datatypes/[phase0, altair], ./helpers, ./eth2_merkleization
+  ./datatypes/[phase0, altair, merge], ./helpers, ./eth2_merkleization
 
 export phase0, altair
 

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -13,7 +13,7 @@ import
   stew/[byteutils, results],
   # Internal
   "."/[helpers, beaconstate, forks],
-  "."/datatypes/[altair, phase0]
+  "."/datatypes/[altair, merge, phase0]
 
 # Otherwise, error.
 import chronicles
@@ -250,7 +250,7 @@ proc addAggregateAndProofSignature*(
 
 proc collectSignatureSets*(
        sigs: var seq[SignatureSet],
-       signed_block: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+       signed_block: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
        validatorKeys: auto,
        state: ForkedHashedBeaconState,
        cache: var StateCache): Result[void, cstring] =

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -250,7 +250,8 @@ proc addAggregateAndProofSignature*(
 
 proc collectSignatureSets*(
        sigs: var seq[SignatureSet],
-       signed_block: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | merge.SignedBeaconBlock,
+       signed_block: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                     merge.SignedBeaconBlock,
        validatorKeys: auto,
        state: ForkedHashedBeaconState,
        cache: var StateCache): Result[void, cstring] =

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -46,7 +46,7 @@ import
   stew/results,
   metrics,
   ../extras,
-  ./datatypes/[phase0, altair],
+  ./datatypes/[phase0, altair, merge],
   "."/[
     beaconstate, eth2_merkleization, forks, helpers, signatures,
     state_transition_block, state_transition_epoch, validator],
@@ -55,7 +55,7 @@ import
 export extras, phase0, altair
 
 # TODO why need anything except the first two?
-type Foo = phase0.SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock | phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock
+type Foo = phase0.SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock | phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock | merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc verify_block_signature(
@@ -80,7 +80,7 @@ proc verify_block_signature(
   true
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc verifyStateRoot(state: SomeBeaconState, blck: phase0.BeaconBlock or phase0.SigVerifiedBeaconBlock or altair.BeaconBlock or altair.SigVerifiedBeaconBlock): bool =
+proc verifyStateRoot(state: SomeBeaconState, blck: phase0.BeaconBlock or phase0.SigVerifiedBeaconBlock or altair.BeaconBlock or altair.SigVerifiedBeaconBlock or merge.BeaconBlock or merge.SigVerifiedBeaconBlock or merge.TrustedBeaconBlock): bool =
   # This is inlined in state_transition(...) in spec.
   let state_root = hash_tree_root(state)
   if state_root != blck.state_root:
@@ -98,9 +98,21 @@ func verifyStateRoot(state: altair.BeaconState, blck: altair.TrustedBeaconBlock)
   # This is inlined in state_transition(...) in spec.
   true
 
+func verifyStateRoot(state: merge.BeaconState, blck: merge.TrustedBeaconBlock): bool =
+  # This is inlined in state_transition(...) in spec.
+  true
+
 # one of these can happen on the fork block itself (it's a phase 0 block which
 # creates an Altair state)
 func verifyStateRoot(state: altair.BeaconState, blck: phase0.TrustedBeaconBlock): bool =
+  # This is inlined in state_transition(...) in spec.
+  true
+
+func verifyStateRoot(state: merge.BeaconState, blck: phase0.TrustedBeaconBlock): bool =
+  # This is inlined in state_transition(...) in spec.
+  true
+
+func verifyStateRoot(state: merge.BeaconState, blck: altair.TrustedBeaconBlock): bool =
   # This is inlined in state_transition(...) in spec.
   true
 
@@ -220,6 +232,15 @@ proc process_slots*(
         # Don't update state root for the slot of the block if going to process
         # block after
         state.hbsAltair.root = hash_tree_root(state)
+    of forkMerge:
+      advance_slot(
+        cfg, state.hbsMerge.data, state.hbsMerge.root, flags, cache, rewards)
+
+      if skipLastStateRootCalculation notin flags or
+          getStateField(state, slot) < slot:
+        # Don't update state root for the slot of the block if going to process
+        # block after
+        state.hbsMerge.root = hash_tree_root(state)
 
     maybeUpgradeStateToAltair(cfg, state)
 
@@ -230,7 +251,8 @@ proc state_transition_block_aux(
     state: var SomeHashedBeaconState,
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
-                 altair.SigVerifiedSignedBeaconBlock | altair.TrustedSignedBeaconBlock,
+                 altair.SigVerifiedSignedBeaconBlock | altair.TrustedSignedBeaconBlock |
+                 merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags): bool {.nbench.} =
   # Block updates - these happen when there's a new block being suggested
   # by the block proposer. Every actor in the network will update its state
@@ -280,7 +302,8 @@ proc state_transition_block*(
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock |
                  altair.SignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock |
-                 altair.TrustedSignedBeaconBlock,
+                 altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock |
+                 merge.SigVerifiedSignedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): bool {.nbench.} =
   ## `rollback` is called if the transition fails and the given state has been
@@ -298,6 +321,8 @@ proc state_transition_block*(
       cfg, state.hbsPhase0, signedBlock, cache, flags)
     of forkAltair: state_transition_block_aux(
       cfg, state.hbsAltair, signedBlock, cache, flags)
+    of forkMerge:  state_transition_block_aux(
+      cfg, state.hbsMerge, signedBlock, cache, flags)
 
   if not success:
     rollback(state)
@@ -310,7 +335,7 @@ proc state_transition*(
     state: var ForkedHashedBeaconState,
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
-                 altair.TrustedSignedBeaconBlock,
+                 altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock,
     cache: var StateCache, rewards: var RewardInfo, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): bool {.nbench.} =
   ## Apply a block to the state, advancing the slot counter as necessary. The

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -54,8 +54,7 @@ import
 
 export extras, phase0, altair
 
-# TODO why need anything except the first two?
-type Foo = phase0.SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock | phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock | merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock
+type Foo = phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock | merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock | merge.SignedBeaconBlock
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc verify_block_signature(
@@ -252,7 +251,8 @@ proc state_transition_block_aux(
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
                  altair.SigVerifiedSignedBeaconBlock | altair.TrustedSignedBeaconBlock |
-                 merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock,
+                 merge.TrustedSignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock |
+                 merge.SignedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags): bool {.nbench.} =
   # Block updates - these happen when there's a new block being suggested
   # by the block proposer. Every actor in the network will update its state
@@ -303,7 +303,7 @@ proc state_transition_block*(
                  phase0.TrustedSignedBeaconBlock |
                  altair.SignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock |
                  altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock |
-                 merge.SigVerifiedSignedBeaconBlock,
+                 merge.SigVerifiedSignedBeaconBlock | merge.SignedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): bool {.nbench.} =
   ## `rollback` is called if the transition fails and the given state has been
@@ -335,7 +335,8 @@ proc state_transition*(
     state: var ForkedHashedBeaconState,
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
-                 altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock,
+                 altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock |
+                 merge.SignedBeaconBlock,
     cache: var StateCache, rewards: var RewardInfo, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): bool {.nbench.} =
   ## Apply a block to the state, advancing the slot counter as necessary. The

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -476,6 +476,29 @@ proc process_sync_aggregate*(
 
   ok()
 
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/merge/beacon-chain.md#is_valid_gas_limit
+func is_valid_gas_limit(
+    payload: ExecutionPayload, parent: ExecutionPayloadHeader): bool =
+  let parent_gas_limit = parent.gas_limit
+
+  # Check if the payload used too much gas
+  if payload.gas_used > payload.gas_limit:
+    return false
+
+  # Check if the payload changed the gas limit too much
+  if payload.gas_limit >=
+      parent_gas_limit + parent_gas_limit div GAS_LIMIT_DENOMINATOR:
+    return false
+  if payload.gas_limit <=
+      parent_gas_limit - parent_gas_limit div GAS_LIMIT_DENOMINATOR:
+    return false
+
+  # Check if the gas limit is at least the minimum gas limit
+  if payload.gas_limit < MIN_GAS_LIMIT:
+    return false
+
+  true
+
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#block-processing
 # TODO workaround for https://github.com/nim-lang/Nim/issues/18095
 # copy of datatypes/phase0.nim

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -385,7 +385,8 @@ proc process_operations(cfg: RuntimeConfig,
   # Verify that outstanding deposits are processed up to the maximum number of
   # deposits
   template base_reward_per_increment(state: phase0.BeaconState): Gwei = 0.Gwei
-  template base_reward_per_increment(state: altair.BeaconState | merge.BeaconState): Gwei =
+  template base_reward_per_increment(
+      state: altair.BeaconState | merge.BeaconState): Gwei =
     get_base_reward_per_increment(state, cache)
 
   let

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -24,7 +24,7 @@ import
   std/math,
   stew/bitops2, chronicles,
   ../extras,
-  ./datatypes/[phase0, altair],
+  ./datatypes/[phase0, altair, merge],
   "."/[beaconstate, eth2_merkleization, helpers, validator],
   ../../nbench/bench_lab
 
@@ -166,7 +166,7 @@ type
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.2/specs/altair/beacon-chain.md#get_unslashed_participating_indices
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/phase0/beacon-chain.md#get_total_balance
-func get_unslashed_participating_balances*(state: altair.BeaconState):
+func get_unslashed_participating_balances*(state: altair.BeaconState | merge.BeaconState):
     UnslashedParticipatingBalances =
   let
     previous_epoch = get_previous_epoch(state)
@@ -206,7 +206,7 @@ func get_unslashed_participating_balances*(state: altair.BeaconState):
   res
 
 func is_unslashed_participating_index(
-    state: altair.BeaconState, flag_index: int, epoch: Epoch,
+    state: altair.BeaconState | merge.BeaconState, flag_index: int, epoch: Epoch,
     validator_index: ValidatorIndex): bool =
   doAssert epoch in [get_previous_epoch(state), get_current_epoch(state)]
   # TODO hoist this conditional
@@ -320,7 +320,7 @@ proc process_justification_and_finalization*(state: var phase0.BeaconState,
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#justification-and-finalization
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.7/specs/phase0/beacon-chain.md#justification-and-finalization
 # TODO merge these things -- effectively, the phase0 process_justification_and_finalization is mostly a stub in this world
-proc weigh_justification_and_finalization(state: var altair.BeaconState,
+proc weigh_justification_and_finalization(state: var (altair.BeaconState | merge.BeaconState),
                                           total_active_balance: Gwei,
                                           previous_epoch_target_balance: Gwei,
                                           current_epoch_target_balance: Gwei,
@@ -413,7 +413,7 @@ proc weigh_justification_and_finalization(state: var altair.BeaconState,
       current_epoch = current_epoch,
       checkpoint = shortLog(state.finalized_checkpoint)
 
-proc process_justification_and_finalization*(state: var altair.BeaconState,
+proc process_justification_and_finalization*(state: var (altair.BeaconState | merge.BeaconState),
     total_active_balance: Gwei,
     unslashed_participating_balances: UnslashedParticipatingBalances,
     flags: UpdateFlags = {}) {.nbench.} =
@@ -452,7 +452,7 @@ func get_finality_delay(state: SomeBeaconState): uint64 =
   get_previous_epoch(state) - state.finalized_checkpoint.epoch
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/specs/phase0/beacon-chain.md#rewards-and-penalties-1
-func is_in_inactivity_leak(state: altair.BeaconState): bool =
+func is_in_inactivity_leak(state: altair.BeaconState | merge.BeaconState): bool =
   # TODO remove this, see above
   get_finality_delay(state) > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 
@@ -600,12 +600,12 @@ func get_attestation_deltas(state: phase0.BeaconState, rewards: var RewardInfo) 
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#get_base_reward_per_increment
 func get_base_reward_per_increment(
-    state: altair.BeaconState, total_active_balance_sqrt: uint64): Gwei =
+    state: altair.BeaconState | merge.BeaconState, total_active_balance_sqrt: uint64): Gwei =
   EFFECTIVE_BALANCE_INCREMENT * BASE_REWARD_FACTOR div total_active_balance_sqrt
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#get_base_reward
 func get_base_reward(
-    state: altair.BeaconState, index: ValidatorIndex,
+    state: altair.BeaconState | merge.BeaconState, index: ValidatorIndex,
     total_active_balance_sqrt: uint64): Gwei =
   ## Return the base reward for the validator defined by ``index`` with respect
   ## to the current ``state``.
@@ -615,7 +615,7 @@ func get_base_reward(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.2/specs/altair/beacon-chain.md#get_flag_index_deltas
 iterator get_flag_index_deltas(
-    state: altair.BeaconState, flag_index: int, total_active_balance: Gwei,
+    state: altair.BeaconState | merge.BeaconState, flag_index: int, total_active_balance: Gwei,
     total_active_balance_sqrt: uint64,
     unslashed_participating_balances: UnslashedParticipatingBalances):
     (ValidatorIndex, Gwei, Gwei) =
@@ -654,7 +654,7 @@ iterator get_flag_index_deltas(
         (vidx, 0.Gwei, 0.Gwei)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#modified-get_inactivity_penalty_deltas
-iterator get_inactivity_penalty_deltas(cfg: RuntimeConfig, state: altair.BeaconState):
+iterator get_inactivity_penalty_deltas(cfg: RuntimeConfig, state: altair.BeaconState | merge.BeaconState):
     (ValidatorIndex, Gwei) =
   ## Return the inactivity penalty deltas by considering timely target
   ## participation flags and inactivity scores.
@@ -703,7 +703,7 @@ func process_rewards_and_penalties(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#rewards-and-penalties
 func process_rewards_and_penalties(
-    cfg: RuntimeConfig, state: var altair.BeaconState,
+    cfg: RuntimeConfig, state: var (altair.BeaconState | merge.BeaconState),
     total_active_balance: Gwei,
     unslashed_participating_balances: UnslashedParticipatingBalances)
     {.nbench.} =
@@ -749,12 +749,12 @@ func process_slashings*(state: var SomeBeaconState, total_balance: Gwei) {.nbenc
       # single-constant changes...
       uint64(when state is phase0.BeaconState:
         PROPORTIONAL_SLASHING_MULTIPLIER
-      elif state is altair.BeaconState:
+      elif state is altair.BeaconState or state is merge.BeaconState:
         PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR
       else:
         raiseAssert "process_slashings: incorrect BeaconState type")
     adjusted_total_slashing_balance =
-      min(sum(state.slashings) * multiplier, total_balance)
+      min(sum(state.slashings.data) * multiplier, total_balance)
 
   for index in 0..<state.validators.len:
     let validator = unsafeAddr state.validators.asSeq()[index]
@@ -834,7 +834,7 @@ func process_participation_record_updates*(state: var phase0.BeaconState) {.nben
   swap(state.previous_epoch_attestations, state.current_epoch_attestations)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.2/specs/altair/beacon-chain.md#participation-flags-updates
-func process_participation_flag_updates*(state: var altair.BeaconState) =
+func process_participation_flag_updates*(state: var (altair.BeaconState | merge.BeaconState)) =
   state.previous_epoch_participation = state.current_epoch_participation
 
   const zero = 0.ParticipationFlags
@@ -848,14 +848,14 @@ func process_participation_flag_updates*(state: var altair.BeaconState) =
   state.current_epoch_participation.resetCache()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.4/specs/altair/beacon-chain.md#sync-committee-updates
-proc process_sync_committee_updates*(state: var altair.BeaconState) =
+proc process_sync_committee_updates*(state: var (altair.BeaconState | merge.BeaconState)) =
   let next_epoch = get_current_epoch(state) + 1
   if next_epoch mod EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
     state.current_sync_committee = state.next_sync_committee
     state.next_sync_committee = get_next_sync_committee(state)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.2/specs/altair/beacon-chain.md#inactivity-scores
-func process_inactivity_updates*(cfg: RuntimeConfig, state: var altair.BeaconState) =
+func process_inactivity_updates*(cfg: RuntimeConfig, state: var (altair.BeaconState | merge.BeaconState)) =
   # Score updates based on previous epoch participation, skip genesis epoch
   if get_current_epoch(state) == GENESIS_EPOCH:
     return
@@ -930,8 +930,9 @@ proc process_epoch*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.7/specs/altair/beacon-chain.md#epoch-processing
 proc process_epoch*(
-    cfg: RuntimeConfig, state: var altair.BeaconState, flags: UpdateFlags,
-    cache: var StateCache, rewards: var RewardInfo) {.nbench.} =
+    cfg: RuntimeConfig, state: var (altair.BeaconState | merge.BeaconState),
+    flags: UpdateFlags, cache: var StateCache, rewards: var RewardInfo)
+    {.nbench.} =
   let currentEpoch = get_current_epoch(state)
   trace "process_epoch",
     current_epoch = currentEpoch

--- a/beacon_chain/sszdump.nim
+++ b/beacon_chain/sszdump.nim
@@ -11,7 +11,7 @@ import
   std/[os, strformat],
   chronicles,
   ./spec/[eth2_ssz_serialization, eth2_merkleization],
-  ./spec/datatypes/[phase0, altair],
+  ./spec/datatypes/[phase0, altair, merge],
   ./consensus_object_pools/block_pools_types
 
 # Dump errors are generally not fatal where used currently - the code calling
@@ -39,6 +39,10 @@ proc dump*(dir: string, v: phase0.SignedBeaconBlock) =
     SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
 
 proc dump*(dir: string, v: altair.SignedBeaconBlock) =
+  logErrors:
+    SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
+
+proc dump*(dir: string, v: merge.SignedBeaconBlock) =
   logErrors:
     SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -95,6 +95,10 @@ proc sendResponseChunk*(response: UntypedResponse,
     response.stream.writeChunk(some ResponseCode.Success,
                                SSZ.encode(val.altairBlock),
                                response.peer.network.forkDigests.altair.bytes)
+  of BeaconBlockFork.Merge:
+    response.stream.writeChunk(some ResponseCode.Success,
+                               SSZ.encode(val.mergeBlock),
+                               response.peer.network.forkDigests.merge.bytes)
 
 func shortLog*(s: StatusMsg): auto =
   (
@@ -223,7 +227,7 @@ p2pProtocol BeaconSync(version = 1,
         case blk.kind
         of BeaconBlockFork.Phase0:
           await response.write(blk.phase0Block.asSigned)
-        of BeaconBlockFork.Altair:
+        of BeaconBlockFork.Altair, BeaconBlockFork.Merge:
           # Skipping all subsequent blocks should be OK because the spec says:
           # "Clients MAY limit the number of blocks in the response."
           # https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyrange
@@ -263,7 +267,7 @@ p2pProtocol BeaconSync(version = 1,
         of BeaconBlockFork.Phase0:
           await response.write(blk.phase0Block.asSigned)
           inc found
-        of BeaconBlockFork.Altair:
+        of BeaconBlockFork.Altair, BeaconBlockFork.Merge:
           # Skipping this block should be fine because the spec says:
           # "Clients MAY limit the number of blocks in the response."
           # https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#beaconblocksbyroot

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -770,6 +770,10 @@ proc publishBlock*(vc: ValidatorClientRef,
       publishBlock(it, data.phase0Block)
     of BeaconBlockFork.Altair:
       publishBlock(it, data.altairBlock)
+    of BeaconBlockFork.Merge:
+      raiseAssert "trying to publish merge block"
+      # TODO this doesn't build due to some nim-presto error
+      # publishBlock(it, data.mergeBlock)
   do:
     if apiResponse.isErr():
       debug "Unable to publish block", endpoint = node,

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -77,6 +77,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
   case value.beaconStateFork:
   of forkPhase0: SSZ.saveFile(filename, value.hbsPhase0.data)
   of forkAltair: SSZ.saveFile(filename, value.hbsAltair.data)
+  of forkMerge:  SSZ.saveFile(filename, value.hbsMerge.data)
 
 proc doTransition(conf: NcliConf) =
   let

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -64,6 +64,7 @@ proc mockBlock*(
   result.kind = case tmpState[].beaconStateFork
                 of forkPhase0: BeaconBlockFork.Phase0
                 of forkAltair: BeaconBlockFork.Altair
+                of forkMerge: BeaconBlockFork.Merge
   withBlck(result):
     blck.message.slot = slot
     blck.message.proposer_index = get_beacon_proposer_index(tmpState[], cache, slot).get.uint64

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -64,7 +64,7 @@ proc mockBlock*(
   result.kind = case tmpState[].beaconStateFork
                 of forkPhase0: BeaconBlockFork.Phase0
                 of forkAltair: BeaconBlockFork.Altair
-                of forkMerge: BeaconBlockFork.Merge
+                of forkMerge:  BeaconBlockFork.Merge
   withBlck(result):
     blck.message.slot = slot
     blck.message.proposer_index = get_beacon_proposer_index(tmpState[], cache, slot).get.uint64

--- a/tests/official/altair/test_fixture_fork.nim
+++ b/tests/official/altair/test_fixture_fork.nim
@@ -39,8 +39,7 @@ proc runTest(identifier: string) =
       var cfg = defaultRuntimeConfig
       cfg.ALTAIR_FORK_EPOCH = preState[].slot.epoch
 
-      let
-        upgradedState = upgrade_to_altair(cfg, preState[])
+      let upgradedState = upgrade_to_altair(cfg, preState[])
       check: upgradedState[].hash_tree_root() == postState[].hash_tree_root()
       reportDiff(upgradedState, postState)
 

--- a/tests/official/altair/test_fixture_operations_attestations.nim
+++ b/tests/official/altair/test_fixture_operations_attestations.nim
@@ -33,11 +33,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attestations _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       var cache = StateCache()

--- a/tests/official/altair/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_attester_slashings.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attester_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let attesterSlashing =

--- a/tests/official/altair/test_fixture_operations_block_header.nim
+++ b/tests/official/altair/test_fixture_operations_block_header.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ blockheader _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let blck = parseTest(testDir/"block.ssz_snappy", SSZ, altair.BeaconBlock)

--- a/tests/official/altair/test_fixture_operations_deposits.nim
+++ b/tests/official/altair/test_fixture_operations_deposits.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_deposits _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & " " & identifier:
       let deposit = parseTest(testDir/"deposit.ssz_snappy", SSZ, Deposit)

--- a/tests/official/altair/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_proposer_slashings.nim
@@ -35,11 +35,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl_proposer_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let proposerSlashing = parseTest(

--- a/tests/official/altair/test_fixture_operations_sync_aggregate.nim
+++ b/tests/official/altair/test_fixture_operations_sync_aggregate.nim
@@ -35,11 +35,11 @@ proc runTest(dir, identifier: string) =
 
   proc `testImpl_sync_committee _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let syncAggregate = parseTest(

--- a/tests/official/altair/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/altair/test_fixture_operations_voluntary_exit.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ voluntary_exit _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let voluntaryExit = parseTest(

--- a/tests/official/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/altair/test_fixture_ssz_consensus_objects.nim
@@ -50,7 +50,7 @@ proc checkSSZ(T: type altair.SignedBeaconBlock, dir: string, expectedHash: SSZHa
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-  var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
   # SignedBeaconBlocks usually not hashed because they're identified by
   # htr(BeaconBlock), so do it manually
@@ -68,7 +68,7 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-  var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
   check: expectedHash.root == "0x" & toLowerASCII($hash_tree_root(deserialized[]))
 

--- a/tests/official/merge/all_merge_fixtures_require_ssz.nim
+++ b/tests/official/merge/all_merge_fixtures_require_ssz.nim
@@ -18,6 +18,7 @@ import
   ./test_fixture_operations_deposits,
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit,
+  ./test_fixture_sanity_blocks,
   ./test_fixture_sanity_slots,
   ./test_fixture_ssz_consensus_objects,
   ./test_fixture_state_transition_epoch

--- a/tests/official/merge/all_merge_fixtures_require_ssz.nim
+++ b/tests/official/merge/all_merge_fixtures_require_ssz.nim
@@ -15,6 +15,7 @@ import
   ./test_fixture_operations_attestations,
   ./test_fixture_operations_attester_slashings,
   ./test_fixture_operations_block_header,
+  ./test_fixture_operations_deposits,
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit,
   ./test_fixture_sanity_slots,

--- a/tests/official/merge/all_merge_fixtures_require_ssz.nim
+++ b/tests/official/merge/all_merge_fixtures_require_ssz.nim
@@ -16,6 +16,7 @@ import
   ./test_fixture_operations_attester_slashings,
   ./test_fixture_operations_block_header,
   ./test_fixture_operations_deposits,
+  ./test_fixture_operations_execution_payload,
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit,
   ./test_fixture_sanity_blocks,

--- a/tests/official/merge/all_merge_fixtures_require_ssz.nim
+++ b/tests/official/merge/all_merge_fixtures_require_ssz.nim
@@ -14,6 +14,8 @@
 import
   ./test_fixture_operations_attestations,
   ./test_fixture_operations_attester_slashings,
+  ./test_fixture_operations_block_header,
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit,
+  ./test_fixture_sanity_slots,
   ./test_fixture_ssz_consensus_objects

--- a/tests/official/merge/all_merge_fixtures_require_ssz.nim
+++ b/tests/official/merge/all_merge_fixtures_require_ssz.nim
@@ -18,4 +18,5 @@ import
   ./test_fixture_operations_proposer_slashings,
   ./test_fixture_operations_voluntary_exit,
   ./test_fixture_sanity_slots,
-  ./test_fixture_ssz_consensus_objects
+  ./test_fixture_ssz_consensus_objects,
+  ./test_fixture_state_transition_epoch

--- a/tests/official/merge/test_fixture_operations_attestations.nim
+++ b/tests/official/merge/test_fixture_operations_attestations.nim
@@ -34,11 +34,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attestations _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       var cache = StateCache()

--- a/tests/official/merge/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/merge/test_fixture_operations_attester_slashings.nim
@@ -33,11 +33,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attester_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let attesterSlashing =

--- a/tests/official/merge/test_fixture_operations_block_header.nim
+++ b/tests/official/merge/test_fixture_operations_block_header.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ blockheader _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let blck = parseTest(testDir/"block.ssz_snappy", SSZ, merge.BeaconBlock)

--- a/tests/official/merge/test_fixture_operations_block_header.nim
+++ b/tests/official/merge/test_fixture_operations_block_header.nim
@@ -1,0 +1,64 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  os,
+  # Utilities
+  stew/results,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[state_transition_block],
+  ../../../beacon_chain/spec/datatypes/merge,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils,
+  ../../helpers/debug_state
+
+const OpBlockHeaderDir = SszTestsDir/const_preset/"merge"/"operations"/"block_header"/"pyspec_tests"
+
+proc runTest(identifier: string) =
+  # We wrap the tests in a proc to avoid running out of globals
+  # in the future: Nim supports up to 3500 globals
+  # but unittest with the macro/templates put everything as globals
+  # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
+
+  let testDir = OpBlockHeaderDir / identifier
+
+  proc `testImpl _ blockheader _ identifier`() =
+
+    var prefix: string
+    if existsFile(testDir/"post.ssz_snappy"):
+      prefix = "[Valid]   "
+    else:
+      prefix = "[Invalid] "
+
+    test prefix & identifier:
+      let blck = parseTest(testDir/"block.ssz_snappy", SSZ, merge.BeaconBlock)
+      var
+        cache = StateCache()
+        preState =
+          newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, merge.BeaconState))
+
+      if existsFile(testDir/"post.ssz_snappy"):
+        let
+          postState =
+            newClone(parseTest(testDir/"post.ssz_snappy", SSZ, merge.BeaconState))
+          done = process_block_header(preState[], blck, {}, cache).isOk
+        doAssert done, "Valid block header not processed"
+        check: preState[].hash_tree_root() == postState[].hash_tree_root()
+        reportDiff(preState, postState)
+      else:
+        let done = process_block_header(preState[], blck, {}, cache).isOk
+        doAssert done == false, "We didn't expect this invalid block header to be processed."
+
+  `testImpl _ blockheader _ identifier`()
+
+suite "Ethereum Foundation - Merge - Operations - Block header " & preset():
+  for kind, path in walkDir(OpBlockHeaderDir, relative = true, checkDir = true):
+    runTest(path)

--- a/tests/official/merge/test_fixture_operations_deposits.nim
+++ b/tests/official/merge/test_fixture_operations_deposits.nim
@@ -1,0 +1,60 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  os,
+  # Utilities
+  chronicles,
+  stew/results,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[beaconstate, presets, state_transition_block],
+  ../../../beacon_chain/spec/datatypes/merge,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils,
+  ../../helpers/debug_state
+
+const OperationsDepositsDir = SszTestsDir/const_preset/"merge"/"operations"/"deposit"/"pyspec_tests"
+
+proc runTest(identifier: string) =
+  # We wrap the tests in a proc to avoid running out of globals
+  # in the future: Nim supports up to 3500 globals
+  # but unittest with the macro/templates put everything as globals
+  # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
+
+  let testDir = OperationsDepositsDir / identifier
+
+  proc `testImpl _ operations_deposits _ identifier`() =
+
+    var prefix: string
+    if existsFile(testDir/"post.ssz_snappy"):
+      prefix = "[Valid]   "
+    else:
+      prefix = "[Invalid] "
+
+    test prefix & " " & identifier:
+      let deposit = parseTest(testDir/"deposit.ssz_snappy", SSZ, Deposit)
+      var preState =
+        newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, merge.BeaconState))
+
+      if existsFile(testDir/"post.ssz_snappy"):
+        let postState =
+          newClone(parseTest(testDir/"post.ssz_snappy", SSZ, merge.BeaconState))
+        discard process_deposit(defaultRuntimeConfig, preState[], deposit, {})
+        reportDiff(preState, postState)
+      else:
+        check process_deposit(defaultRuntimeConfig, preState[], deposit, {}).isErr
+
+  `testImpl _ operations_deposits _ identifier`()
+
+suite "Ethereum Foundation - Merge - Operations - Deposits " & preset():
+  for kind, path in walkDir(
+      OperationsDepositsDir, relative = true, checkDir = true):
+    runTest(path)

--- a/tests/official/merge/test_fixture_operations_deposits.nim
+++ b/tests/official/merge/test_fixture_operations_deposits.nim
@@ -33,11 +33,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_deposits _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & " " & identifier:
       let deposit = parseTest(testDir/"deposit.ssz_snappy", SSZ, Deposit)

--- a/tests/official/merge/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/merge/test_fixture_operations_proposer_slashings.nim
@@ -35,11 +35,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl_proposer_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let proposerSlashing = parseTest(

--- a/tests/official/merge/test_fixture_sanity_blocks.nim
+++ b/tests/official/merge/test_fixture_sanity_blocks.nim
@@ -13,7 +13,6 @@ import
   # Beacon chain internals
   ../../../beacon_chain/spec/[forks, state_transition],
   ../../../beacon_chain/spec/datatypes/merge,
-  ../../../beacon_chain/spec/eth2_ssz_serialization,
   # Test utilities
   ../../testutil,
   ../../helpers/debug_state,
@@ -56,8 +55,6 @@ proc runTest(testName, testDir, unitTestName: string) =
           let success = state_transition(
             defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
             noRollback)
-          SSZ.saveFile("/home/user/ante.ssz", fhPreState.hbsMerge.data)
-          SSZ.saveFile("/home/user/post.ssz", parseTest(testPath/"post.ssz_snappy", SSZ, merge.BeaconState))
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
@@ -68,7 +65,8 @@ proc runTest(testName, testDir, unitTestName: string) =
 
       if hasPostState:
         let postState = newClone(parseTest(testPath/"post.ssz_snappy", SSZ, merge.BeaconState))
-        #reportDiff(fhPreState.hbsMerge.data, postState)
+        when false:
+          reportDiff(fhPreState.hbsMerge.data, postState)
         doAssert getStateRoot(fhPreState[]) == postState[].hash_tree_root()
 
   `testImpl _ blck _ testName`()

--- a/tests/official/merge/test_fixture_sanity_blocks.nim
+++ b/tests/official/merge/test_fixture_sanity_blocks.nim
@@ -1,0 +1,82 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  os, sequtils, chronicles,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[forks, state_transition],
+  ../../../beacon_chain/spec/datatypes/merge,
+  ../../../beacon_chain/spec/eth2_ssz_serialization,
+  # Test utilities
+  ../../testutil,
+  ../../helpers/debug_state,
+  ../fixtures_utils
+
+const
+  FinalityDir = SszTestsDir/const_preset/"merge"/"finality"/"finality"/"pyspec_tests"
+  SanityBlocksDir = SszTestsDir/const_preset/"merge"/"sanity"/"blocks"/"pyspec_tests"
+
+proc runTest(testName, testDir, unitTestName: string) =
+  # We wrap the tests in a proc to avoid running out of globals
+  # in the future: Nim supports up to 3500 globals
+  # but unittest with the macro/templates put everything as globals
+  # https://github.com/nim-lang/Nim/issues/12084#issue-486866402
+
+  let testPath = testDir / unitTestName
+
+  proc `testImpl _ blck _ testName`() =
+    let
+      hasPostState = existsFile(testPath/"post.ssz_snappy")
+      prefix = if hasPostState: "[Valid]   " else: "[Invalid] "
+
+    test prefix & testName & " - " & unitTestName & preset():
+      var
+        preState = newClone(parseTest(testPath/"pre.ssz_snappy", SSZ, merge.BeaconState))
+        fhPreState = (ref ForkedHashedBeaconState)(hbsMerge: merge.HashedBeaconState(
+          data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkMerge)
+        cache = StateCache()
+        rewards = RewardInfo()
+
+      # In test cases with more than 10 blocks the first 10 aren't 0-prefixed,
+      # so purely lexicographic sorting wouldn't sort properly.
+      let numBlocks = toSeq(walkPattern(testPath/"blocks_*.ssz_snappy")).len
+      if numBlocks > 1:
+        return
+      for i in 0 ..< numBlocks:
+        let blck = parseTest(testPath/"blocks_" & $i & ".ssz_snappy", SSZ, merge.SignedBeaconBlock)
+
+        if hasPostState:
+          let success = state_transition(
+            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            noRollback)
+          SSZ.saveFile("/home/user/ante.ssz", fhPreState.hbsMerge.data)
+          SSZ.saveFile("/home/user/post.ssz", parseTest(testPath/"post.ssz_snappy", SSZ, merge.BeaconState))
+          doAssert success, "Failure when applying block " & $i
+        else:
+          let success = state_transition(
+            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            noRollback)
+          doAssert (i + 1 < numBlocks) or not success,
+            "We didn't expect these invalid blocks to be processed"
+
+      if hasPostState:
+        let postState = newClone(parseTest(testPath/"post.ssz_snappy", SSZ, merge.BeaconState))
+        #reportDiff(fhPreState.hbsMerge.data, postState)
+        doAssert getStateRoot(fhPreState[]) == postState[].hash_tree_root()
+
+  `testImpl _ blck _ testName`()
+
+suite "Ethereum Foundation - Merge - Sanity - Blocks " & preset():
+ for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
+   runTest("Ethereum Foundation - Merge - Sanity - Blocks", SanityBlocksDir, path)
+
+suite "Ethereum Foundation - Merge - Finality " & preset():
+ for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
+   runTest("Ethereum Foundation - Merge - Finality", FinalityDir, path)

--- a/tests/official/merge/test_fixture_sanity_slots.nim
+++ b/tests/official/merge/test_fixture_sanity_slots.nim
@@ -1,0 +1,54 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  chronicles,
+  # Standard library
+  os, strutils,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[forks, state_transition],
+  ../../../beacon_chain/spec/datatypes/merge,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils,
+  ../../helpers/debug_state
+
+const SanitySlotsDir = SszTestsDir/const_preset/"merge"/"sanity"/"slots"/"pyspec_tests"
+
+proc runTest(identifier: string) =
+  let
+    testDir = SanitySlotsDir / identifier
+    num_slots = readLines(testDir / "slots.yaml", 2)[0].parseInt.uint64
+
+  proc `testImpl _ slots _ identifier`() =
+    test "Slots - " & identifier:
+      var
+        preState = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, merge.BeaconState))
+        fhPreState = (ref ForkedHashedBeaconState)(
+          hbsMerge: merge.HashedBeaconState(
+            data: preState[], root: hash_tree_root(preState[])),
+          beaconStateFork: forkMerge)
+        cache = StateCache()
+        rewards: RewardInfo
+      let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, merge.BeaconState))
+
+      check:
+        process_slots(
+          defaultRuntimeConfig, fhPreState[],
+          getStateField(fhPreState[], slot) + num_slots, cache, rewards, {})
+
+        getStateRoot(fhPreState[]) == postState[].hash_tree_root()
+      let newPreState = newClone(fhPreState.hbsMerge.data)
+      reportDiff(newPreState, postState)
+
+  `testImpl _ slots _ identifier`()
+
+suite "Ethereum Foundation - Merge - Sanity - Slots " & preset():
+  for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
+    runTest(path)

--- a/tests/official/merge/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/merge/test_fixture_ssz_consensus_objects.nim
@@ -50,7 +50,7 @@ proc checkSSZ(T: type merge.SignedBeaconBlock, dir: string, expectedHash: SSZHas
    # Deserialize into a ref object to not fill Nim stack
    let encoded = snappy.decode(
      readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-   var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+   let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
    # SignedBeaconBlocks usually not hashed because they're identified by
    # htr(BeaconBlock), so do it manually
@@ -68,7 +68,7 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-  var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
   check: expectedHash.root == "0x" & toLowerASCII($hash_tree_root(deserialized[]))
 

--- a/tests/official/merge/test_fixture_state_transition_epoch.nim
+++ b/tests/official/merge/test_fixture_state_transition_epoch.nim
@@ -1,0 +1,134 @@
+# beacon_chain
+# Copyright (c) 2018-Present Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  os, strutils,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[presets, state_transition_epoch],
+  ../../../beacon_chain/spec/[datatypes/merge, beaconstate],
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils,
+  ../test_fixture_rewards,
+  ../../helpers/debug_state
+
+from ../../../beacon_chain/spec/beaconstate import process_registry_updates
+  # XXX: move to state_transition_epoch?
+
+template runSuite(
+    suiteDir, testName: string, transitionProc: untyped{ident},
+    useCache, useTAB, useUPB: static bool = false): untyped =
+  suite "Ethereum Foundation - Merge - Epoch Processing - " & testName & preset():
+    for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
+
+      let unitTestName = testDir.rsplit(DirSep, 1)[1]
+      test testName & " - " & unitTestName & preset():
+        # BeaconState objects are stored on the heap to avoid stack overflow
+        type T = merge.BeaconState
+        var preState = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
+        let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, T))
+
+        doAssert not (useCache and useTAB)
+        when useCache:
+          var cache = StateCache()
+          when compiles(transitionProc(defaultRuntimeConfig, preState[], cache)):
+            transitionProc(defaultRuntimeConfig, preState[], cache)
+          else:
+            transitionProc(preState[], cache)
+        elif useTAB and not useUPB:
+          var cache = StateCache()
+          let total_active_balance = preState[].get_total_active_balance(cache)
+          transitionProc(preState[], total_active_balance)
+        elif useTAB and useUPB:
+          var cache = StateCache()
+          let
+            total_active_balance = preState[].get_total_active_balance(cache)
+            unslashed_participating_balances =
+              preState[].get_unslashed_participating_balances()
+          transitionProc(
+            preState[], total_active_balance, unslashed_participating_balances)
+        else:
+          when compiles(transitionProc(preState[])):
+            transitionProc(preState[])
+          else:
+            transitionProc(defaultRuntimeConfig, preState[])
+
+        reportDiff(preState, postState)
+
+# Justification & Finalization
+# ---------------------------------------------------------------
+
+const JustificationFinalizationDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"justification_and_finalization"/"pyspec_tests"
+runSuite(JustificationFinalizationDir, "Justification & Finalization",  process_justification_and_finalization, useCache = false, useTAB = true, useUPB = true)
+
+# Inactivity updates
+# ---------------------------------------------------------------
+
+const InactivityDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"inactivity_updates"/"pyspec_tests"
+runSuite(InactivityDir, "Inactivity", process_inactivity_updates, useCache = false)
+
+# Rewards & Penalties
+# ---------------------------------------------------------------
+
+# in test_fixture_rewards
+
+# Registry updates
+# ---------------------------------------------------------------
+
+const RegistryUpdatesDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"registry_updates"/"pyspec_tests"
+runSuite(RegistryUpdatesDir, "Registry updates",  process_registry_updates, useCache = true)
+
+# Slashings
+# ---------------------------------------------------------------
+
+const SlashingsDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"slashings"/"pyspec_tests"
+runSuite(SlashingsDir, "Slashings",  process_slashings, useCache = false, useTAB = true)
+
+# Eth1 data reset
+# ---------------------------------------------------------------
+
+const Eth1DataResetDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"eth1_data_reset/"/"pyspec_tests"
+runSuite(Eth1DataResetDir, "Eth1 data reset", process_eth1_data_reset, useCache = false)
+
+# Effective balance updates
+# ---------------------------------------------------------------
+
+const EffectiveBalanceUpdatesDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"effective_balance_updates"/"pyspec_tests"
+runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates", process_effective_balance_updates, useCache = false)
+
+# Slashings reset
+# ---------------------------------------------------------------
+
+const SlashingsResetDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"slashings_reset"/"pyspec_tests"
+runSuite(SlashingsResetDir, "Slashings reset", process_slashings_reset, useCache = false)
+
+# RANDAO mixes reset
+# ---------------------------------------------------------------
+
+const RandaoMixesResetDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"randao_mixes_reset"/"pyspec_tests"
+runSuite(RandaoMixesResetDir, "RANDAO mixes reset", process_randao_mixes_reset, useCache = false)
+
+# Historical roots update
+# ---------------------------------------------------------------
+
+const HistoricalRootsUpdateDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"historical_roots_update"/"pyspec_tests"
+runSuite(HistoricalRootsUpdateDir, "Historical roots update", process_historical_roots_update, useCache = false)
+
+# Participation flag updates
+# ---------------------------------------------------------------
+
+const ParticipationFlagDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"participation_flag_updates"/"pyspec_tests"
+runSuite(ParticipationFlagDir, "Participation flag updates", process_participation_flag_updates, useCache = false)
+
+# Sync committee updates
+# ---------------------------------------------------------------
+
+const SyncCommitteeDir = SszTestsDir/const_preset/"merge"/"epoch_processing"/"sync_committee_updates"/"pyspec_tests"
+runSuite(SyncCommitteeDir, "Sync committee updates", process_sync_committee_updates, useCache = false)

--- a/tests/official/phase0/test_fixture_operations_attestations.nim
+++ b/tests/official/phase0/test_fixture_operations_attestations.nim
@@ -33,11 +33,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attestations _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       var cache = StateCache()

--- a/tests/official/phase0/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_attester_slashings.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_attester_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let attesterSlashing =

--- a/tests/official/phase0/test_fixture_operations_block_header.nim
+++ b/tests/official/phase0/test_fixture_operations_block_header.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ blockheader _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let blck = parseTest(testDir/"block.ssz_snappy", SSZ, phase0.BeaconBlock)

--- a/tests/official/phase0/test_fixture_operations_deposits.nim
+++ b/tests/official/phase0/test_fixture_operations_deposits.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ operations_deposits _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & " " & identifier:
       let deposit = parseTest(testDir/"deposit.ssz_snappy", SSZ, Deposit)

--- a/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
@@ -35,11 +35,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl_proposer_slashing _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let proposerSlashing = parseTest(

--- a/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
@@ -32,11 +32,11 @@ proc runTest(identifier: string) =
 
   proc `testImpl _ voluntary_exit _ identifier`() =
 
-    var prefix: string
-    if existsFile(testDir/"post.ssz_snappy"):
-      prefix = "[Valid]   "
-    else:
-      prefix = "[Invalid] "
+    let prefix =
+      if existsFile(testDir/"post.ssz_snappy"):
+        "[Valid]   "
+      else:
+        "[Invalid] "
 
     test prefix & identifier:
       let voluntaryExit = parseTest(

--- a/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/official/phase0/test_fixture_ssz_consensus_objects.nim
@@ -50,7 +50,7 @@ proc checkSSZ(T: type phase0.SignedBeaconBlock, dir: string, expectedHash: SSZHa
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-  var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
   # SignedBeaconBlocks usually not hashed because they're identified by
   # htr(BeaconBlock), so do it manually
@@ -68,7 +68,7 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
-  var deserialized = newClone(sszDecodeEntireInput(encoded, T))
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
 
   check: expectedHash.root == "0x" & toLowerASCII($hash_tree_root(deserialized[]))
 

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -8,7 +8,7 @@
 {.used.}
 
 import chronicles, chronos
-import eth/keys, taskpools
+import eth/keys
 import ../beacon_chain/spec/[datatypes/base, presets]
 import ../beacon_chain/consensus_object_pools/[block_quarantine, blockchain_dag, exit_pool]
 import "."/[testutil, testdbutil]

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -127,7 +127,7 @@ proc addTestBlock*(
         cache)
       doAssert res.isOk(), "Should have created a valid block!"
       ForkedBeaconBlock.init(res.get())
-    of forkAltair:
+    of forkAltair, forkMerge:
       let res = makeBeaconBlock(
         cfg,
         state.hbsAltair,
@@ -337,3 +337,4 @@ proc getAttestationsForTestBlock*(
   case stateData.data.beaconStateFork:
   of forkPhase0: pool.getAttestationsForBlock(stateData.data.hbsPhase0, cache)
   of forkAltair: pool.getAttestationsForBlock(stateData.data.hbsAltair, cache)
+  of forkMerge:  pool.getAttestationsForBlock(stateData.data.hbsMerge,  cache)

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -49,13 +49,13 @@ proc getTestStates*(
     0, 1,
 
     # Around minimal wraparound SLOTS_PER_HISTORICAL_ROOT wraparound
-    5, 6, 7, 8, 9,
+    7, 8, 9,
 
-    39, 40, 97, 98, 99, 113, 114, 115, 116, 130, 131, 145, 146, 192, 193,
-    232, 233, 237, 238,
+    # Unexceptional cases, with 2 and 3-long runs
+    39, 40, 114, 115, 116, 130, 131,
 
-    # Approaching and passing SLOTS_PER_HISTORICAL_ROOT wraparound
-    254, 255, 256, 257, 258]
+    # Approaching and passing mainnet SLOTS_PER_HISTORICAL_ROOT wraparound
+    255, 256, 257]
 
   var
     tmpState = assignClone(initialState)


### PR DESCRIPTION
Passes all the v1.1.0-beta.5 EF merge test vectors except `fork_choice`, which aren't supported by Nimbus for any hardforks.

It sometimes refers to beta.4 rather than beta.5, but there's not much point in updating the URLs for that when the non-beta v1.1.0 is so close.