### PR TITLE
make preset header comments consistent

### DIFF
--- a/beacon_chain/spec/presets/mainnet/altair_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/altair_preset.nim
@@ -1,5 +1,5 @@
 # Mainnet preset - Altair
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/presets/mainnet/altair.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.5/presets/mainnet/altair.yaml
 const
   # Updated penalty values
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/presets/mainnet/phase0_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/phase0_preset.nim
@@ -1,4 +1,5 @@
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/presets/mainnet/phase0.yaml
+# Mainnet preset - Phase0
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.5/presets/mainnet/phase0.yaml
 
 const
   #

--- a/beacon_chain/spec/presets/minimal/altair_preset.nim
+++ b/beacon_chain/spec/presets/minimal/altair_preset.nim
@@ -1,5 +1,5 @@
-# Mainnet preset - Altair
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/presets/minimal/altair.yaml
+# Minimal preset - Altair
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.5/presets/minimal/altair.yaml
 const
   # Updated penalty values
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/presets/minimal/phase0_preset.nim
+++ b/beacon_chain/spec/presets/minimal/phase0_preset.nim
@@ -1,4 +1,5 @@
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/presets/minimal/phase0.yaml
+# Minimal preset - Phase0
+# https://github.com/ethereum/consensus-specs/blob/v1.1.0-beta.5/presets/minimal/phase0.yaml
 
 const
   #


### PR DESCRIPTION
Currently there is a mix of comment formats in the various preset files.
Altair presets have a leading header line, Phase0 presets don't.
Furthermore, the Altair `minimal` header refers to `mainnet` (#2710).
Updated all of the header lines to match the spec.