### PR TITLE
ci: specify macos host architecture in labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,7 @@ parallel(
 	},
 	"macOS": {
 		throttle(['nimbus-eth2']) {
-			node("macos") {
+			node("macos && x86_64") {
 				withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 					runStages()
 				}


### PR DESCRIPTION
Since now we have a 5th Gen Mac Mini with `arm64` M1 CPU.