### PR TITLE
Update start-syncing.md

### DIFF
--- a/docs/the_nimbus_book/src/start-syncing.md
+++ b/docs/the_nimbus_book/src/start-syncing.md
@@ -1,9 +1,9 @@
 
 # Start syncing
 
-If you're joining a network that has already launched, you need to ensure that your beacon node is [completely synced](./keep-an-eye.md#keep-track-of-your-syncing-progress) before submitting your deposit.
+To minimize the amount of downtime, you should ensure that your beacon node is [completely synced](./keep-an-eye.md#keep-track-of-your-syncing-progress) before submitting your deposit.  If it's not fully synced you will miss attestations and proposals until it becomes synced.
 
-This is particularly important if you are joining a network that's been running for a while.
+This is particularly important if you are joining a network that's been running for a while since the sync could take some time.
 
 > **N.B.** In order to process incoming validator deposits from the eth1 chain, you'll need to run an eth1 client (**web3 provider**) in parallel to your eth2 client. See [here](./eth1.md) for instructions on how to do so.
 


### PR DESCRIPTION
I found this documentation a little confusing because it says "you need to" leading me to think there may be some kind of dire consequences for NOT having it synced before starting the validator (in the context of importing existing keys from another setup, not starting a new validator with a new deposit).  Modifying the language to make the consequences of not having the syncing done clear.