### PR TITLE
time: spring cleaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build/
 /dist
 /benchmark_results
 /.update.timestamp
+resttest0_data

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -77,6 +77,11 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + latest_block_root                                                                          OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
+## Beacon time
+```diff
++ basics                                                                                     OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool altair processing [Preset: mainnet]
 ```diff
 + Invalid signatures [Preset: mainnet]                                                       OK
@@ -436,4 +441,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 236/238 Fail: 0/238 Skip: 2/238
+OK: 237/239 Fail: 0/239 Skip: 2/239

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -139,7 +139,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
 
           withBlck(dag.get(blckRef).data):
             forkChoice.process_block(
-              dag, epochRef, blckRef, blck.message, blckRef.slot.toBeaconTime)
+              dag, epochRef, blckRef, blck.message, blckRef.slot.start_beacon_time)
 
     doAssert status.isOk(), "Error in preloading the fork choice: " & $status.error
 
@@ -459,11 +459,8 @@ func init(
 
   template update_attestation_pool_cache(
       epoch: Epoch, participation_bitmap: untyped) =
-    let
-      start_slot = epoch.compute_start_slot_at_epoch()
-
     for committee_index in get_committee_indices(state.data, epoch, cache):
-      for slot in start_slot..<start_slot + SLOTS_PER_EPOCH:
+      for slot in epoch.slots():
         let committee = get_beacon_committee(
             state.data, slot, committee_index, cache)
         var

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -12,7 +12,6 @@ import
   chronicles,
   stew/[assign2, results],
   eth/keys,
-  ".."/[beacon_clock],
   ../spec/[
     eth2_merkleization, forks, helpers, signatures, signatures_batch,
     state_transition],
@@ -99,16 +98,8 @@ proc addResolvedHeadBlock(
 
   blockRef
 
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-type SomeSignedBlock =
-  phase0.SignedBeaconBlock | phase0.SigVerifiedSignedBeaconBlock |
-  phase0.TrustedSignedBeaconBlock |
-  altair.SignedBeaconBlock | altair.SigVerifiedSignedBeaconBlock |
-  altair.TrustedSignedBeaconBlock |
-  merge.SignedBeaconBlock | merge.SigVerifiedSignedBeaconBlock |
-  merge.TrustedSignedBeaconBlock
 proc checkStateTransition(
-       dag: ChainDAGRef, signedBlock: SomeSignedBlock,
+       dag: ChainDAGRef, signedBlock: SomeForkySignedBeaconBlock,
        cache: var StateCache): Result[void, BlockError] =
   ## Ensure block can be applied on a state
   func restore(v: var ForkedHashedBeaconState) =

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -171,7 +171,7 @@ func atSlot*(bid: BlockId): BlockSlotId =
 
 func atEpochStart*(blck: BlockRef, epoch: Epoch): BlockSlot =
   ## Return the BlockSlot corresponding to the first slot in the given epoch
-  atSlot(blck, epoch.compute_start_slot_at_epoch())
+  atSlot(blck, epoch.start_slot())
 
 func atSlotEpoch*(blck: BlockRef, epoch: Epoch): BlockSlot =
   ## Return the last block that was included in the chain leading
@@ -181,8 +181,9 @@ func atSlotEpoch*(blck: BlockRef, epoch: Epoch): BlockSlot =
   if epoch == GENESIS_EPOCH:
     blck.atEpochStart(epoch)
   else:
-    let start = epoch.compute_start_slot_at_epoch()
-    let tmp = blck.atSlot(start - 1)
+    let
+      start = epoch.start_slot()
+      tmp = blck.atSlot(start - 1)
     if isNil(tmp.blck):
       BlockSlot()
     else:
@@ -215,7 +216,7 @@ func isProposed*(bsi: BlockSlotId): bool =
 func dependentBlock*(head, tail: BlockRef, epoch: Epoch): BlockRef =
   ## The block that determined the proposer shuffling in the given epoch
   let dependentSlot =
-    if epoch >= Epoch(1): epoch.compute_start_slot_at_epoch() - 1
+    if epoch >= Epoch(1): epoch.start_slot() - 1
     else: Slot(0)
   let res = head.atSlot(dependentSlot)
   if isNil(res.blck): tail

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -152,8 +152,8 @@ func makeAttestationData*(
 
   let
     slot = bs.slot
-    current_epoch = slot.compute_epoch_at_slot()
-    epoch_boundary_slot = compute_start_slot_at_epoch(current_epoch)
+    current_epoch = slot.epoch()
+    epoch_boundary_slot = current_epoch.start_slot()
     epoch_boundary_block = bs.blck.atSlot(epoch_boundary_slot)
 
   doAssert current_epoch == epochRef.epoch
@@ -178,9 +178,8 @@ iterator get_committee_assignments*(
   let
     committees_per_slot = get_committee_count_per_slot(epochRef)
     epoch = epochRef.epoch
-    start_slot = compute_start_slot_at_epoch(epoch)
 
-  for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+  for slot in epoch.slots():
     for committee_index in get_committee_indices(committees_per_slot):
       if anyIt(get_beacon_committee(epochRef, slot, committee_index), it in validator_indices):
         yield (

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -15,10 +15,7 @@ import
 
   chronicles,
   # Internal
-  ../beacon_clock,
-  ../spec/datatypes/base,
-  ../consensus_object_pools/block_pools_types
-
+  ../spec/datatypes/base
 # https://github.com/ethereum/consensus-specs/blob/v0.11.1/specs/phase0/fork-choice.md
 # This is a port of https://github.com/sigp/lighthouse/pull/804
 # which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost

--- a/beacon_chain/gossip_processing/consensus_manager.nim
+++ b/beacon_chain/gossip_processing/consensus_manager.nim
@@ -10,7 +10,6 @@
 import
   chronicles, chronos,
   ../spec/datatypes/base,
-  ../beacon_clock,
   ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool]
 
 # TODO: Move to "consensus_object_pools" folder
@@ -80,7 +79,7 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
   ## `pruneFinalized` must be called for pruning.
 
   # Grab the new head according to our latest attestation data
-  let newHead = self.attestationPool[].selectHead(wallSlot.toBeaconTime)
+  let newHead = self.attestationPool[].selectHead(wallSlot.start_beacon_time)
   if newHead.isNil():
     warn "Head selection failed, using previous head",
       head = shortLog(self.dag.head), wallSlot

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -194,7 +194,7 @@ proc blockValidator*(
     return errIgnore("Block before genesis")
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - signedBlock.message.slot.toBeaconTime
+  let delay = wallTime - signedBlock.message.slot.start_beacon_time
 
   # Start of block processing - in reality, we have already gone through SSZ
   # decoding at this stage, which may be significant
@@ -213,7 +213,8 @@ proc blockValidator*(
 
     self.blockProcessor[].addBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),
-      validationDur = self.getCurrentBeaconTime() - wallTime)
+      validationDur = nanoseconds(
+        (self.getCurrentBeaconTime() - wallTime).nanoseconds))
 
     # Validator monitor registration for blocks is done by the processor
     beacon_blocks_received.inc()
@@ -296,7 +297,7 @@ proc attestationValidator*(
     return errIgnore("Attestation before genesis")
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - attestation.data.slot.toBeaconTime
+  let delay = wallTime - attestation.data.slot.start_beacon_time
   debug "Attestation received", delay
 
   # Now proceed to validation
@@ -346,7 +347,7 @@ proc aggregateValidator*(
 
   # Potential under/overflows are fine; would just create odd logs
   let delay =
-    wallTime - signedAggregateAndProof.message.aggregate.data.slot.toBeaconTime
+    wallTime - signedAggregateAndProof.message.aggregate.data.slot.start_beacon_time
   debug "Aggregate received", delay
 
   let v =
@@ -467,7 +468,7 @@ proc syncCommitteeMessageValidator*(
     wallSlot
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - syncCommitteeMsg.slot.toBeaconTime
+  let delay = wallTime - syncCommitteeMsg.slot.start_beacon_time
   debug "Sync committee message received", delay
 
   # Now proceed to validation
@@ -513,7 +514,7 @@ proc contributionValidator*(
     wallSlot
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - contributionAndProof.message.contribution.slot.toBeaconTime
+  let delay = wallTime - contributionAndProof.message.contribution.slot.start_beacon_time
   debug "Contribution received", delay
 
   # Now proceed to validation

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -124,7 +124,7 @@ func check_beacon_and_target_block(
   # attestation.data.target.root
   # the sanity of target.epoch has been checked by check_attestation_slot_target
   let
-    target = blck.atSlot(compute_start_slot_at_epoch(data.target.epoch))
+    target = blck.atSlot(data.target.epoch.start_slot())
 
   if isNil(target.blck):
     # Shouldn't happen - we've checked that the target epoch is within range
@@ -319,8 +319,7 @@ proc validateBeaconBlock*(
   let
     finalized_checkpoint = getStateField(
       dag.headState.data, finalized_checkpoint)
-    ancestor = get_ancestor(
-      parent_ref, compute_start_slot_at_epoch(finalized_checkpoint.epoch))
+    ancestor = get_ancestor(parent_ref, finalized_checkpoint.epoch.start_slot)
 
   if ancestor.isNil:
     # This shouldn't happen: we should always be able to trace the parent back

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -95,7 +95,7 @@ proc initClock(vc: ValidatorClientRef): Future[BeaconClock] {.async.} =
   info "Initializing beacon clock",
        genesis_time = vc.beaconGenesis.genesis_time,
        current_slot = currentSlot, current_epoch = currentEpoch
-  let genesisTime = res.fromNow(toBeaconTime(Slot(0)))
+  let genesisTime = res.fromNow(start_beacon_time(Slot(0)))
   if genesisTime.inFuture:
     notice "Waiting for genesis", genesisIn = genesisTime.offset
     await sleepAsync(genesisTime.offset)
@@ -141,7 +141,7 @@ proc onSlotStart(vc: ValidatorClientRef, wallTime: BeaconTime,
   let
     # If everything was working perfectly, the slot that we should be processing
     expectedSlot = lastSlot + 1
-    delay = wallTime - expectedSlot.toBeaconTime()
+    delay = wallTime - expectedSlot.start_beacon_time()
 
   checkIfShouldStopAtEpoch(wallSlot.slot, vc.config.stopAtEpoch)
 

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -589,13 +589,12 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       var res: seq[RestBeaconStatesCommittees]
       let qepoch =
         if vepoch.isNone:
-          compute_epoch_at_slot(getStateField(stateData.data, slot))
+          epoch(getStateField(stateData.data, slot))
         else:
           vepoch.get()
 
       if vslot.isNone():
-        let start_slot = qepoch.compute_start_slot_at_epoch()
-        for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+        for slot in qepoch.slots():
           forSlot(slot, vindex, res)
       else:
         forSlot(vslot.get(), vindex, res)

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -1,7 +1,10 @@
-import ../spec/helpers
+import
+  ../spec/beacon_time
+
+export beacon_time
 
 const
-  MaxEpoch* = compute_epoch_at_slot(not(0'u64))
+  MaxEpoch* = epoch(FAR_FUTURE_SLOT)
 
   BlockValidationError* =
     "The block failed validation, but was successfully broadcast anyway. It " &

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -66,7 +66,7 @@ proc getCurrentHead*(node: BeaconNode,
                      epoch: Epoch): Result[BlockRef, cstring] =
   if epoch > MaxEpoch:
     return err("Requesting epoch for which slot would overflow")
-  node.getCurrentHead(compute_start_slot_at_epoch(epoch))
+  node.getCurrentHead(epoch.start_slot())
 
 proc getBlockSlot*(node: BeaconNode,
                    stateIdent: StateIdent): Result[BlockSlot, cstring] =

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -79,9 +79,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
         let
           committees_per_slot = get_committee_count_per_slot(epochRef)
-          start_slot = qepoch.compute_start_slot_at_epoch()
         for committee_index in get_committee_indices(committees_per_slot):
-          for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+          for slot in qepoch.slots():
             let committee = get_beacon_committee(epochRef, slot, committee_index)
             for index_in_committee, validator_index in committee:
               if validator_index in indexList:
@@ -143,7 +142,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
               RestProposerDuty(
                 pubkey: epochRef.validatorKey(bp.get()).get().toPubKey(),
                 validator_index: bp.get(),
-                slot: compute_start_slot_at_epoch(qepoch) + i
+                slot: qepoch.start_slot() + i
               )
             )
         res

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -364,13 +364,12 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
       let qepoch =
         if epoch.isNone:
-          compute_epoch_at_slot(getStateField(stateData.data, slot))
+          epoch(getStateField(stateData.data, slot))
         else:
           Epoch(epoch.get())
 
       if slot.isNone:
-        let start_slot = qepoch.compute_start_slot_at_epoch()
-        for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+        for slot in qepoch.slots():
           forSlot(slot, res)
       else:
         forSlot(Slot(slot.get()), res)

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -44,7 +44,7 @@ proc parseRoot*(str: string): Eth2Digest {.raises: [Defect, ValueError].} =
   Eth2Digest(data: hexToByteArray[32](str))
 
 func checkEpochToSlotOverflow*(epoch: Epoch) {.raises: [Defect, ValueError].} =
-  const maxEpoch = compute_epoch_at_slot(not 0'u64)
+  const maxEpoch = epoch(FAR_FUTURE_SLOT)
   if epoch >= maxEpoch:
     raise newException(
       ValueError, "Requesting epoch for which slot would overflow")
@@ -59,7 +59,7 @@ proc doChecksAndGetCurrentHead*(node: BeaconNode, slot: Slot): BlockRef {.raises
 
 proc doChecksAndGetCurrentHead*(node: BeaconNode, epoch: Epoch): BlockRef {.raises: [Defect, CatchableError].} =
   checkEpochToSlotOverflow(epoch)
-  node.doChecksAndGetCurrentHead(epoch.compute_start_slot_at_epoch)
+  node.doChecksAndGetCurrentHead(epoch.start_slot())
 
 proc getBlockSlotFromString*(node: BeaconNode, slot: string): BlockSlot {.raises: [Defect, CatchableError].} =
   if slot.len == 0:

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -92,8 +92,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     let
       committees_per_slot = get_committee_count_per_slot(epochRef)
-      start_slot = compute_start_slot_at_epoch(epoch)
-    for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+    for slot in epoch.slots():
       for committee_index in get_committee_indices(committees_per_slot):
         let committee = get_beacon_committee(epochRef, slot, committee_index)
         for index_in_committee, validator_index in committee:
@@ -122,7 +121,7 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       if bp.isSome():
         result.add((public_key: epochRef.validatorKey(bp.get).get().toPubKey,
                     validator_index: bp.get(),
-                    slot: compute_start_slot_at_epoch(epoch) + i))
+                    slot: epoch.start_slot() + i))
 
   rpcServer.rpc("post_v1_validator_beacon_committee_subscriptions") do (
       committee_index: CommitteeIndex, slot: Slot, aggregator: bool,

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -1,0 +1,255 @@
+# beacon_chain
+# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  std/[hashes, typetraits],
+  chronicles,
+  chronos/timer,
+  json_serialization,
+  ./presets
+
+export hashes, timer, json_serialization, presets
+
+# A collection of time units that permeate the spec - common to all of them is
+# that they expressed relative to the genesis of the chain at varying
+# granularities:
+#
+# * BeaconTime - nanoseconds since genesis
+# * Slot - SLOTS_PER_SECOND seconds since genesis
+# * Epoch - EPOCHS_PER_SLOT slots since genesis
+# * SyncCommitteePeriod - EPOCHS_PER_SYNC_COMMITTEE_PERIOD epochs since genesis
+
+type
+  BeaconTime* = object
+    ## A point in time, relative to the genesis of the chain
+    ##
+    ## Implemented as nanoseconds since genesis - negative means before
+    ## the chain started.
+    ns_since_genesis*: int64
+
+  TimeDiff* = object
+    nanoseconds*: int64
+    ## Difference between two points in time with nanosecond granularity
+    ## Can be negative (unlike timer.Duration)
+
+const
+  # Earlier spec versions had these at a different slot
+  GENESIS_SLOT* = Slot(0)
+  GENESIS_EPOCH* = Epoch(0) # compute_epoch_at_slot(GENESIS_SLOT)
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/fork-choice.md#constant
+  INTERVALS_PER_SLOT* = 3
+
+  FAR_FUTURE_BEACON_TIME* = BeaconTime(ns_since_genesis: int64.high())
+  FAR_FUTURE_SLOT* = Slot(not 0'u64)
+  # FAR_FUTURE_EPOCH* = Epoch(not 0'u64) # in presets
+  FAR_FUTURE_PERIOD* = SyncCommitteePeriod(not 0'u64)
+
+  NANOSECONDS_PER_SLOT = SECONDS_PER_SLOT * 1_000_000_000'u64
+
+# TODO when https://github.com/nim-lang/Nim/issues/14440 lands in Status's Nim,
+# switch proc {.noSideEffect.} to func.
+template ethTimeUnit(typ: type) {.dirty.} =
+  proc `+`*(x: typ, y: uint64): typ {.borrow, noSideEffect.}
+  proc `-`*(x: typ, y: uint64): typ {.borrow, noSideEffect.}
+  proc `-`*(x: uint64, y: typ): typ {.borrow, noSideEffect.}
+
+  # Not closed over type in question (Slot or Epoch)
+  proc `mod`*(x: typ, y: uint64): uint64 {.borrow, noSideEffect.}
+  proc `div`*(x: typ, y: uint64): uint64 {.borrow, noSideEffect.}
+  proc `div`*(x: uint64, y: typ): uint64 {.borrow, noSideEffect.}
+  proc `-`*(x: typ, y: typ): uint64 {.borrow, noSideEffect.}
+
+  proc `*`*(x: typ, y: uint64): uint64 {.borrow, noSideEffect.}
+
+  proc `+=`*(x: var typ, y: typ) {.borrow, noSideEffect.}
+  proc `+=`*(x: var typ, y: uint64) {.borrow, noSideEffect.}
+  proc `-=`*(x: var typ, y: typ) {.borrow, noSideEffect.}
+  proc `-=`*(x: var typ, y: uint64) {.borrow, noSideEffect.}
+
+  # Comparison operators
+  proc `<`*(x: typ, y: typ): bool {.borrow, noSideEffect.}
+  proc `<`*(x: typ, y: uint64): bool {.borrow, noSideEffect.}
+  proc `<`*(x: uint64, y: typ): bool {.borrow, noSideEffect.}
+  proc `<=`*(x: typ, y: typ): bool {.borrow, noSideEffect.}
+  proc `<=`*(x: typ, y: uint64): bool {.borrow, noSideEffect.}
+  proc `<=`*(x: uint64, y: typ): bool {.borrow, noSideEffect.}
+
+  proc `==`*(x: typ, y: typ): bool {.borrow, noSideEffect.}
+  proc `==`*(x: typ, y: uint64): bool {.borrow, noSideEffect.}
+  proc `==`*(x: uint64, y: typ): bool {.borrow, noSideEffect.}
+
+  # Nim integration
+  proc `$`*(x: typ): string {.borrow, noSideEffect.}
+  proc hash*(x: typ): Hash {.borrow, noSideEffect.}
+
+  template asUInt64*(v: typ): uint64 = distinctBase(v)
+  template shortLog*(v: typ): auto = distinctBase(v)
+
+  # Serialization
+  proc writeValue*(writer: var JsonWriter, value: typ)
+                  {.raises: [IOError, Defect].}=
+    writeValue(writer, uint64 value)
+
+  proc readValue*(reader: var JsonReader, value: var typ)
+                 {.raises: [IOError, SerializationError, Defect].} =
+    value = typ reader.readValue(uint64)
+
+ethTimeUnit Slot
+ethTimeUnit Epoch
+ethTimeUnit SyncCommitteePeriod
+
+template `<`*(a, b: BeaconTime): bool = a.ns_since_genesis < b.ns_since_genesis
+template `<=`*(a, b: BeaconTime): bool = a.ns_since_genesis <= b.ns_since_genesis
+template `<`*(a, b: TimeDiff): bool = a.nanoseconds < b.nanoseconds
+template `<=`*(a, b: TimeDiff): bool = a.nanoseconds <= b.nanoseconds
+template `<`*(a: TimeDiff, b: Duration): bool = a.nanoseconds < b.nanoseconds
+
+func toSlot*(t: BeaconTime): tuple[afterGenesis: bool, slot: Slot] =
+  if t == FAR_FUTURE_BEACON_TIME:
+    (true, FAR_FUTURE_SLOT)
+  elif t.ns_since_genesis >= 0:
+    (true, Slot(uint64(t.ns_since_genesis) div NANOSECONDS_PER_SLOT))
+  else:
+    (false, Slot(uint64(-t.ns_since_genesis) div NANOSECONDS_PER_SLOT))
+
+template `+`*(t: BeaconTime, offset: Duration | TimeDiff): BeaconTime =
+  BeaconTime(ns_since_genesis: t.ns_since_genesis + offset.nanoseconds)
+
+template `-`*(t: BeaconTime, offset: Duration | TimeDiff): BeaconTime =
+  BeaconTime(ns_since_genesis: t.ns_since_genesis - offset.nanoseconds)
+
+template `-`*(a, b: BeaconTime): TimeDiff =
+  TimeDiff(nanoseconds: a.ns_since_genesis - b.ns_since_genesis)
+
+template `+`*(a: TimeDiff, b: Duration): TimeDiff =
+  TimeDiff(nanoseconds: a.nanoseconds + b.nanoseconds)
+
+const
+  # Offsets from the start of the slot to when the corresponding message should
+  # be sent
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#attesting
+  attestationSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64 div INTERVALS_PER_SLOT)
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#broadcast-aggregate
+  aggregateSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64  * 2 div INTERVALS_PER_SLOT)
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/validator.md#prepare-sync-committee-message
+  syncCommitteeMessageSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64  div INTERVALS_PER_SLOT)
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/validator.md#broadcast-sync-committee-contribution
+  syncContributionSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64  * 2 div INTERVALS_PER_SLOT)
+
+func toFloatSeconds*(t: TimeDiff): float =
+  float(t.nanoseconds) / 1_000_000_000.0
+
+func start_beacon_time*(s: Slot): BeaconTime =
+  # The point in time that a slot begins
+  const maxSlot = Slot(
+    uint64(FAR_FUTURE_BEACON_TIME.ns_since_genesis) div NANOSECONDS_PER_SLOT)
+  if s > maxSlot: FAR_FUTURE_BEACON_TIME
+  else: BeaconTime(ns_since_genesis: int64(uint64(s) * NANOSECONDS_PER_SLOT))
+
+func block_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time
+func attestation_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time + attestationSlotOffset
+func aggregate_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time + aggregateSlotOffset
+func sync_committee_message_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time + syncCommitteeMessageSlotOffset
+func sync_contribution_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time + syncContributionSlotOffset
+
+func slotOrZero*(time: BeaconTime): Slot =
+  let exSlot = time.toSlot
+  if exSlot.afterGenesis: exSlot.slot
+  else: Slot(0)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#compute_epoch_at_slot
+func epoch*(slot: Slot): Epoch = # aka compute_epoch_at_slot
+  ## Return the epoch number at ``slot``.
+  if slot == FAR_FUTURE_SLOT: FAR_FUTURE_EPOCH
+  else: Epoch(slot div SLOTS_PER_EPOCH)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/fork-choice.md#compute_slots_since_epoch_start
+func since_epoch_start*(slot: Slot): uint64 = # aka compute_slots_since_epoch_start
+  ## How many slots since the beginning of the epoch (`[0..SLOTS_PER_EPOCH-1]`)
+  (slot mod SLOTS_PER_EPOCH)
+
+template is_epoch*(slot: Slot): bool =
+  slot.since_epoch_start == 0
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
+func start_slot*(epoch: Epoch): Slot = # aka compute_start_slot_at_epoch
+  ## Return the start slot of ``epoch``.
+  const maxEpoch = Epoch(FAR_FUTURE_SLOT div SLOTS_PER_EPOCH)
+  if epoch >= maxEpoch: FAR_FUTURE_SLOT
+  else: Slot(epoch * SLOTS_PER_EPOCH)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_previous_epoch
+func get_previous_epoch*(current_epoch: Epoch): Epoch =
+  ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
+  if current_epoch == GENESIS_EPOCH:
+    current_epoch
+  else:
+    current_epoch - 1
+
+iterator slots*(epoch: Epoch): Slot =
+  let start_slot = start_slot(epoch)
+  for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+    yield slot
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/validator.md#sync-committee
+template sync_committee_period*(epoch: Epoch): SyncCommitteePeriod =
+  if epoch == FAR_FUTURE_EPOCH: FAR_FUTURE_PERIOD
+  else: SyncCommitteePeriod(epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+
+template sync_committee_period*(slot: Slot): SyncCommitteePeriod =
+  if slot == FAR_FUTURE_SLOT: FAR_FUTURE_PERIOD
+  else: SyncCommitteePeriod(slot div SLOTS_PER_SYNC_COMMITTEE_PERIOD)
+
+func since_sync_committee_period_start*(slot: Slot): uint64 =
+  ## How many slots since the beginning of the epoch (`[0..SLOTS_PER_SYNC_COMMITTEE_PERIOD-1]`)
+  (slot mod SLOTS_PER_SYNC_COMMITTEE_PERIOD)
+
+func since_sync_committee_period_start*(epoch: Epoch): uint64 =
+  ## How many slots since the beginning of the epoch (`[0..EPOCHS_PER_SYNC_COMMITTEE_PERIOD-1]`)
+  (epoch mod EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+
+template is_sync_committee_period*(slot: Slot): bool =
+  slot.since_sync_committee_period_start() == 0
+
+template is_sync_committee_period*(epoch: Epoch): bool =
+  epoch.since_sync_committee_period_start() == 0
+
+template start_epoch*(period: SyncCommitteePeriod): Epoch =
+  const maxPeriod = SyncCommitteePeriod(
+    FAR_FUTURE_EPOCH div EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+  if period >= maxPeriod: FAR_FUTURE_EPOCH
+  else: Epoch(period * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+
+func shortLog*(t: BeaconTime): string =
+  if t.ns_since_genesis >= 0:
+    $(timer.nanoseconds(t.ns_since_genesis))
+  else:
+    "-" & $(timer.nanoseconds(-t.ns_since_genesis))
+
+func shortLog*(t: TimeDiff): string =
+  if t.nanoseconds >= 0:
+    $(timer.nanoseconds(t.nanoseconds))
+  else:
+    "-" & $(timer.nanoseconds(-t.nanoseconds))
+
+chronicles.formatIt BeaconTime: it.shortLog
+chronicles.formatIt TimeDiff: it.shortLog
+chronicles.formatIt Slot: it.shortLog
+chronicles.formatIt Epoch: it.shortLog
+chronicles.formatIt SyncCommitteePeriod: it.shortLog

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -352,7 +352,7 @@ func get_block_root_at_slot*(state: ForkedHashedBeaconState,
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_block_root
 func get_block_root*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
   ## Return the block root at the start of a recent ``epoch``.
-  get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch))
+  get_block_root_at_slot(state, epoch.start_slot())
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_total_balance
 template get_total_balance(
@@ -488,7 +488,7 @@ proc is_valid_indexed_attestation*(
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
 
 func check_attestation_slot_target*(data: AttestationData): Result[Slot, cstring] =
-  if not (data.target.epoch == compute_epoch_at_slot(data.slot)):
+  if not (data.target.epoch == epoch(data.slot)):
     return err("Target epoch doesn't match attestation slot")
 
   ok(data.slot)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -37,17 +37,6 @@ func integer_squareroot*(n: SomeInteger): SomeInteger =
     y = (x + n div x) div 2
   x
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#compute_epoch_at_slot
-func compute_epoch_at_slot*(slot: Slot|uint64): Epoch =
-  ## Return the epoch number at ``slot``.
-  (slot div SLOTS_PER_EPOCH).Epoch
-
-template epoch*(slot: Slot): Epoch =
-  compute_epoch_at_slot(slot)
-
-template isEpoch*(slot: Slot): bool =
-  (slot mod SLOTS_PER_EPOCH) == 0
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/ssz/merkle-proofs.md#generalized_index_sibling
 template generalized_index_sibling*(
     index: GeneralizedIndex): GeneralizedIndex =
@@ -352,18 +341,6 @@ func build_proof*(anchor: object, leaf_index: uint64,
   doAssert proof.len == log2trunc(leaf_index)
   build_proof_impl(anchor, leaf_index, proof)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/validator.md#sync-committee
-template sync_committee_period*(epoch: Epoch): SyncCommitteePeriod =
-  (epoch div EPOCHS_PER_SYNC_COMMITTEE_PERIOD).SyncCommitteePeriod
-
-template sync_committee_period*(slot: Slot): SyncCommitteePeriod =
-  sync_committee_period(epoch(slot))
-
-# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
-func compute_start_slot_at_epoch*(epoch: Epoch): Slot =
-  ## Return the start slot of ``epoch``.
-  (epoch * SLOTS_PER_EPOCH).Slot
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#is_active_validator
 func is_active_validator*(validator: Validator, epoch: Epoch): bool =
   ## Check if ``validator`` is active
@@ -405,13 +382,12 @@ func get_active_validator_indices_len*(
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: ForkyBeaconState): Epoch =
   ## Return the current epoch.
-  doAssert state.slot >= GENESIS_SLOT, $state.slot
-  compute_epoch_at_slot(state.slot)
+  state.slot.epoch
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: ForkedHashedBeaconState): Epoch =
   ## Return the current epoch.
-  withState(state): state.data.slot.epoch
+  withState(state): get_current_epoch(state.data)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -26,12 +26,8 @@ proc validate_light_client_update*(store: LightClientStore,
 
   # Verify update does not skip a sync committee period
   let
-    finalized_period =
-      compute_epoch_at_slot(store.finalized_header.slot) div
-        EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period =
-      compute_epoch_at_slot(active_header.slot) div
-        EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    finalized_period = sync_committee_period(store.finalized_header.slot)
+    update_period = sync_committee_period(active_header.slot)
 
   if update_period notin [finalized_period, finalized_period + 1]:
     return false
@@ -90,12 +86,8 @@ func apply_light_client_update(
     store: var LightClientStore, update: LightClientUpdate) =
   let
     active_header = get_active_header(update)
-    finalized_period =
-      compute_epoch_at_slot(store.finalized_header.slot) div
-        EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-    update_period =
-      compute_epoch_at_slot(active_header.slot) div
-        EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+    finalized_period = sync_committee_period(store.finalized_header.slot)
+    update_period = sync_committee_period(active_header.slot)
   if update_period == finalized_period + 1:
     store.current_sync_committee = store.next_sync_committee
     store.next_sync_committee = update.next_sync_committee

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -69,12 +69,12 @@ func compute_subnet_for_attestation*(
   # Note, this mimics expected Phase 1 behavior where attestations will be
   # mapped to their shard subnet.
   let
-    slots_since_epoch_start = slot mod SLOTS_PER_EPOCH
+    slots_since_epoch_start = slot.since_epoch_start()
     committees_since_epoch_start =
       committees_per_slot * slots_since_epoch_start
 
   SubnetId(
-    (committees_since_epoch_start + committee_index.uint64) mod
+    (committees_since_epoch_start + committee_index.asUInt64) mod
     ATTESTATION_SUBNET_COUNT)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#broadcast-attestation

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -37,7 +37,7 @@ func compute_slot_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot
     ): Eth2Digest =
   let
-    epoch = compute_epoch_at_slot(slot)
+    epoch = epoch(slot)
     domain = get_domain(
       fork, DOMAIN_SELECTION_PROOF, epoch, genesis_validators_root)
   compute_signing_root(slot, domain)
@@ -88,7 +88,7 @@ func compute_block_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
     blck: Eth2Digest | SomeSomeBeaconBlock | BeaconBlockHeader): Eth2Digest =
   let
-    epoch = compute_epoch_at_slot(slot)
+    epoch = epoch(slot)
     domain = get_domain(
       fork, DOMAIN_BEACON_PROPOSER, epoch, genesis_validators_root)
   compute_signing_root(blck, domain)
@@ -117,7 +117,7 @@ func compute_aggregate_and_proof_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest,
     aggregate_and_proof: AggregateAndProof): Eth2Digest =
   let
-    epoch = compute_epoch_at_slot(aggregate_and_proof.aggregate.data.slot)
+    epoch = epoch(aggregate_and_proof.aggregate.data.slot)
     domain = get_domain(
       fork, DOMAIN_AGGREGATE_AND_PROOF, epoch, genesis_validators_root)
   compute_signing_root(aggregate_and_proof, domain)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -250,7 +250,7 @@ proc collectSignatureSets*(
   if not proposer_key.isSome():
     return err("collectSignatureSets: invalid proposer index")
 
-  let epoch = signed_block.message.slot.compute_epoch_at_slot()
+  let epoch = signed_block.message.slot.epoch()
 
   # 1. Block proposer
   # ----------------------------------------------------

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -944,7 +944,7 @@ func process_participation_flag_updates*(state: var (altair.BeaconState | bellat
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/beacon-chain.md#sync-committee-updates
 proc process_sync_committee_updates*(state: var (altair.BeaconState | bellatrix.BeaconState)) =
   let next_epoch = get_current_epoch(state) + 1
-  if next_epoch mod EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
+  if next_epoch.is_sync_committee_period():
     state.current_sync_committee = state.next_sync_committee
     state.next_sync_committee = get_next_sync_committee(state)
 

--- a/beacon_chain/spec/weak_subjectivity.nim
+++ b/beacon_chain/spec/weak_subjectivity.nim
@@ -33,13 +33,12 @@ func is_within_weak_subjectivity_period*(cfg: RuntimeConfig, current_slot: Slot,
   # Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
   doAssert getStateField(ws_state, latest_block_header).state_root ==
     ws_checkpoint.root
-  doAssert compute_epoch_at_slot(getStateField(ws_state, slot)) ==
-    ws_checkpoint.epoch
+  doAssert epoch(getStateField(ws_state, slot)) == ws_checkpoint.epoch
 
   let
     ws_period = compute_weak_subjectivity_period(cfg, ws_state)
-    ws_state_epoch = compute_epoch_at_slot(getStateField(ws_state, slot))
-    current_epoch = compute_epoch_at_slot(current_slot)
+    ws_state_epoch = epoch(getStateField(ws_state, slot))
+    current_epoch = epoch(current_slot)
 
   current_epoch <= ws_state_epoch + ws_period
 

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -98,7 +98,7 @@ func getMutableValidatorStatuses(state: altair.BeaconState):
 
 func diffStates*(state0, state1: altair.BeaconState): BeaconStateDiff =
   doAssert state1.slot > state0.slot
-  doAssert state0.slot.isEpoch
+  doAssert state0.slot.is_epoch
   doAssert state1.slot == state0.slot + SLOTS_PER_EPOCH
   # TODO not here, but in dag, an isancestorof check
 
@@ -134,9 +134,9 @@ func diffStates*(state0, state1: altair.BeaconState): BeaconStateDiff =
     balances: state1.balances.data,
 
     # RANDAO mixes gets updated every block, in place
-    randao_mix: state1.randao_mixes[state0.slot.compute_epoch_at_slot.uint64 mod
+    randao_mix: state1.randao_mixes[state0.slot.epoch.uint64 mod
       EPOCHS_PER_HISTORICAL_VECTOR.uint64],
-    slashing: state1.slashings[state0.slot.compute_epoch_at_slot.uint64 mod
+    slashing: state1.slashings[state0.slot.epoch.uint64 mod
       EPOCHS_PER_HISTORICAL_VECTOR.uint64],
 
     previous_epoch_participation: state1.previous_epoch_participation.data,

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -378,10 +378,10 @@ proc getRewindPoint*[T](sq: SyncQueue[T], failSlot: Slot,
   case sq.kind
   of SyncQueueKind.Forward:
     # Calculate the latest finalized epoch.
-    let finalizedEpoch = compute_epoch_at_slot(safeSlot)
+    let finalizedEpoch = epoch(safeSlot)
 
     # Calculate failure epoch.
-    let failEpoch = compute_epoch_at_slot(failSlot)
+    let failEpoch = epoch(failSlot)
 
     # Calculate exponential rewind point in number of epochs.
     let epochCount =
@@ -445,16 +445,15 @@ proc getRewindPoint*[T](sq: SyncQueue[T], failSlot: Slot,
         if sq.rewind.isNone():
           finalizedEpoch
         else:
-          compute_epoch_at_slot(sq.rewind.get().failSlot) -
-            sq.rewind.get().epochCount
-      compute_start_slot_at_epoch(rewindEpoch)
+          epoch(sq.rewind.get().failSlot) - sq.rewind.get().epochCount
+      rewindEpoch.start_slot()
     else:
       # Calculate the rewind epoch, which should not be less than the latest
       # finalized epoch.
       let rewindEpoch = failEpoch - epochCount
       # Update and save new rewind point in SyncQueue.
       sq.rewind = some(RewindPoint(failSlot: failSlot, epochCount: epochCount))
-      compute_start_slot_at_epoch(rewindEpoch)
+      rewindEpoch.start_slot()
   of SyncQueueKind.Backward:
     # While we perform backward sync, the only possible slot we could rewind is
     # latest stored block.

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -16,7 +16,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
     fork = vc.fork.get()
 
   debug "Publishing block", validator = shortLog(validator),
-                            delay = vc.getDelay(ZeroDuration),
+                            delay = vc.getDelay(slot.block_deadline()),
                             wall_slot = currentSlot,
                             genesis_root = genesisRoot,
                             graffiti = graffiti, fork = fork, slot = slot,
@@ -152,7 +152,7 @@ proc contains(data: openArray[ProposerTask], duty: RestProposerDuty): bool =
   false
 
 proc checkDuty(duty: RestProposerDuty, epoch: Epoch, slot: Slot): bool =
-  let lastSlot = compute_start_slot_at_epoch(epoch + 1'u64)
+  let lastSlot = start_slot(epoch + 1'u64)
   if duty.slot >= slot:
     if duty.slot < lastSlot:
       true

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -178,8 +178,7 @@ func getNextValidatorAction*(
       return FAR_FUTURE_SLOT
 
     for slotOffset in 0 ..< SLOTS_PER_EPOCH:
-      let nextActionSlot =
-        compute_start_slot_at_epoch(bitmapEpoch) + slotOffset
+      let nextActionSlot = start_slot(bitmapEpoch) + slotOffset
       if ((orderedActionSlots[i] and (1'u32 shl slotOffset)) != 0) and
           nextActionSlot > slot:
         return nextActionSlot
@@ -222,7 +221,7 @@ proc updateActions*(tracker: var ActionTracker, epochRef: EpochRef) =
   for (committeeIndex, subnet_id, slot) in
       get_committee_assignments(epochRef, validatorIndices):
 
-    doAssert compute_epoch_at_slot(slot) == epoch
+    doAssert epoch(slot) == epoch
 
     # Each get_committee_assignments() call here is on the next epoch. At any
     # given time, only care about two epochs, the current and next epoch. So,

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1193,7 +1193,7 @@ proc pruneAfterFinalization*(
   ## slashing protection can fallback to the minimal / high-watermark protection mode.
 
   block: # Prune blocks
-    let finalizedSlot = compute_start_slot_at_epoch(finalizedEpoch)
+    let finalizedSlot = start_slot(finalizedEpoch)
     let status = db.sqlPruneAfterFinalizationBlocks
                    .exec(int64 finalizedSlot)
     doAssert status.isOk(),

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -376,8 +376,7 @@ proc sign*(v: AttachedValidator, msg: ref SignedContributionAndProof,
 func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork,
                       genesis_validators_root: Eth2Digest,
                       slot: Slot): CookedSig =
-  get_epoch_signature(fork, genesis_validators_root,
-                      slot.compute_epoch_at_slot, k)
+  get_epoch_signature(fork, genesis_validators_root, slot.epoch, k)
 
 proc genRandaoReveal*(v: AttachedValidator, fork: Fork,
                       genesis_validators_root: Eth2Digest, slot: Slot):
@@ -390,7 +389,7 @@ proc genRandaoReveal*(v: AttachedValidator, fork: Fork,
                                          slot).toValidatorSig())
     of ValidatorKind.Remote:
       let res = await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              slot.compute_epoch_at_slot())
+                                              slot.epoch())
       if res.isErr():
         SignatureResult.err(res.error())
       else:

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -124,7 +124,7 @@ proc doSlots(conf: NcliConf) =
     cache = StateCache()
     info = ForkedEpochInfo()
   for i in 0'u64..<conf.slot:
-    let isEpoch = (getStateField(stateY[], slot) + 1).isEpoch
+    let isEpoch = (getStateField(stateY[], slot) + 1).is_epoch
     withTimer(timers[if isEpoch: tApplyEpochSlot else: tApplySlot]):
       doAssert process_slots(
         defaultRuntimeConfig, stateY[], getStateField(stateY[], slot) + 1,

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -137,7 +137,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
                 data: data,
                 aggregation_bits: aggregation_bits,
                 signature: sig.toValidatorSig()
-              ), [validator_index], sig, data.slot.toBeaconTime)
+              ), [validator_index], sig, data.slot.start_beacon_time)
     do:
       raiseAssert "withUpdatedState failed"
 
@@ -152,8 +152,8 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
       genesis_validators_root = dag.genesisValidatorsRoot
       fork = dag.forkAtEpoch(slot.epoch)
-      messagesTime = slot.toBeaconTime(attestationSlotOffset)
-      contributionsTime = slot.toBeaconTime(syncContributionSlotOffset)
+      messagesTime = slot.attestation_deadline()
+      contributionsTime = slot.sync_contribution_deadline()
 
     var aggregators: seq[Aggregator]
 
@@ -311,7 +311,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])
@@ -333,7 +333,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])
@@ -355,7 +355,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       blck() = added[]
       dag.updateHead(added[], quarantine[])
@@ -373,7 +373,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     let
       slot = Slot(i + 1)
       t =
-        if slot.isEpoch: tEpoch
+        if slot.is_epoch: tEpoch
         else: tBlock
       now = genesisTime + float(slot * SECONDS_PER_SLOT)
 
@@ -424,7 +424,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
     if t == tEpoch:
       echo &". slot: {shortLog(slot)} ",
-        &"epoch: {shortLog(slot.compute_epoch_at_slot)}"
+        &"epoch: {shortLog(slot.epoch)}"
     else:
       write(stdout, ".")
       flushFile(stdout)

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -91,7 +91,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
 
     let t =
       if (getStateField(state[], slot) > GENESIS_SLOT and
-        (getStateField(state[], slot) + 1).isEpoch): tEpoch
+        (getStateField(state[], slot) + 1).is_epoch): tEpoch
       else: tBlock
 
     withTimer(timers[t]):
@@ -158,7 +158,7 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
 
     flushFile(stdout)
 
-    if getStateField(state[], slot).isEpoch:
+    if getStateField(state[], slot).is_epoch:
       echo &" slot: {shortLog(getStateField(state[], slot))} ",
         &"epoch: {shortLog(state[].get_current_epoch())}"
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -15,6 +15,7 @@ import # Unit test
   ./test_action_tracker,
   ./test_attestation_pool,
   ./test_beacon_chain_db,
+  ./test_beacon_time,
   ./test_block_dag,
   ./test_block_processor,
   ./test_datatypes,

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -162,9 +162,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
     doAssert process_slots(
       cfg, forked[], Slot(UPDATE_TIMEOUT), cache, info, flags = {})
     let
-      snapshot_period =
-        compute_epoch_at_slot(store.optimistic_header.slot) div
-          EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+      snapshot_period = sync_committee_period(store.optimistic_header.slot)
       update_period = sync_committee_period(state.slot)
     check: snapshot_period + 1 == update_period
 
@@ -238,11 +236,8 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
     check: state.finalized_checkpoint.epoch == 3
     # Ensure that it's same period
     let
-      snapshot_period =
-        compute_epoch_at_slot(store.optimistic_header.slot) div
-          EPOCHS_PER_SYNC_COMMITTEE_PERIOD
-      update_period =
-        compute_epoch_at_slot(state.slot) div EPOCHS_PER_SYNC_COMMITTEE_PERIOD
+      snapshot_period = sync_committee_period(store.optimistic_header.slot)
+      update_period = sync_committee_period(state.slot)
     check: snapshot_period == update_period
 
     # Updated sync_committee and finality
@@ -258,7 +253,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         body_root: finalized_block.message.body.hash_tree_root())
     check:
       finalized_block_header.slot ==
-        compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
+        start_slot(state.finalized_checkpoint.epoch)
       finalized_block_header.hash_tree_root() ==
         state.finalized_checkpoint.root
     var finality_branch {.noinit.}:

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -26,7 +26,7 @@ func apply_randao_reveal(state: ForkyBeaconState, blck: var ForkySignedBeaconBlo
   blck.message.body.randao_reveal = get_epoch_signature(
     state.fork,
     state.genesis_validators_root,
-    blck.message.slot.compute_epoch_at_slot,
+    blck.message.slot.epoch,
     privkey).toValidatorSig()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/tests/core/pyspec/eth2spec/test/helpers/block.py#L38-L54

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -660,7 +660,7 @@ suite "Slashing Protection DB" & preset():
       ).error.kind == DoubleProposal
 
       db.pruneAfterFinalization(
-        compute_epoch_at_slot(Slot 1000)
+        epoch(Slot 1000)
       )
 
       doAssert db.checkSlashableBlockProposal(
@@ -702,7 +702,7 @@ suite "Slashing Protection DB" & preset():
 
       # Pruning far in the future
       db.pruneAfterFinalization(
-        compute_epoch_at_slot(Slot 10000)
+        epoch(Slot 10000)
       )
 
       # Last block is still there
@@ -815,7 +815,7 @@ suite "Slashing Protection DB" & preset():
 
       # --------------------------------
       db.pruneAfterFinalization(
-        compute_epoch_at_slot(Slot 10000)
+        epoch(Slot 10000)
       )
       # --------------------------------
 

--- a/tests/spec_epoch_processing/justification_finalization_helpers.nim
+++ b/tests/spec_epoch_processing/justification_finalization_helpers.nim
@@ -23,7 +23,7 @@ func addMockAttestations*(
        sufficient_support = false
   ) =
   # We must be at the end of the epoch
-  doAssert (state.slot + 1).isEpoch
+  doAssert (state.slot + 1).is_epoch
 
   # Alias the attestations container
   var attestations: ptr seq[PendingAttestation]
@@ -39,10 +39,9 @@ func addMockAttestations*(
   var remaining_balance = state.get_total_active_balance(cache).int64 * 2 div 3
 
   let
-    start_slot = compute_start_slot_at_epoch(epoch)
     committees_per_slot = get_committee_count_per_slot(state, epoch, cache)
 
-  for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
+  for slot in epoch.slots():
     for committee_index in get_committee_indices(committees_per_slot):
       let committee = get_beacon_committee(state, slot, committee_index, cache)
 
@@ -87,5 +86,5 @@ func putCheckpointsInBlockRoots*(
        state: var phase0.BeaconState,
        checkpoints: openArray[Checkpoint]) =
   for c in checkpoints:
-    let idx = c.epoch.compute_start_slot_at_epoch() mod SLOTS_PER_HISTORICAL_ROOT
+    let idx = c.epoch.start_slot() mod SLOTS_PER_HISTORICAL_ROOT
     state.block_roots[idx] = c.root

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -85,7 +85,7 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation, @[bc0[0]], attestation.loadSig,
-      attestation.data.slot.toBeaconTime)
+      attestation.data.slot.start_beacon_time)
 
     check:
       # Added attestation, should get it back
@@ -137,7 +137,7 @@ suite "Attestation pool processing" & preset():
       pool[].getAttestationsForBlock(state.data, cache) == []
 
     pool[].addAttestation(
-      att1, @[bc1[0]], att1.loadSig, att1.data.slot.toBeaconTime)
+      att1, @[bc1[0]], att1.loadSig, att1.data.slot.start_beacon_time)
 
     check:
       # but new ones should go in
@@ -146,7 +146,7 @@ suite "Attestation pool processing" & preset():
     let
       att2 = makeAttestation(state[].data, root1, bc1[1], cache)
     pool[].addAttestation(
-      att2, @[bc1[1]], att2.loadSig, att2.data.slot.toBeaconTime)
+      att2, @[bc1[1]], att2.loadSig, att2.data.slot.start_beacon_time)
 
     let
       combined = pool[].getAttestationsForBlock(state.data, cache)
@@ -158,7 +158,7 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       combined[0], @[bc1[1], bc1[0]], combined[0].loadSig,
-      combined[0].data.slot.toBeaconTime)
+      combined[0].data.slot.start_beacon_time)
 
     check:
       # readding the combined attestation shouldn't have an effect
@@ -168,7 +168,7 @@ suite "Attestation pool processing" & preset():
       # Someone votes for a different root
       att3 = makeAttestation(state[].data, Eth2Digest(), bc1[2], cache)
     pool[].addAttestation(
-      att3, @[bc1[2]], att3.loadSig, att3.data.slot.toBeaconTime)
+      att3, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 
     check:
       # We should now get both attestations for the block, but the aggregate
@@ -183,7 +183,7 @@ suite "Attestation pool processing" & preset():
       # Someone votes for a different root
       att4 = makeAttestation(state[].data, Eth2Digest(), bc1[2], cache)
     pool[].addAttestation(
-      att4, @[bc1[2]], att3.loadSig, att3.data.slot.toBeaconTime)
+      att4, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 
   test "Working with aggregates" & preset():
     let
@@ -203,9 +203,9 @@ suite "Attestation pool processing" & preset():
     att1.combine(att2)
 
     pool[].addAttestation(
-      att0, @[bc0[0], bc0[2]], att0.loadSig, att0.data.slot.toBeaconTime)
+      att0, @[bc0[0], bc0[2]], att0.loadSig, att0.data.slot.start_beacon_time)
     pool[].addAttestation(
-      att1, @[bc0[1], bc0[2]], att1.loadSig, att1.data.slot.toBeaconTime)
+      att1, @[bc0[1], bc0[2]], att1.loadSig, att1.data.slot.start_beacon_time)
 
     check:
       process_slots(
@@ -220,7 +220,7 @@ suite "Attestation pool processing" & preset():
 
     # Add in attestation 3 - both aggregates should now have it added
     pool[].addAttestation(
-      att3, @[bc0[3]], att3.loadSig, att3.data.slot.toBeaconTime)
+      att3, @[bc0[3]], att3.loadSig, att3.data.slot.start_beacon_time)
 
     block:
       let attestations = pool[].getAttestationsForBlock(state.data, cache)
@@ -233,7 +233,7 @@ suite "Attestation pool processing" & preset():
     # Add in attestation 0 as single - attestation 1 is now a superset of the
     # aggregates in the pool, so everything else should be removed
     pool[].addAttestation(
-      att0x, @[bc0[0]], att0x.loadSig, att0x.data.slot.toBeaconTime)
+      att0x, @[bc0[0]], att0x.loadSig, att0x.data.slot.start_beacon_time)
 
     block:
       let attestations = pool[].getAttestationsForBlock(state.data, cache)
@@ -255,7 +255,7 @@ suite "Attestation pool processing" & preset():
         root.data[8..<16] = toBytesBE(j.uint64)
         var att = makeAttestation(state[].data, root, bc0[j], cache)
         pool[].addAttestation(
-          att, @[bc0[j]], att.loadSig, att.data.slot.toBeaconTime)
+          att, @[bc0[j]], att.loadSig, att.data.slot.start_beacon_time)
         inc attestations
 
       check:
@@ -293,10 +293,10 @@ suite "Attestation pool processing" & preset():
     # test reverse order
     pool[].addAttestation(
       attestation1, @[bc1[0]], attestation1.loadSig,
-      attestation1.data.slot.toBeaconTime)
+      attestation1.data.slot.start_beacon_time)
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
-      attestation0.data.slot.toBeaconTime)
+      attestation0.data.slot.start_beacon_time)
 
     discard process_slots(
       defaultRuntimeConfig, state.data,
@@ -320,10 +320,10 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
-      attestation0.data.slot.toBeaconTime)
+      attestation0.data.slot.start_beacon_time)
     pool[].addAttestation(
       attestation1, @[bc0[1]], attestation1.loadSig,
-      attestation1.data.slot.toBeaconTime)
+      attestation1.data.slot.start_beacon_time)
 
     check:
       process_slots(
@@ -351,10 +351,10 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
-      attestation0.data.slot.toBeaconTime)
+      attestation0.data.slot.start_beacon_time)
     pool[].addAttestation(
       attestation1, @[bc0[1]], attestation1.loadSig,
-      attestation1.data.slot.toBeaconTime)
+      attestation1.data.slot.start_beacon_time)
 
     check:
       process_slots(
@@ -381,10 +381,10 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation1, @[bc0[1]], attestation1.loadSig,
-      attestation1.data.slot.toBeaconTime)
+      attestation1.data.slot.start_beacon_time)
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
-      attestation0.data.slot.toBeaconTime)
+      attestation0.data.slot.start_beacon_time)
 
     check:
       process_slots(
@@ -405,9 +405,9 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b1Add[].slot.toBeaconTime)
+    let head = pool[].selectHead(b1Add[].slot.start_beacon_time)
 
     check:
       head == b1Add[]
