### PR TITLE
ShortAgent is set without libp2p_agents_metrics

### DIFF
--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -104,11 +104,7 @@ proc toNode(v: PubSubPeer, backoff: Moment): RestPubSubPeer =
       else:
         "<no address>",
     backoff: $(backoff - Moment.now()),
-    agent:
-      when defined(libp2p_agents_metrics):
-        v.shortAgent
-      else:
-        "unknown"
+    agent: v.shortAgent
   )
 
 proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =

--- a/beacon_chain/rpc/rpc_nimbus_api.nim
+++ b/beacon_chain/rpc/rpc_nimbus_api.nim
@@ -156,10 +156,7 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
           else:
             "<no address>",
         backoff: $(backoff - Moment.now()),
-        agent: when defined(libp2p_agents_metrics):
-            v.shortAgent
-          else:
-            "unknown",
+        agent: v.shortAgent
       )
 
     for topic, v in node.network.pubsub.gossipsub:


### PR DESCRIPTION
libp2p_agents_metrics is only used for filtering at the
metrics level, but shortAgent is set even without
-d:libp2p_agents_metrics