### PR TITLE
Eth1 monitor fixes

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -51,7 +51,7 @@ type
   OnReorgCallback* =
     proc(data: ReorgInfoObject) {.gcsafe, raises: [Defect].}
   OnFinalizedCallback* =
-    proc(data: FinalizationInfoObject) {.gcsafe, raises: [Defect].}
+    proc(dag: ChainDAGRef, data: FinalizationInfoObject) {.gcsafe, raises: [Defect].}
 
   KeyedBlockRef* = object
     # Special wrapper for BlockRef used in ChainDAG.blocks that allows lookup
@@ -249,6 +249,9 @@ template epoch*(e: EpochRef): Epoch = e.key.epoch
 func shortLog*(v: EpochKey): string =
   # epoch:root when logging epoch, root:slot when logging slot!
   $v.epoch & ":" & shortLog(v.blck)
+
+template setFinalizationCb*(dag: ChainDAGRef, cb: OnFinalizedCallback) =
+  dag.onFinHappened = cb
 
 func shortLog*(v: EpochRef): string =
   # epoch:root when logging epoch, root:slot when logging slot!

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1531,7 +1531,7 @@ proc updateHead*(
         dag.finalizedHead.blck.root,
         stateRoot,
         dag.finalizedHead.slot.epoch)
-      dag.onFinHappened(data)
+      dag.onFinHappened(dag, data)
 
 proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): Result[void, cstring] =
   # Lightweight check to see if we have the minimal information needed to


### PR DESCRIPTION
* Fix a resource leak introduced in https://github.com/status-im/nimbus-eth2/pull/3279

* Don't restart the Eth1 syncing proggress from scratch in case of
  monitor failures during Eth2 syncing.

* Switch to the primary provider as soon as it is back online.

* Log the web3 credentials in fewer places

Other changes:

The 'web3 test' command has been enhanced to obtain and print more
data regarding the selected provider.