### PR TITLE
dist-macos-arm64: use -mcpu=apple-a13

### DIFF
--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -136,7 +136,7 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
     CC="${CC}" \
     LIBTOOL="arm64-apple-darwin${DARWIN_VER}-libtool" \
     OS="darwin" \
-    NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --clang.exe=${CC}" \
+    NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --passC:'-mcpu=apple-a13' --clang.exe=${CC}" \
     nat-libs
   make \
     -j$(nproc) \
@@ -148,7 +148,7 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
     DSYMUTIL="arm64-apple-darwin${DARWIN_VER}-dsymutil" \
     FORCE_DSYMUTIL=1 \
     USE_VENDORED_LIBUNWIND=1 \
-    NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --clang.exe=${CC} --clang.linkerexe=${CC}" \
+    NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --passC:'-mcpu=apple-a13' --passL:'-mcpu=apple-a13' --clang.exe=${CC} --clang.linkerexe=${CC}" \
     ${BINARIES}
 else
   # Linux AMD64


### PR DESCRIPTION
This turns on the "crypto" hw extension which is picked up and used by BLST, giving us this nice average initial syncing speed on a fifth gen Mac Mini with an Apple M1 CPU:

![mac_mini_m1](https://user-images.githubusercontent.com/495550/146271761-b84beaab-1bc5-475a-a895-a0ed930f8df3.png)
