### PR TITLE
enable libp2p agent metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,8 @@ DEPOSITS_DELAY := 0
 
 #- "--define:release" cannot be added to "config.nims"
 #- disable Nim's default parallelisation because it starts too many processes for too little gain
-NIM_PARAMS += -d:release --parallelBuild:1
+#- https://github.com/status-im/nim-libp2p#use-identify-metrics
+NIM_PARAMS += -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,prysm,teku
 
 ifeq ($(USE_LIBBACKTRACE), 0)
 # Blame Jacek for the lack of line numbers in your stack traces ;-)


### PR DESCRIPTION
For a minimal overhead, we get this:

```text
libp2p_peers_identity{agent="teku"} 2.0
libp2p_peers_identity{agent="lighthouse"} 7.0
libp2p_peers_identity{agent="nimbus"} 6.0
libp2p_peers_identity{agent="prysm"} 11.0
libp2p_peers_identity{agent="unknown"} 0.0
libp2p_peers_traffic_read_total{agent="teku"} 31223107.0
libp2p_peers_traffic_read_total{agent="lighthouse"} 32993703.0
libp2p_peers_traffic_read_total{agent="nimbus"} 67127087.0
libp2p_peers_traffic_read_total{agent="prysm"} 50597997.0
libp2p_peers_traffic_read_total{agent="unknown"} 6214709.0
libp2p_peers_traffic_write_total{agent="teku"} 509614.0
libp2p_peers_traffic_write_total{agent="lighthouse"} 17605.0
libp2p_peers_traffic_write_total{agent="nimbus"} 21334.0
libp2p_peers_traffic_write_total{agent="prysm"} 28200.0
libp2p_peers_traffic_write_total{agent="unknown"} 4855.0
```