### PR TITLE
use isZeroMemory for Eth2Digest comparisons

### DIFF
--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -9,7 +9,6 @@
 
 import
   chronicles,
-  stew/objects,
 
   ../spec/datatypes/[phase0, altair],
   ../spec/[helpers]
@@ -121,7 +120,7 @@ func isAncestorOf*(a, b: BlockRef): bool =
   isAncestor
 
 func link*(parent, child: BlockRef) =
-  doAssert (not (parent.root.isZeroMemory or child.root.isZeroMemory)),
+  doAssert (not (parent.root.isZero or child.root.isZero)),
     "blocks missing root!"
   doAssert parent.root != child.root, "self-references not allowed"
 

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -9,6 +9,7 @@
 
 import
   chronicles,
+  stew/objects,
 
   ../spec/datatypes/[phase0, altair],
   ../spec/[helpers]
@@ -120,7 +121,7 @@ func isAncestorOf*(a, b: BlockRef): bool =
   isAncestor
 
 func link*(parent, child: BlockRef) =
-  doAssert (not (parent.root == Eth2Digest() or child.root == Eth2Digest())),
+  doAssert (not (parent.root.isZeroMemory or child.root.isZeroMemory)),
     "blocks missing root!"
   doAssert parent.root != child.root, "self-references not allowed"
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -9,7 +9,7 @@
 
 import
   std/[options, sequtils, tables, sets],
-  stew/[assign2, byteutils, objects, results],
+  stew/[assign2, byteutils, results],
   metrics, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
     state_transition, validator],
@@ -108,7 +108,7 @@ proc updateValidatorKeys*(dag: ChainDAGRef, validators: openArray[Validator]) =
 proc updateFinalizedBlocks*(dag: ChainDAGRef) =
   template update(s: Slot) =
     if s < dag.tail.slot:
-      if not dag.backfillBlocks[s.int].isZeroMemory:
+      if not dag.backfillBlocks[s.int].isZero:
         dag.db.finalizedBlocks.insert(s, dag.backfillBlocks[s.int])
     else:
       let dagIndex = int(s - dag.tail.slot)
@@ -258,7 +258,7 @@ func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): BlockSlotId =
 
   var pos = slot.int
   while pos >= dag.backfill.slot.int:
-    if not dag.backfillBlocks[pos].isZeroMemory:
+    if not dag.backfillBlocks[pos].isZero:
       return BlockId(root: dag.backfillBlocks[pos], slot: Slot(pos)).atSlot(slot)
     pos -= 1
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -9,7 +9,7 @@
 
 import
   std/[options, sequtils, tables, sets],
-  stew/[assign2, byteutils, results],
+  stew/[assign2, byteutils, objects, results],
   metrics, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
     state_transition, validator],
@@ -108,7 +108,7 @@ proc updateValidatorKeys*(dag: ChainDAGRef, validators: openArray[Validator]) =
 proc updateFinalizedBlocks*(dag: ChainDAGRef) =
   template update(s: Slot) =
     if s < dag.tail.slot:
-      if dag.backfillBlocks[s.int] != Eth2Digest():
+      if not dag.backfillBlocks[s.int].isZeroMemory:
         dag.db.finalizedBlocks.insert(s, dag.backfillBlocks[s.int])
     else:
       let dagIndex = int(s - dag.tail.slot)
@@ -258,7 +258,7 @@ func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): BlockSlotId =
 
   var pos = slot.int
   while pos >= dag.backfill.slot.int:
-    if dag.backfillBlocks[pos] != Eth2Digest():
+    if not dag.backfillBlocks[pos].isZeroMemory:
       return BlockId(root: dag.backfillBlocks[pos], slot: Slot(pos)).atSlot(slot)
     pos -= 1
 

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -14,7 +14,7 @@ import
   chronos, json, metrics, chronicles/timings, stint/endians2,
   web3, web3/ethtypes as web3Types, web3/ethhexstrings, web3/engine_api,
   eth/common/eth_types,
-  eth/async_utils, stew/[objects, byteutils, shims/hashes],
+  eth/async_utils, stew/[byteutils, shims/hashes],
   # Local modules:
   ../spec/[eth2_merkleization, forks, helpers],
   ../spec/datatypes/[base, phase0, bellatrix],
@@ -574,7 +574,7 @@ when hasDepositRootChecks:
     try:
       let fetchedRoot = asEth2Digest(
         awaitOrRaiseOnTimeout(depositRoot, contractCallTimeout))
