### PR TITLE
import `is_valid_merkle_branch` test cases from `nim-eth`

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -290,9 +290,10 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + get_helper_indices                                                                         OK
 + get_path_indices                                                                           OK
 + integer_squareroot                                                                         OK
++ is_valid_merkle_branch                                                                     OK
 + verify_merkle_multiproof                                                                   OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
+OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Specific field types
 ```diff
 + root update                                                                                OK
@@ -388,4 +389,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 212/214 Fail: 0/214 Skip: 2/214
+OK: 213/215 Fail: 0/215 Skip: 2/215

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -127,3 +127,92 @@ suite "Spec helpers":
             verify([a, b, c, d])
             for e in 1 .. 7:
               verify([a, b, c, d, e])
+
+  test "is_valid_merkle_branch":
+    type TestCase = object
+      root: string
+      proof: seq[string]
+      leaf: string
+      index: uint64
+      valid: bool
+
+    let testCases = @[
+      TestCase(
+        root:
+          "2a23ef2b7a7221eaac2ffb3842a506a981c009ca6c2fcbf20adbc595e56f1a93",
+        proof: @[
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"
+        ],
+        leaf:
+          "0100000000000000000000000000000000000000000000000000000000000000",
+        index: 4,
+        valid: true
+      ),
+      TestCase(
+        root:
+          "2a23ef2b7a7221eaac2ffb3842a506a981c009ca6c2fcbf20adbc595e56f1a93",
+        proof: @[
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"
+        ],
+        leaf:
+          "0100000000000000000000000000000000000000000000000000000000000000",
+        index: 6,
+        valid: false
+      ),
+      TestCase(
+        root:
+          "2a23ef2b7a7221eaac2ffb3842a506a981c009ca6c2fcbf20adbc595e56f1a93",
+        proof: @[
+          "0100000000000000000000000000000000000000000000000000000000000000",
+          "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b"
+        ],
+        leaf:
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        index: 5,
+        valid: true
+      ),
+      TestCase(
+        root:
+          "f1824b0084956084591ff4c91c11bcc94a40be82da280e5171932b967dd146e9",
+        proof: @[
+          "35210d64853aee79d03f30cf0f29c1398706cbbcacaf05ab9524f00070aec91e",
+          "f38a181470ef1eee90a29f0af0a9dba6b7e5d48af3c93c29b4f91fa11b777582"
+        ],
+        leaf:
+          "0100000000000000000000000000000000000000000000000000000000000000",
+        index: 7,
+        valid: true
+      ),
+      TestCase(
+        root:
+          "f1824b0084956084591ff4c91c11bcc94a40be82da280e5171932b967dd146e9",
+        proof: @[
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b",
+          "0100000000000000000000000000000000000000000000000000000000000000",
+          "f38a181470ef1eee90a29f0af0a9dba6b7e5d48af3c93c29b4f91fa11b777582"
+        ],
+        leaf:
+          "6001000000000000000000000000000000000000000000000000000000000000",
+        index: 49,
+        valid: true
+      )
+    ]
+
+    for testCase in testCases:
+      let
+        root = Eth2Digest.fromHex(testCase.root)
+        proof = mapIt(testCase.proof, Eth2Digest.fromHex(it))
+        leaf = Eth2Digest.fromHex(testCase.leaf)
+        index = testCase.index.GeneralizedIndex
+        valid = is_valid_merkle_branch(leaf, proof,
+                                       log2trunc(index),
+                                       get_subtree_index(index),
+                                       root)
+      if testCase.valid:
+        check valid
+      else:
+        check (not valid)


### PR DESCRIPTION
As of https://github.com/status-im/nim-eth/pull/379 `nim-eth` defines a
couple static test cases for merkle proof verification.
Since the EF has defined a `is_valid_merkle_branch` function in the spec
we are no longer using the custom implementation from `nim-eth`, but the
tests were never ported to target the new implementation. This patch now
follows up on that and integrates those tests from `nim-eth`.