### PR TITLE
use v1.1.9 test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -263,6 +263,22 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Bellatrix - Finality - finality_rule_2 [Preset: mainnet]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: mainnet]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: mainnet]                    OK
++ [Valid]   EF - Bellatrix - Random - randomized_0 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_1 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_10 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_11 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_12 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_13 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_14 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_15 [Preset: mainnet]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_2 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_3 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_4 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_5 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_6 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_7 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_8 [Preset: mainnet]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_9 [Preset: mainnet]                         OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - attestation [Preset: mainnet]                 OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - attester_slashing [Preset: mainnet]           OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - balance_driven_status_transitions [Preset: ma OK
@@ -363,7 +379,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 360/360 Fail: 0/360 Skip: 0/360
+OK: 376/376 Fail: 0/376 Skip: 0/376
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1055,12 +1071,14 @@ OK: 27/27 Fail: 0/27 Skip: 0/27
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_regular_payload     OK
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_first_payload    OK
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_regular_payload  OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - non_empty_extra_data_first_pay OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - non_empty_extra_data_regular_p OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload          OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload_with_gap OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload        OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload_with_g OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## Proposer Slashing
 ```diff
 + [Invalid] EF - Altair - Operations - Proposer Slashing - epochs_are_different              OK
@@ -1191,4 +1209,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1015/1017 Fail: 0/1017 Skip: 2/1017
+OK: 1033/1035 Fail: 0/1035 Skip: 2/1035

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -276,6 +276,22 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Bellatrix - Finality - finality_rule_2 [Preset: minimal]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: minimal]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: minimal]                    OK
++ [Valid]   EF - Bellatrix - Random - randomized_0 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_1 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_10 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_11 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_12 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_13 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_14 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_15 [Preset: minimal]                        OK
++ [Valid]   EF - Bellatrix - Random - randomized_2 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_3 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_4 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_5 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_6 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_7 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_8 [Preset: minimal]                         OK
++ [Valid]   EF - Bellatrix - Random - randomized_9 [Preset: minimal]                         OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - attestation [Preset: minimal]                 OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - attester_slashing [Preset: minimal]           OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - balance_driven_status_transitions [Preset: mi OK
@@ -389,7 +405,7 @@ ConsensusSpecPreset-minimal
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 386/386 Fail: 0/386 Skip: 0/386
+OK: 402/402 Fail: 0/402 Skip: 0/402
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1125,12 +1141,14 @@ OK: 27/27 Fail: 0/27 Skip: 0/27
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_random_regular_payload     OK
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_first_payload    OK
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - bad_timestamp_regular_payload  OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - non_empty_extra_data_first_pay OK
++ [Valid]   EF - Bellatrix - Operations - Execution Payload - non_empty_extra_data_regular_p OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload          OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_first_payload_with_gap OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload        OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - success_regular_payload_with_g OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
+OK: 14/14 Fail: 0/14 Skip: 0/14
 ## Proposer Slashing
 ```diff
 + [Invalid] EF - Altair - Operations - Proposer Slashing - epochs_are_different              OK
@@ -1268,4 +1286,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1066/1086 Fail: 0/1086 Skip: 20/1086
+OK: 1084/1104 Fail: 0/1104 Skip: 20/1104

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -53,7 +53,7 @@ export
 # Eventually, we could also differentiate between user/tainted data and
 # internal state that's gone through sanity checks already.
 
-const SPEC_VERSION* = "1.1.8"
+const SPEC_VERSION* = "1.1.9"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -35,8 +35,7 @@ const
 
   baseDescription = "EF - Bellatrix - Operations - "
 
-# DS_Store issue: https://github.com/ethereum/consensus-spec-tests/issues/27
-doAssert toHashSet(filterIt(mapIt(toSeq(walkDir(OpDir, relative = false)), it.path), not it.contains("DS_Store"))) ==
+doAssert toHashSet(mapIt(toSeq(walkDir(OpDir, relative = false)), it.path)) ==
   toHashSet([OpAttestationsDir, OpAttSlashingDir, OpBlockHeaderDir,
              OpDepositsDir, OpExecutionPayloadDir, OpProposerSlashingDir,
              OpSyncAggregateDir, OpVoluntaryExitDir])

--- a/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
@@ -22,6 +22,7 @@ import
 
 const
   FinalityDir = SszTestsDir/const_preset/"bellatrix"/"finality"/"finality"/"pyspec_tests"
+  RandomDir = SszTestsDir/const_preset/"bellatrix"/"random"/"random"/"pyspec_tests"
   SanityBlocksDir = SszTestsDir/const_preset/"bellatrix"/"sanity"/"blocks"/"pyspec_tests"
 
 proc runTest(testName, testDir, unitTestName: string) =
@@ -76,10 +77,11 @@ proc runTest(testName, testDir, unitTestName: string) =
 
 suite "EF - Bellatrix - Sanity - Blocks " & preset():
  for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
-   if path.contains("DS_Store"):
-     # https://github.com/ethereum/consensus-spec-tests/issues/27
-     continue
    runTest("EF - Bellatrix - Sanity - Blocks", SanityBlocksDir, path)
+
+suite "EF - Bellatrix - Random " & preset():
+ for kind, path in walkDir(RandomDir, relative = true, checkDir = true):
+   runTest("EF - Bellatrix - Random", RandomDir, path)
 
 suite "EF - Bellatrix - Finality " & preset():
  for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):

--- a/tests/consensus_spec/bellatrix/test_fixture_transition.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_transition.nim
@@ -84,7 +84,4 @@ proc runTest(testName, testDir, unitTestName: string) =
 
 suite "EF - Bellatrix - Transition " & preset():
   for kind, path in walkDir(TransitionDir, relative = true, checkDir = true):
-    # TODO https://github.com/ethereum/consensus-spec-tests/issues/27
-    if path.contains("DS_Store"):
-      continue
     runTest("EF - Bellatrix - Transition", TransitionDir, path)


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.1.9
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.1.9

- use v1.1.9 EF consensus layer spec test vectors
- remove `DS_Store` workarounds
- only non-`tests/` Nim code changed is base datatypes version number
- pick up non-empty `extra_data` Bellatrix tests and add support for new `random` Bellatrix tests