### PR TITLE
rename no{R=>r}eturn, no{I=>i}init, short{l=>L}og, E{T=>t}h2Node, Beacon{c=>C}hainDB

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -569,7 +569,7 @@ proc close*(db: BeaconChainDBV0) =
   discard db.stateStore.close()
   discard db.backend.close()
 
-proc close*(db: BeaconchainDB) =
+proc close*(db: BeaconChainDB) =
   if db.db == nil: return
 
   # Close things in reverse order
@@ -1026,7 +1026,7 @@ proc loadSummaries*(db: BeaconChainDB): Table[Eth2Digest, BeaconBlockSummary] =
   discard db.summaries.find([], proc(k, v: openArray[byte]) =
     var output: BeaconBlockSummary
 
-    if k.len() == sizeof(Eth2Digest) and decodeSSz(v, output):
+    if k.len() == sizeof(Eth2Digest) and decodeSSZ(v, output):
       summaries[Eth2Digest(data: toArray(sizeof(Eth2Digest), k))] = output
     else:
       warn "Invalid summary in database", klen = k.len(), vlen = v.len()

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -940,7 +940,7 @@ func walletsDir*(config: BeaconNodeConf): string =
     config.dataDir / "wallets"
 
 func outWalletName*(config: BeaconNodeConf): Option[WalletName] =
-  proc fail {.noReturn.} =
+  proc fail {.noreturn.} =
     raiseAssert "outWalletName should be used only in the right context"
 
   case config.cmd
@@ -957,7 +957,7 @@ func outWalletName*(config: BeaconNodeConf): Option[WalletName] =
     fail()
 
 func outWalletFile*(config: BeaconNodeConf): Option[OutFile] =
-  proc fail {.noReturn.} =
+  proc fail {.noreturn.} =
     raiseAssert "outWalletName should be used only in the right context"
 
   case config.cmd

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -151,7 +151,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
       dag.headState.data, current_justified_checkpoint).epoch,
     finalized_epoch = getStateField(
       dag.headState.data, finalized_checkpoint).epoch,
-    finalized_root = shortlog(dag.finalizedHead.blck.root)
+    finalized_root = shortLog(dag.finalizedHead.blck.root)
 
   T(
     dag: dag,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1674,7 +1674,7 @@ proc aggregateAll*(
   if not firstKey.isSome():
     return err("aggregate: invalid validator index")
 
-  var aggregateKey{.noInit.}: AggregatePublicKey
+  var aggregateKey{.noinit.}: AggregatePublicKey
 
   aggregateKey.init(firstKey.get())
 
@@ -1694,7 +1694,7 @@ proc aggregateAll*(
     return err("aggregateAll: mismatch in bits length")
 
   var
-    aggregateKey{.noInit.}: AggregatePublicKey
+    aggregateKey{.noinit.}: AggregatePublicKey
     inited = false
 
   for i in 0..<bits.len():

--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -134,7 +134,7 @@ func computeAggregateSig(votes: seq[TrustedSyncCommitteeMsg],
                          subcommitteeIdx: SyncSubcommitteeIndex,
                          contribution: var SyncCommitteeContribution): bool =
   var
-    aggregateSig {.noInit.}: AggregateSignature
+    aggregateSig {.noinit.}: AggregateSignature
     initialized = false
 
   for vote in votes:
@@ -239,7 +239,7 @@ proc addContribution*(pool: var SyncCommitteeMsgPool,
 proc produceSyncAggregateAux(
     bestContributions: BestSyncSubcommitteeContributions): SyncAggregate =
   var
-    aggregateSig {.noInit.}: AggregateSignature
+    aggregateSig {.noinit.}: AggregateSignature
     initialized = false
     startTime = Moment.now
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -417,7 +417,7 @@ func find_head*(
   self.balances = justified_state_balances
 
   # Find the best block
-  var new_head{.noInit.}: Eth2Digest
+  var new_head{.noinit.}: Eth2Digest
   ? self.proto_array.findHead(new_head, justifiedCheckpoint.root)
 
   {.noSideEffect.}:

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -432,7 +432,7 @@ template awaitNonNegativeRequestQuota*(peer: Peer) =
 func allowedOpsPerSecondCost*(n: int): float =
   (replenishRate * 1000000000'f / n.float)
 
-proc isSeen*(network: ETh2Node, peerId: PeerID): bool =
+proc isSeen*(network: Eth2Node, peerId: PeerID): bool =
   ## Returns ``true`` if ``peerId`` present in SeenTable and time period is not
   ## yet expired.
   let currentTime = now(chronos.Moment)
@@ -448,7 +448,7 @@ proc isSeen*(network: ETh2Node, peerId: PeerID): bool =
     else:
       true
 
-proc addSeen*(network: ETh2Node, peerId: PeerID,
+proc addSeen*(network: Eth2Node, peerId: PeerID,
               period: chronos.Duration) =
   ## Adds peer with PeerID ``peerId`` to SeenTable and timeout ``period``.
   let item = SeenItem(peerId: peerId, stamp: now(chronos.Moment) + period)

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -451,21 +451,21 @@ func shortLog*(x: TrustedSig): string =
 # TODO more specific exceptions? don't raise?
 
 # For confutils
-func init*(T: typedesc[ValidatorPrivKey], hex: string): T {.noInit, raises: [ValueError, Defect].} =
+func init*(T: typedesc[ValidatorPrivKey], hex: string): T {.noinit, raises: [ValueError, Defect].} =
   let v = T.fromHex(hex)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
   v[]
 
 # For mainchain monitor
-func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte]): T {.noInit, raises: [ValueError, Defect].} =
+func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte]): T {.noinit, raises: [ValueError, Defect].} =
   let v = T.fromRaw(data)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
   v[]
 
 # For mainchain monitor
-func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte]): T {.noInit, raises: [ValueError, Defect].} =
+func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte]): T {.noinit, raises: [ValueError, Defect].} =
   let v = T.fromRaw(data)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -739,7 +739,7 @@ func shortLog*(v: SomeSignedBeaconBlockHeader): auto =
 func shortLog*(v: DepositData): auto =
   (
     pubkey: shortLog(v.pubkey),
-    withdrawal_credentials: shortlog(v.withdrawal_credentials),
+    withdrawal_credentials: shortLog(v.withdrawal_credentials),
     amount: v.amount,
     signature: shortLog(v.signature)
   )

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -57,7 +57,7 @@ chronicles.formatIt Eth2Digest:
 # TODO: expose an in-place digest function
 #       when hashing in loop or into a buffer
 #       See: https://github.com/cheatfate/nimcrypto/blob/b90ba3abd/nimcrypto/sha2.nim#L570
