### PR TITLE
add Bellatrix fork and transition tests; "Ethereum Foundation" -> EF

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -134,20 +134,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Tail block only in common                                                                  OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Eth1 monitor
-```diff
-+ Rewrite HTTPS Infura URLs                                                                  OK
-+ Roundtrip engine RPC and consensus ExecutionPayload representations                        OK
-```
-OK: 2/2 Fail: 0/2 Skip: 0/2
-## Eth2 specific discovery tests
-```diff
-+ Invalid attnets field                                                                      OK
-+ Subnet query                                                                               OK
-+ Subnet query after ENR update                                                              OK
-```
-OK: 3/3 Fail: 0/3 Skip: 0/3
-## Ethereum Foundation - SSZ generic types
+## EF - SSZ generic types
 ```diff
   Testing basic_vector inputs - invalid                                                      Skip
 + Testing basic_vector inputs - valid                                                        OK
@@ -163,6 +150,19 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Testing uints        inputs - valid                                                        OK
 ```
 OK: 10/12 Fail: 0/12 Skip: 2/12
+## Eth1 monitor
+```diff
++ Rewrite HTTPS Infura URLs                                                                  OK
++ Roundtrip engine RPC and consensus ExecutionPayload representations                        OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
+## Eth2 specific discovery tests
+```diff
++ Invalid attnets field                                                                      OK
++ Subnet query                                                                               OK
++ Subnet query after ENR update                                                              OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Exit pool testing suite
 ```diff
 + addExitMessage/getAttesterSlashingMessage                                                  OK
@@ -442,4 +442,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 238/240 Fail: 0/239 Skip: 2/239
+OK: 238/240 Fail: 0/240 Skip: 2/240

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -2,324 +2,344 @@ ConsensusSpecPreset-mainnet
 ===
 ## 
 ```diff
