### PR TITLE
enable uint128 / uint256 SSZ serialization tests

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -325,6 +325,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Overlong SSZ.decode: HashList[system.uint64, 32]                                           OK
 + Overlong SSZ.decode: List[system.uint64, 32]                                               OK
   Overlong SSZ.decode: Simple                                                                Skip
+  Overlong SSZ.decode: UInt128                                                               Skip
+  Overlong SSZ.decode: UInt256                                                               Skip
   Overlong SSZ.decode: array[0..31, byte]                                                    Skip
   Overlong SSZ.decode: bool                                                                  Skip
   Overlong SSZ.decode: limb_t                                                                Skip
@@ -337,6 +339,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Overlong readSszBytes: HashList[system.uint64, 32]                                         OK
 + Overlong readSszBytes: List[system.uint64, 32]                                             OK
   Overlong readSszBytes: Simple                                                              Skip
++ Overlong readSszBytes: UInt128                                                             OK
++ Overlong readSszBytes: UInt256                                                             OK
 + Overlong readSszBytes: array[0..31, byte]                                                  OK
 + Overlong readSszBytes: bool                                                                OK
 + Overlong readSszBytes: limb_t                                                              OK
@@ -349,6 +353,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Underlong SSZ.decode: HashList[system.uint64, 32]                                          OK
 + Underlong SSZ.decode: List[system.uint64, 32]                                              OK
 + Underlong SSZ.decode: Simple                                                               OK
++ Underlong SSZ.decode: UInt128                                                              OK
++ Underlong SSZ.decode: UInt256                                                              OK
 + Underlong SSZ.decode: array[0..31, byte]                                                   OK
 + Underlong SSZ.decode: bool                                                                 OK
 + Underlong SSZ.decode: limb_t                                                               OK
@@ -361,6 +367,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Underlong readSszBytes: HashList[system.uint64, 32]                                        OK
 + Underlong readSszBytes: List[system.uint64, 32]                                            OK
 + Underlong readSszBytes: Simple                                                             OK
++ Underlong readSszBytes: UInt128                                                            OK
++ Underlong readSszBytes: UInt256                                                            OK
 + Underlong readSszBytes: array[0..31, byte]                                                 OK
 + Underlong readSszBytes: bool                                                               OK
 + Underlong readSszBytes: limb_t                                                             OK
@@ -368,7 +376,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Underlong readSszBytes: uint32                                                             OK
 + Underlong readSszBytes: uint8                                                              OK
 ```
-OK: 36/48 Fail: 0/48 Skip: 12/48
+OK: 42/56 Fail: 0/56 Skip: 14/56
 
 ---TOTAL---
-OK: 201/213 Fail: 0/213 Skip: 12/213
+OK: 207/221 Fail: 0/221 Skip: 14/221

--- a/FixtureSSZGeneric-mainnet.md
+++ b/FixtureSSZGeneric-mainnet.md
@@ -2,8 +2,8 @@ FixtureSSZGeneric-mainnet
 ===
 ## Ethereum Foundation - SSZ generic types
 ```diff
-  Testing basic_vector inputs - invalid - skipping Vector[uint128, N] and Vector[uint256, N] Skip
-+ Testing basic_vector inputs - valid - skipping Vector[uint128, N] and Vector[uint256, N]   OK
+  Testing basic_vector inputs - invalid                                                      Skip
++ Testing basic_vector inputs - valid                                                        OK
 + Testing bitlist      inputs - invalid                                                      OK
 + Testing bitlist      inputs - valid                                                        OK
   Testing bitvector    inputs - invalid                                                      Skip
@@ -12,8 +12,8 @@ FixtureSSZGeneric-mainnet
 + Testing boolean      inputs - valid                                                        OK
 + Testing containers   inputs - invalid - skipping BitsStruct                                OK
 + Testing containers   inputs - valid - skipping BitsStruct                                  OK
-+ Testing uints        inputs - invalid - skipping uint128 and uint256                       OK
-+ Testing uints        inputs - valid - skipping uint128 and uint256                         OK
++ Testing uints        inputs - invalid                                                      OK
++ Testing uints        inputs - valid                                                        OK
 ```
 OK: 10/12 Fail: 0/12 Skip: 2/12
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -9,14 +9,13 @@ import stew/[results, base10, byteutils, endians2], presto/common,
        libp2p/peerid, serialization,
        json_serialization, json_serialization/std/[options, net],
        nimcrypto/utils as ncrutils
-import ".."/[forks, ssz_codec], ".."/datatypes/[phase0, altair, merge],
-       ".."/eth2_ssz_serialization,
-       ".."/".."/ssz/[ssz_serialization, codec, types],
+import ".."/[eth2_ssz_serialization, forks],
+       ".."/datatypes/[phase0, altair, merge],
        "."/rest_types
 
 export
   results, peerid, common, serialization, json_serialization, options, net,
-  rest_types, ssz_codec, ssz_serialization, codec, types
+  eth2_ssz_serialization, rest_types
 
 Json.createFlavor RestJson
 

--- a/beacon_chain/ssz/merkleization.nim
+++ b/beacon_chain/ssz/merkleization.nim
@@ -413,7 +413,7 @@ template merkleizeFields(totalElements: static Limit, body: untyped): Eth2Digest
   getFinalHash(merkleizer)
 
 template writeBytesLE(chunk: var array[bytesPerChunk, byte], atParam: int,
-                      val: SomeUnsignedInt) =
+                      val: UintN) =
   let at = atParam
   chunk[at ..< at + sizeof(val)] = toBytesLE(val)
 
@@ -528,7 +528,7 @@ func maxChunksCount(T: type, maxLen: Limit): Limit =
 func hashTreeRootAux[T](x: T): Eth2Digest =
   when T is bool|char:
     result.data[0] = byte(x)
-  elif T is SomeUnsignedInt:
+  elif T is UintN:
     when cpuEndian == bigEndian:
       result.data[0..<sizeof(x)] = toBytesLE(x)
     else:

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -9,20 +9,20 @@
 
 import
   std/[tables, typetraits, strformat],
-  stew/shims/macros, stew/[byteutils, bitops2, objects],
+  stew/shims/macros, stew/[byteutils, bitops2, objects], stint,
   serialization/[object_serialization, errors],
   json_serialization,
   "."/[bitseqs],
   ../spec/digest
 
-export bitseqs, json_serialization
+export stint, bitseqs, json_serialization
 
 const
   offsetSize* = 4
   bytesPerChunk* = 32
 
 type
-  UintN* = SomeUnsignedInt
+  UintN* = SomeUnsignedInt|UInt128|UInt256
   BasicType* = bool|UintN
 
   Limit* = int64

--- a/tests/ssz/test_ssz_serialization.nim
+++ b/tests/ssz/test_ssz_serialization.nim
@@ -343,6 +343,8 @@ suite "underlong values":
   testit(default(uint16))
   testit(default(uint32))
   testit(default(uint64))
+  testit(default(UInt128))
+  testit(default(UInt256))
   testit(default(array[32, uint8]))
   testit(default(HashArray[32, uint8]))
   testit(List[uint64, 32].init(@[42'u64]))


### PR DESCRIPTION
So far, SSZ tests for `uint128` and `uint256` integers were disabled
due to "compile-time issues". The code has been adjusted to support
those additional test vectors, and the corresponding tests have been
enabled.