### PR TITLE
Bump libp2p

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -66,7 +66,6 @@ type
     wantedPeers*: int
     peerPool*: PeerPool[Peer, PeerID]
     protocolStates*: seq[RootRef]
-    libp2pTransportLoops*: seq[Future[void]]
     metadata*: altair.MetaData
     connectTimeout*: chronos.Duration
     seenThreshold*: chronos.Duration
@@ -1397,7 +1396,7 @@ proc startListening*(node: Eth2Node) {.async.} =
       quit 1
 
   try:
-    node.libp2pTransportLoops = await node.switch.start()
+    await node.switch.start()
   except CatchableError:
     fatal "Failed to start LibP2P transport. TCP port may be already in use"
     quit 1
@@ -1872,6 +1871,7 @@ proc createEth2Node*(rng: ref BrHmacDrbgContext,
     params = GossipSubParams(
       explicit: true,
       pruneBackoff: 1.minutes,
+      unsubscribeBackoff: 10.seconds,
       floodPublish: true,
       gossipFactor: 0.05,
       d: 8,


### PR DESCRIPTION
In this bump:

- https://github.com/status-im/nim-libp2p/pull/598: Allows to use multiple address on a single transport (eg, ipv4 + ipv6, or multiple ipv4 addresses, etc)
- https://github.com/status-im/nim-libp2p/pull/665: Greatly improve mesh health on our busy test nodes. For regular users, fix a rare "race condition"
- https://github.com/status-im/nim-libp2p/pull/662: Improve API (still WiP)
- https://github.com/status-im/nim-libp2p/pull/659: Less copies of message buffers while passing around layers, improves RAM usage
- https://github.com/status-im/nim-libp2p/pull/676: Preparations for `--styleCheck:usages`: fixes all internal issues, still have uptstream incompabilities