### PR TITLE
state_sim: clean up attestation production

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -459,7 +459,9 @@ func init(
 
   template update_attestation_pool_cache(
       epoch: Epoch, participation_bitmap: untyped) =
-    for committee_index in get_committee_indices(state.data, epoch, cache):
+    let committees_per_slot = get_committee_count_per_slot(
+      state.data, epoch, cache)
+    for committee_index in get_committee_indices(committees_per_slot):
       for slot in epoch.slots():
         let committee = get_beacon_committee(
             state.data, slot, committee_index, cache)

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -572,17 +572,15 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
       proc forSlot(slot: Slot, cindex: Option[CommitteeIndex],
                    res: var seq[RestBeaconStatesCommittees]) =
+        let committees_per_slot = get_committee_count_per_slot(
+          stateData.data, slot.epoch, cache)
 
         if cindex.isNone:
-          for committee_index in
-              get_committee_indices(stateData.data, slot.epoch, cache):
+          for committee_index in get_committee_indices(committees_per_slot):
             res.add(getCommittee(slot, committee_index))
         else:
           let
             idx = cindex.get()
-            committees_per_slot = get_committee_count_per_slot(
-              stateData.data, slot.epoch, cache)
-
           if idx < committees_per_slot:
             res.add(getCommittee(slot, idx))
 

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -184,15 +184,6 @@ iterator get_committee_indices*(committee_count_per_slot: uint64): CommitteeInde
     let committee_index = CommitteeIndex.init(idx).expect("value clamped")
     yield committee_index
 
-iterator get_committee_indices*(state: ForkyBeaconState | ForkedHashedBeaconState,
-                                epoch: Epoch,
-                                cache: var StateCache): CommitteeIndex =
-  let committee_count_per_slot =
-    get_committee_count_per_slot(state, epoch, cache)
-
-  for committee_index in get_committee_indices(committee_count_per_slot):
-    yield committee_index
-
 func get_previous_epoch*(state: ForkyBeaconState): Epoch =
   ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
   # Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).


### PR DESCRIPTION
* use same naming as everywhere
* avoid iterator bug that leads to state copy