### PR TITLE
reward accounting for altair+

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -756,7 +756,7 @@ proc get*(dag: ChainDAGRef, root: Eth2Digest): Option[BlockData] =
 
 proc advanceSlots(
     dag: ChainDAGRef, state: var StateData, slot: Slot, save: bool,
-    cache: var StateCache, rewards: var RewardInfo) =
+    cache: var StateCache, info: var ForkedEpochInfo) =
   # Given a state, advance it zero or more slots by applying empty slot
   # processing - the state must be positions at a slot before or equal to the
   # target
@@ -765,7 +765,7 @@ proc advanceSlots(
     loadStateCache(dag, cache, state.blck, getStateField(state.data, slot).epoch)
 
     doAssert process_slots(
-        dag.cfg, state.data, getStateField(state.data, slot) + 1, cache, rewards,
+        dag.cfg, state.data, getStateField(state.data, slot) + 1, cache, info,
         dag.updateFlags),
       "process_slots shouldn't fail when state slot is correct"
     if save:
@@ -774,7 +774,7 @@ proc advanceSlots(
 proc applyBlock(
     dag: ChainDAGRef,
     state: var StateData, blck: BlockData, flags: UpdateFlags,
-    cache: var StateCache, rewards: var RewardInfo): bool =
+    cache: var StateCache, info: var ForkedEpochInfo): bool =
   # Apply a single block to the state - the state must be positioned at the
   # parent of the block with a slot lower than the one of the block being
   # applied
@@ -794,15 +794,15 @@ proc applyBlock(
     of BeaconBlockFork.Phase0:
       state_transition(
         dag.cfg, state.data, blck.data.phase0Block,
-        cache, rewards, flags + dag.updateFlags + {slotProcessed}, restore)
+        cache, info, flags + dag.updateFlags + {slotProcessed}, restore)
     of BeaconBlockFork.Altair:
       state_transition(
         dag.cfg, state.data, blck.data.altairBlock,
-        cache, rewards, flags + dag.updateFlags + {slotProcessed}, restore)
+        cache, info, flags + dag.updateFlags + {slotProcessed}, restore)
     of BeaconBlockFork.Merge:
       state_transition(
         dag.cfg, state.data, blck.data.mergeBlock,
-        cache, rewards, flags + dag.updateFlags + {slotProcessed}, restore)
+        cache, info, flags + dag.updateFlags + {slotProcessed}, restore)
   if ok:
     state.blck = blck.refs
 
