### PR TITLE
Handle access to historical data for which there is no state 

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -134,7 +134,9 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
             epochRef.current_justified_checkpoint,
             epochRef.finalized_checkpoint)
         else:
-          epochRef = dag.getEpochRef(blckRef, blckRef.slot.epoch)
+          epochRef = dag.getEpochRef(blckRef, blckRef.slot.epoch, false).expect(
+            "Getting an EpochRef should always work for non-finalized blocks")
+
           withBlck(dag.get(blckRef).data):
             forkChoice.process_block(
               dag, epochRef, blckRef, blck.message, blckRef.slot.toBeaconTime)

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -46,6 +46,7 @@ type
     fcInconsistentTick
     fcUnknownParent
     fcPruningFromOutdatedFinalizedRoot
+    fcInvalidEpochRef
 
   Index* = int
   Delta* = int64
@@ -56,7 +57,7 @@ type
     of fcFinalizedNodeUnknown,
        fcJustifiedNodeUnknown:
          blockRoot*: Eth2Digest
-    of fcInconsistentTick:
+    of fcInconsistentTick, fcInvalidEpochRef:
       discard
     of fcInvalidNodeIndex,
        fcInvalidJustifiedIndex,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -258,10 +258,16 @@ proc checkForPotentialDoppelganger(
   if attestation.data.slot.epoch <
       self.doppelgangerDetection.broadcastStartEpoch:
     let tgtBlck = self.dag.getRef(attestation.data.target.root)
+
     doAssert not tgtBlck.isNil  # because attestation is valid above
 
+    # We expect the EpochRef not to have been pruned between validating the
+    # attestation and checking for doppelgangers - this may need to be revisited
+    # when online pruning of states is implemented
     let epochRef = self.dag.getEpochRef(
-      tgtBlck, attestation.data.target.epoch)
+      tgtBlck, attestation.data.target.epoch, true).expect(
+        "Target block EpochRef must be valid")
+
     for validatorIndex in attesterIndices:
       let validatorPubkey = epochRef.validatorKey(validatorIndex).get().toPubKey()
       if  self.doppelgangerDetectionEnabled and

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -774,9 +774,11 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     # We "know" the actions for the current and the next epoch
     if node.isSynced(head):
       node.actionTracker.updateActions(
-        node.dag.getEpochRef(head, slot.epoch))
+        node.dag.getEpochRef(head, slot.epoch, false).expect(
+          "Getting head EpochRef should never fail"))
       node.actionTracker.updateActions(
-        node.dag.getEpochRef(head, slot.epoch + 1))
+        node.dag.getEpochRef(head, slot.epoch + 1, false).expect(
+          "Getting head EpochRef should never fail"))
 
   if node.gossipState.card > 0 and targetGossipState.card == 0:
     debug "Disabling topic subscriptions",
@@ -855,8 +857,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     #      pessimistically with respect to the shuffling - this needs fixing
     #      at EpochRef level by not mixing balances and shufflings in the same
     #      place
-    let epochRef = node.dag.getEpochRef(node.dag.head, slot.epoch + 1)
-    node.actionTracker.updateActions(epochRef)
+    node.actionTracker.updateActions(node.dag.getEpochRef(
+      node.dag.head, slot.epoch + 1, false).expect(
+        "Getting head EpochRef should never fail"))
 
   let
     nextAttestationSlot = node.actionTracker.getNextAttestationSlot(slot)

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -185,3 +185,5 @@ const
     "Bad request format"
   InvalidAuthorization* =
     "Invalid Authorization Header"
+  PrunedStateError* =
+    "Trying to access a pruned historical state"

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -209,9 +209,11 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
         res.get()
     let proposalState = assignClone(node.dag.headState)
-    node.dag.withState(proposalState[], head.atSlot(wallSlot)):
+    node.dag.withUpdatedState(proposalState[], head.atSlot(wallSlot)) do:
       return RestApiResponse.jsonResponse(
         node.getBlockProposalEth1Data(stateData.data))
+    do:
+      return RestApiResponse.jsonError(Http400, PrunedStateError)
 
   router.api(MethodGet, "/api/nimbus/v1/debug/chronos/futures") do (
     ) -> RestApiResponse:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -72,7 +72,12 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     let duties =
       block:
         var res: seq[RestAttesterDuty]
