### PR TITLE
add drop and sync committee metrics

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -148,8 +148,7 @@ proc addResolvedBlock(
                      merge.TrustedSignedBeaconBlock,
        parent: BlockRef, cache: var StateCache,
        onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnMergeBlockAdded,
-       stateDataDur, sigVerifyDur,
-       stateVerifyDur: Duration
+       stateDataDur, sigVerifyDur, stateVerifyDur: Duration
      ) =
   doAssert getStateField(state.data, slot) == trustedBlock.message.slot,
     "state must match block"

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -108,8 +108,8 @@ proc addBlock*(
     validationDur = Duration()) =
   ## Enqueue a Gossip-validated block for consensus verification
   # Backpressure:
-  #   There is no backpressure here - producers must wait for the future in the
-  #   BlockEntry to constrain their own processing
+  #   There is no backpressure here - producers must wait for `resfut` to
+  #   constrain their own processing
   # Producers:
   # - Gossip (when synced)
   # - SyncManager (during sync)
@@ -144,11 +144,11 @@ proc dumpBlock*[T](
     else:
       discard
 
-proc storeBlock(
+proc storeBlock*(
     self: var BlockProcessor,
     signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
                  merge.SignedBeaconBlock,
-    wallSlot: Slot): Result[void, BlockError] =
+    wallSlot: Slot): Result[BlockRef, BlockError] =
   let
     attestationPool = self.consensusManager.attestationPool
 
@@ -167,7 +167,7 @@ proc storeBlock(
   # was pruned from the ForkChoice.
   if blck.isErr:
     return err(blck.error[1])
-  ok()
+  ok(blck.get())
 
 # Event Loop
 # ------------------------------------------------------------------------------

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -406,7 +406,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
                          "Beacon node is currently syncing, try again later.")
     let head = node.dag.head
     if head.slot >= blck.message.slot:
-      node.network.broadcastBeaconBlock(ForkedSignedBeaconBlock.init(blck))
+      node.network.broadcastBeaconBlock(blck)
       # The block failed validation, but was successfully broadcast anyway.
       # It was not integrated into the beacon node's database.
       return 202
@@ -415,7 +415,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         node, head, AttachedValidator(),
         ForkedSignedBeaconBlock.init(blck))
       if res == head:
-        node.network.broadcastBeaconBlock(ForkedSignedBeaconBlock.init(blck))
+        node.network.broadcastBeaconBlock(blck)
         # The block failed validation, but was successfully broadcast anyway.
         # It was not integrated into the beacon node''s database.
         return 202

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -514,7 +514,23 @@ func init*(T: type SyncAggregate): SyncAggregate =
 func shortLog*(v: SyncAggregate): auto =
   $(v.sync_committee_bits)
 
+func shortLog*(v: ContributionAndProof): auto =
+  (
+    aggregator_index: v.aggregator_index,
+    contribution: shortLog(v.contribution),
+    selection_proof: shortLog(v.selection_proof)
+  )
+
+func shortLog*(v: SignedContributionAndProof): auto =
+  (
+    message: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )
+
 chronicles.formatIt SyncCommitteeMessage: shortLog(it)
+chronicles.formatIt SyncCommitteeContribution: shortLog(it)
+chronicles.formatIt ContributionAndProof: shortLog(it)
+chronicles.formatIt SignedContributionAndProof: shortLog(it)
 
 template hash*(x: LightClientUpdate): Hash =
   hash(x.header)


### PR DESCRIPTION
* use storeBlock for processing API blocks
* avoid double block dump
* count all gossip metrics at the same spot
* simplify block broadcast