### PR TITLE
Fix typo in name of field in `head` SSE event in beacon node HTTP APIs

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -276,7 +276,7 @@ type
     state_root*: Eth2Digest
     epoch_transition*: bool
     previous_duty_dependent_root*: Eth2Digest
-    current_duty_depenedent_root*: Eth2Digest
+    current_duty_dependent_root*: Eth2Digest
 
   ReorgInfoObject* = object
     slot*: Slot
@@ -353,7 +353,7 @@ func init*(t: typedesc[HeadChangeInfoObject], slot: Slot, blockRoot: Eth2Digest,
     state_root: stateRoot,
     epoch_transition: epochTransition,
     previous_duty_dependent_root: previousDutyDepRoot,
-    current_duty_depenedent_root: currentDutyDepRoot
+    current_duty_dependent_root: currentDutyDepRoot
   )
 
 func init*(t: typedesc[ReorgInfoObject], slot: Slot, depth: uint64,


### PR DESCRIPTION
There was a typo in the name of this field; see the `head` event here: https://ethereum.github.io/beacon-APIs/#/Events/eventstream