### PR TITLE
REST cleanups

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   std/[options, sets, tables, hashes],
   # Status libraries
-  stew/endians2, chronicles,
+  chronicles,
   # Internals
   ../spec/[signatures_batch, forks, helpers],
   ../spec/datatypes/[phase0, altair, merge],

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -9,7 +9,6 @@ import
   std/[typetraits, sequtils, strutils, sets],
   stew/[results, base10],
   chronicles,
-  nimcrypto/utils as ncrutils,
   ./rest_utils,
   ../beacon_node, ../networking/eth2_network,
   ../consensus_object_pools/[blockchain_dag, exit_pool, spec_cache],
@@ -121,14 +120,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -144,14 +142,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -177,14 +174,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -209,14 +205,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -338,14 +333,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -407,14 +401,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -501,14 +494,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
         if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
@@ -519,8 +511,18 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
                                            $repoch.error())
         let res = repoch.get()
-        if res > MaxEpoch:
-          return RestApiResponse.jsonError(Http400, EpochOverflowValueError)
+
+        if res > bslot.slot.epoch + MIN_SEED_LOOKAHEAD:
+          return RestApiResponse.jsonError(
+            Http400, InvalidEpochValueError,
+            "Requested epoch more than 1 epoch past state epoch")
+
+        if res + EPOCHS_PER_HISTORICAL_VECTOR <
+            bslot.slot.epoch + MIN_SEED_LOOKAHEAD:
+          return RestApiResponse.jsonError(
+            Http400, InvalidEpochValueError,
+            "Requested epoch earlier than what committees can be computed for")
+
         some(res)
       else:
         none[Epoch]()
@@ -540,7 +542,24 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if rslot.isErr():
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            $rslot.error())
-        some(rslot.get())
+        let res = rslot.get()
+        if vepoch.isSome():
+          if res.epoch != vepoch.get():
+            return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
+                                             "Slot does not match requested epoch")
+        else:
+          if res.epoch > bslot.slot.epoch + 1:
+            return RestApiResponse.jsonError(
+              Http400, InvalidEpochValueError,
+              "Requested slot more than 1 epoch past state epoch")
+
+          if res.epoch + EPOCHS_PER_HISTORICAL_VECTOR <
+              bslot.slot.epoch + MIN_SEED_LOOKAHEAD:
+            return RestApiResponse.jsonError(
+              Http400, InvalidEpochValueError,
+              "Requested slot earlier than what committees can be computed for")
+
+        some(res)
       else:
         none[Slot]()
     node.withStateForBlockSlot(bslot):
@@ -590,13 +609,15 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
-        # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-        # in current version of database.
         let sid = state_id.get()
-        if sid.kind == StateQueryKind.Root:
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
-
         let bres = node.getBlockSlot(sid)
+        if bres.isErr():
+          if sid.kind == StateQueryKind.Root:
+            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+            # in current version of database.
+            return RestApiResponse.jsonError(Http500, NoImplementationError)
+          return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                           $bres.error())
         bres.get()
 
     let qepoch =

--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -4,8 +4,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import stew/[endians2, base10], chronicles,
-       nimcrypto/utils as ncrutils
+import stew/[byteutils, base10], chronicles
 import ".."/beacon_node,
        ".."/eth1/eth1_monitor,
        ".."/spec/forks,
@@ -171,38 +170,31 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           # JUSTIFICATION_BITS_LENGTH
           # ENDIANNESS
           BLS_WITHDRAWAL_PREFIX:
-            "0x" & ncrutils.toHex([BLS_WITHDRAWAL_PREFIX]),
+            to0xHex([BLS_WITHDRAWAL_PREFIX]),
           ETH1_ADDRESS_WITHDRAWAL_PREFIX:
-            "0x" & ncrutils.toHex([ETH1_ADDRESS_WITHDRAWAL_PREFIX]),
+            to0xHex([ETH1_ADDRESS_WITHDRAWAL_PREFIX]),
           DOMAIN_BEACON_PROPOSER:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_BEACON_PROPOSER).toBytesLE()),
