### PR TITLE
SyncManager cleanups for backfill support

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -8,6 +8,7 @@
 {.push raises: [Defect].}
 
 import
+  std/math,
   chronos, chronicles,
   ./spec/helpers
 
@@ -139,6 +140,15 @@ func shortLog*(d: Duration): string =
 
 func toFloatSeconds*(d: Duration): float =
   float(milliseconds(d)) / 1000.0
+
+func fromFloatSeconds*(T: type Duration, f: float): Duration =
+  case classify(f)
+  of fcNormal:
+    if f >= float(int64.high() div 1_000_000_000): InfiniteDuration
+    elif f <= 0: ZeroDuration
+    else: nanoseconds(int64(f * 1_000_000_000))
+  of fcSubnormal, fcZero, fcNegZero, fcNan, fcNegInf: ZeroDuration
+  of fcInf: InfiniteDuration
 
 func `$`*(v: BeaconTime): string = $(Duration v)
 func shortLog*(v: BeaconTime): string = $(Duration v)

--- a/beacon_chain/sync/peer_scores.nim
+++ b/beacon_chain/sync/peer_scores.nim
@@ -8,6 +8,8 @@
 {.push raises: [Defect].}
 
 const
+  PeerScoreHeadTooNew* = -100
+    ## The peer reports a head newer than our wall clock slot
   PeerScoreNoStatus* = -100
     ## Peer did not answer `status` request.
   PeerScoreStaleStatus* = -50

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -26,6 +26,10 @@ logScope:
 
 type
   GetSlotCallback* = proc(): Slot {.gcsafe, raises: [Defect].}
+  ProcessingCallback* = proc() {.gcsafe, raises: [Defect].}
+  BlockVerifier* =
+    proc(signedBlock: ForkedSignedBeaconBlock):
+      Future[Result[void, BlockError]] {.gcsafe, raises: [Defect].}
 
   SyncQueueKind* {.pure.} = enum
     Forward, Backward
@@ -42,9 +46,9 @@ type
     request*: SyncRequest[T]
     data*: seq[ForkedSignedBeaconBlock]
 
-  SyncWaiter*[T] = object
-    future: Future[bool]
-    request: SyncRequest[T]
+  SyncWaiter* = ref object
+    future: Future[void]
+    reset: bool
 
   RewindPoint = object
     failSlot: Slot
@@ -61,23 +65,16 @@ type
     counter*: uint64
     opcounter*: uint64
     pending*: Table[uint64, SyncRequest[T]]
-    waiters: seq[SyncWaiter[T]]
+    waiters: seq[SyncWaiter]
     getSafeSlot*: GetSlotCallback
     debtsQueue: HeapQueue[SyncRequest[T]]
     debtsCount: uint64
     readyQueue: HeapQueue[SyncResult[T]]
     rewind: Option[RewindPoint]
-    blockProcessor: ref BlockProcessor
+    blockVerifier: BlockVerifier
 
   SyncManagerError* = object of CatchableError
   BeaconBlocksRes* = NetRes[seq[ForkedSignedBeaconBlock]]
-
-proc validate*[T](sq: SyncQueue[T],
-                  blk: ForkedSignedBeaconBlock
-                 ): Future[Result[void, BlockError]] =
-  let resfut = newFuture[Result[void, BlockError]]("sync.manager.validate")
-  sq.blockProcessor[].addBlock(blk, resfut)
-  resfut
 
 proc getShortMap*[T](req: SyncRequest[T],
                      data: openArray[ForkedSignedBeaconBlock]): string =
@@ -170,7 +167,7 @@ proc init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
               queueKind: SyncQueueKind,
               start, final: Slot, chunkSize: uint64,
               getSafeSlotCb: GetSlotCallback,
-              blockProcessor: ref BlockProcessor,
+              blockVerifier: BlockVerifier,
               syncQueueSize: int = -1): SyncQueue[T] =
   ## Create new synchronization queue with parameters
   ##
@@ -227,13 +224,13 @@ proc init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
     chunkSize: chunkSize,
     queueSize: syncQueueSize,
     getSafeSlot: getSafeSlotCb,
-    waiters: newSeq[SyncWaiter[T]](),
+    waiters: newSeq[SyncWaiter](),
     counter: 1'u64,
     pending: initTable[uint64, SyncRequest[T]](),
     debtsQueue: initHeapQueue[SyncRequest[T]](),
     inpSlot: start,
     outSlot: start,
