### PR TITLE
Fix /eth/v1/beacon/states/{state_id}/sync_committees response.

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -606,10 +606,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             offset.inc(length)
           res
 
-      return RestApiResponse.jsonResponse(GetEpochSyncCommitteesResponse(
-        data: RestEpochSyncCommittee(validators: indices,
-                                     validator_aggregates: aggregates)
-      ))
+      return RestApiResponse.jsonResponse(RestEpochSyncCommittee(
+        validators: indices, validator_aggregates: aggregates)
+      )
 
     return RestApiResponse.jsonError(Http400, "Could not get requested state")
 


### PR DESCRIPTION
I'm unable to add tests for this case, because i need to start `beacon_node` already in `altair` fork.