### PR TITLE
disable sync committee subnets in simulation mode

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -431,8 +431,9 @@ proc init*(T: type BeaconNode,
             getProposerSlashingsTopic(network.forkDigests.altair),
             getVoluntaryExitsTopic(network.forkDigests.altair),
             getAggregateAndProofsTopic(network.forkDigests.altair),
-            getSyncCommitteeContributionAndProofTopic(network.forkDigests.altair)
           ]
+      if not config.verifyFinalization:
+        topics &= getSyncCommitteeContributionAndProofTopic(network.forkDigests.altair)
       for subnet_id in 0'u64 ..< ATTESTATION_SUBNET_COUNT:
         topics &= getAttestationTopic(network.forkDigests.phase0, SubnetId(subnet_id))
         topics &= getAttestationTopic(network.forkDigests.altair, SubnetId(subnet_id))

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -436,8 +436,9 @@ proc init*(T: type BeaconNode,
       for subnet_id in 0'u64 ..< ATTESTATION_SUBNET_COUNT:
         topics &= getAttestationTopic(network.forkDigests.phase0, SubnetId(subnet_id))
         topics &= getAttestationTopic(network.forkDigests.altair, SubnetId(subnet_id))
-      for subnet_id in 0'u64 ..< SYNC_COMMITTEE_SUBNET_COUNT:
-        topics &= getSyncCommitteeTopic(network.forkDigests.altair, SyncCommitteeIndex(subnet_id))
+      if not config.verifyFinalization:
+        for subnet_id in 0'u64 ..< SYNC_COMMITTEE_SUBNET_COUNT:
+          topics &= getSyncCommitteeTopic(network.forkDigests.altair, SyncCommitteeIndex(subnet_id))
       topics)
 
   if node.config.inProcessValidators:


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/2895 seems to suffice as a global change, so do that in local testnet/simulation mode, where it's breaking CI