@@ -419,9 +419,9 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head2 = pool[].selectHead(b2Add[].slot.toBeaconTime)
+    let head2 = pool[].selectHead(b2Add[].slot.start_beacon_time)
 
     check:
       head2 == b2Add[]
@@ -435,9 +435,9 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.toBeaconTime)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
 
     check:
       head == b10Add[]
@@ -451,7 +451,7 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       bc1 = get_beacon_committee(
         state[].data, getStateField(state.data, slot) - 1, 1.CommitteeIndex,
@@ -460,9 +460,9 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation0, @[bc1[0]], attestation0.loadSig,
-      attestation0.data.slot.toBeaconTime)
+      attestation0.data.slot.start_beacon_time)
 
-    let head2 = pool[].selectHead(b10Add[].slot.toBeaconTime)
+    let head2 = pool[].selectHead(b10Add[].slot.start_beacon_time)
 
     check:
       # Single vote for b10 and no votes for b11
@@ -473,9 +473,9 @@ suite "Attestation pool processing" & preset():
       attestation2 = makeAttestation(state[].data, b11.root, bc1[2], cache)
     pool[].addAttestation(
       attestation1, @[bc1[1]], attestation1.loadSig,
-      attestation1.data.slot.toBeaconTime)
+      attestation1.data.slot.start_beacon_time)
 
