### PR TITLE
avoid SyncCommitteMsgPool copy

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -427,7 +427,7 @@ proc syncCommitteeMessageValidator*(
 
   # Now proceed to validation
   let v = await validateSyncCommitteeMessage(
-    self.dag, self.batchCrypto, self.syncCommitteeMsgPool[],
+    self.dag, self.batchCrypto, self.syncCommitteeMsgPool,
     syncCommitteeMsg, subcommitteeIdx, wallTime, checkSignature)
   return if v.isOk():
     trace "Sync committee message validated"

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -775,7 +775,7 @@ proc validateVoluntaryExit*(
 proc validateSyncCommitteeMessage*(
     dag: ChainDAGRef,
     batchCrypto: ref BatchCrypto,
-    syncCommitteeMsgPool: SyncCommitteeMsgPool,
+    syncCommitteeMsgPool: ref SyncCommitteeMsgPool,
     msg: SyncCommitteeMessage,
     subcommitteeIdx: SyncSubcommitteeIndex,
     wallTime: BeaconTime,
@@ -810,7 +810,7 @@ proc validateSyncCommitteeMessage*(
     # Note this validation is per topic so that for a given slot, multiple
     # messages could be forwarded with the same validator_index as long as
     # the subnet_ids are distinct.
-    if syncCommitteeMsgPool.isSeen(msg, subcommitteeIdx):
+    if syncCommitteeMsgPool[].isSeen(msg, subcommitteeIdx):
       return errIgnore("SyncCommitteeMessage: duplicate message")
 
   # [REJECT] The signature is valid for the message beacon_block_root for the

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -171,7 +171,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
         let res = waitFor dag.validateSyncCommitteeMessage(
           batchCrypto,
-          syncCommitteePool[],
+          syncCommitteePool,
           msg,
           subcommitteeIdx,
           messagesTime,

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -227,7 +227,7 @@ suite "Gossip validation - Extra": # Not based on preset config
 
       syncCommitteeMsgPool = newClone(SyncCommitteeMsgPool.init())
       res = waitFor validateSyncCommitteeMessage(
-        dag, batchCrypto, syncCommitteeMsgPool[], msg, subcommitteeIdx,
+        dag, batchCrypto, syncCommitteeMsgPool, msg, subcommitteeIdx,
         slot.toBeaconTime(), true)
       (positions, cookedSig) = res.get()
 
@@ -261,5 +261,5 @@ suite "Gossip validation - Extra": # Not based on preset config
 
       # Same message twice should be ignored
       validateSyncCommitteeMessage(
-        dag, batchCrypto, syncCommitteeMsgPool[], msg, subcommitteeIdx,
+        dag, batchCrypto, syncCommitteeMsgPool, msg, subcommitteeIdx,
         state[].data.slot.toBeaconTime(), true).waitFor().isErr()


### PR DESCRIPTION
introduced by batch verification, when verifiers were made async