-        let epochRef = node.dag.getEpochRef(qhead, qepoch)
+        let epochRef = block:
+          let tmp = node.dag.getEpochRef(qhead, qepoch, true)
+          if isErr(tmp):
+            return RestApiResponse.jsonError(Http400, PrunedStateError)
+          tmp.get()
+
         let committees_per_slot = get_committee_count_per_slot(epochRef)
         for i in 0 ..< SLOTS_PER_EPOCH:
           let slot = compute_start_slot_at_epoch(qepoch) + i
@@ -125,7 +130,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     let duties =
       block:
         var res: seq[RestProposerDuty]
-        let epochRef = node.dag.getEpochRef(qhead, qepoch)
+        let epochRef = block:
+          let tmp = node.dag.getEpochRef(qhead, qepoch, true)
+          if isErr(tmp):
+            return RestApiResponse.jsonError(Http400, PrunedStateError)
+          tmp.get()
         for i, bp in epochRef.beacon_proposers:
           if i == 0 and qepoch == 0:
             # Fix for https://github.com/status-im/nimbus-eth2/issues/2488
@@ -259,7 +268,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       # in order to compute the sync committee for the epoch. See the following
       # discussion for more details:
       # https://github.com/status-im/nimbus-eth2/pull/3133#pullrequestreview-817184693
-      node.withStateForBlockSlot(node.dag.getBlockBySlot(earliestSlotInQSyncPeriod)):
+      let bs = node.dag.getBlockBySlot(earliestSlotInQSyncPeriod)
+      if bs.blck.isNil:
+        return RestApiResponse.jsonError(Http404, StateNotFoundError)
+
+      node.withStateForBlockSlot(bs):
         let res = withState(stateData().data):
           when stateFork >= BeaconStateFork.Altair:
             produceResponse(indexList,
@@ -413,7 +426,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             if res.isErr():
               return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
             res.get()
-        let epochRef = node.dag.getEpochRef(qhead, qslot.epoch)
+        let epochRef = block:
+          let tmp = node.dag.getEpochRef(qhead, qslot.epoch, true)
+          if isErr(tmp):
+            return RestApiResponse.jsonError(Http400, PrunedStateError)
+          tmp.get()
         makeAttestationData(epochRef, qhead.atSlot(qslot), qindex)
     return RestApiResponse.jsonResponse(adata)
 
@@ -512,7 +529,12 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     template getAndCacheEpochRef(epochRefVar: var Option[EpochRef],
                                  epoch: Epoch): EpochRef =
       if epochRefVar.isNone:
-        epochRefVar = some node.dag.getEpochRef(head, epoch)
+        epochRefVar = block:
+          let epochRef = node.dag.getEpochRef(head, epoch, true)
+          if isErr(epochRef):
+            return RestApiResponse.jsonError(Http400, PrunedStateError)
+          some epochRef.get()
+
       epochRefVar.get
 
     for request in requests:

--- a/beacon_chain/rpc/rpc_nimbus_api.nim
+++ b/beacon_chain/rpc/rpc_nimbus_api.nim
@@ -108,8 +108,10 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       head = node.doChecksAndGetCurrentHead(wallSlot)
 
     let proposalState = assignClone(node.dag.headState)
-    node.dag.withState(proposalState[], head.atSlot(wallSlot)):
+    node.dag.withUpdatedState(proposalState[], head.atSlot(wallSlot)):
       return node.getBlockProposalEth1Data(stateData.data)
+    do:
+      raise (ref CatchableError)(msg: "Trying to access pruned state")
 
   rpcServer.rpc("debug_getChronosFutures") do () -> seq[FutureInfo]:
     when defined(chronosFutureTracking):

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -35,8 +35,10 @@ template withStateForStateId*(stateId: string, body: untyped): untyped =
       body
   else:
     let rpcState = assignClone(node.dag.headState)
-    node.dag.withState(rpcState[], bs):
+    node.dag.withUpdatedState(rpcState[], bs) do:
       body
+    do:
+      raise (ref CatchableError)(msg: "Trying to access pruned state")
 
 proc parseRoot*(str: string): Eth2Digest {.raises: [Defect, ValueError].} =
   Eth2Digest(data: hexToByteArray[32](str))

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -238,7 +238,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       (ref merge.HashedBeaconState)())
 
   withTimer(timers[tLoadState]):
