### PR TITLE
use tail block as sync pivot

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -468,7 +468,8 @@ proc init*(T: type BeaconNode,
       taskpool)
     syncManager = newSyncManager[Peer, PeerID](
       network.peerPool, SyncQueueKind.Forward, getLocalHeadSlot, getLocalWallSlot,
-      getFirstSlotAtFinalizedEpoch, getBackfillSlot, blockVerifier)
+      getFirstSlotAtFinalizedEpoch, getBackfillSlot, dag.tail.slot,
+      blockVerifier)
 
   let stateTtlCache = if config.restCacheSize > 0:
     StateTtlCache.init(


### PR DESCRIPTION
When syncing, we show how much of the sync has completed - with
checkpoint sync, the syncing does not always go from slot 0 to head, but
rather can start in the middle.

To show a consistent `%` between restarts, we introduce the concept of a
pivot point, such that if I sync 10% of the chain, then restart the
client, it picks up at 10% (instead of counting from 0).

What it looks like:
```
INF ... sync="01d12h41m (15.96%) 13.5158slots/s (QDDQDDQQDP:339018)" ...
```