### PR TITLE
increase Jenkins CI timeout to 4 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ def runStages() {
 parallel(
 	"Linux": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 3, unit: 'HOURS') {
+			timeout(time: 4, unit: 'HOURS') {
 				node("linux") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
 						runStages()
@@ -105,7 +105,7 @@ parallel(
 	},
 	"macOS": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 3, unit: 'HOURS') {
+			timeout(time: 4, unit: 'HOURS') {
 				node("macos && x86_64") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 						runStages()


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/3266 proved insufficient for https://github.com/status-im/nimbus-eth2/pull/3276 which failed in Jenkins CI due to waiting for what must have been more than an hour, that time counting against its timeout, then quickly running out of its remaining allotment of time: https://ci.status.im/blue/organizations/jenkins/nimbus%2Fnimbus-eth2%2Fmultibranch/detail/PR-3276/1/pipeline