### PR TITLE
rest: fix invalid type `RestSyncCommitteeSubscription`

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -606,7 +606,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceSyncCommitteeContribution
   router.api(MethodGet,
              "/eth/v1/validator/sync_committee_contribution") do (
-    slot: Option[Slot], subcommittee_index: Option[uint64],
+    slot: Option[Slot], subcommittee_index: Option[SyncSubCommitteeIndex],
     beacon_block_root: Option[Eth2Digest]) -> RestApiResponse:
     let qslot =
       if slot.isNone():
@@ -626,8 +626,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400,
                                          MissingSubCommitteeIndexValueError)
       else:
-        let v = subcommittee_index.get()
-        let res = (v and SyncSubcommitteeIndex.init(v.get()))
+        let res = subcommittee_index.get()
         if res.isErr():
           return RestApiResponse.jsonError(Http400,
                                             InvalidSubCommitteeIndexValueError,

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -579,6 +579,9 @@ template makeLimitedU64*(T: untyped, limit: uint64) =
   template asInt*(x: T): int = int(distinctBase(x))
   template asUInt64*(x: T): uint64 = uint64(distinctBase(x))
 
+  template toSszType(x: T): uint64 =
+    {.error: "Limited types should not be used with SSZ (abi differences)".}
+
 makeLimitedU64(CommitteeIndex, MAX_COMMITTEES_PER_SLOT)
 makeLimitedU64(SubnetId, ATTESTATION_SUBNET_COUNT)
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -52,7 +52,6 @@ type
     phase0.SignedBeaconBlock |
     altair.SignedBeaconBlock |
     SignedVoluntaryExit |
-    SyncSubcommitteeIndex |
     Web3SignerRequest |
     KeystoresAndSlashingProtection |
     DeleteKeystoresBody
@@ -903,24 +902,6 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconStat
       # TODO SerializationError
       writer.writeField("data", value.mergeData.data)
   writer.endRecord()
-
-# SyncSubcommitteeIndex
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: SyncSubcommitteeIndex) {.
-     raises: [IOError, Defect].} =
-  writeValue(writer, value.asUInt64)
-
-proc readValue*(reader: var JsonReader[RestJson],
-                value: var SyncSubcommitteeIndex) {.
-     raises: [IOError, SerializationError, Defect].} =
-  var v: uint64
-  reader.readValue(v)
-
-  let res = SyncSubcommitteeIndex.init(v)
-  if res.isOk():
-    value = res.get()
-  else:
-    reader.raiseUnexpectedValue($res.error())
 
 # Web3SignerRequest
 proc writeValue*(writer: var JsonWriter[RestJson],

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -138,7 +138,7 @@ type
 
   RestSyncCommitteeSubscription* = object
     validator_index*: ValidatorIndex
-    sync_committee_indices*: seq[SyncSubcommitteeIndex]
+    sync_committee_indices*: seq[IndexInSyncCommittee]
     until_epoch*: Epoch
 
   RestBeaconStatesFinalityCheckpoints* = object


### PR DESCRIPTION
Using the wrong type here causes requests to fail due to the overly
zealous parameter validation - the failure is harmless in the current
duty subscription model, but would have caused more serious failures
down the line.

thanks to @mcdee for reporting!