### PR TITLE
cleanups, partly from kintsugi branch

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -36,8 +36,8 @@ proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool
   quarantine.rng[].brHmacDrbgGenerate(secureRandomBytes)
   try:
     return quarantine.taskpool.batchVerify(quarantine.sigVerifCache, sigs, secureRandomBytes)
-  except Exception:
-    raise newException(Defect, "Unexpected exception in batchVerify.")
+  except Exception as exc:
+    raiseAssert exc.msg
 
 proc addRawBlock*(
       dag: ChainDAGRef, quarantine: QuarantineRef,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -36,7 +36,7 @@ proc batchVerify(quarantine: QuarantineRef, sigs: openArray[SignatureSet]): bool
   quarantine.rng[].brHmacDrbgGenerate(secureRandomBytes)
   try:
     return quarantine.taskpool.batchVerify(quarantine.sigVerifCache, sigs, secureRandomBytes)
-  except Exception as exc:
+  except Exception:
     raise newException(Defect, "Unexpected exception in batchVerify.")
 
 proc addRawBlock*(

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -318,7 +318,7 @@ func asEth2Digest*(x: BlockHash): Eth2Digest =
 template asBlockHash(x: Eth2Digest): BlockHash =
   BlockHash(x.data)
 
-func shortLog(b: Eth1Block): string =
+func shortLog*(b: Eth1Block): string =
   try:
     &"{b.number}:{shortLog b.voteData.block_hash}(deposits = {b.voteData.deposit_count})"
   except ValueError as exc: raiseAssert exc.msg

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -156,7 +156,7 @@ proc processBatch(batchCrypto: ref BatchCrypto) =
       batchCrypto.sigVerifCache,
       batch.pendingBuffer,
       secureRandomBytes)
-  except Exception as exc:
+  except Exception:
     raise newException(Defect, "Unexpected exception in batchVerify.")
 
   trace "batch crypto - finished",

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -156,8 +156,8 @@ proc processBatch(batchCrypto: ref BatchCrypto) =
       batchCrypto.sigVerifCache,
       batch.pendingBuffer,
       secureRandomBytes)
-  except Exception:
-    raise newException(Defect, "Unexpected exception in batchVerify.")
+  except Exception as exc:
+    raiseAssert exc.msg
 
   trace "batch crypto - finished",
     batchSize,

--- a/beacon_chain/spec/datatypes/merge.nim
+++ b/beacon_chain/spec/datatypes/merge.nim
@@ -26,7 +26,6 @@ import
 const
   # https://github.com/ethereum/consensus-specs/blob/v1.1.4/specs/merge/beacon-chain.md#execution
   MAX_BYTES_PER_TRANSACTION* = 1073741824
