### PR TITLE
speed up gossip and sync block validation

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -743,10 +743,10 @@ func getBlockRange*(
 
   o # Return the index of the first non-nil item in the output
 
-func getBlockBySlot*(dag: ChainDAGRef, slot: Slot): BlockRef =
+func getBlockBySlot*(dag: ChainDAGRef, slot: Slot): BlockSlot =
   ## Retrieves the first block in the current canonical chain
   ## with slot number less or equal to `slot`.
-  dag.head.atSlot(slot).blck
+  dag.head.atSlot(slot)
 
 proc getForkedBlock*(dag: ChainDAGRef, blck: BlockRef): ForkedTrustedSignedBeaconBlock =
   case dag.cfg.blockForkAtEpoch(blck.slot.epoch)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -228,13 +228,12 @@ proc validateBeaconBlock*(
     return errIgnore("BeaconBlock: already seen")
 
   let
-    slotBlockRef = getBlockBySlot(dag, signed_beacon_block.message.slot)
+    slotBlock = getBlockBySlot(dag, signed_beacon_block.message.slot)
 
-  if not slotBlockRef.isNil:
-    let blck = dag.get(slotBlockRef).data
+  if slotBlock.slot == signed_beacon_block.message.slot:
+    let blck = dag.get(slotBlock.blck).data
     if getForkedBlockField(blck, proposer_index) ==
           signed_beacon_block.message.proposer_index and
-        getForkedBlockField(blck, slot) == signed_beacon_block.message.slot and
         blck.signature.toRaw() != signed_beacon_block.signature.toRaw():
       return errIgnore("BeaconBlock: already proposed in the same slot")
 

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -282,7 +282,7 @@ proc collectSignatureSets*(
   # ----------------------------------------------------
   sigs.addSignatureSet(
           proposer_key.get(),
-          signed_block.message,
+          signed_block.root,
           signed_block.signature.loadOrExit(
             "collectSignatureSets: cannot load signature"),
           getStateField(state, fork),

--- a/tests/test_block_pool.nim
+++ b/tests/test_block_pool.nim
@@ -467,6 +467,11 @@ suite "chain DAG finalization tests" & preset():
 
     check:
       dag.heads.len() == 1
+      dag.getBlockBySlot(0.Slot) == BlockSlot(blck: dag.genesis, slot: 0.Slot)
+      dag.getBlockBySlot(dag.head.slot) == BlockSlot(
+        blck: dag.head, slot: dag.head.slot.Slot)
+      dag.getBlockBySlot(dag.head.slot + 1) == BlockSlot(
+        blck: dag.head, slot: dag.head.slot.Slot + 1)
 
     check:
       dag.db.immutableValidators.len() == getStateField(dag.headState.data, validators).len()


### PR DESCRIPTION
* avoid recomputing hash for block signature check
* check block slot match before hitting the database