-    blockProcessor: blockProcessor
+    blockVerifier: blockVerifier
   )
 
 proc `<`*[T](a, b: SyncRequest[T]): bool =
@@ -279,36 +276,38 @@ proc updateLastSlot*[T](sq: SyncQueue[T], last: Slot) {.inline.} =
              $sq.finalSlot & " >= " & $last)
     sq.finalSlot = last
 
-proc wakeupWaiters[T](sq: SyncQueue[T], flag = true) =
+proc wakeupWaiters[T](sq: SyncQueue[T], reset = false) =
   ## Wakeup one or all blocked waiters.
   for item in sq.waiters:
-    if not(item.future.finished()):
-      item.future.complete(flag)
+    if reset:
+      item.reset = true
 
-proc waitForChanges[T](sq: SyncQueue[T],
-                       req: SyncRequest[T]): Future[bool] {.async.} =
+    if not(item.future.finished()):
+      item.future.complete()
+
+proc waitForChanges[T](sq: SyncQueue[T]): Future[bool] {.async.} =
   ## Create new waiter and wait for completion from `wakeupWaiters()`.
-  var waitfut = newFuture[bool]("SyncQueue.waitForChanges")
-  let waititem = SyncWaiter[T](future: waitfut, request: req)
+  var waitfut = newFuture[void]("SyncQueue.waitForChanges")
+  let waititem = SyncWaiter(future: waitfut)
   sq.waiters.add(waititem)
   try:
-    let res = await waitfut
-    return res
+    await waitfut
+    return waititem.reset
   finally:
     sq.waiters.delete(sq.waiters.find(waititem))
 
 proc wakeupAndWaitWaiters[T](sq: SyncQueue[T]) {.async.} =
   ## This procedure will perform wakeupWaiters(false) and blocks until last
   ## waiter will be awakened.
-  var waitChanges = sq.waitForChanges(SyncRequest.empty(sq.kind, T))
-  sq.wakeupWaiters(false)
+  var waitChanges = sq.waitForChanges()
+  sq.wakeupWaiters(true)
   discard await waitChanges
 
 proc resetWait*[T](sq: SyncQueue[T], toSlot: Option[Slot]) {.async.} =
   ## Perform reset of all the blocked waiters in SyncQueue.
   ##
   ## We adding one more waiter to the waiters sequence and
-  ## call wakeupWaiters(false). Because our waiter is last in sequence of
+  ## call wakeupWaiters(true). Because our waiter is last in sequence of
   ## waiters it will be resumed only after all waiters will be awakened and
   ## finished.
 
@@ -498,7 +497,8 @@ proc notInRange[T](sq: SyncQueue[T], slot: Slot): bool =
     (uint64(sq.queueSize) * sq.chunkSize <= sq.outSlot - slot)
 
 proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
-              data: seq[ForkedSignedBeaconBlock]) {.async, gcsafe.} =
+              data: seq[ForkedSignedBeaconBlock],
+              processingCb: ProcessingCallback = nil) {.async.} =
   ## Push successful result to queue ``sq``.
   mixin updateScore
 
@@ -514,23 +514,16 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
   # This is backpressure handling algorithm, this algorithm is blocking
   # all pending `push` requests if `request.slot` not in range:
   # [current_queue_slot, current_queue_slot + sq.queueSize * sq.chunkSize].
-  var exitNow = false
   while true:
     if sq.notInRange(sr.slot):
-      let res = await sq.waitForChanges(sr)
-      if res:
-        continue
-      else:
+      let reset = await sq.waitForChanges()
+      if reset:
         # SyncQueue reset happens. We are exiting to wake up sync-worker.
-        exitNow = true
-        break
-    let syncres = SyncResult[T](request: sr, data: data)
-    sq.readyQueue.push(syncres)
-    exitNow = false
-    break
-
-  if exitNow:
-    return
+        return
+    else:
+      let syncres = SyncResult[T](request: sr, data: data)
+      sq.readyQueue.push(syncres)
+      break
 
   while len(sq.readyQueue) > 0:
     let reqres =
@@ -567,6 +560,12 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
         await sq.resetWait(some(rewindSlot))
         break
 
