### PR TITLE
remove `stew/bitseqs` import

### DIFF
--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -14,7 +14,7 @@ import
   # Third-party libraries
   normalize,
   # Status libraries
-  stew/[results, bitseqs, bitops2], stew/shims/macros,
+  stew/[results, bitops2], stew/shims/macros,
   bearssl, eth/keyfile/uuid, blscurve, json_serialization,
   nimcrypto/[sha2, rijndael, pbkdf2, bcmode, hash, scrypt],
   # Local modules


### PR DESCRIPTION
There are multiple copies of `bitseqs` (`nim-stew`, `nim-eth`, and
`nim-ssz-serialization`). To avoid confusion, this patch removes the
final remaining reference of a non-`nim-ssz-serialization` copy.