### PR TITLE
only invalidate {current,previous}_epoch_participation flag cache once

### DIFF
--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -72,8 +72,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     validatorKeyToIndex = initTable[ValidatorPubKey, int]()
     cfg = defaultRuntimeConfig
 
-  cfg.ALTAIR_FORK_EPOCH = 96.Slot.epoch
-  cfg.MERGE_FORK_EPOCH = 160.Slot.epoch
+  cfg.ALTAIR_FORK_EPOCH = 64.Slot.epoch
+  cfg.MERGE_FORK_EPOCH = 128.Slot.epoch
 
   echo "Starting simulation..."
 


### PR DESCRIPTION
It also adjusts the `block_sim` transition epochs to run the merge fork in CI.