### PR TITLE
use REST for make pyrmont/prater; use --rest options for local testnet

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,12 +60,12 @@ def runStages(nodeDir) {
 				sh """#!/bin/bash
 				set -e
 				./scripts/launch_local_testnet.sh --preset minimal --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
-					--data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port \
+					--data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
 					\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 600 \
 					--kill-old-processes \
 					-- --verify-finalization --discv5:no
 				./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
-					--data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rpc-port \
+					--data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
 					\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 2400 \
 					--kill-old-processes \
 					-- --verify-finalization --discv5:no

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2019-2022 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -23,7 +23,7 @@ LINK_PCRE := 0
 
 NODE_ID := 0
 BASE_PORT := 9000
-BASE_RPC_PORT := 9190
+BASE_REST_PORT := 5052
 BASE_METRICS_PORT := 8008
 WEB3_URL := "wss://goerli.infura.io/ws/v3/809a18497dd74102b5f37d25aae3c85a"
 VALIDATORS := 1
@@ -269,8 +269,8 @@ GOERLI_TESTNETS_PARAMS := \
   --udp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
   --metrics \
   --metrics-port=$$(( $(BASE_METRICS_PORT) + $(NODE_ID) )) \
-  --rpc \
-  --rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
+  --rest \
+  --rest-port=$$(( $(BASE_REST_PORT) +$(NODE_ID) ))
 
 eth2_network_simulation: | build deps clean_eth2_network_simulation_all
 	+ GIT_ROOT="$$PWD" NIMFLAGS="$(NIMFLAGS)" LOG_LEVEL="$(LOG_LEVEL)" tests/simulation/start-in-tmux.sh
@@ -349,7 +349,7 @@ define CONNECT_TO_NETWORK_WITH_VALIDATOR_CLIENT
 		--log-level="$(RUNTIME_LOG_LEVEL)" \
 		--log-file=build/data/shared_$(1)_$(NODE_ID)/nbc_vc_$$(date +"%Y%m%d%H%M%S").log \
 		--data-dir=build/data/shared_$(1)_$(NODE_ID) \
-		--rpc-port=$$(( $(BASE_RPC_PORT) +$(NODE_ID) ))
+		--rest-port=$$(( $(BASE_REST_PORT) +$(NODE_ID) ))
 endef
 
 define MAKE_DEPOSIT_DATA

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -27,12 +27,13 @@ fi
 
 ! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then
+  # shellcheck disable=2016
   echo '`getopt --test` failed in this environment.'
   exit 1
 fi
 
 OPTS="ht:n:d:g"
-LONGOPTS="help,preset:,nodes:,data-dir:,with-ganache,stop-at-epoch:,disable-htop,disable-vc,enable-logtrace,log-level:,base-port:,base-rpc-port:,base-metrics-port:,reuse-existing-data-dir,timeout:,kill-old-processes,eth2-docker-image:"
+LONGOPTS="help,preset:,nodes:,data-dir:,with-ganache,stop-at-epoch:,disable-htop,disable-vc,enable-logtrace,log-level:,base-port:,base-rest-port:,base-metrics-port:,reuse-existing-data-dir,timeout:,kill-old-processes,eth2-docker-image:"
 
 # default values
 NUM_NODES="10"
@@ -43,7 +44,7 @@ USE_GANACHE="0"
 LOG_LEVEL="DEBUG; TRACE:networking"
 BASE_PORT="9000"
 BASE_METRICS_PORT="8008"
-BASE_RPC_PORT="7500"
+BASE_REST_PORT="7500"
 REUSE_EXISTING_DATA_DIR="0"
 ENABLE_LOGTRACE="0"
 STOP_AT_EPOCH_FLAG=""
@@ -66,7 +67,7 @@ CI run: $(basename "$0") --disable-htop -- --verify-finalization
                               (default: "${DATA_DIR}")
   --preset                    Const preset to be (default: mainnet)
   --base-port                 bootstrap node's Eth2 traffic port (default: ${BASE_PORT})
-  --base-rpc-port             bootstrap node's RPC port (default: ${BASE_RPC_PORT})
+  --base-rest-port            bootstrap node's REST port (default: ${BASE_REST_PORT})
   --base-metrics-port         bootstrap node's metrics server port (default: ${BASE_METRICS_PORT})
   --disable-htop              don't use "htop" to see the nimbus_beacon_node processes
   --disable-vc                don't use validator client binaries for validators (by default validators are split 50/50 between beacon nodes and validator clients)
@@ -133,8 +134,8 @@ while true; do
       BASE_PORT="$2"
       shift 2
       ;;
-    --base-rpc-port)
-      BASE_RPC_PORT="$2"
+    --base-rest-port)
+      BASE_REST_PORT="$2"
       shift 2
       ;;
     --base-metrics-port)
@@ -212,7 +213,7 @@ fi
 # kill lingering processes from a previous run
 if [[ "${HAVE_LSOF}" == "1" ]]; then
   for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
-    for PORT in $(( BASE_PORT + NUM_NODE )) $(( BASE_METRICS_PORT + NUM_NODE )) $(( BASE_RPC_PORT + NUM_NODE )); do
+    for PORT in $(( BASE_PORT + NUM_NODE )) $(( BASE_METRICS_PORT + NUM_NODE )) $(( BASE_REST_PORT + NUM_NODE )); do
       for PID in $(lsof -n -i tcp:${PORT} -sTCP:LISTEN -t); do
         echo -n "Found old process listening on port ${PORT}, with PID ${PID}. "
         if [[ "${KILL_OLD_PROCESSES}" == "1" ]]; then
@@ -234,7 +235,7 @@ if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
   BINARIES="${BINARIES} logtrace"
 fi
 
-if [[ ! -z "$ETH2_DOCKER_IMAGE" ]]; then
+if [[ -n "$ETH2_DOCKER_IMAGE" ]]; then
   DATA_DIR_FULL_PATH=$(cd "${DATA_DIR}"; pwd)
   # CONTAINER_DATA_DIR must be used everywhere where paths are supplied to BEACON_NODE_COMMAND executions.
   # We'll use the CONTAINER_ prefix throughout the file to indicate such paths.
@@ -265,7 +266,7 @@ cleanup() {
     rm build/${BINARY}
   done
 
-  if [[ ! -z "$ETH2_DOCKER_IMAGE" ]]; then
+  if [[ -n "$ETH2_DOCKER_IMAGE" ]]; then
     docker rm $(docker stop $(docker ps -a -q --filter ancestor=$ETH2_DOCKER_IMAGE --format="{{.ID}}"))
   fi
 }
@@ -483,7 +484,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     ${STOP_AT_EPOCH_FLAG} \
     --rest \
     --rest-address="127.0.0.1" \
-    --rest-port="$(( BASE_RPC_PORT + NUM_NODE ))" \
+    --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics \
     --metrics-address="127.0.0.1" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
@@ -501,7 +502,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
       --log-level="${LOG_LEVEL}" \
       ${STOP_AT_EPOCH_FLAG} \
       --data-dir="${VALIDATOR_DATA_DIR}" \
-      --beacon-node="http://127.0.0.1:$((BASE_RPC_PORT + NUM_NODE))" \
+      --beacon-node="http://127.0.0.1:$((BASE_REST_PORT + NUM_NODE))" \
       > "${DATA_DIR}/log_val${NUM_NODE}.txt" 2>&1 &
   fi
 done


### PR DESCRIPTION
`launch_local_testnet.sh` was already using REST, but had its options labeled as `--rpc`, which was misleading/inconsistent with the rest of Nimbus.