### PR TITLE
Harden CommitteeIndex, SubnetId, SyncSubcommitteeIndex

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -203,7 +203,7 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Gossip validation  [Preset: mainnet]
 ```diff
-+ Any committee index is valid                                                               OK
++ Empty committee when no committee for slot                                                 OK
 + validateAttestation                                                                        OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -415,7 +415,7 @@ proc scheduleContributionChecks*(
       batchCrypto: ref BatchCrypto,
       fork: Fork, genesis_validators_root: Eth2Digest,
       signedContributionAndProof: SignedContributionAndProof,
-      subcommitteeIndex: SyncSubcommitteeIndex,
+      subcommitteeIdx: SyncSubcommitteeIndex,
       dag: ChainDAGRef): Result[tuple[
        aggregatorFut, proofFut, contributionFut: Future[BatchResult],
        sig: CookedSig], cstring] =
@@ -445,7 +445,7 @@ proc scheduleContributionChecks*(
       "SignedContributionAndProof: invalid contribution signature")
 
     contributionKey = ? aggregateAll(
-      dag, dag.syncCommitteeParticipants(contribution.slot, subcommitteeIndex),
+      dag, dag.syncCommitteeParticipants(contribution.slot, subcommitteeIdx),
       contribution.aggregation_bits)
   let
     aggregatorFut = batchCrypto.withBatch("scheduleContributionAndProofChecks.aggregator"):

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -191,9 +191,12 @@ proc storeBlock*(
       src, wallTime, trustedBlock.message)
 
     for attestation in trustedBlock.message.body.attestations:
-      for idx in get_attesting_indices(
-          epochRef, attestation.data, attestation.aggregation_bits):
-        vm[].registerAttestationInBlock(attestation.data, idx,
+      for validator_index in get_attesting_indices(
+          epochRef, attestation.data.slot,
+          CommitteeIndex.init(attestation.data.index).expect(
+            "index has been checked"),
+          attestation.aggregation_bits):
+        vm[].registerAttestationInBlock(attestation.data, validator_index,
           trustedBlock.message)
 
     withState(dag[].clearanceState.data):

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -962,7 +962,7 @@ proc queryRandom*(
             peer = n.record.toURI(), exception = e.name, msg = e.msg
           continue
 
-      for i in allSyncSubcommittees():
+      for i in SyncSubcommitteeIndex:
         if wantedSyncnets[i] and syncnetsNode[i]:
           score += 10 # connecting to the right syncnet is urgent
 
@@ -2220,8 +2220,9 @@ proc broadcastBeaconBlock*(node: Eth2Node, forked: ForkedSignedBeaconBlock) =
   withBlck(forked): node.broadcastBeaconBlock(blck)
 
 proc broadcastSyncCommitteeMessage*(
-    node: Eth2Node, msg: SyncCommitteeMessage, committeeIdx: SyncSubcommitteeIndex) =
-  let topic = getSyncCommitteeTopic(node.forkDigests.altair, committeeIdx)
+    node: Eth2Node, msg: SyncCommitteeMessage,
+    subcommitteeIdx: SyncSubcommitteeIndex) =
+  let topic = getSyncCommitteeTopic(node.forkDigests.altair, subcommitteeIdx)
   node.broadcast(topic, msg)
 
 proc broadcastSignedContributionAndProof*(

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -92,18 +92,17 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     let
       committees_per_slot = get_committee_count_per_slot(epochRef)
-    for i in 0 ..< SLOTS_PER_EPOCH:
-      let slot = compute_start_slot_at_epoch(epoch) + i
-      for committee_index in 0'u64..<committees_per_slot:
-        let committee = get_beacon_committee(
-          epochRef, slot, committee_index.CommitteeIndex)
-        for index_in_committee, validatorIdx in committee:
-          let curr_val_pubkey = epochRef.validatorKey(validatorIdx)
+      start_slot = compute_start_slot_at_epoch(epoch)
+    for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+      for committee_index in get_committee_indices(committees_per_slot):
+        let committee = get_beacon_committee(epochRef, slot, committee_index)
+        for index_in_committee, validator_index in committee:
+          let curr_val_pubkey = epochRef.validatorKey(validator_index)
           if curr_val_pubkey.isSome():
             if public_keys.findIt(it == curr_val_pubkey.get().toPubKey()) != -1:
               result.add((public_key: curr_val_pubkey.get().toPubKey(),
-                          validator_index: validatorIdx,
-                          committee_index: committee_index.CommitteeIndex,
+                          validator_index: validator_index,
+                          committee_index: committee_index,
                           committee_length: committee.lenu64,
                           validator_committee_index: index_in_committee.uint64,
                           slot: slot))

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -503,10 +503,6 @@ type
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
 
-template asInt*(x: SyncSubcommitteeIndex): int = int(x)
-template asUInt8*(x: SyncSubcommitteeIndex): uint8 = uint8(x)
-template asUInt64*(x: SyncSubcommitteeIndex): uint64 = uint64(x)
-
 template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
   a[i.asInt]
 
@@ -514,23 +510,7 @@ template `[]`*(arr: array[SYNC_COMMITTEE_SIZE, any] | seq;
                idx: IndexInSyncCommittee): auto =
   arr[int idx]
 
-template `==`*(x, y: SyncSubcommitteeIndex): bool =
-  distinctBase(x) == distinctBase(y)
-
-iterator allSyncSubcommittees*: SyncSubcommitteeIndex =
-  for subcommitteeIdx in 0 ..< SYNC_COMMITTEE_SUBNET_COUNT:
-    yield SyncSubcommitteeIndex(subcommitteeIdx)
-
-template validateSyncCommitteeIndexOr*(
-    networkValParam: uint64,
-    elseBody: untyped): SyncSubcommitteeIndex =
-  let networkVal = networkValParam
-  if networkVal < SYNC_COMMITTEE_SUBNET_COUNT:
-    SyncSubcommitteeIndex(networkVal)
-  else:
-    elseBody
-
-template asUInt8*(x: SyncSubcommitteeIndex): uint8 = uint8(x)
+makeLimitedU64(SyncSubcommitteeIndex, SYNC_COMMITTEE_SUBNET_COUNT)
 
 func shortLog*(v: SomeBeaconBlock): auto =
   (

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -469,18 +469,16 @@ proc readValue*(reader: var JsonReader[RestJson],
 ## CommitteeIndex
 proc writeValue*(writer: var JsonWriter[RestJson], value: CommitteeIndex) {.
      raises: [IOError, Defect].} =
-  writeValue(writer, Base10.toString(uint8(value)))
+  writeValue(writer, value.asUInt64)
 
 proc readValue*(reader: var JsonReader[RestJson], value: var CommitteeIndex) {.
      raises: [IOError, SerializationError, Defect].} =
-  let svalue = reader.readValue(string)
-  let res = Base10.decode(uint64, svalue)
+  var v: uint64
+  reader.readValue(v)
+
+  let res = CommitteeIndex.init(v)
   if res.isOk():
-    let committee_index = CommitteeIndex.init(res.get())
-    if committee_index.isOk():
-      value = committee_index.get()
-    else:
-      reader.raiseUnexpectedValue($committee_index.error())
+    value = res.get()
   else:
     reader.raiseUnexpectedValue($res.error())
 
@@ -908,18 +906,17 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconStat
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: SyncSubcommitteeIndex) {.
      raises: [IOError, Defect].} =
-  writeValue(writer, Base10.toString(uint8(value)))
+  writeValue(writer, value.asUInt64)
 
 proc readValue*(reader: var JsonReader[RestJson],
                 value: var SyncSubcommitteeIndex) {.
      raises: [IOError, SerializationError, Defect].} =
-  let res = Base10.decode(uint8, reader.readValue(string))
+  var v: uint64
+  reader.readValue(v)
+
+  let res = SyncSubcommitteeIndex.init(v)
   if res.isOk():
-    let subcommittteeIdx = SyncSubcommitteeIndex.init(res.get())
-    if subcommittteeIdx.isOk():
-      value = subcommittteeIdx.get()
-    else:
-      reader.raiseUnexpectedValue("Sync sub-committee index out of rage")
+    value = res.get()
   else:
     reader.raiseUnexpectedValue($res.error())
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -94,7 +94,7 @@ type
     committee_index*: CommitteeIndex
     committee_length*: uint64
     committees_at_slot*: uint64
-    validator_committee_index*: ValidatorIndex
+    validator_committee_index*: uint64
     slot*: Slot
 
   RestProposerDuty* = object

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -87,7 +87,7 @@ func getAttestationTopic*(forkDigest: ForkDigest,
 func getSyncCommitteeTopic*(forkDigest: ForkDigest,
                             subcommitteeIdx: SyncSubcommitteeIndex): string =
   ## For subscribing and unsubscribing to/from a subnet.
-  eth2Prefix(forkDigest) & "sync_committee_" & $(subcommitteeIdx.asUInt8) & "/ssz_snappy"
+  eth2Prefix(forkDigest) & "sync_committee_" & $subcommitteeIdx & "/ssz_snappy"
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/p2p-interface.md#topics-and-messages
 func getSyncCommitteeContributionAndProofTopic*(forkDigest: ForkDigest): string =

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -215,7 +215,7 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
   let
     vc = service.client
     slot = adata.slot
-    committeeIndex = CommitteeIndex(adata.index)
+    committeeIndex = adata.index
     attestationRoot = adata.hash_tree_root()
 
   let aggregateItems =

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -918,8 +918,11 @@ proc sendAggregatedAttestations(
 
   await allFutures(slotSigs)
 
-  for data, fut in zip(slotSigsData, slotSigs).items():
-    let slotSig = fut.read()
+  doAssert slotSigsData.len == slotSigs.len
+  for i in 0..<slotSigs.len:
+    let
+      slotSig = slotSigs[i].read()
+      data = slotSigsData[i]
     if slotSig.isErr():
       error "Unable to create slot signature using remote signer",
             validator = shortLog(data.v),

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -615,12 +615,12 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
         state[].data.get_block_root_at_slot(penultimate_epoch_end_slot)
 
     let first_slot_attesters = block:
-      let committee_count = state[].data.get_committee_count_per_slot(
+      let committees_per_slot = state[].data.get_committee_count_per_slot(
         prev_epoch_target_slot.epoch, cache)
       var indices = HashSet[ValidatorIndex]()
-      for committee_index in 0..<committee_count:
+      for committee_index in get_committee_indices(committees_per_slot):
         for validator_index in state[].data.get_beacon_committee(
-            prev_epoch_target_slot, committee_index.CommitteeIndex, cache):
+            prev_epoch_target_slot, committee_index, cache):
           indices.incl(validator_index)
       indices
     case info.kind

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -1460,9 +1460,9 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "200"},
+      "status": {"operator": "equals", "value": "400"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmps", "start": ["data"], "value": [{"index": "", "slot": "", "validators": [""]}]}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
     }
   },
   {
@@ -2512,9 +2512,9 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "200"},
+      "status": {"operator": "equals", "value": "400"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmps", "start": ["data"],"value": [{"aggregation_bits": "", "signature": "", "data": {"slot": "", "index": "", "beacon_block_root": "", "source": {"epoch": "", "root": ""}, "target": {"epoch": "", "root": ""}}}]}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
     }
   },
   {
@@ -2572,9 +2572,9 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "200"},
+      "status": {"operator": "equals", "value": "400"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmps", "start": ["data"],"value": [{"aggregation_bits": "", "signature": "", "data": {"slot": "", "index": "", "beacon_block_root": "", "source": {"epoch": "", "root": ""}, "target": {"epoch": "", "root": ""}}}]}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
     }
   },
   {
@@ -3017,7 +3017,7 @@
       "headers": {"Accept": "application/json"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "503"},
+      "status": {"operator": "equals", "value": "400"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
       "body": [{"operator": "jstructcmpns", "value": {"code": "", "message": ""}}]
     }

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -206,8 +206,8 @@ proc stepOnAttestation(
     dag.getEpochRef(
       dag.head, time.slotOrZero().compute_epoch_at_slot(),
       false).expect("no pruning in test")
-  let attesters = epochRef.get_attesting_indices(att.data, att.aggregation_bits)
-
+  let attesters = epochRef.get_attesting_indices(
+    att.data.slot, CommitteeIndex(att.data.index), att.aggregation_bits)
   let status = fkChoice[].on_attestation(
     dag,
     att.data.slot, att.data.beacon_block_root, attesters,

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -42,11 +42,9 @@ func addMockAttestations*(
     start_slot = compute_start_slot_at_epoch(epoch)
     committees_per_slot = get_committee_count_per_slot(state, epoch, cache)
 
-  # for-loop of distinct type is broken: https://github.com/nim-lang/Nim/issues/12074
-  for slot in start_slot.uint64 ..< start_slot.uint64 + SLOTS_PER_EPOCH:
-    for index in 0'u64 ..< committees_per_slot:
-      let committee = get_beacon_committee(
-                        state, slot.Slot, index.CommitteeIndex, cache)
+  for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+    for committee_index in get_committee_indices(committees_per_slot):
+      let committee = get_beacon_committee(state, slot, committee_index, cache)
 
       # Create a bitfield filled with the given count per attestation,
       # exactly on the right-most part of the committee field.
@@ -70,7 +68,7 @@ func addMockAttestations*(
         aggregation_bits: aggregation_bits,
         data: AttestationData(
           slot: slot.Slot,
-          index: index,
+          index: committee_index.uint64,
           beacon_block_root: [byte 0xFF] * 32, # Irrelevant for testing
           source: source,
           target: target,

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -566,9 +566,9 @@ suite "Attestation pool processing" & preset():
         pruneAtFinalization(dag, pool[])
 
         attestations.setlen(0)
-        for index in 0'u64 ..< committees_per_slot:
+        for committee_index in get_committee_indices(committees_per_slot):
           let committee = get_beacon_committee(
-            state[].data, getStateField(state.data, slot), index.CommitteeIndex,
+            state[].data, getStateField(state.data, slot), committee_index,
             cache)
 
           # Create a bitfield filled with the given count per attestation,
@@ -581,7 +581,7 @@ suite "Attestation pool processing" & preset():
             aggregation_bits: aggregation_bits,
             data: makeAttestationData(
               state[].data, getStateField(state.data, slot),
-              index.CommitteeIndex, blockRef.get().root)
+              committee_index, blockRef.get().root)
             # signature: ValidatorSig()
           )
 

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -54,7 +54,7 @@ suite "Gossip validation " & preset():
         defaultRuntimeConfig, state.data, getStateField(state.data, slot) + 1,
         cache, info, {})
 
-  test "Any committee index is valid":
+  test "Empty committee when no committee for slot":
     template committee(idx: uint64): untyped =
       get_beacon_committee(
         dag.headState.data, dag.head.slot, idx.CommitteeIndex, cache)
@@ -65,13 +65,11 @@ suite "Gossip validation " & preset():
 
     check:
       committee(0).len > 0
-      committee(10000).len == 0
-      committee(uint64.high).len == 0
+      committee(63).len == 0
 
     check:
       committeeLen(2) > 0
-      committeeLen(10000) == 0
-      committeeLen(uint64.high) == 0
+      committeeLen(63) == 0
 
   test "validateAttestation":
     var


### PR DESCRIPTION
Harden the use of `CommitteeIndex` et al to prevent future issues by
using a distinct type, then validating before use in several cases -
datatypes in spec are kept simple though so that invalid data still can
be read.

* fix invalid epoch used in REST
`/eth/v1/beacon/states/{state_id}/committees` committee length (could
return invalid data)
* normalize some variable names
* normalize committee index loops
* fix `RestAttesterDuty` to use `uint64` for `validator_committee_index`
* validate `CommitteeIndex` on ingress in REST API