### PR TITLE
fix typo (`snapshop` -> `snapshot`)

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -199,6 +199,6 @@ proc getRuntimeConfig*(
     return getMetadataForNetwork(eth2Network.get).cfg
   return defaultRuntimeConfig
 
-proc extractGenesisValidatorRootFromSnapshop*(
+proc extractGenesisValidatorRootFromSnapshot*(
     snapshot: string): Eth2Digest {.raises: [Defect, IOError, SszError].} =
   sszMount(snapshot, phase0.BeaconState).genesis_validators_root[]

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -306,7 +306,7 @@ proc init*(T: type BeaconNode,
   if genesisStateContents.len != 0:
     let
       networkGenesisValidatorsRoot =
-        extractGenesisValidatorRootFromSnapshop(genesisStateContents)
+        extractGenesisValidatorRootFromSnapshot(genesisStateContents)
 
     if networkGenesisValidatorsRoot != databaseGenesisValidatorsRoot:
       fatal "The specified --data-dir contains data for a different network",


### PR DESCRIPTION
This fixes a typo in the word `snapshot` of function name
`extractGenesisValidatorRootFromSnapshop`.