### PR TITLE
register vc duties with subnet tracker

### DIFF
--- a/beacon_chain/beacon_node_common.nim
+++ b/beacon_chain/beacon_node_common.nim
@@ -15,20 +15,20 @@ import
   taskpools,
 
   # Local modules
-  ./conf, ./beacon_clock, ./beacon_chain_db,
-  ./beacon_node_types,
+  "."/[beacon_clock, beacon_chain_db, beacon_node_types, conf],
   ./gossip_processing/[eth2_processor, block_processor, consensus_manager],
   ./networking/eth2_network,
   ./eth1/eth1_monitor,
   ./consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
   ./spec/datatypes/base,
-  ./sync/[sync_manager, request_manager]
+  ./sync/[sync_manager, request_manager],
+  ./validators/action_tracker
 
 export
-  osproc, chronos, httpserver, presto, conf, beacon_clock, beacon_chain_db,
-  attestation_pool, eth2_network, beacon_node_types, eth1_monitor,
-  request_manager, sync_manager, eth2_processor, blockchain_dag, block_quarantine,
-  base
+  osproc, chronos, httpserver, presto, action_tracker, beacon_clock,
+  beacon_chain_db, conf, attestation_pool, eth2_network, beacon_node_types,
+  eth1_monitor, request_manager, sync_manager, eth2_processor, blockchain_dag,
+  block_quarantine, base
 
 type
   RpcServer* = RpcHttpServer
@@ -61,7 +61,7 @@ type
     requestManager*: RequestManager
     syncManager*: SyncManager[Peer, PeerID]
     genesisSnapshotContent*: string
-    attestationSubnets*: AttestationSubnets
+    actionTracker*: ActionTracker
     processor*: ref Eth2Processor
     blockProcessor*: ref BlockProcessor
     consensusManager*: ref ConsensusManager

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -173,12 +173,13 @@ func makeAttestationData*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.2/specs/phase0/validator.md#validator-assignments
 iterator get_committee_assignments*(
-    epochRef: EpochRef, epoch: Epoch, validator_indices: IntSet):
+    epochRef: EpochRef, validator_indices: IntSet):
     tuple[validatorIndices: IntSet,
       committeeIndex: CommitteeIndex,
       subnet_id: SubnetId, slot: Slot] =
   let
     committees_per_slot = get_committee_count_per_slot(epochRef)
+    epoch = epochRef.epoch
     start_slot = compute_start_slot_at_epoch(epoch)
 
   for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2080,6 +2080,9 @@ proc unsubscribeAttestationSubnets*(node: Eth2Node, subnets: BitArray[ATTESTATIO
 proc updateStabilitySubnetMetadata*(
     node: Eth2Node, attnets: BitArray[ATTESTATION_SUBNET_COUNT]) =
   # https://github.com/ethereum/consensus-specs/blob/v1.1.2/specs/phase0/p2p-interface.md#metadata
+  if node.metadata.attnets == attnets:
+    return
+
   node.metadata.seq_number += 1
   node.metadata.attnets = attnets
 
@@ -2124,14 +2127,6 @@ proc updateForkId(node: Eth2Node, value: ENRForkID) =
 proc updateForkId*(node: Eth2Node, epoch: Epoch, genesisValidatorsRoot: Eth2Digest) =
   node.updateForkId(getENRForkId(node.cfg, epoch, genesisValidatorsRoot))
   node.discoveryForkId = getDiscoveryForkID(node.cfg, epoch, genesisValidatorsRoot)
-
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#phase-0-attestation-subnet-stability
-func getStabilitySubnetLength*(node: Eth2Node): uint64 =
-  EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION +
-    node.rng[].rand(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION.int).uint64
-
-func getRandomSubnetId*(node: Eth2Node): SubnetId =
-  node.rng[].rand(ATTESTATION_SUBNET_COUNT - 1).SubnetId
 
 func forkDigestAtEpoch(node: Eth2Node, epoch: Epoch): ForkDigest =
   case node.cfg.stateForkAtEpoch(epoch)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -12,6 +12,7 @@ import
        tables, times, terminal],
 
   # Nimble packages
+  serialization, json_serialization, spec/eth2_apis/eth2_rest_serialization,
   stew/[objects, byteutils, endians2, io2], stew/shims/macros,
   chronos, confutils, metrics, metrics/chronos_httpserver,
   chronicles, bearssl, blscurve, presto,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -917,8 +917,6 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     # Update 1 epoch early to block non-fork-ready peers
     node.network.updateForkId(epoch, node.dag.genesisValidatorsRoot)
 
-  await node.updateGossipStatus(slot)
-
   # When we're not behind schedule, we'll speculatively update the clearance
   # state in anticipation of receiving the next block - we do it after logging
   # slot end since the nextActionWaitTime can be short

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -513,13 +513,12 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                              $res.error())
           res.get()
       let epochRef = node.dag.getEpochRef(head, epoch)
