### PR TITLE
non-march=native builds should use SSSE3 instead of SSE3

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -69,11 +69,16 @@ if defined(windows):
 # engineering a more portable binary release, this should be tweaked but still
 # use at least -msse2 or -msse3.
 #
+# https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#ssse3-supplemental-sse3
+# suggests that SHA256 hashing with SSSE3 is 20% faster than without SSSE3, so
+# given its near-ubiquity in the x86 installed base, it renders a distribution
+# build more viable on an overall broader range of hardware.
+#
 # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
 if defined(disableMarchNative) or (defined(macosx) and defined(arm64)):
   if defined(i386) or defined(amd64):
-    switch("passC", "-msse3")
-    switch("passL", "-msse3")
+    switch("passC", "-mssse3")
+    switch("passL", "-mssse3")
 else:
   switch("passC", "-march=native")
   switch("passL", "-march=native")


### PR DESCRIPTION
https://store.steampowered.com/hwsurvey/ suggests that 99.25% (with whatever their methodology is, but it's a pretty high number) of at least Steam users have CPUs with SSSE3. Not sure how it treats non-x86 CPUs.

Pre-ARM, post-PPC Macs don't support anything else, so they have 100% support for SSSE3. Really, for macOS, it should require a much more recent version of the x86 ISA, because that's all Apple has supported for years, but this picks up one of the main step function thresholds.

Linux has 98.83%. Windows has 99.24%.

Both gcc and clang support `-mssse3` (e.g., https://clang.llvm.org/docs/ClangCommandLineReference.html).

People who try to run such binaries on pre-SSSE3 machines (in practice almost always some kind of AMD Opteron or Construction-Machinery-range) will get `SIGILL`.