### PR TITLE
abort compile when fork epoch is forgotten

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2140,12 +2140,10 @@ func getRandomSubnetId*(node: Eth2Node): SubnetId =
   node.rng[].rand(ATTESTATION_SUBNET_COUNT - 1).SubnetId
 
 func forkDigestAtEpoch(node: Eth2Node, epoch: Epoch): ForkDigest =
-  if epoch < node.cfg.ALTAIR_FORK_EPOCH:
-    node.forkDigests.phase0
-  elif epoch < node.cfg.MERGE_FORK_EPOCH:
-    node.forkDigests.altair
-  else:
-    node.forkDigests.merge
+  case node.cfg.stateForkAtEpoch(epoch)
+  of forkMerge:  node.forkDigests.merge
+  of forkAltair: node.forkDigests.altair
+  of forkPhase0: node.forkDigests.phase0
 
 proc getWallEpoch(node: Eth2Node): Epoch =
   node.getBeaconTime().slotOrZero.epoch

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -391,12 +391,10 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
     if blockRatio > 0.0:
       withTimer(timers[t]):
-        if slot.epoch < dag.cfg.ALTAIR_FORK_EPOCH:
-          proposePhase0Block(slot)
-        elif slot.epoch < dag.cfg.MERGE_FORK_EPOCH:
-          proposeAltairBlock(slot)
-        else:
-          proposeMergeBlock(slot)
+        case dag.cfg.stateForkAtEpoch(slot.epoch)
+        of forkMerge:  proposeMergeBlock(slot)
+        of forkAltair: proposeAltairBlock(slot)
+        of forkPhase0: proposePhase0Block(slot)
     if attesterRatio > 0.0:
       withTimer(timers[tAttest]):
         handleAttestations(slot)


### PR DESCRIPTION
There are a few locations in the code that compare the current epoch to
the various FORK_EPOCH constants and branch off into fork-specific code.
When a new fork is introduced, it is sometimes forgotten to update all
of those branch locations. This patch introduces a compile-time check
that ensures that all branches need to be covered exhaustively. This is
done by replacing if-elif structures with case expressions.