### PR TITLE
limit by-root requests to non-finalized blocks

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -92,7 +92,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 ```diff
 + Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
 + Simple block add&get [Preset: mainnet]                                                     OK
-+ getRef returns nil for missing blocks                                                      OK
++ getBlockRef returns none for missing blocks                                                OK
 + loading tail block works [Preset: mainnet]                                                 OK
 + updateHead updates head and headState [Preset: mainnet]                                    OK
 + updateStateData sanity [Preset: mainnet]                                                   OK

--- a/beacon_chain/gossip_processing/consensus_manager.nim
+++ b/beacon_chain/gossip_processing/consensus_manager.nim
@@ -79,8 +79,8 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
   ## `pruneFinalized` must be called for pruning.
 
   # Grab the new head according to our latest attestation data
-  let newHead = self.attestationPool[].selectHead(wallSlot.start_beacon_time)
-  if newHead.isNil():
+  let newHead = self.attestationPool[].selectHead(
+      wallSlot.start_beacon_time).valueOr:
     warn "Head selection failed, using previous head",
       head = shortLog(self.dag.head), wallSlot
     return

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -115,43 +115,38 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getStateRoot
   router.api(MethodGet, "/eth/v1/beacon/states/{state_id}/root") do (
     state_id: StateIdent) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     node.withStateForBlockSlot(bslot):
       return RestApiResponse.jsonResponse((root: stateRoot))
+
     return RestApiResponse.jsonError(Http404, StateNotFoundError)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getStateFork
   router.api(MethodGet, "/eth/v1/beacon/states/{state_id}/fork") do (
     state_id: StateIdent) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     node.withStateForBlockSlot(bslot):
       return RestApiResponse.jsonResponse(
         (
@@ -169,21 +164,18 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/eth/v1/beacon/states/{state_id}/finality_checkpoints") do (
     state_id: StateIdent) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     node.withStateForBlockSlot(bslot):
       return RestApiResponse.jsonResponse(
         (
@@ -200,21 +192,17 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet, "/eth/v1/beacon/states/{state_id}/validators") do (
     state_id: StateIdent, id: seq[ValidatorIdent],
     status: seq[ValidatorFilter]) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
     let validatorIds =
       block:
         if id.isErr():
@@ -328,24 +316,21 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
           "/eth/v1/beacon/states/{state_id}/validators/{validator_id}") do (
     state_id: StateIdent, validator_id: ValidatorIdent) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
-    if validator_id.isErr():
-      return RestApiResponse.jsonError(Http400, InvalidValidatorIdValueError,
-                                       $validator_id.error())
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      vid = validator_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidValidatorIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     node.withStateForBlockSlot(bslot):
       let
         current_epoch = getStateField(stateData.data, slot).epoch()
@@ -396,21 +381,18 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/eth/v1/beacon/states/{state_id}/validator_balances") do (
     state_id: StateIdent, id: seq[ValidatorIdent]) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     let validatorIds =
       block:
         if id.isErr():
@@ -489,21 +471,18 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
              "/eth/v1/beacon/states/{state_id}/committees") do (
     state_id: StateIdent, epoch: Option[Epoch], index: Option[CommitteeIndex],
     slot: Option[Slot]) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
+
     let vepoch =
       if epoch.isSome():
         let repoch = epoch.get()
@@ -605,21 +584,17 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/eth/v1/beacon/states/{state_id}/sync_committees") do (
     state_id: StateIdent, epoch: Option[Epoch]) -> RestApiResponse:
-    let bslot =
-      block:
-        if state_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
-                                           $state_id.error())
-        let sid = state_id.get()
-        let bres = node.getBlockSlot(sid)
-        if bres.isErr():
-          if sid.kind == StateQueryKind.Root:
-            # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-            # in current version of database.
-            return RestApiResponse.jsonError(Http500, NoImplementationError)
-          return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                           $bres.error())
-        bres.get()
+    let
+      sid = state_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
+                                         $error)
+      bslot = node.getBlockSlot(sid).valueOr:
+        if sid.kind == StateQueryKind.Root:
+          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
+          # in current version of database.
+          return RestApiResponse.jsonError(Http500, NoImplementationError)
+        return RestApiResponse.jsonError(Http404, StateNotFoundError,
+                                          $error)
 
     let qepoch =
       if epoch.isSome():
@@ -715,15 +690,15 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                             $res.error())
         res.get()
 
-
-    let bdata = node.dag.get(blck)
+    let bdata = node.dag.getForkedBlock(blck)
     return
-      withBlck(bdata.data):
+      withBlck(bdata):
         RestApiResponse.jsonResponse(
           [
             (
               root: blck.root,
-              canonical: bdata.refs.isAncestorOf(node.dag.head),
+              canonical: node.dag.isCanonical(
+                BlockId(root: blck.root, slot: blck.message.slot)),
               header: (
                 message: (
                   slot: blck.message.slot,
@@ -741,22 +716,21 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader
   router.api(MethodGet, "/eth/v1/beacon/headers/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
-    let bdata =
-      block:
-        if block_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
-                                           $block_id.error())
-        let res = node.getBlockDataFromBlockIdent(block_id.get())
-        if res.isErr():
-          return RestApiResponse.jsonError(Http404, BlockNotFoundError)
-        res.get()
+    let
+      bid = block_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
+                                         $error)
+
+      bdata = node.getForkedBlock(bid).valueOr:
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
     return
-      withBlck(bdata.data):
+      withBlck(bdata):
         RestApiResponse.jsonResponse(
           (
             root: blck.root,
-            canonical: bdata.refs.isAncestorOf(node.dag.head),
+            canonical: node.dag.isCanonical(
+              BlockId(root: blck.root, slot: blck.message.slot)),
             header: (
               message: (
                 slot: blck.message.slot,
@@ -822,15 +796,14 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlock
   router.api(MethodGet, "/eth/v1/beacon/blocks/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
-    let bdata =
-      block:
-        if block_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
-                                           $block_id.error())
-        let res = node.getBlockDataFromBlockIdent(block_id.get())
-        if res.isErr():
-          return RestApiResponse.jsonError(Http404, BlockNotFoundError)
-        res.get()
+    let
+      bid = block_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
+                                         $error)
+
+      bdata = node.getForkedBlock(bid).valueOr:
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
+
     let contentType =
       block:
         let res = preferredContentType("application/octet-stream",
@@ -839,13 +812,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http406, ContentNotAcceptableError)
         res.get()
     return
-      case bdata.data.kind
+      case bdata.kind
       of BeaconBlockFork.Phase0:
         case contentType
         of "application/octet-stream":
-          RestApiResponse.sszResponse(bdata.data.phase0Data)
+          RestApiResponse.sszResponse(bdata.phase0Data)
         of "application/json":
-          RestApiResponse.jsonResponse(bdata.data.phase0Data)
+          RestApiResponse.jsonResponse(bdata.phase0Data)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)
       of BeaconBlockFork.Altair, BeaconBlockFork.Bellatrix:
@@ -854,15 +827,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2
   router.api(MethodGet, "/eth/v2/beacon/blocks/{block_id}") do (
     block_id: BlockIdent) -> RestApiResponse:
-    let bdata =
-      block:
-        if block_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
-                                           $block_id.error())
-        let res = node.getBlockDataFromBlockIdent(block_id.get())
-        if res.isErr():
-          return RestApiResponse.jsonError(Http404, BlockNotFoundError)
-        res.get()
+    let
+      bid = block_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
+                                         $error)
+
+      bdata = node.getForkedBlock(bid).valueOr:
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
     let contentType =
       block:
         let res = preferredContentType("application/octet-stream",
@@ -873,47 +844,40 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     return
       case contentType
       of "application/octet-stream":
-        case bdata.data.kind
-        of BeaconBlockFork.Phase0:
-          RestApiResponse.sszResponse(bdata.data.phase0Data)
-        of BeaconBlockFork.Altair:
-          RestApiResponse.sszResponse(bdata.data.altairData)
-        of BeaconBlockFork.Bellatrix:
-          RestApiResponse.sszResponse(bdata.data.mergeData)
+        withBlck(bdata):
+          RestApiResponse.sszResponse(blck)
       of "application/json":
-        RestApiResponse.jsonResponsePlain(bdata.data.asSigned())
+        RestApiResponse.jsonResponsePlain(bdata.asSigned())
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockRoot
   router.api(MethodGet, "/eth/v1/beacon/blocks/{block_id}/root") do (
     block_id: BlockIdent) -> RestApiResponse:
-    let blck =
-      block:
-        if block_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
-                                           $block_id.error())
-        let res = node.getBlockRef(block_id.get())
-        if res.isErr():
-          return RestApiResponse.jsonError(Http404, BlockNotFoundError)
-        res.get()
+    let
+      bid = block_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
+                                         $error)
+
+      blck = node.getBlockId(bid).valueOr:
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
+
     return RestApiResponse.jsonResponse((root: blck.root))
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockAttestations
   router.api(MethodGet,
              "/eth/v1/beacon/blocks/{block_id}/attestations") do (
     block_id: BlockIdent) -> RestApiResponse:
-    let bdata =
-      block:
-        if block_id.isErr():
-          return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
-                                           $block_id.error())
-        let res = node.getBlockDataFromBlockIdent(block_id.get())
-        if res.isErr():
-          return RestApiResponse.jsonError(Http404, BlockNotFoundError)
-        res.get()
+    let
+      bid = block_id.valueOr:
+        return RestApiResponse.jsonError(Http400, InvalidBlockIdValueError,
+                                         $error)
+
+      bdata = node.getForkedBlock(bid).valueOr:
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
+
     return
-      withBlck(bdata.data):
+      withBlck(bdata):
         RestApiResponse.jsonResponse(blck.message.body.attestations.asSeq())
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttestations

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -264,7 +264,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       # in order to compute the sync committee for the epoch. See the following
       # discussion for more details:
       # https://github.com/status-im/nimbus-eth2/pull/3133#pullrequestreview-817184693
-      let bs = node.dag.getBlockBySlot(earliestSlotInQSyncPeriod)
+      let bs = node.dag.getBlockAtSlot(earliestSlotInQSyncPeriod)
       if bs.blck.isNil:
         return RestApiResponse.jsonError(Http404, StateNotFoundError)
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -266,9 +266,9 @@ p2pProtocol BeaconSync(version = 1,
 
     var found = 0
     for i in 0..<count:
-      let blockRef = dag.getRef(blockRoots[i])
-      if not isNil(blockRef):
-        let blk = dag.get(blockRef).data
+      let blockRef = dag.getBlockRef(blockRoots[i])
+      if blockRef.isSome():
+        let blk = dag.getForkedBlock(blockRef[])
         case blk.kind
         of BeaconBlockFork.Phase0:
           await response.write(blk.phase0Data.asSigned)
@@ -315,11 +315,10 @@ p2pProtocol BeaconSync(version = 1,
 
       for i in startIndex..endIndex:
         let
-          blk = dag.getForkedBlock(blocks[i])
+          blck = dag.getForkedBlock(blocks[i]).valueOr:
+            continue
 
-        if blk.isSome():
-          let blck = blk.get()
-          await response.write(blck.asSigned)
+        await response.write(blck.asSigned)
 
       debug "Block range request done",
         peer, startSlot, count, reqStep, found = count - startIndex
@@ -346,9 +345,9 @@ p2pProtocol BeaconSync(version = 1,
 
     var found = 0
     for i in 0..<count:
-      let blockRef = dag.getRef(blockRoots[i])
-      if not isNil(blockRef):
-        let blk = dag.getForkedBlock(blockRef)
+      let blockRef = dag.getBlockRef(blockRoots[i])
+      if blockRef.isSome():
+        let blk = dag.getForkedBlock(blockRef[])
         await response.write(blk.asSigned)
         inc found
 

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -7,7 +7,6 @@
 {.push raises: [Defect].}
 
 import
-  std/[os],
   stew/[assign2, base10],
   chronicles, chronos,
   ./sync/sync_manager,
@@ -404,6 +403,8 @@ proc doTrustedNodeSync*(
     checkpointRoot = checkpointBlock.root
 
 when isMainModule:
+  import std/[os]
+
   let backfill = os.paramCount() > 3 and os.paramStr(4) == "true"
 
   waitFor doTrustedNodeSync(

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -485,8 +485,7 @@ proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
-  let blckRef = dag.getRef(fromHex(Eth2Digest, conf.blockRoot))
-  if blckRef == nil:
+  let blckRef = dag.getBlockRef(fromHex(Eth2Digest, conf.blockRoot)).valueOr:
     echo "Block not found in database"
     return
 

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -211,7 +211,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       seq[altair.TrustedSignedBeaconBlock],
       seq[bellatrix.TrustedSignedBeaconBlock])
 
-  echo &"Loaded {dag.blocks.len} blocks, head slot {dag.head.slot}, selected {blockRefs.len} blocks"
+  echo &"Loaded head slot {dag.head.slot}, selected {blockRefs.len} blocks"
   doAssert blockRefs.len() > 0, "Must select at least one block"
 
   for b in 0 ..< blockRefs.len:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -228,7 +228,7 @@ proc stepChecks(
       doAssert fkChoice.checkpoints.time.slotOrZero == time.slotOrZero
     elif check == "head":
       let headRoot = fkChoice[].get_head(dag, time).get()
-      let headRef = dag.getRef(headRoot)
+      let headRef = dag.getBlockRef(headRoot).get()
       doAssert headRef.slot == Slot(val["slot"].getInt())
       doAssert headRef.root == Eth2Digest.fromHex(val["root"].getStr())
     elif check == "justified_checkpoint":

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -403,8 +403,7 @@ suite "Attestation pool processing" & preset():
         pool[].addForkChoice(
           epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b1Add[].slot.start_beacon_time)
-
+    let head = pool[].selectHead(b1Add[].slot.start_beacon_time).get()
     check:
       head == b1Add[]
 
@@ -417,7 +416,7 @@ suite "Attestation pool processing" & preset():
         pool[].addForkChoice(
           epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head2 = pool[].selectHead(b2Add[].slot.start_beacon_time)
+    let head2 = pool[].selectHead(b2Add[].slot.start_beacon_time).get()
 
     check:
       head2 == b2Add[]
@@ -433,7 +432,7 @@ suite "Attestation pool processing" & preset():
         pool[].addForkChoice(
           epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time).get()
 
     check:
       head == b10Add[]
@@ -458,7 +457,7 @@ suite "Attestation pool processing" & preset():
       attestation0, @[bc1[0]], attestation0.loadSig,
       attestation0.data.slot.start_beacon_time)
 
-    let head2 = pool[].selectHead(b10Add[].slot.start_beacon_time)
+    let head2 = pool[].selectHead(b10Add[].slot.start_beacon_time).get()
 
     check:
       # Single vote for b10 and no votes for b11
@@ -471,7 +470,7 @@ suite "Attestation pool processing" & preset():
       attestation1, @[bc1[1]], attestation1.loadSig,
       attestation1.data.slot.start_beacon_time)
 
-    let head3 = pool[].selectHead(b10Add[].slot.start_beacon_time)
+    let head3 = pool[].selectHead(b10Add[].slot.start_beacon_time).get()
     let bigger = if b11.root.data < b10.root.data: b10Add else: b11Add
 
     check:
@@ -482,7 +481,7 @@ suite "Attestation pool processing" & preset():
       attestation2, @[bc1[2]], attestation2.loadSig,
       attestation2.data.slot.start_beacon_time)
 
-    let head4 = pool[].selectHead(b11Add[].slot.start_beacon_time)
+    let head4 = pool[].selectHead(b11Add[].slot.start_beacon_time).get()
 
     check:
       # Two votes for b11
@@ -499,7 +498,7 @@ suite "Attestation pool processing" & preset():
         pool[].addForkChoice(epochRef, blckRef, signedBlock.message,
         blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time).get()
 
     check:
       head == b10Add[]
@@ -530,7 +529,7 @@ suite "Attestation pool processing" & preset():
         pool[].addForkChoice(
           epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-    let head = pool[].selectHead(b10Add[].slot.start_beacon_time)
+    let head = pool[].selectHead(b10Add[].slot.start_beacon_time).get()
 
     doAssert: head == b10Add[]
 
@@ -556,7 +555,7 @@ suite "Attestation pool processing" & preset():
           pool[].addForkChoice(
             epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
-        let head = pool[].selectHead(blockRef[].slot.start_beacon_time)
+        let head = pool[].selectHead(blockRef[].slot.start_beacon_time).get()
         doAssert: head == blockRef[]
         dag.updateHead(head, quarantine[])
         pruneAtFinalization(dag, pool[])


### PR DESCRIPTION
Presently, we keep a mapping from block root to `BlockRef` in memory -
this has simplified reasoning about the dag, but is not sustainable with
the chain growing.

We can distinguish between two cases where by-root access is useful:

* unfinalized blocks - this is where the beacon chain is operating
generally, by validating incoming data as interesting for future fork
choice decisions - bounded by the length of the unfinalized period
* finalized blocks - historical access in the REST API etc - no bounds,
really

In this PR, we limit the by-root block index to the first use case:
finalized chain data can more efficiently be addressed by slot number.

Future work includes:

* limiting the `BlockRef` horizon in general - each instance is 40
bytes+overhead which adds up - this needs further refactoring to deal
with the tail vs state problem
* persisting the finalized slot-to-hash index - this one also keeps
growing unbounded (albeit slowly)

Anyway, this PR easily shaves ~128mb of memory usage at the time of
writing.

* No longer honor `BeaconBlocksByRoot` requests outside of the
non-finalized period - previously, Nimbus would generously return any
block through this libp2p request - per the spec, finalized blocks
should be fetched via `BeaconBlocksByRange` instead.
* return `Opt[BlockRef]` instead of `nil` when blocks can't be found -
this becomes a lot more common now and thus deserves more attention
* `dag.blocks` -> `dag.forkBlocks` - this index only carries unfinalized
blocks from now - `finalizedBlocks` covers the other `BlockRef`
instances
* in backfill, verify that the last backfilled block leads back to
genesis, or panic
* add backfill timings to log
* fix missing check that `BlockRef` block can be fetched with
`getForkedBlock` reliably
* shortcut doppelganger check when feature is not enabled
* in REST/JSON-RPC, fetch blocks without involving `BlockRef`

![Screenshot from 2022-01-17 14-04-38](https://user-images.githubusercontent.com/1382986/149786391-f06a2e77-795c-42ec-8872-c61b4d6521f7.png)