-    let head3 = pool[].selectHead(b10Add[].slot.toBeaconTime)
+    let head3 = pool[].selectHead(b10Add[].slot.start_beacon_time)
     let bigger = if b11.root.data < b10.root.data: b10Add else: b11Add
 
     check:
@@ -484,9 +484,9 @@ suite "Attestation pool processing" & preset():
 
     pool[].addAttestation(
       attestation2, @[bc1[2]], attestation2.loadSig,
-      attestation2.data.slot.toBeaconTime)
+      attestation2.data.slot.start_beacon_time)
 
-    let head4 = pool[].selectHead(b11Add[].slot.toBeaconTime)
+    let head4 = pool[].selectHead(b11Add[].slot.start_beacon_time)
 
     check:
       # Two votes for b11
@@ -501,9 +501,9 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message,
-        blckRef.slot.toBeaconTime)
+        blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.toBeaconTime)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
 
     check:
       head == b10Add[]
@@ -516,7 +516,7 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
     doAssert: b10Add_clone.error == BlockError.Duplicate
 
@@ -532,9 +532,9 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.toBeaconTime)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
 
     doAssert: head == b10Add[]
 
@@ -546,7 +546,7 @@ suite "Attestation pool processing" & preset():
     var attestations: seq[Attestation]
 
     for epoch in 0 ..< 5:
