### PR TITLE
batch-verify sync messages for a small perf boost

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -11,7 +11,7 @@ import
   std/[sets, tables],
   stew/shims/hashes,
   chronicles,
-  ../spec/digest,
+  ../spec/[crypto, digest],
   ../spec/datatypes/altair
 
 export hashes, sets, tables, altair
@@ -97,7 +97,7 @@ func isSeen*(
     subcommitteeIndex: subcommitteeIndex.uint64)
   seenKey in pool.seenSyncMsgByAuthor
 
-func addSyncCommitteeMessage*(
+proc addSyncCommitteeMessage*(
     pool: var SyncCommitteeMsgPool,
     slot: Slot,
     blockRoot: Eth2Digest,
@@ -120,6 +120,9 @@ func addSyncCommitteeMessage*(
       subcommitteeIndex: subcommitteeIndex,
       positionInCommittee: position,
       signature: signature)
+
+  debug "Sync committee message resolved",
+    slot = slot, blockRoot = shortLog(blockRoot), validatorIndex
 
 func computeAggregateSig(votes: seq[TrustedSyncCommitteeMsg],
                          subcommitteeIndex: SyncSubcommitteeIndex,

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -205,9 +205,10 @@ proc scheduleBatch(batchCrypto: ref BatchCrypto, fresh: bool) =
 
 template orReturnErr(v: Option, error: cstring): untyped =
   ## Returns with given error string if the option does not have a value
-  if v.isNone:
+  let tmp = v
+  if tmp.isNone:
     return err(error) # this exits the calling scope, as templates are inlined.
-  v.unsafeGet()
+  tmp.unsafeGet()
 
 template withBatch(
     batchCrypto: ref BatchCrypto, name: cstring,

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -8,6 +8,7 @@
 {.push raises: [Defect].}
 
 import
+  std/sequtils,
   # Status
   chronicles, chronos,
   ../spec/signatures_batch,
@@ -188,6 +189,7 @@ proc getBatch(batchCrypto: ref BatchCrypto): (ref Batch, bool) =
     # len will be 0 when the batch was created but nothing added to it
     # because of early failures
     (batch, batch[].len() == 0)
+
 proc scheduleBatch(batchCrypto: ref BatchCrypto, fresh: bool) =
   if fresh:
     # Every time we start a new round of batching, we need to launch a deferred
@@ -201,12 +203,35 @@ proc scheduleBatch(batchCrypto: ref BatchCrypto, fresh: bool) =
     # If there's a full batch, process it eagerly assuming the callback allows
     batchCrypto.processBatch()
 
+template orReturnErr(v: Option, error: cstring): untyped =
+  ## Returns with given error string if the option does not have a value
+  if v.isNone:
+    return err(error) # this exits the calling scope, as templates are inlined.
+  v.unsafeGet()
+
+template withBatch(
+    batchCrypto: ref BatchCrypto, name: cstring,
+    body: untyped): Future[BatchResult] =
+  block:
+    let
+      (batch {.inject.}, fresh) = batchCrypto.getBatch()
+
+    body
+
+    let fut = newFuture[BatchResult](name)
+
+    batch[].resultsBuffer.add(fut)
+
+    batchCrypto.scheduleBatch(fresh)
+    fut
+
+# See also verify_attestation_signature
 proc scheduleAttestationCheck*(
       batchCrypto: ref BatchCrypto,
       fork: Fork, genesis_validators_root: Eth2Digest,
-      epochRef: EpochRef,
-      attestation: Attestation
-     ): Result[(Future[BatchResult], CookedSig), cstring] =
+      attestationData: AttestationData,
+      pubkey: CookedPubKey, signature: ValidatorSig
+     ): Result[tuple[fut: Future[BatchResult], sig: CookedSig], cstring] =
   ## Schedule crypto verification of an attestation
   ##
   ## The buffer is processed:
@@ -216,37 +241,23 @@ proc scheduleAttestationCheck*(
   ## This returns an error if crypto sanity checks failed
   ## and a future with the deferred attestation check otherwise.
   ##
-  let (batch, fresh) = batchCrypto.getBatch()
+  let
+    sig = signature.load().orReturnErr("attestation: cannot load signature")
+    fut = batchCrypto.withBatch("batch_validation.scheduleAttestationCheck"):
+      batch.pendingBuffer.add_attestation_signature(
+        fork, genesis_validators_root, attestationData, pubkey, sig)
 
-  doAssert batch.pendingBuffer.len < BatchedCryptoSize
-
-  let sig = ? batch
-              .pendingBuffer
-              .addAttestation(
-                fork, genesis_validators_root, epochRef,
-                attestation
-              )
-
-  let fut = newFuture[BatchResult](
-    "batch_validation.scheduleAttestationCheck"
-  )
-
-  batch[].resultsBuffer.add(fut)
-
-  batchCrypto.scheduleBatch(fresh)
-
-  return ok((fut, sig))
+  ok((fut, sig))
 
 proc scheduleAggregateChecks*(
       batchCrypto: ref BatchCrypto,
       fork: Fork, genesis_validators_root: Eth2Digest,
+      signedAggregateAndProof: SignedAggregateAndProof,
       epochRef: EpochRef,
-      signedAggregateAndProof: SignedAggregateAndProof
-     ): Result[
-          (
-            tuple[slotCheck, aggregatorCheck, aggregateCheck: Future[BatchResult]],
-            CookedSig
-          ), cstring] =
+      attesting_indices: openArray[ValidatorIndex]
+     ): Result[tuple[
+        aggregatorFut, slotFut, aggregateFut: Future[BatchResult],
+        sig: CookedSig], cstring] =
   ## Schedule crypto verification of an aggregate
   ##
   ## This involves 3 checks:
@@ -260,72 +271,111 @@ proc scheduleAggregateChecks*(
   ##
   ## This returns None if the signatures could not be loaded.
   ## and 3 futures with the deferred aggregate checks otherwise.
-  let (batch, fresh) = batchCrypto.getBatch()
-
-  doAssert batch[].pendingBuffer.len < BatchedCryptoSize
 
   template aggregate_and_proof: untyped = signedAggregateAndProof.message
   template aggregate: untyped = aggregate_and_proof.aggregate
 
-  type R = (
-    tuple[slotCheck, aggregatorCheck, aggregateCheck:
-      Future[BatchResult]],
-    CookedSig)
+  # Do the eager steps first to avoid polluting batches with needlessly
+  let
+    aggregatorKey =
+      epochRef.validatorKey(aggregate_and_proof.aggregator_index).orReturnErr(
+        "SignedAggregateAndProof: invalid aggregator index")
+    aggregatorSig = signedAggregateAndProof.signature.load().orReturnErr(
+      "aggregateAndProof: invalid proof signature")
+    slotSig = aggregate_and_proof.selection_proof.load().orReturnErr(
+      "aggregateAndProof: invalid selection signature")
+    aggregateKey = ? aggregateAll(epochRef.dag, attesting_indices)
+    aggregateSig = aggregate.signature.load().orReturnErr(
+      "aggregateAndProof: invalid aggregate signature")
 
-  # Enqueue in the buffer
-  # ------------------------------------------------------
-  let aggregator = epochRef.validatorKey(aggregate_and_proof.aggregator_index)
-  if not aggregator.isSome():
-    return err("scheduleAggregateChecks: invalid aggregator index")
-  block:
-    if (let v = batch
-            .pendingBuffer
-            .addSlotSignature(
-              fork, genesis_validators_root,
-              aggregate.data.slot,
-              aggregator.get(),
-              aggregate_and_proof.selection_proof
-            ); v.isErr()):
-      return err(v.error())
+  let
+    aggregatorFut = batchCrypto.withBatch("scheduleAggregateChecks.aggregator"):
+      batch.pendingBuffer.add_aggregate_and_proof_signature(
+        fork, genesis_validators_root, aggregate_and_proof, aggregatorKey,
+        aggregatorSig)
+    slotFut = batchCrypto.withBatch("scheduleAggregateChecks.selection_proof"):
+      batch.pendingBuffer.add_slot_signature(
+        fork, genesis_validators_root, aggregate.data.slot, aggregatorKey,
+        slotSig)
+    aggregateFut = batchCrypto.withBatch("scheduleAggregateChecks.aggregate"):
+      batch.pendingBuffer.add_attestation_signature(
+        fork, genesis_validators_root, aggregate.data, aggregateKey,
+        aggregateSig)
 
-  let futSlot = newFuture[BatchResult](
-    "batch_validation.scheduleAggregateChecks.slotCheck"
-  )
-  batch.resultsBuffer.add(futSlot)
+  ok((aggregatorFut, slotFut, aggregateFut, aggregateSig))
 
-  block:
-    if (let v = batch
-            .pendingBuffer
-            .addAggregateAndProofSignature(
-              fork, genesis_validators_root,
-              aggregate_and_proof,
-              aggregator.get(),
-              signed_aggregate_and_proof.signature
-            ); v.isErr()):
-      batchCrypto.scheduleBatch(fresh)
-      return err(v.error())
+proc scheduleSyncCommitteeMessageCheck*(
+      batchCrypto: ref BatchCrypto,
+      fork: Fork, genesis_validators_root: Eth2Digest,
+      slot: Slot, beacon_block_root: Eth2Digest,
+      pubkey: CookedPubKey, signature: ValidatorSig
+     ): Result[tuple[fut: Future[BatchResult], sig: CookedSig], cstring] =
+  ## Schedule crypto verification of an attestation
+  ##
+  ## The buffer is processed:
+  ## - when eager processing is enabled and the batch is full
+  ## - otherwise after 10ms (BatchAttAccumTime)
+  ##
+  ## This returns an error if crypto sanity checks failed
+  ## and a future with the deferred attestation check otherwise.
+  ##
+  let
+    sig = signature.load().orReturnErr(
+      "SyncCommitteMessage: cannot load signature")
+    fut = batchCrypto.withBatch("scheduleSyncCommitteeMessageCheck"):
+      batch.pendingBuffer.add_sync_committee_message_signature(
+        fork, genesis_validators_root, slot, beacon_block_root, pubkey, sig)
 
-  let futAggregator = newFuture[BatchResult](
-    "batch_validation.scheduleAggregateChecks.aggregatorCheck"
-  )
+  ok((fut, sig))
 
-  batch.resultsBuffer.add(futAggregator)
+proc scheduleContributionChecks*(
+      batchCrypto: ref BatchCrypto,
+      fork: Fork, genesis_validators_root: Eth2Digest,
+      signedContributionAndProof: SignedContributionAndProof,
+      subcommitteeIndex: SyncSubcommitteeIndex,
+      dag: ChainDAGRef): Result[tuple[
+       aggregatorFut, proofFut, contributionFut: Future[BatchResult],
+       sig: CookedSig], cstring] =
+  ## Schedule crypto verification of all signatures in a
+  ## SignedContributionAndProof message
+  ##
+  ## The buffer is processed:
+  ## - when eager processing is enabled and the batch is full
+  ## - otherwise after 10ms (BatchAttAccumTime)
+  ##
+  ## This returns an error if crypto sanity checks failed
+  ## and a future with the deferred check otherwise.
+  ##
+  template contribution_and_proof: untyped = signedContributionAndProof.message
+  template contribution: untyped = contribution_and_proof.contribution
 
-  let sig = batch
-              .pendingBuffer
-              .addAttestation(
-                fork, genesis_validators_root, epochRef,
-                aggregate
-              )
-  if sig.isErr():
-    batchCrypto.scheduleBatch(fresh)
-    return err(sig.error())
+  # Do the eager steps first to avoid polluting batches with needlessly
+  let
+    aggregatorKey =
+      dag.validatorKey(contribution_and_proof.aggregator_index).orReturnErr(
+        "SignedAggregateAndProof: invalid contributor index")
+    aggregatorSig = signedContributionAndProof.signature.load().orReturnErr(
+      "SignedContributionAndProof: invalid proof signature")
+    proofSig = contribution_and_proof.selection_proof.load().orReturnErr(
+      "SignedContributionAndProof: invalid selection signature")
+    contributionSig = contribution.signature.load().orReturnErr(
+      "SignedContributionAndProof: invalid contribution signature")
 
-  let futAggregate = newFuture[BatchResult](
-    "batch_validation.scheduleAggregateChecks.aggregateCheck"
-  )
-  batch.resultsBuffer.add(futAggregate)
+    contributionKey = ? aggregateAll(
+      dag, dag.syncCommitteeParticipants(contribution.slot, subcommitteeIndex),
+      contribution.aggregation_bits)
+  let
+    aggregatorFut = batchCrypto.withBatch("scheduleContributionAndProofChecks.aggregator"):
+      batch.pendingBuffer.add_contribution_and_proof_signature(
+        fork, genesis_validators_root, contribution_and_proof, aggregatorKey,
+        aggregatorSig)
+    proofFut = batchCrypto.withBatch("scheduleContributionAndProofChecks.selection_proof"):
+      batch.pendingBuffer.add_sync_committee_selection_proof(
+        fork, genesis_validators_root, contribution.slot,
+        contribution.subcommittee_index, aggregatorKey, proofSig)
+    contributionFut = batchCrypto.withBatch("scheduleContributionAndProofChecks.contribution"):
+      batch.pendingBuffer.add_sync_committee_message_signature(
+        fork, genesis_validators_root, contribution.slot,
+        contribution.beacon_block_root, contributionKey, contributionSig)
 
-  batchCrypto.scheduleBatch(fresh)
-
-  return ok(((futSlot, futAggregator, futAggregate), sig.get()))
+  ok((aggregatorFut, proofFut, contributionFut, contributionSig))

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -34,6 +34,12 @@ declareCounter beacon_attestations_dropped_queue_full,
 declareCounter beacon_aggregates_dropped_queue_full,
   "Number of aggregates dropped because queue is full"
 
+declareCounter beacon_sync_messages_dropped_queue_full,
+  "Number of sync committee messages dropped because queue is full"
+
+declareCounter beacon_contributions_dropped_queue_full,
+  "Number of sync committee contributions dropped because queue is full"
+
 # This result is a little messy in that it returns Result.ok for
 # ValidationResult.Accept and an err for the others - this helps transport
 # an error message to callers but could arguably be done in an cleaner way.
@@ -412,29 +418,25 @@ proc validateAttestation*(
         attestation.data.target.epoch:
     return errIgnore("Attestation: Validator has already voted in epoch")
 
-  block:
-    # First pass - without cryptography
-    let v = is_valid_indexed_attestation(
-        fork, genesis_validators_root, epochRef, attestation,
-        {skipBLSValidation})
-    if v.isErr():
-      return checkedReject(v.error)
+  let pubkey = epochRef.validatorKey(validator_index)
+  if pubkey.isNone():
+    # can't happen, in theory, because we checked the aggregator index above
+    return errIgnore("Attestation: cannot find validator pubkey")
 
+  # In the spec, is_valid_indexed_attestation is used to verify the signature -
+  # here, we do a batch verification instead
   let sig =
     if checkSignature:
       # Attestation signatures are batch-verified
       let deferredCrypto = batchCrypto
-                            .scheduleAttestationCheck(
-                              fork, genesis_validators_root, epochRef,
-                              attestation
-                            )
+                             .scheduleAttestationCheck(
+                              fork, genesis_validators_root, attestation.data,
+                              pubkey.get(), attestation.signature)
       if deferredCrypto.isErr():
         return checkedReject(deferredCrypto.error)
 
+      let (cryptoFut, sig) = deferredCrypto.get()
       # Await the crypto check
-      let
-        (cryptoFut, sig) = deferredCrypto.get()
-
       var x = (await cryptoFut)
       case x
       of BatchResult.Invalid:
@@ -575,20 +577,35 @@ proc validateAggregate*(
     genesis_validators_root =
       getStateField(pool.dag.headState.data, genesis_validators_root)
 
+  let attesting_indices = get_attesting_indices(
+    epochRef, aggregate.data, aggregate.aggregation_bits)
+
   let deferredCrypto = batchCrypto
                 .scheduleAggregateChecks(
-                  fork, genesis_validators_root, epochRef,
-                  signed_aggregate_and_proof
+                  fork, genesis_validators_root,
+                  signed_aggregate_and_proof, epochRef, attesting_indices
                 )
   if deferredCrypto.isErr():
     return checkedReject(deferredCrypto.error)
 
   let
-    (cryptoFuts, sig) = deferredCrypto.get()
+    (aggregatorFut, slotFut, aggregateFut, sig) = deferredCrypto.get()
+
+  block:
+    # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+    var x = await aggregatorFut
+    case x
+    of BatchResult.Invalid:
+      return checkedReject("Aggregate: invalid aggregator signature")
+    of BatchResult.Timeout:
+      beacon_aggregates_dropped_queue_full.inc()
+      return errIgnore("Aggregate: timeout checking aggregator signature")
+    of BatchResult.Valid:
+      discard
 
   block:
     # [REJECT] aggregate_and_proof.selection_proof
-    var x = await cryptoFuts.slotCheck
+    var x = await slotFut
     case x
     of BatchResult.Invalid:
       return checkedReject("Aggregate: invalid slot signature")
@@ -600,19 +617,7 @@ proc validateAggregate*(
 
   block:
     # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    var x = await cryptoFuts.aggregatorCheck
-    case x
-    of BatchResult.Invalid:
-      return checkedReject("Aggregate: invalid aggregator signature")
-    of BatchResult.Timeout:
-      beacon_aggregates_dropped_queue_full.inc()
-      return errIgnore("Aggregate: timeout checking aggregator signature")
-    of BatchResult.Valid:
-      discard
-
-  block:
-    # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
-    var x = await cryptoFuts.aggregateCheck
+    var x = await aggregateFut
     case x
     of BatchResult.Invalid:
       return checkedReject("Aggregate: invalid aggregate signature")
@@ -637,9 +642,6 @@ proc validateAggregate*(
       aggregate_and_proof.aggregator_index.int + 1)
   pool.nextAttestationEpoch[aggregate_and_proof.aggregator_index].aggregate =
     aggregate.data.target.epoch + 1
-
-  let attesting_indices = get_attesting_indices(
-    epochRef, aggregate.data, aggregate.aggregation_bits)
 
   return ok((attesting_indices, sig))
 
@@ -722,17 +724,20 @@ proc validateVoluntaryExit*(
 # https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/specs/altair/p2p-interface.md#sync_committee_subnet_id
 proc validateSyncCommitteeMessage*(
     dag: ChainDAGRef,
+    batchCrypto: ref BatchCrypto,
     syncCommitteeMsgPool: SyncCommitteeMsgPool,
     msg: SyncCommitteeMessage,
     subcommitteeIdx: SyncSubcommitteeIndex,
     wallTime: BeaconTime,
     checkSignature: bool):
-    Result[(seq[uint64], CookedSig), ValidationError] =
+    Future[Result[(seq[uint64], CookedSig), ValidationError]] {.async.} =
   block:
     # [IGNORE] The signature's slot is for the current slot
     # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     # i.e. sync_committee_message.slot == current_slot.
-    ? check_propagation_slot_range(msg.slot, wallTime)
+    let v = check_propagation_slot_range(msg.slot, wallTime)
+    if v.isErr():
+      return err(v.error())
 
   # [REJECT] The subnet_id is valid for the given validator
   # i.e. subnet_id in compute_subnets_for_sync_committee(state, sync_committee_message.validator_index).
@@ -769,41 +774,62 @@ proc validateSyncCommitteeMessage*(
   if senderPubKey.isNone():
     return errReject("SyncCommitteeMessage: invalid validator index")
 
-  var cookedSignature = msg.signature.load
-  if cookedSignature.isNone:
-    return errReject("SyncCommitteeMessage: signature fails to load")
+  let sig =
+    if checkSignature:
+      # Attestation signatures are batch-verified
+      let deferredCrypto = batchCrypto
+                            .scheduleSyncCommitteeMessageCheck(
+                              fork, genesis_validators_root,
+                              msg.slot, msg.beacon_block_root,
+                              senderPubKey.get(), msg.signature)
+      if deferredCrypto.isErr():
+        return errReject(deferredCrypto.error)
 
-  if checkSignature and
-      not verify_sync_committee_message_signature(epoch,
-                                                  msg.beacon_block_root,
-                                                  fork, genesisValidatorsRoot,
-                                                  senderPubKey.get(),
-                                                  cookedSignature.get):
-    return errReject("SyncCommitteeMessage: signature fails to verify")
+      # Await the crypto check
+      let
+        (cryptoFut, sig) = deferredCrypto.get()
 
-  ok((positionsInSubcommittee, cookedSignature.get()))
+      var x = (await cryptoFut)
+      case x
+      of BatchResult.Invalid:
+        return errReject("SyncCommitteeMessage: invalid signature")
+      of BatchResult.Timeout:
+        beacon_sync_messages_dropped_queue_full.inc()
+        return errIgnore("SyncCommitteeMessage: timeout checking signature")
+      of BatchResult.Valid:
+        sig # keep going only in this case
+    else:
+      let sig = msg.signature.load()
+      if not sig.isSome():
+        return errReject("SyncCommitteeMessage: unable to load signature")
+      sig.get()
+
+  return ok((positionsInSubcommittee, sig))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/altair/p2p-interface.md#sync_committee_contribution_and_proof
 proc validateContribution*(
     dag: ChainDAGRef,
-    syncCommitteeMsgPool: var SyncCommitteeMsgPool,
+    batchCrypto: ref BatchCrypto,
+    syncCommitteeMsgPool: ref SyncCommitteeMsgPool,
     msg: SignedContributionAndProof,
     wallTime: BeaconTime,
     checkSignature: bool):
-    Result[CookedSig, ValidationError] =
+    Future[Result[CookedSig, ValidationError]] {.async.} =
+
+  let
+    syncCommitteeSlot = msg.message.contribution.slot
 
   # [IGNORE] The contribution's slot is for the current slot
   # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
   # i.e. contribution.slot == current_slot.
-  ? check_propagation_slot_range(msg.message.contribution.slot, wallTime)
-  let
-    aggregatorPubKey = dag.validatorKey(msg.message.aggregator_index)
-  if aggregatorPubKey.isNone():
-    return errReject("SignedContributionAndProof: invalid aggregator index")
+  block:
+    let v = check_propagation_slot_range(syncCommitteeSlot, wallTime) # [IGNORE]
+    if v.isErr():
+      return err(v.error())
 
   # [REJECT] The subcommittee index is in the allowed range
   # i.e. contribution.subcommittee_index < SYNC_COMMITTEE_SUBNET_COUNT.
-  let committeeIdx = msg.message.contribution.subcommittee_index.validateSyncCommitteeIndexOr:
+  let subcommitteeIdx = msg.message.contribution.subcommittee_index.validateSyncCommitteeIndexOr:
     return errReject("SignedContributionAndProof: subcommittee index too high")
 
   # [REJECT] contribution_and_proof.selection_proof selects the validator as an aggregator for the slot
@@ -811,14 +837,13 @@ proc validateContribution*(
   if not is_sync_committee_aggregator(msg.message.selection_proof):
     return errReject("SignedContributionAndProof: invalid selection_proof")
 
-  block:
-    # [IGNORE] The sync committee contribution is the first valid contribution
-    # received for the aggregator with index contribution_and_proof.aggregator_index
-    # for the slot contribution.slot and subcommittee index contribution.subcommittee_index
-    # (this requires maintaining a cache of size SYNC_COMMITTEE_SIZE for this
-    #  topic that can be flushed after each slot).
-    if syncCommitteeMsgPool.isSeen(msg.message):
-      return errIgnore("SignedContributionAndProof: duplicate contribution")
+  # [IGNORE] The sync committee contribution is the first valid contribution
+  # received for the aggregator with index contribution_and_proof.aggregator_index
+  # for the slot contribution.slot and subcommittee index contribution.subcommittee_index
+  # (this requires maintaining a cache of size SYNC_COMMITTEE_SIZE for this
+  #  topic that can be flushed after each slot).
+  if syncCommitteeMsgPool[].isSeen(msg.message):
+    return errIgnore("SignedContributionAndProof: duplicate contribution")
 
   # [REJECT] The aggregator's validator index is in the declared subcommittee
   # of the current sync committee.
@@ -827,70 +852,61 @@ proc validateContribution*(
   let
     epoch = msg.message.contribution.slot.epoch
     fork = dag.forkAtEpoch(epoch)
-    genesisValidatorsRoot = dag.genesisValidatorsRoot
+    genesis_validators_root = dag.genesisValidatorsRoot
 
-  # [REJECT] The aggregator signature, signed_contribution_and_proof.signature, is valid
-  if not verify_signed_contribution_and_proof_signature(msg, fork,
-                                                        genesisValidatorsRoot,
-                                                        aggregatorPubKey.get()):
-    return errReject(
-      "SignedContributionAndProof: aggregator signature fails to verify")
-
-  # [REJECT] The contribution_and_proof.selection_proof is a valid signature of the
-  # SyncAggregatorSelectionData derived from the contribution by the validator with
-  # index contribution_and_proof.aggregator_index.
-  if not verify_selection_proof_signature(msg.message, fork,
-                                          genesisValidatorsRoot,
-                                          aggregatorPubKey.get()):
-    return errReject(
-      "SignedContributionAndProof: selection proof signature fails to verify")
-
-  # [REJECT] The aggregate signature is valid for the message beacon_block_root
-  # and aggregate pubkey derived from the participation info in aggregation_bits
-  # for the subcommittee specified by the contribution.subcommittee_index.
-  var
-    committeeAggKey {.noInit.}: AggregatePublicKey
-    initialized = false
-    syncCommitteeSlot = msg.message.contribution.slot + 1
-
-  for validatorIndex in dag.syncCommitteeParticipants(
-      syncCommitteeSlot,
-      committeeIdx,
-      msg.message.contribution.aggregation_bits):
-    let validatorPubKey = dag.validatorKey(validatorIndex)
-    if not validatorPubKey.isSome():
-      # This should never happen (!)
-      warn "Invalid validator index in committee cache",
-        validatorIndex
-      return errIgnore("SignedContributionAndProof: Invalid committee cache")
-
-    if not initialized:
-      initialized = true
-      committeeAggKey.init(validatorPubKey.get())
-    else:
-      committeeAggKey.aggregate(validatorPubKey.get())
-
-  if not initialized:
+  if msg.message.contribution.aggregation_bits.countOnes() == 0:
     # [REJECT] The contribution has participants
     # that is, any(contribution.aggregation_bits).
     return errReject("SignedContributionAndProof: aggregation bits empty")
 
-  let cookedSignature = msg.message.contribution.signature.load
-  if cookedSignature.isNone:
-    return errReject(
-      "SignedContributionAndProof: aggregate signature fails to load")
+  let sig = if checkSignature:
+    let deferredCrypto = batchCrypto.scheduleContributionChecks(
+      fork, genesis_validators_root, msg, subcommitteeIdx, dag)
+    if deferredCrypto.isErr():
+      return errReject(deferredCrypto.error)
 
-  if checkSignature and
-      not verify_sync_committee_message_signature(
-        epoch, msg.message.contribution.beacon_block_root, fork,
-        genesisValidatorsRoot, committeeAggKey.finish, cookedSignature.get):
-    debug "failing_sync_contribution",
-      blk = msg.message.contribution.beacon_block_root,
-      slot = syncCommitteeSlot,
-      subnet = committeeIdx,
-      participants = $(msg.message.contribution.aggregation_bits)
+    let
+      (aggregatorFut, proofFut, contributionFut, sig) = deferredCrypto.get()
 
-    return errReject(
-      "SignedContributionAndProof: aggregate signature fails to verify")
+    block:
+      # [REJECT] The aggregator signature, signed_contribution_and_proof.signature, is valid
+      var x = await aggregatorFut
+      case x
+      of BatchResult.Invalid:
+        return errReject("SignedContributionAndProof: invalid aggregator signature")
+      of BatchResult.Timeout:
+        beacon_contributions_dropped_queue_full.inc()
+        return errIgnore("SignedContributionAndProof: timeout checking aggregator signature")
+      of BatchResult.Valid:
+        discard
 
-  ok(cookedSignature.get)
+    block:
+      var x = await proofFut
+      case x
+      of BatchResult.Invalid:
+        return errReject("SignedContributionAndProof: invalid proof")
+      of BatchResult.Timeout:
+        beacon_contributions_dropped_queue_full.inc()
+        return errIgnore("SignedContributionAndProof: timeout checking proof")
+      of BatchResult.Valid:
+        discard
+
+    block:
+      # [REJECT] The aggregator signature, signed_aggregate_and_proof.signature, is valid.
+      var x = await contributionFut
+      case x
+      of BatchResult.Invalid:
+        return errReject("SignedContributionAndProof: invalid contribution signature")
+      of BatchResult.Timeout:
+        beacon_contributions_dropped_queue_full.inc()
+        return errIgnore("SignedContributionAndProof: timeout checking contribution signature")
+      of BatchResult.Valid:
+        discard
+    sig
+  else:
+    let sig = msg.message.contribution.signature.load()
+    if not sig.isSome():
+      return errReject("SyncCommitteeMessage: unable to load signature")
+    sig.get()
+
+  return ok(sig)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1051,18 +1051,18 @@ proc installMessageValidators(node: BeaconNode) =
     for committeeIdx in allSyncSubcommittees():
       closureScope:
         let idx = committeeIdx
-        node.network.addValidator(
+        node.network.addAsyncValidator(
           getSyncCommitteeTopic(digest, idx),
           # This proc needs to be within closureScope; don't lift out of loop.
-          proc(msg: SyncCommitteeMessage): ValidationResult =
-            toValidationResult(
-              node.processor.syncCommitteeMessageValidator(msg, idx)))
+          proc(msg: SyncCommitteeMessage): Future[ValidationResult] {.async.} =
+            return toValidationResult(
+              await node.processor.syncCommitteeMessageValidator(msg, idx)))
 
-    node.network.addValidator(
+    node.network.addAsyncValidator(
       getSyncCommitteeContributionAndProofTopic(digest),
-      proc(msg: SignedContributionAndProof): ValidationResult =
-        toValidationResult(
-          node.processor.contributionValidator(msg)))
+      proc(msg: SignedContributionAndProof): Future[ValidationResult] {.async.} =
+        return toValidationResult(
+          await node.processor.contributionValidator(msg)))
 
   installSyncCommitteeeValidators(node.dag.forkDigests.altair)
   installSyncCommitteeeValidators(node.dag.forkDigests.merge)

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -303,7 +303,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           msg = request.syncAggregatorSelectionData
-          cooked = get_sync_aggregator_selection_data_signature(forkInfo.fork,
+          cooked = get_sync_committee_selection_proof(forkInfo.fork,
             forkInfo.genesisValidatorsRoot, msg.slot, msg.subcommittee_index,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
@@ -312,7 +312,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           msg = request.syncCommitteeContributionAndProof
-          cooked = get_sync_committee_contribution_and_proof_signature(
+          cooked = get_contribution_and_proof_signature(
             forkInfo.fork, forkInfo.genesisValidatorsRoot, msg,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -7,6 +7,15 @@
 
 {.push raises: [Defect].}
 
+## Signature production and verification for spec types - for every type of
+## signature, there are 3 functions:
+## * `compute_*_signing_root` - reduce message to the data that will be signed
+## * `get_*_signature` - sign the signing root with a private key
+## * `verify_*_signature` - verify a signature produced by `get_*_signature`
+##
+## See also `signatures_batch` for batch verification versions of these
+## functions.
+
 import
   ./datatypes/[phase0, altair, merge], ./helpers, ./eth2_merkleization
 
@@ -24,7 +33,7 @@ func getDepositMessage(depositData: DepositData): DepositMessage =
     amount: depositData.amount,
     withdrawal_credentials: depositData.withdrawal_credentials)
 
-func compute_slot_root*(
+func compute_slot_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot
     ): Eth2Digest =
   let
@@ -37,21 +46,21 @@ func compute_slot_root*(
 func get_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     privkey: ValidatorPrivKey): CookedSig =
-  blsSign(privKey, compute_slot_root(fork, genesis_validators_root, slot).data)
+  let signing_root = compute_slot_signing_root(
+    fork, genesis_validators_root, slot)
+
+  blsSign(privKey, signing_root.data)
 
 proc verify_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
-    let
-      epoch = compute_epoch_at_slot(slot)
-      domain = get_domain(
-        fork, DOMAIN_SELECTION_PROOF, epoch, genesis_validators_root)
-      signing_root = compute_signing_root(slot, domain)
+    let signing_root = compute_slot_signing_root(
+      fork, genesis_validators_root, slot)
 
     blsVerify(pubkey, signing_root.data, signature)
 
-func compute_epoch_root*(
+func compute_epoch_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch
     ): Eth2Digest =
   let domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
@@ -61,32 +70,37 @@ func compute_epoch_root*(
 func get_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
     privkey: ValidatorPrivKey): CookedSig =
-  blsSign(privKey, compute_epoch_root(fork, genesis_validators_root, epoch).data)
+  let signing_root = compute_epoch_signing_root(
+    fork, genesis_validators_root, epoch)
+
+  blsSign(privKey, signing_root.data)
 
 proc verify_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
-    let
-      domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
-      signing_root = compute_signing_root(epoch, domain)
+    let signing_root = compute_epoch_signing_root(
+      fork, genesis_validators_root, epoch)
 
     blsVerify(pubkey, signing_root.data, signature)
 
-func compute_block_root*(
+func compute_block_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    root: Eth2Digest): Eth2Digest =
+    blck: Eth2Digest | SomeSomeBeaconBlock | BeaconBlockHeader): Eth2Digest =
   let
     epoch = compute_epoch_at_slot(slot)
     domain = get_domain(
       fork, DOMAIN_BEACON_PROPOSER, epoch, genesis_validators_root)
-  compute_signing_root(root, domain)
+  compute_signing_root(blck, domain)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/validator.md#signature
 func get_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     root: Eth2Digest, privkey: ValidatorPrivKey): CookedSig =
-  blsSign(privKey, compute_block_root(fork, genesis_validators_root, slot, root).data)
+  let signing_root = compute_block_signing_root(
+    fork, genesis_validators_root, slot, root)
+
+  blsSign(privKey, signing_root.data)
 
 proc verify_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
@@ -94,16 +108,14 @@ proc verify_block_signature*(
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
     let
-      epoch = compute_epoch_at_slot(slot)
-      domain = get_domain(
-        fork, DOMAIN_BEACON_PROPOSER, epoch, genesis_validators_root)
-      signing_root = compute_signing_root(blck, domain)
+      signing_root = compute_block_signing_root(
+        fork, genesis_validators_root, slot, blck)
 
-    blsVerify(pubKey, signing_root.data, signature)
+    blsVerify(pubkey, signing_root.data, signature)
 
-func compute_aggregate_and_proof_root*(fork: Fork, genesis_validators_root: Eth2Digest,
-                                       aggregate_and_proof: AggregateAndProof,
-                                       ): Eth2Digest =
+func compute_aggregate_and_proof_signing_root*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    aggregate_and_proof: AggregateAndProof): Eth2Digest =
   let
     epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
     domain = get_domain(
@@ -114,56 +126,149 @@ func compute_aggregate_and_proof_root*(fork: Fork, genesis_validators_root: Eth2
 func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
                                         aggregate_and_proof: AggregateAndProof,
                                         privKey: ValidatorPrivKey): CookedSig =
-  blsSign(privKey, compute_aggregate_and_proof_root(fork, genesis_validators_root,
-                                                    aggregate_and_proof).data)
+  let signing_root = compute_aggregate_and_proof_signing_root(
+    fork, genesis_validators_root, aggregate_and_proof)
+
+  blsSign(privKey, signing_root.data)
 
 proc verify_aggregate_and_proof_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     aggregate_and_proof: AggregateAndProof,
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
-    let
-      epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
-      domain = get_domain(
-        fork, DOMAIN_AGGREGATE_AND_PROOF, epoch, genesis_validators_root)
-      signing_root = compute_signing_root(aggregate_and_proof, domain)
+    let signing_root = compute_aggregate_and_proof_signing_root(
+      fork, genesis_validators_root, aggregate_and_proof)
 
     blsVerify(pubKey, signing_root.data, signature)
 
-func compute_attestation_root*(
+func compute_attestation_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest,
-    attestation_data: AttestationData
-    ): Eth2Digest =
+    attestation_data: AttestationData): Eth2Digest =
   let
     epoch = attestation_data.target.epoch
     domain = get_domain(
       fork, DOMAIN_BEACON_ATTESTER, epoch, genesis_validators_root)
   compute_signing_root(attestation_data, domain)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#prepare-sync-committee-message
-func sync_committee_msg_signing_root*(
-    fork: Fork, epoch: Epoch,
-    genesis_validators_root: Eth2Digest,
-    block_root: Eth2Digest): Eth2Digest =
-  let domain = get_domain(fork, DOMAIN_SYNC_COMMITTEE, epoch, genesis_validators_root)
-  compute_signing_root(block_root, domain)
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/validator.md#aggregate-signature
+func get_attestation_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    attestation_data: AttestationData,
+    privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_attestation_signing_root(
+    fork, genesis_validators_root, attestation_data)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#signature
-func contribution_and_proof_signing_root*(
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    msg: ContributionAndProof): Eth2Digest =
-  let domain = get_domain(fork, DOMAIN_CONTRIBUTION_AND_PROOF,
-                          msg.contribution.slot.epoch,
-                          genesis_validators_root)
-  compute_signing_root(msg, domain)
+  blsSign(privKey, signing_root.data)
+
+proc verify_attestation_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    attestation_data: AttestationData,
+    pubkeys: auto, signature: SomeSig): bool =
+  withTrust(signature):
+    let signing_root = compute_attestation_signing_root(
+      fork, genesis_validators_root, attestation_data)
+
+    blsFastAggregateVerify(pubkeys, signing_root.data, signature)
+
+func compute_deposit_signing_root*(
+    version: Version,
+    deposit_message: DepositMessage): Eth2Digest =
+  let
+    # Fork-agnostic domain since deposits are valid across forks
+    domain = compute_domain(DOMAIN_DEPOSIT, version)
+  compute_signing_root(deposit_message, domain)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/beacon-chain.md#deposits
+func get_deposit_signature*(preset: RuntimeConfig,
+                            deposit: DepositData,
+                            privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_deposit_signing_root(
+    preset.GENESIS_FORK_VERSION, deposit.getDepositMessage())
+
+  blsSign(privKey, signing_root.data)
+
+func get_deposit_signature*(message: DepositMessage, version: Version,
+                            privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_deposit_signing_root(version, message)
+
+  blsSign(privkey, signing_root.data)
+
+proc verify_deposit_signature*(preset: RuntimeConfig,
+                               deposit: DepositData): bool =
+  let
+    deposit_message = deposit.getDepositMessage()
+    signing_root = compute_deposit_signing_root(
+      preset.GENESIS_FORK_VERSION, deposit_message)
+
+  blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
+
+func compute_voluntary_exit_signing_root*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    voluntary_exit: VoluntaryExit): Eth2Digest =
+  let
+    epoch = voluntary_exit.epoch
+    domain = get_domain(
+      fork, DOMAIN_VOLUNTARY_EXIT, epoch, genesis_validators_root)
+  compute_signing_root(voluntary_exit, domain)
+
+func get_voluntary_exit_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    voluntary_exit: VoluntaryExit,
+    privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_voluntary_exit_signing_root(
+    fork, genesis_validators_root, voluntary_exit)
+
+  blsSign(privKey, signing_root.data)
+
+proc verify_voluntary_exit_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    voluntary_exit: VoluntaryExit,
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
+  withTrust(signature):
+    let signing_root = compute_voluntary_exit_signing_root(
+      fork, genesis_validators_root, voluntary_exit)
+
+    blsVerify(pubkey, signing_root.data, signature)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#prepare-sync-committee-message
+func compute_sync_committee_message_signing_root*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, beacon_block_root: Eth2Digest): Eth2Digest =
+  let domain = get_domain(
+    fork, DOMAIN_SYNC_COMMITTEE, slot.epoch, genesis_validators_root)
+  compute_signing_root(beacon_block_root, domain)
+
+func get_sync_committee_message_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, beacon_block_root: Eth2Digest,
+    privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_sync_committee_message_signing_root(
+    fork, genesis_validators_root, slot, beacon_block_root)
+
+  blsSign(privkey, signing_root.data)
+
+proc verify_sync_committee_message_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, beacon_block_root: Eth2Digest,
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
+  let signing_root = compute_sync_committee_message_signing_root(
+    fork, genesis_validators_root, slot, beacon_block_root)
+
+  blsVerify(pubkey, signing_root.data, signature)
+
+proc verify_sync_committee_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, beacon_block_root: Eth2Digest,
+    pubkeys: auto, signature: SomeSig): bool =
+  let signing_root = compute_sync_committee_message_signing_root(
+    fork, genesis_validators_root, slot, beacon_block_root)
+
+  blsFastAggregateVerify(pubkeys, signing_root.data, signature)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#aggregation-selection
-proc sync_committee_selection_proof_signing_root*(
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    slot: Slot,
-    subcommittee_index: uint64): Eth2Digest =
+func compute_sync_committee_selection_proof_signing_root*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, subcommittee_index: uint64): Eth2Digest =
   let
     domain = get_domain(fork, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF,
                         slot.epoch, genesis_validators_root)
@@ -172,118 +277,43 @@ proc sync_committee_selection_proof_signing_root*(
       subcommittee_index: subcommittee_index)
   compute_signing_root(signing_data, domain)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/validator.md#aggregate-signature
-func get_attestation_signature*(
+func get_sync_committee_selection_proof*(
     fork: Fork, genesis_validators_root: Eth2Digest,
-    attestation_data: AttestationData,
+    slot: Slot, subcommittee_index: uint64,
     privkey: ValidatorPrivKey): CookedSig =
-  blsSign(privKey, compute_attestation_root(fork, genesis_validators_root,
-                                            attestation_data).data)
+  let signing_root = compute_sync_committee_selection_proof_signing_root(
+    fork, genesis_validators_root, slot, subcommittee_index)
 
-proc verify_attestation_signature*(
-    fork: Fork, genesis_validators_root: Eth2Digest,
-    attestation_data: AttestationData,
-    pubkeys: auto,
-    signature: SomeSig): bool =
-  withTrust(signature):
-    let
-      epoch = attestation_data.target.epoch
-      domain = get_domain(
-        fork, DOMAIN_BEACON_ATTESTER, epoch, genesis_validators_root)
-      signing_root = compute_signing_root(attestation_data, domain)
-
-    blsFastAggregateVerify(pubkeys, signing_root.data, signature)
-
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/phase0/beacon-chain.md#deposits
-func get_deposit_signature*(preset: RuntimeConfig,
-                            deposit: DepositData,
-                            privkey: ValidatorPrivKey): CookedSig =
-  let
-    deposit_message = deposit.getDepositMessage()
-    # Fork-agnostic domain since deposits are valid across forks
-    domain = compute_domain(DOMAIN_DEPOSIT, preset.GENESIS_FORK_VERSION)
-    signing_root = compute_signing_root(deposit_message, domain)
-
-  blsSign(privKey, signing_root.data)
-
-func get_deposit_signature*(message: DepositMessage, version: Version,
-                            privkey: ValidatorPrivKey): CookedSig =
-  let
-    domain = compute_domain(DOMAIN_DEPOSIT, version)
-    signing_root = compute_signing_root(message, domain)
   blsSign(privkey, signing_root.data)
 
-proc verify_deposit_signature*(preset: RuntimeConfig,
-                               deposit: DepositData): bool =
-  let
-    deposit_message = deposit.getDepositMessage()
-    # Fork-agnostic domain since deposits are valid across forks
-    domain = compute_domain(DOMAIN_DEPOSIT, preset.GENESIS_FORK_VERSION)
-    signing_root = compute_signing_root(deposit_message, domain)
-
-  blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
-
-func get_voluntary_exit_signature*(
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    voluntary_exit: VoluntaryExit,
-    privkey: ValidatorPrivKey): CookedSig =
-  let
-    domain = get_domain(
-      fork, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch, genesis_validators_root)
-    signing_root = compute_signing_root(voluntary_exit, domain)
-
-  blsSign(privKey, signing_root.data)
-
-proc verify_voluntary_exit_signature*(
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    voluntary_exit: VoluntaryExit,
-    pubkey: ValidatorPubKey,
-    signature: SomeSig): bool =
+proc verify_sync_committee_selection_proof*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    slot: Slot, subcommittee_index: uint64,
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
   withTrust(signature):
-    let
-      domain = get_domain(
-        fork, DOMAIN_VOLUNTARY_EXIT, voluntary_exit.epoch, genesis_validators_root)
-      signing_root = compute_signing_root(voluntary_exit, domain)
+    let signing_root = compute_sync_committee_selection_proof_signing_root(
+      fork, genesis_validators_root, slot, subcommittee_index)
 
     blsVerify(pubkey, signing_root.data, signature)
 
-func get_sync_committee_message_signature*(fork: Fork,
-  genesis_validators_root: Eth2Digest, slot: Slot,
-  block_root: Eth2Digest, privkey: ValidatorPrivKey): CookedSig =
-  let signing_root = sync_committee_msg_signing_root(fork, slot.epoch,
-                       genesis_validators_root, block_root)
+# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#signature
+func compute_contribution_and_proof_signing_root*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    msg: ContributionAndProof): Eth2Digest =
+  let domain = get_domain(fork, DOMAIN_CONTRIBUTION_AND_PROOF,
+                          msg.contribution.slot.epoch,
+                          genesis_validators_root)
+  compute_signing_root(msg, domain)
+
+proc get_contribution_and_proof_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
+    msg: ContributionAndProof,
+    privkey: ValidatorPrivKey): CookedSig =
+  let signing_root = compute_contribution_and_proof_signing_root(
+    fork, genesis_validators_root, msg)
+
   blsSign(privkey, signing_root.data)
 
-func get_sync_aggregator_selection_data_signature*(fork: Fork,
-  genesis_validators_root: Eth2Digest, slot: Slot,
-  subcommittee_index: uint64,
-  privkey: ValidatorPrivKey): CookedSig =
-  let signing_root = sync_committee_selection_proof_signing_root(fork,
-    genesis_validators_root, slot, subcommittee_index)
-  blsSign(privkey, signing_root.data)
-
-proc get_sync_committee_contribution_and_proof_signature*(fork: Fork,
-  genesis_validators_root: Eth2Digest, msg: ContributionAndProof,
-  privkey: ValidatorPrivKey): CookedSig =
-  let signing_root = contribution_and_proof_signing_root(fork,
-    genesis_validators_root, msg)
-  blsSign(privkey, signing_root.data)
-
-proc verify_sync_committee_message_signature*(
-    epoch: Epoch,
-    beacon_block_root: Eth2Digest,
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    pubkey: CookedPubKey,
-    signature: CookedSig): bool =
-  let
-    domain = get_domain(
-      fork, DOMAIN_SYNC_COMMITTEE, epoch, genesis_validators_root)
-    signing_root = compute_signing_root(beacon_block_root, domain)
-
-  blsVerify(pubkey, signing_root.data, signature)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/altair/validator.md#aggregation-selection
 proc is_sync_committee_aggregator*(signature: ValidatorSig): bool =
@@ -292,30 +322,11 @@ proc is_sync_committee_aggregator*(signature: ValidatorSig): bool =
     modulo = max(1'u64, (SYNC_COMMITTEE_SIZE div SYNC_COMMITTEE_SUBNET_COUNT) div TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
   bytes_to_uint64(signatureDigest.data.toOpenArray(0, 7)) mod modulo == 0
 
-proc verify_signed_contribution_and_proof_signature*(
-    msg: SignedContributionAndProof,
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    pubkey: ValidatorPubKey | CookedPubKey): bool =
-  let
-    domain = get_domain(
-      fork, DOMAIN_CONTRIBUTION_AND_PROOF, msg.message.contribution.slot.epoch, genesis_validators_root)
-    signing_root = compute_signing_root(msg.message, domain)
-
-  blsVerify(pubkey, signing_root.data, msg.signature)
-
-proc verify_selection_proof_signature*(
+proc verify_contribution_and_proof_signature*(
+    fork: Fork, genesis_validators_root: Eth2Digest,
     msg: ContributionAndProof,
-    fork: Fork,
-    genesis_validators_root: Eth2Digest,
-    pubkey: ValidatorPubKey | CookedPubKey): bool =
-  let
-    slot = msg.contribution.slot
-    domain = get_domain(
-      fork, DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF, slot.epoch, genesis_validators_root)
-    signing_data = SyncAggregatorSelectionData(
-      slot: slot,
-      subcommittee_index: msg.contribution.subcommittee_index)
-    signing_root = compute_signing_root(signing_data, domain)
+    pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
+  let signing_root = compute_contribution_and_proof_signing_root(
+    fork, genesis_validators_root, msg)
 
-  blsVerify(pubkey, signing_root.data, msg.selection_proof)
+  blsVerify(pubkey, signing_root.data, signature)

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -25,8 +25,8 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
   # TODO: signing_root is recomputed in signBlockProposal just after,
   # but not for locally attached validators.
   let signingRoot =
-    compute_attestation_root(fork, vc.beaconGenesis.genesis_validators_root,
-                             adata)
+    compute_attestation_signing_root(
+      fork, vc.beaconGenesis.genesis_validators_root, adata)
   let attestationRoot = adata.hash_tree_root()
 
   let vindex = validator.index.get()

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -45,8 +45,8 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
 
     let blockRoot = withBlck(beaconBlock): hash_tree_root(blck)
     # TODO: signing_root is recomputed in signBlockProposal just after
-    let signing_root = compute_block_root(fork, genesisRoot, slot,
-                                          blockRoot)
+    let signing_root = compute_block_signing_root(fork, genesisRoot, slot,
+                                                  blockRoot)
     let notSlashable = vc.attachedValidators
       .slashingProtection
       .registerBlock(ValidatorIndex(beaconBlock.proposer_index),

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -34,8 +34,6 @@ proc compute_aggregate_sync_committee_signature(
     root =
       if block_root != ZERO_HASH: block_root
       else: mockBlockForNextSlot(forked).altairData.message.parent_root
-    signing_root = sync_committee_msg_signing_root(
-      state.fork, state.slot.epoch, state.genesis_validators_root, root)
 
   var
     aggregateSig {.noInit.}: AggregateSignature
@@ -43,7 +41,8 @@ proc compute_aggregate_sync_committee_signature(
   for validator_index in participants:
     let
       privkey = MockPrivKeys[validator_index]
-      signature = blsSign(privkey, signing_root.data)
+      signature = get_sync_committee_message_signature(
+        state.fork, state.genesis_validators_root, state.slot, root, privkey)
     if not initialized:
       initialized = true
       aggregateSig.init(signature)

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[json, options, os, strutils, tables],
+  std/[json, os, strutils, tables],
   # Status libraries
   stew/[results, endians2], chronicles,
   eth/keys, taskpools,

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -57,22 +57,19 @@ suite "Sync committee pool":
 
       root1Slot = Slot(100)
       root2Slot = Slot(101)
-      root3Slot = Slot(101)
+      root3Slot = Slot(102)
 
       subcommittee1 = SyncSubcommitteeIndex(0)
       subcommittee2 = SyncSubcommitteeIndex(1)
 
-      sig1 = blsSign(privkey1, sync_committee_msg_signing_root(
-        fork, root1Slot.epoch, genesisValidatorsRoot, root1).data)
-
-      sig2 = blsSign(privkey2, sync_committee_msg_signing_root(
-        fork, root2Slot.epoch, genesisValidatorsRoot, root1).data)
-
-      sig3 = blsSign(privkey3, sync_committee_msg_signing_root(
-        fork, root3Slot.epoch, genesisValidatorsRoot, root1).data)
-
-      sig4 = blsSign(privkey4, sync_committee_msg_signing_root(
-        fork, root3Slot.epoch, genesisValidatorsRoot, root2).data)
+      sig1 = get_sync_committee_message_signature(
+        fork, genesisValidatorsRoot, root1Slot, root1, privkey1)
+      sig2 = get_sync_committee_message_signature(
+        fork, genesisValidatorsRoot, root2Slot, root2, privkey1)
+      sig3 = get_sync_committee_message_signature(
+        fork, genesisValidatorsRoot, root3Slot, root3, privkey1)
+      sig4 = get_sync_committee_message_signature(
+        fork, genesisValidatorsRoot, root3Slot, root2, privkey1)
 
     # Inserting sync committee messages
     #

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -57,7 +57,7 @@ suite "Sync committee pool":
 
       root1Slot = Slot(100)
       root2Slot = Slot(101)
-      root3Slot = Slot(102)
+      root3Slot = Slot(101)
 
       subcommittee1 = SyncSubcommitteeIndex(0)
       subcommittee2 = SyncSubcommitteeIndex(1)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -346,7 +346,7 @@ proc makeSyncAggregate(
           fork, genesis_validators_root,
           slot, latest_block_root,
           MockPrivKeys[validatorIdx])
-        selectionProofSig = get_sync_aggregator_selection_data_signature(
+        selectionProofSig = get_sync_committee_selection_proof(
           fork, genesis_validators_root,
           slot, subcommitteeIdx.uint64,
           MockPrivKeys[validatorIdx])
@@ -371,7 +371,7 @@ proc makeSyncAggregate(
           aggregator_index: uint64 aggregator.validatorIdx,
           contribution: contribution,
           selection_proof: aggregator.selectionProof)
-        contributionSig = get_sync_committee_contribution_and_proof_signature(
+        contributionSig = get_contribution_and_proof_signature(
           fork, genesis_validators_root,
           contributionAndProof,
           MockPrivKeys[aggregator.validatorIdx])


### PR DESCRIPTION
Generally reuses the same structure as attestation and aggregate
verification

* normalize `signatures` and `signature_batch` to use the same pattern
of verification
* normalize parameter names, order etc for signature stuff in general
* avoid calling `blsSign` directly - instead, go through `signatures`
consistently