### PR TITLE
for x86 macOS, require >= Nehalem for non-march=native builds

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -80,8 +80,17 @@ if defined(windows):
 #
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
-    switch("passC", "-mssse3")
-    switch("passL", "-mssse3")
+    if defined(macosx):
+      # https://support.apple.com/kb/SP777
+      # "macOS Mojave - Technical Specifications": EOL as of 2021-10 so macOS
+      # users on pre-Nehalem must be running either some Hackintosh, or using
+      # an unsupported macOS version beyond that most recently EOL'd. Nehalem
+      # supports instruction set extensions through SSE4.2 and POPCNT.
+      switch("passC", "-march=nehalem")
+      switch("passL", "-march=nehalem")
+    else:
+      switch("passC", "-mssse3")
+      switch("passL", "-mssse3")
 elif defined(macosx) and defined(arm64):
   # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
   switch("passC", "-mcpu=apple-a14")


### PR DESCRIPTION
At some point, it's not reasonable to support in any official way running Nimbus on machines Apple themselves don't support, especially as security-relevant software.

It's the oldest CPU x86 microarchitecture supported by the most recently end-of-lifed  macOS version, 10.14 Mojave: https://github.com/status-im/nimbus-eth2/issues/3170

It might be possible to support only microarchitectures supported by non-EOL macOS versions, which would currently mean Ivy Bridge, but that'd be a bit aggressive since Mojave only lost support just over 3 months ago.

This does not drop support, per se, for old macOS versions, but simply uses the supported-machine list, so anyone using a Nehalem or newer CPU (2008) is covered regardless.