### PR TITLE
Reduce the logging-related breaking changes

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -90,13 +90,14 @@ type
       name: "log-level" }: string
 
     logStdout* {.
+      hidden
       desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
-      name: "log-stdout" }: StdoutLogKind
+      name: "log-format" }: StdoutLogKind
 
     logFile* {.
-      desc: "Specifies a path for the written Json log file"
+      desc: "Specifies a path for the written Json log file (deprecated)"
       name: "log-file" }: Option[OutFile]
 
     eth2Network* {.
@@ -532,13 +533,14 @@ type
       name: "log-level" }: string
 
     logStdout* {.
+      hidden
       desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
-      name: "log-stdout" }: StdoutLogKind
+      name: "log-format" }: StdoutLogKind
 
     logFile* {.
-      desc: "Specifies a path for the written Json log file"
+      desc: "Specifies a path for the written Json log file (deprecated)"
       name: "log-file" }: Option[OutFile]
 
     dataDir* {.

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -136,10 +136,7 @@ proc setupLogging*(
 
     let tmp =
       if stdoutKind == StdoutLogKind.Auto:
-        if logFile.isSome():
-          # No stdout logging by default, when file logging is enabled
-          StdoutLogKind.None
-        elif isatty(stdout):
+        if isatty(stdout):
           # On a TTY, let's be fancy
           StdoutLogKind.Colors
         else:
@@ -167,6 +164,8 @@ proc setupLogging*(
     of StdoutLogKind.None:
      defaultChroniclesStream.outputs[0].writer = noOutput
 
+    if logFile.isSome():
+      warn "The --log-file option is deprecated. Consider redirecting the standard output to a file instead"
   try:
     updateLogLevel(logLevel)
   except ValueError as err:

--- a/docs/the_nimbus_book/src/logging.md
+++ b/docs/the_nimbus_book/src/logging.md
@@ -50,3 +50,4 @@ To send logs to a file, you can redirect the stdout logs:
 ```
 
 We recommend keeping an eye on the growth of this file with a [log rotator](./log-rotate.md). Logs are written in the "JSON Lines" format - one `json` entry per line.
+

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -23,7 +23,7 @@ The following options are available:
 
      --log-level               Sets the log level for process and topics (e.g. "DEBUG;
                                TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none") [=INFO].
-     --log-format              Specifies what kind of logs should be written to stdout
+     --log-format              Specifies what kind of logs should be written to stdout (beta)
                                (auto, colors, nocolors, json) [=auto].
      --log-file                Specifies a path for the written Json log file.
      --network                 The Eth2 network to join [=mainnet].

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -23,7 +23,7 @@ The following options are available:
 
      --log-level               Sets the log level for process and topics (e.g. "DEBUG;
                                TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none") [=INFO].
-     --log-stdout              Specifies what kind of logs should be written to stdout
+     --log-format              Specifies what kind of logs should be written to stdout
                                (auto, colors, nocolors, json) [=auto].
      --log-file                Specifies a path for the written Json log file.
      --network                 The Eth2 network to join [=mainnet].

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -443,7 +443,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --nat:extip:127.0.0.1 \
     --network="${DATA_DIR}" \
     --log-level="${LOG_LEVEL}" \
-    --log-stdout=json \
+    --log-format=json \
     --tcp-port=$(( BASE_PORT + NUM_NODE )) \
     --udp-port=$(( BASE_PORT + NUM_NODE )) \
     --max-peers=$(( NUM_NODES - 1 )) \


### PR DESCRIPTION
* Don't disable the stdout log when the `--log-file` option is used
* Rename `--log-stdout` to `--log-format` and hide it
* Deprecate the `--log-file` option