### PR TITLE
valmon: fix `--validator-monitor-totals` feature

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -301,7 +301,7 @@ proc init*(T: type BeaconNode,
 
   let
     validatorMonitor = newClone(ValidatorMonitor.init(
-      config.validatorMonitorAuto))
+      config.validatorMonitorAuto, config.validatorMonitorTotals))
 
   for key in config.validatorMonitorPubkeys:
     validatorMonitor[].addMonitor(key, none(ValidatorIndex))


### PR DESCRIPTION
Else log size explodes for machines with many validators