### PR TITLE
use BeaconTime instead of Slot in fork choice

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -401,4 +401,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 216/218 Fail: 0/218 Skip: 2/218
+OK: 217/219 Fail: 0/219 Skip: 2/219

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -40,13 +40,16 @@ const
   # Offsets from the start of the slot to when the corresponding message should
   # be sent
   # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/validator.md#attesting
-  attestationSlotOffset* = seconds(SECONDS_PER_SLOT.int) div 3
+  attestationSlotOffset* = seconds(SECONDS_PER_SLOT.int) div INTERVALS_PER_SLOT
   # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/validator.md#broadcast-aggregate
-  aggregateSlotOffset* = seconds(SECONDS_PER_SLOT.int) * 2 div 3
+  aggregateSlotOffset* =
+    seconds(SECONDS_PER_SLOT.int) * 2 div INTERVALS_PER_SLOT
   # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#prepare-sync-committee-message
-  syncCommitteeMessageSlotOffset* = seconds(SECONDS_PER_SLOT.int) div 3
+  syncCommitteeMessageSlotOffset* =
+    seconds(SECONDS_PER_SLOT.int) div INTERVALS_PER_SLOT
   # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#broadcast-sync-committee-contribution
-  syncContributionSlotOffset* = seconds(SECONDS_PER_SLOT.int) * 2 div 3
+  syncContributionSlotOffset* =
+    seconds(SECONDS_PER_SLOT.int) * 2 div INTERVALS_PER_SLOT
 
 proc init*(T: type BeaconClock, genesis_time: uint64): T =
   # ~290 billion years into the future

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -347,8 +347,7 @@ proc process_block*(self: var ForkChoice,
   let
     time_into_slot =
       self.checkpoints.time - self.checkpoints.time.slotOrZero.toBeaconTime
-    is_before_attesting_interval =
-      time_into_slot < (SECONDS_PER_SLOT div INTERVALS_PER_SLOT).int64.seconds
+    is_before_attesting_interval = time_into_slot < attestationSlotOffset
   if  self.checkpoints.time.slotOrZero == blck.slot and
       is_before_attesting_interval:
     self.checkpoints.proposer_boost_root = blckRef.root

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -15,6 +15,7 @@ import
 
   chronicles,
   # Internal
+  ../beacon_clock,
   ../spec/datatypes/base,
   ../consensus_object_pools/block_pools_types
 
@@ -108,10 +109,11 @@ type
     balances*: seq[Gwei]
 
   Checkpoints* = object
-    time*: Slot
+    time*: BeaconTime
     justified*: BalanceCheckpoint
     finalized*: Checkpoint
     best_justified*: Checkpoint
+    proposer_boost_root*: Eth2Digest
 
 # Fork choice high-level types
 # ----------------------------------------------------------------------

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -185,7 +185,7 @@ proc storeBlock*(
       blckRef: BlockRef, trustedBlock: Trusted, epochRef: EpochRef):
     # Callback add to fork choice if valid
     attestationPool[].addForkChoice(
-      epochRef, blckRef, trustedBlock.message, wallSlot)
+      epochRef, blckRef, trustedBlock.message, wallTime)
 
     vm[].registerBeaconBlock(
       src, wallTime, trustedBlock.message)
@@ -223,7 +223,7 @@ proc storeBlock*(
   let storeBlockTick = Moment.now()
 
   # Eagerly update head: the incoming block "should" get selected
-  self.consensusManager[].updateHead(wallSlot)
+  self.consensusManager[].updateHead(wallTime.slotOrZero)
 
   let
     updateHeadTick = Moment.now()

--- a/beacon_chain/gossip_processing/consensus_manager.nim
+++ b/beacon_chain/gossip_processing/consensus_manager.nim
@@ -10,6 +10,7 @@
 import
   chronicles, chronos,
   ../spec/datatypes/base,
+  ../beacon_clock,
   ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool]
 
 # TODO: Move to "consensus_object_pools" folder
@@ -79,7 +80,7 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
   ## `pruneFinalized` must be called for pruning.
 
   # Grab the new head according to our latest attestation data
