### PR TITLE
avoid `-Present` in copyrights

### DIFF
--- a/tests/official/altair/test_fixture_fork.nim
+++ b/tests/official/altair/test_fixture_fork.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-Present Status Research & Development GmbH
+# Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_attestations.nim
+++ b/tests/official/altair/test_fixture_operations_attestations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_attester_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_block_header.nim
+++ b/tests/official/altair/test_fixture_operations_block_header.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_deposits.nim
+++ b/tests/official/altair/test_fixture_operations_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/altair/test_fixture_operations_proposer_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_sync_aggregate.nim
+++ b/tests/official/altair/test_fixture_operations_sync_aggregate.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/altair/test_fixture_operations_voluntary_exit.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_sanity_blocks.nim
+++ b/tests/official/altair/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_sanity_slots.nim
+++ b/tests/official/altair/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/official/altair/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/altair/test_fixture_transition.nim
+++ b/tests/official/altair/test_fixture_transition.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-Present Status Research & Development GmbH
+# Copyright (c) 2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/fixtures_utils.nim
+++ b/tests/official/fixtures_utils.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_attestations.nim
+++ b/tests/official/merge/test_fixture_operations_attestations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/merge/test_fixture_operations_attester_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_block_header.nim
+++ b/tests/official/merge/test_fixture_operations_block_header.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_deposits.nim
+++ b/tests/official/merge/test_fixture_operations_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_execution_payload.nim
+++ b/tests/official/merge/test_fixture_operations_execution_payload.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/merge/test_fixture_operations_proposer_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/merge/test_fixture_operations_voluntary_exit.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_sanity_blocks.nim
+++ b/tests/official/merge/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_sanity_slots.nim
+++ b/tests/official/merge/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/merge/test_fixture_state_transition_epoch.nim
+++ b/tests/official/merge/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_attestations.nim
+++ b/tests/official/phase0/test_fixture_operations_attestations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_attester_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_attester_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_block_header.nim
+++ b/tests/official/phase0/test_fixture_operations_block_header.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_deposits.nim
+++ b/tests/official/phase0/test_fixture_operations_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
+++ b/tests/official/phase0/test_fixture_operations_proposer_slashings.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
+++ b/tests/official/phase0/test_fixture_operations_voluntary_exit.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/official/phase0/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_sanity_slots.nim
+++ b/tests/official/phase0/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/phase0/test_fixture_state_transition_epoch.nim
+++ b/tests/official/phase0/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-Present Status Research & Development GmbH
+# Copyright (c) 2018-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/official/test_fixture_rewards.nim
+++ b/tests/official/test_fixture_rewards.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-Present Status Research & Development GmbH
+# Copyright (c) 2020-2021 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Replaced non-conventional `-Present` form in copyright headers with the
more appropriate `-2021` version that is already used by the majority of
the code base. Copyright header should indicate the years during which
the specific file was modified.