### PR TITLE
use `SyncAggregate.init()` everywhere

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -34,9 +34,6 @@ func init*(T: type SyncCommitteeMsgPool,
           ): SyncCommitteeMsgPool =
   T(onContributionReceived: onSyncContribution)
 
-func init(T: type SyncAggregate): SyncAggregate =
-  SyncAggregate(sync_committee_signature: ValidatorSig.infinity)
-
 func pruneData*(pool: var SyncCommitteeMsgPool, slot: Slot) =
   ## This should be called at the end of slot.
   clear pool.seenContributionByAuthor

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -491,6 +491,9 @@ func shortLog*(v: SyncCommitteeMessage): auto =
     signature: shortLog(v.signature)
   )
 
+func init*(T: type SyncAggregate): SyncAggregate =
+  SyncAggregate(sync_committee_signature: ValidatorSig.infinity)
+
 func shortLog*(v: SyncAggregate): auto =
   $(v.sync_committee_bits)
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -454,7 +454,7 @@ proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
 
     let doPhase0 = slot.epoch < node.dag.cfg.ALTAIR_FORK_EPOCH
     return if doPhase0:
-      let sync_aggregate = SyncAggregate(sync_committee_signature: ValidatorSig.infinity)
+      let sync_aggregate = SyncAggregate.init()
       makeBeaconBlock(phase0)
     else:
       let sync_aggregate = node.sync_committee_msg_pool[].produceSyncAggregate(head.root)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -238,7 +238,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         finalizedEpochRef.eth1_deposit_index)
       sync_aggregate =
         when T is phase0.SignedBeaconBlock:
-          SyncAggregate(sync_committee_signature: ValidatorSig.infinity)
+          SyncAggregate.init()
         elif T is altair.SignedBeaconBlock or T is merge.SignedBeaconBlock:
           syncCommitteePool[].produceSyncAggregate(dag.head.root)
         else:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -120,7 +120,7 @@ proc addTestBlock*(
       @[],
       @[],
       @[],
-      SyncAggregate(sync_committee_signature: ValidatorSig.infinity),
+      SyncAggregate.init(),
       default(ExecutionPayload),
       noRollback,
       cache)


### PR DESCRIPTION
The initialization of a `SyncAggregate` to its default value is not very
intuitive. There is an `init` function in `sync_committee_msg_pool` that
provides a convenience wrapper. This patch exports that initializer so
that the rest of the code base can also take advantage of it.