### PR TITLE
Fix a Spec Inconsistency with the `getStateValidators` REST Route

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -287,22 +287,23 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         block:
           var res: seq[RestValidator]
           if len(indices) == 0:
-            # There is no indices, so we going to filter all the validators.
-            for index, validator in getStateField(stateData.data,
-                                                  validators).pairs():
-              let
-                balance = getStateField(stateData.data, balances)[index]
-                status =
-                  block:
-                    let sres = validator.getStatus(current_epoch)
-                    if sres.isErr():
-                      return RestApiResponse.jsonError(Http400,
-                                                   ValidatorStatusNotFoundError,
-                                                   $sres.get())
-                    sres.get()
-              if status in validatorsMask:
-                res.add(RestValidator.init(ValidatorIndex(index), balance,
-                                           toString(status), validator))
+            if len(validatorIds) == 0: # Return nothing if we were given missing keys
+              # There is no indices, so we going to filter all the validators.
+              for index, validator in getStateField(stateData.data,
+                                                    validators).pairs():
+                let
+                  balance = getStateField(stateData.data, balances)[index]
+                  status =
+                    block:
+                      let sres = validator.getStatus(current_epoch)
+                      if sres.isErr():
+                        return RestApiResponse.jsonError(Http400,
+                                                    ValidatorStatusNotFoundError,
+                                                    $sres.get())
+                      sres.get()
+                if status in validatorsMask:
+                  res.add(RestValidator.init(ValidatorIndex(index), balance,
+                                            toString(status), validator))
           else:
             for index in indices:
               let

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -977,6 +977,19 @@
     }
   },
   {
+    "topics": ["beacon", "states_validators"],
+    "comment": "Missing validator ID",
+    "request": {
+      "url": "/eth/v1/beacon/states/head/validators?id=0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000dead",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {
+      "status": {"operator": "equals", "value": "200"},
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "body": [{"operator": "jstructcmps", "start": ["data"], "value": []}]
+    }
+  },
+  {
     "topics": ["beacon", "states_validatorid"],
     "comment": "Correct ValidatorIndex value",
     "request": {


### PR DESCRIPTION
This fixes a small bug with the `/eth/v1/beacon/states/head/validators?id=0x...` REST route, described [here](https://discord.com/channels/613988663034118151/812268053718237196/900853477167759400).

When you pass a validator pubkey in the `id` parameter, but that validator doesn't exist yet, `keysToIndices()` will ignore it and return an empty set. This results in Nimbus returning all of the validators as though you had called the route without any `id` parameter at all.

This is inconsistent with [the official spec](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators), which states the following:
> If an index or public key does not match any known validator, no information will be returned but this will not cause an error.

Typically the returned JSON should look like this:

```
{"data":[]}
``` 

This fix simply introduces a check in the route handler to see if both the number of included validator IDs **and** the number of indices are both zero before returning all of the validators. If the number of indices is zero but the number of validators is not, then it knows it hit a missing validator and returns nothing as expected.

Please confirm that the included unit test for this works as expected; I believe it checks for the correct behavior, but I'm not very familiar with the REST testing system so I would like some extra eyes on it before merging this.