### PR TITLE
converter function for reducing blocks to headers

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -700,13 +700,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               canonical: node.dag.isCanonical(
                 BlockId(root: blck.root, slot: blck.message.slot)),
               header: (
-                message: (
-                  slot: blck.message.slot,
-                  proposer_index: blck.message.proposer_index,
-                  parent_root: blck.message.parent_root,
-                  state_root: blck.message.state_root,
-                  body_root: blck.message.body.hash_tree_root()
-                ),
+                message: blck.toBeaconBlockHeader,
                 signature: blck.signature
               )
             )
@@ -732,13 +726,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             canonical: node.dag.isCanonical(
               BlockId(root: blck.root, slot: blck.message.slot)),
             header: (
-              message: (
-                slot: blck.message.slot,
-                proposer_index: blck.message.proposer_index,
-                parent_root: blck.message.parent_root,
-                state_root: blck.message.state_root,
-                body_root: blck.message.body.hash_tree_root()
-              ),
+              message: blck.toBeaconBlockHeader,
               signature: blck.signature
             )
           )

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -391,13 +391,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         canonical: node.dag.isCanonical(
           BlockId(root: blck.root, slot: blck.message.slot)),
         header: SignedBeaconBlockHeader(
-          message: BeaconBlockHeader(
-            slot: blck.message.slot,
-            proposer_index: blck.message.proposer_index,
-            parent_root: blck.message.parent_root,
-            state_root: blck.message.state_root,
-            body_root: blck.message.body.hash_tree_root()
-          )
+          message: blck.toBeaconBlockHeader
         )
       )
 

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -236,6 +236,21 @@ template toFork*[T: bellatrix.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Bellatrix
 
+func toBeaconBlockHeader*(
+    blck: SomeForkyBeaconBlock): BeaconBlockHeader =
+  ## Reduce a given `BeaconBlock` to just its `BeaconBlockHeader`.
+  BeaconBlockHeader(
+    slot: blck.slot,
+    proposer_index: blck.proposer_index,
+    parent_root: blck.parent_root,
+    state_root: blck.state_root,
+    body_root: blck.body.hash_tree_root())
+
+template toBeaconBlockHeader*(
+    blck: SomeForkySignedBeaconBlock): BeaconBlockHeader =
+  ## Reduce a given `SignedBeaconBlock` to just its `BeaconBlockHeader`.
+  blck.message.toBeaconBlockHeader
+
 template init*(T: type ForkedEpochInfo, info: phase0.EpochInfo): T =
   T(kind: EpochInfoFork.Phase0, phase0Data: info)
 template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -103,12 +103,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
     var cache = StateCache()
     let
       signed_block = block_for_next_slot(cfg, forked[], cache).altairData
-      block_header = BeaconBlockHeader(
-        slot: signed_block.message.slot,
-        proposer_index: signed_block.message.proposer_index,
-        parent_root: signed_block.message.parent_root,
-        state_root: signed_block.message.state_root,
-        body_root: signed_block.message.body.hash_tree_root())
+      block_header = signed_block.toBeaconBlockHeader
     # Sync committee signing the header
       all_pubkeys = state.validators.mapIt(it.pubkey)
       committee = state.current_sync_committee.pubkeys
@@ -168,12 +163,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
 
     let
       signed_block = block_for_next_slot(cfg, forked[], cache).altairData
-      block_header = BeaconBlockHeader(
-        slot: signed_block.message.slot,
-        proposer_index: signed_block.message.proposer_index,
-        parent_root: signed_block.message.parent_root,
-        state_root: signed_block.message.state_root,
-        body_root: signed_block.message.body.hash_tree_root())
+      block_header = signed_block.toBeaconBlockHeader
 
     # Sync committee signing the finalized_block_header
       all_pubkeys = state.validators.mapIt(it.pubkey)
@@ -245,12 +235,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
       array[log2trunc(NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
     let
       finalized_block = blocks[SLOTS_PER_EPOCH - 1].altairData
-      finalized_block_header = BeaconBlockHeader(
-        slot: finalized_block.message.slot,
-        proposer_index: finalized_block.message.proposer_index,
-        parent_root: finalized_block.message.parent_root,
-        state_root: finalized_block.message.state_root,
-        body_root: finalized_block.message.body.hash_tree_root())
+      finalized_block_header = finalized_block.toBeaconBlockHeader
     check:
       finalized_block_header.slot ==
         start_slot(state.finalized_checkpoint.epoch)


### PR DESCRIPTION
This introduces a function to convert `SignedBeaconBlock` to just their
`BeaconBlockHeader` and updates the usages for reduced code duplication.