### PR TITLE
Harden handling of unviable forks

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -74,6 +74,11 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + Reverse order block add & get [Preset: mainnet]                                            OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## Block quarantine
+```diff
++ Unviable smoke test                                                                        OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## BlockId and helpers
 ```diff
 + atSlot sanity                                                                              OK
@@ -361,6 +366,7 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 4/4 Fail: 0/4 Skip: 0/4
 ## SyncManager test suite
 ```diff
++ Process all unviable blocks                                                                OK
 + [SyncQueue#Backward] Async unordered push test                                             OK
 + [SyncQueue#Backward] Async unordered push with rewind test                                 OK
 + [SyncQueue#Backward] Pass through established limits test                                  OK
@@ -380,7 +386,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SyncQueue] getLastNonEmptySlot() test                                                     OK
 + [SyncQueue] hasEndGap() test                                                               OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
+OK: 19/19 Fail: 0/19 Skip: 0/19
 ## Zero signature sanity checks
 ```diff
 + SSZ serialization roundtrip of SignedBeaconBlockHeader                                     OK
@@ -451,4 +457,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 249/253 Fail: 0/253 Skip: 4/253
+OK: 251/255 Fail: 0/255 Skip: 4/255

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -38,8 +38,8 @@ type
       ## appears or be discarded if finality obsoletes it
 
     UnviableFork
-      ## Block is from a different history / fork than the one we're interested
-      ## in (based on our finalized checkpoint)
+      ## Block is from a history / fork that does not include our most current
+      ## finalied checkpoint
 
     Duplicate
       ## We've seen this block already, can't add again

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -39,7 +39,7 @@ type
 
     UnviableFork
       ## Block is from a history / fork that does not include our most current
-      ## finalied checkpoint
+      ## finalized checkpoint
 
     Duplicate
       ## We've seen this block already, can't add again

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -53,9 +53,6 @@ type
   OnFinalizedCallback* =
     proc(data: FinalizationInfoObject) {.gcsafe, raises: [Defect].}
 
-  FetchRecord* = object
-    root*: Eth2Digest
-
   KeyedBlockRef* = object
     # Special wrapper for BlockRef used in ChainDAG.blocks that allows lookup
     # by root without keeping a Table that keeps a separate copy of the digest

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -45,10 +45,18 @@ type
       ## with a valid signature to be dropped
 
     unviable*: OrderedTable[Eth2Digest, tuple[]]
-      ## Unviable blocks are those from a different fork - we keep their hash
+      ## Unviable blocks are those that come from a history that does not
+      ## include the finalized checkpoint we're currently following, and can
+      ## therefore never be included in our canonical chain - we keep their hash
       ## around so that we can avoid cluttering the orphans table with their
-      ## descendants - an ordered table is used to keep them in FIFO order more
-      ## or less..
+      ## descendants - the ChainDAG only keeps track blocks that make up the
+      ## valid and canonical history.
+      ##
+      ## Entries are evicted in FIFO order - recent entries are more likely to
+      ## appear again in attestations and blocks - however, the unviable block
+      ## table is not a complete directory of all unviable blocks circulating -
+      ## only those we have observed, been able to verify as unviable and fit
+      ## in this cache.
 
     missing*: Table[Eth2Digest, MissingBlock]
       ## Roots of blocks that we would like to have (either parent_root of

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,19 +9,25 @@
 
 import
   std/[tables],
-  chronicles,
   stew/bitops2,
-  ../spec/forks,
-  ./block_pools_types
+  ../spec/forks
 
-export tables, forks, block_pools_types
+export tables, forks
 
 const
   MaxMissingItems = 1024
+    ## Arbitrary
+  MaxOrphans = SLOTS_PER_EPOCH * 3
+    ## Enough for finalization in an alternative fork
+  MaxUnviables = 16 * 1024
+    ## About a day of blocks - most likely not needed but it's quite cheap..
 
 type
   MissingBlock* = object
     tries*: int
+
+  FetchRecord* = object
+    root*: Eth2Digest
 
   Quarantine* = object
     ## Keeps track of unvalidated blocks coming from the network
@@ -32,18 +38,21 @@ type
     ##
     ## Trivially invalid blocks may be dropped before reaching this stage.
 
-    orphans*: Table[(Eth2Digest, ValidatorSig), ForkedSignedBeaconBlock] ##\
-    ## Blocks that we don't have a parent for - when we resolve the parent, we
-    ## can proceed to resolving the block as well - we index this by root and
-    ## signature such that a block with invalid signature won't cause a block
-    ## with a valid signature to be dropped
+    orphans*: Table[(Eth2Digest, ValidatorSig), ForkedSignedBeaconBlock]
+      ## Blocks that we don't have a parent for - when we resolve the parent, we
+      ## can proceed to resolving the block as well - we index this by root and
+      ## signature such that a block with invalid signature won't cause a block
+      ## with a valid signature to be dropped
 
