### PR TITLE
[ncli_db] Fix a reward calculation bug affecting Prater epoch 64781

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -275,13 +275,15 @@ proc get*[T](s: DbSeq[T], idx: int64): T =
   let found = queryRes.expectDb()
   if not found: panic()
 
-proc init*(T: type FinalizedBlocks, db: SqStoreRef, name: string): KvResult[T] =
-  ? db.exec("""
-    CREATE TABLE IF NOT EXISTS """ & name & """(
-       id INTEGER PRIMARY KEY,
-       value BLOB NOT NULL
-    );
-  """)
+proc init*(T: type FinalizedBlocks, db: SqStoreRef, name: string,
+           readOnly = false): KvResult[T] =
+  if not readOnly:
+    ? db.exec("""
+      CREATE TABLE IF NOT EXISTS """ & name & """(
+        id INTEGER PRIMARY KEY,
+        value BLOB NOT NULL
+      );
+    """)
 
   let
     insertStmt = db.prepareStmt(

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -641,11 +641,11 @@ func get_flag_index_reward*(state: altair.BeaconState | bellatrix.BeaconState,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#get_flag_index_deltas
 func get_unslashed_participating_increment*(
-    info: altair.EpochInfo, flag_index: int): Gwei =
+    info: altair.EpochInfo | bellatrix.BeaconState, flag_index: int): Gwei =
   info.balances.previous_epoch[flag_index] div EFFECTIVE_BALANCE_INCREMENT
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#get_flag_index_deltas
-func get_active_increments*(info: altair.EpochInfo): Gwei =
+func get_active_increments*(info: altair.EpochInfo | bellatrix.BeaconState): Gwei =
   info.balances.current_epoch div EFFECTIVE_BALANCE_INCREMENT
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#get_flag_index_deltas


### PR DESCRIPTION
To calculate the deltas correctly, the `process_inactivity_updates` function
must be called before the rewards and penalties processing code in order to
update the `inactivity_scores` field in the state. This would have required
duplicating more logic from the spec in the ncli modules, so I've decided to
pay the price of introducing a run-time copy of the state at each epoch which
eliminates the need to duplicate logic (both for this fix and the previous one).

Other changes:

* Fixes for the read-only mode of the `BeaconChainDb`
* Fix an uint64 underflow in the debug output procedure for printing
  balance deltas
* Allow Bellatrix states in the reward computation helpers