### PR TITLE
Switch back to WebSocket URLs in the Eth1Monitor

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -248,16 +248,42 @@ template finalizedDepositsMerkleizer(m: Eth1Monitor): auto =
   m.depositsChain.finalizedDepositsMerkleizer
 
 proc fixupWeb3Urls*(web3Url: var string) =
-  var normalizedUrl = toLowerAscii(web3Url)
-  if not (normalizedUrl.startsWith("https://") or
-          normalizedUrl.startsWith("http://") or
-          normalizedUrl.startsWith("wss://") or
-          normalizedUrl.startsWith("ws://")):
-    normalizedUrl = "ws://" & normalizedUrl
-    warn "The Web3 URL does not specify a protocol. Assuming a WebSocket server", web3Url
+  ## Converts HTTP and HTTPS Infura URLs to their WebSocket equivalents
+  ## because we are missing a functional HTTPS client.
+  let normalizedUrl = toLowerAscii(web3Url)
+  var pos = 0
 
-  # We do this at the end in order to allow the warning above to print the original value
-  web3Url = normalizedUrl
+  template skip(x: string): bool {.dirty.} =
+    if normalizedUrl.len - pos >= x.len and
+       normalizedUrl.toOpenArray(pos, pos + x.len - 1) == x:
+      pos += x.len
+      true
+    else:
+      false
+
+  if not (skip("https://") or skip("http://")):
+    if not (skip("ws://") or skip("wss://")):
+      web3Url = "ws://" & web3Url
+      warn "The Web3 URL does not specify a protocol. Assuming a WebSocket server", web3Url
+    return
+
+  block infuraRewrite:
+    var pos = pos
+    let network = if skip("mainnet"): mainnet
+                  elif skip("goerli"): goerli
+                  else: break
+
+    if not skip(".infura.io/v3/"):
+      break
+
+    template infuraKey: string = normalizedUrl.substr(pos)
+
+    web3Url = "wss://" & $network & ".infura.io/ws/v3/" & infuraKey
+    return
+
+  block gethRewrite:
+    web3Url = "ws://" & normalizedUrl.substr(pos)
+    warn "Only WebSocket web3 providers are supported. Rewriting URL", web3Url
 
 template toGaugeValue(x: Quantity): int64 =
   toGaugeValue(distinctBase x)

--- a/tests/test_eth1_monitor.nim
+++ b/tests/test_eth1_monitor.nim
@@ -36,15 +36,15 @@ suite "Eth1 monitor":
 
     check:
       mainnetWssUrl == "wss://mainnet.infura.io/ws/v3/6224f3c792cc443fafb64e70a98f871e"
-      mainnetHttpUrl == "http://mainnet.infura.io/v3/6224f3c792cc443fafb64e70a98f871e"
-      mainnetHttpsUrl == "https://mainnet.infura.io/v3/6224f3c792cc443fafb64e70a98f871e"
+      mainnetHttpUrl == mainnetWssUrl
+      mainnetHttpsUrl == mainnetWssUrl
 
       goerliWssUrl == "wss://goerli.infura.io/ws/v3/6224f3c792cc443fafb64e70a98f871e"
-      goerliHttpUrl == "http://goerli.infura.io/v3/6224f3c792cc443fafb64e70a98f871e"
-      goerliHttpsUrl == "https://goerli.infura.io/v3/6224f3c792cc443fafb64e70a98f871e"
+      goerliHttpUrl == goerliWssUrl
+      goerliHttpsUrl == goerliWssUrl
 
-      gethHttpUrl == "http://localhost:8545"
-      gethHttpsUrl == "https://localhost:8545"
-      unspecifiedProtocolUrl == "ws://localhost:8545"
+      gethHttpUrl == gethWsUrl
+      gethHttpsUrl == gethWsUrl
+      unspecifiedProtocolUrl == gethWsUrl
 
       gethWsUrl == "ws://localhost:8545"


### PR DESCRIPTION
The HTTP support is not stable enough yet.