+            to0xHex(DOMAIN_BEACON_PROPOSER.data),
           DOMAIN_BEACON_ATTESTER:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_BEACON_ATTESTER).toBytesLE()),
+            to0xHex(DOMAIN_BEACON_ATTESTER.data),
           DOMAIN_RANDAO:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_RANDAO).toBytesLE()),
+            to0xHex(DOMAIN_RANDAO.data),
           DOMAIN_DEPOSIT:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_DEPOSIT).toBytesLE()),
+            to0xHex(DOMAIN_DEPOSIT.data),
           DOMAIN_VOLUNTARY_EXIT:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_VOLUNTARY_EXIT).toBytesLE()),
+            to0xHex(DOMAIN_VOLUNTARY_EXIT.data),
           DOMAIN_SELECTION_PROOF:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_SELECTION_PROOF).toBytesLE()),
+            to0xHex(DOMAIN_SELECTION_PROOF.data),
           DOMAIN_AGGREGATE_AND_PROOF:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_AGGREGATE_AND_PROOF).toBytesLE()),
+            to0xHex(DOMAIN_AGGREGATE_AND_PROOF.data),
 
           # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/beacon-chain.md#constants
           TIMELY_SOURCE_FLAG_INDEX:
-            "0x" & ncrutils.toHex([byte(TIMELY_SOURCE_FLAG_INDEX)]),
+            to0xHex([byte(TIMELY_SOURCE_FLAG_INDEX)]),
           TIMELY_TARGET_FLAG_INDEX:
-            "0x" & ncrutils.toHex([byte(TIMELY_TARGET_FLAG_INDEX)]),
+            to0xHex([byte(TIMELY_TARGET_FLAG_INDEX)]),
           TIMELY_HEAD_FLAG_INDEX:
-            "0x" & ncrutils.toHex([byte(TIMELY_HEAD_FLAG_INDEX)]),
+            to0xHex([byte(TIMELY_HEAD_FLAG_INDEX)]),
           TIMELY_SOURCE_WEIGHT:
             Base10.toString(uint64(TIMELY_SOURCE_WEIGHT)),
           TIMELY_TARGET_WEIGHT:
@@ -216,14 +208,11 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           WEIGHT_DENOMINATOR:
             Base10.toString(uint64(WEIGHT_DENOMINATOR)),
           DOMAIN_SYNC_COMMITTEE:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_SYNC_COMMITTEE).toBytesLE()),
+            to0xHex(DOMAIN_SYNC_COMMITTEE.data),
           DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF).toBytesLE()),
+            to0xHex(DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF.data),
           DOMAIN_CONTRIBUTION_AND_PROOF:
-            "0x" & ncrutils.toHex(
-              uint32(DOMAIN_CONTRIBUTION_AND_PROOF).toBytesLE()),
+            to0xHex(DOMAIN_CONTRIBUTION_AND_PROOF.data),
           # PARTICIPATION_FLAG_WEIGHTS
 
           # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#constants

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -1,10 +1,9 @@
 import
   std/[sequtils],
-  stew/results,
+  stew/[byteutils, results],
   chronicles,
   eth/p2p/discoveryv5/enr,
   libp2p/[multiaddress, multicodec, peerstore],
-  nimcrypto/utils as ncrutils,
   ../version, ../beacon_node, ../sync/sync_manager,
   ../networking/[eth2_network, peer_pool],
   ../spec/datatypes/base,
@@ -158,8 +157,8 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
         discovery_addresses: discoveryAddresses,
         metadata: (
           seq_number: node.network.metadata.seq_number,
-          syncnets: "0x" & ncrutils.toHex(node.network.metadata.syncnets.bytes),
-          attnets: "0x" & ncrutils.toHex(node.network.metadata.attnets.bytes)
+          syncnets: to0xHex(node.network.metadata.syncnets.bytes),
+          attnets: to0xHex(node.network.metadata.attnets.bytes)
         )
       )
     )

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -1,6 +1,5 @@
 import std/[options, macros],
        stew/byteutils, presto,
