### PR TITLE
clean up / document init

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -488,6 +488,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     # This is where we'll start backfilling, worst case - we might refine this
     # while loading blocks, in case backfilling has happened already
     backfill = withBlck(tailBlock): blck.message.toBeaconBlockSummary()
+    # The most recent block that we load from the finalized blocks table
     midRef: BlockRef
     backRoot: Option[Eth2Digest]
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -579,7 +579,8 @@ func init*(t: typedesc[ValidatorIdent], v: ValidatorPubKey): ValidatorIdent =
 
 func init*(t: typedesc[RestBlockInfo],
            v: ForkedTrustedSignedBeaconBlock): RestBlockInfo =
-  RestBlockInfo(slot: v.slot(), blck: v.root())
+  withBlck(v):
+    RestBlockInfo(slot: blck.message.slot, blck: blck.root)
 
 func init*(t: typedesc[RestValidator], index: ValidatorIndex,
            balance: uint64, status: string,

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -473,7 +473,7 @@ func readSszForkedHashedBeaconState*(cfg: RuntimeConfig, data: openArray[byte]):
     data.toOpenArray(0, sizeof(BeaconStateHeader) - 1),
     BeaconStateHeader)
 
-  # careful - `result` is used, RVO didn't seem to work without
+  # TODO https://github.com/nim-lang/Nim/issues/19357
   result = ForkedHashedBeaconState(
     kind: cfg.stateForkAtEpoch(header.slot.epoch()))
 
@@ -498,8 +498,7 @@ func readSszForkedSignedBeaconBlock*(
     data.toOpenArray(0, sizeof(ForkedBeaconBlockHeader) - 1),
     ForkedBeaconBlockHeader)
 
-  # careful - `result` is used, RVO didn't seem to work without
-  # TODO move time helpers somewhere to avoid circular imports
+  # TODO https://github.com/nim-lang/Nim/issues/19357
   result = ForkedSignedBeaconBlock(
     kind: cfg.blockForkAtEpoch(header.slot.epoch()))
 


### PR DESCRIPTION
* drop `immutable_validators` data (pre-altair)
* document versions where data is first added
* avoid needlessly loading genesis block data on startup
* add a few more internal database consistency checks
* remove duplicate state root lookup on state load