### PR TITLE
use SSE3 instead of SSSE3

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -69,16 +69,11 @@ if defined(windows):
 # engineering a more portable binary release, this should be tweaked but still
 # use at least -msse2 or -msse3.
 #
-# https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#ssse3-supplemental-sse3
-# suggests that SHA256 hashing with SSSE3 is 20% faster than without SSSE3, so
-# given its near-ubiquity in the x86 installed base, it renders a distribution
-# build more viable on an overall broader range of hardware.
-#
 # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
 if defined(disableMarchNative) or (defined(macosx) and defined(arm64)):
   if defined(i386) or defined(amd64):
-    switch("passC", "-mssse3")
-    switch("passL", "-mssse3")
+    switch("passC", "-msse3")
+    switch("passL", "-msse3")
 else:
   switch("passC", "-march=native")
   switch("passL", "-march=native")


### PR DESCRIPTION
If it proves on balance beneficial due to a long tail of AMD CPUs which don't support SSSE3, and that it's challenging to communicate for end-user distribution channels the distinctions.