### PR TITLE
Improve discovery during fork

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1096,9 +1096,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     next_action_wait.set(nextActionWaitTime.toFloatSeconds)
 
   let epoch = slot.epoch
-  if epoch >= node.network.forkId.next_fork_epoch:
-    node.network.updateForkId(
-      node.dag.cfg.getENRForkID(epoch, node.dag.genesisValidatorsRoot))
+  if epoch + 1 >= node.network.forkId.next_fork_epoch:
+    # Update 1 epoch early to block non-fork-ready peers
+    node.network.updateForkId(epoch, node.dag.genesisValidatorsRoot)
 
   node.updateGossipStatus(slot)
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -763,6 +763,8 @@ func toGaugeValue*(x: uint64 | Epoch | Slot): int64 =
 # TODO where's borrow support when you need it
 func `==`*(a, b: ForkDigest | Version): bool =
   array[4, byte](a) == array[4, byte](b)
+func `<`*(a, b: ForkDigest | Version): bool =
+  uint32.fromBytesBE(array[4, byte](a)) < uint32.fromBytesBE(array[4, byte](b))
 func len*(v: ForkDigest | Version): int = sizeof(v)
 func low*(v: ForkDigest | Version): int = 0
 func high*(v: ForkDigest | Version): int = len(v) - 1

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -105,3 +105,19 @@ func getENRForkID*(cfg: RuntimeConfig,
     fork_digest: fork_digest,
     next_fork_version: next_fork_version,
     next_fork_epoch: cfg.nextForkEpochAtEpoch(epoch))
+
+func getDiscoveryForkID*(cfg: RuntimeConfig,
+                   epoch: Epoch,
+                   genesis_validators_root: Eth2Digest): ENRForkID =
+  # Until 1 epoch from fork, returns pre-fork value
+  if epoch + 1 >= cfg.ALTAIR_FORK_EPOCH:
+    getENRForkID(cfg, epoch, genesis_validators_root)
+  else:
+    let
+      current_fork_version = cfg.forkVersionAtEpoch(epoch)
+      fork_digest = compute_fork_digest(current_fork_version,
+                                        genesis_validators_root)
+    ENRForkID(
+      fork_digest: fork_digest,
+      next_fork_version: current_fork_version,
+      next_fork_epoch: FAR_FUTURE_EPOCH)

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -149,3 +149,60 @@ suite "Eth2 specific discovery tests":
 
     await node1.closeWait()
     await node2.closeWait()
+
+suite "Fork id compatibility test":
+  test "Digest check":
+    check false == isCompatibleForkId(
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)),
+      ENRForkID(
+        fork_digest: ForkDigest([byte 9, 9, 9, 9]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)))
+
+    check true == isCompatibleForkId(
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)),
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)))
+
+  test "Fork check":
+    # Future fork should work
+    check true == isCompatibleForkId(
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)),
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 2, 2, 2, 2]),
+        next_fork_epoch: Epoch(2)))
+
+    # Past fork should fail
+    check false == isCompatibleForkId(
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 1]),
+        next_fork_epoch: Epoch(0)),
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)))
+
+  test "Next fork epoch check":
+    # Same fork should check next_fork_epoch
+    check false == isCompatibleForkId(
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(0)),
+      ENRForkID(
+        fork_digest: ForkDigest([byte 0, 1, 2, 3]),
+        next_fork_version: Version([byte 0, 0, 0, 0]),
+        next_fork_epoch: Epoch(2)))


### PR DESCRIPTION
This PR allows nimbus to dial peers:
- Which are aware of a fork (when we are not)
- Which are not aware of a fork (when we are)

It does so by adding a `discoveryForkId`, which is the "minimum allowed fork id". Until 1 epoch from a fork, it will be set to the non-fork-aware value. At fork, it will be set to the new fork id.

Any peer discovered needs to have a forkId >= to the discoveryForkId, otherwise it won't be dialed.