-    missing*: Table[Eth2Digest, MissingBlock] ##\
-    ## Roots of blocks that we would like to have (either parent_root of
-    ## unresolved blocks or block roots of attestations)
+    unviable*: OrderedTable[Eth2Digest, tuple[]]
+      ## Unviable blocks are those from a different fork - we keep their hash
+      ## around so that we can avoid cluttering the orphans table with their
+      ## descendants - an ordered table is used to keep them in FIFO order more
+      ## or less..
 
-logScope:
-  topics = "quarant"
+    missing*: Table[Eth2Digest, MissingBlock]
+      ## Roots of blocks that we would like to have (either parent_root of
+      ## unresolved blocks or block roots of attestations)
 
 func init*(T: type Quarantine): T =
   T()
@@ -83,70 +92,112 @@ func addMissing*(quarantine: var Quarantine, root: Eth2Digest) =
   if quarantine.missing.len >= MaxMissingItems:
     return
 
+  if root in quarantine.unviable:
+    # Won't get anywhere with this block
+    return
+
   # It's not really missing if we're keeping it in the quarantine
-  if (not anyIt(quarantine.orphans.keys,  it[0] == root)):
-    # If the block is in orphans, we no longer need it
-    discard quarantine.missing.hasKeyOrPut(root, MissingBlock())
+  if anyIt(quarantine.orphans.keys,  it[0] == root):
+    return
+
+  # Add if it's not there, but don't update missing counter
+  discard quarantine.missing.hasKeyOrPut(root, MissingBlock())
 
 func removeOrphan*(
     quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =
   quarantine.orphans.del((signedBlock.root, signedBlock.signature))
 
 func isViableOrphan(
-    dag: ChainDAGRef, signedBlock: ForkedSignedBeaconBlock): bool =
+    finalizedSlot: Slot, signedBlock: ForkedSignedBeaconBlock): bool =
   # The orphan must be newer than the finalization point so that its parent
   # either is the finalized block or more recent
-  let slot = withBlck(signedBlock): blck.message.slot
-  slot > dag.finalizedHead.slot
+  let
+    slot = getForkedBlockField(signedBlock, slot)
+  slot > finalizedSlot
 
-func removeOldBlocks(quarantine: var Quarantine, dag: ChainDAGRef) =
-  var oldBlocks: seq[(Eth2Digest, ValidatorSig)]
+func cleanupUnviable(quarantine: var Quarantine) =
+  while quarantine.unviable.len() >= MaxUnviables:
+    var toDel: Eth2Digest
+    for k in quarantine.unviable.keys():
+      toDel = k
+      break # Cannot modify while for-looping
+    quarantine.unviable.del(toDel)
 
-  template removeNonviableOrphans(orphans: untyped) =
-    for k, v in orphans.pairs():
-      if not isViableOrphan(dag, v):
-        oldBlocks.add k
+func addUnviable*(quarantine: var Quarantine, root: Eth2Digest) =
+  if root in quarantine.unviable:
+    return
 
-    for k in oldBlocks:
-      orphans.del k
+  quarantine.cleanupUnviable()
 
-  removeNonviableOrphans(quarantine.orphans)
+  # Remove the tree of orphans whose ancestor is unviable - they are now also
+  # unviable! This helps avoiding junk in the quarantine, because we don't keep
+  # unviable parents in the DAG and there's no way to tell an orphan from an
+  # unviable block without the parent.
+  var
+    toRemove: seq[(Eth2Digest, ValidatorSig)] # Can't modify while iterating
+    toCheck = @[root]
+  while toCheck.len > 0:
+    let root = toCheck.pop()
+    for k, v in quarantine.orphans.mpairs():
+      if getForkedBlockField(v, parent_root) == root:
+        toCheck.add(k[0])
+        toRemove.add(k)
+      elif k[0] == root:
+        toRemove.add(k)
+
+    for k in toRemove:
+      quarantine.orphans.del k
+      quarantine.unviable.add(k[0], ())
+
+    toRemove.setLen(0)
+
+  quarantine.unviable.add(root, ())
+
+func cleanupOrphans(quarantine: var Quarantine, finalizedSlot: Slot) =
+  var toDel: seq[(Eth2Digest, ValidatorSig)]
+
+  for k, v in quarantine.orphans.pairs():
+    if not isViableOrphan(finalizedSlot, v):
+      toDel.add k
+
+  for k in toDel:
+    quarantine.addUnviable k[0]
 
 func clearQuarantine*(quarantine: var Quarantine) =
