### PR TITLE
fix type-conversions-to-self, unexport from nimbus_beacon_node, and rm unused vars/procs

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -118,7 +118,7 @@ proc fromNow*(c: BeaconClock, slot: Slot): tuple[inFuture: bool, offset: Duratio
 proc durationToNextSlot*(c: BeaconClock): Duration =
   let (afterGenesis, slot) = c.now().toSlot()
   if afterGenesis:
-    c.fromNow(Slot(slot) + 1'u64).offset
+    c.fromNow(slot + 1'u64).offset
   else:
     c.fromNow(Slot(0)).offset
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -56,7 +56,7 @@ import
   TopicParams, validateParameters, init
 
 type
-  RpcServer* = RpcHttpServer
+  RpcServer = RpcHttpServer
 
 template init(T: type RpcHttpServer, ip: ValidIpAddress, port: Port): T =
   newRpcHttpServer([initTAddress(ip, port)])
@@ -112,14 +112,14 @@ const SlashingDbName = "slashing_protection"
 func getBeaconTimeFn(clock: BeaconClock): GetBeaconTimeFn =
   return proc(): BeaconTime = clock.now()
 
-proc init*(T: type BeaconNode,
-           cfg: RuntimeConfig,
-           rng: ref BrHmacDrbgContext,
-           config: BeaconNodeConf,
-           depositContractDeployedAt: BlockHashOrNumber,
-           eth1Network: Option[Eth1Network],
-           genesisStateContents: string,
-           genesisDepositsSnapshotContents: string): BeaconNode {.
+proc init(T: type BeaconNode,
+          cfg: RuntimeConfig,
+          rng: ref BrHmacDrbgContext,
+          config: BeaconNodeConf,
+          depositContractDeployedAt: BlockHashOrNumber,
+          eth1Network: Option[Eth1Network],
+          genesisStateContents: string,
+          genesisDepositsSnapshotContents: string): BeaconNode {.
     raises: [Defect, CatchableError].} =
 
   var taskpool: TaskpoolPtr
@@ -428,7 +428,7 @@ proc init*(T: type BeaconNode,
 
   var node = BeaconNode(
     nickname: nickname,
-    graffitiBytes: if config.graffiti.isSome: config.graffiti.get.GraffitiBytes
+    graffitiBytes: if config.graffiti.isSome: config.graffiti.get
                    else: defaultGraffitiBytes(),
     network: network,
     netKeys: netKeys,
@@ -1086,7 +1086,7 @@ proc installMessageValidators(node: BeaconNode) =
   installSyncCommitteeeValidators(node.dag.forkDigests.altair)
   installSyncCommitteeeValidators(node.dag.forkDigests.merge)
 
-proc stop*(node: BeaconNode) =
+proc stop(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping
   notice "Graceful shutdown"
   if not node.config.inProcessValidators:
@@ -1103,7 +1103,7 @@ proc stop*(node: BeaconNode) =
   node.db.close()
   notice "Databases closed"
 
-proc run*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
+proc run(node: BeaconNode) {.raises: [Defect, CatchableError].} =
   bnStatus = BeaconNodeStatus.Running
 
   if not(isNil(node.rpcServer)):
@@ -1385,7 +1385,7 @@ proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
     keystoreDir = validatorsDir / validatorKeyAsStr
 
   if not dirExists(keystoreDir):
-    echo "The validator keystores directory '" & config.validatorsDir.string &
+    echo "The validator keystores directory '" & config.validatorsDir &
          "' does not contain a keystore for the selected validator with public " &
          "key '" & validatorKeyAsStr & "'."
     quit 1

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -429,9 +429,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         ires
 
     node.withStateForBlockSlot(bslot):
-      let
-        current_epoch = getStateField(stateData.data, slot).epoch()
-        validatorsCount = lenu64(getStateField(stateData.data, validators))
+      let validatorsCount = lenu64(getStateField(stateData.data, validators))
 
       let indices =
         block:

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -123,7 +123,7 @@ template withStateForBlockSlot*(node: BeaconNode,
 
   if isState(node.dag.headState):
     withStateVars(node.dag.headState):
-      var cache {.inject.}: StateCache
+      var cache {.inject, used.}: StateCache
       body
   else:
     let rpcState = assignClone(node.dag.headState)

--- a/beacon_chain/rpc/rpc_config_api.nim
+++ b/beacon_chain/rpc/rpc_config_api.nim
@@ -21,9 +21,6 @@ logScope: topics = "configapi"
 type
   RpcServer = RpcHttpServer
 
-template unimplemented() =
-  raise (ref CatchableError)(msg: "Unimplemented")
-
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Defect, CatchableError].} =
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -244,7 +244,7 @@ proc initialize_beacon_state_from_eth1*(
 
     pubkeyToIndex.withValue(pubkey, foundIdx) do:
       # Increase balance by deposit amount
-      increase_balance(state, ValidatorIndex foundIdx[], amount)
+      increase_balance(state, foundIdx[], amount)
     do:
       if skipBlsValidation in flags or
          verify_deposit_signature(cfg, deposit):

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -381,7 +381,7 @@ func get_active_validator_indices*(state: ForkyBeaconState, epoch: Epoch):
   ## Return the sequence of active validator indices at ``epoch``.
   var res = newSeqOfCap[ValidatorIndex](state.validators.len)
   for idx in get_active_validator_indices(state, epoch):
-    res.add idx.ValidatorIndex
+    res.add idx
   res
 
 func get_active_validator_indices_len*(state: ForkyBeaconState, epoch: Epoch):

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -171,9 +171,6 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
 template headAge(): uint64 =
   wallSlot - headSlot
 
-template queueAge(): uint64 =
-  wallSlot - man.queue.outSlot
-
 template peerStatusAge(): Duration =
   Moment.now() - peer.state(BeaconSync).statusLastTime
 

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -217,7 +217,6 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
     slot = adata.slot
     committeeIndex = CommitteeIndex(adata.index)
     attestationRoot = adata.hash_tree_root()
-    genesisRoot = vc.beaconGenesis.genesis_validators_root
 
   let aggregateItems =
     block:

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -21,7 +21,6 @@ proc checkDuty(duty: RestAttesterDuty): bool =
   (uint64(duty.validator_index) <= VALIDATOR_REGISTRY_LIMIT)
 
 proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
-  let stateIdent = StateIdent.init(StateIdentType.Head)
   let validatorIdents =
     block:
       var res: seq[ValidatorIdent]
@@ -332,7 +331,6 @@ template checkAndRestart(serviceLoop: DutiesServiceLoop,
 
 proc mainLoop(service: DutiesServiceRef) {.async.} =
   service.state = ServiceState.Running
-  let vc = service.client
 
   try:
     var

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -163,10 +163,10 @@ proc getAttachedValidator*(node: BeaconNode,
   let key = epochRef.validatorKey(idx)
   if key.isSome():
     let validator = node.getAttachedValidator(key.get().toPubKey())
-    if validator != nil and validator.index != some(idx.ValidatorIndex):
+    if validator != nil and validator.index != some(idx):
       # Update index, in case the validator was activated!
       notice "Validator activated", pubkey = validator.pubkey, index = idx
-      validator.index  = some(idx.ValidatorIndex)
+      validator.index = some(idx)
     validator
   else:
     warn "Validator key not found",
@@ -1233,7 +1233,6 @@ proc sendBeaconBlock*(node: BeaconNode, forked: ForkedSignedBeaconBlock
   node.network.broadcastBeaconBlock(forked)
 
   let
-    head = node.dag.head
     wallTime = node.beaconClock.now()
     accepted = withBlck(forked):
       let newBlockRef = node.blockProcessor[].storeBlock(


### PR DESCRIPTION
Nothing imports `nimbus_beacon_node`, so there's no reason to export from it.

A few places used to genuinely need to convert to `ValidatorIndex` values quasi-type-unsafely, but most of those have been fixed already, so now they're just doing nothing.

There were/are some stray unused variables that probably became unnecessary during some other refactoring.