### PR TITLE
shift block_sim fork epochs; allow VC to work with non-multiple-of-3 SECONDS_PER_SLOT

### DIFF
--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 Status Research & Development GmbH
+# Copyright (c) 2021-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -6,7 +6,7 @@
 
 import std/[tables, os, strutils]
 import chronos, chronicles, confutils,
-       stew/[base10, results, byteutils, io2], bearssl, blscurve
+       stew/[base10, results, io2], bearssl, blscurve
 import ".."/validators/slashing_protection
 import ".."/[conf, version, filepath, beacon_node]
 import ".."/spec/[keystore, crypto]

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -13,7 +13,7 @@ import
   # Standard lib
   std/[algorithm, math, sequtils, sets, tables],
   # Status libraries
-  stew/[byteutils, endians2, bitops2],
+  stew/[bitops2, byteutils, endians2],
   chronicles,
   # Internal
   ./datatypes/[phase0, altair, merge],
@@ -299,7 +299,7 @@ func is_valid_merkle_branch*(leaf: Eth2Digest, branch: openArray[Eth2Digest],
     value = eth2digest(buf)
   value == root
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/tests/core/pyspec/eth2spec/test/helpers/merkle.py#L4-L21
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/tests/core/pyspec/eth2spec/test/helpers/merkle.py#L4-L21
 func build_proof_impl(anchor: object, leaf_index: uint64,
                       proof: var openArray[Eth2Digest]) =
   let
@@ -513,11 +513,11 @@ func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   doAssert idx > 0
   uint64(idx mod (type(idx)(1) shl log2trunc(idx)))
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/beacon-chain.md#is_merge_transition_complete
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
 func is_merge_transition_complete*(state: merge.BeaconState): bool =
   state.latest_execution_payload_header != default(ExecutionPayloadHeader)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/beacon-chain.md#is_merge_transition_block
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#is_merge_transition_block
 func is_merge_transition_block(
     state: merge.BeaconState,
     body: merge.BeaconBlockBody | merge.TrustedBeaconBlockBody |
@@ -525,14 +525,14 @@ func is_merge_transition_block(
   not is_merge_transition_complete(state) and
     body.execution_payload != default(merge.ExecutionPayload)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/beacon-chain.md#is_execution_enabled
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#is_execution_enabled
 func is_execution_enabled*(
     state: merge.BeaconState,
     body: merge.BeaconBlockBody | merge.TrustedBeaconBlockBody |
           merge.SigVerifiedBeaconBlockBody): bool =
   is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/beacon-chain.md#compute_timestamp_at_slot
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
 func compute_timestamp_at_slot*(state: ForkyBeaconState, slot: Slot): uint64 =
   # Note: This function is unsafe with respect to overflows and underflows.
   let slots_since_genesis = slot - GENESIS_SLOT

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -114,7 +114,7 @@ const
   DefaultDutyAndProof* = DutyAndProof(epoch: Epoch(0xFFFF_FFFF_FFFF_FFFF'u64))
   SlotDuration* = int64(SECONDS_PER_SLOT).seconds
   EpochDuration* = int64(SLOTS_PER_EPOCH * SECONDS_PER_SLOT).seconds
-  OneThirdDuration* = int64(SECONDS_PER_SLOT div INTERVALS_PER_SLOT).seconds
+  OneThirdDuration* = int64(SECONDS_PER_SLOT).seconds div INTERVALS_PER_SLOT
 
 proc `$`*(bn: BeaconNodeServerRef): string =
   if bn.ident.isSome():

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -71,8 +71,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   var
     cfg = defaultRuntimeConfig
 
-  cfg.ALTAIR_FORK_EPOCH = 64.Slot.epoch
-  cfg.MERGE_FORK_EPOCH = 128.Slot.epoch
+  cfg.ALTAIR_FORK_EPOCH = 32.Slot.epoch
+  cfg.MERGE_FORK_EPOCH = 96.Slot.epoch
 
   echo "Starting simulation..."
 

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -50,7 +50,7 @@ type
 const
   FixturesDir* =
     currentSourcePath.rsplit(DirSep, 1)[0] / ".." / ".." / "vendor" / "nim-eth2-scenarios"
-  SszTestsDir* = FixturesDir / "tests-v1.1.8"
+  SszTestsDir* = FixturesDir / "tests-v" & SPEC_VERSION
   MaxObjectSize* = 3_000_000
 
 proc parseTest*(path: string, Format: typedesc[Json], T: typedesc): T =


### PR DESCRIPTION
- de-emphasizes now-less-relevant phase 0 and emphasizes now-more-relevant bellatrix in `block_sim`
- derive the test fixture directory from `SPEC_VERSION`, so `make test` (and CI) always tests with the EF consensus test vector version they claim to support
- fix validator client timing to work when `SECONDS_PER_SLOT` doesn't divide by `INTERVALS_PER_SLOT` evenly. This doesn't matter for 6 second (`minimal` preset) or 12 second (`mainnet`) slots, but could for some custom presets
- copyright year updates
- import cleanups
- spec URL updates
- use `isZeroMemory` more consistently in light client sync