@@ -933,7 +933,7 @@ proc updateStateData*(
     assignTick = Moment.now()
     startSlot {.used.} = getStateField(state.data, slot) # used in logs below
     startRoot {.used.} = getStateRoot(state.data)
-  var rewards: RewardInfo
+  var info: ForkedEpochInfo
   # Time to replay all the blocks between then and now
   for i in countdown(ancestors.len - 1, 0):
     # Because the ancestors are in the database, there's no need to persist them
@@ -941,11 +941,11 @@ proc updateStateData*(
     # database, we can skip certain checks that have already been performed
     # before adding the block to the database.
     let ok =
-      dag.applyBlock(state, dag.get(ancestors[i]), {}, cache, rewards)
+      dag.applyBlock(state, dag.get(ancestors[i]), {}, cache, info)
     doAssert ok, "Blocks in database should never fail to apply.."
 
   # ...and make sure to process empty slots as requested
-  dag.advanceSlots(state, bs.slot, save, cache, rewards)
+  dag.advanceSlots(state, bs.slot, save, cache, info)
 
   # ...and make sure to load the state cache, if it exists
   loadStateCache(dag, cache, state.blck, getStateField(state.data, slot).epoch)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -547,10 +547,6 @@ type
     # time of attestation.
     previous_epoch_head_attesters_raw*: Gwei
 
-  RewardInfo* = object
-    statuses*: seq[RewardStatus]
-    total_balances*: TotalBalances
-
 func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData2 =
   let cookedKey = validator.pubkey.load() # Loading the pubkey is slow!
   doAssert cookedKey.isSome,

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -242,7 +242,16 @@ type
   SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
+  EpochInfo* = object
+    ## Information about the outcome of epoch processing
+    statuses*: seq[RewardStatus]
+    total_balances*: TotalBalances
+
 chronicles.formatIt BeaconBlock: it.shortLog
+
+func clear*(info: var EpochInfo) =
+  info.statuses.setLen(0)
+  info.total_balances = TotalBalances()
 
 Json.useCustomSerialization(BeaconState.justification_bits):
   read:

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -165,19 +165,18 @@ func clear_epoch_from_cache(cache: var StateCache, epoch: Epoch) =
 proc advance_slot(
     cfg: RuntimeConfig,
     state: var SomeBeaconState, previous_slot_state_root: Eth2Digest,
-    flags: UpdateFlags, cache: var StateCache, rewards: var RewardInfo) {.nbench.} =
+    flags: UpdateFlags, cache: var StateCache, info: var ForkyEpochInfo) {.nbench.} =
   # Do the per-slot and potentially the per-epoch processing, then bump the
   # slot number - we've now arrived at the slot state on top of which a block
   # optionally can be applied.
   process_slot(state, previous_slot_state_root)
 
-  rewards.statuses.setLen(0)
-  rewards.total_balances = TotalBalances()
+  info.clear()
 
   let is_epoch_transition = (state.slot + 1).isEpoch
   if is_epoch_transition:
     # Note: Genesis epoch = 0, no need to test if before Genesis
-    process_epoch(cfg, state, flags, cache, rewards)
+    process_epoch(cfg, state, flags, cache, info)
     clear_epoch_from_cache(cache, (state.slot + 1).compute_epoch_at_slot)
 
   state.slot += 1
@@ -222,7 +221,7 @@ proc maybeUpgradeState*(
 
 proc process_slots*(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState, slot: Slot,
-    cache: var StateCache, rewards: var RewardInfo, flags: UpdateFlags): bool {.nbench.} =
+    cache: var StateCache, info: var ForkedEpochInfo, flags: UpdateFlags): bool {.nbench.} =
   if not (getStateField(state, slot) < slot):
     if slotProcessed notin flags or getStateField(state, slot) != slot:
       notice "Unusual request for a slot in the past",
@@ -234,8 +233,9 @@ proc process_slots*(
   # Update the state so its slot matches that of the block
   while getStateField(state, slot) < slot:
     withState(state):
-      advance_slot(
-        cfg, state.data, state.root, flags, cache, rewards)
+      withEpochInfo(state.data, info):
+        advance_slot(
+          cfg, state.data, state.root, flags, cache, info)
 
       if skipLastStateRootCalculation notin flags or
           state.data.slot < slot:
@@ -334,7 +334,7 @@ proc state_transition*(
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
                  altair.TrustedSignedBeaconBlock | merge.TrustedSignedBeaconBlock |
                  merge.SignedBeaconBlock,
-    cache: var StateCache, rewards: var RewardInfo, flags: UpdateFlags,
+    cache: var StateCache, info: var ForkedEpochInfo, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): bool {.nbench.} =
   ## Apply a block to the state, advancing the slot counter as necessary. The
   ## given state must be of a lower slot, or, in case the `slotProcessed` flag
@@ -352,7 +352,7 @@ proc state_transition*(
   ## object should be rolled back to a consistent state. If the transition fails
   ## before the state has been updated, `rollback` will not be called.
   if not process_slots(
-      cfg, state, signedBlock.message.slot, cache, rewards,
+      cfg, state, signedBlock.message.slot, cache, info,
       flags + {skipLastStateRootCalculation}):
     return false
   state_transition_block(
@@ -494,8 +494,8 @@ proc makeBeaconBlock*(
   # To create a block, we'll first apply a partial block to the state, skipping
   # some validations.
 
-  var blck = partialBeaconBlock(cfg, state, proposer_index, parent_root, 
-                                randao_reveal, eth1_data, graffiti, attestations, deposits, 
+  var blck = partialBeaconBlock(cfg, state, proposer_index, parent_root,
+                                randao_reveal, eth1_data, graffiti, attestations, deposits,
                                 proposerSlashings, attesterSlashings, voluntaryExits,
                                 sync_aggregate, executionPayload)
 
@@ -619,11 +619,11 @@ proc makeBeaconBlock*(
   template makeBeaconBlock(kind: untyped): Result[ForkedBeaconBlock, string] =
     # To create a block, we'll first apply a partial block to the state, skipping
     # some validations.
-  
-    var blck = 
+
+    var blck =
       ForkedBeaconBlock.init(
-        partialBeaconBlock(cfg, state.`hbs kind`, proposer_index, parent_root, 
-                           randao_reveal, eth1_data, graffiti, attestations, deposits, 
+        partialBeaconBlock(cfg, state.`hbs kind`, proposer_index, parent_root,
+                           randao_reveal, eth1_data, graffiti, attestations, deposits,
                            proposerSlashings, attesterSlashings, voluntaryExits,
                            sync_aggregate, executionPayload))
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -380,19 +380,14 @@ proc process_voluntary_exit*(
 proc process_operations(cfg: RuntimeConfig,
                         state: var SomeBeaconState,
                         body: SomeSomeBeaconBlockBody,
+                        base_reward_per_increment: Gwei,
                         flags: UpdateFlags,
                         cache: var StateCache): Result[void, cstring] {.nbench.} =
   # Verify that outstanding deposits are processed up to the maximum number of
   # deposits
-  template base_reward_per_increment(state: phase0.BeaconState): Gwei = 0.Gwei
-  template base_reward_per_increment(
-      state: altair.BeaconState | merge.BeaconState): Gwei =
-    get_base_reward_per_increment(state, cache)
-
   let
     req_deposits = min(MAX_DEPOSITS,
                        state.eth1_data.deposit_count - state.eth1_deposit_index)
-    generalized_base_reward_per_increment = base_reward_per_increment(state)
 
   if state.eth1_data.deposit_count < state.eth1_deposit_index or
       body.deposits.lenu64 != req_deposits:
@@ -403,7 +398,7 @@ proc process_operations(cfg: RuntimeConfig,
   for op in body.attester_slashings:
     ? process_attester_slashing(cfg, state, op, flags, cache)
   for op in body.attestations:
-    ? process_attestation(state, op, flags, generalized_base_reward_per_increment, cache)
+    ? process_attestation(state, op, flags, base_reward_per_increment, cache)
   for op in body.deposits:
     ? process_deposit(cfg, state, op, flags)
   for op in body.voluntary_exits:
@@ -413,7 +408,8 @@ proc process_operations(cfg: RuntimeConfig,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.6/specs/altair/beacon-chain.md#sync-committee-processing
 proc process_sync_aggregate*(
-    state: var (altair.BeaconState | merge.BeaconState), aggregate: SyncAggregate, cache: var StateCache):
+    state: var (altair.BeaconState | merge.BeaconState),
+    aggregate: SyncAggregate, total_active_balance: Gwei, cache: var StateCache):
     Result[void, cstring] {.nbench.} =
   # Verify sync committee aggregate signature signing over the previous slot
   # block root
@@ -441,11 +437,20 @@ proc process_sync_aggregate*(
 
   # Compute participant and proposer rewards
   let
-    total_active_increments = get_total_active_balance(state, cache) div EFFECTIVE_BALANCE_INCREMENT
-    total_base_rewards = get_base_reward_per_increment(state, cache) * total_active_increments
-    max_participant_rewards = total_base_rewards * SYNC_REWARD_WEIGHT div WEIGHT_DENOMINATOR div SLOTS_PER_EPOCH
+    total_active_increments =
+      total_active_balance div EFFECTIVE_BALANCE_INCREMENT
+    total_base_rewards =
+      get_base_reward_per_increment(total_active_balance) * total_active_increments
+    max_participant_rewards =
+      total_base_rewards * SYNC_REWARD_WEIGHT div WEIGHT_DENOMINATOR div SLOTS_PER_EPOCH
     participant_reward = max_participant_rewards div SYNC_COMMITTEE_SIZE
-    proposer_reward = participant_reward * PROPOSER_WEIGHT div (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
+    proposer_reward =
+      participant_reward * PROPOSER_WEIGHT div (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
+    proposer_index = get_beacon_proposer_index(state, cache)
+
+  if proposer_index.isNone:
+    # We're processing a block, so this can't happen, in theory (!)
+    return err("process_sync_aggregate: no proposer")
 
   # Apply participant and proposer rewards
 
@@ -460,19 +465,15 @@ proc process_sync_aggregate*(
 
   # TODO could use a sequtils2 zipIt
   for i in 0 ..< min(
-      state.current_sync_committee.pubkeys.len,
-      aggregate.sync_committee_bits.len):
-    let proposer_index = get_beacon_proposer_index(state, cache)
-    if proposer_index.isSome:
-      let participant_index =
-        pubkeyIndices.getOrDefault(state.current_sync_committee.pubkeys[i])
-      if aggregate.sync_committee_bits[i]:
-        increase_balance(state, participant_index, participant_reward)
-        increase_balance(state, proposer_index.get, proposer_reward)
-      else:
-        decrease_balance(state, participant_index, participant_reward)
+    state.current_sync_committee.pubkeys.len,
+    aggregate.sync_committee_bits.len):
+    let participant_index =
+      pubkeyIndices.getOrDefault(state.current_sync_committee.pubkeys[i])
+    if aggregate.sync_committee_bits[i]:
+      increase_balance(state, participant_index, participant_reward)
+      increase_balance(state, proposer_index.get, proposer_reward)
     else:
-      warn "process_sync_aggregate: get_beacon_proposer_index failed"
+      decrease_balance(state, participant_index, participant_reward)
 
   ok()
 
@@ -561,7 +562,7 @@ proc process_block*(
   ? process_block_header(state, blck, flags, cache)
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
-  ? process_operations(cfg, state, blck.body, flags, cache)
+  ? process_operations(cfg, state, blck.body, 0.Gwei, flags, cache)
 
   ok()
 
@@ -593,8 +594,16 @@ proc process_block*(
   ? process_block_header(state, blck, flags, cache)
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
-  ? process_operations(cfg, state, blck.body, flags, cache)
-  ? process_sync_aggregate(state, blck.body.sync_aggregate, cache)  # [New in Altair]
+
+  let
+    total_active_balance = get_total_active_balance(state, cache)
+    base_reward_per_increment =
+      get_base_reward_per_increment(total_active_balance)
+
+  ? process_operations(
+    cfg, state, blck.body, base_reward_per_increment, flags, cache)
+  ? process_sync_aggregate(
+    state, blck.body.sync_aggregate, total_active_balance, cache)  # [New in Altair]
 
   ok()
 
@@ -617,8 +626,15 @@ proc process_block*(
         func(_: ExecutionPayload): bool = true)
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
-  ? process_operations(cfg, state, blck.body, flags, cache)
-  ? process_sync_aggregate(state, blck.body.sync_aggregate, cache)
+
+  let
+    total_active_balance = get_total_active_balance(state, cache)
+    base_reward_per_increment =
+      get_base_reward_per_increment(total_active_balance)
+  ? process_operations(
+    cfg, state, blck.body, base_reward_per_increment, flags, cache)
+  ? process_sync_aggregate(
+    state, blck.body.sync_aggregate, total_active_balance, cache)
 
   ok()
 

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -93,9 +93,9 @@ proc doTransition(conf: NcliConf) =
 
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
   if not state_transition(getRuntimeConfig(conf.eth2Network),
-                          stateY[], blckX, cache, rewards, flags, noRollback):
+                          stateY[], blckX, cache, info, flags, noRollback):
     error "State transition failed"
     quit 1
   else:
@@ -121,13 +121,13 @@ proc doSlots(conf: NcliConf) =
 
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
   for i in 0'u64..<conf.slot:
     let isEpoch = (getStateField(stateY[], slot) + 1).isEpoch
     withTimer(timers[if isEpoch: tApplyEpochSlot else: tApplySlot]):
       doAssert process_slots(
         defaultRuntimeConfig, stateY[], getStateField(stateY[], slot) + 1,
-        cache, rewards, {})
+        cache, info, {})
 
   withTimer(timers[tSaveState]):
     saveSSZFile(conf.postState, stateY[])

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -118,10 +118,10 @@ proc nfuzz_block(input: openArray[byte], xoutput: ptr byte,
           data: data.state, root: hash_tree_root(data.state)),
         beaconStateFork: forkPhase0)
       cache = StateCache()
-      rewards = RewardInfo()
+      info = ForkedEpochInfo()
     result =
       state_transition(
-        cfg, fhState[], blck, cache, rewards, flags, rollback)
+        cfg, fhState[], blck, cache, info, flags, rollback)
     data.state = fhState.hbsPhase0.data
 
   decodeAndProcess(BlockInput):

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -8,6 +8,9 @@
 {.used.}
 
 import
+  chronicles
+
+import
   ./test_fixture_fork,
   ./test_fixture_merkle_single_proof,
   ./test_fixture_operations_attestations,

--- a/tests/consensus_spec/altair/test_fixture_operations_attestations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations_attestations.nim
@@ -44,10 +44,13 @@ proc runTest(identifier: string) =
       let
         attestation = parseTest(
           testDir/"attestation.ssz_snappy", SSZ, Attestation)
+
+        total_active_balance = get_total_active_balance(preState[], cache)
+        base_reward_per_increment =
+          get_base_reward_per_increment(total_active_balance)
+
         done = process_attestation(
-          preState[], attestation, {},
-          get_base_reward_per_increment(preState[], cache),
-          cache)
+          preState[], attestation, {}, base_reward_per_increment, cache)
 
       if existsFile(testDir/"post.ssz_snappy"):
         let postState =

--- a/tests/consensus_spec/altair/test_fixture_operations_attester_slashings.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations_attester_slashings.nim
@@ -12,6 +12,7 @@ import
   os,
   # Utilities
   stew/results,
+  chronicles,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/altair,

--- a/tests/consensus_spec/altair/test_fixture_operations_deposits.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations_deposits.nim
@@ -12,6 +12,7 @@ import
   os,
   # Utilities
   stew/results,
+  chronicles,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, presets, state_transition_block],
   ../../../beacon_chain/spec/datatypes/altair,

--- a/tests/consensus_spec/altair/test_fixture_operations_sync_aggregate.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations_sync_aggregate.nim
@@ -12,6 +12,7 @@ import
   os,
   # Utilities
   stew/results,
+  chronicles,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, state_transition_block],
   ../../../beacon_chain/spec/datatypes/altair,
@@ -19,9 +20,6 @@ import
   ../../testutil,
   ../fixtures_utils,
   ../../helpers/debug_state
-
-when isMainModule:
-  import chronicles # or some random compile error happens...
 
 const OpSyncAggregateDir = SszTestsDir/const_preset/"altair"/"operations"/"sync_aggregate"/"pyspec_tests"
 
@@ -45,8 +43,9 @@ proc runTest(dir, identifier: string) =
       let
         syncAggregate = parseTest(
           testDir/"sync_aggregate.ssz_snappy", SSZ, SyncAggregate)
+        total_active_balance = get_total_active_balance(preState[], cache)
         done = process_sync_aggregate(
-          preState[], syncAggregate, cache)
+          preState[], syncAggregate, total_active_balance, cache)
 
       if existsFile(testDir/"post.ssz_snappy"):
         let postState =

--- a/tests/consensus_spec/altair/test_fixture_operations_voluntary_exit.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations_voluntary_exit.nim
@@ -12,6 +12,7 @@ import
   os,
   # Utilities
   stew/results,
+  chronicles,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/altair,

--- a/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
@@ -36,7 +36,7 @@ proc runTest(testName, testDir, unitTestName: string) =
         fhPreState = (ref ForkedHashedBeaconState)(hbsAltair: altair.HashedBeaconState(
           data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkAltair)
         cache = StateCache()
-        rewards = RewardInfo()
+        info = ForkedEpochInfo()
 
       # In test cases with more than 10 blocks the first 10 aren't 0-prefixed,
       # so purely lexicographic sorting wouldn't sort properly.
@@ -46,12 +46,12 @@ proc runTest(testName, testDir, unitTestName: string) =
 
         if hasPostState:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert (i + 1 < numBlocks) or not success,
             "We didn't expect these invalid blocks to be processed"

--- a/tests/consensus_spec/altair/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/altair/test_fixture_sanity_slots.nim
@@ -35,13 +35,13 @@ proc runTest(identifier: string) =
             data: preState[], root: hash_tree_root(preState[])),
           beaconStateFork: forkAltair)
         cache = StateCache()
-        rewards: RewardInfo
+        info: ForkedEpochInfo
       let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, altair.BeaconState))
 
       check:
         process_slots(
           defaultRuntimeConfig, fhPreState[],
-          getStateField(fhPreState[], slot) + num_slots, cache, rewards, {})
+          getStateField(fhPreState[], slot) + num_slots, cache, info, {})
 
         getStateRoot(fhPreState[]) == postState[].hash_tree_root()
       let newPreState = newClone(fhPreState.hbsAltair.data)

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -11,6 +11,7 @@ import
   # Standard library
   os, strutils,
   # Beacon chain internals
+  chronicles,
   ../../../beacon_chain/spec/[beaconstate, presets, state_transition_epoch],
   ../../../beacon_chain/spec/datatypes/altair,
   # Test utilities
@@ -19,9 +20,10 @@ import
   ../test_fixture_rewards,
   ../../helpers/debug_state
 
+const RootDir = SszTestsDir/const_preset/"altair"/"epoch_processing"
+
 template runSuite(
-    suiteDir, testName: string, transitionProc: untyped{ident},
-    useCache, useTAB, useUPB: static bool = false): untyped =
+    suiteDir, testName: string, transitionProc: untyped): untyped =
   suite "Ethereum Foundation - Altair - Epoch Processing - " & testName & preset():
     for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
 
@@ -29,47 +31,34 @@ template runSuite(
       test testName & " - " & unitTestName & preset():
         # BeaconState objects are stored on the heap to avoid stack overflow
         type T = altair.BeaconState
-        var preState = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
+        var preState {.inject.} = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
         let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, T))
+        var cache {.inject, used.} = StateCache()
+        template state: untyped {.inject, used.} = preState[]
+        template cfg: untyped {.inject, used.} = defaultRuntimeConfig
 
-        doAssert not (useCache and useTAB)
-        when useCache:
-          var cache = StateCache()
-          when compiles(transitionProc(defaultRuntimeConfig, preState[], cache)):
-            transitionProc(defaultRuntimeConfig, preState[], cache)
-          else:
-            transitionProc(preState[], cache)
-        elif useTAB and not useUPB:
-          var cache = StateCache()
-          let total_active_balance = preState[].get_total_active_balance(cache)
-          transitionProc(preState[], total_active_balance)
-        elif useTAB and useUPB:
-          var cache = StateCache()
-          let
-            total_active_balance = preState[].get_total_active_balance(cache)
-            unslashed_participating_balances =
-              preState[].get_unslashed_participating_balances()
-          transitionProc(
-            preState[], total_active_balance, unslashed_participating_balances)
-        else:
-          when compiles(transitionProc(preState[])):
-            transitionProc(preState[])
-          else:
-            transitionProc(defaultRuntimeConfig, preState[])
+        transitionProc
+
+        check:
+          hash_tree_root(preState[]) == hash_tree_root(postState[])
 
         reportDiff(preState, postState)
 
 # Justification & Finalization
 # ---------------------------------------------------------------
 
-const JustificationFinalizationDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"justification_and_finalization"/"pyspec_tests"
-runSuite(JustificationFinalizationDir, "Justification & Finalization",  process_justification_and_finalization, useCache = false, useTAB = true, useUPB = true)
+const JustificationFinalizationDir = RootDir/"justification_and_finalization"/"pyspec_tests"
+runSuite(JustificationFinalizationDir, "Justification & Finalization"):
+  let info = altair.EpochInfo.init(state)
+  process_justification_and_finalization(state, info.balances)
 
 # Inactivity updates
 # ---------------------------------------------------------------
 
-const InactivityDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"inactivity_updates"/"pyspec_tests"
-runSuite(InactivityDir, "Inactivity", process_inactivity_updates, useCache = false)
+const InactivityDir = RootDir/"inactivity_updates"/"pyspec_tests"
+runSuite(InactivityDir, "Inactivity"):
+  let info = altair.EpochInfo.init(state)
+  process_inactivity_updates(cfg, state, info)
 
 # Rewards & Penalties
 # ---------------------------------------------------------------
@@ -79,53 +68,63 @@ runSuite(InactivityDir, "Inactivity", process_inactivity_updates, useCache = fal
 # Registry updates
 # ---------------------------------------------------------------
 
-const RegistryUpdatesDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"registry_updates"/"pyspec_tests"
-runSuite(RegistryUpdatesDir, "Registry updates",  process_registry_updates, useCache = true)
+const RegistryUpdatesDir = RootDir/"registry_updates"/"pyspec_tests"
+runSuite(RegistryUpdatesDir, "Registry updates"):
+  process_registry_updates(cfg, state, cache)
 
 # Slashings
 # ---------------------------------------------------------------
 
-const SlashingsDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"slashings"/"pyspec_tests"
-runSuite(SlashingsDir, "Slashings",  process_slashings, useCache = false, useTAB = true)
+const SlashingsDir = RootDir/"slashings"/"pyspec_tests"
+runSuite(SlashingsDir, "Slashings"):
+  let info = altair.EpochInfo.init(state)
+  process_slashings(state, info.balances.current_epoch)
 
 # Eth1 data reset
 # ---------------------------------------------------------------
 
-const Eth1DataResetDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"eth1_data_reset/"/"pyspec_tests"
-runSuite(Eth1DataResetDir, "Eth1 data reset", process_eth1_data_reset, useCache = false)
+const Eth1DataResetDir = RootDir/"eth1_data_reset/"/"pyspec_tests"
+runSuite(Eth1DataResetDir, "Eth1 data reset"):
+  process_eth1_data_reset(state)
 
 # Effective balance updates
 # ---------------------------------------------------------------
 
-const EffectiveBalanceUpdatesDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"effective_balance_updates"/"pyspec_tests"
-runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates", process_effective_balance_updates, useCache = false)
+const EffectiveBalanceUpdatesDir = RootDir/"effective_balance_updates"/"pyspec_tests"
+runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates"):
+  process_effective_balance_updates(state)
 
 # Slashings reset
 # ---------------------------------------------------------------
 
-const SlashingsResetDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"slashings_reset"/"pyspec_tests"
-runSuite(SlashingsResetDir, "Slashings reset", process_slashings_reset, useCache = false)
+const SlashingsResetDir = RootDir/"slashings_reset"/"pyspec_tests"
+runSuite(SlashingsResetDir, "Slashings reset"):
+  process_slashings_reset(state)
 
 # RANDAO mixes reset
 # ---------------------------------------------------------------
 
-const RandaoMixesResetDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"randao_mixes_reset"/"pyspec_tests"
-runSuite(RandaoMixesResetDir, "RANDAO mixes reset", process_randao_mixes_reset, useCache = false)
+const RandaoMixesResetDir = RootDir/"randao_mixes_reset"/"pyspec_tests"
+runSuite(RandaoMixesResetDir, "RANDAO mixes reset"):
+  process_randao_mixes_reset(state)
 
 # Historical roots update
 # ---------------------------------------------------------------
 
-const HistoricalRootsUpdateDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"historical_roots_update"/"pyspec_tests"
-runSuite(HistoricalRootsUpdateDir, "Historical roots update", process_historical_roots_update, useCache = false)
+const HistoricalRootsUpdateDir = RootDir/"historical_roots_update"/"pyspec_tests"
+runSuite(HistoricalRootsUpdateDir, "Historical roots update"):
+  process_historical_roots_update(state)
 
 # Participation flag updates
 # ---------------------------------------------------------------
 
-const ParticipationFlagDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"participation_flag_updates"/"pyspec_tests"
-runSuite(ParticipationFlagDir, "Participation flag updates", process_participation_flag_updates, useCache = false)
+const ParticipationFlagDir = RootDir/"participation_flag_updates"/"pyspec_tests"
+runSuite(ParticipationFlagDir, "Participation flag updates"):
+  process_participation_flag_updates(state)
 
 # Sync committee updates
 # ---------------------------------------------------------------
 
-const SyncCommitteeDir = SszTestsDir/const_preset/"altair"/"epoch_processing"/"sync_committee_updates"/"pyspec_tests"
-runSuite(SyncCommitteeDir, "Sync committee updates", process_sync_committee_updates, useCache = false)
+const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
+runSuite(SyncCommitteeDir, "Sync committee updates"):
+  process_sync_committee_updates(state)

--- a/tests/consensus_spec/altair/test_fixture_transition.nim
+++ b/tests/consensus_spec/altair/test_fixture_transition.nim
@@ -12,6 +12,7 @@ import
   # Standard library
   os, sequtils,
   # Status internal
+  chronicles,
   faststreams, streams,
   # Beacon chain internals
   ../../../beacon_chain/spec/[state_transition, forks, helpers],
@@ -45,7 +46,7 @@ proc runTest(testName, testDir, unitTestName: string) =
         fhPreState = (ref ForkedHashedBeaconState)(hbsPhase0: phase0.HashedBeaconState(
           data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkPhase0)
         cache = StateCache()
-        rewards = RewardInfo()
+        info = ForkedEpochInfo()
         cfg = defaultRuntimeConfig
       cfg.ALTAIR_FORK_EPOCH = transitionEpoch.fork_epoch.Epoch
 
@@ -58,16 +59,14 @@ proc runTest(testName, testDir, unitTestName: string) =
           let blck = parseTest(testPath/"blocks_" & $i & ".ssz_snappy", SSZ, phase0.SignedBeaconBlock)
 
           let success = state_transition(
-            cfg, fhPreState[], blck,
-            cache, rewards,
+            cfg, fhPreState[], blck, cache, info,
             flags = {skipStateRootValidation}, noRollback)
           doAssert success, "Failure when applying block " & $i
         else:
           let blck = parseTest(testPath/"blocks_" & $i & ".ssz_snappy", SSZ, altair.SignedBeaconBlock)
 
           let success = state_transition(
-            cfg, fhPreState[], blck,
-            cache, rewards,
+            cfg, fhPreState[], blck, cache, info,
             flags = {skipStateRootValidation}, noRollback)
           doAssert success, "Failure when applying block " & $i
 

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -9,9 +9,8 @@ import
   # Standard library
   std/[os, strutils, typetraits],
   # Internals
-  ../../beacon_chain/spec/datatypes/[phase0, altair],
   ../../beacon_chain/spec/[
-    eth2_merkleization, eth2_ssz_serialization, state_transition_epoch],
+    eth2_merkleization, eth2_ssz_serialization],
   # Status libs,
   snappy,
   stew/byteutils
@@ -72,18 +71,3 @@ proc parseTest*(path: string, Format: typedesc[SSZ], T: typedesc): T =
     stderr.write $Format & " load issue for file \"", path, "\"\n"
     stderr.write err.formatMsg(path), "\n"
     quit 1
-
-proc process_justification_and_finalization*(state: var phase0.BeaconState) =
-  var cache = StateCache()
-
-  var rewards: RewardInfo
-  rewards.init(state)
-  rewards.process_attestations(state, cache)
-  process_justification_and_finalization(state, rewards.total_balances)
-
-func process_slashings*(state: var phase0.BeaconState) =
-  var cache = StateCache()
-  var rewards: RewardInfo
-  rewards.init(state)
-  rewards.process_attestations(state, cache)
-  process_slashings(state, rewards.total_balances.current_epoch)

--- a/tests/consensus_spec/merge/test_fixture_operations_attestations.nim
+++ b/tests/consensus_spec/merge/test_fixture_operations_attestations.nim
@@ -45,8 +45,8 @@ proc runTest(identifier: string) =
         attestation = parseTest(
           testDir/"attestation.ssz_snappy", SSZ, Attestation)
         done = process_attestation(
-          preState[], attestation, {},
-          get_base_reward_per_increment(preState[], cache), cache)
+          preState[], attestation, {}, get_base_reward_per_increment(
+            get_total_active_balance(preState[], cache)), cache)
 
       if existsFile(testDir/"post.ssz_snappy"):
         let postState =

--- a/tests/consensus_spec/merge/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/merge/test_fixture_sanity_blocks.nim
@@ -36,7 +36,7 @@ proc runTest(testName, testDir, unitTestName: string) =
         fhPreState = (ref ForkedHashedBeaconState)(hbsMerge: merge.HashedBeaconState(
           data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkMerge)
         cache = StateCache()
-        rewards = RewardInfo()
+        info = ForkedEpochInfo()
 
       # In test cases with more than 10 blocks the first 10 aren't 0-prefixed,
       # so purely lexicographic sorting wouldn't sort properly.
@@ -48,12 +48,12 @@ proc runTest(testName, testDir, unitTestName: string) =
 
         if hasPostState:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert (i + 1 < numBlocks) or not success,
             "We didn't expect these invalid blocks to be processed"

--- a/tests/consensus_spec/merge/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/merge/test_fixture_sanity_slots.nim
@@ -35,13 +35,13 @@ proc runTest(identifier: string) =
             data: preState[], root: hash_tree_root(preState[])),
           beaconStateFork: forkMerge)
         cache = StateCache()