-func eth2digest*(v: openArray[byte]): Eth2Digest {.noInit.} =
+func eth2digest*(v: openArray[byte]): Eth2Digest {.noinit.} =
   ## Apply the Eth2 Hash function
   ## Do NOT use for secret data.
   when BLS_BACKEND == BLST:
@@ -85,15 +85,15 @@ template withEth2Hash*(body: untyped): Eth2Digest =
   else:
     when BLS_BACKEND == BLST:
       block:
-        var h  {.inject, noInit.}: Eth2DigestCtx
+        var h  {.inject, noinit.}: Eth2DigestCtx
         init(h)
         body
-        var res {.noInit.}: Eth2Digest
+        var res {.noinit.}: Eth2Digest
         finalize(res.data, h)
         res
     else:
       block:
-        var h  {.inject, noInit.}: Eth2DigestCtx
+        var h  {.inject, noinit.}: Eth2DigestCtx
         init(h)
         body
         finish(h)

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -336,7 +336,7 @@ else:
 
   #   let preset = try: readPresetFile(path)
   #                except CatchableError as err:
-  #                  error err.msg # TODO: This should be marked as noReturn
+  #                  error err.msg # TODO: This should be marked as noreturn
   #                  return
 
   #   for name, value in preset.values:

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -83,7 +83,7 @@ proc aggregateAttesters(
   if not firstKey.isSome():
     return err("aggregateAttesters: invalid attesting index")
 
-  var attestersAgg{.noInit.}: AggregatePublicKey
+  var attestersAgg{.noinit.}: AggregatePublicKey
 
   attestersAgg.init(firstKey.get())
   for i in 1 ..< validatorIndices.len:
@@ -106,7 +106,7 @@ proc aggregateAttesters(
     # - https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
     return err("aggregateAttesters: no attesting indices")
 
-  var attestersAgg{.noInit.}: AggregatePublicKey
+  var attestersAgg{.noinit.}: AggregatePublicKey
 
   var inited = false
   for i in 0..<bits.len:

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -36,7 +36,7 @@ proc compute_aggregate_sync_committee_signature(
       else: mockBlockForNextSlot(forked).altairData.message.parent_root
 
   var
-    aggregateSig {.noInit.}: AggregateSignature
+    aggregateSig {.noinit.}: AggregateSignature
     initialized = false
   for validator_index in participants:
     let

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -39,7 +39,7 @@ func combine(tgt: var Attestation, src: Attestation) =
 
   tgt.aggregation_bits.incl(src.aggregation_bits)
 
-  var agg {.noInit.}: AggregateSignature
+  var agg {.noinit.}: AggregateSignature
   agg.init(tgt.signature.load().get())
   agg.aggregate(src.signature.load.get())
   tgt.signature = agg.finish().toValidatorSig()

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -8,7 +8,7 @@ import
   ./testblockutil
 
 func aggregate(sigs: openarray[CookedSig]): CookedSig =
-  var agg {.noInit.}: AggregateSignature
+  var agg {.noinit.}: AggregateSignature
   agg.init sigs[0]
   for i in 1 ..< sigs.len:
     agg.aggregate sigs[i]

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -188,7 +188,7 @@ func makeAttestationSig*(
     fork, genesis_validators_root, data)
 
   var
-    agg {.noInit.}: AggregateSignature
+    agg {.noinit.}: AggregateSignature
     first = true
 
   for i in 0..<bits.len():


### PR DESCRIPTION
Start preparing `nimbus-eth2` for `--styleCheck:usage --styleCheck:error`.

These are either where the language itself assigns a canonically correct version (`noinit` and `noreturn`) or where the issues are effectively typos, not equivalently good but by chance inconsistent capitalization patterns (one could argue for `ETH2Node` or `Eth2Node`, but not as readily for `ETh2Node`, for example).

https://nim-lang.org/docs/manual.html#pragmas-noreturn-pragma has a section header of "noReturn" but states the pragma name is `noreturn`. `styleCheck:usage` prefers the latter.

https://nim-lang.org/docs/manual.html#statements-and-expressions-var-statement shows the `noinit` version, and indeed: `Hint: 'noInit' should be: 'noinit' [Name]`