### PR TITLE
use v1.1.6 test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -55,8 +55,6 @@ ConsensusSpecPreset-mainnet
 + Ethereum Foundation - Altair - Transition - transition_with_proposer_slashing_right_before OK
 + Ethereum Foundation - Altair - Transition - transition_with_random_half_participation [Pre OK
 + Ethereum Foundation - Altair - Transition - transition_with_random_three_quarters_particip OK
-+ Ethereum Foundation - Altair - Transition - transition_with_voluntary_exit_right_after_for OK
-+ Ethereum Foundation - Altair - Transition - transition_with_voluntary_exit_right_before_fo OK
 + Ethereum Foundation - Merge - Rewards - all_balances_too_low_for_reward [Preset: mainnet]  OK
 + Ethereum Foundation - Merge - Rewards - empty [Preset: mainnet]                            OK
 + Ethereum Foundation - Merge - Rewards - empty_leak [Preset: mainnet]                       OK
@@ -267,6 +265,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: mainne OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - inactivity_scores_full_participa OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - inactivity_scores_leaking [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - is_execution_enabled_false [Pres OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
@@ -338,7 +337,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 335/335 Fail: 0/335 Skip: 0/335
+OK: 334/334 Fail: 0/334 Skip: 0/334
 ## Attestation
 ```diff
 + [Invalid] Ethereum Foundation - Altair - Operations - Attestation - after_epoch_slots      OK
@@ -770,13 +769,16 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 ```diff
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
+  ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  Skip
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
 + ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/basic                        OK
 + ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
   ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               OK
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
 ```
-OK: 6/7 Fail: 0/7 Skip: 1/7
+OK: 8/10 Fail: 0/10 Skip: 2/10
 ## Ethereum Foundation - Merge - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1165,4 +1167,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 990/991 Fail: 0/991 Skip: 1/991
+OK: 991/993 Fail: 0/993 Skip: 2/993

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -279,6 +279,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - historical_batch [Preset: minima OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - inactivity_scores_full_participa OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - inactivity_scores_leaking [Prese OK
++ [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - is_execution_enabled_false [Pres OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_no_o OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_attester_slashings_part OK
 + [Valid]   Ethereum Foundation - Merge - Sanity - Blocks - multiple_different_proposer_slas OK
@@ -341,7 +342,7 @@ ConsensusSpecPreset-minimal
 + finality_root_merkle_proof                                                                 OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 338/338 Fail: 0/338 Skip: 0/338
+OK: 339/339 Fail: 0/339 Skip: 0/339
 ## Attestation
 ```diff
 + [Invalid] Ethereum Foundation - Altair - Operations - Attestation - after_epoch_slots      OK
@@ -789,6 +790,7 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/filtered_block_tree          Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/genesis                      Skip
+  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta Skip
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/basic                        Skip
@@ -803,8 +805,10 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots_ Skip
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_update_justified_ch Skip
+  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               Skip
+  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo Skip
 ```
-OK: 0/17 Fail: 0/17 Skip: 17/17
+OK: 0/20 Fail: 0/20 Skip: 20/20
 ## Ethereum Foundation - Merge - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1219,4 +1223,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1020/1037 Fail: 0/1037 Skip: 17/1037
+OK: 1021/1041 Fail: 0/1041 Skip: 20/1041

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -57,7 +57,7 @@ export
 # Eventually, we could also differentiate between user/tainted data and
 # internal state that's gone through sanity checks already.
 
-const SPEC_VERSION* = "1.1.5"
+const SPEC_VERSION* = "1.1.6"
 ## Spec version we're aiming to be compatible with, right now
 
 const
@@ -81,6 +81,9 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/phase0/validator.md#misc
   ATTESTATION_SUBNET_COUNT* = 64
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/fork-choice.md#constant
+  INTERVALS_PER_SLOT* = 3
 
 template maxSize*(n: int) {.pragma.}
 

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -84,12 +84,11 @@ type
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/merge/fork-choice.md#powblock
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/fork-choice.md#powblock
   PowBlock* = object
     block_hash*: Eth2Digest
     parent_hash*: Eth2Digest
     total_difficulty*: Eth2Digest   # uint256
-    difficulty*: Eth2Digest         # uint256
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/merge/beacon-chain.md#beaconstate
   BeaconState* = object

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -50,7 +50,7 @@ type
 const
   FixturesDir* =
     currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / "vendor" / "nim-eth2-scenarios"
-  SszTestsDir* = FixturesDir / "tests-v1.1.5"
+  SszTestsDir* = FixturesDir / "tests-v1.1.6"
   MaxObjectSize* = 3_000_000
 
 proc parseTest*(path: string, Format: typedesc[Json], T: typedesc): T =

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -5,11 +5,13 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.used.}
+
 import
   # Standard library
-  std/[strformat, tables, options, json, os, strutils],
+  std/[json, options, os, strutils, tables],
   # Status libraries
-  stew/[results, endians2], snappy, chronicles,
+  stew/[results, endians2], chronicles,
   eth/keys, taskpools,
   # Internals
   ../../beacon_chain/spec/[helpers, forks],
@@ -216,7 +218,7 @@ proc stepChecks(
        checks: JsonNode,
        dag: ChainDagRef,
        fkChoice: ref ForkChoice,
-       time: Slot  
+       time: Slot
      ) =
   doAssert checks.len >= 1, "No checks found"
   for check, val in checks:
@@ -246,6 +248,9 @@ proc stepChecks(
       let checkpointEpoch = fkChoice.checkpoints.best_justified.epoch
       doAssert checkpointEpoch == Epoch(val["epoch"].getInt())
       doAssert checkpointRoot == Eth2Digest.fromHex(val["root"].getStr())
+    elif check == "proposer_boost_root":
+      # TODO needs fork choice to know about BeaconTime
+      discard
     elif check == "genesis_time":
       # The fork choice is pruned regularly
       # and does not store the genesis time,
@@ -322,6 +327,9 @@ suite "Ethereum Foundation - ForkChoice" & preset():
     # test: tests/fork_choice/scenarios/no_votes.nim
     #       "Ensure the head is still 4 whilst the justified epoch is 0."
     "on_block_future_block",
+
+    # TODO needs fork choice to know about BeaconTime
+    "proposer_boost_correct_head"
   ]
 
   for fork in [BeaconBlockFork.Phase0]: # TODO: init ChainDAG from Merge/Altair


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.1.6
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.1.6

A safe/semantically-empty subset of https://github.com/status-im/nimbus-eth2/pull/3138

No regressions, but it also doesn't verify the proposer boost aspect of v1.1.6.