### PR TITLE
proc -> func, mainly in spec/state transition and adjacent modules

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -894,7 +894,7 @@ func parseCmdArg*(T: type Checkpoint, input: TaintedString): T
 func completeCmdArg*(T: type Checkpoint, input: TaintedString): seq[string] =
   return @[]
 
-proc isPrintable(rune: Rune): bool =
+func isPrintable(rune: Rune): bool =
   # This can be eventually replaced by the `unicodeplus` package, but a single
   # proc does not justify the extra dependencies at the moment:
   # https://github.com/nitely/nim-unicodeplus
@@ -924,7 +924,7 @@ proc parseCmdArg*(T: type enr.Record, p: TaintedString): T
   if not fromURI(result, p):
     raise newException(ConfigurationError, "Invalid ENR")
 
-proc completeCmdArg*(T: type enr.Record, val: TaintedString): seq[string] =
+func completeCmdArg*(T: type enr.Record, val: TaintedString): seq[string] =
   return @[]
 
 func validatorsDir*(config: AnyConf): string =

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -205,7 +205,7 @@ proc updateCurrent(pool: var AttestationPool, wallSlot: Slot) =
 
   pool.startingSlot = newStartingSlot
 
-proc oneIndex(bits: CommitteeValidatorsBits): Option[int] =
+func oneIndex(bits: CommitteeValidatorsBits): Option[int] =
   # Find the index of the set bit, iff one bit is set
   var res = none(int)
   for idx in 0..<bits.len():