-  quarantine.orphans.clear()
-  quarantine.missing.clear()
+  quarantine = Quarantine()
 
 # Typically, blocks will arrive in mostly topological order, with some
 # out-of-order block pairs. Therefore, it is unhelpful to use either a
 # FIFO or LIFO discpline, and since by definition each block gets used
 # either 0 or 1 times it's not a cache either. Instead, stop accepting
-# new blocks, and rely on syncing to cache up again if necessary. When
-# using forward sync, blocks only arrive in an order not requiring the
-# quarantine.
+# new blocks, and rely on syncing to cache up again if necessary.
 #
 # For typical use cases, this need not be large, as they're two or three
 # blocks arriving out of order due to variable network delays. As blocks
 # for future slots are rejected before reaching quarantine, this usually
 # will be a block for the last couple of slots for which the parent is a
 # likely imminent arrival.
-
-# Since we start forward sync when about one epoch is missing, that's as
-# good a number as any.
-const MAX_QUARANTINE_ORPHANS = SLOTS_PER_EPOCH
-
-func add*(quarantine: var Quarantine, dag: ChainDAGRef,
-          signedBlock: ForkedSignedBeaconBlock): bool =
+func addOrphan*(
+    quarantine: var Quarantine, finalizedSlot: Slot,
+    signedBlock: ForkedSignedBeaconBlock): bool =
   ## Adds block to quarantine's `orphans` and `missing` lists.
-  if not isViableOrphan(dag, signedBlock):
+  if not isViableOrphan(finalizedSlot, signedBlock):
+    quarantine.addUnviable(signedBlock.root)
     return false
 
-  quarantine.removeOldBlocks(dag)
+  quarantine.cleanupOrphans(finalizedSlot)
+
+  let parent_root = getForkedBlockField(signedBlock, parent_root)
+
+  if parent_root in quarantine.unviable:
+    quarantine.unviable.add(signedBlock.root, ())
+    return true
 
   # Even if the quarantine is full, we need to schedule its parent for
   # downloading or we'll never get to the bottom of things
-  withBlck(signedBlock): quarantine.addMissing(blck.message.parent_root)
+  quarantine.addMissing(parent_root)
 
-  if quarantine.orphans.lenu64 >= MAX_QUARANTINE_ORPHANS:
+  if quarantine.orphans.lenu64 >= MaxOrphans:
     return false
 
   quarantine.orphans[(signedBlock.root, signedBlock.signature)] =
@@ -164,7 +215,7 @@ iterator pop*(quarantine: var Quarantine, root: Eth2Digest):
     for k in toRemove:
       quarantine.orphans.del k
 
-  for k, v in quarantine.orphans:
+  for k, v in quarantine.orphans.mpairs():
     if getForkedBlockField(v, parent_root) == root:
       toRemove.add(k)
       yield v

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -30,14 +30,15 @@ import
   ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/[eth2_ssz_serialization, network, helpers, forks],
   ../validators/keystore_management,
-  ./eth2_discovery, ./peer_pool, ./libp2p_json_serialization
+  "."/[eth2_discovery, libp2p_json_serialization, peer_pool, peer_scores]
 
 when chronicles.enabledLogLevel == LogLevel.TRACE:
   import std/sequtils
 
 export
-  tables, version, multiaddress, peer_pool, peerinfo, p2pProtocol, connection,
-  libp2p_json_serialization, eth2_ssz_serialization, results, eth2_discovery
+  tables, version, multiaddress, peerinfo, p2pProtocol, connection,
+  libp2p_json_serialization, eth2_ssz_serialization, results, eth2_discovery,
+  peer_pool, peer_scores
 
 logScope:
   topics = "networking"
@@ -215,15 +216,6 @@ func phase0metadata*(node: Eth2Node): phase0.MetaData =
 const
   clientId* = "Nimbus beacon node " & fullVersionStr
   nodeMetadataFilename = "node-metadata.json"
-
-  NewPeerScore = 200
-    ## Score which will be assigned to new connected Peer
-  PeerScoreLowLimit = 0
-    ## Score after which peer will be kicked
-  PeerScoreHighLimit = 1000
-    ## Max value of peer's score
-  PeerScoreInvalidRequest = -500
-    ## This peer is sending malformed or nonsensical data
 
   ConcurrentConnections = 20
     ## Maximum number of active concurrent connection requests.

--- a/beacon_chain/networking/peer_scores.nim
+++ b/beacon_chain/networking/peer_scores.nim
@@ -8,6 +8,15 @@
 {.push raises: [Defect].}
 
 const
