### PR TITLE
Bugfix: Avoid the aggregation of duplicate signatures when creating sync committee contributions

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -131,13 +131,14 @@ func computeAggregateSig(votes: seq[TrustedSyncCommitteeMsg],
     if vote.subcommitteeIndex != subcommitteeIndex:
       continue
 
-    if not initialized:
-      initialized = true
-      aggregateSig.init(vote.signature)
-    else:
-      aggregateSig.aggregate(vote.signature)
+    if not contribution.aggregation_bits[vote.positionInCommittee]:
+      if not initialized:
+        initialized = true
+        aggregateSig.init(vote.signature)
+      else:
+        aggregateSig.aggregate(vote.signature)
 
-    contribution.aggregation_bits.setBit vote.positionInCommittee
+      contribution.aggregation_bits.setBit vote.positionInCommittee
 
   if initialized:
     contribution.signature = aggregateSig.finish.toValidatorSig
@@ -156,7 +157,8 @@ func produceContribution*(
     outContribution.subcommittee_index = subcommitteeIndex.asUInt64
     try:
       computeAggregateSig(pool.syncMessages[headRoot],
-                          subcommitteeIndex, outContribution)
+                          subcommitteeIndex,
+                          outContribution)
     except KeyError:
       raiseAssert "We have checked for the key upfront"
   else:

--- a/beacon_chain/ssz/types.nim
+++ b/beacon_chain/ssz/types.nim
@@ -188,6 +188,7 @@ template bytes*(x: BitList): auto = seq[byte](x)
 template `[]`*(x: BitList, idx: auto): auto = BitSeq(x)[idx]
 template `[]=`*(x: var BitList, idx: auto, val: bool) = BitSeq(x)[idx] = val
 template `==`*(a, b: BitList): bool = BitSeq(a) == BitSeq(b)
+template getBit*(x: var BitList, idx: Natural): bool = getBit(BitSeq(x), idx)
 template setBit*(x: var BitList, idx: Natural) = setBit(BitSeq(x), idx)
 template clearBit*(x: var BitList, idx: Natural) = clearBit(BitSeq(x), idx)
 template overlaps*(a, b: BitList): bool = overlaps(BitSeq(a), BitSeq(b))

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -207,9 +207,10 @@ suite "Gossip validation - Extra": # Not based on preset config
           dag.updateHead(added[], quarantine)
         dag
       state = assignClone(dag.headState.data.altairData)
+      slot = state[].data.slot
 
       subcommitteeIdx = 0.SyncSubcommitteeIndex
-      syncCommittee = @(dag.syncCommitteeParticipants(state[].data.slot))
+      syncCommittee = @(dag.syncCommitteeParticipants(slot))
       subcommittee = toSeq(syncCommittee.syncSubcommittee(subcommitteeIdx))
 
       pubkey = subcommittee[0]
@@ -220,13 +221,13 @@ suite "Gossip validation - Extra": # Not based on preset config
       validator = AttachedValidator(pubKey: pubkey,
         kind: ValidatorKind.Local, data: privateItem, index: some(index))
       msg = waitFor signSyncCommitteeMessage(
-        validator, state[].data.slot,
+        validator, slot,
         state[].data.fork, state[].data.genesis_validators_root, state[].root)
 
       syncCommitteeMsgPool = newClone(SyncCommitteeMsgPool.init())
       res = validateSyncCommitteeMessage(
         dag, syncCommitteeMsgPool[], msg, subcommitteeIdx,
-        state[].data.slot.toBeaconTime(), true)
+        slot.toBeaconTime(), true)
       (positions, cookedSig) = res.get()
 
     syncCommitteeMsgPool[].addSyncCommitteeMsg(
@@ -241,7 +242,7 @@ suite "Gossip validation - Extra": # Not based on preset config
       contribution = block:
         var contribution = (ref SignedContributionAndProof)()
         check: syncCommitteeMsgPool[].produceContribution(
-          state[].data.slot, state[].root, subcommitteeIdx,
+          slot, state[].root, subcommitteeIdx,
           contribution.message.contribution)
         syncCommitteeMsgPool[].addSyncContribution(
           contribution[], contribution.message.contribution.signature.load.get)

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -81,6 +81,9 @@ suite "Sync committee pool":
     pool.addSyncCommitteeMsg(root2Slot, root1, 3, sig3, subcommittee2, [7'u64])
     pool.addSyncCommitteeMsg(root2Slot, root2, 4, sig4, subcommittee2, [3'u64])
 
+    # Insert a duplicate message (this should be handled gracefully)
+    pool.addSyncCommitteeMsg(root1Slot, root1, 1, sig1, subcommittee1, [1'u64])
+
     # Producing contributions
     #
     block:


### PR DESCRIPTION
Also introduces more sanity checks that would prevent aggregating sync committee messages created against a different head state.