### PR TITLE
dist: cross-build ARM64 on Debian-10.10

### DIFF
--- a/docker/dist/Dockerfile.arm64
+++ b/docker/dist/Dockerfile.arm64
@@ -1,5 +1,5 @@
 # The build is reproducible only if this base image stays the same.
-FROM statusteam/nimbus_beacon_node:dist_base_20210525175232_arm64_v3@sha256:42d4c07aad4630c36123cab0283e8a5372515a0c1eec2bc9b7ac21c483e560c9
+FROM statusteam/nimbus_beacon_node:dist_base_20211001175744_arm64_v4@sha256:558c34dcac4beaa6ca5256c6301b4768f206afeb9dea44d185e42295d5123e61
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Dockerfile.arm64
+++ b/docker/dist/base_image/Dockerfile.arm64
@@ -6,9 +6,9 @@
 # it once, upload it to Docker Hub and make sure it's being pulled regularly so
 # it's not deleted after 6 months of inactivity.
 
-# We use an older Ubuntu version so we can support Raspbian's glibc-2.28:
+# We use an older Debian version so we can support Raspbian's glibc-2.28:
 # https://github.com/status-im/nimbus-eth2/issues/2583
-FROM ubuntu:18.04
+FROM debian:10.10
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/base_image/Makefile
+++ b/docker/dist/base_image/Makefile
@@ -19,7 +19,7 @@ build-amd64:
 	$(CURDIR)/make_base_image.sh amd64 "$(IMAGE_NAME)"
 
 build-arm64:
-	$(CURDIR)/make_base_image.sh arm64 "$(IMAGE_NAME)_arm64_v3"
+	$(CURDIR)/make_base_image.sh arm64 "$(IMAGE_NAME)_arm64_v4"
 
 build-arm:
 	$(CURDIR)/make_base_image.sh arm "$(IMAGE_NAME)_arm_v2"
@@ -38,7 +38,7 @@ build-macos:
 #	docker push $(IMAGE_NAME)
 
 #push-arm64: build-arm64
-#	docker push $(IMAGE_NAME)_arm64_v3
+#	docker push $(IMAGE_NAME)_arm64_v4
 
 #push-arm: build-arm
 #	docker push $(IMAGE_NAME)_arm_v2


### PR DESCRIPTION
instead of Ubuntu-18.04. This fixes a crash when stress-testing the metrics HTTP server. We think it was due to gcc-7.4.0 miscompiling something. The new distro/version gives us gcc-8.3.0, but with the same old glibc-2.28 we need on Raspbian.

Kudos to @jclapis for reporting and debugging the problem.