### PR TITLE
altair fork handling cleanups

### DIFF
--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -17,7 +17,7 @@ import
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#beaconstate
   # Memory-representation-equivalent to a phase0 BeaconState for in-place SSZ reading and writing
-  BeaconStateNoImmutableValidators* = object
+  Phase0BeaconStateNoImmutableValidators* = object
     # Versioning
     genesis_time*: uint64
     genesis_validators_root*: Eth2Digest

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -374,8 +374,7 @@ proc addAttestation*(pool: var AttestationPool,
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
                     blckRef: BlockRef,
-                    blck: phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock |
-                          merge.TrustedBeaconBlock,
+                    blck: ForkyTrustedBeaconBlock,
                     wallSlot: Slot) =
   ## Add a verified block to the fork choice context
   let state = pool.forkChoice.process_block(
@@ -510,7 +509,7 @@ proc score(
   bitsScore
 
 proc getAttestationsForBlock*(pool: var AttestationPool,
-                              state: SomeHashedBeaconState,
+                              state: ForkyHashedBeaconState,
                               cache: var StateCache): seq[Attestation] =
   ## Retrieve attestations that may be added to a new block at the slot of the
   ## given state

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -183,7 +183,7 @@ type
       ## block - we limit the number of held EpochRefs to put a cap on
       ## memory usage
 
-    forkDigests*: ForkDigestsRef
+    forkDigests*: ref ForkDigests
       ## Cached copy of the fork digests associated with the current
       ## database. We use a ref type to facilitate sharing this small
       ## value with other components which don't have access to the

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -12,6 +12,7 @@ import
   chronicles,
   stew/bitops2,
   eth/keys,
+  ../spec/forks,
   ../spec/datatypes/[phase0, altair, merge],
   ./block_pools_types
 
@@ -102,9 +103,7 @@ func removeOrphan*(
   quarantine.orphansMerge.del((signedBlock.root, signedBlock.signature))
 
 func isViableOrphan(
-    dag: ChainDAGRef,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-                 merge.SignedBeaconBlock): bool =
+    dag: ChainDAGRef, signedBlock: ForkySignedBeaconBlock): bool =
   # The orphan must be newer than the finalization point so that its parent
   # either is the finalized block or more recent
   signedBlock.message.slot > dag.finalizedHead.slot

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -132,7 +132,7 @@ func getExitMessagesForBlock(
 
   subpool.clear()
 
-func getBeaconBlockExits*(pool: var ExitPool, state: SomeBeaconState): BeaconBlockExits =
+func getBeaconBlockExits*(pool: var ExitPool, state: ForkyBeaconState): BeaconBlockExits =
   var
     indices: HashSet[uint64]
     res: BeaconBlockExits

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -130,8 +130,7 @@ proc addBlock*(
 
 proc dumpBlock*[T](
     self: BlockProcessor,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-                 merge.SignedBeaconBlock,
+    signedBlock: ForkySignedBeaconBlock,
     res: Result[T, (ValidationResult, BlockError)]) =
   if self.dumpEnabled and res.isErr:
     case res.error[1]
@@ -146,8 +145,7 @@ proc dumpBlock*[T](
 
 proc storeBlock*(
     self: var BlockProcessor,
-    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-                 merge.SignedBeaconBlock,
+    signedBlock: ForkySignedBeaconBlock,
     wallSlot: Slot): Result[BlockRef, BlockError] =
   let
     attestationPool = self.consensusManager.attestationPool

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -76,7 +76,7 @@ type
     connTable: HashSet[PeerID]
     forkId*: ENRForkID
     discoveryForkId*: ENRForkID
-    forkDigests*: ForkDigestsRef
+    forkDigests*: ref ForkDigests
     rng*: ref BrHmacDrbgContext
     peers*: Table[PeerID, Peer]
     validTopics: HashSet[string]
@@ -1302,7 +1302,7 @@ proc onConnEvent(node: Eth2Node, peerId: PeerID, event: ConnEvent) {.async.} =
       peer.connectionState = Disconnected
 
 proc new*(T: type Eth2Node, config: BeaconNodeConf, runtimeCfg: RuntimeConfig,
-          enrForkId: ENRForkID, discoveryForkId: ENRForkId, forkDigests: ForkDigestsRef,
+          enrForkId: ENRForkID, discoveryForkId: ENRForkId, forkDigests: ref ForkDigests,
           getBeaconTime: GetBeaconTimeFn, switch: Switch,
           pubsub: GossipSub, ip: Option[ValidIpAddress], tcpPort,
           udpPort: Option[Port], privKey: keys.PrivateKey, discovery: bool,
@@ -1827,7 +1827,7 @@ proc createEth2Node*(rng: ref BrHmacDrbgContext,
                      config: BeaconNodeConf,
                      netKeys: NetKeyPair,
                      cfg: RuntimeConfig,
-                     forkDigests: ForkDigestsRef,
+                     forkDigests: ref ForkDigests,
                      getBeaconTime: GetBeaconTimeFn,
                      genesisValidatorsRoot: Eth2Digest): Eth2Node
                     {.raises: [Defect, CatchableError].} =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -12,7 +12,7 @@ import
        tables, times, terminal],
 
   # Nimble packages
-  serialization, json_serialization, spec/eth2_apis/eth2_rest_serialization,
+  spec/eth2_apis/eth2_rest_serialization,
   stew/[objects, byteutils, endians2, io2], stew/shims/macros,
   chronos, confutils, metrics, metrics/chronos_httpserver,
   chronicles, bearssl, blscurve, presto,

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -14,7 +14,7 @@ import
   ../beacon_node, ../networking/eth2_network,
   ../consensus_object_pools/[blockchain_dag, exit_pool, spec_cache],
   ../validators/validator_duties,
-  ../spec/[eth2_merkleization, forks, network],
+  ../spec/[eth2_merkleization, forks, network, validator],
   ../spec/datatypes/[phase0, altair]
 
 export rest_utils

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -77,8 +77,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return
         case contentType
         of "application/json":
-          RestApiResponse.jsonResponsePlain(
-            ForkedBeaconState.init(stateData.data))
+          RestApiResponse.jsonResponsePlain(stateData.data)
         of "application/octet-stream":
           withState(stateData.data):
             RestApiResponse.sszResponse(state.data)

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -17,7 +17,7 @@ import
   ../networking/eth2_network,
   ../validators/validator_duties,
   ../consensus_object_pools/blockchain_dag,
-  ../spec/[eth2_merkleization, forks, network],
+  ../spec/[eth2_merkleization, forks, network, validator],
   ../spec/datatypes/[phase0],
   ./rpc_utils
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -14,17 +14,17 @@ import
   chronicles,
   ../extras,
   ./datatypes/[phase0, altair, merge],
-  "."/[eth2_merkleization, helpers, signatures, validator],
+  "."/[eth2_merkleization, forks, signatures, validator],
   ../../nbench/bench_lab
 
-export extras, phase0, altair, merge
+export extras, forks, validator
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#increase_balance
 func increase_balance*(balance: var Gwei, delta: Gwei) =
   balance += delta
 
 func increase_balance*(
-    state: var SomeBeaconState, index: ValidatorIndex, delta: Gwei) =
+    state: var ForkyBeaconState, index: ValidatorIndex, delta: Gwei) =
   ## Increase the validator balance at index ``index`` by ``delta``.
   if delta != 0: # avoid dirtying the balance cache if not needed
     increase_balance(state.balances[index], delta)
@@ -38,7 +38,7 @@ func decrease_balance*(balance: var Gwei, delta: Gwei) =
       balance - delta
 
 func decrease_balance*(
-    state: var SomeBeaconState, index: ValidatorIndex, delta: Gwei) =
+    state: var ForkyBeaconState, index: ValidatorIndex, delta: Gwei) =
   ## Decrease the validator balance at index ``index`` by ``delta``, with
   ## underflow protection.
   if delta != 0: # avoid dirtying the balance cache if not needed
@@ -71,7 +71,7 @@ func compute_activation_exit_epoch*(epoch: Epoch): Epoch =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_validator_churn_limit
 func get_validator_churn_limit*(
-      cfg: RuntimeConfig, state: SomeBeaconState, cache: var StateCache):
+      cfg: RuntimeConfig, state: ForkyBeaconState, cache: var StateCache):
     uint64 =
   ## Return the validator churn limit for the current epoch.
   max(
@@ -80,7 +80,7 @@ func get_validator_churn_limit*(
       state, state.get_current_epoch(), cache) div cfg.CHURN_LIMIT_QUOTIENT)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#initiate_validator_exit
-func initiate_validator_exit*(cfg: RuntimeConfig, state: var SomeBeaconState,
+func initiate_validator_exit*(cfg: RuntimeConfig, state: var ForkyBeaconState,
                               index: ValidatorIndex, cache: var StateCache) =
   ## Initiate the exit of the validator with index ``index``.
 
@@ -122,7 +122,7 @@ func initiate_validator_exit*(cfg: RuntimeConfig, state: var SomeBeaconState,
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#slash_validator
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/altair/beacon-chain.md#modified-slash_validator
 proc slash_validator*(
-    cfg: RuntimeConfig, state: var SomeBeaconState,
+    cfg: RuntimeConfig, state: var ForkyBeaconState,
     slashed_index: ValidatorIndex, cache: var StateCache) =
   ## Slash the validator with index ``index``.
   let epoch = get_current_epoch(state)
@@ -183,26 +183,6 @@ proc slash_validator*(
 
 func genesis_time_from_eth1_timestamp*(cfg: RuntimeConfig, eth1_timestamp: uint64): uint64 =
   eth1_timestamp + cfg.GENESIS_DELAY
-
-func genesisFork*(cfg: RuntimeConfig): Fork =
-  Fork(
-    previous_version: cfg.GENESIS_FORK_VERSION,
-    current_version: cfg.GENESIS_FORK_VERSION,
-    epoch: GENESIS_EPOCH)
-
-func altairFork*(cfg: RuntimeConfig): Fork =
-  Fork(
-    previous_version: cfg.GENESIS_FORK_VERSION,
-    current_version: cfg.ALTAIR_FORK_VERSION,
-    epoch: cfg.ALTAIR_FORK_EPOCH)
-
-func mergeFork*(cfg: RuntimeConfig): Fork =
-  # TODO in theory, the altair + merge forks could be in same epoch, so the
-  # previous fork version would be the GENESIS_FORK_VERSION
-  Fork(
-    previous_version: cfg.ALTAIR_FORK_VERSION,
-    current_version: cfg.MERGE_FORK_VERSION,
-    epoch: cfg.MERGE_FORK_EPOCH)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#genesis
 proc initialize_beacon_state_from_eth1*(
@@ -315,8 +295,7 @@ func get_initial_beacon_block*(state: phase0.BeaconState):
     message: message, root: hash_tree_root(message))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_block_root_at_slot
-func get_block_root_at_slot*(state: SomeBeaconState,
-                             slot: Slot): Eth2Digest =
+func get_block_root_at_slot*(state: ForkyBeaconState, slot: Slot): Eth2Digest =
   ## Return the block root at a recent ``slot``.
 
   # Potential overflow/wrap shouldn't occur, as get_block_root_at_slot() called
@@ -327,14 +306,20 @@ func get_block_root_at_slot*(state: SomeBeaconState,
   doAssert slot < state.slot
   state.block_roots[slot mod SLOTS_PER_HISTORICAL_ROOT]
 
+func get_block_root_at_slot*(state: ForkedHashedBeaconState,
+                             slot: Slot): Eth2Digest =
+  ## Return the block root at a recent ``slot``.
+  withState(state):
+    get_block_root_at_slot(state.data, slot)
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_block_root
-func get_block_root*(state: SomeBeaconState, epoch: Epoch): Eth2Digest =
+func get_block_root*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
   ## Return the block root at the start of a recent ``epoch``.
   get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_total_balance
 template get_total_balance(
-    state: SomeBeaconState, validator_indices: untyped): Gwei =
+    state: ForkyBeaconState, validator_indices: untyped): Gwei =
   ## Return the combined effective balance of the ``indices``.
   ## ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
   ## Math safe up to ~10B ETH, afterwhich this overflows uint64.
@@ -350,7 +335,7 @@ func is_eligible_for_activation_queue*(validator: Validator): bool =
     validator.effective_balance == MAX_EFFECTIVE_BALANCE
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#is_eligible_for_activation
-func is_eligible_for_activation*(state: SomeBeaconState, validator: Validator):
+func is_eligible_for_activation*(state: ForkyBeaconState, validator: Validator):
     bool =
   ## Check if ``validator`` is eligible for activation.
 
@@ -361,7 +346,7 @@ func is_eligible_for_activation*(state: SomeBeaconState, validator: Validator):
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
-    state: SomeBeaconState, indexed_attestation: SomeIndexedAttestation,
+    state: ForkyBeaconState, indexed_attestation: SomeIndexedAttestation,
     flags: UpdateFlags): Result[void, cstring] =
   ## Check if ``indexed_attestation`` is not empty, has sorted and unique
   ## indices and has a valid aggregate signature.
@@ -398,7 +383,7 @@ proc is_valid_indexed_attestation*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_attesting_indices
-func get_attesting_indices*(state: SomeBeaconState,
+func get_attesting_indices*(state: ForkyBeaconState,
                             data: AttestationData,
                             bits: CommitteeValidatorsBits,
                             cache: var StateCache): seq[ValidatorIndex] =
@@ -419,8 +404,21 @@ func get_attesting_indices*(state: SomeBeaconState,
 
   res
 
+proc get_attesting_indices*(state: ForkedHashedBeaconState;
+                            data: AttestationData;
+                            bits: CommitteeValidatorsBits;
+                            cache: var StateCache): seq[ValidatorIndex] =
+  # TODO when https://github.com/nim-lang/Nim/issues/18188 fixed, use an
+  # iterator
+
+  var idxBuf: seq[ValidatorIndex]
+  withState(state):
+    for vidx in state.data.get_attesting_indices(data, bits, cache):
+      idxBuf.add vidx
+  idxBuf
+
 proc is_valid_indexed_attestation*(
-    state: SomeBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
+    state: ForkyBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] =
   # This is a variation on `is_valid_indexed_attestation` that works directly
   # with an attestation instead of first constructing an `IndexedAttestation`
@@ -524,7 +522,7 @@ func get_attestation_participation_flag_indices(state: altair.BeaconState | merg
 # better to centralize around that if feasible
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#get_total_active_balance
-func get_total_active_balance*(state: SomeBeaconState, cache: var StateCache): Gwei =
+func get_total_active_balance*(state: ForkyBeaconState, cache: var StateCache): Gwei =
   ## Return the combined effective balance of the active validators.
   # Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei
   # minimum to avoid divisions by zero.
@@ -555,7 +553,7 @@ func get_base_reward(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
-    state: SomeBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
+    state: ForkyBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] =
   ## Check that an attestation follows the rules of being included in the state
   ## at the current slot. When acting as a proposer, the same rules need to
@@ -589,7 +587,7 @@ proc check_attestation*(
   ok()
 
 proc process_attestation*(
-    state: var SomeBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
+    state: var ForkyBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
     base_reward_per_increment: Gwei, cache: var StateCache):
     Result[void, cstring] {.nbench.} =
   # In the spec, attestation validation is mixed with state mutation, so here

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -543,3 +543,14 @@ template hash*(x: LightClientUpdate): Hash =
 func clear*(info: var EpochInfo) =
   info.validators.setLen(0)
   info.balances = UnslashedParticipatingBalances()
+
+template asSigned*(x: SigVerifiedSignedBeaconBlock | TrustedSignedBeaconBlock):
+    SignedBeaconBlock =
+  isomorphicCast[SignedBeaconBlock](x)
+
+template asSigVerified*(x: SignedBeaconBlock | TrustedSignedBeaconBlock): SigVerifiedSignedBeaconBlock =
+  isomorphicCast[SigVerifiedSignedBeaconBlock](x)
+
+template asTrusted*(
+    x: SignedBeaconBlock | SigVerifiedSignedBeaconBlock): TrustedSignedBeaconBlock =
+  isomorphicCast[TrustedSignedBeaconBlock](x)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -734,6 +734,7 @@ template assignClone*[T: not ref](x: T): ref T =
   # This is a bit of a mess: if x is an rvalue (temporary), RVO kicks in for
   # newClone - if it's not, `genericAssign` will be called which is ridiculously
   # slow - so `assignClone` should be used when RVO doesn't work. sigh.
+  mixin assign
   let res = new typeof(x) # TODO safe to do noinit here?
   assign(res[], x)
   res
@@ -938,6 +939,12 @@ func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
     # is still better to keep field names parallel.
     result.add((name.replace("blob", "data"), sizeof(value), n))
 
+## At the GC-level, the GC is type-agnostic; it's all type-erased so
+## casting between seq[Attestation] and seq[TrustedAttestation] will
+## not disrupt GC operations.
+##
+## These SHOULD be used in function calls to avoid expensive temporary.
+## see https://github.com/status-im/nimbus-eth2/pull/2250#discussion_r562010679
 template isomorphicCast*[T, U](x: U): T =
   # Each of these pairs of types has ABI-compatible memory representations.
   static:

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -167,9 +167,6 @@ type
     data*: BeaconState
     root*: Eth2Digest # hash_tree_root(data)
 
-  SomeBeaconState* = BeaconState | altair.BeaconState | phase0.BeaconState
-  SomeHashedBeaconState* = HashedBeaconState | altair.HashedBeaconState | phase0.HashedBeaconState
-
   # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beaconblock
   BeaconBlock* = object
     ## For each slot, a proposer is chosen from the validator pool to propose
@@ -397,3 +394,14 @@ func shortLog*(v: SomeSignedBeaconBlock): auto =
     blck: shortLog(v.message),
     signature: shortLog(v.signature)
   )
+
+template asSigned*(x: SigVerifiedSignedBeaconBlock | TrustedSignedBeaconBlock):
+    SignedBeaconBlock =
+  isomorphicCast[SignedBeaconBlock](x)
+
+template asSigVerified*(x: SignedBeaconBlock | TrustedSignedBeaconBlock): SigVerifiedSignedBeaconBlock =
+  isomorphicCast[SigVerifiedSignedBeaconBlock](x)
+
+template asTrusted*(
+    x: SignedBeaconBlock | SigVerifiedSignedBeaconBlock): TrustedSignedBeaconBlock =
+  isomorphicCast[TrustedSignedBeaconBlock](x)

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -289,3 +289,14 @@ func shortLog*(v: SomeSignedBeaconBlock): auto =
     blck: shortLog(v.message),
     signature: shortLog(v.signature)
   )
+
+template asSigned*(x: SigVerifiedSignedBeaconBlock | TrustedSignedBeaconBlock):
+    SignedBeaconBlock =
+  isomorphicCast[SignedBeaconBlock](x)
+
+template asSigVerified*(x: SignedBeaconBlock | TrustedSignedBeaconBlock): SigVerifiedSignedBeaconBlock =
+  isomorphicCast[SigVerifiedSignedBeaconBlock](x)
+
+template asTrusted*(
+    x: SignedBeaconBlock | SigVerifiedSignedBeaconBlock): TrustedSignedBeaconBlock =
+  isomorphicCast[TrustedSignedBeaconBlock](x)

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -414,7 +414,7 @@ type
   GetStateResponse* = DataEnclosedObject[phase0.BeaconState]
   GetBlockV2Response* = ForkedSignedBeaconBlock
   GetBlockV2Header* = ForkedSignedBlockHeader
-  GetStateV2Response* = ForkedBeaconState
+  GetStateV2Response* = ForkedHashedBeaconState
   GetStateV2Header* = ForkedBeaconStateHeader
   GetPhase0StateSszResponse* = phase0.BeaconState
   GetAltairStateSszResponse* = altair.BeaconState

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -250,8 +250,7 @@ proc addAggregateAndProofSignature*(
 
 proc collectSignatureSets*(
        sigs: var seq[SignatureSet],
-       signed_block: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-                     merge.SignedBeaconBlock,
+       signed_block: ForkySignedBeaconBlock,
        validatorKeys: auto,
        state: ForkedHashedBeaconState,
        cache: var StateCache): Result[void, cstring] =

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -58,9 +58,9 @@ type Foo = phase0.SignedBeaconBlock | altair.SignedBeaconBlock | phase0.TrustedS
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc verify_block_signature(
-    #state: SomeBeaconState, signed_block: SomeSomeSignedBeaconBlock): bool {.nbench.} =
-    state: SomeBeaconState, signed_block: Foo): bool {.nbench.} =
-    #state: SomeBeaconState, signed_block: phase0.SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock): bool {.nbench.} =
+    #state: ForkyBeaconState, signed_block: SomeSomeSignedBeaconBlock): bool {.nbench.} =
+    state: ForkyBeaconState, signed_block: Foo): bool {.nbench.} =
+    #state: ForkyBeaconState, signed_block: phase0.SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock): bool {.nbench.} =
   let
     proposer_index = signed_block.message.proposer_index
   if proposer_index >= state.validators.lenu64:
@@ -79,7 +79,7 @@ proc verify_block_signature(
   true
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc verifyStateRoot(state: SomeBeaconState, blck: phase0.BeaconBlock or phase0.SigVerifiedBeaconBlock or altair.BeaconBlock or altair.SigVerifiedBeaconBlock or merge.BeaconBlock or merge.SigVerifiedBeaconBlock or merge.TrustedBeaconBlock): bool =
+proc verifyStateRoot(state: ForkyBeaconState, blck: phase0.BeaconBlock or phase0.SigVerifiedBeaconBlock or altair.BeaconBlock or altair.SigVerifiedBeaconBlock or merge.BeaconBlock or merge.SigVerifiedBeaconBlock or merge.TrustedBeaconBlock): bool =
   # This is inlined in state_transition(...) in spec.
   let state_root = hash_tree_root(state)
   if state_root != blck.state_root:
@@ -135,7 +135,7 @@ type
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 func process_slot*(
-    state: var SomeBeaconState, pre_state_root: Eth2Digest) {.nbench.} =
+    state: var ForkyBeaconState, pre_state_root: Eth2Digest) {.nbench.} =
   # `process_slot` is the first stage of per-slot processing - it is run for
   # every slot, including epoch slots - it does not however update the slot
   # number! `pre_state_root` refers to the state root of the incoming
@@ -164,7 +164,7 @@ func clear_epoch_from_cache(cache: var StateCache, epoch: Epoch) =
 # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc advance_slot(
     cfg: RuntimeConfig,
-    state: var SomeBeaconState, previous_slot_state_root: Eth2Digest,
+    state: var ForkyBeaconState, previous_slot_state_root: Eth2Digest,
     flags: UpdateFlags, cache: var StateCache, info: var ForkyEpochInfo) {.nbench.} =
   # Do the per-slot and potentially the per-epoch processing, then bump the
   # slot number - we've now arrived at the slot state on top of which a block
@@ -249,7 +249,7 @@ proc process_slots*(
 
 proc state_transition_block_aux(
     cfg: RuntimeConfig,
-    state: var SomeHashedBeaconState,
+    state: var ForkyHashedBeaconState,
     signedBlock: phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
                  phase0.TrustedSignedBeaconBlock | altair.SignedBeaconBlock |
                  altair.SigVerifiedSignedBeaconBlock | altair.TrustedSignedBeaconBlock |

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -461,7 +461,7 @@ func get_proposer_reward(base_reward: Gwei): Gwei =
 func is_in_inactivity_leak(finality_delay: uint64): bool =
   finality_delay > MIN_EPOCHS_TO_INACTIVITY_PENALTY
 
-func get_finality_delay(state: SomeBeaconState): uint64 =
+func get_finality_delay(state: ForkyBeaconState): uint64 =
   get_previous_epoch(state) - state.finalized_checkpoint.epoch
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#rewards-and-penalties-1
@@ -746,7 +746,7 @@ func process_rewards_and_penalties(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#registry-updates
 func process_registry_updates*(
-    cfg: RuntimeConfig, state: var SomeBeaconState, cache: var StateCache) {.nbench.} =
+    cfg: RuntimeConfig, state: var ForkyBeaconState, cache: var StateCache) {.nbench.} =
   ## Process activation eligibility and ejections
 
   # Make visible, e.g.,
@@ -796,7 +796,7 @@ func process_registry_updates*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#slashings
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/altair/beacon-chain.md#slashings
-func process_slashings*(state: var SomeBeaconState, total_balance: Gwei) {.nbench.} =
+func process_slashings*(state: var ForkyBeaconState, total_balance: Gwei) {.nbench.} =
   let
     epoch = get_current_epoch(state)
     multiplier =
@@ -824,7 +824,7 @@ func process_slashings*(state: var SomeBeaconState, total_balance: Gwei) {.nbenc
       decrease_balance(state, index.ValidatorIndex, penalty)
 
 # https://github.com/ethereum/consensus-specs/blob/34cea67b91/specs/phase0/beacon-chain.md#eth1-data-votes-updates
-func process_eth1_data_reset*(state: var SomeBeaconState) {.nbench.} =
+func process_eth1_data_reset*(state: var ForkyBeaconState) {.nbench.} =
   let next_epoch = get_current_epoch(state) + 1
 
   # Reset eth1 data votes
@@ -832,7 +832,7 @@ func process_eth1_data_reset*(state: var SomeBeaconState) {.nbench.} =
     state.eth1_data_votes = default(type state.eth1_data_votes)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#effective-balances-updates
-func process_effective_balance_updates*(state: var SomeBeaconState) {.nbench.} =
+func process_effective_balance_updates*(state: var ForkyBeaconState) {.nbench.} =
   # Update effective balances with hysteresis
   for index in 0..<state.validators.len:
     let balance = state.balances.asSeq()[index]
@@ -851,14 +851,14 @@ func process_effective_balance_updates*(state: var SomeBeaconState) {.nbench.} =
           MAX_EFFECTIVE_BALANCE)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#slashings-balances-updates
-func process_slashings_reset*(state: var SomeBeaconState) {.nbench.} =
+func process_slashings_reset*(state: var ForkyBeaconState) {.nbench.} =
   let next_epoch = get_current_epoch(state) + 1
 
   # Reset slashings
   state.slashings[int(next_epoch mod EPOCHS_PER_SLASHINGS_VECTOR)] = 0.Gwei
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#randao-mixes-updates
-func process_randao_mixes_reset*(state: var SomeBeaconState) {.nbench.} =
+func process_randao_mixes_reset*(state: var ForkyBeaconState) {.nbench.} =
   let
     current_epoch = get_current_epoch(state)
     next_epoch = current_epoch + 1
@@ -868,7 +868,7 @@ func process_randao_mixes_reset*(state: var SomeBeaconState) {.nbench.} =
     get_randao_mix(state, current_epoch)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/phase0/beacon-chain.md#historical-roots-updates
-func process_historical_roots_update*(state: var SomeBeaconState) {.nbench.} =
+func process_historical_roots_update*(state: var ForkyBeaconState) {.nbench.} =
   ## Set historical root accumulator
   let next_epoch = get_current_epoch(state) + 1
 

--- a/beacon_chain/sszdump.nim
+++ b/beacon_chain/sszdump.nim
@@ -10,9 +10,12 @@
 import
   std/[os, strformat],
   chronicles,
-  ./spec/[eth2_ssz_serialization, eth2_merkleization],
+  ./spec/[eth2_ssz_serialization, eth2_merkleization, forks],
   ./spec/datatypes/[phase0, altair, merge],
   ./consensus_object_pools/block_pools_types
+
+export
+  eth2_ssz_serialization, eth2_merkleization, forks, block_pools_types
 
 # Dump errors are generally not fatal where used currently - the code calling
 # these functions, like most code, is not exception safe
@@ -46,14 +49,14 @@ proc dump*(dir: string, v: merge.SignedBeaconBlock) =
   logErrors:
     SSZ.saveFile(dir / &"block-{v.message.slot}-{shortLog(v.root)}.ssz", v)
 
-proc dump*(dir: string, v: SomeHashedBeaconState, blck: BlockRef) =
+proc dump*(dir: string, v: ForkyHashedBeaconState, blck: BlockRef) =
   mixin saveFile
   logErrors:
     SSZ.saveFile(
       dir / &"state-{v.data.slot}-{shortLog(blck.root)}-{shortLog(v.root)}.ssz",
       v.data)
 
-proc dump*(dir: string, v: SomeHashedBeaconState) =
+proc dump*(dir: string, v: ForkyHashedBeaconState) =
   mixin saveFile
   logErrors:
     SSZ.saveFile(

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -152,7 +152,7 @@ proc runFullTransition*(dir, preState, blocksPrefix: string, blocksQty: int, ski
     phase0Data: phase0.HashedBeaconState(data: parseSSZ(prePath, phase0.BeaconState)),
     kind: BeaconStateFork.Phase0
   )
-  setStateRoot(state[], hash_tree_root(state[]))
+  setStateRoot(state[], hash_tree_root(state[].phase0Data.data))
 
   for i in 0 ..< blocksQty:
     let blockPath = dir / blocksPrefix & $i & ".ssz"
@@ -177,7 +177,7 @@ proc runProcessSlots*(dir, preState: string, numSlots: uint64) =
     phase0Data: phase0.HashedBeaconState(
       data: parseSSZ(prePath, phase0.BeaconState)),
     kind: BeaconStateFork.Phase0)
-  setStateRoot(state[], hash_tree_root(state[]))
+  setStateRoot(state[], hash_tree_root(state[].phase0Data.data))
 
   # Shouldn't necessarily assert, because nbench can run test suite
   discard process_slots(

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -89,7 +89,7 @@ proc doTransition(conf: NcliConf) =
     blckX = SSZ.loadFile(conf.blck, phase0.SignedBeaconBlock)
     flags = if not conf.verifyStateRoot: {skipStateRootValidation} else: {}
 
-  setStateRoot(stateY[], hash_tree_root(stateY[]))
+  setStateRoot(stateY[], hash_tree_root(stateY[].phase0Data.data))
 
   var
     cache = StateCache()
@@ -117,7 +117,7 @@ proc doSlots(conf: NcliConf) =
       kind: BeaconStateFork.Phase0
     )
 
-  setStateRoot(stateY[], hash_tree_root(stateY[]))
+  setStateRoot(stateY[], hash_tree_root(stateY[].phase0Data.data))
 
   var
     cache = StateCache()
@@ -147,7 +147,9 @@ proc doSSZ(conf: NcliConf) =
       if cmpIgnoreCase(ext, ".ssz") == 0:
         SSZ.loadFile(file, t)
       elif cmpIgnoreCase(ext, ".json") == 0:
-        JSON.loadFile(file, t)
+        # JSON.loadFile(file, t)
+        echo "TODO needs porting to RestJson"
+        quit 1
       else:
         echo "Unknown file type: ", ext
         quit 1

--- a/research/stack_sizes.nim
+++ b/research/stack_sizes.nim
@@ -9,7 +9,7 @@ proc print(t: auto, n: string, indent: int) =
     for n, p in t.fieldPairs:
       print(p, n, indent + 1)
 
-print(BeaconState(), "state", 0)
+print((ref BeaconState)()[], "state", 0)
 
 echo ""
 

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -44,7 +44,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
     (hashedState, _) = loadGenesis(validators, validate)
     genesisBlock = get_initial_beacon_block(hashedState.data)
     state = (ref ForkedHashedBeaconState)(
-      phase0Data: hashedState[], kind: BeaconStateFork.Phase0)
+      kind: BeaconStateFork.Phase0, phase0Data: hashedState[])
 
   echo "Starting simulation..."
 

--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -26,8 +26,8 @@ proc mockAttestationData(
 
   if slot == state.slot:
     let forkedState = (ref ForkedHashedBeaconState)(kind: BeaconStateFork.Phase0,
-      phase0Data: phase0.HashedBeaconState(root: hash_tree_root(state), data: state))[]
-    result.beacon_block_root = mockBlockForNextSlot(forkedState).phase0Data.message.parent_root
+      phase0Data: phase0.HashedBeaconState(root: hash_tree_root(state), data: state))
+    result.beacon_block_root = mockBlockForNextSlot(forkedState[]).phase0Data.message.parent_root
   else:
     result.beacon_block_root = get_block_root_at_slot(state, slot)
 

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -17,10 +17,7 @@ import
 # ---------------------------------------------------------------
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/tests/core/pyspec/eth2spec/test/helpers/block.py#L26-L35
-func apply_randao_reveal(
-    state: SomeBeaconState,
-    blck: var (phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-               merge.SignedBeaconBlock)) =
+func apply_randao_reveal(state: ForkyBeaconState, blck: var ForkySignedBeaconBlock) =
   doAssert state.slot <= blck.message.slot
   let
     proposer_index = blck.message.proposer_index.ValidatorIndex
@@ -33,10 +30,7 @@ func apply_randao_reveal(
     privkey).toValidatorSig()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/tests/core/pyspec/eth2spec/test/helpers/block.py#L38-L54
-func sign_block(
-    state: SomeBeaconState,
-    blck: var (phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-               merge.SignedBeaconBlock)) =
+func sign_block(state: ForkyBeaconState, blck: var ForkySignedBeaconBlock) =
   let
     proposer_index = blck.message.proposer_index.ValidatorIndex
     privkey = MockPrivKeys[proposer_index]
@@ -50,8 +44,7 @@ func sign_block(
     privkey).toValidatorSig()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py#L1-L31
-func build_empty_execution_payload(
-    state: merge.BeaconState): ExecutionPayload =
+func build_empty_execution_payload(state: merge.BeaconState): ExecutionPayload =
   ## Assuming a pre-state of the same slot, build a valid ExecutionPayload
   ## without any transactions.
   let

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -20,7 +20,7 @@ import
   ../beacon_chain/consensus_object_pools/[
     block_quarantine, blockchain_dag, block_clearance, attestation_pool],
   ../beacon_chain/spec/datatypes/phase0,
-  ../beacon_chain/spec/[forks, state_transition, helpers],
+  ../beacon_chain/spec/[helpers, state_transition, validator],
   # Test utilities
   ./testutil, ./testdbutil, ./testblockutil
 

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -265,7 +265,7 @@ suite "Block pool processing" & preset():
     check:
       # ensure we loaded the correct head state
       dag2.head.root == b2.root
-      hash_tree_root(dag2.headState.data) == b2.message.state_root
+      getStateRoot(dag2.headState.data) == b2.message.state_root
       dag2.get(b1.root).isSome()
       dag2.get(b2.root).isSome()
       dag2.heads.len == 1
@@ -443,7 +443,7 @@ suite "chain DAG finalization tests" & preset():
       dag2.head.root == dag.head.root
       dag2.finalizedHead.blck.root == dag.finalizedHead.blck.root
       dag2.finalizedHead.slot == dag.finalizedHead.slot
-      hash_tree_root(dag2.headState.data) == hash_tree_root(dag.headState.data)
+      getStateRoot(dag2.headState.data) == getStateRoot(dag.headState.data)
 
   test "orphaned epoch block" & preset():
     var prestate = (ref ForkedHashedBeaconState)(kind: BeaconStateFork.Phase0)
@@ -516,8 +516,10 @@ suite "chain DAG finalization tests" & preset():
         assign(tmpStateData[], dag.headState)
         dag.updateStateData(tmpStateData[], cur.atSlot(cur.slot), false, cache)
         check:
-          dag.get(cur).data.phase0Data.message.state_root == getStateRoot(tmpStateData[].data)
-          getStateRoot(tmpStateData[].data) == hash_tree_root(tmpStateData[].data)
+          dag.get(cur).data.phase0Data.message.state_root ==
+            getStateRoot(tmpStateData[].data)
+          getStateRoot(tmpStateData[].data) == hash_tree_root(
+            tmpStateData[].data.phase0Data.data)
         cur = cur.parent
 
     let
@@ -529,7 +531,7 @@ suite "chain DAG finalization tests" & preset():
       dag2.head.root == dag.head.root
       dag2.finalizedHead.blck.root == dag.finalizedHead.blck.root
       dag2.finalizedHead.slot == dag.finalizedHead.slot
-      hash_tree_root(dag2.headState.data) == hash_tree_root(dag.headState.data)
+      getStateRoot(dag2.headState.data) == getStateRoot(dag.headState.data)
 
 suite "Old database versions" & preset():
   setup:
@@ -555,7 +557,7 @@ suite "Old database versions" & preset():
     db.putTailBlock(genBlock.root)
     db.putHeadBlock(genBlock.root)
     db.putStateRoot(genBlock.root, genState.slot, genBlock.message.state_root)
-    db.putGenesisBlockRoot(genBlock.root)
+    db.putGenesisBlock(genBlock.root)
 
     var
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, {})

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -22,7 +22,7 @@ import
     block_quarantine, blockchain_dag, block_clearance, attestation_pool,
     sync_committee_msg_pool],
   ../beacon_chain/spec/datatypes/[phase0, altair],
-  ../beacon_chain/spec/[forks, state_transition, helpers, network],
+  ../beacon_chain/spec/[state_transition, helpers, network, validator],
   ../beacon_chain/validators/validator_pool,
   # Test utilities
   ./testutil, ./testdbutil, ./testblockutil
@@ -206,7 +206,7 @@ suite "Gossip validation - Extra": # Not based on preset config
           check: added.isOk()
           dag.updateHead(added[], quarantine)
         dag
-      state = newClone(dag.headState.data.altairData)
+      state = assignClone(dag.headState.data.altairData)
 
       syncCommitteeIdx = 0.SyncSubcommitteeIndex
       syncCommittee = @(dag.syncCommitteeParticipants(state[].data.slot))

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -47,5 +47,5 @@ suite "state diff tests" & preset():
               getStateField(testStates[j][], validators).len - 1],
             it.getImmutableValidatorData),
           diff)
-        check hash_tree_root(testStates[j][]) ==
+        check hash_tree_root(testStates[j][].phase0Data.data) ==
           hash_tree_root(tmpStateApplyBase[])

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -10,7 +10,8 @@ import
   options, stew/endians2,
   ../beacon_chain/validators/validator_pool,
   ../beacon_chain/spec/datatypes/merge,
-  ../beacon_chain/spec/[helpers, keystore, signatures, state_transition, forks]
+  ../beacon_chain/spec/[
+    beaconstate, helpers, keystore, signatures, state_transition, validator]
 
 type
   MockPrivKeysT = object
@@ -289,15 +290,15 @@ iterator makeTestBlocks*(
   attested: bool,
   cfg = defaultRuntimeConfig): ForkedSignedBeaconBlock =
   var
-    state = assignClone(state)[]
+    state = assignClone(state)
     parent_root = parent_root
   for _ in 0..<blocks:
     let attestations = if attested:
-      makeFullAttestations(state, parent_root, getStateField(state, slot), cache)
+      makeFullAttestations(state[], parent_root, getStateField(state[], slot), cache)
     else:
       @[]
 
     let blck = addTestBlock(
-      state, parent_root, cache, attestations = attestations, cfg = cfg)
+      state[], parent_root, cache, attestations = attestations, cfg = cfg)
     yield blck
     parent_root = blck.root


### PR DESCRIPTION
* fix stack overflow crash in REST/debug/getStateV2
* introduce `ForkyXxx` for generic type matching of `Xxx` across
branches (SomeHashedBeaconState -> ForkyHashedBeaconState et al) -
`Some` is already used for other types of type classes
* consolidate function naming in BeaconChainDB, use some generics
* import `forks.nim` from other spec modules and move `Forked*` helpers
around to resolve circular imports
* remove `ForkedBeaconState`, use `ForkedHashedBeaconState` throughout
(less data shuffling between the types)
* fix several cases of states being stored on stack in tests, causing
random failures on some platforms
* remove reading json support from ncli - this should be ported to the
rest json reading instead (doesn't currently work because stack sizes)