### PR TITLE
remove privkey from mock withdrawal credentials

### DIFF
--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -128,8 +128,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
               sig =
                 get_attestation_signature(getStateField(stateData.data, fork),
                   getStateField(stateData.data, genesis_validators_root),
-                  data, hackPrivKey(
-                    getStateField(stateData.data, validators)[validatorIdx]))
+                  data, MockPrivKeys[validatorIdx])
             var aggregation_bits = CommitteeValidatorsBits.init(committee.len)
             aggregation_bits.setBit index_in_committee
 
@@ -165,7 +164,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
         let
           validatorIdx = validatorKeyToIndex[valKey]
-          validarorPrivKey = makeFakeValidatorPrivKey(validatorIdx)
+          validarorPrivKey = MockPrivKeys[validatorIdx.ValidatorIndex]
           signature = blsSign(validarorPrivKey, signingRoot.data)
           msg = SyncCommitteeMessage(
             slot: slot,
@@ -210,7 +209,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
           signingRoot = contribution_and_proof_signing_root(
             fork, genesisValidatorsRoot, contributionAndProof)
 
-          validarorPrivKey = makeFakeValidatorPrivKey(aggregator.validatorIdx)
+          validarorPrivKey = 
+            MockPrivKeys[aggregator.validatorIdx.ValidatorIndex]
 
           signedContributionAndProof = SignedContributionAndProof(
             message: contributionAndProof,
@@ -230,8 +230,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       finalizedEpochRef = dag.getFinalizedEpochRef()
       proposerIdx = get_beacon_proposer_index(
         stateData.data, cache, getStateField(stateData.data, slot)).get()
-      privKey = hackPrivKey(
-        getStateField(stateData.data, validators)[proposerIdx])
+      privKey = MockPrivKeys[proposerIdx]
       eth1ProposalData = eth1Chain.getBlockProposalData(
         stateData.data,
         finalizedEpochRef.eth1_data,

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -218,7 +218,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         state[].data.validators.mapIt(it.pubkey).find(pubKey))
       validator = AttachedValidator(
         pubKey: pubkey,
-        kind: inProcess, privKey: hackPrivKey(state[].data.validators[index]),
+        kind: inProcess, privKey: MockPrivKeys[index],
         index: some(index))
       msg = waitFor signSyncCommitteeMessage(
         validator, state[].data.slot,

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -47,10 +47,10 @@ suite "Sync committee pool":
       fork = altairFork(defaultRuntimeConfig)
       genesisValidatorsRoot = eth2digest(@[5.byte, 6, 7])
 
-      privkey1 = makeFakeValidatorPrivKey(1)
-      privkey2 = makeFakeValidatorPrivKey(2)
-      privkey3 = makeFakeValidatorPrivKey(3)
-      privkey4 = makeFakeValidatorPrivKey(4)
+      privkey1 = MockPrivKeys[1.ValidatorIndex]
+      privkey2 = MockPrivKeys[2.ValidatorIndex]
+      privkey3 = MockPrivKeys[3.ValidatorIndex]
+      privkey4 = MockPrivKeys[4.ValidatorIndex]
 
       root1 = eth2digest(@[1.byte])
       root2 = eth2digest(@[1.byte, 2])


### PR DESCRIPTION
In tests, the private key was put into the validator deposit's withdraw
credentials so that it can be recovered later. This leads to problems
when creating the validators through other means that do not put the key
there. In general, mock private keys only depend on the validator index,
though, and because it is clear what the index of a validator is, it is
not actually needed to put the key into the credentials.