### PR TITLE
Fix missing checkpoint states`

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -222,6 +222,12 @@ proc addHeadBlock*(
   # blocks we add to the database are clean for the given state
   let startTick = Moment.now()
 
+  # The clearance state works as the canonical
+  # "let's make things permanent" point and saves things to the database -
+  # storing things is slow, so we don't want to do so before there's a
+  # reasonable chance that the information will become more permanently useful -
+  # by the time a new block reaches this point, the parent block will already
+  # have "established" itself in the network to some degree at least.
   var cache = StateCache()
   updateStateData(
     dag, dag.clearanceState, parent.atSlot(signedBlock.message.slot), true, cache)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -201,7 +201,7 @@ func isProposed*(bid: BlockId, slot: Slot): bool =
 
 func isProposed*(blck: BlockRef, slot: Slot): bool =
   ## Return true if `blck` was proposed in the given slot
-  not isNil(blck) and blck.isProposed(slot)
+  not isNil(blck) and blck.bid.isProposed(slot)
 
 func isProposed*(bs: BlockSlot): bool =
   ## Return true if `bs` represents the proposed block (as opposed to an empty

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -87,6 +87,9 @@ suite "BlockSlot and helpers":
       s24.parent == BlockSlot(blck: s2, slot: Slot(3))
       s24.parent.parent == s22
 
+      s22.isProposed()
+      not s24.isProposed()
+
 suite "BlockId and helpers":
   test "atSlot sanity":
     let


### PR DESCRIPTION
With the right sequence of events (for example a REST request or a
validation followed by a reorg), it can happen that the first traversal across a state
checkpoint boundary is done without storing that state on disk - this
causes problens when replaying states, because now states may be missing
from the database.

Here, we simply avoid using the caches when advancing a state that will
go into the database, ensuring that the information lost during caching
always is permanently stored.

* fix recursion bug in `isProposed`