### PR TITLE
remove unnecessary binaries from builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,6 @@ XML_TEST_BINARIES := \
 
 # test suite
 TEST_BINARIES := \
-	proto_array \
-	fork_choice \
 	state_sim \
 	block_sim
 .PHONY: $(TEST_BINARIES) $(XML_TEST_BINARIES)
@@ -284,7 +282,7 @@ clean-testnet0:
 clean-testnet1:
 	rm -rf build/data/testnet1*
 
-testnet0 testnet1: | nimbus_beacon_node nimbus_signing_node
+testnet0 testnet1: | nimbus_beacon_node
 	build/nimbus_beacon_node \
 		--network=$@ \
 		--log-level="$(RUNTIME_LOG_LEVEL)" \

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -223,7 +223,7 @@ if [[ "${HAVE_LSOF}" == "1" ]]; then
 fi
 
 # Build the binaries
-BINARIES="nimbus_beacon_node nimbus_signing_node nimbus_validator_client deposit_contract"
+BINARIES="nimbus_beacon_node nimbus_validator_client deposit_contract"
 if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
   BINARIES="${BINARIES} logtrace"
 fi


### PR DESCRIPTION
* `fork_choice` and `proto_array` are already covered by better tests
* `nimbus_signing_node` is not used by local testnet