### PR TITLE
fix missing backfill when restarting node

### DIFF
--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -69,7 +69,7 @@ func init*(T: type BlockRef, root: Eth2Digest, blck: SomeForkyBeaconBlock):
     BlockRef =
   BlockRef.init(root, blck.slot)
 
-func toBlockId*(blck: SomeSomeSignedBeaconBlock): BlockId =
+func toBlockId*(blck: SomeForkySignedBeaconBlock): BlockId =
   BlockId(root: blck.root, slot: blck.message.slot)
 
 func toBlockId*(blck: ForkedSignedBeaconBlock): BlockId =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -487,7 +487,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   var
     backfillBlocks = newSeq[Eth2Digest](tailRef.slot.int)
-    backfill = BeaconBlockSummary(slot: GENESIS_SLOT)
+    backfill = withBlck(tailBlock): blck.message.toBeaconBlockSummary()
     midRef: BlockRef
     backRoot: Option[Eth2Digest]
     startTick = Moment.now()
@@ -540,9 +540,6 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       if backRoot.isNone():
         backfill = blck.summary
     elif blck.summary.slot == tailRef.slot:
-      if backRoot.isNone():
-        backfill = blck.summary
-
       if curRef == nil:
         curRef = tailRef
         headRef = tailRef

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -314,15 +314,6 @@ type
   SomeBeaconBlock* = BeaconBlock | SigVerifiedBeaconBlock | TrustedBeaconBlock
   SomeBeaconBlockBody* = BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody
 
-  # TODO see above, re why does it fail
-  SomeSomeBeaconBlockBody* =
-    BeaconBlockBody | SigVerifiedBeaconBlockBody | TrustedBeaconBlockBody |
-    altair.BeaconBlockBody | altair.SigVerifiedBeaconBlockBody | altair.TrustedBeaconBlockBody |
-    phase0.BeaconBlockBody | phase0.SigVerifiedBeaconBlockBody | phase0.TrustedBeaconBlockBody
-  #SomeSomeBeaconBlockBody* = SomeBeaconBlockBody | phase0.SomeBeaconBlockBody
-
-  SomeSomeSignedBeaconBlock* = SomeSignedBeaconBlock | altair.SomeSignedBeaconBlock | phase0.SomeSignedBeaconBlock
-
   BlockParams = object
     parentHash*: string
     timestamp*: string

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -61,6 +61,26 @@ type
     Altair
     Bellatrix
 
+  ForkyBeaconBlockBody* =
+    phase0.BeaconBlockBody |
+    altair.BeaconBlockBody |
+    bellatrix.BeaconBlockBody
+
+  ForkySigVerifiedBeaconBlockBody* =
+    phase0.SigVerifiedBeaconBlockBody |
+    altair.SigVerifiedBeaconBlockBody |
+    bellatrix.SigVerifiedBeaconBlockBody
+
+  ForkyTrustedBeaconBlockBody* =
+    phase0.TrustedBeaconBlockBody |
+    altair.TrustedBeaconBlockBody |
+    bellatrix.TrustedBeaconBlockBody
+
+  SomeForkyBeaconBlockBody* =
+    ForkyBeaconBlockBody |
+    ForkySigVerifiedBeaconBlockBody |
+    ForkyTrustedBeaconBlockBody
+
   ForkyBeaconBlock* =
     phase0.BeaconBlock |
     altair.BeaconBlock |

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -73,7 +73,7 @@ func `xor`[T: array](a, b: T): T =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#randao
 proc process_randao(
-    state: var ForkyBeaconState, body: SomeSomeBeaconBlockBody, flags: UpdateFlags,
+    state: var ForkyBeaconState, body: SomeForkyBeaconBlockBody, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] =
   let
     proposer_index = get_beacon_proposer_index(state, cache)
@@ -105,7 +105,7 @@ proc process_randao(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#eth1-data
-func process_eth1_data(state: var ForkyBeaconState, body: SomeSomeBeaconBlockBody): Result[void, cstring]=
+func process_eth1_data(state: var ForkyBeaconState, body: SomeForkyBeaconBlockBody): Result[void, cstring]=
   if not state.eth1_data_votes.add body.eth1_data:
     # Count is reset  in process_final_updates, so this should never happen
     return err("process_eth1_data: no more room for eth1 data")
@@ -398,7 +398,7 @@ proc process_voluntary_exit*(
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#operations
 proc process_operations(cfg: RuntimeConfig,
                         state: var ForkyBeaconState,
-                        body: SomeSomeBeaconBlockBody,
+                        body: SomeForkyBeaconBlockBody,
                         base_reward_per_increment: Gwei,
                         flags: UpdateFlags,
                         cache: var StateCache): Result[void, cstring] =


### PR DESCRIPTION
When node is restarted before backfill has started but after some blocks
have finalized with forward sync, we would not start the backfill.

* also clean up one last `SomeSome`