-      let subnet = uint8(compute_subnet_for_attestation(
+      let subnet = compute_subnet_for_attestation(
         get_committee_count_per_slot(epochRef), request.slot,
         request.committee_index)
-      )
 
       node.registerDuty(
-        request.slot, SubnetId(subnet), request.validator_index,
+        request.slot, subnet, request.validator_index,
         request.is_aggregator)
 
     return RestApiResponse.jsonMsgResponse(BeaconCommitteeSubscriptionSuccess)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -517,7 +517,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         get_committee_count_per_slot(epochRef), request.slot,
         request.committee_index)
       )
-    warn "Beacon committee subscription request served, but not implemented"
+
+      node.registerDuty(
+        request.slot, SubnetId(subnet), request.validator_index,
+        request.is_aggregator)
+
     return RestApiResponse.jsonMsgResponse(BeaconCommitteeSubscriptionSuccess)
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/prepareSyncCommitteeSubnets

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -162,18 +162,8 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       subnet_id = compute_subnet_for_attestation(
         get_committee_count_per_slot(epochRef), slot, committee_index)
 
-    # Either subnet already subscribed or not. If not, subscribe. If it is,
-    # extend subscription. All one knows from the API combined with how far
-    # ahead one can check for attestation schedule is that it might be used
-    # for up to the end of next epoch. Therefore, arrange for subscriptions
-    # to last at least that long.
-    if not node.attestationSubnets.aggregateSubnets[subnet_id.uint64]:
-      # When to subscribe. Since it's not clear when from the API it's first
-      # needed, do so immediately.
-      node.attestationSubnets.subscribeSlot[subnet_id.uint64] =
-        min(node.attestationSubnets.subscribeSlot[subnet_id.uint64], wallSlot)
-
-    node.attestationSubnets.unsubscribeSlot[subnet_id.uint64] =
-      max(
-        compute_start_slot_at_epoch(epoch + 2),
-        node.attestationSubnets.unsubscribeSlot[subnet_id.uint64])
+    # The validator index here is invalid, but since JSON-RPC is on its way
+    # to deprecation, this is fine
+    node.registerDuty(
+      slot, subnet_id, 0.ValidatorIndex,
+       is_aggregator(epochRef, slot, committee_index, slot_signature))

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -159,11 +159,11 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     let
       head = node.doChecksAndGetCurrentHead(epoch)
       epochRef = node.dag.getEpochRef(head, epoch)
