### PR TITLE
sync status: better ETA calculation

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1248,24 +1248,30 @@ proc initStatusBar(node: BeaconNode) {.raises: [Defect, ValueError].} =
     # arbitrary expression that is resolvable through this API.
     case expr.toLowerAscii
     of "connected_peers":
-      $(node.connectedPeersCount)
+      try:
+        fmt("{(node.connectedPeersCount):>3}")
+      except ValueError:
+        "N/A"
 
     of "head_root":
       shortLog(node.dag.head.root)
     of "head_epoch":
       $(node.dag.head.slot.epoch)
     of "head_epoch_slot":
-      $(node.dag.head.slot mod SLOTS_PER_EPOCH)
+      try:
+        fmt("{(node.dag.head.slot mod SLOTS_PER_EPOCH):02}")
+      except ValueError:
+        "N/A"
     of "head_slot":
       $(node.dag.head.slot)
 
-    of "justifed_root":
+    of "justified_root":
       shortLog(justified.blck.root)
-    of "justifed_epoch":
+    of "justified_epoch":
       $(justified.slot.epoch)
-    of "justifed_epoch_slot":
+    of "justified_epoch_slot":
       $(justified.slot mod SLOTS_PER_EPOCH)
-    of "justifed_slot":
+    of "justified_slot":
       $(justified.slot)
 
     of "finalized_root":
@@ -1281,7 +1287,10 @@ proc initStatusBar(node: BeaconNode) {.raises: [Defect, ValueError].} =
       $node.currentSlot.epoch
 
     of "epoch_slot":
-      $(node.currentSlot mod SLOTS_PER_EPOCH)
+      try:
+        fmt("{(node.currentSlot mod SLOTS_PER_EPOCH):02}")
+      except ValueError:
+        "N/A"
 
     of "slot":
       $node.currentSlot


### PR DESCRIPTION
...and stop the status bar from jumping left and right.

## long story short

A day ago I finished syncing mainnet from scratch, in 3d8h40m. The initial ETA was way, way off and it stayed unusable for most of the duration of that initial sync, so I did something about it.

### commands used

```text
./run-mainnet-beacon-node.sh --web3-url="wss://mainnet.infura.io/ws/v3/TOKEN_HERE" --metrics --metrics-port=8008 --enr-auto-update --doppelganger-detection=off --log-file=build/data/shared_mainnet_0/nimbus.log --num-threads=0
# in some other terminal:
grep 'Slot start' build/data/shared_mainnet_0/nimbus.log | jq '.sync'
```

### before

```text
"13h43m (0.05%) 55.9907slots/s (PDQDQDQDDD:1248)"
"17h30m (0.05%) 43.8854slots/s (DPQQDQDQDQ:1408)"
"22h48m (0.06%) 33.6848slots/s (DDPDQDQDQD:1600)"
"01d00h33m (0.08%) 31.2586slots/s (QDQDQDQPDQ:2144)"
"20h36m (0.10%) 37.2633slots/s (DDPDQDQDQD:2880)"
"19h00m (0.13%) 40.3822slots/s (DDDDPDQDQD:3552)"
"18h30m (0.15%) 41.4705slots/s (QQQQQQQDQP:4096)"
"17h43m (0.17%) 43.2838slots/s (DDDDPDQDQD:4832)"
"17h02m (0.20%) 44.9881slots/s (DQDDDDPDQD:5504)"
"16h44m (0.22%) 45.8222slots/s (QQQQQDQDQP:6016)"
"16h34m (0.24%) 46.2587slots/s (QQQQQQQDQP:6656)"
"16h26m (0.26%) 46.6243slots/s (DDQDQPDQDQ:7232)"
"16h32m (0.28%) 46.3174slots/s (DDQPQQDDDD:7840)"
"16h34m (0.30%) 46.2444slots/s (DPQQDDQDQD:8384)"
```

### after

```text
"03d01h21m (0.04%) 30.40slt/s (DDQQDDDDDP)"
"03d20h08m (0.05%) 40.45slt/s (QQDDDPQQQQ)"
"04d10h58m (0.05%) 33.54slt/s (QDQQQDDDPQ)"
"04d21h38m (0.06%) 30.01slt/s (QQDDDPQQQQ)"
"04d06h01m (0.08%) 27.67slt/s (QQPDDQQQQQ)"
"03d15h02m (0.13%) 36.25slt/s (QQQPQQQQDD)"
"03d12h45m (0.15%) 38.27slt/s (QQQQQQQDQQ)"
"03d10h46m (0.16%) 39.88slt/s (QQDDDPQQQQ)"
"03d08h37m (0.18%) 40.90slt/s (QQQPQQDDDD)"
"03d06h55m (0.21%) 42.03slt/s (DDQQQDDDPQ)"
"03d04h13m (0.25%) 44.12slt/s (PQQDDDQDQQ)"
"03d04h45m (0.26%) 45.23slt/s (QDQQDDDPQQ)"
"03d04h22m (0.28%) 44.80slt/s (QQDDDPQQQD)"
"03d03h46m (0.30%) 45.17slt/s (QDQPQQDDDQ)"
```

