### PR TITLE
remove disabled incorrect attestation test

### DIFF
--- a/tests/mocking/mock_attestations.nim
+++ b/tests/mocking/mock_attestations.nim
@@ -54,7 +54,7 @@ proc mockAttestationData(
     epoch: target_epoch, root: epoch_boundary_root
   )
 
-proc signMockAttestation*(state: phase0.BeaconState, attestation: var Attestation) =
+proc signMockAttestation(state: phase0.BeaconState, attestation: var Attestation) =
   var cache = StateCache()
 
   var agg {.noInit.}: AggregateSignature

--- a/tests/spec_block_processing/test_process_attestation.nim
+++ b/tests/spec_block_processing/test_process_attestation.nim
@@ -73,18 +73,8 @@ suite "[Unit - Spec - Block processing] Attestations " & preset():
     getStateField(state[], slot) = Slot(SLOTS_PER_EPOCH - 1)
     nextEpoch(state[])
 
-  # TODO: regression BLS V0.10.1
-  echo "[Skipping] \"Empty aggregation bit\""
-
-  # valid_attestation("Empty aggregation bit"):
-  #   var attestation = mockAttestation(state)
-  #   state.data.slot += MIN_ATTESTATION_INCLUSION_DELAY
-
-  #   # Overwrite committee
-  #   attestation.aggregation_bits = init(CommitteeValidatorsBits, attestation.aggregation_bits.len)
-  #   signMockAttestation(state, attestation)
-
 # TODO - invalid attestations
+# - Empty aggregation bit
 # - Wrong end epoch
 # - Invalid signature
 # - Before inclusion delay


### PR DESCRIPTION
In #780 a test was disabled that verified that an attestation with
empty `aggregation_bits` completes successfully. The test was never
re-introduced, and as of the current consensus spec v1.1.6, such
attestations are not considered valid, as they fail the check in
`is_valid_indexed_attestation`. This patch fully removes that outdated
test, and moves it to the list of pending invalid attestation tests.