### PR TITLE
Speed up altair block processing 2x

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -71,6 +71,11 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + latest_block_root                                                                          OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
+## Block pool altair processing [Preset: mainnet]
+```diff
++ Invalid signatures [Preset: mainnet]                                                       OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool processing [Preset: mainnet]
 ```diff
 + Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
@@ -165,7 +170,7 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Gossip validation  [Preset: mainnet]
 ```diff
 + Any committee index is valid                                                               OK
-+ Validation sanity                                                                          OK
++ validateAttestation                                                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Gossip validation - Extra
@@ -366,4 +371,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 206/208 Fail: 0/208 Skip: 2/208
+OK: 207/209 Fail: 0/209 Skip: 2/209

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -198,6 +198,12 @@ type
     onFinHappened*: OnFinalizedCallback
       ## On finalization callback
 
+    headSyncCommittees*: SyncCommitteeCache ##\
+      ## A cache of the sync committees, as they appear in the head state -
+      ## using the head state is slightly wrong - if a reorg deeper than
+      ## EPOCHS_PER_SYNC_COMMITTEE_PERIOD is happening, some valid sync
+      ## committee messages will be rejected
+
   EpochKey* = object
     ## The epoch key fully determines the shuffling for proposers and
     ## committees in a beacon state - the epoch level information in the state

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -357,7 +357,9 @@ type
     ## - ProposerSlashing (SignedBeaconBlockHeader)
     ## - AttesterSlashing (IndexedAttestation)
     ## - SignedVoluntaryExits
+    ## - SyncAggregate
     ##
+    ## However:
     ## - ETH1Data (Deposits) can contain invalid BLS signatures
     ##
     ## The block state transition has NOT been verified
@@ -373,7 +375,7 @@ type
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
 
     # [New in Altair]
-    sync_aggregate*: SyncAggregate # TODO TrustedSyncAggregate after batching
+    sync_aggregate*: TrustedSyncAggregate
 
   SyncnetBits* = BitArray[SYNC_COMMITTEE_SUBNET_COUNT]
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -380,12 +380,17 @@ type
     message*: AggregateAndProof
     signature*: ValidatorSig
 
+  SyncCommitteeCache* = object
+    current_sync_committee*: array[SYNC_COMMITTEE_SIZE, ValidatorIndex]
+    next_sync_committee*: array[SYNC_COMMITTEE_SIZE, ValidatorIndex]
+
   # This doesn't know about forks or branches in the DAG. It's for straight,
   # linear chunks of the chain.
   StateCache* = object
     shuffled_active_validator_indices*:
       Table[Epoch, seq[ValidatorIndex]]
     beacon_proposer_indices*: Table[Slot, Option[ValidatorIndex]]
+    sync_committees*: Table[SyncCommitteePeriod, SyncCommitteeCache]
 
   # This matches the mutable state of the Solidity deposit contract
   # https://github.com/ethereum/consensus-specs/blob/v1.1.2/solidity_deposit_contract/deposit_contract.sol

--- a/beacon_chain/spec/eth2_apis/eth2_json_rpc_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_json_rpc_serialization.nim
@@ -40,10 +40,7 @@ proc toJsonHex(data: openArray[byte]): string =
 
 proc fromJson*(n: JsonNode, argName: string, result: var ValidatorPubKey) {.raises: [Defect, ValueError].} =
   n.kind.expect(JString, argName)
-  var tmp = ValidatorPubKey.fromHex(n.getStr()).tryGet()
-  if not tmp.loadWithCache().isSome():
-    raise (ref ValueError)(msg: "Invalid public BLS key")
-  result = tmp
+  result = ValidatorPubKey.fromHex(n.getStr()).tryGet()
 
 proc `%`*(pubkey: ValidatorPubKey): JsonNode =
   newJString(toJsonHex(toRaw(pubkey)))

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -415,6 +415,8 @@ proc collectSignatureSets*(
             DOMAIN_VOLUNTARY_EXIT)
 
   block:
+    # 7. SyncAggregate
+    # ----------------------------------------------------
     withState(state):
       when stateFork >= BeaconStateFork.Altair and
           (signed_block is altair.SignedBeaconBlock or

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -414,4 +414,46 @@ proc collectSignatureSets*(
             volex.message.epoch,
             DOMAIN_VOLUNTARY_EXIT)
 
+  block:
+    withState(state):
+      when stateFork >= BeaconStateFork.Altair and
+          (signed_block is altair.SignedBeaconBlock or
+            signed_block is merge.SignedBeaconBlock):
+        let
+          current_sync_committee =
+            state.data.get_sync_committee_cache(cache).current_sync_committee
+
+        var inited = false
+        var attestersAgg{.noInit.}: AggregatePublicKey
+        for i in 0 ..< current_sync_committee.len:
+          if signed_block.message.body.sync_aggregate.sync_committee_bits[i]:
+            let key = validatorKeys.load(current_sync_committee[i])
+            if not key.isSome():
+              return err("Invalid key cache")
+
+            if not inited: # first iteration
+              attestersAgg.init(key.get())
+              inited = true
+            else:
+              attestersAgg.aggregate(key.get())
+
+        if not inited:
+          if signed_block.message.body.sync_aggregate.sync_committee_signature !=
+              default(CookedSig).toValidatorSig():
+            return err("process_sync_aggregate: empty sync aggregates need signature of point at infinity")
+        else:
+          let
+            attesters = finish(attestersAgg)
+            previous_slot = max(state.data.slot, Slot(1)) - 1
+
+          sigs.addSignatureSet(
+            attesters,
+            get_block_root_at_slot(state.data, previous_slot),
+            signed_block.message.body.sync_aggregate.sync_committee_signature.loadOrExit(
+              "process_sync_aggregate: cannot load signature"),
+            state.data.fork,
+            state.data.genesis_validators_root,
+            previous_slot.epoch,
+            DOMAIN_SYNC_COMMITTEE)
+
   ok()

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -69,10 +69,7 @@ suite "Gossip validation " & preset():
       committeeLen(10000) == 0
       committeeLen(uint64.high) == 0
 
-  test "Validation sanity":
-    # TODO: refactor tests to avoid skipping BLS validation
-    dag.updateFlags.incl {skipBLSValidation}
-
+  test "validateAttestation":
     var
       cache: StateCache
     for blck in makeTestBlocks(
@@ -210,11 +207,9 @@ suite "Gossip validation - Extra": # Not based on preset config
       subcommitteeIdx = 0.SyncSubcommitteeIndex
       syncCommittee = @(dag.syncCommitteeParticipants(slot))
       subcommittee = toSeq(syncCommittee.syncSubcommittee(subcommitteeIdx))
-
-      pubkey = subcommittee[0]
-      expectedCount = subcommittee.count(pubkey)
-      index = ValidatorIndex(
-        state[].data.validators.mapIt(it.pubkey).find(pubKey))
+      index = subcommittee[0]
+      expectedCount = subcommittee.count(index)
+      pubkey = state[].data.validators[index].pubkey
       privateItem = ValidatorPrivateItem(privateKey: MockPrivKeys[index])
       validator = AttachedValidator(pubKey: pubkey,
         kind: ValidatorKind.Local, data: privateItem, index: some(index))


### PR DESCRIPTION
Like #3089, this PR drastially speeds up historical REST queries and
other long state replays.

* cache sync committee validator indices
* use ~80mb less memory for validator pubkey mappings
* batch-verify sync aggregate signature (fixes #2985)
* document sync committee hack with head block vs sync message block
* add batch signature verification failure tests

Before:

```
../env.sh nim c -d:release -r ncli_db --db:mainnet_0/db bench --start-slot:-1000
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
Validation is turned off meaning that no BLS operations are performed
    5830.675,        0.000,     5830.675,     5830.675,            1, Initialize DB
       0.481,        1.878,        0.215,       59.167,          981, Load block from database
    8422.566,        0.000,     8422.566,     8422.566,            1, Load state from database
       6.996,        1.678,        0.042,       14.385,          969, Advance slot, non-epoch
      93.217,        8.318,       84.192,      122.209,           32, Advance slot, epoch
      20.513,       23.665,       11.510,      201.561,          981, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database load
       0.000,        0.000,        0.000,        0.000,            0, Database store
```

After:

```
    7081.422,        0.000,     7081.422,     7081.422,            1, Initialize DB
       0.553,        2.122,        0.175,       66.692,          981, Load block from database
    5439.446,        0.000,     5439.446,     5439.446,            1, Load state from database
       6.829,        1.575,        0.043,       12.156,          969, Advance slot, non-epoch
      94.716,        2.749,       88.395,      100.026,           32, Advance slot, epoch
      11.636,       23.766,        4.889,      205.250,          981, Apply block, no slot processing
       0.000,        0.000,        0.000,        0.000,            0, Database load
       0.000,        0.000,        0.000,        0.000,            0, Database store
```