## the data

![Screenshot 2021-12-19 at 05-11-32 NBC local testnet sim (all nodes) - Grafana](https://user-images.githubusercontent.com/495550/146814363-906556d3-d613-4ee5-a653-14a7314370a9.png)

You can see how a naive ETA algorithm - one assuming a linear syncing speed - would be so bad as to be unusable. Any straight line from the origin to any point on that curve fails to predict the rest of it.

## curve fitting

However, we're lucky to know beforehand how the real syncing curve looks like. We can just do some curve fitting on it and use that polynomial as our ETA prediction function. I chose R for this task, because I find the language and ecosystem hilarious. "curve_fit.R":

```r
#!/usr/bin/env Rscript

# Model the initial block syncing speed of nimbus_beacon_node on mainnet, on a
# local desktop, with multi-threading enabled.

# Got the query params from Grafana and lowered the step:
# curl -s 'http://localhost:9090/api/v1/query_range?query=beacon_head_slot&start=1639667400&end=1639865880&step=20' | jq -r '.data.result[0].values | map([.[0], .[1]] | join(", ")) | join("\n")' > slots.csv
data <- read.csv("./slots.csv", header=FALSE, col.names=c("unix_timestamp", "slots"))

# It's hard to get a good fit with a single polynomial, but easy with two.
curve_split_after_seconds <- 40000 # corresponds to slot 751597
curve_split <- curve_split_after_seconds / 20 # in number of elements in the vector

# "lm()" won't work on Unix timestamps - maybe because they are too close in
# the floating point domain. We need to lower these values so they start from
# zero.
slots_processed_all <- data.frame(slots = data$slots, seconds = mapply(function(x) x - data$unix_timestamp[1], data$unix_timestamp))
str(slots_processed_all)

png(file="slots.png", width=1000, height=800)
plot(slots_processed_all$seconds, slots_processed_all$slots, main="processed slots (mainnet)", xlab="seconds from start", ylab="slots", xaxt="n", pch=16, cex=.1)
axis(side=1, tck=-0.015, at=c(seq(from=0,to=200000,by=1000)))
grid(nx = 220, ny = NULL, col = "lightgray", lty = "dotted", lwd = par("lwd"), equilogs = TRUE)

message("Polynomial model for seconds_from_start=f(slots_synced) for the first ", curve_split_after_seconds, "s")
slots_processed_initial <- data.frame(slots = slots_processed_all$slots[1:curve_split], seconds = slots_processed_all$seconds[1:curve_split])
initial_fit <- lm(seconds~poly(slots, 3, raw=TRUE), data=slots_processed_initial)
summary(initial_fit)
# y = -3.910e-15 x^3 + 4.547e-08 x^2 + 2.173e-02 x + 6.760e+01
lines(predict(initial_fit, data.frame(slots = slots_processed_initial$slots)), slots_processed_initial$slots, col='red')

message("Polynomial model for seconds_from_start=f(slots_synced), after the first ", curve_split_after_seconds, "s")
slots_processed_final <- data.frame(slots = tail(slots_processed_all$slots, -curve_split), seconds = tail(slots_processed_all$seconds, -curve_split))
str(slots_processed_final)
final_fit <- lm(seconds~poly(slots, 3, raw=TRUE), data=slots_processed_final)
summary(final_fit)
# y = 1.436e-15 x^3 + 2.510e-08 x^2 + 1.743e-02 x + 1.314e+04
lines(predict(final_fit, data.frame(slots = slots_processed_final$slots)), slots_processed_final$slots, col='blue')
```

Yeah, I ended up with two different curves, for a better fit. The resulting plot:

![slots](https://user-images.githubusercontent.com/495550/146815539-bb24c2c7-7d07-47fa-a43a-cf799aa4b88d.png)

Implementing those fitted curves in Nim was trivial.

The beauty of this scheme is that it's a net improvement for any network, not just mainnet, and it will continue to be useful - without more curve fitting - until the merge makes blocks significantly bigger.