### PR TITLE
fix `firstSlot` computation for backfill sync

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -103,7 +103,7 @@ proc initQueue[A, B](man: SyncManager[A, B]) =
                     firstSlot
                   else:
                     Slot(firstSlot - 1'u64)
-    man.queue = SyncQueue.init(A, man.direction, firstSlot, lastSlot,
+    man.queue = SyncQueue.init(A, man.direction, startSlot, lastSlot,
                                man.chunkSize, man.getSafeSlot,
                                man.blockVerifier, 1)
 


### PR DESCRIPTION
When initializing backfill sync, the implementation intends to start at
the first unknown slot (`1` before tail). However, an incorrect variable
is passed, and backfill sync actually starts at the tail slot instead.
This patch corrects this by passing the intended variable. The problem
was introduced with the original backfill implementation at #3263.