### PR TITLE
clean up sync subcommittee handling

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -24,11 +24,11 @@ type
   SyncCommitteeMsgKey* = object
     originator*: ValidatorIndex
     slot*: Slot
-    committeeIdx*: SyncCommitteeIndex
+    committeeIdx*: SyncSubcommitteeIndex
 
   TrustedSyncCommitteeMsg* = object
     slot*: Slot
-    committeeIdx*: SyncCommitteeIndex
+    committeeIdx*: SyncSubcommitteeIndex
     positionInCommittee*: uint64
     signature*: CookedSig
 
@@ -91,7 +91,7 @@ func addSyncCommitteeMsg*(
     slot: Slot,
     blockRoot: Eth2Digest,
     signature: CookedSig,
-    committeeIdx: SyncCommitteeIndex,
+    committeeIdx: SyncSubcommitteeIndex,
     positionInCommittee: uint64) =
   pool.syncMessages.mgetOrPut(blockRoot, @[]).add TrustedSyncCommitteeMsg(
     slot: slot,
@@ -100,7 +100,7 @@ func addSyncCommitteeMsg*(
     signature: signature)
 
 func computeAggregateSig(votes: seq[TrustedSyncCommitteeMsg],
-                         committeeIdx: SyncCommitteeIndex,
+                         committeeIdx: SyncSubcommitteeIndex,
                          contribution: var SyncCommitteeContribution): bool =
   var
     aggregateSig {.noInit.}: AggregateSignature
@@ -127,7 +127,7 @@ func produceContribution*(
     pool: SyncCommitteeMsgPool,
     slot: Slot,
     headRoot: Eth2Digest,
-    committeeIdx: SyncCommitteeIndex,
+    committeeIdx: SyncSubcommitteeIndex,
     outContribution: var SyncCommitteeContribution): bool =
   if headRoot in pool.syncMessages:
     outContribution.slot = slot

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -393,7 +393,7 @@ proc voluntaryExitValidator*(
 proc syncCommitteeMsgValidator*(
     self: ref Eth2Processor,
     syncCommitteeMsg: SyncCommitteeMessage,
-    committeeIdx: SyncCommitteeIndex,
+    committeeIdx: SyncSubcommitteeIndex,
     checkSignature: bool = true): ValidationResult =
   logScope:
     syncCommitteeMsg = shortLog(syncCommitteeMsg)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -755,7 +755,7 @@ proc validateSyncCommitteeMessage*(
     dag: ChainDAGRef,
     syncCommitteeMsgPool: ref SyncCommitteeMsgPool,
     msg: SyncCommitteeMessage,
-    syncCommitteeIdx: SyncCommitteeIndex,
+    syncCommitteeIdx: SyncSubcommitteeIndex,
     wallTime: BeaconTime,
     checkSignature: bool):
     Result[void, (ValidationResult, cstring)] =

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1083,7 +1083,7 @@ proc getLowSubnets(node: Eth2Node, epoch: Epoch):
     # We start looking one epoch before the transition in order to allow
     # some time for the gossip meshes to get healthy:
     if epoch + 1 >= node.cfg.ALTAIR_FORK_EPOCH:
-      findLowSubnets(getSyncCommitteeTopic, SyncCommitteeIndex, SYNC_COMMITTEE_SUBNET_COUNT)
+      findLowSubnets(getSyncCommitteeTopic, SyncSubcommitteeIndex, SYNC_COMMITTEE_SUBNET_COUNT)
     else:
       default(BitArray[SYNC_COMMITTEE_SUBNET_COUNT])
   )
@@ -2186,7 +2186,7 @@ proc broadcastBeaconBlock*(node: Eth2Node, forked: ForkedSignedBeaconBlock) =
   withBlck(forked): node.broadcastBeaconBlock(blck)
 
 proc broadcastSyncCommitteeMessage*(
-    node: Eth2Node, msg: SyncCommitteeMessage, committeeIdx: SyncCommitteeIndex) =
+    node: Eth2Node, msg: SyncCommitteeMessage, committeeIdx: SyncSubcommitteeIndex) =
   let topic = getSyncCommitteeTopic(node.forkDigests.altair, committeeIdx)
   node.broadcast(topic, msg)
 

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -326,13 +326,11 @@ func syncCommitteeParticipants*(forkedState: ForkedHashedBeaconState,
   withState(forkedState):
     when stateFork >= BeaconStateFork.Altair:
       let
-        headSlot = state.data.slot
-        epochPeriod = syncCommitteePeriod(epoch.compute_start_slot_at_epoch())
-        currentPeriod = syncCommitteePeriod(headSlot)
-        nextPeriod = currentPeriod + 1'u64
-      if epochPeriod == currentPeriod:
+        epochPeriod = sync_committee_period(epoch)
+        curPeriod = sync_committee_period(state.data.slot)
+      if epochPeriod == curPeriod:
         ok(@(state.data.current_sync_committee.pubkeys.data))
-      elif epochPeriod == nextPeriod:
+      elif epochPeriod == curPeriod + 1:
         ok(@(state.data.next_sync_committee.pubkeys.data))
       else:
         err("Epoch is outside the sync committee period of the state")

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -426,34 +426,34 @@ type
   SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
-  SyncCommitteeIndex* = distinct uint8
+  SyncSubcommitteeIndex* = distinct uint8
 
 chronicles.formatIt BeaconBlock: it.shortLog
-chronicles.formatIt SyncCommitteeIndex: uint8(it)
+chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
 
-template asInt*(x: SyncCommitteeIndex): int = int(x)
-template asUInt8*(x: SyncCommitteeIndex): uint8 = uint8(x)
-template asUInt64*(x: SyncCommitteeIndex): uint64 = uint64(x)
+template asInt*(x: SyncSubcommitteeIndex): int = int(x)
+template asUInt8*(x: SyncSubcommitteeIndex): uint8 = uint8(x)
+template asUInt64*(x: SyncSubcommitteeIndex): uint64 = uint64(x)
 
-template `[]`*(a: auto; i: SyncCommitteeIndex): auto = a[i.asInt]
+template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto = a[i.asInt]
 
-template `==`*(x, y: SyncCommitteeIndex): bool =
+template `==`*(x, y: SyncSubcommitteeIndex): bool =
   distinctBase(x) == distinctBase(y)
 
-iterator allSyncCommittees*: SyncCommitteeIndex =
+iterator allSyncCommittees*: SyncSubcommitteeIndex =
   for committeeIdx in 0 ..< SYNC_COMMITTEE_SUBNET_COUNT:
-    yield SyncCommitteeIndex(committeeIdx)
+    yield SyncSubcommitteeIndex(committeeIdx)
 
 template validateSyncCommitteeIndexOr*(
     networkValParam: uint64,
-    elseBody: untyped): SyncCommitteeIndex =
+    elseBody: untyped): SyncSubcommitteeIndex =
   let networkVal = networkValParam
   if networkVal < SYNC_COMMITTEE_SUBNET_COUNT:
