### PR TITLE
Make sync horizon configurable

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -348,6 +348,13 @@ type
         name: "doppelganger-detection"
       }: bool
 
+      syncHorizon* {.
+        hidden
+        desc: "Number of empty slots to process before considering the client out of sync"
+        defaultValue: MaxEmptySlotCount
+        defaultValueDesc: "50"
+        name: "sync-horizon" }: uint64
+
     of createTestnet:
       testnetDepositsFile* {.
         desc: "A LaunchPad deposits file for the genesis state validators"

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -171,12 +171,10 @@ proc isSynced*(node: BeaconNode, head: BlockRef): bool =
     beaconTime = node.beaconClock.now()
     wallSlot = beaconTime.toSlot()
 
-  # TODO: MaxEmptySlotCount should likely involve the weak subjectivity period.
-
   # TODO if everyone follows this logic, the network will not recover from a
   #      halt: nobody will be producing blocks because everone expects someone
   #      else to do it
-  if wallSlot.afterGenesis and head.slot + MaxEmptySlotCount < wallSlot.slot:
+  if wallSlot.afterGenesis and head.slot + node.config.syncHorizon < wallSlot.slot:
     false
   else:
     true


### PR DESCRIPTION
Currently, we don't have a good answer to the question "are we synced
yet" - the sync manager syncs based on the peers it's connected to, but
just because some peer looks like it should be synced from doesn't mean
we're out of sync.

Instead, we use a very silly time-based heuristic - the problem with
that is that the network can go into a rut where nobody produces blocks
- better heuristics would be needed here, but in the meantime, a command
line option can get us out of a tight spot - this PR places such an
option in the client, in the unlikely event it should be needed (most
likely in a testnet).