### PR TITLE
make `SyncQueue` / `SyncManager` generic

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -414,7 +414,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SyncQueue#Forward] getRewindPoint() test                                                  OK
 + [SyncQueue] checkResponse() test                                                           OK
 + [SyncQueue] contains() test                                                                OK
-+ [SyncQueue] getLastNonEmptySlot() test                                                     OK
++ [SyncQueue] getLastNonEmptyKey() test                                                      OK
 + [SyncQueue] hasEndGap() test                                                               OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -59,8 +59,8 @@ type
     eventBus*: AsyncEventBus
     vcProcess*: Process
     requestManager*: RequestManager
-    syncManager*: SyncManager[Peer, PeerID]
-    backfiller*: SyncManager[Peer, PeerID]
+    syncManager*: BeaconBlocksSyncManager[Peer, PeerID]
+    backfiller*: BeaconBlocksSyncManager[Peer, PeerID]
     genesisSnapshotContent*: string
     actionTracker*: ActionTracker
     processor*: ref Eth2Processor

--- a/beacon_chain/networking/peer_scores.nim
+++ b/beacon_chain/networking/peer_scores.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,7 +18,7 @@ const
     ## This peer is sending malformed or nonsensical data
 
   PeerScoreHeadTooNew* = -100
-    ## The peer reports a head newer than our wall clock slot
+    ## The peer reports a head newer than our wall clock
   PeerScoreNoStatus* = -100
     ## Peer did not answer `status` request.
   PeerScoreStaleStatus* = -50
@@ -28,18 +28,18 @@ const
   PeerScoreGoodStatus* = 50
     ## Peer's `status` answer is fine.
   PeerScoreNoBlocks* = -100
-    ## Peer did not respond in time on `blocksByRange` request.
+    ## Peer did not respond in time to `ByRange` request.
   PeerScoreGoodBlocks* = 100
-    ## Peer's `blocksByRange` answer is fine.
+    ## Peer's `ByRange` answer is fine.
   PeerScoreBadBlocks* = -1000
-    ## Peer's response contains incorrect blocks.
+    ## Peer's response contains incorrect values.
   PeerScoreBadResponse* = -1000
     ## Peer's response is not in requested range.
   PeerScoreMissingBlocks* = -25
-    ## Peer response contains too many empty blocks - this can happen either
+    ## Peer response contains too many empty values - this can happen either
     ## because a long reorg happened or the peer is falsely trying to convince
     ## us that a long reorg happened.
-    ## Peer's `blocksByRange` answer is fine.
+    ## Peer's `ByRange` answer is fine.
   PeerScoreUnviableFork* = -200
-    ## Peer responded with blocks from an unviable fork - are they on a
+    ## Peer responded with values from an unviable fork - are they on a
     ## different chain?

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -490,11 +490,11 @@ proc init*(T: type BeaconNode,
       blockProcessor, validatorMonitor, dag, attestationPool, exitPool,
       validatorPool, syncCommitteeMsgPool, quarantine, rng, getBeaconTime,
       taskpool)
-    syncManager = newSyncManager[Peer, PeerID](
+    syncManager = newBeaconBlocksSyncManager[Peer, PeerID](
       network.peerPool, SyncQueueKind.Forward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       dag.tail.slot, blockVerifier)
-    backfiller = newSyncManager[Peer, PeerID](
+    backfiller = newBeaconBlocksSyncManager[Peer, PeerID](
       network.peerPool, SyncQueueKind.Backward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       dag.backfill.slot, blockVerifier, maxHeadAge = 0)


### PR DESCRIPTION
The libp2p light client sync protocol defines an endpoint for syncing
historic data that is structured similarly to `beaconBlocksByRange`,
i.e., it uses a start/count/step tuple to sync from finalized to head.
See https://github.com/ethereum/consensus-specs/pull/2802
As preparation, this patch extends the `SyncQueue` and `SyncManager`
implementations to work with such new `ByRange` endpoints as well.