### PR TITLE
use v1.1.5 consensus spec test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -56,7 +56,7 @@ export
 # Eventually, we could also differentiate between user/tainted data and
 # internal state that's gone through sanity checks already.
 
-const SPEC_VERSION* = "1.1.4"
+const SPEC_VERSION* = "1.1.5"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -50,7 +50,7 @@ type
 const
   FixturesDir* =
     currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / "vendor" / "nim-eth2-scenarios"
-  SszTestsDir* = FixturesDir / "tests-v1.1.4"
+  SszTestsDir* = FixturesDir / "tests-v1.1.5"
   MaxObjectSize* = 3_000_000
 
 proc parseTest*(path: string, Format: typedesc[Json], T: typedesc): T =


### PR DESCRIPTION
As required for https://hackmd.io/@n0ble/kintsugi-spec v2.

https://github.com/ethereum/consensus-specs/releases/tag/v1.1.5
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.1.5