### PR TITLE
update sync committee gossip validation comments; spec URL updates

### DIFF
--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -125,7 +125,7 @@ type
     current_sync_committee*: SyncCommittee     # [New in Altair]
     next_sync_committee*: SyncCommittee        # [New in Altair]
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/beacon-chain.md#beaconstate
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#beaconstate
   # Memory-representation-equivalent to a Merge BeaconState for in-place SSZ
   # reading and writing
   MergeBeaconStateNoImmutableValidators* = object

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -505,7 +505,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
                               cache: var StateCache): seq[Attestation] =
   ## Retrieve attestations that may be added to a new block at the slot of the
   ## given state
-  ## https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/validator.md#attestations
+  ## https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/validator.md#attestations
   let newBlockSlot = state.data.slot.uint64
 
   if newBlockSlot < MIN_ATTESTATION_INCLUSION_DELAY:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -211,7 +211,7 @@ template validateBeaconBlockBellatrix(
       of BeaconBlockFork.Altair:
         false
       of BeaconBlockFork.Bellatrix:
-        # https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/beacon-chain.md#process_execution_payload
+        # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/bellatrix/beacon-chain.md#process_execution_payload
         # shows how this gets folded into the state each block; checking this
         # is equivalent, without ever requiring state replay or any similarly
         # expensive computation.
@@ -360,7 +360,7 @@ proc validateBeaconBlock*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
 proc validateAttestation*(
     pool: ref AttestationPool,
     batchCrypto: ref BatchCrypto,
@@ -787,7 +787,7 @@ proc validateVoluntaryExit*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.0-alpha.8/specs/altair/p2p-interface.md#sync_committee_subnet_id
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/p2p-interface.md#sync_committee_subnet_id
 proc validateSyncCommitteeMessage*(
     dag: ChainDAGRef,
     batchCrypto: ref BatchCrypto,
@@ -798,9 +798,9 @@ proc validateSyncCommitteeMessage*(
     checkSignature: bool):
     Future[Result[(seq[uint64], CookedSig), ValidationError]] {.async.} =
   block:
-    # [IGNORE] The signature's slot is for the current slot
-    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
-    # i.e. sync_committee_message.slot == current_slot.
+    # [IGNORE] The message's slot is for the current slot (with a
+    # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e.
+    # `sync_committee_message.slot == current_slot`.
     let v = check_propagation_slot_range(msg.slot, wallTime)
     if v.isErr():
       return err(v.error())
@@ -818,10 +818,9 @@ proc validateSyncCommitteeMessage*(
       "SyncCommitteeMessage: originator not part of sync committee")
 
   block:
-    # [IGNORE] There has been no other valid sync committee signature for the
-    # declared slot for the validator referenced by sync_committee_message.validator_index
-    # (this requires maintaining a cache of size SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT
-    # for each subnet that can be flushed after each slot).
+    # [IGNORE] There has been no other valid sync committee message for the
+    # declared `slot` for the validator referenced by
+    # `sync_committee_message.validator_index`
     #
     # Note this validation is per topic so that for a given slot, multiple
     # messages could be forwarded with the same validator_index as long as

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -192,7 +192,7 @@ func finish*(agg: AggregateSignature): CookedSig {.inline.} =
   sig.finish(agg)
   CookedSig(sig)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#bls-signatures
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#bls-signatures
 proc blsVerify*(
     pubkey: CookedPubKey, message: openArray[byte],
     signature: CookedSig): bool =
@@ -205,7 +205,7 @@ proc blsVerify*(
   ## to enforce correct usage.
   PublicKey(pubkey).verify(message, blscurve.Signature(signature))
 
-# https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#bls-signatures
+# https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#bls-signatures
 proc blsVerify*(
     pubkey: ValidatorPubKey, message: openArray[byte],
     signature: CookedSig): bool =

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -829,7 +829,7 @@ func process_registry_updates*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/phase0/beacon-chain.md#slashings
 # https://github.com/ethereum/consensus-specs/blob/v1.1.8/specs/altair/beacon-chain.md#slashings
-# https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/beacon-chain.md#slashings
+# https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/beacon-chain.md#slashings
 func process_slashings*(state: var ForkyBeaconState, total_balance: Gwei) =
   let
     epoch = get_current_epoch(state)


### PR DESCRIPTION
Mostly comments. The only non-comment changes are updating, for spec-consistency, the `aggregate` parameter of `process_sync_aggregate` to `sync_aggregate`.

Some of the updates not quite to 1.1.8 but rather to 1.1.7 are the bellatrix ones which depend on updating constants, which can't be 100% completed until Kintsugi switches over to using the 1.1.8 names. 1.1.7 is the last spec version calling the "bellatrix" fork "merge".