### PR TITLE
ci: throttle builds to avoid tests clashing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,16 +93,20 @@ def runStages() {
 
 parallel(
 	"Linux": {
-		node("linux") {
-			withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
-				runStages()
+		throttle(['nimbus-eth2']) {
+			node("linux") {
+				withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
+					runStages()
+				}
 			}
 		}
 	},
 	"macOS": {
-		node("macos") {
-			withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
-				runStages()
+		throttle(['nimbus-eth2']) {
+			node("macos") {
+				withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
+					runStages()
+				}
 			}
 		}
 	},


### PR DESCRIPTION
Uses: https://plugins.jenkins.io/throttle-concurrents/#example-1-throttling-of-node-runs

The `nimbus-eth` category limits builds to one per node in global settings.

![image](https://user-images.githubusercontent.com/2212681/143493443-427225a9-fb7f-4472-bb00-9b3f140c03cd.png)