### PR TITLE
use `allSyncCommittees` everywhere

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -171,13 +171,13 @@ proc produceSyncAggregateAux(
     initialized = false
     startTime = Moment.now
 
-  for subnetId in 0 ..< SYNC_COMMITTEE_SUBNET_COUNT:
+  for subnetId in allSyncCommittees():
     if bestContributions.subnets[subnetId].totalParticipants == 0:
       continue
 
     for pos, value in bestContributions.subnets[subnetId].participationBits:
       if value:
-        let globalPos = subnetId * SYNC_SUBCOMMITTEE_SIZE + pos
+        let globalPos = subnetId.asInt * SYNC_SUBCOMMITTEE_SIZE + pos
         result.sync_committee_bits.setBit globalPos
 
     if not initialized:

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -941,7 +941,7 @@ proc queryRandom*(
             peer = n.record.toURI(), exception = e.name, msg = e.msg
           continue
 
-      for i in 0..<SYNC_COMMITTEE_SUBNET_COUNT:
+      for i in allSyncCommittees():
         if wantedSyncnets[i] and syncnetsNode[i]:
           score += 10 # connecting to the right syncnet is urgent
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -437,8 +437,8 @@ proc init*(T: type BeaconNode,
         topics &= getAttestationTopic(network.forkDigests.phase0, SubnetId(subnet_id))
         topics &= getAttestationTopic(network.forkDigests.altair, SubnetId(subnet_id))
       if not config.verifyFinalization:
-        for subnet_id in 0'u64 ..< SYNC_COMMITTEE_SUBNET_COUNT:
-          topics &= getSyncCommitteeTopic(network.forkDigests.altair, SyncCommitteeIndex(subnet_id))
+        for subnet_id in allSyncCommittees():
+          topics &= getSyncCommitteeTopic(network.forkDigests.altair, subnet_id)
       topics)
 
   if node.config.inProcessValidators:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -468,8 +468,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http400,
                                            InvalidSubCommitteeIndexValueError,
                                            $res.error())
-        let value = res.get()
-        if value >= SYNC_COMMITTEE_SUBNET_COUNT:
+        let value = res.get().validateSyncCommitteeIndexOr:
           return RestApiResponse.jsonError(Http400,
                                            InvalidSubCommitteeIndexValueError,
                                            "subcommittee_index exceeds " &
@@ -494,7 +493,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     var contribution = SyncCommitteeContribution()
     let res = node.syncCommitteeMsgPool[].produceContribution(
-      qslot, qroot, SyncCommitteeIndex(qindex), contribution)
+      qslot, qroot, qindex, contribution)
     if not(res):
       return RestApiResponse.jsonError(Http400, ProduceContributionError)
     return RestApiResponse.jsonResponse(contribution)

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -426,6 +426,8 @@ template asInt*(x: SyncCommitteeIndex): int = int(x)
 template asUInt8*(x: SyncCommitteeIndex): uint8 = uint8(x)
 template asUInt64*(x: SyncCommitteeIndex): uint64 = uint64(x)
 
+template `[]`*(a: auto; i: SyncCommitteeIndex): auto = a[i.asInt]
+
 template `==`*(x, y: SyncCommitteeIndex): bool =
   distinctBase(x) == distinctBase(y)
 
@@ -433,7 +435,9 @@ iterator allSyncCommittees*: SyncCommitteeIndex =
   for committeeIdx in 0 ..< SYNC_COMMITTEE_SUBNET_COUNT:
     yield SyncCommitteeIndex(committeeIdx)
 
-template validateSyncCommitteeIndexOr*(networkValParam: uint64, elseBody: untyped) =
+template validateSyncCommitteeIndexOr*(
+    networkValParam: uint64, 
+    elseBody: untyped): SyncCommitteeIndex =
   let networkVal = networkValParam
   if networkVal < SYNC_COMMITTEE_SUBNET_COUNT:
     SyncCommitteeIndex(networkVal)


### PR DESCRIPTION
There are still a few cases with manual loops through sync subcommittees
even though an `allSyncCommittees` iterator exists. Adjusted the few
remaining instances to also use the iterator instead.