### PR TITLE
allow Eth1 monitor to run without genesis_deposit_contract_snapshot.ssz

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -868,11 +868,35 @@ proc init*(T: type Eth1Chain, cfg: RuntimeConfig, db: BeaconChainDB): T =
     finalizedBlockHash: finalizedDeposits.eth1Block,
     finalizedDepositsMerkleizer: finalizedDeposits.createMerkleizer)
 
+proc createInitialDepositSnapshot*(
+    depositContractAddress: Eth1Address,
+    depositContractDeployedAt: BlockHashOrNumber,
+    web3Url: string): Future[Result[DepositContractSnapshot, string]] {.async.} =
+
+  let dataProviderRes =
+    await Web3DataProvider.new(depositContractAddress, web3Url)
+  if dataProviderRes.isErr:
+    return err(dataProviderRes.error)
+  var dataProvider = dataProviderRes.get
+
+  let knownStartBlockHash =
+    if depositContractDeployedAt.isHash:
+      depositContractDeployedAt.hash
+    else:
+      try:
+        var blk = awaitWithRetries(
+          dataProvider.getBlockByNumber(depositContractDeployedAt.number))
+        blk.hash.asEth2Digest
+      except CatchableError as err:
+        return err(err.msg)
+
+  return ok DepositContractSnapshot(eth1Block: knownStartBlockHash)
+
 proc init*(T: type Eth1Monitor,
            cfg: RuntimeConfig,
            db: BeaconChainDB,
            web3Urls: seq[string],
-           depositContractSnapshot: DepositContractSnapshot,
+           depositContractSnapshot: Option[DepositContractSnapshot],
            eth1Network: Option[Eth1Network],
            forcePolling: bool): T =
   doAssert web3Urls.len > 0
