### PR TITLE
Correct implementation of the /validator/duties/sync/{epoch} API

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -215,7 +215,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             for idx, pubkey in syncCommittee:
               if pubkey == res[resIdx].pubkey:
                 res[resIdx].validator_sync_committee_indices.add(
-                  ValidatorIndexInSyncCommittee idx)
+                  IndexInSyncCommittee idx)
           res
 
       return RestApiResponse.jsonResponse(duties)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -19,9 +19,6 @@ import
 
 export extras, forks, validator
 
-type
-  SomeBeaconState* = phase0.BeaconState | altair.BeaconState | merge.BeaconState
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.4/specs/phase0/beacon-chain.md#increase_balance
 func increase_balance*(balance: var Gwei, delta: Gwei) =
   balance += delta
@@ -859,6 +856,6 @@ func upgrade_to_merge*(cfg: RuntimeConfig, pre: altair.BeaconState):
     latest_execution_payload_header: ExecutionPayloadHeader()
   )
 
-template isValidInState*(idx: ValidatorIndex, state: SomeBeaconState): bool =
-  idx.int < state.validators.len
+template isValidInState*(idx: ValidatorIndex, state: ForkyBeaconState): bool =
+  idx.uint64 < state.validators.lenu64
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -19,6 +19,9 @@ import
 
 export extras, forks, validator
 
+type
+  SomeBeaconState* = phase0.BeaconState | altair.BeaconState | merge.BeaconState
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.4/specs/phase0/beacon-chain.md#increase_balance
 func increase_balance*(balance: var Gwei, delta: Gwei) =
   balance += delta
@@ -855,3 +858,7 @@ func upgrade_to_merge*(cfg: RuntimeConfig, pre: altair.BeaconState):
     # Execution-layer
     latest_execution_payload_header: ExecutionPayloadHeader()
   )
+
+template isValidInState*(idx: ValidatorIndex, state: SomeBeaconState): bool =
+  idx.int < state.validators.len
+

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -432,7 +432,7 @@ type
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
   SyncSubcommitteeIndex* = distinct uint8
-  ValidatorIndexInSyncCommittee* = distinct uint16
+  IndexInSyncCommittee* = distinct uint16
 
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
@@ -445,7 +445,7 @@ template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
   a[i.asInt]
 
 template `[]`*(arr: array[SYNC_COMMITTEE_SIZE, any] | seq;
-               idx: ValidatorIndexInSyncCommittee): auto =
+               idx: IndexInSyncCommittee): auto =
   arr[int idx]
 
 template `==`*(x, y: SyncSubcommitteeIndex): bool =

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -432,6 +432,7 @@ type
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
   SyncSubcommitteeIndex* = distinct uint8
+  ValidatorIndexInSyncCommittee* = distinct uint16
 
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
@@ -440,7 +441,12 @@ template asInt*(x: SyncSubcommitteeIndex): int = int(x)
 template asUInt8*(x: SyncSubcommitteeIndex): uint8 = uint8(x)
 template asUInt64*(x: SyncSubcommitteeIndex): uint64 = uint64(x)
 
-template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto = a[i.asInt]
+template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
+  a[i.asInt]
+
+template `[]`*(arr: array[SYNC_COMMITTEE_SIZE, any] | seq;
+               idx: ValidatorIndexInSyncCommittee): auto =
+  arr[int idx]
 
 template `==`*(x, y: SyncSubcommitteeIndex): bool =
   distinctBase(x) == distinctBase(y)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -412,12 +412,12 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Epoch) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## ValidatorIndex
-proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndex) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndex)
+                {.raises: [IOError, Defect].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
-proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex) {.
-     raises: [IOError, SerializationError, Defect].} =
+proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex)
+               {.raises: [IOError, SerializationError, Defect].} =
   let svalue = reader.readValue(string)
   let res = Base10.decode(uint64, svalue)
   if res.isOk():
@@ -427,6 +427,24 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex) {.
     else:
       reader.raiseUnexpectedValue(
         "Validator index is bigger then VALIDATOR_REGISTRY_LIMIT")
+  else:
+    reader.raiseUnexpectedValue($res.error())
+
+proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndexInSyncCommittee)
+                {.raises: [IOError, Defect].} =
+  writeValue(writer, Base10.toString(distinctBase(value)))
+
+proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndexInSyncCommittee)
+               {.raises: [IOError, SerializationError, Defect].} =
+  let svalue = reader.readValue(string)
+  let res = Base10.decode(uint64, svalue)
+  if res.isOk():
+    let v = res.get()
+    if v < SYNC_COMMITTEE_SIZE:
+      value = ValidatorIndexInSyncCommittee(v)
+    else:
+      reader.raiseUnexpectedValue(
+        "Validator index is bigger then SYNC_COMMITTEE_SIZE")
   else:
     reader.raiseUnexpectedValue($res.error())
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -430,21 +430,21 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex)
   else:
     reader.raiseUnexpectedValue($res.error())
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndexInSyncCommittee)
+proc writeValue*(writer: var JsonWriter[RestJson], value: IndexInSyncCommittee)
                 {.raises: [IOError, Defect].} =
   writeValue(writer, Base10.toString(distinctBase(value)))
 
-proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndexInSyncCommittee)
+proc readValue*(reader: var JsonReader[RestJson], value: var IndexInSyncCommittee)
                {.raises: [IOError, SerializationError, Defect].} =
   let svalue = reader.readValue(string)
   let res = Base10.decode(uint64, svalue)
   if res.isOk():
     let v = res.get()
     if v < SYNC_COMMITTEE_SIZE:
-      value = ValidatorIndexInSyncCommittee(v)
+      value = IndexInSyncCommittee(v)
     else:
       reader.raiseUnexpectedValue(
-        "Validator index is bigger then SYNC_COMMITTEE_SIZE")
+        "Index in committee is bigger than SYNC_COMMITTEE_SIZE")
   else:
     reader.raiseUnexpectedValue($res.error())
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -105,7 +105,7 @@ type
   RestSyncCommitteeDuty* = object
     pubkey*: ValidatorPubKey
     validator_index*: ValidatorIndex
-    validator_sync_committee_indices*: seq[SyncSubcommitteeIndex]
+    validator_sync_committee_indices*: seq[ValidatorIndexInSyncCommittee]
 
   RestSyncCommitteeMessage* = object
     slot*: Slot

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -105,7 +105,7 @@ type
   RestSyncCommitteeDuty* = object
     pubkey*: ValidatorPubKey
     validator_index*: ValidatorIndex
-    validator_sync_committee_indices*: seq[ValidatorIndexInSyncCommittee]
+    validator_sync_committee_indices*: seq[IndexInSyncCommittee]
 
   RestSyncCommitteeMessage* = object
     slot*: Slot


### PR DESCRIPTION
According to the spec, this call should return the positions of
the specified validators within the sync committee. The existing
code was instead returning the indices of the sync sub-committees
where the validator is a member.