-      let start_slot = compute_start_slot_at_epoch(Epoch epoch)
+      let start_slot = start_slot(Epoch epoch)
       let committees_per_slot =
         get_committee_count_per_slot(state[].data, Epoch epoch, cache)
       for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
@@ -558,9 +558,9 @@ suite "Attestation pool processing" & preset():
             epochRef: EpochRef):
           # Callback add to fork choice if valid
           pool[].addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-        let head = pool[].selectHead(blockRef[].slot.toBeaconTime)
+        let head = pool[].selectHead(blockRef[].slot.start_beacon_time)
         doAssert: head == blockRef[]
         dag.updateHead(head, quarantine[])
         pruneAtFinalization(dag, pool[])
@@ -601,6 +601,6 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
     doAssert: b10Add_clone.error == BlockError.Duplicate

--- a/tests/test_beacon_time.nim
+++ b/tests/test_beacon_time.nim
@@ -1,0 +1,36 @@
+import
+  unittest2,
+
+  ../beacon_chain/spec/beacon_time
+
+suite "Beacon time":
+  test "basics":
+    let
+      s0 = Slot(0)
+
+    check:
+      s0.epoch() == Epoch(0)
+      s0.start_beacon_time() == BeaconTime()
+      s0.sync_committee_period() == SyncCommitteePeriod(0)
+
+      # Roundtrip far times we treat these as "Infinitiy"
+      FAR_FUTURE_SLOT.epoch.start_slot() == FAR_FUTURE_SLOT
+      FAR_FUTURE_EPOCH.start_slot().epoch() == FAR_FUTURE_EPOCH
+      FAR_FUTURE_SLOT.start_beacon_time().slotOrZero() == FAR_FUTURE_SLOT
+      FAR_FUTURE_PERIOD.start_epoch().sync_committee_period() == FAR_FUTURE_PERIOD
+
+      BeaconTime(ns_since_genesis: -10000000000).slotOrZero == Slot(0)
+      Slot(5).since_epoch_start() == 5
+      (Epoch(42).start_slot() + 5).since_epoch_start() == 5
+
+      Slot(5).start_beacon_time() > Slot(4).start_beacon_time()
+
+      Slot(4).start_beacon_time() +
+        (Slot(5).start_beacon_time() - Slot(4).start_beacon_time()) ==
+        Slot(5).start_beacon_time()
+
+      Epoch(3).start_slot.is_epoch()
+      SyncCommitteePeriod(5).start_epoch().is_sync_committee_period()
+
+      Epoch(5).start_slot.sync_committee_period ==
+        Epoch(5).sync_committee_period

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -60,9 +60,9 @@ suite "BlockSlot and helpers":
       s2 = BlockRef(bid: BlockId(slot: Slot(2)), parent: s1)
       s4 = BlockRef(bid: BlockId(slot: Slot(4)), parent: s2)
       se1 = BlockRef(bid:
-        BlockId(slot: Epoch(1).compute_start_slot_at_epoch()), parent: s2)
+        BlockId(slot: Epoch(1).start_slot()), parent: s2)
       se2 = BlockRef(bid:
-        BlockId(slot: Epoch(2).compute_start_slot_at_epoch()), parent: se1)
+        BlockId(slot: Epoch(2).start_slot()), parent: se1)
 
     check:
       s0.atSlot(Slot(0)).blck == s0

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -38,14 +38,14 @@ suite "Block processor" & preset():
       cache = StateCache()
       b1 = addTestBlock(state[], cache).phase0Data
       b2 = addTestBlock(state[], cache).phase0Data