-       nimcrypto/utils as ncrutils,
        ../spec/[forks],
        ../spec/eth2_apis/[rest_types, eth2_rest_serialization],
        ../beacon_node,

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -67,11 +67,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if res.isErr():
           return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
         res.get()
-    let droot =
-      if qepoch >= Epoch(2):
-        qhead.atSlot(compute_start_slot_at_epoch(qepoch - 1) - 1).blck.root
-      else:
-        node.dag.genesis.root
+    let droot = qhead.prevDependentBlock(node.dag.tail, qepoch).root
     let duties =
       block:
         var res: seq[RestAttesterDuty]
@@ -129,11 +125,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if res.isErr():
           return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
         res.get()
-    let droot =
-      if qepoch >= Epoch(1):
-        qhead.atSlot(compute_start_slot_at_epoch(qepoch - 1)).blck.root
-      else:
-        node.dag.genesis.root
+    let droot = qhead.dependentBlock(node.dag.tail, qepoch).root
     let duties =
       block:
         var res: seq[RestProposerDuty]

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -9,10 +9,9 @@
 
 import
   std/[parseutils, sequtils, strutils, sets],
-  stew/results,
+  stew/[byteutils, results],
   json_rpc/servers/httpserver,
   chronicles,
-  nimcrypto/utils as ncrutils,
   ../beacon_node,
   ../networking/eth2_network,
   ../validators/validator_duties,
@@ -452,7 +451,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     for item in node.attestationPool[].attestations(qslot, qindex):
       let atuple = (
-        aggregation_bits: "0x" & ncrutils.toHex(item.aggregation_bits.bytes),
+        aggregation_bits: to0xHex(item.aggregation_bits.bytes),
         data: item.data,
         signature: item.signature
       )

--- a/beacon_chain/rpc/rpc_config_api.nim
+++ b/beacon_chain/rpc/rpc_config_api.nim
@@ -8,10 +8,9 @@
 {.push raises: [Defect].}
 
 import
-  stew/endians2,
+  stew/[byteutils],
   json_rpc/servers/httpserver,
   chronicles,
-  nimcrypto/utils as ncrutils,
   ../beacon_node,
   ../eth1/eth1_monitor,
   ../spec/forks
@@ -59,7 +58,7 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "EFFECTIVE_BALANCE_INCREMENT": $EFFECTIVE_BALANCE_INCREMENT,
       "GENESIS_FORK_VERSION":
         "0x" & $node.dag.cfg.GENESIS_FORK_VERSION,
-      "BLS_WITHDRAWAL_PREFIX": "0x" & ncrutils.toHex([BLS_WITHDRAWAL_PREFIX]),
+      "BLS_WITHDRAWAL_PREFIX": to0xHex([BLS_WITHDRAWAL_PREFIX]),
       "GENESIS_DELAY": $node.dag.cfg.GENESIS_DELAY,
       "SECONDS_PER_SLOT": $SECONDS_PER_SLOT,
       "MIN_ATTESTATION_INCLUSION_DELAY": $MIN_ATTESTATION_INCLUSION_DELAY,
@@ -88,19 +87,19 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "MAX_DEPOSITS": $MAX_DEPOSITS,
       "MAX_VOLUNTARY_EXITS": $MAX_VOLUNTARY_EXITS,
       "DOMAIN_BEACON_PROPOSER":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_BEACON_PROPOSER).toBytesLE()),
+        to0xHex(DOMAIN_BEACON_PROPOSER.data),
       "DOMAIN_BEACON_ATTESTER":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_BEACON_ATTESTER).toBytesLE()),
+        to0xHex(DOMAIN_BEACON_ATTESTER.data),
       "DOMAIN_RANDAO":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_RANDAO).toBytesLE()),
+        to0xHex(DOMAIN_RANDAO.data),
       "DOMAIN_DEPOSIT":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_DEPOSIT).toBytesLE()),
