### PR TITLE
rename upgrade_to_{merge,bellatrix}; detect unchanging spec YAMLs

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1603,7 +1603,7 @@ proc aggregateAll*(
     # Aggregation spec requires non-empty collection
     # - https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04
     # Eth2 spec requires at least one attesting index in attestation
-    # - https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
+    # - https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
     return err("aggregate: no attesting keys")
 
   let

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -258,7 +258,7 @@ proc validateBeaconBlock*(
   # proposer for the slot, signed_beacon_block.message.slot.
   #
   # While this condition is similar to the proposer slashing condition at
-  # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#proposer-slashing
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#proposer-slashing
   # it's not identical, and this check does not address slashing:
   #
   # (1) The beacon blocks must be conflicting, i.e. different, for the same
@@ -712,7 +712,7 @@ proc validateAggregate*(
 
   return ok((attesting_indices, sig))
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#attester_slashing
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/p2p-interface.md#attester_slashing
 proc validateAttesterSlashing*(
     pool: ExitPool, attester_slashing: AttesterSlashing):
     Result[void, ValidationError] =
@@ -735,7 +735,7 @@ proc validateAttesterSlashing*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#proposer_slashing
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/p2p-interface.md#proposer_slashing
 proc validateProposerSlashing*(
     pool: ExitPool, proposer_slashing: ProposerSlashing):
     Result[void, ValidationError] =
@@ -758,7 +758,7 @@ proc validateProposerSlashing*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#voluntary_exit
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/p2p-interface.md#voluntary_exit
 proc validateVoluntaryExit*(
     pool: ExitPool, signed_voluntary_exit: SignedVoluntaryExit):
     Result[void, ValidationError] =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1552,7 +1552,6 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
 
   var metadata = config.loadEth2Network()
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.6/specs/merge/client-settings.md#override-terminal-total-difficulty
   if config.terminalTotalDifficultyOverride.isSome:
     metadata.cfg.TERMINAL_TOTAL_DIFFICULTY =
       parse(config.terminalTotalDifficultyOverride.get, UInt256, 10)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -844,7 +844,7 @@ proc upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState): ref altair
   post
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/fork.md#upgrading-the-state
-func upgrade_to_merge*(cfg: RuntimeConfig, pre: altair.BeaconState):
+func upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     ref bellatrix.BeaconState =
   let epoch = get_current_epoch(pre)
   (ref bellatrix.BeaconState)(

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -80,7 +80,7 @@ type
     parent_hash*: Eth2Digest
     total_difficulty*: Eth2Digest   # uint256
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/beacon-chain.md#beaconstate
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#beaconstate
   BeaconState* = object
     # Versioning
     genesis_time*: uint64
@@ -138,7 +138,7 @@ type
     next_sync_committee*: SyncCommittee
 
     # Execution
-    latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Merge]
+    latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Bellatrix]
 
   # TODO Careful, not nil analysis is broken / incomplete and the semantics will
   #      likely change in future versions of the language:

--- a/beacon_chain/spec/presets/mainnet/phase0_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/phase0_preset.nim
@@ -1,5 +1,5 @@
 # Mainnet preset - Phase0
-# https://github.com/ethereum/consensus-specs/blob/v1.1.6/presets/mainnet/phase0.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/presets/mainnet/phase0.yaml
 
 const
   #

--- a/beacon_chain/spec/presets/minimal/bellatrix_preset.nim
+++ b/beacon_chain/spec/presets/minimal/bellatrix_preset.nim
@@ -1,5 +1,5 @@
 # Minimal preset - Merge
-# https://github.com/ethereum/consensus-specs/blob/v1.1.4/presets/minimal/merge.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.1.7/presets/minimal/merge.yaml
 const
   # Updated penalty values
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -207,7 +207,7 @@ func maybeUpgradeStateToBellatrix(
   # once by checking for existing fork.
   if getStateField(state, slot).epoch == cfg.MERGE_FORK_EPOCH and
       state.kind == BeaconStateFork.Altair:
-    var newState = upgrade_to_merge(cfg, state.altairData.data)
+    var newState = upgrade_to_bellatrix(cfg, state.altairData.data)
     state = (ref ForkedHashedBeaconState)(
       kind: BeaconStateFork.Bellatrix,
       mergeData: bellatrix.HashedBeaconState(

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -355,7 +355,7 @@ proc getSyncCommitteeSelectionProof*(v: AttachedValidator,
       else:
         SignatureResult.ok(res.get().toValidatorSig())
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.1/specs/altair/validator.md#signature
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/validator.md#signature
 proc sign*(v: AttachedValidator, msg: ref SignedContributionAndProof,
            fork: Fork, genesis_validators_root: Eth2Digest
           ): Future[SignatureResult] {.async.} =

--- a/scripts/find_unchanged_consensus_spec_files.sh
+++ b/scripts/find_unchanged_consensus_spec_files.sh
@@ -8,7 +8,7 @@ NIMBUS_SOURCE_DIR=${3}
 TMPDIR1=$(mktemp -d)
 TMPDIR2=$(mktemp -d)
 REPO_URL=https://github.com/ethereum/consensus-specs.git
-VALID=".*\\.\\(md\\|py\\)"
+VALID=".*\\.\\(md\\|py\\|yaml\\)"
 UNCHANGED_SPEC_FILES=$(comm -12 --check-order <(git clone --branch "${PREV_VERSION}" --config advice.detachedHead=false --depth 1 --quiet "${REPO_URL}" "${TMPDIR1}" && cd "${TMPDIR1}" && find . -type f -regex "${VALID}" -print0 | xargs -0 sha256sum | sort) <(git clone --branch "${NEXT_VERSION}" --config advice.detachedHead=false --depth 1 --quiet "${REPO_URL}" "${TMPDIR2}" && cd "${TMPDIR2}" && find . -type f -regex "${VALID}" -print0 | xargs -0 sha256sum | sort) | awk '{print $2}' | sed -e"s/^\.\///" | shuf)
 
 # One can use this to automate the search andreplace with a tool such as

--- a/tests/consensus_spec/bellatrix/test_fixture_fork.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_fork.nim
@@ -33,7 +33,7 @@ proc runTest(identifier: string) =
 
       var cfg = defaultRuntimeConfig
 
-      let upgradedState = upgrade_to_merge(cfg, preState[])
+      let upgradedState = upgrade_to_bellatrix(cfg, preState[])
       check: upgradedState[].hash_tree_root() == postState[].hash_tree_root()
       reportDiff(upgradedState, postState)
 


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/fork.md#upgrading-the-state does use `upgrade_to_bellatrix`; didn't update URL until the spec constants it uses also get updated.

The YAMLs are mostly interesting for being the formats the (minimal, mainnet) x (phase0, altair, bellatrix) presets are defined in.

The explicit TTD override command-line option requirement seems to have been removed, so that's not a spec point anymore nor should it be documented as such, but Nimbus still needs one at least for a while, so keep the existing code in place.

The phase0 exit gossip validations should now get updated automatically along with everything else in phase0, with the usual spec updates which literally do not change most phase0 spec documents even a single byte.