-      getTimeFn = proc(): BeaconTime = b2.message.slot.toBeaconTime()
+      getTimeFn = proc(): BeaconTime = b2.message.slot.start_beacon_time()
       processor = BlockProcessor.new(
         false, "", "", keys.newRng(), taskpool, consensusManager,
         validatorMonitor, getTimeFn)
 
   test "Reverse order block add & get" & preset():
     let missing = processor[].storeBlock(
-      MsgSource.gossip, b2.message.slot.toBeaconTime(), b2)
+      MsgSource.gossip, b2.message.slot.start_beacon_time(), b2)
     check: missing.error == BlockError.MissingParent
 
     check:
@@ -55,7 +55,7 @@ suite "Block processor" & preset():
 
     let
       status = processor[].storeBlock(
-        MsgSource.gossip, b2.message.slot.toBeaconTime(), b1)
+        MsgSource.gossip, b2.message.slot.start_beacon_time(), b1)
       b1Get = dag.get(b1.root)
 
     check:

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -49,7 +49,7 @@ suite "ChainDAG helpers":
     let
       farEpoch = Epoch(42)
       farTail = BlockRef(
-        bid: BlockId(slot: farEpoch.compute_start_slot_at_epoch() + 5))
+        bid: BlockId(slot: farEpoch.start_slot() + 5))
     check:
 
       not isNil(epochAncestor(farTail, farEpoch).blck)