-        rewards: RewardInfo
+        info = ForkedEpochInfo()
       let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, merge.BeaconState))
 
       check:
         process_slots(
           defaultRuntimeConfig, fhPreState[],
-          getStateField(fhPreState[], slot) + num_slots, cache, rewards, {})
+          getStateField(fhPreState[], slot) + num_slots, cache, info, {})
 
         getStateRoot(fhPreState[]) == postState[].hash_tree_root()
       let newPreState = newClone(fhPreState.hbsMerge.data)

--- a/tests/consensus_spec/phase0/test_fixture_operations_attestations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations_attestations.nim
@@ -11,6 +11,7 @@ import
   # Standard library
   os,
   # Utilities
+  chronicles,
   unittest2,
   stew/results,
   # Beacon chain internals

--- a/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
@@ -36,7 +36,7 @@ proc runTest(testName, testDir, unitTestName: string) =
         fhPreState = (ref ForkedHashedBeaconState)(hbsPhase0: phase0.HashedBeaconState(
           data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkPhase0)
         cache = StateCache()
-        rewards = RewardInfo()
+        info = ForkedEpochInfo()
 
       # In test cases with more than 10 blocks the first 10 aren't 0-prefixed,
       # so purely lexicographic sorting wouldn't sort properly.
@@ -46,12 +46,12 @@ proc runTest(testName, testDir, unitTestName: string) =
 
         if hasPostState:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert success, "Failure when applying block " & $i
         else:
           let success = state_transition(
-            defaultRuntimeConfig, fhPreState[], blck, cache, rewards, flags = {},
+            defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
             noRollback)
           doAssert (i + 1 < numBlocks) or not success,
             "We didn't expect these invalid blocks to be processed"

--- a/tests/consensus_spec/phase0/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/phase0/test_fixture_sanity_slots.nim
@@ -32,14 +32,14 @@ proc runTest(identifier: string) =
         fhPreState = (ref ForkedHashedBeaconState)(hbsPhase0: phase0.HashedBeaconState(
           data: preState[], root: hash_tree_root(preState[])), beaconStateFork: forkPhase0)
         cache = StateCache()
-        rewards: RewardInfo
+        info: ForkedEpochInfo
       let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, phase0.BeaconState))
 
       check:
         process_slots(
           defaultRuntimeConfig,
           fhPreState[], getStateField(fhPreState[], slot) + num_slots, cache,
-          rewards, {})
+          info, {})
 
         getStateRoot(fhPreState[]) == postState[].hash_tree_root()
       let newPreState = newClone(fhPreState.hbsPhase0.data)