-  MAX_TRANSACTIONS_PER_PAYLOAD* = 1048576
   BYTES_PER_LOGS_BLOOM = 256
   MAX_EXTRA_DATA_BYTES = 32
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1384,7 +1384,7 @@ proc decodeBytes*[T: DecodeTypes](t: typedesc[T], value: openarray[byte],
   of "application/json":
     try:
       ok RestJson.decode(value, T, allowUnknownFields = isExtensibleType)
-    except SerializationError as exc:
+    except SerializationError:
       err("Serialization error")
   else:
     err("Content-Type not supported")

--- a/beacon_chain/spec/eth2_apis/rest_remote_signer_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_remote_signer_calls.nim
@@ -88,7 +88,6 @@ proc signData*(client: RestClientRef, identifier: ValidatorPubKey,
       inc(nbc_remote_signer_communication_errors)
       return Web3SignerDataResponse.err(msg)
     except CatchableError as exc:
-      let signDur = Moment.now() - startSignTick
       let msg = "[" & $exc.name & "] " & $exc.msg
       debug "Unexpected error occured while generating signature",
             validator = shortLog(identifier),

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -203,16 +203,16 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
   of BeaconStateFork.Merge:
-    const stateFork {.inject.} = BeaconStateFork.Merge
-    template state: untyped {.inject.} = x.mergeData
+    const stateFork {.inject, used.} = BeaconStateFork.Merge
+    template state: untyped {.inject, used.} = x.mergeData
     body
   of BeaconStateFork.Altair:
-    const stateFork {.inject.} = BeaconStateFork.Altair
-    template state: untyped {.inject.} = x.altairData
+    const stateFork {.inject, used.} = BeaconStateFork.Altair
+    template state: untyped {.inject, used.} = x.altairData
     body
   of BeaconStateFork.Phase0:
-    const stateFork {.inject.} = BeaconStateFork.Phase0
-    template state: untyped {.inject.} = x.phase0Data
+    const stateFork {.inject, used.} = BeaconStateFork.Phase0
+    template state: untyped {.inject, used.} = x.phase0Data
     body
 
 template withEpochInfo*(x: ForkedEpochInfo, body: untyped): untyped =
@@ -297,15 +297,15 @@ template withBlck*(
     body: untyped): untyped =
   case x.kind
   of BeaconBlockFork.Phase0:
-    const stateFork {.inject.} = BeaconStateFork.Phase0
+    const stateFork {.inject, used.} = BeaconStateFork.Phase0
     template blck: untyped {.inject.} = x.phase0Data
     body
   of BeaconBlockFork.Altair:
-    const stateFork {.inject.} = BeaconStateFork.Altair
+    const stateFork {.inject, used.} = BeaconStateFork.Altair
     template blck: untyped {.inject.} = x.altairData
     body
   of BeaconBlockFork.Merge:
-    const stateFork {.inject.} = BeaconStateFork.Merge
+    const stateFork {.inject, used.} = BeaconStateFork.Merge
     template blck: untyped {.inject.} = x.mergeData
     body
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -202,6 +202,7 @@ func get_unslashed_participating_balances*(state: altair.BeaconState | merge.Bea
           res.previous_epoch[flag_index] += validator_effective_balance
 
     # Only TIMELY_TARGET_FLAG_INDEX is used with the current epoch in Altair
+    # and merge
     if is_active_current_epoch and has_flag(
         state.current_epoch_participation[validator_index],
         TIMELY_TARGET_FLAG_INDEX):

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -64,7 +64,7 @@ proc readChunkPayload*(conn: Connection, peer: Peer,
   var contextBytes: ForkDigest
   try:
     await conn.readExactly(addr contextBytes, sizeof contextBytes)
-  except CatchableError as e:
+  except CatchableError:
     return neterr UnexpectedEOF
 
   if contextBytes == peer.network.forkDigests.phase0:

--- a/docs/interop_merge.md
+++ b/docs/interop_merge.md
@@ -23,23 +23,6 @@ kintsugi test vectors passed
 
 # Verify that Nimbus runs through the same examples
 
-- Ensure `tests/test_merge_vectors.nim` points to the correct Web3 URL, e.g.:
-```
-diff --git a/tests/test_merge_vectors.nim b/tests/test_merge_vectors.nim
-index 7eedb46d..1a573c80 100644
---- a/tests/test_merge_vectors.nim
-+++ b/tests/test_merge_vectors.nim
-@@ -12,7 +12,7 @@ import
-
- suite "Merge test vectors":
-   let web3Provider = (waitFor Web3DataProvider.new(
--    default(Eth1Address), "ws://127.0.0.1:8551")).get
-+    default(Eth1Address), "ws://127.0.0.1:8546")).get
-
-   test "getPayload, executePayload, and forkchoiceUpdated":
-     const feeRecipient =
-```
-
 - Run `./env.sh nim c -r tests/test_merge_vectors.nim`. It should show output akin to:
 
 ```

--- a/scripts/run-catalyst.sh
+++ b/scripts/run-catalyst.sh
@@ -53,4 +53,4 @@ echo \{\
 ~/execution_clients/go-ethereum/build/bin/geth --catalyst --http --ws -http.api "engine" --datadir "${GETHDATADIR}" account import <(echo 45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8)
 
 # Start the node (and press enter once to unlock the account)
-~/execution_clients/go-ethereum/build/bin/geth --catalyst --http --ws --http.api "eth,net,engine" -ws.api "eth,net,engine" --datadir "${GETHDATADIR}" --allow-insecure-unlock --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" --password "" --nodiscover console
+~/execution_clients/go-ethereum/build/bin/geth --catalyst --http --ws --ws.port 8551 --http.port 8550 --http.api "eth,net,engine" -ws.api "eth,net,engine" --datadir "${GETHDATADIR}" --allow-insecure-unlock --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" --password "" --nodiscover console

--- a/tests/test_eth2_ssz_serialization.nim
+++ b/tests/test_eth2_ssz_serialization.nim
@@ -12,9 +12,6 @@ import
   ../beacon_chain/spec/datatypes/[phase0, altair],
   ../beacon_chain/spec/eth2_ssz_serialization
 
-template reject(stmt) =
-  doAssert(not compiles(stmt))
-
 static:
   doAssert isFixedSize(Slot) == true
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -198,7 +198,6 @@ func makeAttestation*(
   # montonoic enumerable index, is wasteful and slow. Most test callers
   # want ValidatorIndex, so that's supported too.
   let
-    validator = getStateField(state, validators)[validator_index]
     sac_index = committee.find(validator_index)
     data = makeAttestationData(state, slot, index, beacon_block_root)
 


### PR DESCRIPTION
- don't name variables in exception handling if not referenced
- unexport some functions from `eth1_monitor`
- avoid false positive unused-hints by marking some `withFoo`-template-created variables as `used`
- remove obsolete docs section which aligned Geth/Nimbus ports