@@ -172,7 +172,7 @@ suite "Block pool processing" & preset():
     # A fork forces the clearance state to a point where it cannot be advanced
     let
       nextEpoch = dag.head.slot.epoch + 1
-      nextEpochSlot = nextEpoch.compute_start_slot_at_epoch()
+      nextEpochSlot = nextEpoch.start_slot()
       stateCheckpoint = dag.head.parent.atSlot(nextEpochSlot).stateCheckpoint
 
     check:
@@ -282,7 +282,7 @@ suite "Block pool altair processing" & preset():
     # Advance to altair
     check:
       process_slots(
-        cfg, state[], cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch(), cache,
+        cfg, state[], cfg.ALTAIR_FORK_EPOCH.start_slot(), cache,
         info, {})
 
       state[].kind == BeaconStateFork.Altair

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -50,20 +50,20 @@ suite "Forked SSZ readers":
       testHashedBeaconState(merge.BeaconState, 0.Slot)
 
   test "load altair state":
-    testHashedBeaconState(altair.BeaconState, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+    testHashedBeaconState(altair.BeaconState, cfg.ALTAIR_FORK_EPOCH.start_slot)
 
     expect(SszError):
-      testHashedBeaconState(phase0.BeaconState, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+      testHashedBeaconState(phase0.BeaconState, cfg.ALTAIR_FORK_EPOCH.start_slot)
     expect(SszError):
-      testHashedBeaconState(merge.BeaconState, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+      testHashedBeaconState(merge.BeaconState, cfg.ALTAIR_FORK_EPOCH.start_slot)
 
   test "load merge state":
-    testHashedBeaconState(merge.BeaconState, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+    testHashedBeaconState(merge.BeaconState, cfg.MERGE_FORK_EPOCH.start_slot)
 
     expect(SszError):
-      testHashedBeaconState(phase0.BeaconState, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+      testHashedBeaconState(phase0.BeaconState, cfg.MERGE_FORK_EPOCH.start_slot)
     expect(SszError):
-      testHashedBeaconState(altair.BeaconState, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+      testHashedBeaconState(altair.BeaconState, cfg.MERGE_FORK_EPOCH.start_slot)
 
   test "should raise on unknown data":
     let
@@ -79,19 +79,19 @@ suite "Forked SSZ readers":
       testTrustedSignedBeaconBlock(merge.TrustedSignedBeaconBlock, 0.Slot)
 
   test "load altair block":
-    testTrustedSignedBeaconBlock(altair.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+    testTrustedSignedBeaconBlock(altair.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.start_slot)
     expect(SszError):
-      testTrustedSignedBeaconBlock(phase0.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+      testTrustedSignedBeaconBlock(phase0.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.start_slot)
     expect(SszError):
-      testTrustedSignedBeaconBlock(merge.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.compute_start_slot_at_epoch)
+      testTrustedSignedBeaconBlock(merge.TrustedSignedBeaconBlock, cfg.ALTAIR_FORK_EPOCH.start_slot)
 
   test "load merge block":
-    testTrustedSignedBeaconBlock(merge.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+    testTrustedSignedBeaconBlock(merge.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.start_slot)
 
     expect(SszError):
-      testTrustedSignedBeaconBlock(phase0.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+      testTrustedSignedBeaconBlock(phase0.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.start_slot)
     expect(SszError):
-      testTrustedSignedBeaconBlock(altair.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.compute_start_slot_at_epoch)
+      testTrustedSignedBeaconBlock(altair.TrustedSignedBeaconBlock, cfg.MERGE_FORK_EPOCH.start_slot)
 
   test "should raise on unknown data":
     let

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -81,7 +81,7 @@ suite "Gossip validation " & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.toBeaconTime)
+          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       check: added.isOk()
       dag.updateHead(added[], quarantine[])
@@ -104,7 +104,7 @@ suite "Gossip validation " & preset():
         committees_per_slot,
         att_1_0.data.slot, att_1_0.data.index.CommitteeIndex)
 
-      beaconTime = att_1_0.data.slot.toBeaconTime()
+      beaconTime = att_1_0.data.slot.start_beacon_time()
 
     check:
       validateAttestation(pool, batchCrypto, att_1_0, beaconTime, subnet, true).waitFor().isOk
@@ -230,7 +230,7 @@ suite "Gossip validation - Extra": # Not based on preset config
       syncCommitteeMsgPool = newClone(SyncCommitteeMsgPool.init())
       res = waitFor validateSyncCommitteeMessage(
         dag, batchCrypto, syncCommitteeMsgPool, msg, subcommitteeIdx,
-        slot.toBeaconTime(), true)
+        slot.start_beacon_time(), true)
       (positions, cookedSig) = res.get()
 
     syncCommitteeMsgPool[].addSyncCommitteeMessage(
@@ -264,4 +264,4 @@ suite "Gossip validation - Extra": # Not based on preset config
       # Same message twice should be ignored
       validateSyncCommitteeMessage(
         dag, batchCrypto, syncCommitteeMsgPool, msg, subcommitteeIdx,
-        state[].data.slot.toBeaconTime(), true).waitFor().isErr()
+        state[].data.slot.start_beacon_time(), true).waitFor().isErr()

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -63,14 +63,14 @@ suite "Beacon state" & preset():
     check:
       get_beacon_proposer_index(state[].phase0Data.data, cache, Slot 1).isSome()
       get_beacon_proposer_index(
-        state[].phase0Data.data, cache, Epoch(1).compute_start_slot_at_epoch()).isNone()
+        state[].phase0Data.data, cache, Epoch(1).start_slot()).isNone()
       get_beacon_proposer_index(
-        state[].phase0Data.data, cache, Epoch(2).compute_start_slot_at_epoch()).isNone()
+        state[].phase0Data.data, cache, Epoch(2).start_slot()).isNone()
 
     check:
-      process_slots(cfg, state[], Epoch(1).compute_start_slot_at_epoch(), cache, info, {})
+      process_slots(cfg, state[], Epoch(1).start_slot(), cache, info, {})
       get_beacon_proposer_index(state[].phase0Data.data, cache, Slot 1).isNone()
       get_beacon_proposer_index(
-        state[].phase0Data.data, cache, Epoch(1).compute_start_slot_at_epoch()).isSome()
+        state[].phase0Data.data, cache, Epoch(1).start_slot()).isSome()
       get_beacon_proposer_index(
-        state[].phase0Data.data, cache, Epoch(2).compute_start_slot_at_epoch()).isNone()
+        state[].phase0Data.data, cache, Epoch(2).start_slot()).isNone()

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -792,9 +792,9 @@ suite "SyncManager test suite":
                                  Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                  1'u64, getFirstSlotAtFinalizedEpoch,
                                  collector(aq), 2)
-      let finalizedSlot = compute_start_slot_at_epoch(Epoch(0'u64))
-      let startSlot = compute_start_slot_at_epoch(Epoch(0'u64)) + 1'u64
-      let finishSlot = compute_start_slot_at_epoch(Epoch(2'u64))
+      let finalizedSlot = start_slot(Epoch(0'u64))
+      let startSlot = start_slot(Epoch(0'u64)) + 1'u64
+      let finishSlot = start_slot(Epoch(2'u64))
 
       for i in uint64(startSlot) ..< uint64(finishSlot):
         check queue.getRewindPoint(Slot(i), finalizedSlot) == finalizedSlot
@@ -804,9 +804,9 @@ suite "SyncManager test suite":
                                  Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                  1'u64, getFirstSlotAtFinalizedEpoch,
                                  collector(aq), 2)
-      let finalizedSlot = compute_start_slot_at_epoch(Epoch(1'u64))
-      let startSlot = compute_start_slot_at_epoch(Epoch(1'u64)) + 1'u64
-      let finishSlot = compute_start_slot_at_epoch(Epoch(3'u64))
+      let finalizedSlot = start_slot(Epoch(1'u64))
+      let startSlot = start_slot(Epoch(1'u64)) + 1'u64
+      let finishSlot = start_slot(Epoch(3'u64))
 
       for i in uint64(startSlot) ..< uint64(finishSlot) :
         check queue.getRewindPoint(Slot(i), finalizedSlot) == finalizedSlot
@@ -816,16 +816,16 @@ suite "SyncManager test suite":
                                  Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                  1'u64, getFirstSlotAtFinalizedEpoch,
                                  collector(aq), 2)
-      let finalizedSlot = compute_start_slot_at_epoch(Epoch(0'u64))
+      let finalizedSlot = start_slot(Epoch(0'u64))
       let failSlot = Slot(0xFFFF_FFFF_FFFF_FFFFF'u64)
-      let failEpoch = compute_epoch_at_slot(failSlot)
+      let failEpoch = epoch(failSlot)
 
       var counter = 1'u64
       for i in 0 ..< 64:
         if counter >= failEpoch:
           break
         let rewindEpoch = failEpoch - counter
-        let rewindSlot = compute_start_slot_at_epoch(rewindEpoch)
+        let rewindSlot = start_slot(rewindEpoch)
         check queue.getRewindPoint(failSlot, finalizedSlot) == rewindSlot
         counter = counter shl 1
 
@@ -834,15 +834,15 @@ suite "SyncManager test suite":
                                  Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                  1'u64, getFirstSlotAtFinalizedEpoch,
                                  collector(aq), 2)
-      let finalizedSlot = compute_start_slot_at_epoch(Epoch(1'u64))
+      let finalizedSlot = start_slot(Epoch(1'u64))
       let failSlot = Slot(0xFFFF_FFFF_FFFF_FFFFF'u64)
-      let failEpoch = compute_epoch_at_slot(failSlot)
+      let failEpoch = epoch(failSlot)
       var counter = 1'u64
       for i in 0 ..< 64:
         if counter >= failEpoch:
           break
         let rewindEpoch = failEpoch - counter
-        let rewindSlot = compute_start_slot_at_epoch(rewindEpoch)
+        let rewindSlot = start_slot(rewindEpoch)
         check queue.getRewindPoint(failSlot, finalizedSlot) == rewindSlot
         counter = counter shl 1
 

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -71,7 +71,7 @@ proc getTestStates*(
     cfg.MERGE_FORK_EPOCH = 1.Epoch
 
   for i, epoch in stateEpochs:
-    let slot = epoch.Epoch.compute_start_slot_at_epoch
+    let slot = epoch.Epoch.start_slot
     if getStateField(tmpState[], slot) < slot:
       doAssert process_slots(
         cfg, tmpState[], slot, cache, info, {})


### PR DESCRIPTION
Time in the beacon chain is expressed relative to the genesis time -
this PR creates a `beacon_time` module that collects helpers and
utilities for dealing the time units - the new module does not deal with
actual wall time (that's remains in `beacon_clock`).

Collecting the time related stuff in one place makes it easier to find,
avoids some circular imports and allows more easily identifying the code
actually needs wall time to operate.

* move genesis-time-related functionality into `spec/beacon_time`
* avoid using `chronos.Duration` for time differences - it does not
support negative values (such as when something happens earlier than it
should)
* saturate conversions between `FAR_FUTURE_XXX`, so as to avoid
overflows
* fix delay reporting in validator client so it uses the expected
deadline of the slot, not "closest wall slot"
* simplify looping over the slots of an epoch
* `compute_start_slot_at_epoch` -> `start_slot`
* `compute_epoch_at_slot` -> `epoch`

A follow-up PR will (likely) introduce saturating arithmetic for the
time units - this is merely code moves, renames and fixing of small
bugs.