-      if blk.voteData.deposit_root.isZeroMemory:
+      if blk.voteData.deposit_root.isZero:
         blk.voteData.deposit_root = fetchedRoot
         result = Fetched
       elif blk.voteData.deposit_root == fetchedRoot:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -574,7 +574,7 @@ when hasDepositRootChecks:
     try:
       let fetchedRoot = asEth2Digest(
         awaitOrRaiseOnTimeout(depositRoot, contractCallTimeout))
-      if blk.voteData.deposit_root == default(Eth2Digest):
+      if blk.voteData.deposit_root.isZeroMemory:
         blk.voteData.deposit_root = fetchedRoot
         result = Fetched
       elif blk.voteData.deposit_root == fetchedRoot:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   std/[sequtils, tables],
   # Status libraries
-  stew/[objects, results], chronicles,
+  stew/results, chronicles,
   # Internal
   ../spec/[beaconstate, helpers],
   ../spec/datatypes/[phase0, altair, bellatrix],
@@ -159,7 +159,7 @@ func process_attestation*(
        block_root: Eth2Digest,
        target_epoch: Epoch
      ) =
-  if block_root.isZeroMemory:
+  if block_root.isZero:
     return
 
   ## Add an attestation to the fork choice context
@@ -206,7 +206,7 @@ proc on_attestation*(
      ): FcResult[void] =
   ? self.update_time(dag, wallTime)
 
-  if beacon_block_root.isZeroMemory:
+  if beacon_block_root.isZero:
     return ok()
 
   if attestation_slot < self.checkpoints.time.slotOrZero:
