### PR TITLE
clean up hashed rollback proc declarations

### DIFF
--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -87,19 +87,12 @@ func verifyStateRoot(
 
 type
   RollbackProc* = proc() {.gcsafe, noSideEffect, raises: [Defect].}
+  RollbackHashedProc[T] =
+    proc(state: var T) {.gcsafe, noSideEffect, raises: [Defect].}
+  RollbackForkedHashedProc* = RollbackHashedProc[ForkedHashedBeaconState]
 
 func noRollback*() =
   trace "Skipping rollback of broken state"
-
-type
-  RollbackPhase0HashedProc =
-    proc(state: var phase0.HashedBeaconState)    {.gcsafe, noSideEffect, raises: [Defect].}
-  RollbackAltairHashedProc =
-    proc(state: var altair.HashedBeaconState)    {.gcsafe, noSideEffect, raises: [Defect].}
-  RollbackBellatrixHashedProc =
-    proc(state: var bellatrix.HashedBeaconState) {.gcsafe, noSideEffect, raises: [Defect].}
-  RollbackForkedHashedProc* =
-    proc(state: var ForkedHashedBeaconState)     {.gcsafe, noSideEffect, raises: [Defect].}
 
 # Hashed-state transition functions
 # ---------------------------------------------------------------
@@ -335,7 +328,7 @@ proc makeBeaconBlock*(
     exits: BeaconBlockExits,
     sync_aggregate: SyncAggregate,
     execution_payload: ExecutionPayload,
-    rollback: RollbackPhase0HashedProc,
+    rollback: RollbackHashedProc[phase0.HashedBeaconState],
     cache: var StateCache): Result[phase0.BeaconBlock, cstring] =
   ## Create a block for the given state. The latest block applied to it will
   ## be used for the parent_root value, and the slot will be take from
@@ -400,7 +393,7 @@ proc makeBeaconBlock*(
     exits: BeaconBlockExits,
     sync_aggregate: SyncAggregate,
     execution_payload: ExecutionPayload,
-    rollback: RollbackAltairHashedProc,
+    rollback: RollbackHashedProc[altair.HashedBeaconState],
     cache: var StateCache): Result[altair.BeaconBlock, cstring] =
   ## Create a block for the given state. The latest block applied to it will
   ## be used for the parent_root value, and the slot will be take from
@@ -466,7 +459,7 @@ proc makeBeaconBlock*(
     exits: BeaconBlockExits,
     sync_aggregate: SyncAggregate,
     execution_payload: ExecutionPayload,
-    rollback: RollbackBellatrixHashedProc,
+    rollback: RollbackHashedProc[bellatrix.HashedBeaconState],
     cache: var StateCache): Result[bellatrix.BeaconBlock, cstring] =
   ## Create a block for the given state. The latest block applied to it will
   ## be used for the parent_root value, and the slot will be take from

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -86,15 +86,20 @@ func verifyStateRoot(
   ok()
 
 type
-  RollbackProc* = proc() {.gcsafe, raises: [Defect].}
+  RollbackProc* = proc() {.gcsafe, noSideEffect, raises: [Defect].}
 
 func noRollback*() =
   trace "Skipping rollback of broken state"
 
 type
-  RollbackHashedProc* =          proc(state: var phase0.HashedBeaconState)    {.gcsafe, raises: [Defect].}
-  RollbackAltairHashedProc* =    proc(state: var altair.HashedBeaconState)    {.gcsafe, raises: [Defect].}
-  RollbackBellatrixHashedProc* = proc(state: var bellatrix.HashedBeaconState) {.gcsafe, raises: [Defect].}
+  RollbackPhase0HashedProc =
+    proc(state: var phase0.HashedBeaconState)    {.gcsafe, noSideEffect, raises: [Defect].}
+  RollbackAltairHashedProc =
+    proc(state: var altair.HashedBeaconState)    {.gcsafe, noSideEffect, raises: [Defect].}
+  RollbackBellatrixHashedProc =
+    proc(state: var bellatrix.HashedBeaconState) {.gcsafe, noSideEffect, raises: [Defect].}
+  RollbackForkedHashedProc* =
+    proc(state: var ForkedHashedBeaconState)     {.gcsafe, noSideEffect, raises: [Defect].}
 
 # Hashed-state transition functions
 # ---------------------------------------------------------------
@@ -236,10 +241,6 @@ proc state_transition_block_aux(
 
   ok()
 
-type
-  RollbackForkedHashedProc* =
-    proc(state: var ForkedHashedBeaconState) {.gcsafe, raises: [Defect].}
-
 func noRollback*(state: var ForkedHashedBeaconState) =
   trace "Skipping rollback of broken state"
 
@@ -334,7 +335,7 @@ proc makeBeaconBlock*(
     exits: BeaconBlockExits,
     sync_aggregate: SyncAggregate,
     execution_payload: ExecutionPayload,
-    rollback: RollbackHashedProc,
+    rollback: RollbackPhase0HashedProc,
     cache: var StateCache): Result[phase0.BeaconBlock, cstring] =
   ## Create a block for the given state. The latest block applied to it will
   ## be used for the parent_root value, and the slot will be take from

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -223,7 +223,7 @@ func makeAttestation*(
     flags: UpdateFlags = {}): Attestation =
   # Avoids state_sim silliness; as it's responsible for all validators,
   # transforming, from monotonic enumerable index -> committee index ->
-  # montonoic enumerable index, is wasteful and slow. Most test callers
+  # monotonic enumerable index, is wasteful and slow. Most test callers
   # want ValidatorIndex, so that's supported too.
   let
     sac_index = committee.find(validator_index)


### PR DESCRIPTION
- enforce `noSideEffect`
- consistent naming including phase 0
- don't export unless necessary