### PR TITLE
Assorted logging improvements

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1054,7 +1054,7 @@ proc syncBlockRange(m: Eth1Monitor,
       else:
         discard
 
-      notice "Eth1 sync progress",
+      info "Eth1 sync progress",
         blockNumber = lastBlock.number,
         depositsProcessed = lastBlock.voteData.deposit_count
 

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -186,6 +186,16 @@ func getNextValidatorAction*(
 
   FAR_FUTURE_SLOT
 
+func getNextAttestationSlot*(tracker: ActionTracker, slot: Slot): Slot =
+  getNextValidatorAction(
+    tracker.attestingSlots,
+    tracker.lastCalculatedEpoch, slot)
+
+func getNextProposalSlot*(tracker: ActionTracker, slot: Slot): Slot =
+  getNextValidatorAction(
+    tracker.proposingSlots,
+    tracker.lastCalculatedEpoch, slot)
+
 proc updateActions*(tracker: var ActionTracker, epochRef: EpochRef) =
   # Updates the schedule for upcoming attestation and proposal work
   let


### PR DESCRIPTION
* log doppelganger detection when it activates and when it causes missed
duties
* less prominent eth1 sync progress
* log in-progress sync at notice only when actually missing duties
* better detail in replay log
* don't log finalization checkpoints - this is quite verbose when
syncing and already included in "Slot start"