@@ -472,7 +472,7 @@ func compute_deltas(
   for val_index, vote in votes.mpairs():
     # No need to create a score change if the validator has never voted
     # or if votes are for the zero hash (alias to the genesis block)
-    if vote.current_root.isZeroMemory and vote.next_root.isZeroMemory:
+    if vote.current_root.isZero and vote.next_root.isZero:
       continue
 
     # If the validator was not included in `old_balances` (i.e. did not exist)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   std/[sequtils, tables],
   # Status libraries
-  stew/results, chronicles,
+  stew/[objects, results], chronicles,
   # Internal
   ../spec/[beaconstate, helpers],
   ../spec/datatypes/[phase0, altair, bellatrix],
@@ -159,7 +159,7 @@ func process_attestation*(
        block_root: Eth2Digest,
        target_epoch: Epoch
      ) =
-  if block_root == Eth2Digest():
+  if block_root.isZeroMemory:
     return
 
   ## Add an attestation to the fork choice context
@@ -206,7 +206,7 @@ proc on_attestation*(
      ): FcResult[void] =
   ? self.update_time(dag, wallTime)
 
-  if beacon_block_root == Eth2Digest():
+  if beacon_block_root.isZeroMemory:
     return ok()
 
   if attestation_slot < self.checkpoints.time.slotOrZero:
@@ -472,7 +472,7 @@ func compute_deltas(
   for val_index, vote in votes.mpairs():
     # No need to create a score change if the validator has never voted
     # or if votes are for the zero hash (alias to the genesis block)
-    if vote.current_root == default(Eth2Digest) and vote.next_root == default(Eth2Digest):
+    if vote.current_root.isZeroMemory and vote.next_root.isZeroMemory:
       continue
 
     # If the validator was not included in `old_balances` (i.e. did not exist)

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -12,7 +12,7 @@ import
   std/[options, tables, typetraits],
   # Status libraries
   chronicles,
-  stew/[objects, results],
+  stew/results,
   # Internal
   ../spec/datatypes/base,
   # Fork choice
@@ -169,7 +169,7 @@ func applyScoreChanges*(self: var ProtoArray,
 
   # Iterate backwards through all the indices in `self.nodes`
   for nodePhysicalIdx in countdown(self.nodes.len - 1, 0):
-    if node.root.isZeroMemory:
+    if node.root.isZero:
       continue
 
     var nodeDelta = deltas[nodePhysicalIdx]
@@ -177,7 +177,7 @@ func applyScoreChanges*(self: var ProtoArray,
     # If we find the node for which the proposer boost was previously applied,
     # decrease the delta by the previous score amount.
     if  useProposerBoost and
-        (not self.previousProposerBoostRoot.isZeroMemory) and
+        (not self.previousProposerBoostRoot.isZero) and
         self.previousProposerBoostRoot == node.root:
           if  nodeDelta < 0 and
               nodeDelta - low(Delta) < self.previousProposerBoostScore:
@@ -190,8 +190,7 @@ func applyScoreChanges*(self: var ProtoArray,
     # the delta by the new score amount.
     #
     # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/fork-choice.md#get_latest_attesting_balance
-    if  useProposerBoost and
-        (not proposer_boost_root.isZeroMemory) and
+    if  useProposerBoost and (not proposer_boost_root.isZero) and
         proposer_boost_root == node.root:
       proposerBoostScore = calculateProposerBoost(newBalances)
       if  nodeDelta >= 0 and
@@ -251,7 +250,7 @@ func applyScoreChanges*(self: var ProtoArray,
     self.previousProposerBoostScore = proposerBoostScore
 
   for nodePhysicalIdx in countdown(self.nodes.len - 1, 0):
-    if node.root.isZeroMemory:
+    if node.root.isZero:
       continue
 
     if node.parent.isSome():

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -338,7 +338,9 @@ proc validateBeaconBlock*(
     # to the finalized checkpoint (else it wouldn't be in the DAG)
     return errIgnore("BeaconBlock: Can't find ancestor")
 
-  if not (finalized_checkpoint.root in [ancestor.root, Eth2Digest()]):
+  if not (
+      finalized_checkpoint.root == ancestor.root or
+      finalized_checkpoint.root.isZeroMemory):
     quarantine[].addUnviable(signed_beacon_block.root)
 
     return errReject("BeaconBlock: Finalized checkpoint not an ancestor")

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -340,7 +340,7 @@ proc validateBeaconBlock*(
 
   if not (
       finalized_checkpoint.root == ancestor.root or
-      finalized_checkpoint.root.isZeroMemory):
+      finalized_checkpoint.root.isZero):
     quarantine[].addUnviable(signed_beacon_block.root)
 
     return errReject("BeaconBlock: Finalized checkpoint not an ancestor")

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -27,7 +27,7 @@ import
   # Status libraries
   chronicles,
   nimcrypto/[sha2, hash],
-  stew/[endians2, byteutils],
+  stew/[byteutils, endians2, objects],
   json_serialization,
   blscurve
 
@@ -110,6 +110,9 @@ func `==`*(a, b: Eth2Digest): bool =
     # nimcrypto uses a constant-time comparison for all MDigest types which for
     # Eth2Digest is unnecessary - the type should never hold a secret!
     equalMem(unsafeAddr a.data[0], unsafeAddr b.data[0], sizeof(a.data))
+
+func isZero*(x: Eth2Digest): bool =
+  x.isZeroMemory
 
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [Defect, IOError, SerializationError].} =
   w.writeValue $a

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -42,7 +42,7 @@
 
 import
   chronicles,
-  stew/results,
+  stew/[objects, results],
   ../extras,
   ./datatypes/[phase0, altair, bellatrix],
   "."/[
@@ -228,7 +228,7 @@ proc state_transition_block_aux(
 
   # only blocks currently being produced have an empty state root - we use a
   # separate function for those
-  doAssert signedBlock.message.state_root != Eth2Digest(),
+  doAssert not signedBlock.message.state_root.isZeroMemory,
     "see makeBeaconBlock for block production"
   state.root = signedBlock.message.state_root
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -42,7 +42,7 @@
 
 import
   chronicles,
-  stew/[objects, results],
+  stew/results,
   ../extras,
   ./datatypes/[phase0, altair, bellatrix],
   "."/[
@@ -228,7 +228,7 @@ proc state_transition_block_aux(
 
   # only blocks currently being produced have an empty state root - we use a
   # separate function for those
-  doAssert not signedBlock.message.state_root.isZeroMemory,
+  doAssert not signedBlock.message.state_root.isZero,
     "see makeBeaconBlock for block production"
   state.root = signedBlock.message.state_root
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -9,7 +9,7 @@
 
 import
   options, tables, sets, macros,
-  chronicles, chronos, stew/ranges/bitranges, libp2p/switch,
+  chronicles, chronos, stew/[objects, ranges/bitranges], libp2p/switch,
   ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/[helpers, forks, network],
   ".."/[beacon_clock],
@@ -137,8 +137,8 @@ proc checkStatusMsg(state: BeaconSyncNetworkState, status: StatusMsg):
   if status.finalizedEpoch <= dag.finalizedHead.slot.epoch:
     let blockId = dag.getBlockIdAtSlot(status.finalizedEpoch.start_slot())
     if status.finalizedRoot != blockId.bid.root and
-        blockId.bid.root != Eth2Digest() and
-        status.finalizedRoot != Eth2Digest():
+        (not blockId.bid.root.isZeroMemory) and
+        (not status.finalizedRoot.isZeroMemory):
       return err("peer following different finality")
 
   ok()

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -9,7 +9,7 @@
 
 import
   options, tables, sets, macros,
-  chronicles, chronos, stew/[objects, ranges/bitranges], libp2p/switch,
+  chronicles, chronos, stew/ranges/bitranges, libp2p/switch,
   ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/[helpers, forks, network],
   ".."/[beacon_clock],
@@ -137,8 +137,8 @@ proc checkStatusMsg(state: BeaconSyncNetworkState, status: StatusMsg):
   if status.finalizedEpoch <= dag.finalizedHead.slot.epoch:
     let blockId = dag.getBlockIdAtSlot(status.finalizedEpoch.start_slot())
     if status.finalizedRoot != blockId.bid.root and
-        (not blockId.bid.root.isZeroMemory) and
-        (not status.finalizedRoot.isZeroMemory):
+        (not blockId.bid.root.isZero) and
+        (not status.finalizedRoot.isZero):
       return err("peer following different finality")
 
   ok()

--- a/tests/test_eth2_ssz_serialization.nim
+++ b/tests/test_eth2_ssz_serialization.nim
@@ -9,7 +9,6 @@
 
 import
   unittest2,
-  stew/objects,
   ../beacon_chain/spec/datatypes/[phase0, altair],
   ../beacon_chain/spec/eth2_ssz_serialization
 
@@ -43,7 +42,7 @@ suite "Specific field types":
       t = default(type t)
       readSszBytes(encoded, t, false)
       check:
-        t.root.isZeroMemory
+        t.root.isZero
 
     testit(phase0.SignedBeaconBlock)
     testit(phase0.TrustedSignedBeaconBlock)

--- a/tests/test_eth2_ssz_serialization.nim
+++ b/tests/test_eth2_ssz_serialization.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,6 +9,7 @@
 
 import
   unittest2,
+  stew/objects,
   ../beacon_chain/spec/datatypes/[phase0, altair],
   ../beacon_chain/spec/eth2_ssz_serialization
 
@@ -42,7 +43,7 @@ suite "Specific field types":
       t = default(type t)
       readSszBytes(encoded, t, false)
       check:
-        t.root == Eth2Digest()
+        t.root.isZeroMemory
 
     testit(phase0.SignedBeaconBlock)
     testit(phase0.TrustedSignedBeaconBlock)


### PR DESCRIPTION
Each `foo == default(Eth2Digest)`, `foo != default(Eth2Digest)`, `foo == Eth2Digest()`, or `foo != Eth2Digest()` creates one additional 32-byte `nimZeroMem()` call every time the comparison's done and each reference to an anonymous r-value `Eth2Digest` used for the comparison allocates another 32 bytes on the local C stack up to stack alignment considerations.

For example:
```nim
var a: Eth2Digest
echo a == default(Eth2Digest)
```

Adds one additional local C array, for the `default(Eth2Digest)` in `== default(Eth2Digest)`, and calls `nimZeroMem()` on it before comparing `a` and the object it just constructed.

```nim
var a: Eth2Digest
for i in [0, 1]:
  echo a == default(Eth2Digest)
```
calls `nimZeroMem` 3 times in its main function (once for `a`, as above, but now once per loop iteration). However, scope-wise, there's still only one distinct Nim-anonymous `Eth2Digest`, so it uses the same stack space as the first example in terms of `Eth2Digest` objects (excluding the loop counter).

```nim
var a: Eth2Digest
echo a == default(Eth2Digest)   # this
echo a == default(Eth2Digest)   # and this Eth2Digest are distinct for Nim
```
does not combine the two `default(Eth2Digest)`, and treats them separately, for 3 `nimZeroMem`s including for `a`, and both anonymous/temporary `default(Eth2Digest)` values at least notionally getting a C local variable.

With decent lifetime analysis and optimization, a C compiler should notice that they never coexist and be able to reuse the same stack space, but that's not ideal to rely on.

There are a few other places which compare with `default(Foo)`, but those aren't necessarily appropriate to use `isZeroMemory` for. This PR targets only `Eth2Digest`, to which it is applicable.