### PR TITLE
ignore instead of reject duplicate sync msgs

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -796,7 +796,7 @@ proc validateSyncCommitteeMessage*(
       committeeIdx: syncCommitteeIdx)
 
     if msgKey in syncCommitteeMsgPool.seenSyncMsgByAuthor:
-      return errReject("SyncCommitteeMessage: duplicate message")
+      return errIgnore("SyncCommitteeMessage: duplicate message")
     else:
       syncCommitteeMsgPool.seenSyncMsgByAuthor.incl msgKey
 


### PR DESCRIPTION
The P2P spec defines how certain error classes should be handled through
either IGNORE or REJECT verdicts. For sync committee message, the spec
defines that only the first message from each validator per subcommittee
and slot shall be accepted, the rest is ignored. However, current code
rejects those messages instead of ignoring them. Fixed to match spec.