+    if processingCb != nil:
+      processingCb()
+
+    template isOkResponse(res: auto): bool =
+      res.isOk() or res.error in {BlockError.Duplicate, BlockError.UnviableFork}
+
     # Validating received blocks one by one
     var res: Result[void, BlockError]
     var failSlot: Option[Slot]
@@ -574,8 +573,8 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
       for blk in sq.blocks(item):
         trace "Pushing block", block_root = blk.root,
                                block_slot = blk.slot
-        res = await sq.validate(blk)
-        if res.isErr():
+        res = await sq.blockVerifier(blk)
+        if not res.isOkResponse():
           failSlot = some(blk.slot)
           break
     else:
@@ -585,7 +584,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
     # not stuck.
     inc(sq.opcounter)
 
-    if res.isOk():
+    if res.isOkResponse():
       sq.advanceOutput(item.request.count)
       if len(item.data) > 0:
         # If there no error and response was not empty we should reward peer
@@ -603,7 +602,8 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
 
       var resetSlot: Option[Slot]
 
-      if res.error == BlockError.MissingParent:
+      case res.error
+      of BlockError.MissingParent:
         # If we got `BlockError.MissingParent` it means that peer returns chain
         # of blocks with holes or `block_pool` is in incomplete state. We going
         # to rewind to the first slot at latest finalized epoch.
@@ -650,21 +650,15 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
                   request_step = req.step, blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data), topics = "syncman"
             req.item.updateScore(PeerScoreBadBlocks)
-      elif res.error == BlockError.Invalid:
+      of BlockError.Invalid:
         let req = item.request
         warn "Received invalid sequence of blocks", peer = req.item,
               request_slot = req.slot, request_count = req.count,
               request_step = req.step, blocks_count = len(item.data),
               blocks_map = getShortMap(req, item.data), topics = "syncman"
         req.item.updateScore(PeerScoreBadBlocks)
-      else:
-        let req = item.request
-        warn "Received unexpected response from block_pool", peer = req.item,
-             request_slot = req.slot, request_count = req.count,
-             request_step = req.step, blocks_count = len(item.data),
-             blocks_map = getShortMap(req, item.data), errorCode = res.error,
-             topics = "syncman"
-        req.item.updateScore(PeerScoreBadBlocks)
+      of BlockError.Duplicate, BlockError.UnviableFork:
+        raiseAssert "Handled above"
 
       # We need to move failed response to the debts queue.
       sq.toDebtsQueue(item.request)
@@ -773,11 +767,9 @@ proc total*[T](sq: SyncQueue[T]): uint64 {.inline.} =
     sq.startSlot + 1'u64 - sq.finalSlot
 
 proc progress*[T](sq: SyncQueue[T]): uint64 =
-  ## Returns queue's ``sq`` progress string.
-  let curSlot =
-    case sq.kind
-    of SyncQueueKind.Forward:
-      sq.outSlot - sq.startSlot
-    of SyncQueueKind.Backward:
-      sq.startSlot - sq.outSlot
-  (curSlot * 100'u64) div sq.total()
+  ## How many slots we've synced so far
+  case sq.kind
+  of SyncQueueKind.Forward:
+    sq.outSlot - sq.startSlot
+  of SyncQueueKind.Backward:
+    sq.startSlot - sq.outSlot


### PR DESCRIPTION
Cleanups, fixes and simplifications, in anticipation of backfill support
for the `SyncManager`:

* reformat sync progress indicator to show time left and % done more
prominently:
  * old: `sync="sPssPsssss:2:2.4229:00h57m (2706898)"`
  * new: `sync="14d12h31m (0.52%) 1.1378slots/s (wQQQQQDDQQ:1287520)"`
* reset average speed when going out of sync
* pass all block errors to sync manager, including duplicate/unviable
* penalize peers for reporting a head block that is outside of our
expected wall clock time (they're likely on a different network or
trying to disrupt sync)
* remove `SyncFailureKind` (unused)
* remove `inRange` (unused)
* add `Q` for sync queue requests that are in the `SyncQueue` but not
yet in the `BlockProcessor` queue
* update last slot in `SyncQueue` after getting peer status
* fix race condition between `wakeupWaiters` and `resetWait`, where
workers would not be correctly reset if block verification returned a
completed future without event loop
* log syncmanager direction