-      subnet_id = compute_subnet_for_attestation(
+      subnet = compute_subnet_for_attestation(
         get_committee_count_per_slot(epochRef), slot, committee_index)
 
     # The validator index here is invalid, but since JSON-RPC is on its way
     # to deprecation, this is fine
     node.registerDuty(
-      slot, subnet_id, 0.ValidatorIndex,
+      slot, subnet, 0.ValidatorIndex,
        is_aggregator(epochRef, slot, committee_index, slot_signature))

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -802,9 +802,6 @@ template queueAge(): uint64 =
 template peerStatusAge(): Duration =
   Moment.now() - peer.state(BeaconSync).statusLastTime
 
-func syncQueueLen*[A, B](man: SyncManager[A, B]): uint64 =
-  man.queue.len
-
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
   let wallSlot = man.getLocalWallSlot()
   let headSlot = man.getLocalHeadSlot()

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -1,0 +1,198 @@
+import
+  std/[sequtils, intsets, sets, tables],
+  chronicles,
+  bearssl,
+  eth/p2p/discoveryv5/random2,
+  ../spec/datatypes/base,
+  ../spec/helpers,
+  ../consensus_object_pools/[block_pools_types, spec_cache]
+
+export base, helpers, sets, tables
+
+const
+  SUBNET_SUBSCRIPTION_LEAD_TIME_SLOTS* = 4
+
+type
+  SubnetBits* = BitArray[ATTESTATION_SUBNET_COUNT]
+
+  AggregatorDuty* = object
+    subnet*: SubnetId
+    slot*: Slot
+
+  ActionTracker* = object
+    rng: ref BrHmacDrbgContext
+
+    subscribeAllSubnets*: bool
+
+    currentSlot*: Slot
+
+    subscribedSubnets*: SubnetBits ##\
+      ## All subnets we're current subscribed to
+
+    stabilitySubnets: seq[tuple[subnet: SubnetId, expiration: Epoch]] ##\
+      ## The subnets on which we listen and broadcast gossip traffic to maintain
+      ## the health of the network - these are advertised in the ENR
+    nextCycleEpoch*: Epoch
+
+    # Used to track the next attestation and proposal slots using an
+    # epoch-relative coordinate system. Doesn't need initialization.
+    attestingSlots*: array[2, uint32]
+    proposingSlots*: array[2, uint32]
+    lastCalculatedEpoch*: Epoch
+
+    knownValidators*: Table[ValidatorIndex, Slot]
+      ## Validators that we've recently seen - we'll subscribe to one stability
+      ## subnet for each such validator - the slot is used to expire validators
+      ## that no longer are posting duties
+
+    duties*: seq[AggregatorDuty] ##\
+      ## Known aggregation duties in the near future - before each such
+      ## duty, we'll subscribe to the corresponding subnet to collect
+
+# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#phase-0-attestation-subnet-stability
+func randomStabilitySubnet*(
+    self: ActionTracker, epoch: Epoch): tuple[subnet: SubnetId, expiration: Epoch] =
+  (
+    self.rng[].rand(ATTESTATION_SUBNET_COUNT - 1).SubnetId,
+    epoch + EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION +
+      self.rng[].rand(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION.int).uint64,
+  )
+
+proc registerDuty*(
+    tracker: var ActionTracker, slot: Slot, subnet: SubnetId,
+    vidx: ValidatorIndex, isAggregator: bool) =
+  # Only register relevant duties
+  if slot < tracker.currentSlot or
+      slot + (SLOTS_PER_EPOCH * 2) <= tracker.currentSlot:
+    debug "Irrelevant duty", slot, subnet, vidx
+    return
+
+  tracker.knownValidators[vidx] = slot # Update validator last-seen registry
+
+  if isAggregator:
+    let newDuty = AggregatorDuty(slot: slot, subnet: subnet)
+
+    for duty in tracker.duties.mitems():
+      if duty == newDuty:
+        return
+
+    debug "Registering aggregation duty", slot, subnet, vidx
+    tracker.duties.add(newDuty)
+
+const allSubnetBits = block:
+  var res: SubnetBits
+  for i in 0..<res.len: res[i] = true
+  res
+
+func aggregateSubnets*(tracker: ActionTracker, wallSlot: Slot): SubnetBits =
+  var res: SubnetBits
+  # Subscribe to subnets for upcoming duties
+  for duty in tracker.duties:
+
+    if wallSlot <= duty.slot and
+        wallSlot + SUBNET_SUBSCRIPTION_LEAD_TIME_SLOTS > duty.slot:
+
+      res[duty.subnet.int] = true
+  res
+
+func stabilitySubnets*(tracker: ActionTracker, slot: Slot): SubnetBits =
+  if tracker.subscribeAllSubnets:
+    allSubnetBits
+  else:
+    var res: SubnetBits
+    for v in tracker.stabilitySubnets:
+      res[v.subnet.int] = true
+    res
+
+func updateSlot*(tracker: var ActionTracker, wallSlot: Slot) =
+  # Prune duties from the past - this collection is kept small because there
+  # are only so many slot/subnet combos - prune both internal and API-supplied
+  # duties at the same time
+  tracker.duties.keepItIf(it.slot >= wallSlot)
+
+  # Keep stability subnets for as long as validators are validating
+  var toPrune: seq[ValidatorIndex]
+  for k, v in tracker.knownValidators:
+    if v + SLOTS_PER_EPOCH * 3 < wallSlot: toPrune.add k
+  for k in toPrune: tracker.knownValidators.del k
+
+  # One stability subnet per known validator
+  static: doAssert RANDOM_SUBNETS_PER_VALIDATOR == 1
+
+  # https://github.com/ethereum/eth2.0-specs/blob/v1.1.2/specs/phase0/validator.md#phase-0-attestation-subnet-stability
+  let expectedSubnets =
+    min(ATTESTATION_SUBNET_COUNT, tracker.knownValidators.len)
+
+  let epoch = wallSlot.epoch
+  block:
+    # If we have too many stability subnets, remove some expired ones
+    var i = 0
+    while tracker.stabilitySubnets.len > expectedSubnets and
+        i < tracker.stabilitySubnets.len:
+      if epoch >= tracker.stabilitySubnets[i].expiration:
+        tracker.stabilitySubnets.delete(i)
+      else:
+        inc i
+
+  for ss in tracker.stabilitySubnets.mitems():
+    if epoch >= ss.expiration:
+      ss = tracker.randomStabilitySubnet(epoch)
+
+  # and if we have too few, add a few more
+  for i in tracker.stabilitySubnets.len..<expectedSubnets:
+    tracker.stabilitySubnets.add(tracker.randomStabilitySubnet(epoch))
+
+  tracker.currentSlot = wallSlot
+
+proc updateActions*(tracker: var ActionTracker, epochRef: EpochRef) =
+  # Updates the schedule for upcoming attestation and proposal work
+  let
+    epoch = epochRef.epoch
+
+  if tracker.lastCalculatedEpoch == epoch:
+    return
+  tracker.lastCalculatedEpoch = epoch
+
+  let
+    validatorIndices = toIntSet(toSeq(tracker.knownValidators.keys()))
+
+  # Update proposals
+  tracker.proposingSlots[epoch mod 2] = 0
+  for i, proposer in epochRef.beacon_proposers:
+    # TODO unsafe int conversion
+    if proposer.isSome and proposer.get().int in validatorIndices:
+      tracker.proposingSlots[epoch mod 2] =
+        tracker.proposingSlots[epoch mod 2] or (1'u32 shl i)
+
+  tracker.attestingSlots[epoch mod 2] = 0
+
+  # The relevant bitmaps are 32 bits each.
+  static: doAssert SLOTS_PER_EPOCH <= 32
+
+  for (validatorIndices, committeeIndex, subnet_id, slot) in
+      get_committee_assignments(epochRef, validatorIndices):
+
+    doAssert compute_epoch_at_slot(slot) == epoch
+
+    # Each get_committee_assignments() call here is on the next epoch. At any
+    # given time, only care about two epochs, the current and next epoch. So,
+    # after it is done for an epoch, [aS[epoch mod 2], aS[1 - (epoch mod 2)]]
+    # provides, sequentially, the current and next epochs' slot schedules. If
+    # get_committee_assignments() has not been called for the next epoch yet,
+    # typically because there hasn't been a block in the current epoch, there
+    # isn't valid information in aS[1 - (epoch mod 2)], and only slots within
+    # the current epoch can be known. Usually, this is not a major issue, but
+    # when there hasn't been a block substantially through an epoch, it might
+    # prove misleading to claim that there aren't attestations known, when it
+    # only might be known either way for 3 more slots. However, it's also not
+    # as important to attest when blocks aren't flowing as only attestions in
+    # blocks garner rewards.
+    tracker.attestingSlots[epoch mod 2] =
+      tracker.attestingSlots[epoch mod 2] or
+        (1'u32 shl (slot mod SLOTS_PER_EPOCH))
+
+proc init*(T: type ActionTracker, rng: ref BrHmacDrbgContext, subscribeAllSubnets: bool): T =
+  T(
+    rng: rng,
+    subscribeAllSubnets: subscribeAllSubnets
+  )

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -660,11 +660,11 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
             data.target.epoch,
             signing_root)
       if registered.isOk():
-        let subnet_id = compute_subnet_for_attestation(
+        let subnet = compute_subnet_for_attestation(
           committees_per_slot, data.slot, data.index.CommitteeIndex)
         asyncSpawn createAndSendAttestation(
           node, fork, genesis_validators_root, validator, data,
-          committee.len(), index_in_committee, subnet_id)
+          committee.len(), index_in_committee, subnet)
       else:
         warn "Slashing protection activated for attestation",
           validator = validator.pubkey,
@@ -1104,10 +1104,10 @@ proc sendAttestation*(node: BeaconNode,
   let
     epochRef = node.dag.getEpochRef(
       attestationBlock, attestation.data.target.epoch)
-    subnet_id = compute_subnet_for_attestation(
+    subnet = compute_subnet_for_attestation(
       get_committee_count_per_slot(epochRef), attestation.data.slot,
       attestation.data.index.CommitteeIndex)
-    res = await node.sendAttestation(attestation, subnet_id,
+    res = await node.sendAttestation(attestation, subnet,
                                      checkSignature = true)
   if not(res):
     return SendResult.err("Attestation failed validation")

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -22,7 +22,8 @@ import
   # Local modules
   ../spec/datatypes/[phase0, altair, merge],
   ../spec/[
-    eth2_merkleization, forks, helpers, network, signatures, state_transition],
+    eth2_merkleization, forks, helpers, network, signatures, state_transition,
+    validator],
   ../consensus_object_pools/[
     spec_cache, blockchain_dag, block_clearance, attestation_pool, exit_pool,
     sync_committee_msg_pool],
@@ -82,12 +83,18 @@ proc findValidator(validators: auto, pubKey: ValidatorPubKey):
   else:
     some(idx.ValidatorIndex)
 
-proc addLocalValidator(node: BeaconNode, item: ValidatorPrivateItem) =
-  node.attachedValidators[].addLocalValidator(item)
+proc addLocalValidator(node: BeaconNode,
+                       validators: auto,
+                       item: ValidatorPrivateItem) =
+  let pubKey = item.privateKey.toPubKey()
+  node.attachedValidators[].addLocalValidator(
+    item,
+    findValidator(validators, pubKey.toPubKey()))
 
 proc addLocalValidators*(node: BeaconNode) =
-  for validatorItem in node.config.validatorItems():
-    node.addLocalValidator(validatorItem)
+  withState(node.dag.headState.data):
+    for validatorItem in node.config.validatorItems():
+      node.addLocalValidator(state.data.validators.asSeq(), validatorItem)
 
 proc addRemoteValidators*(node: BeaconNode) {.raises: [Defect, OSError, IOError].} =
   # load all the validators from the child process - loop until `end`
@@ -1175,3 +1182,45 @@ proc sendBeaconBlock*(node: BeaconNode, forked: ForkedSignedBeaconBlock
     node.network.broadcastBeaconBlock(forked)
     return SendBlockResult.ok(false)
   return SendBlockResult.ok(true)
+
+proc registerDuty*(
+    node: BeaconNode, slot: Slot, subnet: SubnetId, vidx: ValidatorIndex,
+    isAggregator: bool) =
+  # Only register relevant duties
+  node.actionTracker.registerDuty(slot, subnet, vidx, isAggregator)
+
+proc registerDuties*(node: BeaconNode, wallSlot: Slot) {.async.} =
+  ## Register upcoming duties of attached validators with the duty tracker
+
+  if node.attachedValidators[].count() == 0 or not node.isSynced(node.dag.head):
+    # Nothing to do because we have no validator attached
+    return
+
+  let
+    genesis_validators_root =
+      getStateField(node.dag.headState.data, genesis_validators_root)
+    head = node.dag.head
+
+  # Getting the slot signature is expensive but cached - in "normal" cases we'll
+  # be getting the duties one slot at a time
+  for slot in wallSlot ..< wallSlot + SUBNET_SUBSCRIPTION_LEAD_TIME_SLOTS:
+    let
+      epochRef = node.dag.getEpochRef(head, slot.epoch)
+      fork = node.dag.forkAtEpoch(slot.epoch)
+      committees_per_slot = get_committee_count_per_slot(epochRef)
+
+    for committee_index in 0'u64..<committees_per_slot:
+      let committee = get_beacon_committee(
+        epochRef, slot, committee_index.CommitteeIndex)
+
+      for index_in_committee, validatorIdx in committee:
+        let validator = node.getAttachedValidator(epochRef, validatorIdx)
+        if validator != nil:
+          let
+            subnet = compute_subnet_for_attestation(
+              committees_per_slot, slot, committee_index.CommitteeIndex)
+            slotSig = await getSlotSig(
+              validator, fork, genesis_validators_root, slot)
+            isAggregator = is_aggregator(committee.lenu64, slotSig)
+
+          node.registerDuty(slot, subnet, validatorIdx, isAggregator)

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -13,6 +13,7 @@ import
 
 import # Unit test
   ./ssz/all_tests as ssz_all_tests,
+  ./test_action_tracker,
   ./test_attestation_pool,
   ./test_beacon_chain_db,
   ./test_beaconstate,

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -3,8 +3,7 @@
 import
   unittest2,
   eth/keys,
-  ../beacon_chain/validators/action_tracker,
-  testblockutil
+  ../beacon_chain/validators/action_tracker
 
 suite "subnet tracker":
   let rng = keys.newRng()
@@ -29,6 +28,11 @@ suite "subnet tracker":
     check:
       tracker.aggregateSubnets(Slot(0)).countOnes() == 2
       tracker.aggregateSubnets(Slot(1)).countOnes() == 1
+
+    tracker.registerDuty(Slot(SUBNET_SUBSCRIPTION_LEAD_TIME_SLOTS), SubnetId(2), ValidatorIndex(0), true)
+    check:
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 2
+      tracker.aggregateSubnets(Slot(1)).countOnes() == 2
 
     # Guaranteed to expire
     tracker.updateSlot(

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -1,0 +1,39 @@
+{.used.}
+
+import
+  unittest2,
+  eth/keys,
+  ../beacon_chain/validators/action_tracker,
+  testblockutil
+
+suite "subnet tracker":
+  let rng = keys.newRng()
+
+  test "should register stability subnets on attester duties":
+    var tracker = ActionTracker.init(rng, false)
+
+    check:
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 0
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 0
+
+    tracker.registerDuty(Slot(0), SubnetId(0), ValidatorIndex(0), true)
+
+    tracker.updateSlot(Slot(0))
+
+    check:
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 1
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 1
+      tracker.aggregateSubnets(Slot(1)).countOnes() == 0
+
+    tracker.registerDuty(Slot(1), SubnetId(1), ValidatorIndex(0), true)
+    check:
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 2
+      tracker.aggregateSubnets(Slot(1)).countOnes() == 1
+
+    # Guaranteed to expire
+    tracker.updateSlot(
+      Slot(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION * 2 * SLOTS_PER_EPOCH))
+
+    check:
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 0
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 0


### PR DESCRIPTION
* fix activation logging during startup
* cache slot signature to avoid duplicate signature work
* schedule aggregation duties one slot at a time to avoid CPU spike at
each epoch
* lower aggregation subnet pre-subscription time to 4 slots (lowers
bandwidth and CPU usage)