### PR TITLE
Remove web3-mode, always keep web3 monitor enabled when given

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -65,11 +65,6 @@ type
   Web3Cmd* {.pure.} = enum
     test = "Test a web3 provider"
 
-  Web3Mode* {.pure.} = enum
-    auto # Enabled only when validators are attached
-    enabled # Always enabled
-    disabled # Always disabled
-
   SlashingDbKind* {.pure.} = enum
     v1
     v2
@@ -118,12 +113,6 @@ type
     web3Urls* {.
       desc: "One or more Web3 provider URLs used for obtaining deposit contract data"
       name: "web3-url" }: seq[string]
-
-    web3Mode* {.
-      hidden
-      defaultValue: Web3Mode.auto
-      desc: "URL of the Web3 server to observe Eth1"
-      name: "web3-mode" }: Web3Mode
 
     nonInteractive* {.
       desc: "Do not display interative prompts. Quit on missing configuration"

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1151,7 +1151,7 @@ proc start(m: Eth1Monitor, delayBeforeStart: Duration) =
       if runFut.failed:
         if runFut.error[] of CatchableError:
           if runFut == m.runFut:
-            error "Eth1 chain monitoring failure, restarting", err = runFut.error.msg
+            warn "Eth1 chain monitoring failure, restarting", err = runFut.error.msg
             m.state = Failed
         else:
           fatal "Fatal exception reached", err = runFut.error.msg


### PR DESCRIPTION
* Init some components fully before BeaconNode, per component dependency
graph
* remove `--web3-mode` option
* fixes https://github.com/status-im/nimbus-eth2/issues/2685
* reshuffle some beacon node init code