### PR TITLE
fix CI for contributions from forked repos (#3028)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,30 +287,13 @@ jobs:
           make -j$ncpu ARCH_OVERRIDE=$PLATFORM DISABLE_TEST_FIXTURES_SCRIPT=1 test
 
       # The upload creates a combined report that gets posted as a comment on the PR
+      # https://github.com/EnricoMi/publish-unit-test-result-action
       - name: Upload combined results
         if: matrix.target.TEST_KIND == 'unit-tests'
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
           path: nimbus-eth2/build/*.xml
-
-      # Linux
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always() && matrix.target.TEST_KIND == 'unit-tests' && runner.os == 'Linux'
-        with:
-          files: nimbus-eth2/build/*.xml
-          check_name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
-          comment_mode: off
-
-      # Windows and macOS
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
-        if: always() && matrix.target.TEST_KIND == 'unit-tests' && runner.os != 'Linux'
-        with:
-          files: nimbus-eth2/build/*.xml
-          check_name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
-          comment_mode: off
 
       - name: Run nimbus-eth2 testnet0 (minimal)
         if: matrix.target.TEST_KIND == 'finalization-minimal'
@@ -326,20 +309,13 @@ jobs:
         run: |
           ./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --log-level DEBUG --disable-htop --enable-logtrace --data-dir local_testnet0_data --base-port 9000 --base-rpc-port 7000 --base-metrics-port 8008 --timeout 2400 -- --verify-finalization --discv5:no
 
-  publish-test-results:
-    name: "Publish Unit Tests Results"
-    needs: build
+  # https://github.com/EnricoMi/publish-unit-test-result-action
+  event_file:
+    name: "Event File"
     runs-on: ubuntu-latest
-    # the build job might be skipped, we don't need to run this job then
-    if: success() || failure()
-
     steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          files: artifacts/**/*.xml
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+        name: Event File
+        path: ${{ github.event_path }}

--- a/.github/workflows/unit-test-results.yml
+++ b/.github/workflows/unit-test-results.yml
@@ -1,0 +1,38 @@
+# https://github.com/EnricoMi/publish-unit-test-result-action
+name: Unit Test Results
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  unit-test-results:
+    name: Unit Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
Cherry-picked from the "stable" branch, after merging https://github.com/status-im/nimbus-eth2/pull/3028 there.

---

This updates the publish-unit-test-result integration with support for
pull requests coming from forked repositories. The update changes the
behaviour so that (a) unit test results are displayed as a comment, and
(b) macOS and Windows builds no longer time out during the CI action.
The official guide for the publish-unit-test-result action has been
followed for this purpose. See the official readme at:
https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.23/README.md#support-fork-repositories-and-dependabot-branches