+  NewPeerScore* = 300
+    ## Score which will be assigned to new connected Peer
+  PeerScoreLowLimit* = 0
+    ## Score after which peer will be kicked
+  PeerScoreHighLimit* = 1000
+    ## Max value of peer's score
+  PeerScoreInvalidRequest* = -500
+    ## This peer is sending malformed or nonsensical data
+
   PeerScoreHeadTooNew* = -100
     ## The peer reports a head newer than our wall clock slot
   PeerScoreNoStatus* = -100
@@ -26,5 +35,11 @@ const
     ## Peer's response contains incorrect blocks.
   PeerScoreBadResponse* = -1000
     ## Peer's response is not in requested range.
-  PeerScoreMissingBlocks* = -200
-    ## Peer response contains too many empty blocks.
+  PeerScoreMissingBlocks* = -25
+    ## Peer response contains too many empty blocks - this can happen either
+    ## because a long reorg happened or the peer is falsely trying to convince
+    ## us that a long reorg happened.
+    ## Peer's `blocksByRange` answer is fine.
+  PeerScoreUnviableFork* = -200
+    ## Peer responded with blocks from an unviable fork - are they on a
+    ## different chain?

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -13,9 +13,9 @@ import
   ../spec/datatypes/[phase0, altair],
   ../spec/eth2_apis/rpc_types,
   ../spec/[helpers, forks],
-  ../networking/[peer_pool, eth2_network],
+  ../networking/[peer_pool, peer_scores, eth2_network],
   ../beacon_clock,
-  ./peer_scores, ./sync_queue
+  ./sync_queue
 
 export phase0, altair, merge, chronos, chronicles, results,
        helpers, peer_scores, sync_queue, forks

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -18,6 +18,7 @@ import # Unit test
   ./test_beacon_time,
   ./test_block_dag,
   ./test_block_processor,
+  ./test_block_quarantine,
   ./test_datatypes,
   ./test_discovery,
   ./test_eth1_monitor,

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -1,0 +1,59 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  chronicles,
+  unittest2,
+  ../beacon_chain/spec/forks,
+  ../beacon_chain/spec/datatypes/phase0,
+  ../beacon_chain/consensus_object_pools/block_quarantine
+
+proc makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
+  var
+    b = phase0.SignedBeaconBlock(
+      message: phase0.BeaconBlock(slot: slot, parent_root: parent))
+  b.root = hash_tree_root(b.message)
+  ForkedSignedBeaconBlock.init(b)
+
+suite "Block quarantine":
+  test "Unviable smoke test":
+    let
+      b0 = makeBlock(Slot 0, Eth2Digest())
+      b1 = makeBlock(Slot 1, b0.root)
+      b2 = makeBlock(Slot 2, b1.root)
+      b3 = makeBlock(Slot 3, b2.root)
+      b4 = makeBlock(Slot 4, b2.root)
+
+    var quarantine: Quarantine
+
+    quarantine.addMissing(b1.root)
+    check:
+      FetchRecord(root: b1.root) in quarantine.checkMissing()
+
+      quarantine.addOrphan(Slot 0, b1)
+
+      FetchRecord(root: b1.root) notin quarantine.checkMissing()
+
+      quarantine.addOrphan(Slot 0, b2)
+      quarantine.addOrphan(Slot 0, b3)
+      quarantine.addOrphan(Slot 0, b4)
+
+      (b4.root, ValidatorSig()) in quarantine.orphans
+
+    quarantine.addUnviable(b4.root)
+
+    check:
+      (b4.root, ValidatorSig()) notin quarantine.orphans
+
+    quarantine.addUnviable(b1.root)
+
+    check:
+      (b1.root, ValidatorSig()) notin quarantine.orphans
+      (b2.root, ValidatorSig()) notin quarantine.orphans
+      (b3.root, ValidatorSig()) notin quarantine.orphans


### PR DESCRIPTION
In our current handling of unviable forks, we allow peers to send us
blocks that come from a different fork - this is not necessarily an
error as it can happen naturally, but it does open up the client to a
case where the same unviable fork keeps getting requested - rather than
allowing this to happen, we'll now give these peers a small negative
score - if it keeps happening, we'll disconnect them.

* keep track of unviable forks in quarantine, to avoid filling it with
known junk
* collect peer scores in single module
* descore peers when they send unviable blocks during sync
* don't give score for duplicate blocks
* increase quarantine size to a level that allows finality to happen
under optimal conditions - this helps avoid downloading the same blocks
over and over in case of an unviable fork
* increase initial score for new peers to make room for one more failure
before disconnection
* log and score invalid/unviable blocks in requestmanager too
* avoid ChainDAG dependency in quarantine
* reject gossip blocks with unviable parent
* continue processing unviable sync blocks in order to build unviable
dag