### PR TITLE
fix slot number display during sync

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -594,7 +594,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
         else: InfiniteDuration
       currentSlot = Base10.toString(
         if man.queue.kind == SyncQueueKind.Forward:
-          min(uint64(man.queue.outSlot) - 1'u64, 0'u64)
+          max(uint64(man.queue.outSlot), 1'u64) - 1'u64
         else:
           uint64(man.queue.outSlot) + 1'u64
       )


### PR DESCRIPTION
#3304 introduced a regression to the sync status string displayed in the
status bar; during the main forward sync, the current slot is no longer
reported and always displays as `0`. This patch corrects the computation
to accurately report the current slot once more.