### PR TITLE
fix `markleizer` typo (-> `merkleizer`)

### DIFF
--- a/beacon_chain/ssz/merkleization.nim
+++ b/beacon_chain/ssz/merkleization.nim
@@ -545,8 +545,8 @@ func hashTreeRootAux[T](x: T): Eth2Digest =
           pos += sizeof(E)
     else:
       trs "FIXED TYPE; USE CHUNK STREAM"
-      var markleizer = createMerkleizer(maxChunksCount(T, Limit x.len))
-      chunkedHashTreeRootForBasicTypes(markleizer, x)
+      var merkleizer = createMerkleizer(maxChunksCount(T, Limit x.len))
+      chunkedHashTreeRootForBasicTypes(merkleizer, x)
   elif T is BitArray:
     hashTreeRootAux(x.bytes)
   elif T is SingleMemberUnion:


### PR DESCRIPTION
Fix for a typo in a variable name.