--- a/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
@@ -11,6 +11,7 @@ import
   # Standard library
   os, strutils,
   # Beacon chain internals
+  chronicles,
   ../../../beacon_chain/spec/state_transition_epoch,
   ../../../beacon_chain/spec/datatypes/phase0,
   # Test utilities
@@ -19,7 +20,9 @@ import
   ../test_fixture_rewards,
   ../../helpers/debug_state
 
-template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, useCache: static bool): untyped =
+const RootDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"
+
+template runSuite(suiteDir, testName: string, transitionProc: untyped): untyped =
   suite "Ethereum Foundation - Phase 0 - Epoch Processing - " & testName & preset():
     for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
 
@@ -27,23 +30,28 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped{ident}, us
       test testName & " - " & unitTestName & preset():
         # BeaconState objects are stored on the heap to avoid stack overflow
         type T = phase0.BeaconState
-        var preState = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
+        var preState {.inject.} = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
         let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, T))
-        var cache {.used.}: StateCache
-        when compiles(transitionProc(defaultRuntimeConfig, preState[], cache)):
-          transitionProc(defaultRuntimeConfig, preState[], cache)
-        elif compiles(transitionProc(preState[], cache)):
-          transitionProc(preState[], cache)
-        else:
-          transitionProc(preState[])
+        var cache {.inject, used.} = StateCache()
+        var info {.inject.}: EpochInfo
+        template state: untyped {.inject, used.} = preState[]
+        template cfg: untyped {.inject, used.} = defaultRuntimeConfig
+        init(info, preState[])
+
+        transitionProc
+
+        check:
+          hash_tree_root(preState[]) == hash_tree_root(postState[])
 
         reportDiff(preState, postState)
 
 # Justification & Finalization
 # ---------------------------------------------------------------
 
