### PR TITLE
bump nim-web3 to fix kiln interop

### DIFF
--- a/tests/test_merge_vectors.nim
+++ b/tests/test_merge_vectors.nim
@@ -13,7 +13,7 @@ import
 suite "Merge test vectors":
   setup:
     let web3Provider = (waitFor Web3DataProvider.new(
-      default(Eth1Address), "http://127.0.0.1:8550")).get
+      default(Eth1Address), "ws://127.0.0.1:8551")).get
 
   test "getPayload, newPayload, and forkchoiceUpdated":
     const feeRecipient =
@@ -48,6 +48,6 @@ suite "Merge test vectors":
 
     check:
       payloadStatus.status == PayloadExecutionStatus.valid
-      fcupdatedStatus.payloadStatus == ForkchoiceUpdatedStatus.valid
+      fcupdatedStatus.payloadStatus.status == PayloadExecutionStatus.valid
       payloadStatus2.status == PayloadExecutionStatus.valid
-      fcupdatedStatus2.payloadStatus == ForkchoiceUpdatedStatus.valid
+      fcupdatedStatus2.payloadStatus.status == PayloadExecutionStatus.valid


### PR DESCRIPTION
This doesn't affect non-merge/kiln at all, either this repo's changes or the nim-web3 bump.

This brings `unstable` (and soon `kiln`) up to date with the `nim-web3` which has the correct `forkchoiceUpdated` response type.

The nim-web3 bump also contains some new MEV code, which by default isn't called anywhere yet. Also a non-issue risk-wise for merging.