-  let newHead = self.attestationPool[].selectHead(wallSlot)
+  let newHead = self.attestationPool[].selectHead(wallSlot.toBeaconTime)
   if newHead.isNil():
     warn "Head selection failed, using previous head",
       head = shortLog(self.dag.head), wallSlot

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -335,7 +335,7 @@ proc publishAttestationsAndAggregates(service: AttestationServiceRef,
   let aggregateTime =
     # chronos.Duration substraction could not return negative value, in such
     # case it will return `ZeroDuration`.
-    vc.beaconClock.durationToNextSlot() - seconds(int64(SECONDS_PER_SLOT) div 3)
+    vc.beaconClock.durationToNextSlot() - OneThirdDuration
   if aggregateTime != ZeroDuration:
     await sleepAsync(aggregateTime)
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -114,7 +114,7 @@ const
   DefaultDutyAndProof* = DutyAndProof(epoch: Epoch(0xFFFF_FFFF_FFFF_FFFF'u64))
   SlotDuration* = int64(SECONDS_PER_SLOT).seconds
   EpochDuration* = int64(SLOTS_PER_EPOCH * SECONDS_PER_SLOT).seconds
-  OneThirdDuration* = int64(SECONDS_PER_SLOT div 3).seconds
+  OneThirdDuration* = int64(SECONDS_PER_SLOT div INTERVALS_PER_SLOT).seconds
 
 proc `$`*(bn: BeaconNodeServerRef): string =
   if bn.ident.isSome():

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -137,7 +137,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
                 data: data,
                 aggregation_bits: aggregation_bits,
                 signature: sig.toValidatorSig()
-              ), [validatorIdx], sig, data.slot)
+              ), [validatorIdx], sig, data.slot.toBeaconTime)
 
   proc handleSyncCommitteeActions(slot: Slot) =
     type
@@ -309,7 +309,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])
@@ -329,7 +329,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])
@@ -349,7 +349,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -150,8 +150,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
       genesis_validators_root = dag.genesisValidatorsRoot
       fork = dag.forkAtEpoch(slot.epoch)
-      messagesTime = slot.toBeaconTime(seconds(SECONDS_PER_SLOT div 3))
-      contributionsTime = slot.toBeaconTime(seconds(2 * SECONDS_PER_SLOT div 3))
+      messagesTime = slot.toBeaconTime(attestationSlotOffset)
+      contributionsTime = slot.toBeaconTime(aggregateSlotOffset)
 
     var aggregators: seq[Aggregator]
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -151,7 +151,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       genesis_validators_root = dag.genesisValidatorsRoot
       fork = dag.forkAtEpoch(slot.epoch)
       messagesTime = slot.toBeaconTime(attestationSlotOffset)
-      contributionsTime = slot.toBeaconTime(aggregateSlotOffset)
+      contributionsTime = slot.toBeaconTime(syncContributionSlotOffset)
 
     var aggregators: seq[Aggregator]
 

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -82,7 +82,8 @@ suite "Gossip validation " & preset():
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
-        pool[].addForkChoice(epochRef, blckRef, signedBlock.message, blckRef.slot)
+        pool[].addForkChoice(
+          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
 
       check: added.isOk()
       dag.updateHead(added[], quarantine[])


### PR DESCRIPTION
The `Slot` to `BeaconTime` change is required due to https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/fork-choice.md#on_block:
```python
    # Add proposer score boost if the block is timely
    time_into_slot = (store.time - store.genesis_time) % SECONDS_PER_SLOT
    is_before_attesting_interval = time_into_slot < SECONDS_PER_SLOT // INTERVALS_PER_SLOT
    if get_current_slot(store) == block.slot and is_before_attesting_interval:
        store.proposer_boost_root = hash_tree_root(block)
```
such that fork choice now depends on finer granularity than slots.

This PR shouldn't introduce any regressions in terms of what already works, but also doesn't introduce the
```python
    proposer_score = Gwei(0)
    if store.proposer_boost_root != Root():
        block = store.blocks[root]
        if get_ancestor(store, root, block.slot) == store.proposer_boost_root:
            num_validators = len(get_active_validator_indices(state, get_current_epoch(state)))
            avg_balance = get_total_active_balance(state) // num_validators
            committee_size = num_validators // SLOTS_PER_EPOCH
            committee_weight = committee_size * avg_balance
            proposer_score = (committee_weight * PROPOSER_SCORE_BOOST) // 100
    return attestation_score + proposer_score
```
logic from https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/fork-choice.md#get_latest_attesting_balance, so skips the added `proposer_boost_correct_head` fork choice test. This allows it to be merged while remaining compatible with the non-proposer-boosted merge devnet.

The `proposer_boost_root` tests which run (phase 0 and mainnet only due to other pre-existing issues) do run and pass, however.