### PR TITLE
Backfill support for ChainDAG

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -44,6 +44,12 @@ OK: 25/25 Fail: 0/25 Skip: 0/25
 + Working with aggregates [Preset: mainnet]                                                  OK
 ```
 OK: 11/11 Fail: 0/11 Skip: 0/11
+## Backfill
+```diff
++ backfill to genesis                                                                        OK
++ reload backfill position                                                                   OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -389,4 +395,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 213/215 Fail: 0/215 Skip: 2/215
+OK: 215/217 Fail: 0/217 Skip: 2/217

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -137,6 +137,9 @@ type
       ## only recent contract state data (i.e. only recent `deposit_roots`).
     kHashToStateDiff # Obsolete
     kHashToStateOnlyMutableValidators
+    kBackfillBlock
+      ## Pointer to the earliest block that we have backfilled - if this is not
+      ## set, backfill == tail
 
   BeaconBlockSummary* = object
     ## Cache of beacon block summaries - during startup when we construct the
@@ -588,6 +591,9 @@ proc putTailBlock*(db: BeaconChainDB, key: Eth2Digest) =
 proc putGenesisBlock*(db: BeaconChainDB, key: Eth2Digest) =
   db.keyValues.putRaw(subkey(kGenesisBlock), key)
 
+proc putBackfillBlock*(db: BeaconChainDB, key: Eth2Digest) =
+  db.keyValues.putRaw(subkey(kBackfillBlock), key)
+
 proc putEth2FinalizedTo*(db: BeaconChainDB,
                          eth1Checkpoint: DepositContractSnapshot) =
   db.keyValues.putSnappySSZ(subkey(kDepositsFinalizedByEth2), eth1Checkpoint)
@@ -790,6 +796,9 @@ proc getGenesisBlock(db: BeaconChainDBV0): Opt[Eth2Digest] =
 proc getGenesisBlock*(db: BeaconChainDB): Opt[Eth2Digest] =
   db.keyValues.getRaw(subkey(kGenesisBlock), Eth2Digest) or
     db.v0.getGenesisBlock()
+
+proc getBackfillBlock*(db: BeaconChainDB): Opt[Eth2Digest] =
+  db.keyValues.getRaw(subkey(kBackfillBlock), Eth2Digest)
 
 proc getEth2FinalizedTo(db: BeaconChainDBV0): Opt[DepositContractSnapshot] =
   result.ok(DepositContractSnapshot())

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -92,13 +92,30 @@ type
 
     finalizedBlocks*: seq[BlockRef] ##\
     ## Slot -> BlockRef mapping for the canonical chain - use getBlockBySlot
-    ## to access, generally
+    ## to access, generally - coverst the slots
+    ## `tail.slot..finalizedHead.slot` (including the finalized head slot) -
+    ## indices are thus offset by tail.slot
+
+    backfillBlocks*: seq[Eth2Digest] ##\
+    ## Slot -> Eth2Digest, tail.slot entries
 
     genesis*: BlockRef ##\
     ## The genesis block of the network
 
     tail*: BlockRef ##\
