### PR TITLE
allow `withState` to be called multiple times

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -74,11 +74,12 @@ template withState*(
   ## TODO async transformations will lead to a race where stateData gets updated
   ##      while waiting for future to complete - catch this here somehow?
 
-  var cache {.inject.} = StateCache()
-  updateStateData(dag, stateData, blockSlot, false, cache)
+  block:
+    var cache {.inject.} = StateCache()
+    updateStateData(dag, stateData, blockSlot, false, cache)
 
-  withStateVars(stateData):
-    body
+    withStateVars(stateData):
+      body
 
 func parent*(bs: BlockSlot): BlockSlot =
   ## Return a blockslot representing the previous slot, using the parent block


### PR DESCRIPTION
This allows `blockchain_dag`'s `withState` template to be called more
than once in a single function. This led to a compilation error before
because the injected variables and functions shared the same scope.