@@ -881,7 +905,8 @@ proc init*(T: type Eth1Monitor,
   for url in mitems(web3Urls):
     fixupWeb3Urls url
 
-  putInitialDepositContractSnapshot(db, depositContractSnapshot)
+  if depositContractSnapshot.isSome:
+    putInitialDepositContractSnapshot(db, depositContractSnapshot.get)
 
   T(state: Initialized,
     depositsChain: Eth1Chain.init(cfg, db),
@@ -910,6 +935,19 @@ proc resetState(m: Eth1Monitor) {.async.} =
   if m.dataProvider != nil:
     await m.dataProvider.close()
     m.dataProvider = nil
+
+proc ensureDataProvider*(m: Eth1Monitor) {.async.} =
+  if not m.dataProvider.isNil:
+    return
+
+  let web3Url = m.web3Urls[m.startIdx mod m.web3Urls.len]
+  inc m.startIdx
+
+  m.dataProvider = block:
+    let v = await Web3DataProvider.new(m.depositContractAddress, web3Url)
+    if v.isErr():
+      raise (ref CatchableError)(msg: v.error())
+    v.get()
 
 proc stop(m: Eth1Monitor) {.async.} =
   if m.state == Started:
@@ -1112,19 +1150,13 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
   if delayBeforeStart != ZeroDuration:
     await sleepAsync(delayBeforeStart)
 
-  let web3Url = m.web3Urls[m.startIdx mod m.web3Urls.len]
-  inc m.startIdx
+  await m.ensureDataProvider()
+  let
+    web3Url = m.web3Urls[(m.startIdx + m.web3Urls.len - 1) mod m.web3Urls.len]
+    web3 = m.dataProvider.web3
 
   info "Starting Eth1 deposit contract monitoring",
     contract = $m.depositContractAddress, url = web3Url
-
-  m.dataProvider = block:
-    let v = await Web3DataProvider.new(m.depositContractAddress, web3Url)
-    if v.isErr():
-      raise (ref CatchableError)(msg: v.error())
-    v.get()
-
-  let web3 = m.dataProvider.web3
 
   if m.state == Initialized and m.eth1Network.isSome:
     let

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1271,6 +1271,7 @@ proc start(m: Eth1Monitor, delayBeforeStart: Duration) =
         if runFut.error[] of CatchableError:
           if runFut == m.runFut:
             warn "Eth1 chain monitoring failure, restarting", err = runFut.error.msg
+            m.dataProvider = nil
             m.state = Failed
         else:
           fatal "Fatal exception reached", err = runFut.error.msg

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -119,10 +119,19 @@ proc init*(T: type BeaconNode,
            depositContractDeployedAt: BlockHashOrNumber,
            eth1Network: Option[Eth1Network],
            genesisStateContents: string,
-           genesisDepositsSnapshotContents: string): BeaconNode {.
+           depositContractSnapshotContents: string): BeaconNode {.
     raises: [Defect, CatchableError].} =
 
   var taskpool: TaskpoolPtr
+
+  let depositContractSnapshot = if depositContractSnapshotContents.len > 0:
+    try:
+      some SSZ.decode(depositContractSnapshotContents, DepositContractSnapshot)
+    except CatchableError as err:
+      fatal "Invalid deposit contract snapshot", err = err.msg
+      quit 1
+  else:
+    none DepositContractSnapshot
 
   try:
     if config.numThreads < 0:
@@ -199,6 +208,24 @@ proc init*(T: type BeaconNode,
     fatal "--finalized-checkpoint-block cannot be specified without --finalized-checkpoint-state"
     quit 1
 
+  template getDepositContractSnapshot: auto =
+    if depositContractSnapshot.isSome:
+      depositContractSnapshot
+    elif not cfg.DEPOSIT_CONTRACT_ADDRESS.isZeroMemory:
+      let snapshotRes = waitFor createInitialDepositSnapshot(
+        cfg.DEPOSIT_CONTRACT_ADDRESS,
+        depositContractDeployedAt,
+        config.web3Urls[0])
+      if snapshotRes.isErr:
+        fatal "Failed to locate the deposit contract deployment block",
+              depositContract = cfg.DEPOSIT_CONTRACT_ADDRESS,
+              deploymentBlock = $depositContractDeployedAt
+        quit 1
+      else:
+        some snapshotRes.get
+    else:
+      none(DepositContractSnapshot)
+
   var eth1Monitor: Eth1Monitor
   if not ChainDAGRef.isInitialized(db).isOk():
     var
@@ -207,7 +234,7 @@ proc init*(T: type BeaconNode,
 
     if genesisStateContents.len == 0 and checkpointState == nil:
       when hasGenesisDetection:
-        if genesisDepositsSnapshotContents.len > 0:
+        if depositContractSnapshotContents.len > 0:
           fatal "A deposits snapshot cannot be provided without also providing a matching beacon state snapshot"
           quit 1
 
@@ -224,7 +251,7 @@ proc init*(T: type BeaconNode,
           cfg,
           db,
           config.web3Urls,
-          depositContractDeployedAt,
+          getDepositContractSnapshot(),
           eth1Network,
           config.web3ForcePolling)
 
@@ -346,16 +373,12 @@ proc init*(T: type BeaconNode,
             headStateSlot = getStateField(dag.headState.data, slot)
       quit 1
 
-  if eth1Monitor.isNil and
-     config.web3Urls.len > 0 and
-     genesisDepositsSnapshotContents.len > 0:
-    let genesisDepositsSnapshot = SSZ.decode(genesisDepositsSnapshotContents,
-                                             DepositContractSnapshot)
+  if eth1Monitor.isNil and config.web3Urls.len > 0:
     eth1Monitor = Eth1Monitor.init(
       cfg,
       db,
       config.web3Urls,
-      genesisDepositsSnapshot,
+      getDepositContractSnapshot(),
       eth1Network,
       config.web3ForcePolling)
 


### PR DESCRIPTION
Allows Eth1 monitor not only to use a provided deposit contract, but fetch it dynamically from a deposit contract address. This is useful for test networks such as kintsugi which might not have a bundled `genesis_deposit_contract_snapshot.ssz` in their network definition directory.

For example:
```
eth2-networks/shared$ ls -1 {pyrmont,prater,mainnet}/{deposit_contract_block.txt,deposit_contract.txt,genesis_deposit_contract_snapshot.ssz}
mainnet/deposit_contract_block.txt
mainnet/deposit_contract.txt
mainnet/genesis_deposit_contract_snapshot.ssz
prater/deposit_contract_block.txt
prater/deposit_contract.txt
prater/genesis_deposit_contract_snapshot.ssz
pyrmont/deposit_contract_block.txt
pyrmont/deposit_contract.txt
pyrmont/genesis_deposit_contract_snapshot.ssz
```

https://github.com/eth-clients/merge-testnets/tree/main/kintsugi, however, does not have this `genesis_deposit_contract_snapshot.ssz` which Nimbus otherwise would read directly, and without which the Eth1 monitor won't ideally function.

Post-merge (not just Bellatrix, but actual-The-Merge) a Web3 connection is necessary for block processing and proposal. Part of this involves specifically monitoring the Eth1/EL chain for blocks satisfying certain criteria (such as total difficulty, or a special block hash) signifying The Merge, and part asking the EL for validity of embedded `ExecutionPayload`s in Eth2/CL blocks.

Furthermore, for purposes of having a single policy point in place for choosing, say, between round-robin and primary/backup approaches to multiple Web3 URLs and Web3 URL failovers, and to ensure the Eth1 monitor and block processing/proposal Web3 connections have the same view of the network, it's useful not to simply duplicate this connection elsewhere, but to centralize management in the component which already monitors the Eth1/EL chain.

Therefore, allow the Eth1/EL chain monitor to find the genesis deposit contract itself, if it's not provided in the network definition, so that it can run on test networks such as kintsugi in a way compatible with implementing other Web3 connections required for The Merge.