-const JustificationFinalizationDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"justification_and_finalization"/"pyspec_tests"
-runSuite(JustificationFinalizationDir, "Justification & Finalization",  process_justification_and_finalization, useCache = false)
+const JustificationFinalizationDir = RootDir/"justification_and_finalization"/"pyspec_tests"
+runSuite(JustificationFinalizationDir, "Justification & Finalization"):
+  info.process_attestations(state, cache)
+  process_justification_and_finalization(state, info.total_balances)
 
 # Rewards & Penalties
 # ---------------------------------------------------------------
@@ -53,32 +61,41 @@ runSuite(JustificationFinalizationDir, "Justification & Finalization",  process_
 # Registry updates
 # ---------------------------------------------------------------
 
-const RegistryUpdatesDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"registry_updates"/"pyspec_tests"
-runSuite(RegistryUpdatesDir, "Registry updates",  process_registry_updates, useCache = true)
+const RegistryUpdatesDir = RootDir/"registry_updates"/"pyspec_tests"
+runSuite(RegistryUpdatesDir, "Registry updates"):
+  process_registry_updates(cfg, state, cache)
 
 # Slashings
 # ---------------------------------------------------------------
 
-const SlashingsDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"slashings"/"pyspec_tests"
-runSuite(SlashingsDir, "Slashings",  process_slashings, useCache = false)
+const SlashingsDir = RootDir/"slashings"/"pyspec_tests"
+runSuite(SlashingsDir, "Slashings"):
+  info.process_attestations(state, cache)
+  process_slashings(state, info.total_balances.current_epoch)
 
 # Final updates
 # ---------------------------------------------------------------
 
-const Eth1DataResetDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"eth1_data_reset/"/"pyspec_tests"
-runSuite(Eth1DataResetDir, "Eth1 data reset", process_eth1_data_reset, useCache = false)
+const Eth1DataResetDir = RootDir/"eth1_data_reset/"/"pyspec_tests"
+runSuite(Eth1DataResetDir, "Eth1 data reset"):
+  process_eth1_data_reset(state)
 
-const EffectiveBalanceUpdatesDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"effective_balance_updates"/"pyspec_tests"
-runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates", process_effective_balance_updates, useCache = false)
+const EffectiveBalanceUpdatesDir = RootDir/"effective_balance_updates"/"pyspec_tests"
+runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates"):
+  process_effective_balance_updates(state)
 
-const SlashingsResetDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"slashings_reset"/"pyspec_tests"
-runSuite(SlashingsResetDir, "Slashings reset", process_slashings_reset, useCache = false)
+const SlashingsResetDir = RootDir/"slashings_reset"/"pyspec_tests"
+runSuite(SlashingsResetDir, "Slashings reset"):
+  process_slashings_reset(state)
 
-const RandaoMixesResetDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"randao_mixes_reset"/"pyspec_tests"
-runSuite(RandaoMixesResetDir, "RANDAO mixes reset", process_randao_mixes_reset, useCache = false)
+const RandaoMixesResetDir = RootDir/"randao_mixes_reset"/"pyspec_tests"
+runSuite(RandaoMixesResetDir, "RANDAO mixes reset"):
+  process_randao_mixes_reset(state)
 
-const HistoricalRootsUpdateDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"historical_roots_update"/"pyspec_tests"
-runSuite(HistoricalRootsUpdateDir, "Historical roots update", process_historical_roots_update, useCache = false)
+const HistoricalRootsUpdateDir = RootDir/"historical_roots_update"/"pyspec_tests"
+runSuite(HistoricalRootsUpdateDir, "Historical roots update"):
+  process_historical_roots_update(state)
 
-const ParticipationRecordsDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"/"participation_record_updates"/"pyspec_tests"
-runSuite(ParticipationRecordsDir, "Participation record updates", process_participation_record_updates, useCache = false)
+const ParticipationRecordsDir = RootDir/"participation_record_updates"/"pyspec_tests"
+runSuite(ParticipationRecordsDir, "Participation record updates"):
+  process_participation_record_updates(state)

--- a/tests/consensus_spec/test_fixture_rewards.nim
+++ b/tests/consensus_spec/test_fixture_rewards.nim
@@ -13,8 +13,8 @@ import
   # Utilities
   stew/results,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/phase0,
   ../../beacon_chain/spec/[validator, helpers, state_transition_epoch],
+  ../../beacon_chain/spec/datatypes/phase0,
   # Test utilities
   ../testutil,
   ./fixtures_utils
@@ -60,13 +60,13 @@ proc runTest(rewardsDir, identifier: string) =
           parseTest(testDir/"inactivity_penalty_deltas.ssz_snappy", SSZ, Deltas)
 
       var
-        rewards = RewardInfo()
+        info: phase0.EpochInfo
         finality_delay = (state[].get_previous_epoch() - state[].finalized_checkpoint.epoch)
 
-      rewards.init(state[])
-      rewards.process_attestations(state[], cache)
+      info.init(state[])
+      info.process_attestations(state[], cache)
       let
-        total_balance = rewards.total_balances.current_epoch
+        total_balance = info.total_balances.current_epoch
         total_balance_sqrt = integer_squareroot(total_balance)
 
       var
@@ -76,7 +76,7 @@ proc runTest(rewardsDir, identifier: string) =
         inclusionDelayDeltas2 = Deltas.init(state[].validators.len)
         inactivityPenaltyDeltas2 = Deltas.init(state[].validators.len)
 
-      for index, validator in rewards.statuses.mpairs():
+      for index, validator in info.statuses.mpairs():
         if not is_eligible_validator(validator):
           continue
 
@@ -85,11 +85,11 @@ proc runTest(rewardsDir, identifier: string) =
             state[], index.ValidatorIndex, total_balance_sqrt)
 
         sourceDeltas2.add(index, get_source_delta(
-          validator, base_reward, rewards.total_balances, finality_delay))
+          validator, base_reward, info.total_balances, finality_delay))
         targetDeltas2.add(index, get_target_delta(
-          validator, base_reward, rewards.total_balances, finality_delay))
+          validator, base_reward, info.total_balances, finality_delay))
         headDeltas2.add(index, get_head_delta(
-          validator, base_reward, rewards.total_balances, finality_delay))
+          validator, base_reward, info.total_balances, finality_delay))
 
         let
           (inclusion_delay_delta, proposer_delta) =

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -88,8 +88,8 @@ proc mockBlock*(
     cache = StateCache()
     tmpState = assignClone(state)
   if getStateField(state, slot) != slot:
-    var rewards = RewardInfo()
-    doAssert process_slots(cfg, tmpState[], slot, cache, rewards, flags = {})
+    var info = ForkedEpochInfo()
+    doAssert process_slots(cfg, tmpState[], slot, cache, info, flags = {})
 
   result.kind = case tmpState[].beaconStateFork
                 of forkPhase0: BeaconBlockFork.Phase0

--- a/tests/mocking/mock_state.nim
+++ b/tests/mocking/mock_state.nim
@@ -17,17 +17,17 @@ proc nextEpoch*(state: var ForkedHashedBeaconState) =
   ## Transition to the start of the next epoch
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
   let slot =
     getStateField(state, slot) + SLOTS_PER_EPOCH -
       (getStateField(state, slot) mod SLOTS_PER_EPOCH)
-  doAssert process_slots(defaultRuntimeConfig, state, slot, cache, rewards, {})
+  doAssert process_slots(defaultRuntimeConfig, state, slot, cache, info, {})
 
 proc nextSlot*(state: var ForkedHashedBeaconState) =
   ## Transition to the next slot
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
 
   doAssert process_slots(
-    defaultRuntimeConfig, state, getStateField(state, slot) + 1, cache, rewards, {})
+    defaultRuntimeConfig, state, getStateField(state, slot) + 1, cache, info, {})

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -9,19 +9,19 @@ import
   # Specs
   ../../beacon_chain/spec/[
     forks, presets, state_transition, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/base
+  ../../beacon_chain/spec/datatypes/phase0
 
 proc processSlotsUntilEndCurrentEpoch(state: var ForkedHashedBeaconState) =
   # Process all slots until the end of the last slot of the current epoch
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
   let slot =
     getStateField(state, slot) + SLOTS_PER_EPOCH -
       (getStateField(state, slot) mod SLOTS_PER_EPOCH)
 
   # Transition to slot before the epoch state transition
-  discard process_slots(defaultRuntimeConfig, state, slot - 1, cache, rewards, {})
+  discard process_slots(defaultRuntimeConfig, state, slot - 1, cache, info, {})
 
   # For the last slot of the epoch,
   # only process_slot without process_epoch
@@ -34,9 +34,9 @@ proc transitionEpochUntilJustificationFinalization*(state: var ForkedHashedBeaco
 
   var
     cache = StateCache()
-    rewards = RewardInfo()
+    info: phase0.EpochInfo
 
-  rewards.init(state.hbsPhase0.data)
-  rewards.process_attestations(state.hbsPhase0.data, cache)
+  info.init(state.hbsPhase0.data)
+  info.process_attestations(state.hbsPhase0.data, cache)
   process_justification_and_finalization(
-    state.hbsPhase0.data, rewards.total_balances)
+    state.hbsPhase0.data, info.total_balances)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -65,11 +65,11 @@ suite "Attestation pool processing" & preset():
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()
-      rewards: RewardInfo
+      info = ForkedEpochInfo()
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:
       process_slots(
-        dag.cfg, state.data, getStateField(state.data, slot) + 1, cache, rewards,
+        dag.cfg, state.data, getStateField(state.data, slot) + 1, cache, info,
         {})
 
   test "Can add and retrieve simple attestations" & preset():
@@ -102,7 +102,7 @@ suite "Attestation pool processing" & preset():
       process_slots(
         defaultRuntimeConfig, state.data,
         getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
-        rewards, {})
+        info, {})
 
     let attestations = pool[].getAttestationsForBlock(state.data, cache)
 