-    ## The earliest finalized block we know about
+    ## The earliest finalized block for which we have a corresponding state -
+    ## when making a replay of chain history, this is as far back as we can
+    ## go - the tail block is unique in that its parent is set to `nil`, even
+    ## in the case where a later genesis block exists.
+
+    backfill*: tuple[slot: Slot, root: Eth2Digest] ##\
+    ## The backfill is root of the parent of the the earliest block that we
+    ## have synced, when performing a checkpoint sync start. Because the
+    ## `tail` BlockRef does not have a parent, we store here the root of the
+    ## block we're expecting during backfill.
+    ## When starting a checkpoint sync, `backfill` == `tail.parent_root` - we
+    ## then sync backards, moving the backfill (but not tail!) until we hit
+    ## genesis at which point we set backfill to the zero hash.
 
     heads*: seq[BlockRef] ##\
     ## Candidate heads of candidate chains

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -175,7 +175,7 @@ proc storeBlock*(
   self.consensusManager.quarantine[].removeOrphan(signedBlock)
 
   type Trusted = typeof signedBlock.asTrusted()
-  let blck = dag.addRawBlock(self.verifier, signedBlock) do (
+  let blck = dag.addHeadBlock(self.verifier, signedBlock) do (
       blckRef: BlockRef, trustedBlock: Trusted, epochRef: EpochRef):
     # Callback add to fork choice if valid
     attestationPool[].addForkChoice(

--- a/docs/block_flow.md
+++ b/docs/block_flow.md
@@ -133,7 +133,7 @@ To mitigate blocking networking and timeshare between Io and compute, blocks are
 
 This in turn calls:
 - `storeBlock(Eth2Processor, SignedBeaconBlock, Slot)`
-- `addRawBlock(ChainDAGRef, var BatchVerifier, SignedBeaconBlock, forkChoiceCallback)`
+- `addHeadBlock(ChainDAGRef, var BatchVerifier, SignedBeaconBlock, forkChoiceCallback)`
 - trigger sending attestation if relevant
 
 ### Steady state (synced to head)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -303,7 +303,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     dag.withState(tmpState[], dag.head.atSlot(slot)):
       let
         newBlock = getNewBlock[phase0.SignedBeaconBlock](stateData, slot, cache)
-        added = dag.addRawBlock(verifier, newBlock) do (
+        added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
@@ -323,7 +323,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     dag.withState(tmpState[], dag.head.atSlot(slot)):
       let
         newBlock = getNewBlock[altair.SignedBeaconBlock](stateData, slot, cache)
-        added = dag.addRawBlock(verifier, newBlock) do (
+        added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: altair.TrustedSignedBeaconBlock,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
@@ -343,7 +343,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     dag.withState(tmpState[], dag.head.atSlot(slot)):
       let
         newBlock = getNewBlock[merge.SignedBeaconBlock](stateData, slot, cache)
-        added = dag.addRawBlock(verifier, newBlock) do (
+        added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: merge.TrustedSignedBeaconBlock,
             epochRef: EpochRef):
           # Callback add to fork choice if valid

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -181,7 +181,7 @@ proc stepOnBlock(
   else:
     type TrustedBlock = merge.TrustedSignedBeaconBlock
 
-  let blockAdded = dag.addRawBlock(verifier, signedBlock) do (
+  let blockAdded = dag.addHeadBlock(verifier, signedBlock) do (
       blckRef: BlockRef, signedBlock: TrustedBlock, epochRef: EpochRef
     ):
 

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -6,7 +6,8 @@ import
   ../beacon_chain/validators/action_tracker
 
 suite "subnet tracker":
-  let rng = keys.newRng()
+  setup:
+    let rng = keys.newRng()
 
   test "should register stability subnets on attester duties":
     var tracker = ActionTracker.init(rng, false)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -382,7 +382,7 @@ suite "Attestation pool processing" & preset():
     var cache = StateCache()
     let
       b1 = addTestBlock(state.data, cache).phase0Data
-      b1Add = dag.addRawBlock(verifier, b1) do (
+      b1Add = dag.addHeadBlock(verifier, b1) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -395,7 +395,7 @@ suite "Attestation pool processing" & preset():
 
     let
       b2 = addTestBlock(state.data, cache).phase0Data
-      b2Add = dag.addRawBlock(verifier, b2) do (
+      b2Add = dag.addHeadBlock(verifier, b2) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -410,7 +410,7 @@ suite "Attestation pool processing" & preset():
     var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, cache).phase0Data
-      b10Add = dag.addRawBlock(verifier, b10) do (
+      b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -425,7 +425,7 @@ suite "Attestation pool processing" & preset():
       b11 = makeTestBlock(state.data, cache,
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       ).phase0Data
-      b11Add = dag.addRawBlock(verifier, b11) do (
+      b11Add = dag.addHeadBlock(verifier, b11) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -471,7 +471,7 @@ suite "Attestation pool processing" & preset():
     var cache = StateCache()
     let
       b10 = makeTestBlock(state.data, cache).phase0Data
-      b10Add = dag.addRawBlock(verifier, b10) do (
+      b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -485,7 +485,7 @@ suite "Attestation pool processing" & preset():
     # -------------------------------------------------------------
     # Add back the old block to ensure we have a duplicate error
     let b10_clone = b10 # Assumes deep copy
-    let b10Add_clone = dag.addRawBlock(verifier, b10_clone) do (
+    let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -500,7 +500,7 @@ suite "Attestation pool processing" & preset():
     var cache = StateCache()
     let
       b10 = addTestBlock(state.data, cache).phase0Data
-      b10Add = dag.addRawBlock(verifier, b10) do (
+      b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -525,7 +525,7 @@ suite "Attestation pool processing" & preset():
         let new_block = addTestBlock(
           state.data, cache, attestations = attestations).phase0Data
 
-        let blockRef = dag.addRawBlock(verifier, new_block) do (
+        let blockRef = dag.addHeadBlock(verifier, new_block) do (
             blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
@@ -567,7 +567,7 @@ suite "Attestation pool processing" & preset():
     doAssert: b10.root notin pool.forkChoice.backend
 
     # Add back the old block to ensure we have a duplicate error
-    let b10Add_clone = dag.addRawBlock(verifier, b10_clone) do (
+    let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -219,6 +219,9 @@ suite "Block pool processing" & preset():
       tmpState.blck == b1Add[].parent
       getStateField(tmpState.data, slot) == bs1.parent.slot
 
+when declared(GC_fullCollect): # i386 test machines seem to run low..
+  GC_fullCollect()
+
 suite "Block pool altair processing" & preset():
   setup:
     var

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -645,6 +645,13 @@ suite "Backfill":
       dag.getBlockSlotIdBySlot(Slot(0)) == dag.genesis.bid.atSlot(Slot(0))
       dag.getBlockSlotIdBySlot(Slot(1)) == BlockSlotId()
 
+    var
+      badBlock = blocks[^2].phase0Data
+    badBlock.signature = blocks[^3].phase0Data.signature
+
+    check:
+      dag.addBackfillBlock(badBlock).error == BlockError.Invalid
+
     check:
       dag.addBackfillBlock(blocks[^3].phase0Data).error == BlockError.MissingParent
       dag.addBackfillBlock(tailBlock.phase0Data).error == BlockError.Duplicate

--- a/tests/test_eth1_monitor.nim
+++ b/tests/test_eth1_monitor.nim
@@ -6,9 +6,6 @@ import
   ../beacon_chain/eth1/eth1_monitor,
   ./testutil
 
-suite "Eth1 Chain":
-  discard
-
 suite "Eth1 monitor":
   test "Rewrite HTTPS Infura URLs":
     var

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -75,7 +75,7 @@ suite "Gossip validation " & preset():
       cache: StateCache
     for blck in makeTestBlocks(
         dag.headState.data, cache, int(SLOTS_PER_EPOCH * 5), false):
-      let added = dag.addRawBlock(verifier, blck.phase0Data) do (
+      let added = dag.addHeadBlock(verifier, blck.phase0Data) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
         # Callback add to fork choice if valid
@@ -197,13 +197,13 @@ suite "Gossip validation - Extra": # Not based on preset config
             case blck.kind
             of BeaconBlockFork.Phase0:
               const nilCallback = OnPhase0BlockAdded(nil)
-              dag.addRawBlock(verifier, blck.phase0Data, nilCallback)
+              dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
             of BeaconBlockFork.Altair:
               const nilCallback = OnAltairBlockAdded(nil)
-              dag.addRawBlock(verifier, blck.altairData, nilCallback)
+              dag.addHeadBlock(verifier, blck.altairData, nilCallback)
             of BeaconBlockFork.Merge:
               const nilCallback = OnMergeBlockAdded(nil)
-              dag.addRawBlock(verifier, blck.mergeData, nilCallback)
+              dag.addHeadBlock(verifier, blck.mergeData, nilCallback)
           check: added.isOk()
           dag.updateHead(added[], quarantine[])
         dag

--- a/tests/test_merge_vectors.nim
+++ b/tests/test_merge_vectors.nim
@@ -11,8 +11,9 @@ import
   ./testutil
 
 suite "Merge test vectors":
-  let web3Provider = (waitFor Web3DataProvider.new(
-    default(Eth1Address), "http://127.0.0.1:8550")).get
+  setup:
+    let web3Provider = (waitFor Web3DataProvider.new(
+      default(Eth1Address), "http://127.0.0.1:8550")).get
 
   test "getPayload, executePayload, and forkchoiceUpdated":
     const feeRecipient =


### PR DESCRIPTION
In the ChainDAG, 3 block pointers are kept: genesis, tail and head. This
PR adds one more block pointer: the backfill block which represents the
block that has been backfilled so far.

When doing a checkpoint sync, a random block is given as starting point
- this is the tail block, and we require that the tail block has a
corresponding state.

When backfilling, we end up with blocks without corresponding states,
hence we cannot use `tail` as a backfill pointer - there is no state.

Nonetheless, we need to keep track of where we are in the backfill
process between restarts, such that we can answer GetBeaconBlocksByRange
requests.

This PR adds the basic support for backfill handling - it needs to be
integrated with backfill sync, and the REST API needs to be adjusted to
take advantage of the new backfilled blocks when responding to certain
requests.

Future work will also enable moving the tail in either direction:
* pruning means moving the tail forward in time and removing states
* backwards means recreating past states from genesis, such that
intermediate states are recreated step by step all the way to the tail -
at that point, tail, genesis and backfill will match up.
* backfilling is done when backfill != genesis - later, this will be the
WSS checkpoint instead