-    SyncCommitteeIndex(networkVal)
+    SyncSubcommitteeIndex(networkVal)
   else:
     elseBody
 
-template asUInt8*(x: SyncCommitteeIndex): uint8 = uint8(x)
+template asUInt8*(x: SyncSubcommitteeIndex): uint8 = uint8(x)
 
 Json.useCustomSerialization(BeaconState.justification_bits):
   read:

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -50,7 +50,7 @@ type
     phase0.SignedBeaconBlock |
     altair.SignedBeaconBlock |
     SignedVoluntaryExit |
-    SyncCommitteeIndex
+    SyncSubcommitteeIndex
 
   EncodeArrays* =
     seq[ValidatorIndex] |
@@ -867,19 +867,19 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconState) {.
       writer.writeField("data", value.mergeData)
   writer.endRecord()
 
-# SyncCommitteeIndex
+# SyncSubcommitteeIndex
 proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: SyncCommitteeIndex) {.
+                 value: SyncSubcommitteeIndex) {.
      raises: [IOError, Defect].} =
   writeValue(writer, Base10.toString(uint8(value)))
 
 proc readValue*(reader: var JsonReader[RestJson],
-                value: var SyncCommitteeIndex) {.
+                value: var SyncSubcommitteeIndex) {.
      raises: [IOError, SerializationError, Defect].} =
   let res = Base10.decode(uint8, reader.readValue(string))
   if res.isOk():
     if res.get() < SYNC_COMMITTEE_SUBNET_COUNT:
