### PR TITLE
handle duplicate pubkeys in sync committee

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -108,6 +108,11 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Validation sanity                                                                          OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## Gossip validation - Extra
+```diff
++ validateSyncCommitteeMessage                                                               OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Honest validator
 ```diff
 + General pubsub topics                                                                      OK
@@ -354,4 +359,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 36/48 Fail: 0/48 Skip: 12/48
 
 ---TOTAL---
-OK: 192/204 Fail: 0/204 Skip: 12/204
+OK: 193/205 Fail: 0/205 Skip: 12/205

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -774,10 +774,10 @@ proc validateSyncCommitteeMessage*(
   # Note this validation implies the validator is part of the broader
   # current sync committee along with the correct subcommittee.
   # This check also ensures that the validator index is in range
-  let positionInSubcommittee = dag.getSubcommitteePosition(
+  let positionsInSubcommittee = dag.getSubcommitteePositions(
     msg.slot + 1, syncCommitteeIdx, msg.validator_index)
 
-  if positionInSubcommittee.isNone:
+  if positionsInSubcommittee.len == 0:
     return errReject(
       "SyncCommitteeMessage: originator not part of sync committee")
 
@@ -824,12 +824,13 @@ proc validateSyncCommitteeMessage*(
                                                    cookedSignature.get):
       return errReject("SyncCommitteeMessage: signature fails to verify")
 
-    syncCommitteeMsgPool[].addSyncCommitteeMsg(
-      msg.slot,
-      msg.beacon_block_root,
-      cookedSignature.get,
-      syncCommitteeIdx,
-      positionInSubcommittee.get)
+    for positionInSubcommittee in positionsInSubcommittee:
+      syncCommitteeMsgPool[].addSyncCommitteeMsg(
+        msg.slot,
+        msg.beacon_block_root,
+        cookedSignature.get,
+        syncCommitteeIdx,
+        positionInSubcommittee)
 
   ok()
 


### PR DESCRIPTION
When sync committee message handling was introduced in #2830, the edge
case of the same validator being selected multiple times as part of a
sync subcommittee was not covered. Not handling that edge case makes
sync contributions have a lower-than-expected participation rate as each
sync validator is only counted up through once per subcommittee.
This patch ensures that this edge case is properly covered.