-    dag.updateStateData(
+    doAssert dag.updateStateData(
       stateData[], blockRefs[^1].atSlot(blockRefs[^1].slot - 1), false, cache)
 
   template processBlocks(blocks: auto) =
@@ -486,10 +486,11 @@ proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
     return
 
   let tmpState = assignClone(dag.headState)
-  dag.withState(tmpState[], blckRef.atSlot(Slot(conf.slot))):
+  dag.withUpdatedState(tmpState[], blckRef.atSlot(Slot(conf.slot))) do:
     echo "Writing state..."
     withState(stateData.data):
       dump("./", state)
+  do: raiseAssert "withUpdatedState failed"
 
 func atCanonicalSlot(blck: BlockRef, slot: Slot): BlockSlot =
   if slot == 0:
@@ -527,8 +528,9 @@ proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
     var e2s = E2Store.open(".", name, firstSlot).get()
     defer: e2s.close()
 
-    dag.withState(tmpState[], canonical):
+    dag.withUpdatedState(tmpState[], canonical) do:
       e2s.appendRecord(stateData.data.phase0Data.data).get()
+    do: raiseAssert "withUpdatedState failed"
 
     var
       ancestors: seq[BlockRef]
@@ -589,7 +591,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
     blockRefs[^1].slot.epoch, " - ", blockRefs[0].slot.epoch
 
   let state = newClone(dag.headState)
-  dag.updateStateData(
+  doAssert dag.updateStateData(
     state[], blockRefs[^1].atSlot(blockRefs[^1].slot - 1), false, cache)
 
   proc processEpoch() =
@@ -831,7 +833,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
     start.epoch, " - ", ends.epoch
 
   let state = newClone(dag.headState)
-  dag.updateStateData(
+  doAssert dag.updateStateData(
     state[], blockRefs[^1].atSlot(if start > 0: start - 1 else: 0.Slot),
     false, cache)
 

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -166,7 +166,7 @@ proc stepOnBlock(
        signedBlock: ForkySignedBeaconBlock,
        time: BeaconTime): Result[BlockRef, BlockError] =
   # 1. Move state to proper slot.
-  dag.updateStateData(
+  doAssert dag.updateStateData(
     state,
     dag.head.atSlot(time.slotOrZero),
     save = false,
@@ -203,7 +203,9 @@ proc stepOnAttestation(
        att: Attestation,
        time: BeaconTime): FcResult[void] =
   let epochRef =
-    dag.getEpochRef(dag.head, time.slotOrZero.compute_epoch_at_slot())
+    dag.getEpochRef(
+      dag.head, time.slotOrZero().compute_epoch_at_slot(),
+      false).expect("no pruning in test")
   let attesters = epochRef.get_attesting_indices(att.data, att.aggregation_bits)
 
   let status = fkChoice[].on_attestation(


### PR DESCRIPTION
With checkpoint sync in particular, and state pruning in the future,
loading states or state-dependent data may fail. This PR adjusts the
code to allow this to be handled gracefully.

In particular, the new availability assumption is that states are always
available for the finalized checkpoint and newer, but may fail for
anything older.

The `tail` remains the point where state loading de-facto fails, meaning
that between the tail and the finalized checkpoint, we can still get
historical data (but code should be prepared to handle this as an
error).

However, to harden the code against long replays, several operations
which are assumed to work only with non-final data (such as gossip
verification and validator duties) now limit their search horizon to
post-finalized data.

* harden several state-dependent operations by logging an error instead
of introducing a panic when state loading fails
* `withState` -> `withUpdatedState` to differentiate from the other
`withState`
* `updateStateData` can now fail if no state is found in database - it
is also hardened against excessively long replays
* `getEpochRef` can now fail when replay fails
* reject blocks with invalid target root - they would be ignored
previously
* ~~fix recursion bug in `isProposed`~~ fix included in https://github.com/status-im/nimbus-eth2/pull/3225