### PR TITLE
introduce strong typing for sync committee periods

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -721,6 +721,7 @@ func `as`*(d: DepositData, T: type DepositMessage): T =
 
 ethTimeUnit Slot
 ethTimeUnit Epoch
+ethTimeUnit SyncCommitteePeriod
 
 template newClone*[T: not ref](x: T): ref T =
   # TODO not nil in return type: https://github.com/nim-lang/Nim/issues/14146

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -9,9 +9,9 @@ import stew/[results, base10, byteutils, endians2], presto/common,
        libp2p/peerid, serialization,
        json_serialization, json_serialization/std/[options, net, sets],
        nimcrypto/utils as ncrutils
-import ".."/[eth2_ssz_serialization, forks],
-       ".."/datatypes/[phase0, altair, merge],
-       "."/rest_types
+import "."/rest_types,
+       ".."/[eth2_ssz_serialization, forks],
+       ".."/datatypes/[phase0, altair, merge]
 
 export
   results, peerid, common, serialization, json_serialization, options, net, sets,

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -353,11 +353,11 @@ func build_proof*(anchor: object, leaf_index: uint64,
   build_proof_impl(anchor, leaf_index, proof)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/altair/validator.md#sync-committee
-template sync_committee_period*(epoch: Epoch): uint64 =
-  epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+template sync_committee_period*(epoch: Epoch): SyncCommitteePeriod =
+  (epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD).SyncCommitteePeriod
 
-template sync_committee_period*(slot: Slot): uint64 =
-  epoch(slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+template sync_committee_period*(slot: Slot): SyncCommitteePeriod =
+  sync_committee_period(epoch(slot))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
 func compute_start_slot_at_epoch*(epoch: Epoch): Slot =

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -13,8 +13,9 @@ proc validate_light_client_update*(snapshot: LightClientSnapshot,
     return false
 
   # Verify update does not skip a sync committee period
-  var snapshot_period = compute_epoch_at_slot(snapshot.header.slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-  var update_period = compute_epoch_at_slot(update.header.slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+  let
+    snapshot_period = sync_committee_period(snapshot.header.slot)
+    update_period = sync_committee_period(update.header.slot)
   if update_period notin [snapshot_period, snapshot_period + 1]:
     return false
 
@@ -67,8 +68,9 @@ proc validate_light_client_update*(snapshot: LightClientSnapshot,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/altair/sync-protocol.md#apply_light_client_update
 proc apply_light_client_update(snapshot: var LightClientSnapshot, update: LightClientUpdate) =
-  let snapshot_period = compute_epoch_at_slot(snapshot.header.slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-  let update_period = compute_epoch_at_slot(update.header.slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+  let
+    snapshot_period = sync_committee_period(snapshot.header.slot)
+    update_period = sync_committee_period(update.header.slot)
   if update_period == snapshot_period + 1:
     snapshot.current_sync_committee = snapshot.next_sync_committee
     snapshot.next_sync_committee = update.next_sync_committee

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -25,6 +25,7 @@ const
 type
   Slot* = distinct uint64
   Epoch* = distinct uint64
+  SyncCommitteePeriod* = distinct uint64
   Version* = distinct array[4, byte]
   Eth1Address* = ethtypes.Address
 

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -159,9 +159,8 @@ suite "Ethereum Foundation - Altair - Unittests - Sync protocol" & preset():
       cfg, forked[], Slot(SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD),
       cache, info, flags = {})
     let
-      snapshot_period =
-        pre_snapshot.header.slot.epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-      update_period = state.slot.epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+      snapshot_period = sync_committee_period(pre_snapshot.header.slot)
+      update_period = sync_committee_period(state.slot)
     check: snapshot_period + 1 == update_period
 
     let
@@ -232,9 +231,8 @@ suite "Ethereum Foundation - Altair - Unittests - Sync protocol" & preset():
     check: state.finalized_checkpoint.epoch == 3
     # Ensure that it's same period
     let
-      snapshot_period =
-        pre_snapshot.header.slot.epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-      update_period = state.slot.epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+      snapshot_period = sync_committee_period(pre_snapshot.header.slot)
+      update_period = sync_committee_period(state.slot)
     check: snapshot_period == update_period
 
     # Updated sync_committee and finality


### PR DESCRIPTION
The sync committee period used to be a plain `uint64`. With the light
client sync relying more heavily on them, it makes sense to introduce
a proper type for them, similar to how they are already used for `Slot`
and `Epoch`. This introduces such a `SyncCommitteePeriod` type.
Furthermore, some usage code dealing with those periods is cleaned up.