### PR TITLE
ci: add 3 hour timeout for jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,18 +94,22 @@ def runStages() {
 parallel(
 	"Linux": {
 		throttle(['nimbus-eth2']) {
-			node("linux") {
-				withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
-					runStages()
+			timeout(time: 3, unit: 'HOURS') {
+				node("linux") {
+					withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
+						runStages()
+					}
 				}
 			}
 		}
 	},
 	"macOS": {
 		throttle(['nimbus-eth2']) {
-			node("macos && x86_64") {
-				withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
-					runStages()
+			timeout(time: 3, unit: 'HOURS') {
+				node("macos && x86_64") {
+					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
+						runStages()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
If we had a pipeline we could just specify this in options:
https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#timeout-enforce-time-limit
```Jenkinsfile
  options {
      timeout(time: 3, unit: 'HOURS') 
  }
```
But as is we need to do more levels of nesting.

Resolves: https://github.com/status-im/nimbus-eth2/issues/3264