@@ -482,7 +482,7 @@ func init(
   update_attestation_pool_cache(
     cur_epoch, state.data.current_epoch_participation)
 
-proc score(
+func score(
     attCache: var AttestationCache, data: AttestationData,
     aggregation_bits: CommitteeValidatorsBits): int =
   # The score of an attestation is loosely based on how many new votes it brings
@@ -681,7 +681,7 @@ func getAggregatedAttestation*(pool: var AttestationPool,
 
   none(Attestation)
 
-proc getAggregatedAttestation*(pool: var AttestationPool,
+func getAggregatedAttestation*(pool: var AttestationPool,
                                slot: Slot,
                                index: CommitteeIndex): Option[Attestation] =
   ## Select the attestation that has the most votes going for it in the given

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -843,7 +843,7 @@ func stateCheckpoint*(bs: BlockSlot): BlockSlot =
 template forkAtEpoch*(dag: ChainDAGRef, epoch: Epoch): Fork =
   forkAtEpoch(dag.cfg, epoch)
 
-proc forkDigestAtEpoch*(dag: ChainDAGRef, epoch: Epoch): ForkDigest =
+func forkDigestAtEpoch*(dag: ChainDAGRef, epoch: Epoch): ForkDigest =
   case dag.cfg.stateForkAtEpoch(epoch)
   of BeaconStateFork.Bellatrix: dag.forkDigests.bellatrix
   of BeaconStateFork.Altair:    dag.forkDigests.altair

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -55,7 +55,7 @@ type
     dag*: ChainDAGRef
     onVoluntaryExitReceived*: OnVoluntaryExitCallback
 
-proc init*(T: type ExitPool, dag: ChainDAGRef,
+func init*(T: type ExitPool, dag: ChainDAGRef,
            onVoluntaryExit: OnVoluntaryExitCallback = nil): T =
   ## Initialize an ExitPool from the dag `headState`
   T(

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -47,7 +47,7 @@ func compute_deltas(
 logScope:
   topics = "fork_choice"
 
-proc init*(T: type ForkChoiceBackend,
+func init*(T: type ForkChoiceBackend,
            justifiedCheckpoint: Checkpoint,
            finalizedCheckpoint: Checkpoint,
            useProposerBoosting: bool): T =

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -98,7 +98,7 @@ proc new*(T: type BlockProcessor,
 # Sync callbacks
 # ------------------------------------------------------------------------------
 
-proc hasBlocks*(self: BlockProcessor): bool =
+func hasBlocks*(self: BlockProcessor): bool =
   self.blockQueue.len() > 0
 
 # Storage

--- a/beacon_chain/gossip_processing/consensus_manager.nim
+++ b/beacon_chain/gossip_processing/consensus_manager.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -31,7 +31,7 @@ type
 # Initialization
 # ------------------------------------------------------------------------------
 
-proc new*(T: type ConsensusManager,
+func new*(T: type ConsensusManager,
           dag: ChainDAGRef,
           attestationPool: ref AttestationPool,
           quarantine: ref Quarantine

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1053,7 +1053,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # above, this will be done just before the next slot starts
   await node.updateGossipStatus(slot + 1)
 
-proc syncStatus(node: BeaconNode): string =
+func syncStatus(node: BeaconNode): string =
   if node.syncManager.inProgress: node.syncManager.syncStatus
   elif node.backfiller.inProgress: "backfill: " & node.backfiller.syncStatus
   else: "synced"

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -122,7 +122,7 @@ func initiate_validator_exit*(cfg: RuntimeConfig, state: var ForkyBeaconState,
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#slash_validator
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#modified-slash_validator
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#modified-slash_validator
-proc get_slashing_penalty*(state: ForkyBeaconState,
+func get_slashing_penalty*(state: ForkyBeaconState,
                            validator_effective_balance: Gwei): Gwei =
   # TODO Consider whether this is better than splitting the functions apart; in
   # each case, tradeoffs. Here, it's just changing a couple of constants.
@@ -641,7 +641,7 @@ proc check_attestation*(
 
   ok()
 
-proc get_proposer_reward*(state: ForkyBeaconState,
+func get_proposer_reward*(state: ForkyBeaconState,
                           attestation: SomeAttestation,
                           base_reward_per_increment: Gwei,
                           cache: var StateCache,
@@ -757,7 +757,7 @@ func get_next_sync_committee_keys(state: altair.BeaconState | bellatrix.BeaconSt
   res
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#get_next_sync_committee
-proc get_next_sync_committee*(state: altair.BeaconState | bellatrix.BeaconState):
+func get_next_sync_committee*(state: altair.BeaconState | bellatrix.BeaconState):
     SyncCommittee =
   ## Return the *next* sync committee for a given ``state``.
   var res: SyncCommittee
@@ -795,7 +795,8 @@ func translate_participation(
         state.previous_epoch_participation[index] =
           add_flag(state.previous_epoch_participation[index], flag_index)
 
-proc upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState): ref altair.BeaconState =
+func upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState):
+    ref altair.BeaconState =
   var
     empty_participation = EpochParticipationFlags()
     inactivity_scores = HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]()

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -106,7 +106,7 @@ func toPubKey*(pubKey: CookedPubKey): ValidatorPubKey =
   # Un-specced in either hash-to-curve or Eth2
   ValidatorPubKey(blob: pubKey.toRaw())
 
-proc load*(v: ValidatorPubKey): Option[CookedPubKey] =
+func load*(v: ValidatorPubKey): Option[CookedPubKey] =
   ## Parse signature blob - this may fail
   var val: blscurve.PublicKey
   if fromBytes(val, v.blob):
@@ -114,7 +114,7 @@ proc load*(v: ValidatorPubKey): Option[CookedPubKey] =
   else:
     none CookedPubKey
 
-proc load*(v: UncompressedPubKey): Option[CookedPubKey] =
+func load*(v: UncompressedPubKey): Option[CookedPubKey] =
   ## Parse signature blob - this may fail
   var val: blscurve.PublicKey
   if fromBytes(val, v.blob):
@@ -150,7 +150,7 @@ proc loadWithCache*(v: ValidatorPubKey): Option[CookedPubKey] =
       cache[v.blob] = cooked.get()
     return cooked
 
-proc load*(v: ValidatorSig): Option[CookedSig] =
+func load*(v: ValidatorSig): Option[CookedSig] =
   ## Parse signature blob - this may fail
   var parsed: blscurve.Signature
   if fromBytes(parsed, v.blob):
@@ -165,7 +165,7 @@ func init*(agg: var AggregatePublicKey, pubkey: CookedPubKey) {.inline.}=
 func init*(T: type AggregatePublicKey, pubkey: CookedPubKey): T =
   result.init(pubkey)
 
-proc aggregate*(agg: var AggregatePublicKey, pubkey: CookedPubKey) {.inline.}=
+func aggregate*(agg: var AggregatePublicKey, pubkey: CookedPubKey) {.inline.}=
   ## Aggregate two valid Validator Public Keys
   agg.aggregate(blscurve.PublicKey(pubkey))
 
@@ -182,7 +182,7 @@ func init*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
 func init*(T: type AggregateSignature, sig: CookedSig): T =
   result.init(sig)
 
-proc aggregate*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
+func aggregate*(agg: var AggregateSignature, sig: CookedSig) {.inline.}=
   ## Aggregate two valid Validator Signatures
   agg.aggregate(blscurve.Signature(sig))
 
@@ -193,7 +193,7 @@ func finish*(agg: AggregateSignature): CookedSig {.inline.} =
   CookedSig(sig)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#bls-signatures
-proc blsVerify*(
+func blsVerify*(
     pubkey: CookedPubKey, message: openArray[byte],
     signature: CookedSig): bool =
   ## Check that a signature is valid for a message
@@ -230,7 +230,7 @@ proc blsVerify*(
   # Guard against invalid signature blobs that fail to parse
   parsedSig.isSome() and blsVerify(pubkey, message, parsedSig.get())
 
-proc blsVerify*(sigSet: SignatureSet): bool =
+func blsVerify*(sigSet: SignatureSet): bool =
   ## Unbatched verification
   ## of 1 SignatureSet
   ## tuple[pubkey: blscurve.PublicKey, message: array[32, byte], blscurve.signature: Signature]
@@ -244,7 +244,7 @@ func blsSign*(privkey: ValidatorPrivKey, message: openArray[byte]): CookedSig =
   ## Computes a signature from a secret key and a message
   CookedSig(SecretKey(privkey).sign(message))
 
-proc blsFastAggregateVerify*(
+func blsFastAggregateVerify*(
        publicKeys: openArray[CookedPubKey],
        message: openArray[byte],
        signature: CookedSig
@@ -284,7 +284,7 @@ proc blsFastAggregateVerify*(
 
   fastAggregateVerify(unwrapped, message, blscurve.Signature(signature))
 
-proc blsFastAggregateVerify*(
+func blsFastAggregateVerify*(
        publicKeys: openArray[CookedPubKey],
        message: openArray[byte],
        signature: ValidatorSig
@@ -474,5 +474,5 @@ func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte]): T {.noinit
 func infinity*(T: type ValidatorSig): T =
   result.blob[0] = byte 0xC0
 
-proc burnMem*(key: var ValidatorPrivKey) =
+func burnMem*(key: var ValidatorPrivKey) =
   burnMem(addr key, sizeof(ValidatorPrivKey))

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -613,7 +613,7 @@ proc readValue*(
   except ValueError:
     raiseUnexpectedValue(reader, "Hex string of 4 bytes expected")
 
-proc `$`*(x: JustificationBits): string =
+func `$`*(x: JustificationBits): string =
   "0x" & toHex(uint8(x))
 
 proc readValue*(reader: var JsonReader, value: var JustificationBits)
@@ -856,7 +856,7 @@ proc readValue*(r: var JsonReader, T: type GraffitiBytes): T
   except ValueError as err:
     r.raiseUnexpectedValue err.msg
 
-proc load*(
+func load*(
     validators: openArray[ImmutableValidatorData2],
     index: ValidatorIndex | uint64): Option[CookedPubKey] =
   if validators.lenu64() <= index.uint64:
@@ -896,7 +896,7 @@ template isomorphicCast*[T, U](x: U): T =
     doAssert getSizeofSig(T()) == getSizeofSig(U())
   cast[ptr T](unsafeAddr x)[]
 
-proc clear*(cache: var StateCache) =
+func clear*(cache: var StateCache) =
   cache.shuffled_active_validator_indices.clear
   cache.beacon_proposer_indices.clear
   cache.sync_committees.clear

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -327,11 +327,11 @@ type
 func encodeQuantityHex*(x: auto): string =
   "0x" & x.toHex
 
-proc fromHex*(T: typedesc[BloomLogs], s: string): T {.
+func fromHex*(T: typedesc[BloomLogs], s: string): T {.
      raises: [Defect, ValueError].} =
   hexToByteArray(s, result.data)
 
-proc fromHex*(T: typedesc[ExecutionAddress], s: string): T {.
+func fromHex*(T: typedesc[ExecutionAddress], s: string): T {.
      raises: [Defect, ValueError].} =
   hexToByteArray(s, result.data)
 

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -123,7 +123,7 @@ proc readValue*(r: var JsonReader, a: var Eth2Digest) {.raises: [Defect, IOError
   except ValueError:
     raiseUnexpectedValue(r, "Hex string expected")
 
-proc toGaugeValue*(hash: Eth2Digest): int64 =
+func toGaugeValue*(hash: Eth2Digest): int64 =
   # Only the last 8 bytes are taken into consideration in accordance
   # to the ETH2 metrics spec:
   # https://github.com/ethereum/eth2.0-metrics/blob/6a79914cb31f7d54858c7dd57eee75b6162ec737/metrics.md#interop-metrics

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -429,19 +429,19 @@ func bellatrixFork*(cfg: RuntimeConfig): Fork =
     current_version: cfg.BELLATRIX_FORK_VERSION,
     epoch: cfg.BELLATRIX_FORK_EPOCH)
 
-proc forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
+func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
   case cfg.stateForkAtEpoch(epoch)
   of BeaconStateFork.Bellatrix: cfg.bellatrixFork
   of BeaconStateFork.Altair:    cfg.altairFork
   of BeaconStateFork.Phase0:    cfg.genesisFork
 
-proc forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
+func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   case cfg.stateForkAtEpoch(epoch)
   of BeaconStateFork.Bellatrix: cfg.BELLATRIX_FORK_VERSION
   of BeaconStateFork.Altair:    cfg.ALTAIR_FORK_VERSION
   of BeaconStateFork.Phase0:    cfg.GENESIS_FORK_VERSION
 
-proc nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
+func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   case cfg.stateForkAtEpoch(epoch)
   of BeaconStateFork.Bellatrix: FAR_FUTURE_EPOCH
   of BeaconStateFork.Altair:    cfg.BELLATRIX_FORK_EPOCH

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -69,7 +69,7 @@ proc verify_block_signature(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
-proc verifyStateRoot(
+func verifyStateRoot(
     state: ForkyBeaconState, blck: ForkyBeaconBlock | ForkySigVerifiedBeaconBlock):
     Result[void, cstring] =
   # This is inlined in state_transition(...) in spec.
@@ -151,7 +151,7 @@ func noRollback*(state: var altair.HashedBeaconState) =
 func noRollback*(state: var bellatrix.HashedBeaconState) =
   trace "Skipping rollback of broken Bellatrix state"
 
-proc maybeUpgradeStateToAltair(
+func maybeUpgradeStateToAltair(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState) =
   # Both process_slots() and state_transition_block() call this, so only run it
   # once by checking for existing fork.
@@ -175,7 +175,7 @@ func maybeUpgradeStateToBellatrix(
       bellatrixData: bellatrix.HashedBeaconState(
         root: hash_tree_root(newState[]), data: newState[]))[]
 
-proc maybeUpgradeState*(
+func maybeUpgradeState*(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState) =
   cfg.maybeUpgradeStateToAltair(state)
   cfg.maybeUpgradeStateToBellatrix(state)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -255,7 +255,7 @@ proc process_attester_slashing*(
 
   ok()
 
-proc findValidatorIndex*(state: ForkyBeaconState, pubkey: ValidatorPubKey): int =
+func findValidatorIndex*(state: ForkyBeaconState, pubkey: ValidatorPubKey): int =
   # This linear scan is unfortunate, but should be fairly fast as we do a simple
   # byte comparison of the key. The alternative would be to build a Table, but
   # given that each block can hold no more than 16 deposits, it's slower to
@@ -558,13 +558,13 @@ proc process_block*(
 
   ok()
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var altair.BeaconState, blck: SomePhase0Block, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] =
   err("process_block: Altair state with Phase 0 block")
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var bellatrix.BeaconState, blck: SomePhase0Block, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring] =
@@ -630,25 +630,25 @@ proc process_block*(
 
   ok()
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var phase0.BeaconState, blck: SomeAltairBlock, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring]=
   err("process_block: Phase 0 state with Altair block")
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var phase0.BeaconState, blck: SomeMergeBlock, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring]=
   err("process_block: Phase 0 state with Merge block")
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var altair.BeaconState, blck: SomeMergeBlock, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring]=
   err("process_block: Altair state with Merge block")
 
-proc process_block*(
+func process_block*(
     cfg: RuntimeConfig,
     state: var bellatrix.BeaconState, blck: SomeAltairBlock, flags: UpdateFlags,
     cache: var StateCache): Result[void, cstring]=

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -985,7 +985,8 @@ func process_participation_flag_updates*(state: var (altair.BeaconState | bellat
   state.current_epoch_participation.resetCache()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#sync-committee-updates
-proc process_sync_committee_updates*(state: var (altair.BeaconState | bellatrix.BeaconState)) =
+func process_sync_committee_updates*(
+    state: var (altair.BeaconState | bellatrix.BeaconState)) =
   let next_epoch = get_current_epoch(state) + 1
   if next_epoch.is_sync_committee_period():
     state.current_sync_committee = state.next_sync_committee

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[tables, sequtils],
   bearssl,
@@ -199,10 +206,10 @@ func getNextProposalSlot*(tracker: ActionTracker, slot: Slot): Slot =
     tracker.proposingSlots,
     tracker.lastCalculatedEpoch, slot)
 
-proc dependentRoot(epoch: Epoch, head, tail: BlockRef): Eth2Digest =
+func dependentRoot(epoch: Epoch, head, tail: BlockRef): Eth2Digest =
   head.prevDependentBlock(tail, epoch).root
 
-proc needsUpdate*(
+func needsUpdate*(
     tracker: ActionTracker, epoch: Epoch, head, tail: BlockRef): bool =
   # Using prevDependentBlock here means we lock the action tracking to
   # the dependent root for attestation duties and not block proposal -
@@ -210,7 +217,7 @@ proc needsUpdate*(
   # and the action tracker is speculative in nature.
   tracker.dependentRoot != dependentRoot(epoch, head, tail)
 
-proc updateActions*(
+func updateActions*(
     tracker: var ActionTracker, epochRef: EpochRef, head, tail: BlockRef) =
   # Updates the schedule for upcoming attestation and proposal work
   let
@@ -258,7 +265,7 @@ proc updateActions*(
       tracker.attestingSlots[epoch mod 2] or
         (1'u32 shl (slot mod SLOTS_PER_EPOCH))
 
-proc init*(
+func init*(
     T: type ActionTracker, rng: ref BrHmacDrbgContext,
     subscribeAllAttnets: bool): T =
   T(

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   re, strutils, os, math,
   stew/bitops2,
@@ -45,7 +52,7 @@ const
   epochFileNameExtension* = ".epoch"
   epochNumberRegexStr = r"\d{" & $epochInfoFileNameDigitsCount & r"}\"
 
-proc copyParticipationFlags*(auxiliaryState: var AuxiliaryState,
+func copyParticipationFlags*(auxiliaryState: var AuxiliaryState,
                              forkedState: ForkedHashedBeaconState) =
   withState(forkedState):
     when stateFork > BeaconStateFork.Phase0:
@@ -91,14 +98,14 @@ proc getAggregatedFilesLastEpoch*(dir: string): Epoch =
         largestEpochInFileName = fileLastEpoch
   return largestEpochInFileName.Epoch
 
-proc epochAsString*(epoch: Epoch): string =
+func epochAsString*(epoch: Epoch): string =
   let strEpoch = $epoch
   '0'.repeat(epochInfoFileNameDigitsCount - strEpoch.len) & strEpoch
 
-proc getFilePathForEpoch*(epoch: Epoch, dir: string): string =
+func getFilePathForEpoch*(epoch: Epoch, dir: string): string =
   dir / epochAsString(epoch) & epochFileNameExtension
 
-proc getFilePathForEpochs*(startEpoch, endEpoch: Epoch, dir: string): string =
+func getFilePathForEpochs*(startEpoch, endEpoch: Epoch, dir: string): string =
   let fileName = epochAsString(startEpoch) & "_"  &
                  epochAsString(endEpoch) & epochFileNameExtension
   dir / fileName
@@ -119,7 +126,7 @@ func getBlockRange*(dag: ChainDAGRef, start, ends: Slot): seq[BlockRef] =
 func getOutcome(delta: RewardDelta): int64 =
   delta.rewards.int64 - delta.penalties.int64
 
-proc collectSlashings(
+func collectSlashings(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     state: ForkyBeaconState, total_balance: Gwei) =
   let
@@ -134,7 +141,7 @@ proc collectSlashings(
         validator[].get_slashing_penalty(
           adjusted_total_slashing_balance, total_balance).int64
 
-proc getFinalizedCheckpoint(state: ForkyBeaconState,
+func getFinalizedCheckpoint(state: ForkyBeaconState,
                             total_active_balance,
                             previous_epoch_target_balance,
                             current_epoch_target_balance: Gwei):
@@ -189,13 +196,13 @@ proc getFinalizedCheckpoint(state: ForkyBeaconState,
 
   return state.finalized_checkpoint
 
-proc getFinalizedCheckpoint(state: phase0.BeaconState, balances: TotalBalances):
+func getFinalizedCheckpoint(state: phase0.BeaconState, balances: TotalBalances):
     Checkpoint =
   getFinalizedCheckpoint(state, balances.current_epoch,
                          balances.previous_epoch_target_attesters,
                          balances.current_epoch_target_attesters)
 
-proc getFinalizedCheckpoint(
+func getFinalizedCheckpoint(
     state: altair.BeaconState | bellatrix.BeaconState,
     balances: UnslashedParticipatingBalances): Checkpoint =
   getFinalizedCheckpoint(state, balances.current_epoch,
@@ -206,7 +213,7 @@ func getFinalityDelay*(state: ForkyBeaconState,
                        finalizedCheckpoint: Checkpoint): uint64 =
   state.get_previous_epoch - finalizedCheckpoint.epoch
 
-proc collectEpochRewardsAndPenalties*(
+func collectEpochRewardsAndPenalties*(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     state: phase0.BeaconState, cache: var StateCache, cfg: RuntimeConfig,
     flags: UpdateFlags) =
@@ -271,7 +278,7 @@ proc collectEpochRewardsAndPenalties*(
 
   rewardsAndPenalties.collectSlashings(state, info.balances.current_epoch)
 
-proc collectEpochRewardsAndPenalties*(
+func collectEpochRewardsAndPenalties*(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     state: altair.BeaconState | bellatrix.BeaconState,
     cache: var StateCache, cfg: RuntimeConfig, flags: UpdateFlags) =
@@ -326,7 +333,7 @@ proc collectEpochRewardsAndPenalties*(
 
   rewardsAndPenalties.collectSlashings(state, info.balances.current_epoch)
 
-proc collectFromSlashedValidator(
+func collectFromSlashedValidator(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     state: ForkyBeaconState, slashedIndex, proposerIndex: ValidatorIndex) =
   template slashed_validator: untyped = state.validators[slashedIndex]
@@ -335,7 +342,7 @@ proc collectFromSlashedValidator(
   rewardsAndPenalties[slashedIndex].slashing_outcome -= slashingPenalty.int64
   rewardsAndPenalties[proposerIndex].slashing_outcome += whistleblowerReward.int64
 
-proc collectFromProposerSlashings(
+func collectFromProposerSlashings(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock) =
@@ -346,7 +353,7 @@ proc collectFromProposerSlashings(
       rewardsAndPenalties.collectFromSlashedValidator(state.data,
         slashedIndex.ValidatorIndex, blck.message.proposer_index.ValidatorIndex)
 
-proc collectFromAttesterSlashings(
+func collectFromAttesterSlashings(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock) =
@@ -359,7 +366,7 @@ proc collectFromAttesterSlashings(
         rewardsAndPenalties.collectFromSlashedValidator(
           state.data, slashedIndex, blck.message.proposer_index.ValidatorIndex)
 
-proc collectFromAttestations(
+func collectFromAttestations(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock,
@@ -408,7 +415,7 @@ proc collectFromDeposits(
         rewardsAndPenalties.add(
           RewardsAndPenalties(deposits: amount))
 
-proc collectFromSyncAggregate(
+func collectFromSyncAggregate(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock,

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -92,7 +92,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     quarantine = newClone(Quarantine.init())
     attPool = AttestationPool.init(dag, quarantine)
     batchCrypto = BatchCrypto.new(
-      keys.newRng(), eager = proc(): bool = true, taskpool)
+      keys.newRng(), eager = func(): bool = true, taskpool)
     syncCommitteePool = newClone SyncCommitteeMsgPool.init(keys.newRng())
     timers: array[Timers, RunningStat]
     attesters: RunningStat

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -89,7 +89,7 @@ template mockGenesisDepositsImpl(
       depositsData.add result[valIdx]
       depositsDataHash.add hash_tree_root(result[valIdx])
 
-proc mockGenesisBalancedDeposits*(
+func mockGenesisBalancedDeposits*(
         validatorCount: uint64,
         amountInEth: Positive,
         flags: UpdateFlags = {}
@@ -106,7 +106,7 @@ proc mockGenesisBalancedDeposits*(
   mockGenesisDepositsImpl(result, validatorCount,amount,flags):
     discard
 
-proc mockUpdateStateForNewDeposit*(
+func mockUpdateStateForNewDeposit*(
        state: var ForkyBeaconState,
        validator_index: uint64,
        amount: uint64,

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -14,7 +14,7 @@ import
   ../beacon_chain/spec/datatypes/phase0,
   ../beacon_chain/consensus_object_pools/block_quarantine
 
-proc makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
+func makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
   var
     b = phase0.SignedBeaconBlock(
       message: phase0.BeaconBlock(slot: slot, parent_root: parent))


### PR DESCRIPTION
While some parts of Nimbus intrinsically interact with, say, a network or database and side effects are part of their job, it's useful to ensure some of the more purely algorithmic code truly is only algorithmic. There used to be more intermixing of side effects with otherwise-only-algorithmic-code via Chronicles logging, but since switching the state transition function and adjacent modules to Result-style error handling, for the most part this can now be automatically checked by Nim.

For human readers of the code, this also helps establish some visible architectural layering heuristics.

For testing and making auditing easier, this bounds the scope of the possible state that code depends on to that which is mostly explicitly provided.