@@ -122,7 +122,7 @@ suite "Attestation pool processing" & preset():
       process_slots(
         defaultRuntimeConfig, state.data,
         getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
-        rewards, {})
+        info, {})
 
     check:
       # shouldn't include already-included attestations
@@ -200,7 +200,7 @@ suite "Attestation pool processing" & preset():
       process_slots(
         defaultRuntimeConfig, state.data,
         getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
-        rewards, {})
+        info, {})
 
     check:
       pool[].getAttestationsForBlock(state.data, cache).len() == 2
@@ -247,7 +247,7 @@ suite "Attestation pool processing" & preset():
       check:
         process_slots(
           defaultRuntimeConfig, state.data,
-          getStateField(state.data, slot) + 1, cache, rewards, {})
+          getStateField(state.data, slot) + 1, cache, info, {})
 
     doAssert attestations.uint64 > MAX_ATTESTATIONS,
       "6*SLOTS_PER_EPOCH validators > 128 mainnet MAX_ATTESTATIONS"
@@ -269,7 +269,7 @@ suite "Attestation pool processing" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, state.data, getStateField(state.data, slot) + 1,
-        cache, rewards, {})
+        cache, info, {})
 
     let
       bc1 = get_beacon_committee(state[].data,
@@ -284,7 +284,7 @@ suite "Attestation pool processing" & preset():
 
     discard process_slots(
       defaultRuntimeConfig, state.data,
-      MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, rewards, {})
+      MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {})
 
     let attestations = pool[].getAttestationsForBlock(state.data, cache)
 