-+ Ethereum Foundation - Altair - Rewards - all_balances_too_low_for_reward [Preset: mainnet] OK
-+ Ethereum Foundation - Altair - Rewards - empty [Preset: mainnet]                           OK
-+ Ethereum Foundation - Altair - Rewards - empty_leak [Preset: mainnet]                      OK
-+ Ethereum Foundation - Altair - Rewards - full_all_correct [Preset: mainnet]                OK
-+ Ethereum Foundation - Altair - Rewards - full_but_partial_participation [Preset: mainnet]  OK
-+ Ethereum Foundation - Altair - Rewards - full_but_partial_participation_leak [Preset: main OK
-+ Ethereum Foundation - Altair - Rewards - full_leak [Preset: mainnet]                       OK
-+ Ethereum Foundation - Altair - Rewards - full_random_0 [Preset: mainnet]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_1 [Preset: mainnet]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_2 [Preset: mainnet]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_3 [Preset: mainnet]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_4 [Preset: mainnet]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_leak [Preset: mainnet]                OK
-+ Ethereum Foundation - Altair - Rewards - full_random_low_balances_0 [Preset: mainnet]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_low_balances_1 [Preset: mainnet]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_misc_balances [Preset: mainnet]       OK
-+ Ethereum Foundation - Altair - Rewards - full_random_seven_epoch_leak [Preset: mainnet]    OK
-+ Ethereum Foundation - Altair - Rewards - full_random_ten_epoch_leak [Preset: mainnet]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_without_leak_0 [Preset: mainnet]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_without_leak_and_current_exit_0 [Pres OK
-+ Ethereum Foundation - Altair - Rewards - half_full [Preset: mainnet]                       OK
-+ Ethereum Foundation - Altair - Rewards - half_full_leak [Preset: mainnet]                  OK
-+ Ethereum Foundation - Altair - Rewards - quarter_full [Preset: mainnet]                    OK
-+ Ethereum Foundation - Altair - Rewards - quarter_full_leak [Preset: mainnet]               OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_attested [P OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_attested_le OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_did_not_att OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_did_not_att OK
-+ Ethereum Foundation - Altair - Rewards - with_exited_validators [Preset: mainnet]          OK
-+ Ethereum Foundation - Altair - Rewards - with_exited_validators_leak [Preset: mainnet]     OK
-+ Ethereum Foundation - Altair - Rewards - with_not_yet_activated_validators [Preset: mainne OK
-+ Ethereum Foundation - Altair - Rewards - with_not_yet_activated_validators_leak [Preset: m OK
-+ Ethereum Foundation - Altair - Rewards - with_slashed_validators [Preset: mainnet]         OK
-+ Ethereum Foundation - Altair - Rewards - with_slashed_validators_leak [Preset: mainnet]    OK
-+ Ethereum Foundation - Altair - Transition - normal_transition [Preset: mainnet]            OK
-+ Ethereum Foundation - Altair - Transition - transition_missing_first_post_block [Preset: m OK
-+ Ethereum Foundation - Altair - Transition - transition_missing_last_pre_fork_block [Preset OK
-+ Ethereum Foundation - Altair - Transition - transition_only_blocks_post_fork [Preset: main OK
-+ Ethereum Foundation - Altair - Transition - transition_with_activation_at_fork_epoch [Pres OK
-+ Ethereum Foundation - Altair - Transition - transition_with_attester_slashing_right_after_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_attester_slashing_right_before OK
-+ Ethereum Foundation - Altair - Transition - transition_with_deposit_right_after_fork [Pres OK
-+ Ethereum Foundation - Altair - Transition - transition_with_deposit_right_before_fork [Pre OK
-+ Ethereum Foundation - Altair - Transition - transition_with_finality [Preset: mainnet]     OK
-+ Ethereum Foundation - Altair - Transition - transition_with_leaking_at_fork [Preset: mainn OK
-+ Ethereum Foundation - Altair - Transition - transition_with_leaking_pre_fork [Preset: main OK
-+ Ethereum Foundation - Altair - Transition - transition_with_no_attestations_until_after_fo OK
-+ Ethereum Foundation - Altair - Transition - transition_with_non_empty_activation_queue [Pr OK
-+ Ethereum Foundation - Altair - Transition - transition_with_one_fourth_exiting_validators_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_proposer_slashing_right_after_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_proposer_slashing_right_before OK
-+ Ethereum Foundation - Altair - Transition - transition_with_random_half_participation [Pre OK
-+ Ethereum Foundation - Altair - Transition - transition_with_random_three_quarters_particip OK
-+ Ethereum Foundation - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: mainn OK
-+ Ethereum Foundation - Bellatrix - Rewards - empty [Preset: mainnet]                        OK
-+ Ethereum Foundation - Bellatrix - Rewards - empty_leak [Preset: mainnet]                   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_all_correct [Preset: mainnet]             OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_but_partial_participation [Preset: mainne OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_but_partial_participation_leak [Preset: m OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_leak [Preset: mainnet]                    OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_0 [Preset: mainnet]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_1 [Preset: mainnet]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_2 [Preset: mainnet]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_3 [Preset: mainnet]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_4 [Preset: mainnet]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_leak [Preset: mainnet]             OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_low_balances_0 [Preset: mainnet]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_low_balances_1 [Preset: mainnet]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_misc_balances [Preset: mainnet]    OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_seven_epoch_leak [Preset: mainnet] OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_ten_epoch_leak [Preset: mainnet]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_without_leak_0 [Preset: mainnet]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_without_leak_and_current_exit_0 [P OK
-+ Ethereum Foundation - Bellatrix - Rewards - half_full [Preset: mainnet]                    OK
-+ Ethereum Foundation - Bellatrix - Rewards - half_full_leak [Preset: mainnet]               OK
-+ Ethereum Foundation - Bellatrix - Rewards - quarter_full [Preset: mainnet]                 OK
-+ Ethereum Foundation - Bellatrix - Rewards - quarter_full_leak [Preset: mainnet]            OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_attested OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_attested OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_ OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_ OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_exited_validators [Preset: mainnet]       OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_exited_validators_leak [Preset: mainnet]  OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_not_yet_activated_validators [Preset: mai OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_not_yet_activated_validators_leak [Preset OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_slashed_validators [Preset: mainnet]      OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_slashed_validators_leak [Preset: mainnet] OK
-+ Ethereum Foundation - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: mainnet OK
-+ Ethereum Foundation - Phase 0 - Rewards - duplicate_attestations_at_later_slots [Preset: m OK
-+ Ethereum Foundation - Phase 0 - Rewards - empty [Preset: mainnet]                          OK
-+ Ethereum Foundation - Phase 0 - Rewards - empty_leak [Preset: mainnet]                     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_all_correct [Preset: mainnet]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_but_partial_participation [Preset: mainnet] OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_but_partial_participation_leak [Preset: mai OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_correct_target_incorrect_head [Preset: main OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_correct_target_incorrect_head_leak [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_delay_max_slots [Preset: mainnet]           OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_delay_one_slot [Preset: mainnet]            OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_correct_target_incorrect_head [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_correct_target_incorrect_head_leak [Pr OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_correct_head [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_correct_head_leak [Pr OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head [Prese OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head_leak [ OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_leak [Preset: mainnet]                      OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_mixed_delay [Preset: mainnet]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_0 [Preset: mainnet]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_1 [Preset: mainnet]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_2 [Preset: mainnet]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_3 [Preset: mainnet]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_4 [Preset: mainnet]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_leak [Preset: mainnet]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_low_balances_0 [Preset: mainnet]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_low_balances_1 [Preset: mainnet]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_misc_balances [Preset: mainnet]      OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_seven_epoch_leak [Preset: mainnet]   OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_ten_epoch_leak [Preset: mainnet]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_without_leak_0 [Preset: mainnet]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_without_leak_and_current_exit_0 [Pre OK
-+ Ethereum Foundation - Phase 0 - Rewards - half_full [Preset: mainnet]                      OK
-+ Ethereum Foundation - Phase 0 - Rewards - half_full_leak [Preset: mainnet]                 OK
-+ Ethereum Foundation - Phase 0 - Rewards - one_attestation_one_correct [Preset: mainnet]    OK
-+ Ethereum Foundation - Phase 0 - Rewards - one_attestation_one_correct_leak [Preset: mainne OK
-+ Ethereum Foundation - Phase 0 - Rewards - proposer_not_in_attestations [Preset: mainnet]   OK
-+ Ethereum Foundation - Phase 0 - Rewards - quarter_full [Preset: mainnet]                   OK
-+ Ethereum Foundation - Phase 0 - Rewards - quarter_full_leak [Preset: mainnet]              OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_attested [ OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_attested_l OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_at OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_at OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_exited_validators [Preset: mainnet]         OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_exited_validators_leak [Preset: mainnet]    OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_not_yet_activated_validators [Preset: mainn OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset:  OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_slashed_validators [Preset: mainnet]        OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_slashed_validators_leak [Preset: mainnet]   OK
++ EF - Altair - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                  OK
++ EF - Altair - Rewards - empty [Preset: mainnet]                                            OK
++ EF - Altair - Rewards - empty_leak [Preset: mainnet]                                       OK
++ EF - Altair - Rewards - full_all_correct [Preset: mainnet]                                 OK
++ EF - Altair - Rewards - full_but_partial_participation [Preset: mainnet]                   OK
++ EF - Altair - Rewards - full_but_partial_participation_leak [Preset: mainnet]              OK
++ EF - Altair - Rewards - full_leak [Preset: mainnet]                                        OK
++ EF - Altair - Rewards - full_random_0 [Preset: mainnet]                                    OK
++ EF - Altair - Rewards - full_random_1 [Preset: mainnet]                                    OK
++ EF - Altair - Rewards - full_random_2 [Preset: mainnet]                                    OK
++ EF - Altair - Rewards - full_random_3 [Preset: mainnet]                                    OK
++ EF - Altair - Rewards - full_random_4 [Preset: mainnet]                                    OK
++ EF - Altair - Rewards - full_random_leak [Preset: mainnet]                                 OK
++ EF - Altair - Rewards - full_random_low_balances_0 [Preset: mainnet]                       OK
++ EF - Altair - Rewards - full_random_low_balances_1 [Preset: mainnet]                       OK
++ EF - Altair - Rewards - full_random_misc_balances [Preset: mainnet]                        OK
++ EF - Altair - Rewards - full_random_seven_epoch_leak [Preset: mainnet]                     OK
++ EF - Altair - Rewards - full_random_ten_epoch_leak [Preset: mainnet]                       OK
++ EF - Altair - Rewards - full_random_without_leak_0 [Preset: mainnet]                       OK
++ EF - Altair - Rewards - full_random_without_leak_and_current_exit_0 [Preset: mainnet]      OK
++ EF - Altair - Rewards - half_full [Preset: mainnet]                                        OK
++ EF - Altair - Rewards - half_full_leak [Preset: mainnet]                                   OK
++ EF - Altair - Rewards - quarter_full [Preset: mainnet]                                     OK
++ EF - Altair - Rewards - quarter_full_leak [Preset: mainnet]                                OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_attested [Preset: mainnet]   OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: mainn OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: main OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Preset: OK
++ EF - Altair - Rewards - with_exited_validators [Preset: mainnet]                           OK
++ EF - Altair - Rewards - with_exited_validators_leak [Preset: mainnet]                      OK
++ EF - Altair - Rewards - with_not_yet_activated_validators [Preset: mainnet]                OK
++ EF - Altair - Rewards - with_not_yet_activated_validators_leak [Preset: mainnet]           OK
++ EF - Altair - Rewards - with_slashed_validators [Preset: mainnet]                          OK
++ EF - Altair - Rewards - with_slashed_validators_leak [Preset: mainnet]                     OK
++ EF - Altair - Transition - normal_transition [Preset: mainnet]                             OK
++ EF - Altair - Transition - transition_missing_first_post_block [Preset: mainnet]           OK
++ EF - Altair - Transition - transition_missing_last_pre_fork_block [Preset: mainnet]        OK
++ EF - Altair - Transition - transition_only_blocks_post_fork [Preset: mainnet]              OK
++ EF - Altair - Transition - transition_with_activation_at_fork_epoch [Preset: mainnet]      OK
++ EF - Altair - Transition - transition_with_attester_slashing_right_after_fork [Preset: mai OK
++ EF - Altair - Transition - transition_with_attester_slashing_right_before_fork [Preset: ma OK
++ EF - Altair - Transition - transition_with_deposit_right_after_fork [Preset: mainnet]      OK
++ EF - Altair - Transition - transition_with_deposit_right_before_fork [Preset: mainnet]     OK
++ EF - Altair - Transition - transition_with_finality [Preset: mainnet]                      OK
++ EF - Altair - Transition - transition_with_leaking_at_fork [Preset: mainnet]               OK
++ EF - Altair - Transition - transition_with_leaking_pre_fork [Preset: mainnet]              OK
++ EF - Altair - Transition - transition_with_no_attestations_until_after_fork [Preset: mainn OK
++ EF - Altair - Transition - transition_with_non_empty_activation_queue [Preset: mainnet]    OK
++ EF - Altair - Transition - transition_with_one_fourth_exiting_validators_exit_at_fork [Pre OK
++ EF - Altair - Transition - transition_with_proposer_slashing_right_after_fork [Preset: mai OK
++ EF - Altair - Transition - transition_with_proposer_slashing_right_before_fork [Preset: ma OK
++ EF - Altair - Transition - transition_with_random_half_participation [Preset: mainnet]     OK
++ EF - Altair - Transition - transition_with_random_three_quarters_participation [Preset: ma OK
++ EF - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: mainnet]               OK
++ EF - Bellatrix - Rewards - empty [Preset: mainnet]                                         OK
++ EF - Bellatrix - Rewards - empty_leak [Preset: mainnet]                                    OK
++ EF - Bellatrix - Rewards - full_all_correct [Preset: mainnet]                              OK
++ EF - Bellatrix - Rewards - full_but_partial_participation [Preset: mainnet]                OK
++ EF - Bellatrix - Rewards - full_but_partial_participation_leak [Preset: mainnet]           OK
++ EF - Bellatrix - Rewards - full_leak [Preset: mainnet]                                     OK
++ EF - Bellatrix - Rewards - full_random_0 [Preset: mainnet]                                 OK
++ EF - Bellatrix - Rewards - full_random_1 [Preset: mainnet]                                 OK
++ EF - Bellatrix - Rewards - full_random_2 [Preset: mainnet]                                 OK
++ EF - Bellatrix - Rewards - full_random_3 [Preset: mainnet]                                 OK
++ EF - Bellatrix - Rewards - full_random_4 [Preset: mainnet]                                 OK
++ EF - Bellatrix - Rewards - full_random_leak [Preset: mainnet]                              OK
++ EF - Bellatrix - Rewards - full_random_low_balances_0 [Preset: mainnet]                    OK
++ EF - Bellatrix - Rewards - full_random_low_balances_1 [Preset: mainnet]                    OK
++ EF - Bellatrix - Rewards - full_random_misc_balances [Preset: mainnet]                     OK
++ EF - Bellatrix - Rewards - full_random_seven_epoch_leak [Preset: mainnet]                  OK
++ EF - Bellatrix - Rewards - full_random_ten_epoch_leak [Preset: mainnet]                    OK
++ EF - Bellatrix - Rewards - full_random_without_leak_0 [Preset: mainnet]                    OK
++ EF - Bellatrix - Rewards - full_random_without_leak_and_current_exit_0 [Preset: mainnet]   OK
++ EF - Bellatrix - Rewards - half_full [Preset: mainnet]                                     OK
++ EF - Bellatrix - Rewards - half_full_leak [Preset: mainnet]                                OK
++ EF - Bellatrix - Rewards - quarter_full [Preset: mainnet]                                  OK
++ EF - Bellatrix - Rewards - quarter_full_leak [Preset: mainnet]                             OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_attested [Preset: mainnet OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: ma OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: m OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Pres OK
++ EF - Bellatrix - Rewards - with_exited_validators [Preset: mainnet]                        OK
++ EF - Bellatrix - Rewards - with_exited_validators_leak [Preset: mainnet]                   OK
++ EF - Bellatrix - Rewards - with_not_yet_activated_validators [Preset: mainnet]             OK
++ EF - Bellatrix - Rewards - with_not_yet_activated_validators_leak [Preset: mainnet]        OK
++ EF - Bellatrix - Rewards - with_slashed_validators [Preset: mainnet]                       OK
++ EF - Bellatrix - Rewards - with_slashed_validators_leak [Preset: mainnet]                  OK
++ EF - Bellatrix - Transition - normal_transition [Preset: mainnet]                          OK
++ EF - Bellatrix - Transition - sample_transition [Preset: mainnet]                          OK
++ EF - Bellatrix - Transition - transition_missing_first_post_block [Preset: mainnet]        OK
++ EF - Bellatrix - Transition - transition_missing_last_pre_fork_block [Preset: mainnet]     OK
++ EF - Bellatrix - Transition - transition_only_blocks_post_fork [Preset: mainnet]           OK
++ EF - Bellatrix - Transition - transition_with_activation_at_fork_epoch [Preset: mainnet]   OK
++ EF - Bellatrix - Transition - transition_with_attester_slashing_right_after_fork [Preset:  OK
++ EF - Bellatrix - Transition - transition_with_attester_slashing_right_before_fork [Preset: OK
++ EF - Bellatrix - Transition - transition_with_deposit_right_after_fork [Preset: mainnet]   OK
++ EF - Bellatrix - Transition - transition_with_deposit_right_before_fork [Preset: mainnet]  OK
++ EF - Bellatrix - Transition - transition_with_finality [Preset: mainnet]                   OK
++ EF - Bellatrix - Transition - transition_with_leaking_at_fork [Preset: mainnet]            OK
++ EF - Bellatrix - Transition - transition_with_leaking_pre_fork [Preset: mainnet]           OK
++ EF - Bellatrix - Transition - transition_with_no_attestations_until_after_fork [Preset: ma OK
++ EF - Bellatrix - Transition - transition_with_non_empty_activation_queue [Preset: mainnet] OK
++ EF - Bellatrix - Transition - transition_with_one_fourth_exiting_validators_exit_at_fork [ OK
++ EF - Bellatrix - Transition - transition_with_proposer_slashing_right_after_fork [Preset:  OK
++ EF - Bellatrix - Transition - transition_with_proposer_slashing_right_before_fork [Preset: OK
++ EF - Bellatrix - Transition - transition_with_random_half_participation [Preset: mainnet]  OK
++ EF - Bellatrix - Transition - transition_with_random_three_quarters_participation [Preset: OK
++ EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                 OK
++ EF - Phase 0 - Rewards - duplicate_attestations_at_later_slots [Preset: mainnet]           OK
++ EF - Phase 0 - Rewards - empty [Preset: mainnet]                                           OK
++ EF - Phase 0 - Rewards - empty_leak [Preset: mainnet]                                      OK
++ EF - Phase 0 - Rewards - full_all_correct [Preset: mainnet]                                OK
++ EF - Phase 0 - Rewards - full_but_partial_participation [Preset: mainnet]                  OK
++ EF - Phase 0 - Rewards - full_but_partial_participation_leak [Preset: mainnet]             OK
++ EF - Phase 0 - Rewards - full_correct_target_incorrect_head [Preset: mainnet]              OK
++ EF - Phase 0 - Rewards - full_correct_target_incorrect_head_leak [Preset: mainnet]         OK
++ EF - Phase 0 - Rewards - full_delay_max_slots [Preset: mainnet]                            OK
++ EF - Phase 0 - Rewards - full_delay_one_slot [Preset: mainnet]                             OK
++ EF - Phase 0 - Rewards - full_half_correct_target_incorrect_head [Preset: mainnet]         OK
++ EF - Phase 0 - Rewards - full_half_correct_target_incorrect_head_leak [Preset: mainnet]    OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_correct_head [Preset: mainnet]         OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_correct_head_leak [Preset: mainnet]    OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head [Preset: mainnet]       OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head_leak [Preset: mainnet]  OK
++ EF - Phase 0 - Rewards - full_leak [Preset: mainnet]                                       OK
++ EF - Phase 0 - Rewards - full_mixed_delay [Preset: mainnet]                                OK
++ EF - Phase 0 - Rewards - full_random_0 [Preset: mainnet]                                   OK
++ EF - Phase 0 - Rewards - full_random_1 [Preset: mainnet]                                   OK
++ EF - Phase 0 - Rewards - full_random_2 [Preset: mainnet]                                   OK
++ EF - Phase 0 - Rewards - full_random_3 [Preset: mainnet]                                   OK
++ EF - Phase 0 - Rewards - full_random_4 [Preset: mainnet]                                   OK
++ EF - Phase 0 - Rewards - full_random_leak [Preset: mainnet]                                OK
++ EF - Phase 0 - Rewards - full_random_low_balances_0 [Preset: mainnet]                      OK
++ EF - Phase 0 - Rewards - full_random_low_balances_1 [Preset: mainnet]                      OK
++ EF - Phase 0 - Rewards - full_random_misc_balances [Preset: mainnet]                       OK
++ EF - Phase 0 - Rewards - full_random_seven_epoch_leak [Preset: mainnet]                    OK
++ EF - Phase 0 - Rewards - full_random_ten_epoch_leak [Preset: mainnet]                      OK
++ EF - Phase 0 - Rewards - full_random_without_leak_0 [Preset: mainnet]                      OK
++ EF - Phase 0 - Rewards - full_random_without_leak_and_current_exit_0 [Preset: mainnet]     OK
++ EF - Phase 0 - Rewards - half_full [Preset: mainnet]                                       OK
++ EF - Phase 0 - Rewards - half_full_leak [Preset: mainnet]                                  OK
++ EF - Phase 0 - Rewards - one_attestation_one_correct [Preset: mainnet]                     OK
++ EF - Phase 0 - Rewards - one_attestation_one_correct_leak [Preset: mainnet]                OK
++ EF - Phase 0 - Rewards - proposer_not_in_attestations [Preset: mainnet]                    OK
++ EF - Phase 0 - Rewards - quarter_full [Preset: mainnet]                                    OK
++ EF - Phase 0 - Rewards - quarter_full_leak [Preset: mainnet]                               OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_attested [Preset: mainnet]  OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: main OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: mai OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Preset OK
++ EF - Phase 0 - Rewards - with_exited_validators [Preset: mainnet]                          OK
++ EF - Phase 0 - Rewards - with_exited_validators_leak [Preset: mainnet]                     OK
++ EF - Phase 0 - Rewards - with_not_yet_activated_validators [Preset: mainnet]               OK
++ EF - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset: mainnet]          OK
++ EF - Phase 0 - Rewards - with_slashed_validators [Preset: mainnet]                         OK
++ EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: mainnet]                    OK
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_same_proposer_slashings_ OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_similar_proposer_slashin OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_validator_exit_same_bloc OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - duplicate_attester_slashing [Pr OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - expected_deposit_in_block [Pres OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_block_sig [Preset: main OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_proposer_index_sig_from OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_proposer_index_sig_from OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_state_root [Preset: mai OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - parent_from_same_slot [Preset:  OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - prev_slot_block_transition [Pre OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: mainnet OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_same_proposer_slashin OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_similar_proposer_slas OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_validator_exit_same_b OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - duplicate_attester_slashing  OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - expected_deposit_in_block [P OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_block_sig [Preset: m OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_f OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_f OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_state_root [Preset:  OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - parent_from_same_slot [Prese OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - prev_slot_block_transition [ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - same_slot_block_transition [ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - slash_and_exit_same_index [P OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - zero_block_sig [Preset: main OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - duplicate_attester_slashing [P OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - expected_deposit_in_block [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_block_sig [Preset: mai OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_fro OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_fro OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_state_root [Preset: ma OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - parent_from_same_slot [Preset: OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - prev_slot_block_transition [Pr OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - proposal_for_genesis_slot [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - same_slot_block_transition [Pr OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - zero_block_sig [Preset: mainne OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_no_updates_at_genesis [Preset OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_1 [Preset: mainnet]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_2 [Preset: mainnet]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_3 [Preset: mainnet]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_4 [Preset: mainnet]      OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_0 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_1 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_10 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_11 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_12 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_13 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_14 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_15 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_2 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_3 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_4 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_5 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_6 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_7 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_8 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_9 [Preset: mainnet]           OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - attestation [Preset: mainnet]   OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - attester_slashing [Preset: main OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - balance_driven_status_transitio OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - deposit_in_block [Preset: mainn OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - deposit_top_up [Preset: mainnet OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_block_transition [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_epoch_transition [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_sync_committee_committee  OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_sync_committee_committee_ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_0 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_1 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_2 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_3 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_sync_committee_committee [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_sync_committee_committee_g OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - half_sync_committee_committee [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - half_sync_committee_committee_g OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - high_proposer_index [Preset: ma OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - historical_batch [Preset: mainn OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - inactivity_scores_full_particip OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - inactivity_scores_leaking [Pres OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_attester_slashings_no_ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_attester_slashings_par OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_different_proposer_sla OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_different_validator_ex OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_after_inactive_index [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_self_slashing [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_slashing [Preset: main OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: mainnet] OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: mainnet OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_no_updates_at_genesis [Pre OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_1 [Preset: mainnet]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_2 [Preset: mainnet]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_3 [Preset: mainnet]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_4 [Preset: mainnet]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - attestation [Preset: mainnet OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - attester_slashing [Preset: m OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - balance_driven_status_transi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - deposit_in_block [Preset: ma OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - deposit_top_up [Preset: main OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_block_transition [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_block_transition_no_tx OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_epoch_transition [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_sync_committee_committ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_sync_committee_committ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_0 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_1 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_2 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_3 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - half_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - half_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - high_proposer_index [Preset: OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - historical_batch [Preset: ma OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - inactivity_scores_full_parti OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - inactivity_scores_leaking [P OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - is_execution_enabled_false [ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_attester_slashings_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_attester_slashings_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_different_proposer_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_different_validator OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_after_inactive_inde OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_self_slashing [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_slashing [Preset: m OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - skipped_slots [Preset: mainn OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - slash_and_exit_diff_index [P OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: main OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: mainnet]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: mainnet]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_3 [Preset: mainnet]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_4 [Preset: mainnet]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_0 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_1 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_10 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_11 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_12 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_13 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_14 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_15 [Preset: mainnet]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_2 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_3 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_4 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_5 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_6 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_7 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_8 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_9 [Preset: mainnet]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - attestation [Preset: mainnet]  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - attester_slashing [Preset: mai OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - balance_driven_status_transiti OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: main OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: mainne OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_block_transition [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_0 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_1 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_2 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_3 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: m OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - historical_batch [Preset: main OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_attester_slashings_pa OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_different_proposer_sl OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_different_validator_e OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_after_inactive_index  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: mai OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - skipped_slots [Preset: mainnet OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Pre OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainne OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: mainne OK
++ [Invalid] EF - Altair - Sanity - Blocks - duplicate_attester_slashing [Preset: mainnet]    OK
++ [Invalid] EF - Altair - Sanity - Blocks - expected_deposit_in_block [Preset: mainnet]      OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_block_sig [Preset: mainnet]              OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_proposer_index_sig_from_expected_propose OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_index [ OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_state_root [Preset: mainnet]             OK
++ [Invalid] EF - Altair - Sanity - Blocks - parent_from_same_slot [Preset: mainnet]          OK
++ [Invalid] EF - Altair - Sanity - Blocks - prev_slot_block_transition [Preset: mainnet]     OK
++ [Invalid] EF - Altair - Sanity - Blocks - same_slot_block_transition [Preset: mainnet]     OK
++ [Invalid] EF - Altair - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]      OK
++ [Invalid] EF - Altair - Sanity - Blocks - zero_block_sig [Preset: mainnet]                 OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_same_proposer_slashings_same_block [Pr OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_similar_proposer_slashings_same_block  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_validator_exit_same_block [Preset: mai OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - duplicate_attester_slashing [Preset: mainnet] OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - expected_deposit_in_block [Preset: mainnet]   OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_block_sig [Preset: mainnet]           OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_from_expected_prop OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_inde OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_state_root [Preset: mainnet]          OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - parent_from_same_slot [Preset: mainnet]       OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - prev_slot_block_transition [Preset: mainnet]  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - same_slot_block_transition [Preset: mainnet]  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]   OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - zero_block_sig [Preset: mainnet]              OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_same_proposer_slashings_same_block [Pres OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_similar_proposer_slashings_same_block [P OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_validator_exit_same_block [Preset: mainn OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - duplicate_attester_slashing [Preset: mainnet]   OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - expected_deposit_in_block [Preset: mainnet]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_block_sig [Preset: mainnet]             OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_from_expected_propos OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_index  OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_state_root [Preset: mainnet]            OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - parent_from_same_slot [Preset: mainnet]         OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - prev_slot_block_transition [Preset: mainnet]    OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - proposal_for_genesis_slot [Preset: mainnet]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - same_slot_block_transition [Preset: mainnet]    OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - zero_block_sig [Preset: mainnet]                OK
++ [Valid]   EF - Altair - Finality - finality_no_updates_at_genesis [Preset: mainnet]        OK
++ [Valid]   EF - Altair - Finality - finality_rule_1 [Preset: mainnet]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_2 [Preset: mainnet]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_3 [Preset: mainnet]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_4 [Preset: mainnet]                       OK
++ [Valid]   EF - Altair - Random - randomized_0 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_1 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_10 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_11 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_12 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_13 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_14 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_15 [Preset: mainnet]                           OK
++ [Valid]   EF - Altair - Random - randomized_2 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_3 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_4 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_5 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_6 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_7 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_8 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Random - randomized_9 [Preset: mainnet]                            OK
++ [Valid]   EF - Altair - Sanity - Blocks - attestation [Preset: mainnet]                    OK
++ [Valid]   EF - Altair - Sanity - Blocks - attester_slashing [Preset: mainnet]              OK
++ [Valid]   EF - Altair - Sanity - Blocks - balance_driven_status_transitions [Preset: mainn OK
++ [Valid]   EF - Altair - Sanity - Blocks - deposit_in_block [Preset: mainnet]               OK
++ [Valid]   EF - Altair - Sanity - Blocks - deposit_top_up [Preset: mainnet]                 OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_block_transition [Preset: mainnet]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_sync_committee_committee [Preset: mainnet] OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_sync_committee_committee_genesis [Preset:  OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_sync_committee_committee [Preset: mainnet]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_sync_committee_committee_genesis [Preset: m OK
++ [Valid]   EF - Altair - Sanity - Blocks - half_sync_committee_committee [Preset: mainnet]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - half_sync_committee_committee_genesis [Preset: m OK
++ [Valid]   EF - Altair - Sanity - Blocks - high_proposer_index [Preset: mainnet]            OK
++ [Valid]   EF - Altair - Sanity - Blocks - historical_batch [Preset: mainnet]               OK
++ [Valid]   EF - Altair - Sanity - Blocks - inactivity_scores_full_participation_leaking [Pr OK
++ [Valid]   EF - Altair - Sanity - Blocks - inactivity_scores_leaking [Preset: mainnet]      OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset:  OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pre OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_different_proposer_slashings_same_block OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_different_validator_exits_same_block [P OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_after_inactive_index [Preset: mainnet]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_slashing [Preset: mainnet]              OK
++ [Valid]   EF - Altair - Sanity - Blocks - skipped_slots [Preset: mainnet]                  OK
++ [Valid]   EF - Altair - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]      OK
++ [Valid]   EF - Altair - Sanity - Blocks - voluntary_exit [Preset: mainnet]                 OK
++ [Valid]   EF - Bellatrix - Finality - finality_no_updates_at_genesis [Preset: mainnet]     OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_1 [Preset: mainnet]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_2 [Preset: mainnet]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: mainnet]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: mainnet]                    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - attestation [Preset: mainnet]                 OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - attester_slashing [Preset: mainnet]           OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - balance_driven_status_transitions [Preset: ma OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - deposit_in_block [Preset: mainnet]            OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - deposit_top_up [Preset: mainnet]              OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_block_transition [Preset: mainnet]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_block_transition_no_tx [Preset: mainnet OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_sync_committee_committee [Preset: mainn OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_sync_committee_committee_genesis [Prese OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_sync_committee_committee [Preset: mainne OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_sync_committee_committee_genesis [Preset OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - half_sync_committee_committee [Preset: mainne OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - half_sync_committee_committee_genesis [Preset OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - high_proposer_index [Preset: mainnet]         OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - historical_batch [Preset: mainnet]            OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - inactivity_scores_full_participation_leaking  OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - inactivity_scores_leaking [Preset: mainnet]   OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - is_execution_enabled_false [Preset: mainnet]  OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_attester_slashings_no_overlap [Prese OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_attester_slashings_partial_overlap [ OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_different_proposer_slashings_same_bl OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_different_validator_exits_same_block OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_after_inactive_index [Preset: mainne OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_slashing [Preset: mainnet]           OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - skipped_slots [Preset: mainnet]               OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]   OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: mainnet]              OK
++ [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_1 [Preset: mainnet]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_2 [Preset: mainnet]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_3 [Preset: mainnet]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_4 [Preset: mainnet]                      OK
++ [Valid]   EF - Phase 0 - Random - randomized_0 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_1 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_10 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_11 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_12 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_13 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_14 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_15 [Preset: mainnet]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_2 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_3 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_4 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_5 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_6 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_7 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_8 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_9 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - attestation [Preset: mainnet]                   OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - attester_slashing [Preset: mainnet]             OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - balance_driven_status_transitions [Preset: main OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: mainnet]              OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: mainnet]                OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition [Preset: mainnet]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: mainnet]           OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - historical_batch [Preset: mainnet]              OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset: OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pr OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_proposer_slashings_same_bloc OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_validator_exits_same_block [ OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_after_inactive_index [Preset: mainnet] OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: mainnet]             OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - skipped_slots [Preset: mainnet]                 OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + altair_fork_random_0                                                                       OK
 + altair_fork_random_1                                                                       OK
 + altair_fork_random_2                                                                       OK
@@ -328,6 +348,12 @@ ConsensusSpecPreset-mainnet
 + altair_fork_random_low_balances                                                            OK
 + altair_fork_random_misc_balances                                                           OK
 + altair_fork_random_mismatched_attestations                                                 OK
++ bellatrix_fork_random_0                                                                    OK
++ bellatrix_fork_random_1                                                                    OK
++ bellatrix_fork_random_2                                                                    OK
++ bellatrix_fork_random_3                                                                    OK
++ bellatrix_fork_random_low_balances                                                         OK
++ bellatrix_fork_random_misc_balances                                                        OK
 + finality_root_merkle_proof                                                                 OK
 + fork_base_state                                                                            OK
 + fork_many_next_epoch                                                                       OK
@@ -337,304 +363,304 @@ ConsensusSpecPreset-mainnet
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 334/334 Fail: 0/334 Skip: 0/334
+OK: 360/360 Fail: 0/360 Skip: 0/360
 ## Attestation
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - after_epoch_slots      OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - bad_source_root        OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - before_inclusion_delay OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - correct_after_epoch_de OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - empty_participants_see OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - empty_participants_zer OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - future_target_epoch    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_after_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_after OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_attestation_si OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_current_source OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_index          OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_previous_sourc OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - mismatched_target_and_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - new_source_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - old_source_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - old_target_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - source_root_is_target_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - too_few_aggregation_bi OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - too_many_aggregation_b OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_commit OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_slot_0 OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_slot_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - after_epoch_slots   OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - bad_source_root     OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - before_inclusion_de OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - correct_after_epoch OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - empty_participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - empty_participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - future_target_epoch OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_afte OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_af OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_attestation OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_current_sou OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_index       OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_previous_so OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - mismatched_target_a OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - new_source_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - old_source_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - old_target_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - source_root_is_targ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - too_few_aggregation OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - too_many_aggregatio OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_com OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_slo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_slo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - after_epoch_slots     OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - bad_source_root       OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - before_inclusion_dela OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - correct_after_epoch_d OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - empty_participants_se OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - empty_participants_ze OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - future_target_epoch   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_after_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_afte OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_attestation_s OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_current_sourc OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_index         OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_previous_sour OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - mismatched_target_and OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - new_source_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - old_source_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - old_target_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - source_root_is_target OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - too_few_aggregation_b OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - too_many_aggregation_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_commi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_slot_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_slot_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_epoch_delay    OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_min_inclusion_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_sqrt_epoch_del OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_epoch_d OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_min_inc OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_sqrt_ep OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_epoch OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_min_i OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_sqrt_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success                OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success_multi_proposer OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success_previous_epoch OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_epoch_delay OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_min_inclusi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_sqrt_epoch_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_epoc OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_min_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_sqrt OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_ep OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_mi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_sq OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success             OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success_multi_propo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success_previous_ep OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_epoch_delay   OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_min_inclusion OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_sqrt_epoch_de OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_epoch_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_min_in OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_sqrt_e OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_epoc OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_min_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_sqrt OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success               OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success_multi_propose OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success_previous_epoc OK
++ [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
++ [Invalid] EF - Altair - Operations - Attestation - bad_source_root                         OK
++ [Invalid] EF - Altair - Operations - Attestation - before_inclusion_delay                  OK
++ [Invalid] EF - Altair - Operations - Attestation - correct_after_epoch_delay               OK
++ [Invalid] EF - Altair - Operations - Attestation - empty_participants_seemingly_valid_sig  OK
++ [Invalid] EF - Altair - Operations - Attestation - empty_participants_zeroes_sig           OK
++ [Invalid] EF - Altair - Operations - Attestation - future_target_epoch                     OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_head_after_epoch_delay        OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_head_and_target_after_epoch_d OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_target_after_epoch_delay      OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_attestation_signature           OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_current_source_root             OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_index                           OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_previous_source_root            OK
++ [Invalid] EF - Altair - Operations - Attestation - mismatched_target_and_slot              OK
++ [Invalid] EF - Altair - Operations - Attestation - new_source_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - old_source_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - old_target_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - source_root_is_target_root              OK
++ [Invalid] EF - Altair - Operations - Attestation - too_few_aggregation_bits                OK
++ [Invalid] EF - Altair - Operations - Attestation - too_many_aggregation_bits               OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_committee_signature     OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_slot_0                  OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_slot_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - after_epoch_slots                    OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - bad_source_root                      OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - before_inclusion_delay               OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - correct_after_epoch_delay            OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - empty_participants_seemingly_valid_s OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - empty_participants_zeroes_sig        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - future_target_epoch                  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_head_after_epoch_delay     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_after_epoc OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_target_after_epoch_delay   OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_attestation_signature        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_current_source_root          OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_index                        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_previous_source_root         OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - mismatched_target_and_slot           OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - new_source_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - old_source_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - old_target_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - source_root_is_target_root           OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - too_few_aggregation_bits             OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - too_many_aggregation_bits            OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_committee_signature  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_slot_0               OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_slot_1               OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - after_epoch_slots                      OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - bad_source_root                        OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - before_inclusion_delay                 OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - correct_after_epoch_delay              OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - empty_participants_seemingly_valid_sig OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - empty_participants_zeroes_sig          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - future_target_epoch                    OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_head_after_epoch_delay       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_after_epoch_ OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_target_after_epoch_delay     OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_attestation_signature          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_current_source_root            OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_index                          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_previous_source_root           OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - mismatched_target_and_slot             OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - new_source_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - old_source_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - old_target_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - source_root_is_target_root             OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - too_few_aggregation_bits               OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - too_many_aggregation_bits              OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_committee_signature    OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_slot_0                 OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_slot_1                 OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_epoch_delay                     OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_min_inclusion_delay             OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_sqrt_epoch_delay                OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_epoch_delay   OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_min_inclusion OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_sqrt_epoch_de OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_epoch_delay              OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_min_inclusion_delay      OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_sqrt_epoch_delay         OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_epoch_delay            OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_min_inclusion_delay    OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_sqrt_epoch_delay       OK
++ [Valid]   EF - Altair - Operations - Attestation - success                                 OK
++ [Valid]   EF - Altair - Operations - Attestation - success_multi_proposer_index_iterations OK
++ [Valid]   EF - Altair - Operations - Attestation - success_previous_epoch                  OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_epoch_delay                  OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_min_inclusion_delay          OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_sqrt_epoch_delay             OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_epoch_dela OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_min_inclus OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_sqrt_epoch OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_epoch_delay           OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_min_inclusion_delay   OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_sqrt_epoch_delay      OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_epoch_delay         OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_min_inclusion_delay OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_sqrt_epoch_delay    OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success                              OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success_multi_proposer_index_iterati OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success_previous_epoch               OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_epoch_delay                    OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_min_inclusion_delay            OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_sqrt_epoch_delay               OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_epoch_delay  OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_min_inclusio OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_sqrt_epoch_d OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_epoch_delay             OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_min_inclusion_delay     OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_sqrt_epoch_delay        OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_epoch_delay           OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_min_inclusion_delay   OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_sqrt_epoch_delay      OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success                                OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success_multi_proposer_index_iteration OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success_previous_epoch                 OK
 ```
 OK: 117/117 Fail: 0/117 Skip: 0/117
 ## Attester Slashing
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - all_empty_indice OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_bad_extra_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_bad_replace OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_empty_indic OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_high_index  OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_bad_extra_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_bad_replace OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_empty_indic OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_high_index  OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_1    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_2    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - no_double_or_sur OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - participants_alr OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - same_data        OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - unsorted_att_1   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - unsorted_att_2   OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - all_empty_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_bad_extr OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_bad_repl OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_empty_in OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_high_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_bad_extr OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_bad_repl OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_empty_in OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_high_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_2 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - no_double_or_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - same_data     OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - unsorted_att_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - unsorted_att_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - all_empty_indic OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_bad_extra_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_bad_replac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_empty_indi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_high_index OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_bad_extra_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_bad_replac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_empty_indi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_high_index OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_1   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_2   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - no_double_or_su OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - participants_al OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - same_data       OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - unsorted_att_1  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - unsorted_att_2  OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_already_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_already_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_attestat OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_double   OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_low_bala OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_misc_bal OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_proposer OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_surround OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_with_eff OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_alrea OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_alrea OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_attes OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_doubl OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_low_b OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_misc_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_propo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_surro OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_with_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_already OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_already OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_attesta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_double  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_low_bal OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_misc_ba OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_propose OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_surroun OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_with_ef OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - all_empty_indices                 OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_bad_extra_index              OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_bad_replaced_index           OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_duplicate_index_double_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_duplicate_index_normal_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_empty_indices                OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_high_index                   OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_bad_extra_index              OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_bad_replaced_index           OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_duplicate_index_double_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_duplicate_index_normal_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_empty_indices                OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_high_index                   OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_1                     OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_1_and_2               OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_2                     OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - no_double_or_surround             OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - participants_already_slashed      OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - same_data                         OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - unsorted_att_1                    OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - unsorted_att_2                    OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - all_empty_indices              OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_bad_extra_index           OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_bad_replaced_index        OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_duplicate_index_double_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_duplicate_index_normal_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_empty_indices             OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_high_index                OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_bad_extra_index           OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_bad_replaced_index        OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_duplicate_index_double_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_duplicate_index_normal_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_empty_indices             OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_high_index                OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_1_and_2            OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_2                  OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - no_double_or_surround          OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - participants_already_slashed   OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - same_data                      OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - unsorted_att_1                 OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - unsorted_att_2                 OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - all_empty_indices                OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_bad_extra_index             OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_bad_replaced_index          OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_duplicate_index_double_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_duplicate_index_normal_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_empty_indices               OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_high_index                  OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_bad_extra_index             OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_bad_replaced_index          OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_duplicate_index_double_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_duplicate_index_normal_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_empty_indices               OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_high_index                  OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_1                    OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_1_and_2              OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_2                    OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - no_double_or_surround            OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - participants_already_slashed     OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - same_data                        OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - unsorted_att_1                   OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - unsorted_att_2                   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_already_exited_long_ago   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_already_exited_recent     OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_attestation_from_future   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_double                    OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_low_balances              OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_misc_balances             OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_proposer_index_slashed    OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_surround                  OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_with_effective_balance_di OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_already_exited_long_ag OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_already_exited_recent  OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_attestation_from_futur OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_double                 OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_low_balances           OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_misc_balances          OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_proposer_index_slashed OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_surround               OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_with_effective_balance OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_already_exited_long_ago  OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_already_exited_recent    OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_attestation_from_future  OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_double                   OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_low_balances             OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_misc_balances            OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_proposer_index_slashed   OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_surround                 OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_with_effective_balance_d OK
 ```
 OK: 90/90 Fail: 0/90 Skip: 0/90
 ## Block Header
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_multiple_bloc OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_parent_root   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_proposer_inde OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_slot_block_he OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - proposer_slashed      OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_multiple_b OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_parent_roo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_proposer_i OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_slot_block OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - proposer_slashed   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_multiple_blo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_parent_root  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_proposer_ind OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_slot_block_h OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - proposer_slashed     OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Block Header - success_block_header  OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Block Header - success_block_head OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Block Header - success_block_header OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_multiple_blocks_single_slot    OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_parent_root                    OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_proposer_index                 OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_slot_block_header              OK
++ [Invalid] EF - Altair - Operations - Block Header - proposer_slashed                       OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_multiple_blocks_single_slot OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_parent_root                 OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_proposer_index              OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_slot_block_header           OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - proposer_slashed                    OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_parent_root                   OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_proposer_index                OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_slot_block_header             OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - proposer_slashed                      OK
++ [Valid]   EF - Altair - Operations - Block Header - success_block_header                   OK
++ [Valid]   EF - Bellatrix - Operations - Block Header - success_block_header                OK
++ [Valid]   EF - Phase 0 - Operations - Block Header - success_block_header                  OK
 ```
 OK: 18/18 Fail: 0/18 Skip: 0/18
 ## Deposit
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Deposit - bad_merkle_proof           OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Deposit - wrong_deposit_for_deposit_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Deposit - bad_merkle_proof        OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Deposit - wrong_deposit_for_depos OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Deposit - bad_merkle_proof          OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Deposit - wrong_deposit_for_deposit OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_new_deposit    OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_other_version  OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_top_up         OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_withdrawal_credent OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_eth1_withdrawa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_max            OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_non_versioned_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_over_max       OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_under_max      OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - success_top_up             OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - valid_sig_but_forked_state OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_new_deposit OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_other_versi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_top_up      OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_withdrawal_cred OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_eth1_withdr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_max         OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_non_version OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_over_max    OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_under_max   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - success_top_up          OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - valid_sig_but_forked_st OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_new_deposit   OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_other_version OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_top_up        OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_withdrawal_creden OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_eth1_withdraw OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_max           OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_non_versioned OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_over_max      OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_under_max     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - success_top_up            OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - valid_sig_but_forked_stat OK
++ [Invalid] EF - Altair - Operations - Deposit - bad_merkle_proof                            OK
++ [Invalid] EF - Altair - Operations - Deposit - wrong_deposit_for_deposit_count             OK
++ [Invalid] EF - Bellatrix - Operations - Deposit - bad_merkle_proof                         OK
++ [Invalid] EF - Bellatrix - Operations - Deposit - wrong_deposit_for_deposit_count          OK
++ [Invalid] EF - Phase 0 - Operations - Deposit - bad_merkle_proof                           OK
++ [Invalid] EF - Phase 0 - Operations - Deposit - wrong_deposit_for_deposit_count            OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_new_deposit                     OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_other_version                   OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_top_up                          OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_withdrawal_credentials_top_up       OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_eth1_withdrawal_credentials     OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_max                             OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_over_max                        OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_under_max                       OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up                              OK
++ [Valid]   EF - Altair - Operations - Deposit - valid_sig_but_forked_state                  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_new_deposit                  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_other_version                OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_top_up                       OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_withdrawal_credentials_top_up    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_eth1_withdrawal_credentials  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_max                          OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_over_max                     OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_under_max                    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up                           OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - valid_sig_but_forked_state               OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_new_deposit                    OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_top_up                         OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_withdrawal_credentials_top_up      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_eth1_withdrawal_credentials    OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_max                            OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_over_max                       OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_under_max                      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
 OK: 39/39 Fail: 0/39 Skip: 0/39
-## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
+## EF - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Eth1 data reset [Preset: mainnet]
+## EF - Altair - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Altair - Epoch Processing - Historical roots update [Preset: mainnet]
+## EF - Altair - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Inactivity [Preset: mainnet]
+## EF - Altair - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
 + Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: mainnet]      OK
@@ -657,7 +683,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19
-## Ethereum Foundation - Altair - Epoch Processing - Justification & Finalization [Preset: mainnet]
+## EF - Altair - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
 + Justification & Finalization - 123_poor_support [Preset: mainnet]                          OK
@@ -671,7 +697,7 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Altair - Epoch Processing - Participation flag updates [Preset: mainnet]
+## EF - Altair - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
 + Participation flag updates - current_epoch_zeroed [Preset: mainnet]                        OK
@@ -685,12 +711,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Altair - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
+## EF - Altair - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Registry updates [Preset: mainnet]
+## EF - Altair - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: mainnet] OK
@@ -704,7 +730,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Altair - Epoch Processing - Slashings [Preset: mainnet]
+## EF - Altair - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
 + Slashings - max_penalties [Preset: mainnet]                                                OK
@@ -713,12 +739,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Altair - Epoch Processing - Slashings reset [Preset: mainnet]
+## EF - Altair - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - SSZ consensus objects  [Preset: mainnet]
+## EF - Altair - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -757,30 +783,30 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 35/35 Fail: 0/35 Skip: 0/35
-## Ethereum Foundation - Altair - Unittests - Sync protocol [Preset: mainnet]
+## EF - Altair - Unittests - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
-## Ethereum Foundation - Bellatrix - Epoch Processing - Effective balance updates [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Eth1 data reset [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Bellatrix - Epoch Processing - Historical roots update [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Inactivity [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
 + Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: mainnet]      OK
@@ -803,7 +829,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19
-## Ethereum Foundation - Bellatrix - Epoch Processing - Justification & Finalization [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
 + Justification & Finalization - 123_poor_support [Preset: mainnet]                          OK
@@ -817,7 +843,7 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Bellatrix - Epoch Processing - Participation flag updates [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
 + Participation flag updates - current_epoch_zeroed [Preset: mainnet]                        OK
@@ -831,12 +857,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Registry updates [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: mainnet] OK
@@ -850,7 +876,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Bellatrix - Epoch Processing - Slashings [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
 + Slashings - max_penalties [Preset: mainnet]                                                OK
@@ -859,12 +885,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Bellatrix - Epoch Processing - Slashings reset [Preset: mainnet]
+## EF - Bellatrix - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - SSZ consensus objects  [Preset: mainnet]
+## EF - Bellatrix - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -906,7 +932,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 38/38 Fail: 0/38 Skip: 0/38
-## Ethereum Foundation - ForkChoice [Preset: mainnet]
+## EF - ForkChoice [Preset: mainnet]
 ```diff
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
@@ -920,23 +946,23 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
 ```
 OK: 8/10 Fail: 0/10 Skip: 2/10
-## Ethereum Foundation - Phase 0 - Epoch Processing - Effective balance updates [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Eth1 data reset [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Phase 0 - Epoch Processing - Historical roots update [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Justification & Finalization [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
 + Justification & Finalization - 123_poor_support [Preset: mainnet]                          OK
@@ -950,17 +976,17 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Phase 0 - Epoch Processing - Participation record updates [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Participation record updates [Preset: mainnet]
 ```diff
 + Participation record updates - updated_participation_record [Preset: mainnet]              OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Registry updates [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: mainnet] OK
@@ -974,7 +1000,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Phase 0 - Epoch Processing - Slashings [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
 + Slashings - max_penalties [Preset: mainnet]                                                OK
@@ -983,12 +1009,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Phase 0 - Epoch Processing - Slashings reset [Preset: mainnet]
+## EF - Phase 0 - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - SSZ consensus objects  [Preset: mainnet]
+## EF - Phase 0 - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -1021,148 +1047,148 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 ## Execution Payload
 ```diff
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_everythin OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_execution OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_execution OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_parent_ha OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_random_fi OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_random_re OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_timestamp OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_timestamp OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_first OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_first OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_regul OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_regul OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_everything_regular_payload OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_execution_first_payload    OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_execution_regular_payload  OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_parent_hash_regular_payloa OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_first_payload       OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_regular_payload     OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_first_payload    OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_regular_payload  OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload          OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload_with_gap OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload        OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload_with_g OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Proposer Slashing
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - epochs_are_diffe OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - headers_are_same OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - headers_are_same OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_differen OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_proposer OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_2    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_not_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_slas OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_with OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - epochs_are_di OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - headers_are_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - headers_are_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_diffe OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_propo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_2 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_n OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_w OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - epochs_are_diff OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - headers_are_sam OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - headers_are_sam OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_differe OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_propose OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_2   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_not OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_sla OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_wit OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success          OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success_block_he OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success_slashed_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success       OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success_block OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success_slash OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success_block_h OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success_slashed OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - epochs_are_different              OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - headers_are_same_sigs_are_differe OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - headers_are_same_sigs_are_same    OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_different_proposer_indice OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_proposer_index            OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1                     OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1_and_2               OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1_and_2_swap          OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_2                     OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_not_activated         OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_slashed               OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_withdrawn             OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - epochs_are_different           OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - headers_are_same_sigs_are_diff OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - headers_are_same_sigs_are_same OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_different_proposer_ind OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_proposer_index         OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1_and_2            OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1_and_2_swap       OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_2                  OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_not_activated      OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_slashed            OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_withdrawn          OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - epochs_are_different             OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - headers_are_same_sigs_are_differ OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - headers_are_same_sigs_are_same   OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_different_proposer_indic OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_proposer_index           OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1                    OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_and_2              OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_and_2_swap         OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_2                    OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_not_activated        OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_slashed              OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_withdrawn            OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success                           OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success_block_header_from_future  OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success_slashed_and_proposer_inde OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success                        OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success_block_header_from_futu OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success_slashed_and_proposer_i OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success                          OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success_block_header_from_future OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success_slashed_and_proposer_ind OK
 ```
 OK: 45/45 Fail: 0/45 Skip: 0/45
 ## Sync Aggregate
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_b OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_m OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_n OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_p OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_all_but_one_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_high_partici OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_low_particip OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_misc_balance OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_only_one_par OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_with_exits_w OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_all_but_o OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_high_part OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_low_parti OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_misc_bala OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_only_one_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_with_exit OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_bad_domain         OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_extra_participant  OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_infinite_signature OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_infinite_signature OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_missing_participan OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_no_participants    OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_past_block         OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_bad_domain      OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_extra_participa OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_infinite_signat OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_infinite_signat OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_missing_partici OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_no_participants OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_past_block      OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_all_but_one_participating_wit OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_high_participation_with_dupli OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_low_participation_with_duplic OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_misc_balances_and_half_partic OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_only_one_participant_with_dup OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_with_exits_with_duplicates    OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_duplicate_com OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_duplicate_com OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_duplicate_com OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_empty_partici OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_not_full_part OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_nonparticipating OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_nonparticipating OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_ex OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_wi OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_all_but_one_participating_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_high_participation_with_du OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_low_participation_with_dup OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_misc_balances_and_half_par OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_only_one_participant_with_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_with_exits_with_duplicates OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_duplicate_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_duplicate_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_duplicate_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_empty_part OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_not_full_p OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_nonparticipat OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_nonparticipat OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
 ```
 OK: 44/44 Fail: 0/44 Skip: 0/44
 ## Voluntary Exit
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - invalid_signature   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_already_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_exit_in_f OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_invalid_v OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_not_activ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_not_activ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_alread OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_exit_i OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_invali OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_not_ac OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_not_ac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - invalid_signature  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_already_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_exit_in_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_invalid_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_not_acti OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_not_acti OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - default_exit_epoch_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - success             OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - success_exit_queue_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - default_exit_epo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - success          OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - success_exit_que OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - default_exit_epoch OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - success            OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - success_exit_queue OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - invalid_signature                    OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_already_exited             OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_exit_in_future             OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_invalid_validator_index    OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_not_active                 OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_not_active_long_enough     OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - invalid_signature                 OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_already_exited          OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_exit_in_future          OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_invalid_validator_index OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_not_active              OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_not_active_long_enough  OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - invalid_signature                   OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_already_exited            OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_exit_in_future            OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_invalid_validator_index   OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_not_active                OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_not_active_long_enough    OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - default_exit_epoch_subsequent_exit   OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - success                              OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__min_churn        OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - default_exit_epoch_subsequent_exi OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - success                           OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - success_exit_queue__min_churn     OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - default_exit_epoch_subsequent_exit  OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - success                             OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - success_exit_queue__min_churn       OK
 ```
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 989/991 Fail: 0/991 Skip: 2/991
+OK: 1015/1017 Fail: 0/1017 Skip: 2/1017

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -2,343 +2,367 @@ ConsensusSpecPreset-minimal
 ===
 ## 
 ```diff
-+ Ethereum Foundation - Altair - Rewards - all_balances_too_low_for_reward [Preset: minimal] OK
-+ Ethereum Foundation - Altair - Rewards - empty [Preset: minimal]                           OK
-+ Ethereum Foundation - Altair - Rewards - empty_leak [Preset: minimal]                      OK
-+ Ethereum Foundation - Altair - Rewards - full_all_correct [Preset: minimal]                OK
-+ Ethereum Foundation - Altair - Rewards - full_but_partial_participation [Preset: minimal]  OK
-+ Ethereum Foundation - Altair - Rewards - full_but_partial_participation_leak [Preset: mini OK
-+ Ethereum Foundation - Altair - Rewards - full_leak [Preset: minimal]                       OK
-+ Ethereum Foundation - Altair - Rewards - full_random_0 [Preset: minimal]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_1 [Preset: minimal]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_2 [Preset: minimal]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_3 [Preset: minimal]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_4 [Preset: minimal]                   OK
-+ Ethereum Foundation - Altair - Rewards - full_random_leak [Preset: minimal]                OK
-+ Ethereum Foundation - Altair - Rewards - full_random_low_balances_0 [Preset: minimal]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_low_balances_1 [Preset: minimal]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_misc_balances [Preset: minimal]       OK
-+ Ethereum Foundation - Altair - Rewards - full_random_seven_epoch_leak [Preset: minimal]    OK
-+ Ethereum Foundation - Altair - Rewards - full_random_ten_epoch_leak [Preset: minimal]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_without_leak_0 [Preset: minimal]      OK
-+ Ethereum Foundation - Altair - Rewards - full_random_without_leak_and_current_exit_0 [Pres OK
-+ Ethereum Foundation - Altair - Rewards - half_full [Preset: minimal]                       OK
-+ Ethereum Foundation - Altair - Rewards - half_full_leak [Preset: minimal]                  OK
-+ Ethereum Foundation - Altair - Rewards - quarter_full [Preset: minimal]                    OK
-+ Ethereum Foundation - Altair - Rewards - quarter_full_leak [Preset: minimal]               OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_attested [P OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_attested_le OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_did_not_att OK
-+ Ethereum Foundation - Altair - Rewards - some_very_low_effective_balances_that_did_not_att OK
-+ Ethereum Foundation - Altair - Rewards - with_exited_validators [Preset: minimal]          OK
-+ Ethereum Foundation - Altair - Rewards - with_exited_validators_leak [Preset: minimal]     OK
-+ Ethereum Foundation - Altair - Rewards - with_not_yet_activated_validators [Preset: minima OK
-+ Ethereum Foundation - Altair - Rewards - with_not_yet_activated_validators_leak [Preset: m OK
-+ Ethereum Foundation - Altair - Rewards - with_slashed_validators [Preset: minimal]         OK
-+ Ethereum Foundation - Altair - Rewards - with_slashed_validators_leak [Preset: minimal]    OK
-+ Ethereum Foundation - Altair - Transition - normal_transition [Preset: minimal]            OK
-+ Ethereum Foundation - Altair - Transition - transition_missing_first_post_block [Preset: m OK
-+ Ethereum Foundation - Altair - Transition - transition_missing_last_pre_fork_block [Preset OK
-+ Ethereum Foundation - Altair - Transition - transition_only_blocks_post_fork [Preset: mini OK
-+ Ethereum Foundation - Altair - Transition - transition_with_activation_at_fork_epoch [Pres OK
-+ Ethereum Foundation - Altair - Transition - transition_with_attester_slashing_right_after_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_attester_slashing_right_before OK
-+ Ethereum Foundation - Altair - Transition - transition_with_deposit_right_after_fork [Pres OK
-+ Ethereum Foundation - Altair - Transition - transition_with_deposit_right_before_fork [Pre OK
-+ Ethereum Foundation - Altair - Transition - transition_with_finality [Preset: minimal]     OK
-+ Ethereum Foundation - Altair - Transition - transition_with_leaking_at_fork [Preset: minim OK
-+ Ethereum Foundation - Altair - Transition - transition_with_leaking_pre_fork [Preset: mini OK
-+ Ethereum Foundation - Altair - Transition - transition_with_no_attestations_until_after_fo OK
-+ Ethereum Foundation - Altair - Transition - transition_with_non_empty_activation_queue [Pr OK
-+ Ethereum Foundation - Altair - Transition - transition_with_one_fourth_exiting_validators_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_one_fourth_exiting_validators_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_one_fourth_slashed_active_vali OK
-+ Ethereum Foundation - Altair - Transition - transition_with_proposer_slashing_right_after_ OK
-+ Ethereum Foundation - Altair - Transition - transition_with_proposer_slashing_right_before OK
-+ Ethereum Foundation - Altair - Transition - transition_with_random_half_participation [Pre OK
-+ Ethereum Foundation - Altair - Transition - transition_with_random_three_quarters_particip OK
-+ Ethereum Foundation - Altair - Transition - transition_with_voluntary_exit_right_after_for OK
-+ Ethereum Foundation - Altair - Transition - transition_with_voluntary_exit_right_before_fo OK
-+ Ethereum Foundation - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: minim OK
-+ Ethereum Foundation - Bellatrix - Rewards - empty [Preset: minimal]                        OK
-+ Ethereum Foundation - Bellatrix - Rewards - empty_leak [Preset: minimal]                   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_all_correct [Preset: minimal]             OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_but_partial_participation [Preset: minima OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_but_partial_participation_leak [Preset: m OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_leak [Preset: minimal]                    OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_0 [Preset: minimal]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_1 [Preset: minimal]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_2 [Preset: minimal]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_3 [Preset: minimal]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_4 [Preset: minimal]                OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_leak [Preset: minimal]             OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_low_balances_0 [Preset: minimal]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_low_balances_1 [Preset: minimal]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_misc_balances [Preset: minimal]    OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_seven_epoch_leak [Preset: minimal] OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_ten_epoch_leak [Preset: minimal]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_without_leak_0 [Preset: minimal]   OK
-+ Ethereum Foundation - Bellatrix - Rewards - full_random_without_leak_and_current_exit_0 [P OK
-+ Ethereum Foundation - Bellatrix - Rewards - half_full [Preset: minimal]                    OK
-+ Ethereum Foundation - Bellatrix - Rewards - half_full_leak [Preset: minimal]               OK
-+ Ethereum Foundation - Bellatrix - Rewards - quarter_full [Preset: minimal]                 OK
-+ Ethereum Foundation - Bellatrix - Rewards - quarter_full_leak [Preset: minimal]            OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_attested OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_attested OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_ OK
-+ Ethereum Foundation - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_ OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_exited_validators [Preset: minimal]       OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_exited_validators_leak [Preset: minimal]  OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_not_yet_activated_validators [Preset: min OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_not_yet_activated_validators_leak [Preset OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_slashed_validators [Preset: minimal]      OK
-+ Ethereum Foundation - Bellatrix - Rewards - with_slashed_validators_leak [Preset: minimal] OK
-+ Ethereum Foundation - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: minimal OK
-+ Ethereum Foundation - Phase 0 - Rewards - duplicate_attestations_at_later_slots [Preset: m OK
-+ Ethereum Foundation - Phase 0 - Rewards - empty [Preset: minimal]                          OK
-+ Ethereum Foundation - Phase 0 - Rewards - empty_leak [Preset: minimal]                     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_all_correct [Preset: minimal]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_but_partial_participation [Preset: minimal] OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_but_partial_participation_leak [Preset: min OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_correct_target_incorrect_head [Preset: mini OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_correct_target_incorrect_head_leak [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_delay_max_slots [Preset: minimal]           OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_delay_one_slot [Preset: minimal]            OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_correct_target_incorrect_head [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_correct_target_incorrect_head_leak [Pr OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_correct_head [Preset: OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_correct_head_leak [Pr OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head [Prese OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head_leak [ OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_leak [Preset: minimal]                      OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_mixed_delay [Preset: minimal]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_0 [Preset: minimal]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_1 [Preset: minimal]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_2 [Preset: minimal]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_3 [Preset: minimal]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_4 [Preset: minimal]                  OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_leak [Preset: minimal]               OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_low_balances_0 [Preset: minimal]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_low_balances_1 [Preset: minimal]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_misc_balances [Preset: minimal]      OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_seven_epoch_leak [Preset: minimal]   OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_ten_epoch_leak [Preset: minimal]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_without_leak_0 [Preset: minimal]     OK
-+ Ethereum Foundation - Phase 0 - Rewards - full_random_without_leak_and_current_exit_0 [Pre OK
-+ Ethereum Foundation - Phase 0 - Rewards - half_full [Preset: minimal]                      OK
-+ Ethereum Foundation - Phase 0 - Rewards - half_full_leak [Preset: minimal]                 OK
-+ Ethereum Foundation - Phase 0 - Rewards - one_attestation_one_correct [Preset: minimal]    OK
-+ Ethereum Foundation - Phase 0 - Rewards - one_attestation_one_correct_leak [Preset: minima OK
-+ Ethereum Foundation - Phase 0 - Rewards - proposer_not_in_attestations [Preset: minimal]   OK
-+ Ethereum Foundation - Phase 0 - Rewards - quarter_full [Preset: minimal]                   OK
-+ Ethereum Foundation - Phase 0 - Rewards - quarter_full_leak [Preset: minimal]              OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_attested [ OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_attested_l OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_at OK
-+ Ethereum Foundation - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_at OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_exited_validators [Preset: minimal]         OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_exited_validators_leak [Preset: minimal]    OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_not_yet_activated_validators [Preset: minim OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset:  OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_slashed_validators [Preset: minimal]        OK
-+ Ethereum Foundation - Phase 0 - Rewards - with_slashed_validators_leak [Preset: minimal]   OK
++ EF - Altair - Rewards - all_balances_too_low_for_reward [Preset: minimal]                  OK
++ EF - Altair - Rewards - empty [Preset: minimal]                                            OK
++ EF - Altair - Rewards - empty_leak [Preset: minimal]                                       OK
++ EF - Altair - Rewards - full_all_correct [Preset: minimal]                                 OK
++ EF - Altair - Rewards - full_but_partial_participation [Preset: minimal]                   OK
++ EF - Altair - Rewards - full_but_partial_participation_leak [Preset: minimal]              OK
++ EF - Altair - Rewards - full_leak [Preset: minimal]                                        OK
++ EF - Altair - Rewards - full_random_0 [Preset: minimal]                                    OK
++ EF - Altair - Rewards - full_random_1 [Preset: minimal]                                    OK
++ EF - Altair - Rewards - full_random_2 [Preset: minimal]                                    OK
++ EF - Altair - Rewards - full_random_3 [Preset: minimal]                                    OK
++ EF - Altair - Rewards - full_random_4 [Preset: minimal]                                    OK
++ EF - Altair - Rewards - full_random_leak [Preset: minimal]                                 OK
++ EF - Altair - Rewards - full_random_low_balances_0 [Preset: minimal]                       OK
++ EF - Altair - Rewards - full_random_low_balances_1 [Preset: minimal]                       OK
++ EF - Altair - Rewards - full_random_misc_balances [Preset: minimal]                        OK
++ EF - Altair - Rewards - full_random_seven_epoch_leak [Preset: minimal]                     OK
++ EF - Altair - Rewards - full_random_ten_epoch_leak [Preset: minimal]                       OK
++ EF - Altair - Rewards - full_random_without_leak_0 [Preset: minimal]                       OK
++ EF - Altair - Rewards - full_random_without_leak_and_current_exit_0 [Preset: minimal]      OK
++ EF - Altair - Rewards - half_full [Preset: minimal]                                        OK
++ EF - Altair - Rewards - half_full_leak [Preset: minimal]                                   OK
++ EF - Altair - Rewards - quarter_full [Preset: minimal]                                     OK
++ EF - Altair - Rewards - quarter_full_leak [Preset: minimal]                                OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_attested [Preset: minimal]   OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: minim OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: mini OK
++ EF - Altair - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Preset: OK
++ EF - Altair - Rewards - with_exited_validators [Preset: minimal]                           OK
++ EF - Altair - Rewards - with_exited_validators_leak [Preset: minimal]                      OK
++ EF - Altair - Rewards - with_not_yet_activated_validators [Preset: minimal]                OK
++ EF - Altair - Rewards - with_not_yet_activated_validators_leak [Preset: minimal]           OK
++ EF - Altair - Rewards - with_slashed_validators [Preset: minimal]                          OK
++ EF - Altair - Rewards - with_slashed_validators_leak [Preset: minimal]                     OK
++ EF - Altair - Transition - normal_transition [Preset: minimal]                             OK
++ EF - Altair - Transition - transition_missing_first_post_block [Preset: minimal]           OK
++ EF - Altair - Transition - transition_missing_last_pre_fork_block [Preset: minimal]        OK
++ EF - Altair - Transition - transition_only_blocks_post_fork [Preset: minimal]              OK
++ EF - Altair - Transition - transition_with_activation_at_fork_epoch [Preset: minimal]      OK
++ EF - Altair - Transition - transition_with_attester_slashing_right_after_fork [Preset: min OK
++ EF - Altair - Transition - transition_with_attester_slashing_right_before_fork [Preset: mi OK
++ EF - Altair - Transition - transition_with_deposit_right_after_fork [Preset: minimal]      OK
++ EF - Altair - Transition - transition_with_deposit_right_before_fork [Preset: minimal]     OK
++ EF - Altair - Transition - transition_with_finality [Preset: minimal]                      OK
++ EF - Altair - Transition - transition_with_leaking_at_fork [Preset: minimal]               OK
++ EF - Altair - Transition - transition_with_leaking_pre_fork [Preset: minimal]              OK
++ EF - Altair - Transition - transition_with_no_attestations_until_after_fork [Preset: minim OK
++ EF - Altair - Transition - transition_with_non_empty_activation_queue [Preset: minimal]    OK
++ EF - Altair - Transition - transition_with_one_fourth_exiting_validators_exit_at_fork [Pre OK
++ EF - Altair - Transition - transition_with_one_fourth_exiting_validators_exit_post_fork [P OK
++ EF - Altair - Transition - transition_with_one_fourth_slashed_active_validators_pre_fork [ OK
++ EF - Altair - Transition - transition_with_proposer_slashing_right_after_fork [Preset: min OK
++ EF - Altair - Transition - transition_with_proposer_slashing_right_before_fork [Preset: mi OK
++ EF - Altair - Transition - transition_with_random_half_participation [Preset: minimal]     OK
++ EF - Altair - Transition - transition_with_random_three_quarters_participation [Preset: mi OK
++ EF - Altair - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minima OK
++ EF - Altair - Transition - transition_with_voluntary_exit_right_before_fork [Preset: minim OK
++ EF - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: minimal]               OK
++ EF - Bellatrix - Rewards - empty [Preset: minimal]                                         OK
++ EF - Bellatrix - Rewards - empty_leak [Preset: minimal]                                    OK
++ EF - Bellatrix - Rewards - full_all_correct [Preset: minimal]                              OK
++ EF - Bellatrix - Rewards - full_but_partial_participation [Preset: minimal]                OK
++ EF - Bellatrix - Rewards - full_but_partial_participation_leak [Preset: minimal]           OK
++ EF - Bellatrix - Rewards - full_leak [Preset: minimal]                                     OK
++ EF - Bellatrix - Rewards - full_random_0 [Preset: minimal]                                 OK
++ EF - Bellatrix - Rewards - full_random_1 [Preset: minimal]                                 OK
++ EF - Bellatrix - Rewards - full_random_2 [Preset: minimal]                                 OK
++ EF - Bellatrix - Rewards - full_random_3 [Preset: minimal]                                 OK
++ EF - Bellatrix - Rewards - full_random_4 [Preset: minimal]                                 OK
++ EF - Bellatrix - Rewards - full_random_leak [Preset: minimal]                              OK
++ EF - Bellatrix - Rewards - full_random_low_balances_0 [Preset: minimal]                    OK
++ EF - Bellatrix - Rewards - full_random_low_balances_1 [Preset: minimal]                    OK
++ EF - Bellatrix - Rewards - full_random_misc_balances [Preset: minimal]                     OK
++ EF - Bellatrix - Rewards - full_random_seven_epoch_leak [Preset: minimal]                  OK
++ EF - Bellatrix - Rewards - full_random_ten_epoch_leak [Preset: minimal]                    OK
++ EF - Bellatrix - Rewards - full_random_without_leak_0 [Preset: minimal]                    OK
++ EF - Bellatrix - Rewards - full_random_without_leak_and_current_exit_0 [Preset: minimal]   OK
++ EF - Bellatrix - Rewards - half_full [Preset: minimal]                                     OK
++ EF - Bellatrix - Rewards - half_full_leak [Preset: minimal]                                OK
++ EF - Bellatrix - Rewards - quarter_full [Preset: minimal]                                  OK
++ EF - Bellatrix - Rewards - quarter_full_leak [Preset: minimal]                             OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_attested [Preset: minimal OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: mi OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: m OK
++ EF - Bellatrix - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Pres OK
++ EF - Bellatrix - Rewards - with_exited_validators [Preset: minimal]                        OK
++ EF - Bellatrix - Rewards - with_exited_validators_leak [Preset: minimal]                   OK
++ EF - Bellatrix - Rewards - with_not_yet_activated_validators [Preset: minimal]             OK
++ EF - Bellatrix - Rewards - with_not_yet_activated_validators_leak [Preset: minimal]        OK
++ EF - Bellatrix - Rewards - with_slashed_validators [Preset: minimal]                       OK
++ EF - Bellatrix - Rewards - with_slashed_validators_leak [Preset: minimal]                  OK
++ EF - Bellatrix - Transition - normal_transition [Preset: minimal]                          OK
++ EF - Bellatrix - Transition - sample_transition [Preset: minimal]                          OK
++ EF - Bellatrix - Transition - transition_missing_first_post_block [Preset: minimal]        OK
++ EF - Bellatrix - Transition - transition_missing_last_pre_fork_block [Preset: minimal]     OK
++ EF - Bellatrix - Transition - transition_only_blocks_post_fork [Preset: minimal]           OK
++ EF - Bellatrix - Transition - transition_with_activation_at_fork_epoch [Preset: minimal]   OK
++ EF - Bellatrix - Transition - transition_with_attester_slashing_right_after_fork [Preset:  OK
++ EF - Bellatrix - Transition - transition_with_attester_slashing_right_before_fork [Preset: OK
++ EF - Bellatrix - Transition - transition_with_deposit_right_after_fork [Preset: minimal]   OK
++ EF - Bellatrix - Transition - transition_with_deposit_right_before_fork [Preset: minimal]  OK
++ EF - Bellatrix - Transition - transition_with_finality [Preset: minimal]                   OK
++ EF - Bellatrix - Transition - transition_with_leaking_at_fork [Preset: minimal]            OK
++ EF - Bellatrix - Transition - transition_with_leaking_pre_fork [Preset: minimal]           OK
++ EF - Bellatrix - Transition - transition_with_no_attestations_until_after_fork [Preset: mi OK
++ EF - Bellatrix - Transition - transition_with_non_empty_activation_queue [Preset: minimal] OK
++ EF - Bellatrix - Transition - transition_with_one_fourth_exiting_validators_exit_at_fork [ OK
++ EF - Bellatrix - Transition - transition_with_one_fourth_exiting_validators_exit_post_fork OK
++ EF - Bellatrix - Transition - transition_with_one_fourth_slashed_active_validators_pre_for OK
++ EF - Bellatrix - Transition - transition_with_proposer_slashing_right_after_fork [Preset:  OK
++ EF - Bellatrix - Transition - transition_with_proposer_slashing_right_before_fork [Preset: OK
++ EF - Bellatrix - Transition - transition_with_random_half_participation [Preset: minimal]  OK
++ EF - Bellatrix - Transition - transition_with_random_three_quarters_participation [Preset: OK
++ EF - Bellatrix - Transition - transition_with_voluntary_exit_right_after_fork [Preset: min OK
++ EF - Bellatrix - Transition - transition_with_voluntary_exit_right_before_fork [Preset: mi OK
++ EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: minimal]                 OK
++ EF - Phase 0 - Rewards - duplicate_attestations_at_later_slots [Preset: minimal]           OK
++ EF - Phase 0 - Rewards - empty [Preset: minimal]                                           OK
++ EF - Phase 0 - Rewards - empty_leak [Preset: minimal]                                      OK
++ EF - Phase 0 - Rewards - full_all_correct [Preset: minimal]                                OK
++ EF - Phase 0 - Rewards - full_but_partial_participation [Preset: minimal]                  OK
++ EF - Phase 0 - Rewards - full_but_partial_participation_leak [Preset: minimal]             OK
++ EF - Phase 0 - Rewards - full_correct_target_incorrect_head [Preset: minimal]              OK
++ EF - Phase 0 - Rewards - full_correct_target_incorrect_head_leak [Preset: minimal]         OK
++ EF - Phase 0 - Rewards - full_delay_max_slots [Preset: minimal]                            OK
++ EF - Phase 0 - Rewards - full_delay_one_slot [Preset: minimal]                             OK
++ EF - Phase 0 - Rewards - full_half_correct_target_incorrect_head [Preset: minimal]         OK
++ EF - Phase 0 - Rewards - full_half_correct_target_incorrect_head_leak [Preset: minimal]    OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_correct_head [Preset: minimal]         OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_correct_head_leak [Preset: minimal]    OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head [Preset: minimal]       OK
++ EF - Phase 0 - Rewards - full_half_incorrect_target_incorrect_head_leak [Preset: minimal]  OK
++ EF - Phase 0 - Rewards - full_leak [Preset: minimal]                                       OK
++ EF - Phase 0 - Rewards - full_mixed_delay [Preset: minimal]                                OK
++ EF - Phase 0 - Rewards - full_random_0 [Preset: minimal]                                   OK
++ EF - Phase 0 - Rewards - full_random_1 [Preset: minimal]                                   OK
++ EF - Phase 0 - Rewards - full_random_2 [Preset: minimal]                                   OK
++ EF - Phase 0 - Rewards - full_random_3 [Preset: minimal]                                   OK
++ EF - Phase 0 - Rewards - full_random_4 [Preset: minimal]                                   OK
++ EF - Phase 0 - Rewards - full_random_leak [Preset: minimal]                                OK
++ EF - Phase 0 - Rewards - full_random_low_balances_0 [Preset: minimal]                      OK
++ EF - Phase 0 - Rewards - full_random_low_balances_1 [Preset: minimal]                      OK
++ EF - Phase 0 - Rewards - full_random_misc_balances [Preset: minimal]                       OK
++ EF - Phase 0 - Rewards - full_random_seven_epoch_leak [Preset: minimal]                    OK
++ EF - Phase 0 - Rewards - full_random_ten_epoch_leak [Preset: minimal]                      OK
++ EF - Phase 0 - Rewards - full_random_without_leak_0 [Preset: minimal]                      OK
++ EF - Phase 0 - Rewards - full_random_without_leak_and_current_exit_0 [Preset: minimal]     OK
++ EF - Phase 0 - Rewards - half_full [Preset: minimal]                                       OK
++ EF - Phase 0 - Rewards - half_full_leak [Preset: minimal]                                  OK
++ EF - Phase 0 - Rewards - one_attestation_one_correct [Preset: minimal]                     OK
++ EF - Phase 0 - Rewards - one_attestation_one_correct_leak [Preset: minimal]                OK
++ EF - Phase 0 - Rewards - proposer_not_in_attestations [Preset: minimal]                    OK
++ EF - Phase 0 - Rewards - quarter_full [Preset: minimal]                                    OK
++ EF - Phase 0 - Rewards - quarter_full_leak [Preset: minimal]                               OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_attested [Preset: minimal]  OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_attested_leak [Preset: mini OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_attest [Preset: min OK
++ EF - Phase 0 - Rewards - some_very_low_effective_balances_that_did_not_attest_leak [Preset OK
++ EF - Phase 0 - Rewards - with_exited_validators [Preset: minimal]                          OK
++ EF - Phase 0 - Rewards - with_exited_validators_leak [Preset: minimal]                     OK
++ EF - Phase 0 - Rewards - with_not_yet_activated_validators [Preset: minimal]               OK
++ EF - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset: minimal]          OK
++ EF - Phase 0 - Rewards - with_slashed_validators [Preset: minimal]                         OK
++ EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: minimal]                    OK
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_same_proposer_slashings_ OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_similar_proposer_slashin OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - double_validator_exit_same_bloc OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - duplicate_attester_slashing [Pr OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - expected_deposit_in_block [Pres OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_block_sig [Preset: mini OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_proposer_index_sig_from OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_proposer_index_sig_from OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - invalid_state_root [Preset: min OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - parent_from_same_slot [Preset:  OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - prev_slot_block_transition [Pre OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - same_slot_block_transition [Pre OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_same_index [Pres OK
-+ [Invalid] Ethereum Foundation - Altair - Sanity - Blocks - zero_block_sig [Preset: minimal OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_same_proposer_slashin OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_similar_proposer_slas OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - double_validator_exit_same_b OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - duplicate_attester_slashing  OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - expected_deposit_in_block [P OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_block_sig [Preset: m OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_f OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_f OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - invalid_state_root [Preset:  OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - parent_from_same_slot [Prese OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - prev_slot_block_transition [ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - same_slot_block_transition [ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - slash_and_exit_same_index [P OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Sanity - Blocks - zero_block_sig [Preset: mini OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_same_proposer_slashings OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_similar_proposer_slashi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - double_validator_exit_same_blo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - duplicate_attester_slashing [P OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - expected_deposit_in_block [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_block_sig [Preset: min OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_fro OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_fro OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - invalid_state_root [Preset: mi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - parent_from_same_slot [Preset: OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - prev_slot_block_transition [Pr OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - proposal_for_genesis_slot [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - same_slot_block_transition [Pr OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Pre OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Sanity - Blocks - zero_block_sig [Preset: minima OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_no_updates_at_genesis [Preset OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_1 [Preset: minimal]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_2 [Preset: minimal]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_3 [Preset: minimal]      OK
-+ [Valid]   Ethereum Foundation - Altair - Finality - finality_rule_4 [Preset: minimal]      OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_0 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_1 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_10 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_11 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_12 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_13 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_14 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_15 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_2 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_3 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_4 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_5 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_6 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_7 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_8 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Random - randomized_9 [Preset: minimal]           OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - attestation [Preset: minimal]   OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - attester_slashing [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - balance_driven_status_transitio OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - deposit_in_block [Preset: minim OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - deposit_top_up [Preset: minimal OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_block_transition [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_block_transition_large_va OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_epoch_transition [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_epoch_transition_large_va OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_epoch_transition_not_fina OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_sync_committee_committee  OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - empty_sync_committee_committee_ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - eth1_data_votes_consensus [Pres OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - eth1_data_votes_no_consensus [P OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_0 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_1 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_2 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_random_operations_3 [Prese OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_sync_committee_committee [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - full_sync_committee_committee_g OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - half_sync_committee_committee [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - half_sync_committee_committee_g OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - high_proposer_index [Preset: mi OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - historical_batch [Preset: minim OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - inactivity_scores_full_particip OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - inactivity_scores_leaking [Pres OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_attester_slashings_no_ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_attester_slashings_par OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_different_proposer_sla OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - multiple_different_validator_ex OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_after_inactive_index [ OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_self_slashing [Preset: OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - proposer_slashing [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - skipped_slots [Preset: minimal] OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - slash_and_exit_diff_index [Pres OK
-+ [Valid]   Ethereum Foundation - Altair - Sanity - Blocks - voluntary_exit [Preset: minimal OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_no_updates_at_genesis [Pre OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_1 [Preset: minimal]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_2 [Preset: minimal]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_3 [Preset: minimal]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Finality - finality_rule_4 [Preset: minimal]   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - attestation [Preset: minimal OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - attester_slashing [Preset: m OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - balance_driven_status_transi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - deposit_in_block [Preset: mi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - deposit_top_up [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_block_transition [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_block_transition_large OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_block_transition_no_tx OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_epoch_transition [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_epoch_transition_large OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_epoch_transition_not_f OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_sync_committee_committ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - empty_sync_committee_committ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - eth1_data_votes_consensus [P OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - eth1_data_votes_no_consensus OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_0 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_1 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_2 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_random_operations_3 [Pr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - full_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - half_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - half_sync_committee_committe OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - high_proposer_index [Preset: OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - historical_batch [Preset: mi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - inactivity_scores_full_parti OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - inactivity_scores_leaking [P OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - is_execution_enabled_false [ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_attester_slashings_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_attester_slashings_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_different_proposer_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - multiple_different_validator OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_after_inactive_inde OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_self_slashing [Pres OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - proposer_slashing [Preset: m OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - skipped_slots [Preset: minim OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - slash_and_exit_diff_index [P OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_no_updates_at_genesis [Prese OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_1 [Preset: minimal]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_2 [Preset: minimal]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_3 [Preset: minimal]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Finality - finality_rule_4 [Preset: minimal]     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_0 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_1 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_10 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_11 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_12 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_13 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_14 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_15 [Preset: minimal]         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_2 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_3 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_4 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_5 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_6 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_7 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_8 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Random - randomized_9 [Preset: minimal]          OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - attestation [Preset: minimal]  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - attester_slashing [Preset: min OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - balance_driven_status_transiti OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: minima OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_block_transition [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_block_transition_large_v OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_epoch_transition_large_v OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - empty_epoch_transition_not_fin OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - eth1_data_votes_consensus [Pre OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - eth1_data_votes_no_consensus [ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_0 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_1 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_2 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - full_random_operations_3 [Pres OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: m OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - historical_batch [Preset: mini OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_attester_slashings_pa OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_different_proposer_sl OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - multiple_different_validator_e OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_after_inactive_index  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: min OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - skipped_slots [Preset: minimal OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Pre OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minima OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
++ [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: minima OK
++ [Invalid] EF - Altair - Sanity - Blocks - duplicate_attester_slashing [Preset: minimal]    OK
++ [Invalid] EF - Altair - Sanity - Blocks - expected_deposit_in_block [Preset: minimal]      OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_block_sig [Preset: minimal]              OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_proposer_index_sig_from_expected_propose OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_index [ OK
++ [Invalid] EF - Altair - Sanity - Blocks - invalid_state_root [Preset: minimal]             OK
++ [Invalid] EF - Altair - Sanity - Blocks - parent_from_same_slot [Preset: minimal]          OK
++ [Invalid] EF - Altair - Sanity - Blocks - prev_slot_block_transition [Preset: minimal]     OK
++ [Invalid] EF - Altair - Sanity - Blocks - same_slot_block_transition [Preset: minimal]     OK
++ [Invalid] EF - Altair - Sanity - Blocks - slash_and_exit_same_index [Preset: minimal]      OK
++ [Invalid] EF - Altair - Sanity - Blocks - zero_block_sig [Preset: minimal]                 OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_same_proposer_slashings_same_block [Pr OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_similar_proposer_slashings_same_block  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - double_validator_exit_same_block [Preset: min OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - duplicate_attester_slashing [Preset: minimal] OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - expected_deposit_in_block [Preset: minimal]   OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_block_sig [Preset: minimal]           OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_from_expected_prop OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_inde OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_state_root [Preset: minimal]          OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - parent_from_same_slot [Preset: minimal]       OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - prev_slot_block_transition [Preset: minimal]  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - same_slot_block_transition [Preset: minimal]  OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - slash_and_exit_same_index [Preset: minimal]   OK
++ [Invalid] EF - Bellatrix - Sanity - Blocks - zero_block_sig [Preset: minimal]              OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_same_proposer_slashings_same_block [Pres OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_similar_proposer_slashings_same_block [P OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - double_validator_exit_same_block [Preset: minim OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - duplicate_attester_slashing [Preset: minimal]   OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - expected_deposit_in_block [Preset: minimal]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_block_sig [Preset: minimal]             OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_from_expected_propos OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposer_index_sig_from_proposer_index  OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_state_root [Preset: minimal]            OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - parent_from_same_slot [Preset: minimal]         OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - prev_slot_block_transition [Preset: minimal]    OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - proposal_for_genesis_slot [Preset: minimal]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - same_slot_block_transition [Preset: minimal]    OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Preset: minimal]     OK
++ [Invalid] EF - Phase 0 - Sanity - Blocks - zero_block_sig [Preset: minimal]                OK
++ [Valid]   EF - Altair - Finality - finality_no_updates_at_genesis [Preset: minimal]        OK
++ [Valid]   EF - Altair - Finality - finality_rule_1 [Preset: minimal]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_2 [Preset: minimal]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_3 [Preset: minimal]                       OK
++ [Valid]   EF - Altair - Finality - finality_rule_4 [Preset: minimal]                       OK
++ [Valid]   EF - Altair - Random - randomized_0 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_1 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_10 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_11 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_12 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_13 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_14 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_15 [Preset: minimal]                           OK
++ [Valid]   EF - Altair - Random - randomized_2 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_3 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_4 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_5 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_6 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_7 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_8 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Random - randomized_9 [Preset: minimal]                            OK
++ [Valid]   EF - Altair - Sanity - Blocks - attestation [Preset: minimal]                    OK
++ [Valid]   EF - Altair - Sanity - Blocks - attester_slashing [Preset: minimal]              OK
++ [Valid]   EF - Altair - Sanity - Blocks - balance_driven_status_transitions [Preset: minim OK
++ [Valid]   EF - Altair - Sanity - Blocks - deposit_in_block [Preset: minimal]               OK
++ [Valid]   EF - Altair - Sanity - Blocks - deposit_top_up [Preset: minimal]                 OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_block_transition [Preset: minimal]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_block_transition_large_validator_set [Pres OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_epoch_transition [Preset: minimal]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_epoch_transition_large_validator_set [Pres OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset: m OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_sync_committee_committee [Preset: minimal] OK
++ [Valid]   EF - Altair - Sanity - Blocks - empty_sync_committee_committee_genesis [Preset:  OK
++ [Valid]   EF - Altair - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]      OK
++ [Valid]   EF - Altair - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]   OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_0 [Preset: minimal]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_1 [Preset: minimal]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_2 [Preset: minimal]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_random_operations_3 [Preset: minimal]       OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_sync_committee_committee [Preset: minimal]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - full_sync_committee_committee_genesis [Preset: m OK
++ [Valid]   EF - Altair - Sanity - Blocks - half_sync_committee_committee [Preset: minimal]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - half_sync_committee_committee_genesis [Preset: m OK
++ [Valid]   EF - Altair - Sanity - Blocks - high_proposer_index [Preset: minimal]            OK
++ [Valid]   EF - Altair - Sanity - Blocks - historical_batch [Preset: minimal]               OK
++ [Valid]   EF - Altair - Sanity - Blocks - inactivity_scores_full_participation_leaking [Pr OK
++ [Valid]   EF - Altair - Sanity - Blocks - inactivity_scores_leaking [Preset: minimal]      OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset:  OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pre OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_different_proposer_slashings_same_block OK
++ [Valid]   EF - Altair - Sanity - Blocks - multiple_different_validator_exits_same_block [P OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_after_inactive_index [Preset: minimal]  OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_self_slashing [Preset: minimal]         OK
++ [Valid]   EF - Altair - Sanity - Blocks - proposer_slashing [Preset: minimal]              OK
++ [Valid]   EF - Altair - Sanity - Blocks - skipped_slots [Preset: minimal]                  OK
++ [Valid]   EF - Altair - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]      OK
++ [Valid]   EF - Altair - Sanity - Blocks - voluntary_exit [Preset: minimal]                 OK
++ [Valid]   EF - Bellatrix - Finality - finality_no_updates_at_genesis [Preset: minimal]     OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_1 [Preset: minimal]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_2 [Preset: minimal]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: minimal]                    OK
++ [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: minimal]                    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - attestation [Preset: minimal]                 OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - attester_slashing [Preset: minimal]           OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - balance_driven_status_transitions [Preset: mi OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - deposit_in_block [Preset: minimal]            OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - deposit_top_up [Preset: minimal]              OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_block_transition [Preset: minimal]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_block_transition_large_validator_set [P OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_block_transition_no_tx [Preset: minimal OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_epoch_transition [Preset: minimal]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_epoch_transition_large_validator_set [P OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_sync_committee_committee [Preset: minim OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - empty_sync_committee_committee_genesis [Prese OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]   OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_0 [Preset: minimal]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_1 [Preset: minimal]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_2 [Preset: minimal]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_random_operations_3 [Preset: minimal]    OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_sync_committee_committee [Preset: minima OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - full_sync_committee_committee_genesis [Preset OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - half_sync_committee_committee [Preset: minima OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - half_sync_committee_committee_genesis [Preset OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - high_proposer_index [Preset: minimal]         OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - historical_batch [Preset: minimal]            OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - inactivity_scores_full_participation_leaking  OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - inactivity_scores_leaking [Preset: minimal]   OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - is_execution_enabled_false [Preset: minimal]  OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_attester_slashings_no_overlap [Prese OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_attester_slashings_partial_overlap [ OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_different_proposer_slashings_same_bl OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - multiple_different_validator_exits_same_block OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_after_inactive_index [Preset: minima OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_self_slashing [Preset: minimal]      OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - proposer_slashing [Preset: minimal]           OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - skipped_slots [Preset: minimal]               OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]   OK
++ [Valid]   EF - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: minimal]              OK
++ [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_1 [Preset: minimal]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_2 [Preset: minimal]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_3 [Preset: minimal]                      OK
++ [Valid]   EF - Phase 0 - Finality - finality_rule_4 [Preset: minimal]                      OK
++ [Valid]   EF - Phase 0 - Random - randomized_0 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_1 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_10 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_11 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_12 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_13 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_14 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_15 [Preset: minimal]                          OK
++ [Valid]   EF - Phase 0 - Random - randomized_2 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_3 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_4 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_5 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_6 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_7 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_8 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Random - randomized_9 [Preset: minimal]                           OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - attestation [Preset: minimal]                   OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - attester_slashing [Preset: minimal]             OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - balance_driven_status_transitions [Preset: mini OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: minimal]              OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: minimal]                OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition [Preset: minimal]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition_large_validator_set [Pre OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset: minimal]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition_large_validator_set [Pre OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset:  OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]     OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]  OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_0 [Preset: minimal]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_1 [Preset: minimal]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_2 [Preset: minimal]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_3 [Preset: minimal]      OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: minimal]           OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - historical_batch [Preset: minimal]              OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset: OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pr OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_proposer_slashings_same_bloc OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_validator_exits_same_block [ OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_after_inactive_index [Preset: minimal] OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset: minimal]        OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: minimal]             OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - skipped_slots [Preset: minimal]                 OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
++ [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + altair_fork_random_0                                                                       OK
 + altair_fork_random_1                                                                       OK
 + altair_fork_random_2                                                                       OK
@@ -348,6 +372,13 @@ ConsensusSpecPreset-minimal
 + altair_fork_random_low_balances                                                            OK
 + altair_fork_random_misc_balances                                                           OK
 + altair_fork_random_mismatched_attestations                                                 OK
++ bellatrix_fork_random_0                                                                    OK
++ bellatrix_fork_random_1                                                                    OK
++ bellatrix_fork_random_2                                                                    OK
++ bellatrix_fork_random_3                                                                    OK
++ bellatrix_fork_random_large_validator_set                                                  OK
++ bellatrix_fork_random_low_balances                                                         OK
++ bellatrix_fork_random_misc_balances                                                        OK
 + finality_root_merkle_proof                                                                 OK
 + fork_base_state                                                                            OK
 + fork_many_next_epoch                                                                       OK
@@ -358,304 +389,304 @@ ConsensusSpecPreset-minimal
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 355/355 Fail: 0/355 Skip: 0/355
+OK: 386/386 Fail: 0/386 Skip: 0/386
 ## Attestation
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - after_epoch_slots      OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - bad_source_root        OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - before_inclusion_delay OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - correct_after_epoch_de OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - empty_participants_see OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - empty_participants_zer OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - future_target_epoch    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_after_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_after OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_attestation_si OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_current_source OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_index          OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - invalid_previous_sourc OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - mismatched_target_and_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - new_source_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - old_source_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - old_target_epoch       OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - source_root_is_target_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - too_few_aggregation_bi OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - too_many_aggregation_b OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_commit OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_slot_0 OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attestation - wrong_index_for_slot_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - after_epoch_slots   OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - bad_source_root     OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - before_inclusion_de OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - correct_after_epoch OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - empty_participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - empty_participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - future_target_epoch OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_afte OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_af OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_attestation OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_current_sou OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_index       OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - invalid_previous_so OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - mismatched_target_a OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - new_source_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - old_source_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - old_target_epoch    OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - source_root_is_targ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - too_few_aggregation OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - too_many_aggregatio OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_com OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_slo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attestation - wrong_index_for_slo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - after_epoch_slots     OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - bad_source_root       OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - before_inclusion_dela OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - correct_after_epoch_d OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - empty_participants_se OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - empty_participants_ze OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - future_target_epoch   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_after_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_afte OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_attestation_s OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_current_sourc OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_index         OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - invalid_previous_sour OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - mismatched_target_and OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - new_source_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - old_source_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - old_target_epoch      OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - source_root_is_target OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - too_few_aggregation_b OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - too_many_aggregation_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_commi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_slot_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attestation - wrong_index_for_slot_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_epoch_delay    OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_min_inclusion_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - correct_sqrt_epoch_del OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_and_tar OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_epoch_d OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_min_inc OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_head_sqrt_ep OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_epoch OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_min_i OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - incorrect_target_sqrt_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success                OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success_multi_proposer OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attestation - success_previous_epoch OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_epoch_delay OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_min_inclusi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - correct_sqrt_epoch_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_and_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_epoc OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_min_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_head_sqrt OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_ep OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_mi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - incorrect_target_sq OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success             OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success_multi_propo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attestation - success_previous_ep OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_epoch_delay   OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_min_inclusion OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - correct_sqrt_epoch_de OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_and_ta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_epoch_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_min_in OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_head_sqrt_e OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_epoc OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_min_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - incorrect_target_sqrt OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success               OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success_multi_propose OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attestation - success_previous_epoc OK
++ [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
++ [Invalid] EF - Altair - Operations - Attestation - bad_source_root                         OK
++ [Invalid] EF - Altair - Operations - Attestation - before_inclusion_delay                  OK
++ [Invalid] EF - Altair - Operations - Attestation - correct_after_epoch_delay               OK
++ [Invalid] EF - Altair - Operations - Attestation - empty_participants_seemingly_valid_sig  OK
++ [Invalid] EF - Altair - Operations - Attestation - empty_participants_zeroes_sig           OK
++ [Invalid] EF - Altair - Operations - Attestation - future_target_epoch                     OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_head_after_epoch_delay        OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_head_and_target_after_epoch_d OK
++ [Invalid] EF - Altair - Operations - Attestation - incorrect_target_after_epoch_delay      OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_attestation_signature           OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_current_source_root             OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_index                           OK
++ [Invalid] EF - Altair - Operations - Attestation - invalid_previous_source_root            OK
++ [Invalid] EF - Altair - Operations - Attestation - mismatched_target_and_slot              OK
++ [Invalid] EF - Altair - Operations - Attestation - new_source_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - old_source_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - old_target_epoch                        OK
++ [Invalid] EF - Altair - Operations - Attestation - source_root_is_target_root              OK
++ [Invalid] EF - Altair - Operations - Attestation - too_few_aggregation_bits                OK
++ [Invalid] EF - Altair - Operations - Attestation - too_many_aggregation_bits               OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_committee_signature     OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_slot_0                  OK
++ [Invalid] EF - Altair - Operations - Attestation - wrong_index_for_slot_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - after_epoch_slots                    OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - bad_source_root                      OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - before_inclusion_delay               OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - correct_after_epoch_delay            OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - empty_participants_seemingly_valid_s OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - empty_participants_zeroes_sig        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - future_target_epoch                  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_head_after_epoch_delay     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_after_epoc OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - incorrect_target_after_epoch_delay   OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_attestation_signature        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_current_source_root          OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_index                        OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - invalid_previous_source_root         OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - mismatched_target_and_slot           OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - new_source_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - old_source_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - old_target_epoch                     OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - source_root_is_target_root           OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - too_few_aggregation_bits             OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - too_many_aggregation_bits            OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_committee_signature  OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_slot_0               OK
++ [Invalid] EF - Bellatrix - Operations - Attestation - wrong_index_for_slot_1               OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - after_epoch_slots                      OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - bad_source_root                        OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - before_inclusion_delay                 OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - correct_after_epoch_delay              OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - empty_participants_seemingly_valid_sig OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - empty_participants_zeroes_sig          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - future_target_epoch                    OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_head_after_epoch_delay       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_after_epoch_ OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - incorrect_target_after_epoch_delay     OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_attestation_signature          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_current_source_root            OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_index                          OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - invalid_previous_source_root           OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - mismatched_target_and_slot             OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - new_source_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - old_source_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - old_target_epoch                       OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - source_root_is_target_root             OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - too_few_aggregation_bits               OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - too_many_aggregation_bits              OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_committee_signature    OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_slot_0                 OK
++ [Invalid] EF - Phase 0 - Operations - Attestation - wrong_index_for_slot_1                 OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_epoch_delay                     OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_min_inclusion_delay             OK
++ [Valid]   EF - Altair - Operations - Attestation - correct_sqrt_epoch_delay                OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_epoch_delay   OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_min_inclusion OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_and_target_sqrt_epoch_de OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_epoch_delay              OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_min_inclusion_delay      OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_head_sqrt_epoch_delay         OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_epoch_delay            OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_min_inclusion_delay    OK
++ [Valid]   EF - Altair - Operations - Attestation - incorrect_target_sqrt_epoch_delay       OK
++ [Valid]   EF - Altair - Operations - Attestation - success                                 OK
++ [Valid]   EF - Altair - Operations - Attestation - success_multi_proposer_index_iterations OK
++ [Valid]   EF - Altair - Operations - Attestation - success_previous_epoch                  OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_epoch_delay                  OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_min_inclusion_delay          OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - correct_sqrt_epoch_delay             OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_epoch_dela OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_min_inclus OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_and_target_sqrt_epoch OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_epoch_delay           OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_min_inclusion_delay   OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_head_sqrt_epoch_delay      OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_epoch_delay         OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_min_inclusion_delay OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - incorrect_target_sqrt_epoch_delay    OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success                              OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success_multi_proposer_index_iterati OK
++ [Valid]   EF - Bellatrix - Operations - Attestation - success_previous_epoch               OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_epoch_delay                    OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_min_inclusion_delay            OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - correct_sqrt_epoch_delay               OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_epoch_delay  OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_min_inclusio OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_and_target_sqrt_epoch_d OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_epoch_delay             OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_min_inclusion_delay     OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_head_sqrt_epoch_delay        OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_epoch_delay           OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_min_inclusion_delay   OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - incorrect_target_sqrt_epoch_delay      OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success                                OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success_multi_proposer_index_iteration OK
++ [Valid]   EF - Phase 0 - Operations - Attestation - success_previous_epoch                 OK
 ```
 OK: 117/117 Fail: 0/117 Skip: 0/117
 ## Attester Slashing
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - all_empty_indice OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_bad_extra_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_bad_replace OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_empty_indic OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att1_high_index  OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_bad_extra_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_bad_replace OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_duplicate_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_empty_indic OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - att2_high_index  OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_1    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - invalid_sig_2    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - no_double_or_sur OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - participants_alr OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - same_data        OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - unsorted_att_1   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Attester Slashing - unsorted_att_2   OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - all_empty_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_bad_extr OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_bad_repl OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_empty_in OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att1_high_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_bad_extr OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_bad_repl OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_duplicat OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_empty_in OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - att2_high_ind OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - invalid_sig_2 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - no_double_or_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - participants_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - same_data     OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - unsorted_att_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Attester Slashing - unsorted_att_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - all_empty_indic OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_bad_extra_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_bad_replac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_empty_indi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att1_high_index OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_bad_extra_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_bad_replac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_duplicate_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_empty_indi OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - att2_high_index OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_1   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - invalid_sig_2   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - no_double_or_su OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - participants_al OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - same_data       OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - unsorted_att_1  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Attester Slashing - unsorted_att_2  OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_already_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_already_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_attestat OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_double   OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_low_bala OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_misc_bal OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_proposer OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_surround OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Attester Slashing - success_with_eff OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_alrea OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_alrea OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_attes OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_doubl OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_low_b OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_misc_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_propo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_surro OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Attester Slashing - success_with_ OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_already OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_already OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_attesta OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_double  OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_low_bal OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_misc_ba OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_propose OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_surroun OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Attester Slashing - success_with_ef OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - all_empty_indices                 OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_bad_extra_index              OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_bad_replaced_index           OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_duplicate_index_double_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_duplicate_index_normal_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_empty_indices                OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att1_high_index                   OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_bad_extra_index              OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_bad_replaced_index           OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_duplicate_index_double_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_duplicate_index_normal_signe OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_empty_indices                OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - att2_high_index                   OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_1                     OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_1_and_2               OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - invalid_sig_2                     OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - no_double_or_surround             OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - participants_already_slashed      OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - same_data                         OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - unsorted_att_1                    OK
++ [Invalid] EF - Altair - Operations - Attester Slashing - unsorted_att_2                    OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - all_empty_indices              OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_bad_extra_index           OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_bad_replaced_index        OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_duplicate_index_double_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_duplicate_index_normal_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_empty_indices             OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att1_high_index                OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_bad_extra_index           OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_bad_replaced_index        OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_duplicate_index_double_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_duplicate_index_normal_si OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_empty_indices             OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - att2_high_index                OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_1_and_2            OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_sig_2                  OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - no_double_or_surround          OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - participants_already_slashed   OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - same_data                      OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - unsorted_att_1                 OK
++ [Invalid] EF - Bellatrix - Operations - Attester Slashing - unsorted_att_2                 OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - all_empty_indices                OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_bad_extra_index             OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_bad_replaced_index          OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_duplicate_index_double_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_duplicate_index_normal_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_empty_indices               OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att1_high_index                  OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_bad_extra_index             OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_bad_replaced_index          OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_duplicate_index_double_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_duplicate_index_normal_sign OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_empty_indices               OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - att2_high_index                  OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_1                    OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_1_and_2              OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - invalid_sig_2                    OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - no_double_or_surround            OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - participants_already_slashed     OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - same_data                        OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - unsorted_att_1                   OK
++ [Invalid] EF - Phase 0 - Operations - Attester Slashing - unsorted_att_2                   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_already_exited_long_ago   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_already_exited_recent     OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_attestation_from_future   OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_double                    OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_low_balances              OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_misc_balances             OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_proposer_index_slashed    OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_surround                  OK
++ [Valid]   EF - Altair - Operations - Attester Slashing - success_with_effective_balance_di OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_already_exited_long_ag OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_already_exited_recent  OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_attestation_from_futur OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_double                 OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_low_balances           OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_misc_balances          OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_proposer_index_slashed OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_surround               OK
++ [Valid]   EF - Bellatrix - Operations - Attester Slashing - success_with_effective_balance OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_already_exited_long_ago  OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_already_exited_recent    OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_attestation_from_future  OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_double                   OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_low_balances             OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_misc_balances            OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_proposer_index_slashed   OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_surround                 OK
++ [Valid]   EF - Phase 0 - Operations - Attester Slashing - success_with_effective_balance_d OK
 ```
 OK: 90/90 Fail: 0/90 Skip: 0/90
 ## Block Header
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_multiple_bloc OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_parent_root   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_proposer_inde OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - invalid_slot_block_he OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Block Header - proposer_slashed      OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_multiple_b OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_parent_roo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_proposer_i OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - invalid_slot_block OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Block Header - proposer_slashed   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_multiple_blo OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_parent_root  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_proposer_ind OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - invalid_slot_block_h OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Block Header - proposer_slashed     OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Block Header - success_block_header  OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Block Header - success_block_head OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Block Header - success_block_header OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_multiple_blocks_single_slot    OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_parent_root                    OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_proposer_index                 OK
++ [Invalid] EF - Altair - Operations - Block Header - invalid_slot_block_header              OK
++ [Invalid] EF - Altair - Operations - Block Header - proposer_slashed                       OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_multiple_blocks_single_slot OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_parent_root                 OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_proposer_index              OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - invalid_slot_block_header           OK
++ [Invalid] EF - Bellatrix - Operations - Block Header - proposer_slashed                    OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_parent_root                   OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_proposer_index                OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - invalid_slot_block_header             OK
++ [Invalid] EF - Phase 0 - Operations - Block Header - proposer_slashed                      OK
++ [Valid]   EF - Altair - Operations - Block Header - success_block_header                   OK
++ [Valid]   EF - Bellatrix - Operations - Block Header - success_block_header                OK
++ [Valid]   EF - Phase 0 - Operations - Block Header - success_block_header                  OK
 ```
 OK: 18/18 Fail: 0/18 Skip: 0/18
 ## Deposit
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Deposit - bad_merkle_proof           OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Deposit - wrong_deposit_for_deposit_ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Deposit - bad_merkle_proof        OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Deposit - wrong_deposit_for_depos OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Deposit - bad_merkle_proof          OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Deposit - wrong_deposit_for_deposit OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_new_deposit    OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_other_version  OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_sig_top_up         OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - invalid_withdrawal_credent OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_eth1_withdrawa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_max            OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_non_versioned_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_over_max       OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - new_deposit_under_max      OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - success_top_up             OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Deposit - valid_sig_but_forked_state OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_new_deposit OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_other_versi OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_sig_top_up      OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - invalid_withdrawal_cred OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_eth1_withdr OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_max         OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_non_version OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_over_max    OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - new_deposit_under_max   OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - success_top_up          OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Deposit - valid_sig_but_forked_st OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_new_deposit   OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_other_version OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_sig_top_up        OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - invalid_withdrawal_creden OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_eth1_withdraw OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_max           OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_non_versioned OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_over_max      OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - new_deposit_under_max     OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - success_top_up            OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Deposit - valid_sig_but_forked_stat OK
++ [Invalid] EF - Altair - Operations - Deposit - bad_merkle_proof                            OK
++ [Invalid] EF - Altair - Operations - Deposit - wrong_deposit_for_deposit_count             OK
++ [Invalid] EF - Bellatrix - Operations - Deposit - bad_merkle_proof                         OK
++ [Invalid] EF - Bellatrix - Operations - Deposit - wrong_deposit_for_deposit_count          OK
++ [Invalid] EF - Phase 0 - Operations - Deposit - bad_merkle_proof                           OK
++ [Invalid] EF - Phase 0 - Operations - Deposit - wrong_deposit_for_deposit_count            OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_new_deposit                     OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_other_version                   OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_sig_top_up                          OK
++ [Valid]   EF - Altair - Operations - Deposit - invalid_withdrawal_credentials_top_up       OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_eth1_withdrawal_credentials     OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_max                             OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_over_max                        OK
++ [Valid]   EF - Altair - Operations - Deposit - new_deposit_under_max                       OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up                              OK
++ [Valid]   EF - Altair - Operations - Deposit - valid_sig_but_forked_state                  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_new_deposit                  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_other_version                OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_top_up                       OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - invalid_withdrawal_credentials_top_up    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_eth1_withdrawal_credentials  OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_max                          OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_over_max                     OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_under_max                    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up                           OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - valid_sig_but_forked_state               OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_new_deposit                    OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_top_up                         OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - invalid_withdrawal_credentials_top_up      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_eth1_withdrawal_credentials    OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_max                            OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_over_max                       OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_under_max                      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
 OK: 39/39 Fail: 0/39 Skip: 0/39
-## Ethereum Foundation - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
+## EF - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Eth1 data reset [Preset: minimal]
+## EF - Altair - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Altair - Epoch Processing - Historical roots update [Preset: minimal]
+## EF - Altair - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Inactivity [Preset: minimal]
+## EF - Altair - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
 + Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: minimal]      OK
@@ -678,7 +709,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19
-## Ethereum Foundation - Altair - Epoch Processing - Justification & Finalization [Preset: minimal]
+## EF - Altair - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
 + Justification & Finalization - 123_poor_support [Preset: minimal]                          OK
@@ -692,7 +723,7 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Altair - Epoch Processing - Participation flag updates [Preset: minimal]
+## EF - Altair - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
 + Participation flag updates - current_epoch_zeroed [Preset: minimal]                        OK
@@ -708,12 +739,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
-## Ethereum Foundation - Altair - Epoch Processing - RANDAO mixes reset [Preset: minimal]
+## EF - Altair - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Registry updates [Preset: minimal]
+## EF - Altair - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: minimal] OK
@@ -731,7 +762,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 ```
 OK: 14/14 Fail: 0/14 Skip: 0/14
-## Ethereum Foundation - Altair - Epoch Processing - Slashings [Preset: minimal]
+## EF - Altair - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
 + Slashings - max_penalties [Preset: minimal]                                                OK
@@ -740,12 +771,12 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Altair - Epoch Processing - Slashings reset [Preset: minimal]
+## EF - Altair - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Altair - Epoch Processing - Sync committee updates [Preset: minimal]
+## EF - Altair - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_boundary [Preset: minimal]        OK
 + Sync committee updates - sync_committees_progress_genesis [Preset: minimal]                OK
@@ -754,7 +785,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Altair - SSZ consensus objects  [Preset: minimal]
+## EF - Altair - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -793,30 +824,30 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 35/35 Fail: 0/35 Skip: 0/35
-## Ethereum Foundation - Altair - Unittests - Sync protocol [Preset: minimal]
+## EF - Altair - Unittests - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
-## Ethereum Foundation - Bellatrix - Epoch Processing - Effective balance updates [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Eth1 data reset [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Bellatrix - Epoch Processing - Historical roots update [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Inactivity [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
 + Inactivity - all_zero_inactivity_scores_empty_participation_leaking [Preset: minimal]      OK
@@ -839,7 +870,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19
-## Ethereum Foundation - Bellatrix - Epoch Processing - Justification & Finalization [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
 + Justification & Finalization - 123_poor_support [Preset: minimal]                          OK
@@ -853,7 +884,7 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Bellatrix - Epoch Processing - Participation flag updates [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
 + Participation flag updates - current_epoch_zeroed [Preset: minimal]                        OK
@@ -869,12 +900,12 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
-## Ethereum Foundation - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Registry updates [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: minimal] OK
@@ -892,7 +923,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 ```
 OK: 14/14 Fail: 0/14 Skip: 0/14
-## Ethereum Foundation - Bellatrix - Epoch Processing - Slashings [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
 + Slashings - max_penalties [Preset: minimal]                                                OK
@@ -901,12 +932,12 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Bellatrix - Epoch Processing - Slashings reset [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Bellatrix - Epoch Processing - Sync committee updates [Preset: minimal]
+## EF - Bellatrix - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_boundary [Preset: minimal]        OK
 + Sync committee updates - sync_committees_progress_genesis [Preset: minimal]                OK
@@ -915,7 +946,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Bellatrix - SSZ consensus objects  [Preset: minimal]
+## EF - Bellatrix - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -957,7 +988,7 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 38/38 Fail: 0/38 Skip: 0/38
-## Ethereum Foundation - ForkChoice [Preset: minimal]
+## EF - ForkChoice [Preset: minimal]
 ```diff
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/filtered_block_tree          Skip
@@ -981,23 +1012,23 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo Skip
 ```
 OK: 0/20 Fail: 0/20 Skip: 20/20
-## Ethereum Foundation - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Eth1 data reset [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
-## Ethereum Foundation - Phase 0 - Epoch Processing - Historical roots update [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Justification & Finalization [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
 + Justification & Finalization - 123_poor_support [Preset: minimal]                          OK
@@ -1011,17 +1042,17 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## Ethereum Foundation - Phase 0 - Epoch Processing - Participation record updates [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Participation record updates [Preset: minimal]
 ```diff
 + Participation record updates - updated_participation_record [Preset: minimal]              OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - Epoch Processing - Registry updates [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
 + Registry updates - activation_queue_activation_and_ejection__churn_limit [Preset: minimal] OK
@@ -1039,7 +1070,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 ```
 OK: 14/14 Fail: 0/14 Skip: 0/14
-## Ethereum Foundation - Phase 0 - Epoch Processing - Slashings [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
 + Slashings - max_penalties [Preset: minimal]                                                OK
@@ -1048,12 +1079,12 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## Ethereum Foundation - Phase 0 - Epoch Processing - Slashings reset [Preset: minimal]
+## EF - Phase 0 - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Ethereum Foundation - Phase 0 - SSZ consensus objects  [Preset: minimal]
+## EF - Phase 0 - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
 +   Testing    Attestation                                                                   OK
@@ -1086,155 +1117,155 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 27/27 Fail: 0/27 Skip: 0/27
 ## Execution Payload
 ```diff
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_everythin OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_execution OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_execution OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_parent_ha OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_random_fi OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_random_re OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_timestamp OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Execution Payload - bad_timestamp OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_first OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_first OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_regul OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Execution Payload - success_regul OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_everything_regular_payload OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_execution_first_payload    OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_execution_regular_payload  OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_parent_hash_regular_payloa OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_first_payload       OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_regular_payload     OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_first_payload    OK
++ [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_regular_payload  OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload          OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload_with_gap OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload        OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload_with_g OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Proposer Slashing
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - epochs_are_diffe OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - headers_are_same OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - headers_are_same OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_differen OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_proposer OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_1_an OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - invalid_sig_2    OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_not_ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_slas OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Proposer Slashing - proposer_is_with OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - epochs_are_di OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - headers_are_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - headers_are_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_diffe OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_propo OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_1 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - invalid_sig_2 OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_n OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_s OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - proposer_is_w OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - epochs_are_diff OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - headers_are_sam OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - headers_are_sam OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_differe OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_propose OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_a OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - invalid_sig_2   OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_not OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_sla OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - proposer_is_wit OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success          OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success_block_he OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Proposer Slashing - success_slashed_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success       OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success_block OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Proposer Slashing - success_slash OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success         OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success_block_h OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Proposer Slashing - success_slashed OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - epochs_are_different              OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - headers_are_same_sigs_are_differe OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - headers_are_same_sigs_are_same    OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_different_proposer_indice OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_proposer_index            OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1                     OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1_and_2               OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_1_and_2_swap          OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_sig_2                     OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_not_activated         OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_slashed               OK
++ [Invalid] EF - Altair - Operations - Proposer Slashing - proposer_is_withdrawn             OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - epochs_are_different           OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - headers_are_same_sigs_are_diff OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - headers_are_same_sigs_are_same OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_different_proposer_ind OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_proposer_index         OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1                  OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1_and_2            OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_1_and_2_swap       OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_sig_2                  OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_not_activated      OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_slashed            OK
++ [Invalid] EF - Bellatrix - Operations - Proposer Slashing - proposer_is_withdrawn          OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - epochs_are_different             OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - headers_are_same_sigs_are_differ OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - headers_are_same_sigs_are_same   OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_different_proposer_indic OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_proposer_index           OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1                    OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_and_2              OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_1_and_2_swap         OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - invalid_sig_2                    OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_not_activated        OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_slashed              OK
++ [Invalid] EF - Phase 0 - Operations - Proposer Slashing - proposer_is_withdrawn            OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success                           OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success_block_header_from_future  OK
++ [Valid]   EF - Altair - Operations - Proposer Slashing - success_slashed_and_proposer_inde OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success                        OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success_block_header_from_futu OK
++ [Valid]   EF - Bellatrix - Operations - Proposer Slashing - success_slashed_and_proposer_i OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success                          OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success_block_header_from_future OK
++ [Valid]   EF - Phase 0 - Operations - Proposer Slashing - success_slashed_and_proposer_ind OK
 ```
 OK: 45/45 Fail: 0/45 Skip: 0/45
 ## Sync Aggregate
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_b OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_i OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_m OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_n OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_p OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Sync Aggregate - invalid_signature_p OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - invalid_signatur OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - proposer_in_committ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - proposer_in_committ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_all_but_one_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_high_partici OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_low_particip OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_misc_balance OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_only_one_par OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - random_with_exits_w OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_rewa OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - sync_committee_with OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Sync Aggregate - valid_signature_fut OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - proposer_in_comm OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - proposer_in_comm OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_all_but_o OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_high_part OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_low_parti OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_misc_bala OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_only_one_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - random_with_exit OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_r OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - sync_committee_w OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Sync Aggregate - valid_signature_ OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_bad_domain         OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_extra_participant  OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_infinite_signature OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_infinite_signature OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_missing_participan OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_no_participants    OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_past_block         OK
++ [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_previous_committee OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_bad_domain      OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_extra_participa OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_infinite_signat OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_infinite_signat OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_missing_partici OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_no_participants OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_past_block      OK
++ [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_previous_commit OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - proposer_in_committee_with_participa OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - proposer_in_committee_without_partic OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_all_but_one_participating_wit OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_high_participation_without_du OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_low_participation_without_dup OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_misc_balances_and_half_partic OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_only_one_participant_without_ OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - random_with_exits_without_duplicates OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_empty_partici OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_nonduplicate_ OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_rewards_not_full_part OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_nonparticipating OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_nonparticipating OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_ex OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_wi OK
++ [Valid]   EF - Altair - Operations - Sync Aggregate - valid_signature_future_committee     OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - proposer_in_committee_with_partic OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - proposer_in_committee_without_par OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_all_but_one_participating_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_high_participation_without OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_low_participation_without_ OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_misc_balances_and_half_par OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_only_one_participant_witho OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - random_with_exits_without_duplica OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_empty_part OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_nonduplica OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_rewards_not_full_p OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_nonparticipat OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_nonparticipat OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
++ [Valid]   EF - Bellatrix - Operations - Sync Aggregate - valid_signature_future_committee  OK
 ```
 OK: 48/48 Fail: 0/48 Skip: 0/48
 ## Voluntary Exit
 ```diff
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - invalid_signature   OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_already_e OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_exit_in_f OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_invalid_v OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_not_activ OK
-+ [Invalid] Ethereum Foundation - Altair - Operations - Voluntary Exit - validator_not_activ OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - invalid_signatur OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_alread OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_exit_i OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_invali OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_not_ac OK
-+ [Invalid] Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - validator_not_ac OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - invalid_signature  OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_already_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_exit_in_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_invalid_ OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_not_acti OK
-+ [Invalid] Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - validator_not_acti OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - default_exit_epoch_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - success             OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - success_exit_queue_ OK
-+ [Valid]   Ethereum Foundation - Altair - Operations - Voluntary Exit - success_exit_queue_ OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - default_exit_epo OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - success          OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - success_exit_que OK
-+ [Valid]   Ethereum Foundation - Bellatrix - Operations - Voluntary Exit - success_exit_que OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - default_exit_epoch OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - success            OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - success_exit_queue OK
-+ [Valid]   Ethereum Foundation - Phase 0 - Operations - Voluntary Exit - success_exit_queue OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - invalid_signature                    OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_already_exited             OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_exit_in_future             OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_invalid_validator_index    OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_not_active                 OK
++ [Invalid] EF - Altair - Operations - Voluntary Exit - validator_not_active_long_enough     OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - invalid_signature                 OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_already_exited          OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_exit_in_future          OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_invalid_validator_index OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_not_active              OK
++ [Invalid] EF - Bellatrix - Operations - Voluntary Exit - validator_not_active_long_enough  OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - invalid_signature                   OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_already_exited            OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_exit_in_future            OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_invalid_validator_index   OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_not_active                OK
++ [Invalid] EF - Phase 0 - Operations - Voluntary Exit - validator_not_active_long_enough    OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - default_exit_epoch_subsequent_exit   OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - success                              OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__min_churn        OK
++ [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__scaled_churn     OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - default_exit_epoch_subsequent_exi OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - success                           OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - success_exit_queue__min_churn     OK
++ [Valid]   EF - Bellatrix - Operations - Voluntary Exit - success_exit_queue__scaled_churn  OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - default_exit_epoch_subsequent_exit  OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - success                             OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - success_exit_queue__min_churn       OK
++ [Valid]   EF - Phase 0 - Operations - Voluntary Exit - success_exit_queue__scaled_churn    OK
 ```
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1035/1055 Fail: 0/1055 Skip: 20/1055
+OK: 1066/1086 Fail: 0/1086 Skip: 20/1086

--- a/tests/consensus_spec/all_tests.nim
+++ b/tests/consensus_spec/all_tests.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/altair/test_fixture_merkle_single_proof.nim
+++ b/tests/consensus_spec/altair/test_fixture_merkle_single_proof.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -58,6 +58,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ merkle_single_proof _ identifier`()
 
-suite "Ethereum Foundation - Altair - Merkle - Single proof" & preset():
+suite "EF - Altair - Merkle - Single proof" & preset():
   for kind, path in walkDir(TestsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -32,7 +32,7 @@ const
   OpSyncAggregateDir    = OpDir/"sync_aggregate"
   OpVoluntaryExitDir    = OpDir/"voluntary_exit"
 
-  baseDescription = "Ethereum Foundation - Altair - Operations - "
+  baseDescription = "EF - Altair - Operations - "
 
 doAssert toHashSet(mapIt(toSeq(walkDir(OpDir, relative = false)), it.path)) ==
   toHashSet([OpAttestationsDir, OpAttSlashingDir, OpBlockHeaderDir,

--- a/tests/consensus_spec/altair/test_fixture_rewards.nim
+++ b/tests/consensus_spec/altair/test_fixture_rewards.nim
@@ -35,7 +35,7 @@ proc runTest(rewardsDir, identifier: string) =
   let testDir = rewardsDir / identifier
 
   proc `testImpl _ rewards _ identifier`() =
-    test "Ethereum Foundation - Altair - Rewards - " & identifier & preset():
+    test "EF - Altair - Rewards - " & identifier & preset():
       var info: altair.EpochInfo
 
       let
@@ -79,7 +79,7 @@ proc runTest(rewardsDir, identifier: string) =
 
   `testImpl _ rewards _ identifier`()
 
-suite "Ethereum Foundation - Altair - Rewards " & preset():
+suite "EF - Altair - Rewards " & preset():
   for rewardsDir in [RewardsDirBasic, RewardsDirLeak, RewardsDirRandom]:
     for kind, path in walkDir(rewardsDir, relative = true, checkDir = true):
       runTest(rewardsDir, path)

--- a/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -64,14 +64,14 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   `testImpl _ blck _ testName`()
 
-suite "Ethereum Foundation - Altair - Sanity - Blocks " & preset():
+suite "EF - Altair - Sanity - Blocks " & preset():
  for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
-   runTest("Ethereum Foundation - Altair - Sanity - Blocks", SanityBlocksDir, path)
+   runTest("EF - Altair - Sanity - Blocks", SanityBlocksDir, path)
 
-suite "Ethereum Foundation - Altair - Finality " & preset():
+suite "EF - Altair - Finality " & preset():
  for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
-   runTest("Ethereum Foundation - Altair - Finality", FinalityDir, path)
+   runTest("EF - Altair - Finality", FinalityDir, path)
 
-suite "Ethereum Foundation - Altair - Random" & preset():
+suite "EF - Altair - Random" & preset():
  for kind, path in walkDir(RandomDir, relative = true, checkDir = true):
-   runTest("Ethereum Foundation - Altair - Random", RandomDir, path)
+   runTest("EF - Altair - Random", RandomDir, path)

--- a/tests/consensus_spec/altair/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/altair/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -49,6 +49,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ slots _ identifier`()
 
-suite "Ethereum Foundation - Altair - Sanity - Slots " & preset():
+suite "EF - Altair - Sanity - Slots " & preset():
   for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -78,7 +78,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # Test runner
 # ----------------------------------------------------------------
 
-suite "Ethereum Foundation - Altair - SSZ consensus objects " & preset():
+suite "EF - Altair - SSZ consensus objects " & preset():
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -24,7 +24,7 @@ const RootDir = SszTestsDir/const_preset/"altair"/"epoch_processing"
 
 template runSuite(
     suiteDir, testName: string, transitionProc: untyped): untyped =
-  suite "Ethereum Foundation - Altair - Epoch Processing - " & testName & preset():
+  suite "EF - Altair - Epoch Processing - " & testName & preset():
     for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
 
       let unitTestName = testDir.rsplit(DirSep, 1)[1]

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -84,7 +84,7 @@ func initialize_light_client_store(state: auto): LightClientStore =
     current_max_active_participants: 0,
   )
 
-suite "Ethereum Foundation - Altair - Unittests - Sync protocol" & preset():
+suite "EF - Altair - Unittests - Sync protocol" & preset():
   let
     cfg = block:
       var res = defaultRuntimeConfig

--- a/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
+++ b/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,8 +8,10 @@
 {.used.}
 
 import
+  ./test_fixture_fork,
   ./test_fixture_operations,
   ./test_fixture_sanity_blocks,
   ./test_fixture_sanity_slots,
   ./test_fixture_ssz_consensus_objects,
-  ./test_fixture_state_transition_epoch
+  ./test_fixture_state_transition_epoch,
+  ./test_fixture_transition

--- a/tests/consensus_spec/bellatrix/test_fixture_fork.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_fork.nim
@@ -1,0 +1,44 @@
+# beacon_chain
+# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  os,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/[beaconstate, helpers],
+  ../../../beacon_chain/spec/datatypes/[altair, merge],
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils,
+  ../../helpers/debug_state
+
+const OpForkDir = SszTestsDir/const_preset/"bellatrix"/"fork"/"fork"/"pyspec_tests"
+
+proc runTest(identifier: string) =
+  let testDir = OpForkDir / identifier
+
+  proc `testImpl _ fork _ identifier`() =
+    test identifier:
+      let
+        preState = newClone(
+          parseTest(testDir/"pre.ssz_snappy", SSZ, altair.BeaconState))
+        postState = newClone(
+          parseTest(testDir/"post.ssz_snappy", SSZ, merge.BeaconState))
+
+      var cfg = defaultRuntimeConfig
+
+      let upgradedState = upgrade_to_merge(cfg, preState[])
+      check: upgradedState[].hash_tree_root() == postState[].hash_tree_root()
+      reportDiff(upgradedState, postState)
+
+  `testImpl _ fork _ identifier`()
+
+suite "EF - Bellatrix - Fork " & preset():
+  for kind, path in walkDir(OpForkDir, relative = true, checkDir = true):
+    runTest(path)

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -33,7 +33,7 @@ const
   OpSyncAggregateDir    = OpDir/"sync_aggregate"
   OpVoluntaryExitDir    = OpDir/"voluntary_exit"
 
-  baseDescription = "Ethereum Foundation - Bellatrix - Operations - "
+  baseDescription = "EF - Bellatrix - Operations - "
 
 # DS_Store issue: https://github.com/ethereum/consensus-spec-tests/issues/27
 doAssert toHashSet(filterIt(mapIt(toSeq(walkDir(OpDir, relative = false)), it.path), not it.contains("DS_Store"))) ==

--- a/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
@@ -35,7 +35,7 @@ proc runTest(rewardsDir, identifier: string) =
   let testDir = rewardsDir / identifier
 
   proc `testImpl _ rewards _ identifier`() =
-    test "Ethereum Foundation - Bellatrix - Rewards - " & identifier & preset():
+    test "EF - Bellatrix - Rewards - " & identifier & preset():
       var info: altair.EpochInfo
 
       let
@@ -79,7 +79,7 @@ proc runTest(rewardsDir, identifier: string) =
 
   `testImpl _ rewards _ identifier`()
 
-suite "Ethereum Foundation - Bellatrix - Rewards " & preset():
+suite "EF - Bellatrix - Rewards " & preset():
   for rewardsDir in [RewardsDirBasic, RewardsDirLeak, RewardsDirRandom]:
     for kind, path in walkDir(rewardsDir, relative = true, checkDir = true):
       runTest(rewardsDir, path)

--- a/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
@@ -69,13 +69,13 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   `testImpl _ blck _ testName`()
 
-suite "Ethereum Foundation - Bellatrix - Sanity - Blocks " & preset():
+suite "EF - Bellatrix - Sanity - Blocks " & preset():
  for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
    if path.contains("DS_Store"):
      # https://github.com/ethereum/consensus-spec-tests/issues/27
      continue
-   runTest("Ethereum Foundation - Bellatrix - Sanity - Blocks", SanityBlocksDir, path)
+   runTest("EF - Bellatrix - Sanity - Blocks", SanityBlocksDir, path)
 
-suite "Ethereum Foundation - Bellatrix - Finality " & preset():
+suite "EF - Bellatrix - Finality " & preset():
  for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
-   runTest("Ethereum Foundation - Bellatrix - Finality", FinalityDir, path)
+   runTest("EF - Bellatrix - Finality", FinalityDir, path)

--- a/tests/consensus_spec/bellatrix/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_sanity_slots.nim
@@ -48,6 +48,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ slots _ identifier`()
 
-suite "Ethereum Foundation - Bellatrix - Sanity - Slots " & preset():
+suite "EF - Bellatrix - Sanity - Slots " & preset():
   for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -78,7 +78,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # Test runner
 # ----------------------------------------------------------------
 
-suite "Ethereum Foundation - Bellatrix - SSZ consensus objects " & preset():
+suite "EF - Bellatrix - SSZ consensus objects " & preset():
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir

--- a/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -23,7 +23,7 @@ const RootDir = SszTestsDir/const_preset/"bellatrix"/"epoch_processing"
 
 template runSuite(
     suiteDir, testName: string, transitionProc: untyped): untyped =
-  suite "Ethereum Foundation - Bellatrix - Epoch Processing - " & testName & preset():
+  suite "EF - Bellatrix - Epoch Processing - " & testName & preset():
     for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
 
       let unitTestName = testDir.rsplit(DirSep, 1)[1]

--- a/tests/consensus_spec/consensus_spec_tests_preset.nim
+++ b/tests/consensus_spec/consensus_spec_tests_preset.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/phase0/all_phase0_fixtures.nim
+++ b/tests/consensus_spec/phase0/all_phase0_fixtures.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/phase0/test_fixture_operations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -31,7 +31,7 @@ const
   OpProposerSlashingDir = OpDir/"proposer_slashing"
   OpVoluntaryExitDir    = OpDir/"voluntary_exit"
 
-  baseDescription = "Ethereum Foundation - Phase 0 - Operations - "
+  baseDescription = "EF - Phase 0 - Operations - "
 
 doAssert toHashSet(mapIt(toSeq(walkDir(OpDir, relative = false)), it.path)) ==
   toHashSet([OpAttestationsDir, OpAttSlashingDir, OpBlockHeaderDir,

--- a/tests/consensus_spec/phase0/test_fixture_rewards.nim
+++ b/tests/consensus_spec/phase0/test_fixture_rewards.nim
@@ -39,7 +39,7 @@ proc runTest(rewardsDir, identifier: string) =
   let testDir = rewardsDir / identifier
 
   proc `testImpl _ rewards _ identifier`() =
-    test "Ethereum Foundation - Phase 0 - Rewards - " & identifier & preset():
+    test "EF - Phase 0 - Rewards - " & identifier & preset():
       let
         state = newClone(
           parseTest(testDir/"pre.ssz_snappy", SSZ, phase0.BeaconState))
@@ -107,7 +107,7 @@ proc runTest(rewardsDir, identifier: string) =
 
   `testImpl _ rewards _ identifier`()
 
-suite "Ethereum Foundation - Phase 0 - Rewards " & preset():
+suite "EF - Phase 0 - Rewards " & preset():
   for rewardsDir in [RewardsDirBasic, RewardsDirLeak, RewardsDirRandom]:
     for kind, path in walkDir(rewardsDir, relative = true, checkDir = true):
       runTest(rewardsDir, path)

--- a/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -64,14 +64,14 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   `testImpl _ blck _ testName`()
 
-suite "Ethereum Foundation - Phase 0 - Sanity - Blocks " & preset():
+suite "EF - Phase 0 - Sanity - Blocks " & preset():
   for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
-    runTest("Ethereum Foundation - Phase 0 - Sanity - Blocks", SanityBlocksDir, path)
+    runTest("EF - Phase 0 - Sanity - Blocks", SanityBlocksDir, path)
 
-suite "Ethereum Foundation - Phase 0 - Finality " & preset():
+suite "EF - Phase 0 - Finality " & preset():
   for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
-    runTest("Ethereum Foundation - Phase 0 - Finality", FinalityDir, path)
+    runTest("EF - Phase 0 - Finality", FinalityDir, path)
 
-suite "Ethereum Foundation - Phase 0 - Random " & preset():
+suite "EF - Phase 0 - Random " & preset():
   for kind, path in walkDir(RandomDir, relative = true, checkDir = true):
-    runTest("Ethereum Foundation - Phase 0 - Random", RandomDir, path)
+    runTest("EF - Phase 0 - Random", RandomDir, path)

--- a/tests/consensus_spec/phase0/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/phase0/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -47,6 +47,6 @@ proc runTest(identifier: string) =
 
   `testImpl _ slots _ identifier`()
 
-suite "Ethereum Foundation - Phase 0 - Sanity - Slots " & preset():
+suite "EF - Phase 0 - Sanity - Slots " & preset():
   for kind, path in walkDir(SanitySlotsDir, relative = true, checkDir = true):
     runTest(path)

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -78,7 +78,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # Test runner
 # ----------------------------------------------------------------
 
-suite "Ethereum Foundation - Phase 0 - SSZ consensus objects " & preset():
+suite "EF - Phase 0 - SSZ consensus objects " & preset():
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir

--- a/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -23,7 +23,7 @@ import
 const RootDir = SszTestsDir/const_preset/"phase0"/"epoch_processing"
 
 template runSuite(suiteDir, testName: string, transitionProc: untyped): untyped =
-  suite "Ethereum Foundation - Phase 0 - Epoch Processing - " & testName & preset():
+  suite "EF - Phase 0 - Epoch Processing - " & testName & preset():
     for testDir in walkDirRec(suiteDir, yieldFilter = {pcDir}, checkDir = true):
 
       let unitTestName = testDir.rsplit(DirSep, 1)[1]

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -321,7 +321,7 @@ proc runTest(path: string, fork: BeaconBlockFork) =
     else:
       doAssert false, "Unsupported"
 
-suite "Ethereum Foundation - ForkChoice" & preset():
+suite "EF - ForkChoice" & preset():
   const SKIP = [
     # protoArray can handle blocks in the future gracefully
     # spec: https://github.com/ethereum/consensus-specs/blame/v1.1.3/specs/phase0/fork-choice.md#L349

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -245,7 +245,7 @@ proc sszCheck(baseDir, sszType, sszSubType: string) =
 # Test runner
 # ------------------------------------------------------------------------
 
-suite "Ethereum Foundation - SSZ generic types":
+suite "EF - SSZ generic types":
   doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -79,7 +79,7 @@ proc sqlite3db_delete(basepath, dbname: string) =
   removeFile(basepath / dbname&".sqlite3-wal")
   removeFile(basepath / dbname&".sqlite3")
 
-const InterchangeTestsDir = FixturesDir / "tests-slashing-v5.0.0" / "generated"
+const InterchangeTestsDir = FixturesDir / "tests-slashing-v5.0.0" / "tests" / "generated"
 const TestDir = ""
 const TestDbPrefix = "test_slashprot_"
 


### PR DESCRIPTION
- only repository changes are in `tests` and in the Markdown summaries
- add Bellatrix fork and transition tests, including more stray `DS_Store` tarball workarounds
- use just "EF" instead of more verbose "Ethereum Foundation"
- copyright year updates
- fix HTTP 404 error in downloading slashing interchange tests