### PR TITLE
deactivate doppelganger protection during genesis

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -78,7 +78,7 @@ type
     ## of gossip interleaving between nodes so long as they don't gossip at
     ## the same time.
 
-    nodeLaunchSlot: Slot ##\
+    nodeLaunchSlot*: Slot ##\
     ## Set once, at node launch. This functions as a basic protection against
     ## false positives from attestations persisting within the gossip network
     ## across quick restarts.

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -260,7 +260,8 @@ proc checkForPotentialDoppelganger(
     return
 
   if attestation.data.slot.epoch <
-      self.doppelgangerDetection.broadcastStartEpoch:
+      self.doppelgangerDetection.broadcastStartEpoch and
+     self.doppelgangerDetection.nodeLaunchSlot > GENESIS_SLOT:
     for validatorIndex in attesterIndices:
       let validatorPubkey = self.dag.validatorKey(validatorIndex).get().toPubKey()
       if not isNil(self.validatorPool[].getValidator(validatorPubkey)):

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1029,6 +1029,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
   # means that it'd be okay not to continue, but it won't gossip regardless.
   if curSlot.epoch <
         node.processor[].doppelgangerDetection.broadcastStartEpoch and
+      node.processor[].doppelgangerDetection.nodeLaunchSlot > GENESIS_SLOT and
       node.config.doppelgangerDetection:
     let
       nextAttestationSlot = node.actionTracker.getNextAttestationSlot(slot - 1)

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2021 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2022 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -487,7 +487,6 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --metrics \
     --metrics-address="127.0.0.1" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
-    --doppelganger-detection=off \
     ${EXTRA_ARGS} \
     > "${DATA_DIR}/log${NUM_NODE}.txt" 2>&1 &
 


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/2451

The local testnet script change both simplifies that setup and tests this change: the local testnet doesn't work well if all the nodes wait for two epochs to start attesting or proposing.