### PR TITLE
support GOSSIP_MAX_SIZE_MERGE blocks; prevent fork choice stutter via aggregate attestations

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -278,7 +278,7 @@ proc attestationValidator*(
     await self.attestationPool.validateAttestation(
       self.batchCrypto, attestation, wallTime, subnet_id, checkSignature)
   return if v.isOk():
-    # Due to async validation the wallSlot here might have changed
+    # Due to async validation the wallTime here might have changed
     wallTime = self.getCurrentBeaconTime()
 
     let (attester_index, sig) = v.get()
@@ -304,8 +304,8 @@ proc attestationValidator*(
 proc aggregateValidator*(
     self: ref Eth2Processor, src: MsgSource,
     signedAggregateAndProof: SignedAggregateAndProof): Future[ValidationRes] {.async.} =
-  let wallTime = self.getCurrentBeaconTime()
-  var (afterGenesis, wallSlot) = wallTime.toSlot()
+  var wallTime = self.getCurrentBeaconTime()
+  let (afterGenesis, wallSlot) = wallTime.toSlot()
 
   logScope:
     aggregate = shortLog(signedAggregateAndProof.message.aggregate)
@@ -328,8 +328,8 @@ proc aggregateValidator*(
       self.batchCrypto, signedAggregateAndProof, wallTime)
 
   return if v.isOk():
-    # Due to async validation the wallSlot here might have changed
-    wallSlot = self.getCurrentBeaconTime().slotOrZero()
+    # Due to async validation the wallTime here might have changed
+    wallTime = self.getCurrentBeaconTime()
 
     let (attesting_indices, sig) = v.get()
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1844,7 +1844,7 @@ template gossipMaxSize(T: untyped): uint32 =
          T is altair.SignedBeaconBlock:
       GOSSIP_MAX_SIZE
     else:
-      static: raiseAssert false
+      static: raiseAssert "unknown type"
   static: doAssert maxSize <= maxGossipMaxSize()
   maxSize.uint32
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1844,7 +1844,7 @@ template gossipMaxSize(T: untyped): uint32 =
          T is altair.SignedBeaconBlock:
       GOSSIP_MAX_SIZE
     else:
-      raiseAssert false
+      static: raiseAssert false
   static: doAssert maxSize <= maxGossipMaxSize()
   maxSize.uint32
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1005,18 +1005,16 @@ proc installMessageValidators(node: BeaconNode) =
 
   node.network.addValidator(
     getBeaconBlocksTopic(node.dag.forkDigests.phase0),
-    BeaconBlockFork.Phase0,
     proc (signedBlock: phase0.SignedBeaconBlock): ValidationResult =
       toValidationResult(node.processor[].blockValidator(
         MsgSource.gossip, signedBlock)))
 
-  template installPhase0Validators(msgFork, digest: auto) =
+  template installPhase0Validators(digest: auto) =
     for it in 0'u64 ..< ATTESTATION_SUBNET_COUNT.uint64:
       closureScope:
         let subnet_id = SubnetId(it)
         node.network.addAsyncValidator(
           getAttestationTopic(digest, subnet_id),
-          msgFork,
           # This proc needs to be within closureScope; don't lift out of loop.
           proc(attestation: Attestation): Future[ValidationResult] {.async.} =
             return toValidationResult(
@@ -1025,7 +1023,6 @@ proc installMessageValidators(node: BeaconNode) =
 
     node.network.addAsyncValidator(
       getAggregateAndProofsTopic(digest),
-      msgFork,
       proc(signedAggregateAndProof: SignedAggregateAndProof):
           Future[ValidationResult] {.async.} =
         return toValidationResult(
@@ -1034,7 +1031,6 @@ proc installMessageValidators(node: BeaconNode) =
 
     node.network.addValidator(
       getAttesterSlashingsTopic(digest),
-      msgFork,
       proc (attesterSlashing: AttesterSlashing): ValidationResult =
         toValidationResult(
           node.processor[].attesterSlashingValidator(
@@ -1042,7 +1038,6 @@ proc installMessageValidators(node: BeaconNode) =
 
     node.network.addValidator(
       getProposerSlashingsTopic(digest),
-      msgFork,
       proc (proposerSlashing: ProposerSlashing): ValidationResult =
         toValidationResult(
           node.processor[].proposerSlashingValidator(
@@ -1050,40 +1045,36 @@ proc installMessageValidators(node: BeaconNode) =
 
     node.network.addValidator(
       getVoluntaryExitsTopic(digest),
-      msgFork,
       proc (signedVoluntaryExit: SignedVoluntaryExit): ValidationResult =
         toValidationResult(
           node.processor[].voluntaryExitValidator(
             MsgSource.gossip, signedVoluntaryExit)))
 
-  installPhase0Validators(BeaconBlockFork.Phase0, node.dag.forkDigests.phase0)
+  installPhase0Validators(node.dag.forkDigests.phase0)
 
   # Validators introduced in phase0 are also used in altair and merge, but with
   # different fork digest
-  installPhase0Validators(BeaconBlockFork.Altair, node.dag.forkDigests.altair)
-  installPhase0Validators(BeaconBlockFork.Merge, node.dag.forkDigests.merge)
+  installPhase0Validators(node.dag.forkDigests.altair)
+  installPhase0Validators(node.dag.forkDigests.merge)
 
   node.network.addValidator(
     getBeaconBlocksTopic(node.dag.forkDigests.altair),
-    BeaconBlockFork.Altair,
     proc (signedBlock: altair.SignedBeaconBlock): ValidationResult =
       toValidationResult(node.processor[].blockValidator(
         MsgSource.gossip, signedBlock)))
 
   node.network.addValidator(
     getBeaconBlocksTopic(node.dag.forkDigests.merge),
-    BeaconBlockFork.Merge,
     proc (signedBlock: merge.SignedBeaconBlock): ValidationResult =
       toValidationResult(node.processor[].blockValidator(
         MsgSource.gossip, signedBlock)))
 
-  template installSyncCommitteeeValidators(msgFork, digest: auto) =
+  template installSyncCommitteeeValidators(digest: auto) =
     for committeeIdx in allSyncSubcommittees():
       closureScope:
         let idx = committeeIdx
         node.network.addAsyncValidator(
           getSyncCommitteeTopic(digest, idx),
-          msgFork,
           # This proc needs to be within closureScope; don't lift out of loop.
           proc(msg: SyncCommitteeMessage): Future[ValidationResult] {.async.} =
             return toValidationResult(
@@ -1092,15 +1083,12 @@ proc installMessageValidators(node: BeaconNode) =
 
     node.network.addAsyncValidator(
       getSyncCommitteeContributionAndProofTopic(digest),
-      msgFork,
       proc(msg: SignedContributionAndProof): Future[ValidationResult] {.async.} =
         return toValidationResult(
           await node.processor.contributionValidator(MsgSource.gossip, msg)))
 
-  installSyncCommitteeeValidators(
-    BeaconBlockFork.Altair, node.dag.forkDigests.altair)
-  installSyncCommitteeeValidators(
-    BeaconBlockFork.Merge, node.dag.forkDigests.merge)
+  installSyncCommitteeeValidators(node.dag.forkDigests.altair)
+  installSyncCommitteeeValidators(node.dag.forkDigests.merge)
 
 proc stop(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping


### PR DESCRIPTION
- the merge fork supports larger (10MB) blocks to accommodate transactions. It's not ideal that the message ID function doesn't tightly bound the message size, but that's baked into how libp2p works, conceptually and in terms of its current interfaces. It doesn't have any internal sense of the idea of an Ethereum fork, nor should it. It treats the topic, even though there is a syntax that it could conceivably be taught how to decode to determine the fork and therefore the max gossip size, as a black box. Meanwhile, this would somewhat pointlessly complicate its inner message-processing loops. While any of this could be changed, the design costs and layer mixing/leaky abstractions and excessive specialization for libp2p for Ethereum peculiarities resulting probably wouldn't be worthwhile; and

- the aggregated attestation validator wasn't properly using the post-async-timeskip walltime, so could set fork choice time backwards