@@ -310,7 +310,7 @@ suite "Attestation pool processing" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, state.data,
-        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, rewards, {})
+        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {})
 
     let attestations = pool[].getAttestationsForBlock(state.data, cache)
 
@@ -339,7 +339,7 @@ suite "Attestation pool processing" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, state.data,
-        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, rewards, {})
+        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {})
 
     let attestations = pool[].getAttestationsForBlock(state.data, cache)
 
@@ -367,7 +367,7 @@ suite "Attestation pool processing" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, state.data,
-        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, rewards, {})
+        MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {})
 
     let attestations = pool[].getAttestationsForBlock(state.data, cache)
 

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -125,7 +125,7 @@ suite "Block pool processing" & preset():
       nilPhase0Callback: OnPhase0BlockAdded
       state = newClone(dag.headState.data)
       cache = StateCache()
-      rewards = RewardInfo()
+      info = ForkedEpochInfo()
       att0 = makeFullAttestations(state[], dag.tail.root, 0.Slot, cache)
       b1 = addTestBlock(state[], dag.tail.root, cache, attestations = att0).phase0Block
       b2 = addTestBlock(state[], b1.root, cache).phase0Block
@@ -178,7 +178,7 @@ suite "Block pool processing" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, state[], getStateField(state[], slot) + 1, cache,
-        rewards, {})
+        info, {})
 
     let
       b4 = addTestBlock(state[], b2.root, cache).phase0Block
@@ -352,7 +352,7 @@ suite "chain DAG finalization tests" & preset():
       quarantine = QuarantineRef.init(keys.newRng(), taskpool)
       nilPhase0Callback: OnPhase0BlockAdded
       cache = StateCache()
-      rewards = RewardInfo()
+      info = ForkedEpochInfo()
 
   test "prune heads on finalization" & preset():
     # Create a fork that will not be taken
