### PR TITLE
Cleanups

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -35,6 +35,18 @@ type
 
   GetBeaconTimeFn* = proc(): BeaconTime {.gcsafe, raises: [Defect].}
 
+const
+  # Offsets from the start of the slot to when the corresponding message should
+  # be sent
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/phase0/validator.md#attesting
+  attestationSlotOffset* = seconds(SECONDS_PER_SLOT.int) div 3
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/phase0/validator.md#broadcast-aggregate
+  aggregateSlotOffset* = seconds(SECONDS_PER_SLOT.int) * 2 div 3
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/altair/validator.md#prepare-sync-committee-message
+  syncCommitteeMessageSlotOffset* = seconds(SECONDS_PER_SLOT.int) div 3
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/altair/validator.md#broadcast-sync-committee-contribution
+  syncContributionSlotOffset* = seconds(SECONDS_PER_SLOT.int) * 2 div 3
+
 proc init*(T: type BeaconClock, genesis_time: uint64): T =
   # ~290 billion years into the future
   doAssert genesis_time <= high(int64).uint64

--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -96,7 +96,7 @@ func isSeen*(
     subcommitteeIndex: subcommitteeIndex.uint64)
   seenKey in pool.seenSyncMsgByAuthor
 
-func addSyncCommitteeMsg*(
+func addSyncCommitteeMessage*(
     pool: var SyncCommitteeMsgPool,
     slot: Slot,
     blockRoot: Eth2Digest,
@@ -187,7 +187,7 @@ func isSeen*(
     subcommitteeIndex: msg.contribution.subcommittee_index)
   seenKey in pool.seenContributionByAuthor
 
-proc addSyncContribution(pool: var SyncCommitteeMsgPool,
+proc addContribution(pool: var SyncCommitteeMsgPool,
                          aggregator_index: uint64,
                          contribution: SyncCommitteeContribution,
                          signature: CookedSig) =
@@ -217,10 +217,10 @@ proc addSyncContribution(pool: var SyncCommitteeMsgPool,
     except KeyError:
       raiseAssert "We have checked for the key upfront"
 
-proc addSyncContribution*(pool: var SyncCommitteeMsgPool,
+proc addContribution*(pool: var SyncCommitteeMsgPool,
                           scproof: SignedContributionAndProof,
                           signature: CookedSig) =
-  pool.addSyncContribution(
+  pool.addContribution(
     scproof.message.aggregator_index, scproof.message.contribution, signature)
 
   if not(isNil(pool.onContributionReceived)):

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -406,7 +406,7 @@ proc voluntaryExitValidator*(
 
   v
 
-proc syncCommitteeMsgValidator*(
+proc syncCommitteeMessageValidator*(
     self: ref Eth2Processor,
     syncCommitteeMsg: SyncCommitteeMessage,
     subcommitteeIdx: SyncSubcommitteeIndex,
@@ -432,7 +432,7 @@ proc syncCommitteeMsgValidator*(
     trace "Sync committee message validated"
     let (positions, cookedSig) = v.get()
 
-    self.syncCommitteeMsgPool[].addSyncCommitteeMsg(
+    self.syncCommitteeMsgPool[].addSyncCommitteeMessage(
       syncCommitteeMsg.slot,
       syncCommitteeMsg.beacon_block_root,
       syncCommitteeMsg.validator_index,
@@ -448,7 +448,7 @@ proc syncCommitteeMsgValidator*(
     beacon_sync_committee_messages_dropped.inc(1, [$v.error[0]])
     err(v.error())
 
-proc syncCommitteeContributionValidator*(
+proc contributionValidator*(
     self: ref Eth2Processor,
     contributionAndProof: SignedContributionAndProof,
     checkSignature: bool = true): Result[void, ValidationError] =
@@ -468,14 +468,13 @@ proc syncCommitteeContributionValidator*(
   debug "Contribution received", delay
 
   # Now proceed to validation
-  let v = validateSignedContributionAndProof(self.dag,
-                                             self.syncCommitteeMsgPool[],
-                                             contributionAndProof, wallTime,
-                                             checkSignature)
+  let v = validateContribution(
+    self.dag, self.syncCommitteeMsgPool[], contributionAndProof, wallTime,
+    checkSignature)
 
   return if v.isOk():
     trace "Contribution validated"
-    self.syncCommitteeMsgPool[].addSyncContribution(contributionAndProof, v.get)
+    self.syncCommitteeMsgPool[].addContribution(contributionAndProof, v.get)
     beacon_sync_committee_contributions_received.inc()
 
     ok()

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -786,7 +786,7 @@ proc validateSyncCommitteeMessage*(
   ok((positionsInSubcommittee, cookedSignature.get()))
 
 # https://github.com/ethereum/eth2.0-specs/blob/v1.1.5/specs/altair/p2p-interface.md#sync_committee_contribution_and_proof
-proc validateSignedContributionAndProof*(
+proc validateContribution*(
     dag: ChainDAGRef,
     syncCommitteeMsgPool: var SyncCommitteeMsgPool,
     msg: SignedContributionAndProof,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1059,13 +1059,13 @@ proc installMessageValidators(node: BeaconNode) =
           # This proc needs to be within closureScope; don't lift out of loop.
           proc(msg: SyncCommitteeMessage): ValidationResult =
             toValidationResult(
-              node.processor.syncCommitteeMsgValidator(msg, idx)))
+              node.processor.syncCommitteeMessageValidator(msg, idx)))
 
     node.network.addValidator(
       getSyncCommitteeContributionAndProofTopic(digest),
       proc(msg: SignedContributionAndProof): ValidationResult =
         toValidationResult(
-          node.processor.syncCommitteeContributionValidator(msg)))
+          node.processor.contributionValidator(msg)))
 
   installSyncCommitteeeValidators(node.dag.forkDigests.altair)
   installSyncCommitteeeValidators(node.dag.forkDigests.merge)

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -244,14 +244,14 @@ type
 
   EpochInfo* = object
     ## Information about the outcome of epoch processing
-    statuses*: seq[RewardStatus]
-    total_balances*: TotalBalances
+    validators*: seq[RewardStatus]
+    balances*: TotalBalances
 
 chronicles.formatIt BeaconBlock: it.shortLog
 
 func clear*(info: var EpochInfo) =
-  info.statuses.setLen(0)
-  info.total_balances = TotalBalances()
+  info.validators.setLen(0)
+  info.balances = TotalBalances()
 
 Json.useCustomSerialization(BeaconState.justification_bits):
   read:

--- a/nbench/scenarios.nim
+++ b/nbench/scenarios.nim
@@ -223,7 +223,7 @@ proc bench_process_justification_and_finalization(state: var phase0.BeaconState)
     info: phase0.EpochInfo
   info.init(state)
   info.process_attestations(state, cache)
-  process_justification_and_finalization(state, info.total_balances)
+  process_justification_and_finalization(state, info.balances)
 
 func bench_process_slashings(state: var phase0.BeaconState) =
   var
@@ -231,7 +231,7 @@ func bench_process_slashings(state: var phase0.BeaconState) =
     info: phase0.EpochInfo
   info.init(state)
   info.process_attestations(state, cache)
-  process_slashings(state, info.total_balances.current_epoch)
+  process_slashings(state, info.balances.current_epoch)
 
 template processBlockScenarioImpl(
            dir, preState: string, skipBLS: bool,

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -607,7 +607,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
     case info.kind
     of EpochInfoFork.Phase0:
       template info: untyped = info.phase0Data
-      for i, s in info.statuses.pairs():
+      for i, s in info.validators.pairs():
         let perf = addr perfs[i]
         if RewardFlags.isActiveInPreviousEpoch in s.flags:
           if s.is_previous_epoch_attester.isSome():
@@ -836,16 +836,16 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
       template info: untyped = info.phase0Data
       insertEpochInfo.exec(
         (getStateField(state[].data, slot).epoch.int64,
-        info.total_balances.current_epoch_raw.int64,
-        info.total_balances.previous_epoch_raw.int64,
-        info.total_balances.current_epoch_attesters_raw.int64,
-        info.total_balances.current_epoch_target_attesters_raw.int64,
-        info.total_balances.previous_epoch_attesters_raw.int64,
-        info.total_balances.previous_epoch_target_attesters_raw.int64,
-        info.total_balances.previous_epoch_head_attesters_raw.int64)
+        info.balances.current_epoch_raw.int64,
+        info.balances.previous_epoch_raw.int64,
+        info.balances.current_epoch_attesters_raw.int64,
+        info.balances.current_epoch_target_attesters_raw.int64,
+        info.balances.previous_epoch_attesters_raw.int64,
+        info.balances.previous_epoch_target_attesters_raw.int64,
+        info.balances.previous_epoch_head_attesters_raw.int64)
         ).expect("DB")
 
-      for index, status in info.statuses.pairs():
+      for index, status in info.validators.pairs():
         if not is_eligible_validator(status):
           continue
         let

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -178,7 +178,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
         let (positions, cookedSig) = res.get()
 
-        syncCommitteePool[].addSyncCommitteeMsg(
+        syncCommitteePool[].addSyncCommitteeMessage(
           msg.slot,
           msg.beacon_block_root,
           msg.validator_index,
@@ -221,7 +221,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             message: contributionAndProof,
             signature: blsSign(validarorPrivKey, signingRoot.data).toValidatorSig)
 
-          res = dag.validateSignedContributionAndProof(
+          res = dag.validateContribution(
             syncCommitteePool[],
             signedContributionAndProof,
             contributionsTime,
@@ -229,8 +229,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
         doAssert res.isOk
 
-        syncCommitteePool[].addSyncContribution(
-          signedContributionAndProof, res.get)
+        syncCommitteePool[].addContribution(
+          signedContributionAndProof, res.get())
 
   proc getNewBlock[T](
       stateData: var StateData, slot: Slot, cache: var StateCache): T =

--- a/tests/consensus_spec/phase0/test_fixture_rewards.nim
+++ b/tests/consensus_spec/phase0/test_fixture_rewards.nim
@@ -61,7 +61,7 @@ proc runTest(rewardsDir, identifier: string) =
       info.init(state[])
       info.process_attestations(state[], cache)
       let
-        total_balance = info.total_balances.current_epoch
+        total_balance = info.balances.current_epoch
         total_balance_sqrt = integer_squareroot(total_balance)
 
       var
@@ -71,7 +71,7 @@ proc runTest(rewardsDir, identifier: string) =
         inclusionDelayDeltas2 = Deltas.init(state[].validators.len)
         inactivityPenaltyDeltas2 = Deltas.init(state[].validators.len)
 
-      for index, validator in info.statuses.mpairs():
+      for index, validator in info.validators.mpairs():
         if not is_eligible_validator(validator):
           continue
 
@@ -80,11 +80,11 @@ proc runTest(rewardsDir, identifier: string) =
             state[], index.ValidatorIndex, total_balance_sqrt)
 
         sourceDeltas2.add(index, get_source_delta(
-          validator, base_reward, info.total_balances, finality_delay))
+          validator, base_reward, info.balances, finality_delay))
         targetDeltas2.add(index, get_target_delta(
-          validator, base_reward, info.total_balances, finality_delay))
+          validator, base_reward, info.balances, finality_delay))
         headDeltas2.add(index, get_head_delta(
-          validator, base_reward, info.total_balances, finality_delay))
+          validator, base_reward, info.balances, finality_delay))
 
         let
           (inclusion_delay_delta, proposer_delta) =

--- a/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
@@ -51,7 +51,7 @@ template runSuite(suiteDir, testName: string, transitionProc: untyped): untyped 
 const JustificationFinalizationDir = RootDir/"justification_and_finalization"/"pyspec_tests"
 runSuite(JustificationFinalizationDir, "Justification & Finalization"):
   info.process_attestations(state, cache)
-  process_justification_and_finalization(state, info.total_balances)
+  process_justification_and_finalization(state, info.balances)
 
 # Rewards & Penalties
 # ---------------------------------------------------------------
@@ -71,7 +71,7 @@ runSuite(RegistryUpdatesDir, "Registry updates"):
 const SlashingsDir = RootDir/"slashings"/"pyspec_tests"
 runSuite(SlashingsDir, "Slashings"):
   info.process_attestations(state, cache)
-  process_slashings(state, info.total_balances.current_epoch)
+  process_slashings(state, info.balances.current_epoch)
 
 # Final updates
 # ---------------------------------------------------------------

--- a/tests/spec_epoch_processing/epoch_utils.nim
+++ b/tests/spec_epoch_processing/epoch_utils.nim
@@ -39,4 +39,4 @@ proc transitionEpochUntilJustificationFinalization*(state: var ForkedHashedBeaco
   info.init(state.phase0Data.data)
   info.process_attestations(state.phase0Data.data, cache)
   process_justification_and_finalization(
-    state.phase0Data.data, info.total_balances)
+    state.phase0Data.data, info.balances)

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -10,7 +10,8 @@
 import chronicles, chronos
 import eth/keys
 import ../beacon_chain/spec/[datatypes/base, forks, presets]
-import ../beacon_chain/consensus_object_pools/[block_quarantine, blockchain_dag, exit_pool]
+import ../beacon_chain/consensus_object_pools/[
+    block_quarantine, blockchain_dag, exit_pool]
 import "."/[testutil, testdbutil]
 
 suite "Exit pool testing suite":

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -223,7 +223,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         slot.toBeaconTime(), true)
       (positions, cookedSig) = res.get()
 
-    syncCommitteeMsgPool[].addSyncCommitteeMsg(
+    syncCommitteeMsgPool[].addSyncCommitteeMessage(
       msg.slot,
       msg.beacon_block_root,
       msg.validator_index,
@@ -237,7 +237,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         check: syncCommitteeMsgPool[].produceContribution(
           slot, state[].root, subcommitteeIdx,
           contribution.message.contribution)
-        syncCommitteeMsgPool[].addSyncContribution(
+        syncCommitteeMsgPool[].addContribution(
           contribution[], contribution.message.contribution.signature.load.get)
         waitFor validator.sign(
           contribution, state[].data.fork, state[].data.genesis_validators_root)

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -76,13 +76,13 @@ suite "Sync committee pool":
 
     # Inserting sync committee messages
     #
-    pool.addSyncCommitteeMsg(root1Slot, root1, 1, sig1, subcommittee1, [1'u64])
-    pool.addSyncCommitteeMsg(root1Slot, root1, 2, sig2, subcommittee1, [10'u64])
-    pool.addSyncCommitteeMsg(root2Slot, root1, 3, sig3, subcommittee2, [7'u64])
-    pool.addSyncCommitteeMsg(root2Slot, root2, 4, sig4, subcommittee2, [3'u64])
+    pool.addSyncCommitteeMessage(root1Slot, root1, 1, sig1, subcommittee1, [1'u64])
+    pool.addSyncCommitteeMessage(root1Slot, root1, 2, sig2, subcommittee1, [10'u64])
+    pool.addSyncCommitteeMessage(root2Slot, root1, 3, sig3, subcommittee2, [7'u64])
+    pool.addSyncCommitteeMessage(root2Slot, root2, 4, sig4, subcommittee2, [3'u64])
 
     # Insert a duplicate message (this should be handled gracefully)
-    pool.addSyncCommitteeMsg(root1Slot, root1, 1, sig1, subcommittee1, [1'u64])
+    pool.addSyncCommitteeMessage(root1Slot, root1, 1, sig1, subcommittee1, [1'u64])
 
     # Producing contributions
     #
@@ -120,7 +120,7 @@ suite "Sync committee pool":
         contribution.aggregation_bits[10] == true
         contribution.signature == expectedSig.toValidatorSig
 
-      pool.addSyncContribution(outContribution, expectedSig)
+      pool.addContribution(outContribution, expectedSig)
       check: pool.isSeen(outContribution.message)
 
     block:
@@ -142,7 +142,7 @@ suite "Sync committee pool":
         contribution.aggregation_bits[7] == true
         contribution.signature == sig3.toValidatorSig
 
-      pool.addSyncContribution(outContribution, sig3)
+      pool.addContribution(outContribution, sig3)
       check: pool.isSeen(outContribution.message)
 
     block:
@@ -165,7 +165,7 @@ suite "Sync committee pool":
         contribution.aggregation_bits[3] == true
         contribution.signature == sig4.toValidatorSig
 
-      pool.addSyncContribution(outContribution, sig4)
+      pool.addContribution(outContribution, sig4)
       check: pool.isSeen(outContribution.message)
 
     block:


### PR DESCRIPTION
Renames and cleanups split out from the validator monitoring branch, so
as to reduce conflict area vs other PR:s

* add constants for expected message timing
* name validators after the messages they validate, mostly, to make
grepping easier
* unify field naming of EpochInfo across forks to make cross-fork code
easier