-      value = SyncCommitteeIndex(res.get())
+      value = SyncSubcommitteeIndex(res.get())
     else:
       reader.raiseUnexpectedValue("Sync sub-committee index out of rage")
   else:
@@ -982,7 +982,7 @@ proc decodeBytes*[T: SszDecodeTypes](t: typedesc[T], value: openarray[byte],
 proc encodeString*(value: string): RestResult[string] =
   ok(value)
 
-proc encodeString*(value: Epoch|Slot|CommitteeIndex|SyncCommitteeIndex): RestResult[string] =
+proc encodeString*(value: Epoch|Slot|CommitteeIndex|SyncSubcommitteeIndex): RestResult[string] =
   ok(Base10.toString(uint64(value)))
 
 proc encodeString*(value: ValidatorSig): RestResult[string] =
@@ -1220,8 +1220,8 @@ proc decodeString*(t: typedesc[CommitteeIndex],
   let res = ? Base10.decode(uint64, value)
   ok(CommitteeIndex(res))
 
-proc decodeString*(t: typedesc[SyncCommitteeIndex],
-                   value: string): Result[SyncCommitteeIndex, cstring] =
+proc decodeString*(t: typedesc[SyncSubcommitteeIndex],
+                   value: string): Result[SyncSubcommitteeIndex, cstring] =
   let res = ? Base10.decode(uint8, value)
   if res.get < SYNC_COMMITTEE_SUBNET_COUNT:
     ok(CommitteeIndex(res))

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -105,7 +105,7 @@ type
   RestSyncCommitteeDuty* = object
     pubkey*: ValidatorPubKey
     validator_index*: ValidatorIndex
-    validator_sync_committee_indices*: seq[SyncCommitteeIndex]
+    validator_sync_committee_indices*: seq[SyncSubcommitteeIndex]
 
   RestSyncCommitteeMessage* = object
     slot*: Slot
@@ -138,7 +138,7 @@ type
 
   RestSyncCommitteeSubscription* = object
     validator_index*: ValidatorIndex
-    sync_committee_indices*: seq[SyncCommitteeIndex]
+    sync_committee_indices*: seq[SyncSubcommitteeIndex]
     until_epoch*: Epoch
 
   RestBeaconStatesFinalityCheckpoints* = object

--- a/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
@@ -75,7 +75,7 @@ proc prepareSyncCommitteeSubnets*(body: seq[RestSyncCommitteeSubscription]): Res
   ## https://ethereum.github.io/beacon-APIs/#/Validator/prepareSyncCommitteeSubnets
 
 proc produceSyncCommitteeContribution*(slot: Slot,
-                                       subcommittee_index: SyncCommitteeIndex,
+                                       subcommittee_index: SyncSubcommitteeIndex,
                                        beacon_block_root: Eth2Digest): RestPlainResponse {.
      rest, endpoint: "/eth/v1/validator/sync_committee_contribution",
      meth: MethodGet.}

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -352,17 +352,12 @@ func build_proof*(anchor: object, leaf_index: uint64,
   doAssert proof.len == log2trunc(leaf_index)
   build_proof_impl(anchor, leaf_index, proof)
 
-const SLOTS_PER_SYNC_COMMITTEE_PERIOD* =
-  EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH
-
-template syncCommitteePeriod*(epoch: Epoch): uint64 =
+# https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/altair/validator.md#sync-committee
+template sync_committee_period*(epoch: Epoch): uint64 =
   epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 
-template syncCommitteePeriod*(slot: Slot): uint64 =
+template sync_committee_period*(slot: Slot): uint64 =
   epoch(slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-
-func syncCommitteePeriodStartSlot*(period: uint64): Slot =
-  Slot(period * EPOCHS_PER_SYNC_COMMITTEE_PERIOD * SLOTS_PER_EPOCH)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
 func compute_start_slot_at_epoch*(epoch: Epoch): Slot =

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -81,7 +81,7 @@ func getAttestationTopic*(forkDigest: ForkDigest,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/specs/altair/p2p-interface.md#topics-and-messages
 func getSyncCommitteeTopic*(forkDigest: ForkDigest,
-                            committeeIdx: SyncCommitteeIndex): string =
+                            committeeIdx: SyncSubcommitteeIndex): string =
   ## For subscribing and unsubscribing to/from a subnet.
   eth2Prefix(forkDigest) & "sync_committee_" & $(committeeIdx.asUInt8) & "/ssz"
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -142,7 +142,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   proc handleSyncCommitteeActions(slot: Slot) =
     type
       Aggregator = object
-        committeeIdx: SyncCommitteeIndex
+        committeeIdx: SyncSubcommitteeIndex
         validatorIdx: int
         selectionProof: ValidatorSig
 

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -208,7 +208,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         dag
       state = newClone(dag.headState.data.altairData)
 
-      syncCommitteeIdx = 0.SyncCommitteeIndex
+      syncCommitteeIdx = 0.SyncSubcommitteeIndex
       syncCommittee = @(dag.syncCommitteeParticipants(state[].data.slot))
       subcommittee = toSeq(syncCommittee.syncSubcommittee(syncCommitteeIdx))
 

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -60,11 +60,11 @@ suite "Honest validator":
         "/eth2/00000000/beacon_attestation_62/ssz"
       getAttestationTopic(forkDigest, SubnetId(63)) ==
         "/eth2/00000000/beacon_attestation_63/ssz"
-      getSyncCommitteeTopic(forkDigest, SyncCommitteeIndex(0)) ==
+      getSyncCommitteeTopic(forkDigest, SyncSubcommitteeIndex(0)) ==
         "/eth2/00000000/sync_committee_0/ssz"
-      getSyncCommitteeTopic(forkDigest, SyncCommitteeIndex(1)) ==
+      getSyncCommitteeTopic(forkDigest, SyncSubcommitteeIndex(1)) ==
         "/eth2/00000000/sync_committee_1/ssz"
-      getSyncCommitteeTopic(forkDigest, SyncCommitteeIndex(3)) ==
+      getSyncCommitteeTopic(forkDigest, SyncSubcommitteeIndex(3)) ==
         "/eth2/00000000/sync_committee_3/ssz"
 
   test "is_aggregator":

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -24,7 +24,7 @@ suite "Sync committee pool":
     let success = pool.produceContribution(
       Slot(1),
       headRoot,
-      SyncCommitteeIndex(0),
+      SyncSubcommitteeIndex(0),
       outContribution)
 
     check(success == false)
@@ -59,8 +59,8 @@ suite "Sync committee pool":
       root2Slot = Slot(101)
       root3Slot = Slot(101)
 
-      subcommittee1 = SyncCommitteeIndex(0)
-      subcommittee2 = SyncCommitteeIndex(1)
+      subcommittee1 = SyncSubcommitteeIndex(0)
+      subcommittee2 = SyncSubcommitteeIndex(1)
 
       sig1 = blsSign(privkey1, sync_committee_msg_signing_root(
         fork, root1Slot.epoch, genesisValidatorsRoot, root1).data)


### PR DESCRIPTION
* `SyncCommitteeIndex` -> `SyncSubcommitteeIndex`
* `syncCommitteePeriod` -> `sync_committee_period` (spec spelling)
* tighten period comparisons
* fix assert when validating committee message with non-altair state in
REST api