@@ -363,7 +363,7 @@ suite "chain DAG finalization tests" & preset():
       process_slots(
         defaultRuntimeConfig, tmpState[],
         getStateField(tmpState[], slot) + (5 * SLOTS_PER_EPOCH).uint64,
-        cache, rewards, {})
+        cache, info, {})
 
     let lateBlock = addTestBlock(tmpState[], dag.head.root, cache).phase0Block
     block:
@@ -466,7 +466,7 @@ suite "chain DAG finalization tests" & preset():
 
     doAssert process_slots(
       defaultRuntimeConfig, prestate[], getStateField(prestate[], slot) + 1,
-      cache, rewards, {})
+      cache, info, {})
 
     # create another block, orphaning the head
     let blck = makeTestBlock(prestate[], dag.head.parent.root, cache).phase0Block
@@ -495,7 +495,7 @@ suite "chain DAG finalization tests" & preset():
     check:
       process_slots(
         defaultRuntimeConfig, dag.headState.data, Slot(SLOTS_PER_EPOCH * 6 + 2),
-        cache, rewards, {})
+        cache, info, {})
 
     var blck = makeTestBlock(
       dag.headState.data, dag.head.root, cache,
@@ -586,7 +586,7 @@ suite "Diverging hardforks":
       nilPhase0Callback: OnPhase0BlockAdded
       state = newClone(dag.headState.data)
       cache = StateCache()
-      rewards = RewardInfo()
+      info = ForkedEpochInfo()
       blck = makeTestBlock(dag.headState.data, dag.head.root, cache)
       tmpState = assignClone(dag.headState.data)
 
@@ -595,7 +595,7 @@ suite "Diverging hardforks":
       process_slots(
         phase0RuntimeConfig, tmpState[],
         getStateField(tmpState[], slot) + (3 * SLOTS_PER_EPOCH).uint64,
-        cache, rewards, {})
+        cache, info, {})
 
     # Because the first block is after the Altair transition, the only block in
     # common is the tail block
@@ -614,7 +614,7 @@ suite "Diverging hardforks":
       process_slots(
         phase0RuntimeConfig, tmpState[],
         getStateField(tmpState[], slot) + SLOTS_PER_EPOCH.uint64,
-        cache, rewards, {})
+        cache, info, {})
 
     # There's a block in the shared-correct phase0 hardfork, before epoch 2
     var
@@ -626,7 +626,7 @@ suite "Diverging hardforks":
       process_slots(
         phase0RuntimeConfig, tmpState[],
         getStateField(tmpState[], slot) + (3 * SLOTS_PER_EPOCH).uint64,
-        cache, rewards, {})
+        cache, info, {})
 
     var
       b2 = addTestBlock(tmpState[], b1.root, cache).phase0Block

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -42,13 +42,13 @@ suite "Gossip validation " & preset():
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()
-      rewards = RewardInfo()
+      info = ForkedEpochInfo()
       batchCrypto = BatchCrypto.new(keys.newRng(), eager = proc(): bool = false, taskpool)
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:
       process_slots(
         defaultRuntimeConfig, state.data, getStateField(state.data, slot) + 1,
-        cache, rewards, {})
+        cache, info, {})
 
   test "Any committee index is valid":
     template committee(idx: uint64): untyped =

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -11,7 +11,7 @@ import
   # Status libraries
   stew/bitops2,
   # Beacon chain internals
-  ../beacon_chain/spec/[helpers, state_transition],
+  ../beacon_chain/spec/[forks, helpers, state_transition],
   # Test utilities
   ./unittest2, mocking/mock_genesis
 
@@ -29,9 +29,9 @@ suite "Spec helpers":
     var
       forked = newClone(initGenesisState())
       cache = StateCache()
-      rewards = RewardInfo()
-    doAssert process_slots(defaultRuntimeConfig, forked[], 
-                           Slot(100), cache, rewards, flags = {})
+      info = ForkedEpochInfo()
+    doAssert process_slots(defaultRuntimeConfig, forked[],
+                           Slot(100), cache, info, flags = {})
 
     let
       state = forked[].hbsPhase0.data
@@ -46,10 +46,10 @@ suite "Spec helpers":
         let depth = log2trunc(i)
         var proof = newSeq[Eth2Digest](depth)
         build_proof(state, i, proof)
-        check: is_valid_merkle_branch(hash_tree_root(fieldVar), proof, 
+        check: is_valid_merkle_branch(hash_tree_root(fieldVar), proof,
                                       depth, get_subtree_index(i), root)
         when fieldVar is object and not (fieldVar is Eth2Digest):
-          let 
+          let
             numChildLeaves = fieldVar.numLeaves
             childDepth = log2trunc(numChildLeaves)
           process(fieldVar, i shl childDepth)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -15,7 +15,7 @@ import
 type
   MockPrivKeysT = object
   MockPubKeysT = object
-const 
+const
   MockPrivKeys* = MockPrivKeysT()
   MockPubKeys* = MockPubKeysT()
 
@@ -36,8 +36,8 @@ func makeFakeHash*(i: int): Eth2Digest =
   copyMem(addr result.data[0], addr bytes[0], sizeof(bytes))
 
 func makeDeposit*(
-    i: int, 
-    flags: UpdateFlags = {}, 
+    i: int,
+    flags: UpdateFlags = {},
     cfg = defaultRuntimeConfig): DepositData =
   let
     privkey = MockPrivKeys[i.ValidatorIndex]
@@ -84,9 +84,9 @@ proc addTestBlock*(
     cfg = defaultRuntimeConfig): ForkedSignedBeaconBlock =
   # Create and add a block to state - state will advance by one slot!
   if nextSlot:
-    var rewards: RewardInfo
+    var info = ForkedEpochInfo()
     doAssert process_slots(
-      cfg, state, getStateField(state, slot) + 1, cache, rewards, flags)
+      cfg, state, getStateField(state, slot) + 1, cache, info, flags)
 
   let
     proposer_index = get_beacon_proposer_index(
@@ -101,7 +101,7 @@ proc addTestBlock*(
       else:
         ValidatorSig()
 
-  let 
+  let
     message = makeBeaconBlock(
       cfg,
       state,

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -60,7 +60,7 @@ proc getTestStates*(
   var
     tmpState = assignClone(initialState)
     cache = StateCache()
-    rewards = RewardInfo()
+    info = ForkedEpochInfo()
     cfg = defaultRuntimeConfig
 
   if stateFork in [forkAltair, forkMerge]:
@@ -73,7 +73,7 @@ proc getTestStates*(
     let slot = epoch.Epoch.compute_start_slot_at_epoch
     if getStateField(tmpState[], slot) < slot:
       doAssert process_slots(
-        cfg, tmpState[], slot, cache, rewards, {})
+        cfg, tmpState[], slot, cache, info, {})
 
     if i mod 3 == 0:
       withState(tmpState[]):


### PR DESCRIPTION
Similar to the existing `RewardInfo`, this PR adds the infrastructure
needed to export epoch processing information from altair+. Because
accounting is done somewhat differently, the PR uses a fork-specific
object to extrct the information in order to make the cost on the spec
side low.

* RewardInfo -> EpochInfo, ForkedEpochInfo
* use array for computing new sync committee
* avoid repeated total active balance computations in block processing
* simplify proposer index check
* simplify epoch transition tests
* pre-compute base increment and reuse in epoch processing, and a few
other small optimizations

This PR introduces the type and does the heavy lifting in terms of
refactoring - the tools that use the accounting will need separate PR:s
(as well as refinements to the exportred information)