### PR TITLE
Change concurrent dials from 10 to 20

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -226,7 +226,7 @@ const
   PeerScoreInvalidRequest* = -500
     ## This peer is sending malformed or nonsensical data
 
-  ConcurrentConnections = 10
+  ConcurrentConnections = 20
     ## Maximum number of active concurrent connection requests.
 
   SeenTableTimeTimeout =


### PR DESCRIPTION
One easy way to get peers connected quicker would be simply to dial more in parallel.
This probably would have most effect the closer after start-up, as more new peers will be discovered.

This will obviously cause more discovery requests and dials, and thus traffic related to that. However, in theory, we are searching for peers as long as our subnets are unhealthy, so it should stop/slow down eventually. Node without incoming peers might go on longer/forever.

Here's a screenshot of a few days ago, the two settings, with a node on mainnet, no incoming connections (can't test with incoming connections right now).

![Screenshot 2021-10-07 at 15-26-25 NBC local testnet sim (all nodes) 2 - Grafana](https://user-images.githubusercontent.com/7857583/136397626-71d11270-112d-45c3-9816-d9fb3af4342f.png)
