### PR TITLE
add copyright header to streams backends

### DIFF
--- a/beacon_chain/networking/faststreams_backend.nim
+++ b/beacon_chain/networking/faststreams_backend.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 type
   LibP2PInputStream = ref object of InputStream
     conn: Connection
@@ -131,4 +138,3 @@ proc readResponse(s: AsyncInputStream,
       return await s.readResponseChunk(noSnappy, MsgType)
     else:
       return neterr UnexpectedEOF
-

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # TODO: How can this be tested?
 proc uncompressFramedStream*(conn: Connection,
                              expectedSize: int): Future[Result[seq[byte], cstring]]


### PR DESCRIPTION
This adds the common copyright header to `libp2p_streams_backend.nim`
and `faststreams_backend.nim`. It was not present before in these file.