### PR TITLE
Broadcast blocks before integrating in ChainDAG 

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -799,6 +799,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
     if not(res.get()):
       return RestApiResponse.jsonError(Http202, BlockValidationError)
+
     return RestApiResponse.jsonMsgResponse(BlockValidationSuccess)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlock

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -53,20 +53,6 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     else:
       raiseNoAltairSupport()
 
-  rpcServer.rpc("post_v1_validator_block") do (body: phase0.SignedBeaconBlock) -> bool:
-    debug "post_v1_validator_block",
-      slot = body.message.slot,
-      prop_idx = body.message.proposer_index
-    let head = node.doChecksAndGetCurrentHead(body.message.slot)
-
-    if head.slot >= body.message.slot:
-      raise newException(CatchableError,
-        "Proposal is for a past slot: " & $body.message.slot)
-    if head == await proposeSignedBlock(
-        node, head, AttachedValidator(), ForkedSignedBeaconBlock.init(body)):
-      raise newException(CatchableError, "Could not propose block")
-    return true
-
   rpcServer.rpc("get_v1_validator_attestation_data") do (
       slot: Slot, committee_index: CommitteeIndex) -> AttestationData:
     debug "get_v1_validator_attestation_data", slot = slot

--- a/beacon_chain/spec/eth2_apis/rpc_validator_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rpc_validator_calls.nim
@@ -7,8 +7,6 @@ import
 
 proc get_v1_validator_block(slot: Slot, graffiti: GraffitiBytes, randao_reveal: ValidatorSig): phase0.BeaconBlock
 
-proc post_v1_validator_block(body: phase0.SignedBeaconBlock): bool
-
 proc get_v1_validator_attestation_data(slot: Slot, committee_index: CommitteeIndex): AttestationData
 
 proc get_v1_validator_aggregate_attestation(slot: Slot, attestation_data_root: Eth2Digest): Attestation


### PR DESCRIPTION
This PR fixes two issues with block publishing:

* Gossip-valid blocks are published before integrating them into the
chain, giving broadcasting a head start, both for rest block and
* Outright invalid blocks from the API that could lead to the descoring
of the node are no longer broadcast

Bonus:

* remove undocumented and duplicated `post_v1_validator_block` JSON-RPC
call