### PR TITLE
Add CORS support for the REST services

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -331,6 +331,11 @@ type
         defaultValueDesc: "127.0.0.1"
         name: "rest-address" }: ValidIpAddress
 
+      restAllowedOrigin* {.
+        desc: "Limit the access to the REST API to a particular hostname " &
+              "(for CORS-enabled clients such as browsers)"
+        name: "rest-allow-origin" }: Option[string]
+
       restCacheSize* {.
         defaultValue: 3
         desc: "The maximum number of recently accessed states that are kept in " &
@@ -376,6 +381,11 @@ type
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: "127.0.0.1"
         name: "keymanager-address" }: ValidIpAddress
+
+      keymanagerAllowedOrigin* {.
+        desc: "Limit the access to the Keymanager API to a particular hostname " &
+              "(for CORS-enabled clients such as browsers)"
+        name: "keymanager-allow-origin" }: Option[string]
 
       keymanagerTokenFile* {.
         desc: "A file specifying the authorizition token required for accessing the keymanager API"

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -271,8 +271,8 @@ func keysToIndices*(cacheTable: var Table[ValidatorPubKey, ValidatorIndex],
         indices[listIndex[]] = some(ValidatorIndex(validatorIndex))
   indices
 
-proc getRouter*(): RestRouter =
-  RestRouter.init(validate)
+proc getRouter*(allowedOrigin: Option[string]): RestRouter =
+  RestRouter.init(validate, allowedOrigin = allowedOrigin)
 
 const
   jsonMediaType* = MediaType.init("application/json")


### PR DESCRIPTION
The added options work in opt-in fashion. If they are not specified,
the server will respond to all requests as if the CORS specification
doesn't exist. This will result in errors in CORS-enabled clients.

If the options are provided, the server will enforce the Origin by
returning 403 Forbidden when the requests headers don't match the
desired value.

Please note that future versions may support more than one allowed
origin. The option names will stay the same, but the user will be
able to repeat them on the command line (similar to other options
such as --web3-url).

To be documented in the guide in a separate PR.