### PR TITLE
val_mon: register locally produced aggregates

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -69,7 +69,6 @@ type
     attachedValidatorBalanceTotal*: uint64
     gossipState*: GossipState
     beaconClock*: BeaconClock
-    onAttestationSent*: OnAttestationCallback
     restKeysCache*: Table[ValidatorPubKey, ValidatorIndex]
     validatorMonitor*: ref ValidatorMonitor
     stateTtlCache*: StateTtlCache

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -360,7 +360,7 @@ proc aggregateValidator*(
       wallTime)
 
     self.validatorMonitor[].registerAggregate(
-      src, wallTime, signedAggregateAndProof, attesting_indices)
+      src, wallTime, signedAggregateAndProof.message, attesting_indices)
 
     beacon_aggregates_received.inc()
     beacon_aggregate_delay.observe(delay.toFloatSeconds())
@@ -518,7 +518,7 @@ proc contributionValidator*(
       contributionAndProof, v.get()[0])
 
     self.validatorMonitor[].registerSyncContribution(
-      src, wallTime, contributionAndProof, v.get()[1])
+      src, wallTime, contributionAndProof.message, v.get()[1])
 
     beacon_sync_committee_contributions_received.inc()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -159,8 +159,6 @@ proc init*(T: type BeaconNode,
 
   proc onAttestationReceived(data: Attestation) =
     eventBus.emit("attestation-received", data)
-  proc onAttestationSent(data: Attestation) =
-    eventBus.emit("attestation-sent", data)
   proc onVoluntaryExitAdded(data: SignedVoluntaryExit) =
     eventBus.emit("voluntary-exit", data)
   proc onBlockAdded(data: ForkedTrustedSignedBeaconBlock) =
@@ -539,7 +537,6 @@ proc init*(T: type BeaconNode,
     consensusManager: consensusManager,
     gossipState: {},
     beaconClock: beaconClock,
-    onAttestationSent: onAttestationSent,
     validatorMonitor: validatorMonitor,
     stateTtlCache: stateTtlCache
   )


### PR DESCRIPTION
These use a separate flow, and were previously only registered from the
network

* don't log successes in totals mode (TMI)
* remove `attestation-sent` event which is unused