### PR TITLE
remove unused `sleepTime` from `SyncManager`

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -45,7 +45,6 @@ type
   SyncManager*[A, B] = ref object
     pool: PeerPool[A, B]
     responseTimeout: chronos.Duration
-    sleepTime: chronos.Duration
     maxHeadAge: uint64
     toleranceValue: uint64
     getLocalHeadSlot: GetSlotCallback
@@ -116,8 +115,6 @@ proc newSyncManager*[A, B](pool: PeerPool[A, B],
                            progressPivot: Slot,
                            blockVerifier: BlockVerifier,
                            maxHeadAge = uint64(SLOTS_PER_EPOCH * 1),
-                           sleepTime = (int(SLOTS_PER_EPOCH) *
-                                        int(SECONDS_PER_SLOT)).seconds,
                            chunkSize = uint64(SLOTS_PER_EPOCH),
                            toleranceValue = uint64(1)
                            ): SyncManager[A, B] =
@@ -137,7 +134,6 @@ proc newSyncManager*[A, B](pool: PeerPool[A, B],
     getLastSlot: getLastSlot,
     progressPivot: progressPivot,
     maxHeadAge: maxHeadAge,
-    sleepTime: sleepTime,
     chunkSize: chunkSize,
     blockVerifier: blockVerifier,
     notInSyncEvent: newAsyncEvent(),


### PR DESCRIPTION
The `SyncManager` has a leftover optional `sleepTime` parameter in
its constructor that used to configure the sync loop polling rate.
This parameter was replaced with a constant in #1602 and is no longer
functional. This patch removes the `sleepTime` leftovers.