+        to0xHex(DOMAIN_DEPOSIT.data),
       "DOMAIN_VOLUNTARY_EXIT":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_VOLUNTARY_EXIT).toBytesLE()),
+        to0xHex(DOMAIN_VOLUNTARY_EXIT.data),
       "DOMAIN_SELECTION_PROOF":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_SELECTION_PROOF).toBytesLE()),
+        to0xHex(DOMAIN_SELECTION_PROOF.data),
       "DOMAIN_AGGREGATE_AND_PROOF":
-        "0x" & ncrutils.toHex(uint32(DOMAIN_AGGREGATE_AND_PROOF).toBytesLE())
+        to0xHex(DOMAIN_AGGREGATE_AND_PROOF.data)
     }
 
   rpcServer.rpc("get_v1_config_deposit_contract") do () -> JsonNode:

--- a/beacon_chain/rpc/rpc_node_api.nim
+++ b/beacon_chain/rpc/rpc_node_api.nim
@@ -7,12 +7,13 @@
 
 {.push raises: [Defect].}
 
-import std/[options, sequtils],
+import
+  std/[options, sequtils],
+  stew/byteutils,
   chronicles,
   json_rpc/servers/httpserver,
   eth/p2p/discoveryv5/enr,
   libp2p/[multiaddress, multicodec, peerstore],
-  nimcrypto/utils as ncrutils,
   ../beacon_node, ../version,
   ../networking/[eth2_network, peer_pool],
   ../sync/sync_manager,
@@ -174,7 +175,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       p2p_addresses: p2pAddresses,
       discovery_addresses: discoveryAddresses,
       metadata: (node.network.metadata.seq_number,
-                 "0x" & ncrutils.toHex(node.network.metadata.attnets.bytes))
+                 to0xHex(node.network.metadata.attnets.bytes))
     )
 
   rpcServer.rpc("get_v1_node_peers") do (state: Option[seq[string]],

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -724,7 +724,7 @@ func get_next_sync_committee_keys(state: altair.BeaconState | bellatrix.BeaconSt
     hash_buffer: array[40, byte]
   hash_buffer[0..31] = seed.data
   while index < SYNC_COMMITTEE_SIZE:
-    hash_buffer[32..39] = uint_to_bytes8(uint64(i div 32))
+    hash_buffer[32..39] = uint_to_bytes(uint64(i div 32))
     let
       shuffled_index = compute_shuffled_index(uint64(i mod active_validator_count), active_validator_count, seed)
       candidate_index = active_validator_indices[shuffled_index]

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -30,8 +30,9 @@ import
   stew/[endians2, objects, results, byteutils],
   blscurve,
   chronicles,
-  json_serialization,
-  nimcrypto/utils as ncrutils
+  json_serialization
+
+from nimcrypto/utils import burnMem
 
 export options, results, json_serialization, blscurve
 
@@ -474,4 +475,4 @@ func infinity*(T: type ValidatorSig): T =
   result.blob[0] = byte 0xC0
 
 proc burnMem*(key: var ValidatorPrivKey) =
-  ncrutils.burnMem(addr key, sizeof(ValidatorPrivKey))
+  burnMem(addr key, sizeof(ValidatorPrivKey))

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -9,10 +9,7 @@
 
 import
   std/[macros, strutils, parseutils, tables],
-  stew/endians2, stint, web3/[ethtypes]
-
-export
-  toBytesBE
+  stew/[byteutils], stint, web3/[ethtypes]
 
 const
   # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#withdrawal-prefixes
@@ -376,7 +373,7 @@ template parse(T: type byte, input: string): T =
 
 func parse(T: type Version, input: string): T
            {.raises: [ValueError, Defect].} =
-  Version toBytesBE(uint32 parse(uint64, input))
+  Version hexToByteArray(input, 4)
 
 template parse(T: type Slot, input: string): T =
   Slot parse(uint64, input)

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -96,15 +96,15 @@ proc sendResponseChunk*(response: UntypedResponse,
   of BeaconBlockFork.Phase0:
     response.stream.writeChunk(some ResponseCode.Success,
                                SSZ.encode(val.phase0Data),
-                               response.peer.network.forkDigests.phase0.bytes)
+                               response.peer.network.forkDigests.phase0.data)
   of BeaconBlockFork.Altair:
     response.stream.writeChunk(some ResponseCode.Success,
                                SSZ.encode(val.altairData),
-                               response.peer.network.forkDigests.altair.bytes)
+                               response.peer.network.forkDigests.altair.data)
   of BeaconBlockFork.Bellatrix:
     response.stream.writeChunk(some ResponseCode.Success,
                                SSZ.encode(val.mergeData),
-                               response.peer.network.forkDigests.bellatrix.bytes)
+                               response.peer.network.forkDigests.bellatrix.data)
 
 func shortLog*(s: StatusMsg): auto =
   (

--- a/docs/the_nimbus_book/src/api.md
+++ b/docs/the_nimbus_book/src/api.md
@@ -2,9 +2,11 @@
 
 The `JSON-RPC API` is a collection of APIs for querying the state of the application at runtime.
 
-The API is based on the common [eth2 APIs](https://github.com/ethereum/eth2.0-APIs) with the exception that `JSON-RPC` is used instead of [http `REST`](./rest-api.md) (the method names, parameters and results are all the same except for the encoding / access method).
+The API is based on an early version of the common [beacon APIs](https://github.com/ethereum/beacon-APIs) with the exception that `JSON-RPC` is used instead of [http `REST`](./rest-api.md) (the method names, parameters and results are all the same except for the encoding / access method).
 
 Nimbus also implements the [common REST API](./rest-api.md) - new applications should consider using it instead of JSON RPC.
+
+The `JSON-RPC API` should not be exposed to the public internet.
 
 ## Introduction
 

--- a/docs/the_nimbus_book/src/rest-api.md
+++ b/docs/the_nimbus_book/src/rest-api.md
@@ -2,7 +2,7 @@
 
 Nimbus exposes a high-performance implementation of the [Beacon Node API](https://ethereum.github.io/beacon-APIs/).
 
-The API is a `REST` interface accessed via `HTTP`. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks through endpoints triggering heavy processing.
+The API is a `REST` interface accessed via `HTTP`. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks.
 
 The API can be used with any conforming consumer, including alternative validator client implementations, explorers and tooling.
 

--- a/docs/the_nimbus_book/src/rest-api.md
+++ b/docs/the_nimbus_book/src/rest-api.md
@@ -8,7 +8,9 @@ The API can be used with any conforming consumer, including alternative validato
 
 ## Configuration
 
-By default, the REST interace is disabled. To enable it, use the `--rest` option when starting the beacon node, then access the API from http://localhost:5052/.
+By default, the REST interface is disabled. To enable it, start the beacon node with the `--rest` option, then access the API from http://localhost:5052/.
+
+> **Warning:** If you are using a validator client with a Nimbus beacon node, and running a Nimbus version prior to `v1.5.5`,  then you will need to launch the node with the `--subscribe-all-subnets` option enabled.
 
 By default, only connections from the same machine are entertained. The port and listening address can be further configured through the options `--rest-port` and `--rest-address`.
 

--- a/docs/the_nimbus_book/src/rest-api.md
+++ b/docs/the_nimbus_book/src/rest-api.md
@@ -1,31 +1,29 @@
 # REST API
 
-Nimbus supports the [common REST API](https://ethereum.github.io/beacon-APIs/) for runtime communication. To enable it, use the `--rest` option when starting the beacon node, then access the API from http://localhost:5052/. The port and listening address can be further configured through the options `--rest-port` and `--rest-address`.
+Nimbus exposes a high-performance implementation of the [Beacon Node API](https://ethereum.github.io/beacon-APIs/).
 
-The API is a REST interface, accessed via HTTP. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks through endpoints triggering heavy processing.
+The API is a `REST` interface accessed via `HTTP`. The API should not, unless protected by additional security layers, be exposed to the public Internet as the API includes multiple endpoints which could open your node to denial-of-service (DoS) attacks through endpoints triggering heavy processing.
 
-The beacon node (BN) maintains the state of the beacon chain by communicating with other beacon nodes in the Ethereum network. Conceptually, it does not maintain keypairs that participate with the beacon chain.
+The API can be used with any conforming consumer, including alternative validator client implementations, explorers and tooling.
 
-The validator client (VC) is a conceptually separate entity which utilizes private keys to perform validator related tasks, called "duties", on the beacon chain. These duties include the production of beacon blocks and signing of attestations.
+## Configuration
 
-> Please note that using a validator client with a Nimbus beacon node requires the node to be launched with the `--subscribe-all-subnets` option. This limitation will be removed in Nimbus 1.6.
+By default, the REST interace is disabled. To enable it, use the `--rest` option when starting the beacon node, then access the API from http://localhost:5052/.
 
-The goal of this specification is to promote interoperability between various beacon node implementations.
+By default, only connections from the same machine are entertained. The port and listening address can be further configured through the options `--rest-port` and `--rest-address`.
 
 ## Specification
+
 The specification is documented [here](https://ethereum.github.io/beacon-APIs/).
 
-See the Readme [here](https://github.com/ethereum/beacon-apis).
+See the Readme [here](https://github.com/ethereum/beacon-APIs).
 
 ## Quickly test your tooling against Nimbus
 
  The [Nimbus REST api](https://nimbus.guide/rest-api.html) is now available from:
- 
+
 * http://testing.mainnet.beacon-api.nimbus.team/
 * http://unstable.mainnet.beacon-api.nimbus.team/
 * http://unstable.prater.beacon-api.nimbus.team/
 
-
 Note that right now these are very much unstable testing instances. They may be unresponsive at times - so **please do not rely on them for validation**. We may also disable them at any time.
-
-

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -1037,7 +1037,7 @@
     },
     "response": {
       "status": {"operator": "oneof", "value": ["404", "200"]},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}]
     }
   },
   {
@@ -1139,7 +1139,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -1150,7 +1150,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -1161,7 +1161,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -1172,7 +1172,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -1183,7 +1183,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -1270,7 +1270,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "oneof", "value": ["400", "200"]},
+      "status": {"operator": "oneof", "value": ["400", "200"]}
     }
   },
   {
@@ -1492,18 +1492,6 @@
   {
     "topics": ["beacon", "states_committees"],
     "request": {
-      "url": "/eth/v1/beacon/states/head/committees?slot=18446744073709551615",
-      "headers": {"Accept": "application/json"}
-    },
-    "response": {
-      "status": {"operator": "equals", "value": "200"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmps", "start": ["data"], "value": [{"index": "", "slot": "", "validators": [""]}]}]
-    }
-  },
-  {
-    "topics": ["beacon", "states_committees"],
-    "request": {
       "url": "/eth/v1/beacon/states/head/committees?slot=18446744073709551616",
       "headers": {"Accept": "application/json"}
     },
@@ -1517,18 +1505,6 @@
     "topics": ["beacon", "states_committees"],
     "request": {
       "url": "/eth/v1/beacon/states/head/committees?epoch=0",
-      "headers": {"Accept": "application/json"}
-    },
-    "response": {
-      "status": {"operator": "equals", "value": "200"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmps", "start": ["data"], "value": [{"index": "", "slot": "", "validators": [""]}]}]
-    }
-  },
-  {
-    "topics": ["beacon", "states_committees"],
-    "request": {
-      "url": "/eth/v1/beacon/states/head/committees?epoch=576460752303423487",
       "headers": {"Accept": "application/json"}
     },
     "response": {
@@ -2941,19 +2917,6 @@
   },
   {
     "topics": ["validator", "proposer_duties", "mainnet"],
-    "comment": "Maximum epoch for mainnet parameters",
-    "request": {
-      "url": "/eth/v1/validator/duties/proposer/576460752303423487",
-      "headers": {"Accept": "application/json"}
-    },
-    "response": {
-      "status": {"operator": "equals", "value": "503"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
-    }
-  },
-  {
-    "topics": ["validator", "proposer_duties", "mainnet"],
     "comment": "Maximum epoch + 1 for mainnet parameters",
     "request": {
       "url": "/eth/v1/validator/duties/proposer/576460752303423488",
@@ -3138,7 +3101,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "oneof", "value": ["400", "200"]},
+      "status": {"operator": "oneof", "value": ["400", "200"]}
     }
   },
   {
@@ -3188,24 +3151,10 @@
     "request": {
       "method": "POST",
       "url": "/eth/v1/validator/duties/attester/0",
-      "headers": {"Accept": "application/json"},
+      "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "400"},
-    }
-  },
-  {
-    "topics": ["validator", "attester_duties"],
-    "request": {
-      "url": "/eth/v1/validator/duties/attester/576460752303423487",
-      "method": "POST",
-      "headers": {"Accept": "application/json"},
-      "body": {"content-type": "application/json", "data": "[\"0\"]"}
-    },
-    "response": {
-      "status": {"operator": "equals", "value": "503"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
+      "status": {"operator": "equals", "value": "400"}
     }
   },
   {
@@ -3255,7 +3204,7 @@
     "request": {
       "url": "/eth/v1/validator/duties/attester/foobar",
       "method": "POST",
-      "headers": {"Accept": "application/json"},
+      "headers": {"Accept": "application/json"}
     },
     "response": {
       "status": {"operator": "equals", "value": "400"}

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -1041,7 +1041,8 @@ proc startTests(conf: RestTesterConf, uri: Uri,
 
             let tcaseRes = fut.read()
             results[tcaseRes.index] = tcaseRes.data
-            notice "Got test result", index = tcaseRes.index,
+            notice "Got test result", name = rules[tcaseRes.index].getTestName(),
+                                      index = tcaseRes.index,
                                       value = tcaseRes.data.kind
             pending[i] = nil
 

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -59,6 +59,10 @@ suite "BlockSlot and helpers":
       s1 = BlockRef(bid: BlockId(slot: Slot(1)), parent: s0)
       s2 = BlockRef(bid: BlockId(slot: Slot(2)), parent: s1)
       s4 = BlockRef(bid: BlockId(slot: Slot(4)), parent: s2)
+      se1 = BlockRef(bid:
+        BlockId(slot: Epoch(1).compute_start_slot_at_epoch()), parent: s2)
+      se2 = BlockRef(bid:
+        BlockId(slot: Epoch(2).compute_start_slot_at_epoch()), parent: se1)
 
     check:
       s0.atSlot(Slot(0)).blck == s0
@@ -68,6 +72,14 @@ suite "BlockSlot and helpers":
       s4.atSlot(Slot(0)).blck == s0
 
       s4.atSlot() == s4.atSlot(s4.slot)
+
+      se2.dependentBlock(s0, Epoch(2)) == se1
+      se2.dependentBlock(s0, Epoch(1)) == s2
+      se2.dependentBlock(s0, Epoch(0)) == s0
+
+      se2.prevDependentBlock(s0, Epoch(2)) == s2
+      se2.prevDependentBlock(s0, Epoch(1)) == s0
+      se2.prevDependentBlock(s0, Epoch(0)) == s0
 
   test "parent sanity":
     let


### PR DESCRIPTION
* reject out-of-range committee requests
* print all hex values as lower-case
* allow requesting state information by head state root
* turn `DomainType` into array (follow spec)
* `uint_to_bytesXX` -> `uint_to_bytes` (follow spec)
* fix wrong dependent root in `/eth/v1/validator/duties/proposer/`
* update documentation - `--subscribe-all-subnets` is no longer needed
when using the REST interface with validator clients (as of https://github.com/status-im/nimbus-eth2/pull/2949 which is included in 1.5.5)