### PR TITLE
chaindag: don't keep backfill block table in memory

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -119,10 +119,28 @@ type
       ## are stored in a mod-increment pattern across fixed-sized arrays, which
       ## addresses most of the rest of the BeaconState sizes.
 
-    summaries: KvStoreRef # BlockRoot -> BeaconBlockSummary
+    summaries: KvStoreRef
+      ## BlockRoot -> BeaconBlockSummary - permits looking up basic block
+      ## information via block root - contains only summaries that were valid
+      ## at some point in history - it is however possible that entries exist
+      ## that are no longer part of the finalized chain history, thus the
+      ## cache should not be used to answer fork choice questions - see
+      ## `getHeadBlock` and `finalizedBlocks` instead.
+      ##
+      ## May contain entries for blocks that are not stored in the database.
+      ##
+      ## See `finalizedBlocks` for an index in the other direction.
 
     finalizedBlocks*: FinalizedBlocks
       ## Blocks that are known to be finalized, per the latest head (v1.7.0+)
+      ## Only blocks that have passed verification, either via state transition
+      ## or backfilling are indexed here - thus, similar to `head`, it is part
+      ## of the inner security ring and is used to answer security questions
+      ## in the chaindag.
+      ##
+      ## May contain entries for blocks that are not stored in the database.
+      ##
+      ## See `summaries` for an index in the other direction.
 
   DbKeyKind = enum
     kHashToState

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -9,11 +9,9 @@
 
 import
   chronicles,
+  ../spec/forks
 
-  ../spec/datatypes/[phase0, altair],
-  ../spec/[helpers]
-
-export chronicles, phase0, altair, helpers
+export chronicles, forks
 
 type
   BlockId* = object

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -106,25 +106,16 @@ proc updateValidatorKeys*(dag: ChainDAGRef, validators: openArray[Validator]) =
   dag.db.updateImmutableValidators(validators)
 
 proc updateFinalizedBlocks*(dag: ChainDAGRef) =
-  template update(s: Slot) =
-    if s < dag.tail.slot:
-      if not dag.backfillBlocks[s.int].isZero:
-        dag.db.finalizedBlocks.insert(s, dag.backfillBlocks[s.int])
-    else:
-      let dagIndex = int(s - dag.tail.slot)
-      if not isNil(dag.finalizedBlocks[dagIndex]):
-        dag.db.finalizedBlocks.insert(s, dag.finalizedBlocks[dagIndex].root)
+  if dag.db.db.readOnly: return # TODO abstraction leak - where to put this?
 
-  if not dag.db.db.readOnly: # TODO abstraction leak - where to put this?
-    dag.db.withManyWrites:
-      if dag.db.finalizedBlocks.low.isNone():
-        for s in dag.backfill.slot .. dag.finalizedHead.slot:
-          update(s)
-      else:
-        for s in dag.backfill.slot ..< dag.db.finalizedBlocks.low.get():
-          update(s)
-        for s in dag.db.finalizedBlocks.high.get() + 1 .. dag.finalizedHead.slot:
-          update(s)
+  dag.db.withManyWrites:
+    let high = dag.db.finalizedBlocks.high.expect(
+      "wrote at least tailRef during init")
+
+    for s in high + 1 .. dag.finalizedHead.slot:
+      let tailIdx = int(s - dag.tail.slot)
+      if not isNil(dag.finalizedBlocks[tailIdx]):
+        dag.db.finalizedBlocks.insert(s, dag.finalizedBlocks[tailIdx].root)
 
 func validatorKey*(
     dag: ChainDAGRef, index: ValidatorIndex or uint64): Option[CookedPubKey] =
@@ -219,7 +210,6 @@ func getBlockAtSlot*(dag: ChainDAGRef, slot: Slot): BlockSlot =
   ## May return an empty BlockSlot (where blck is nil!)
 
   if slot == dag.genesis.slot:
-    # There may be gaps in the
     return dag.genesis.atSlot(slot)
 
   if slot > dag.finalizedHead.slot:
@@ -230,47 +220,53 @@ func getBlockAtSlot*(dag: ChainDAGRef, slot: Slot): BlockSlot =
   doAssert dag.finalizedBlocks.len ==
     (dag.finalizedHead.slot - dag.tail.slot).int + 1, "see updateHead"
 
-  if slot >= dag.tail.slot:
-    var pos = int(slot - dag.tail.slot)
+  var pos = slot
+  while pos >= dag.tail.slot:
+    var tailPos = int(slot - dag.tail.slot)
 
-    while true:
-      if dag.finalizedBlocks[pos] != nil:
-        return dag.finalizedBlocks[pos].atSlot(slot)
+    if dag.finalizedBlocks[tailPos] != nil:
+      return dag.finalizedBlocks[tailPos].atSlot(slot)
 
-      if pos == 0:
-        break
+    doAssert pos > dag.tail.slot, "We should have returned the tail"
 
-      pos -= 1
-
-  if dag.tail.slot == 0:
-    raiseAssert "Genesis missing"
+    pos = pos - 1
 
   BlockSlot() # nil blck!
 
 func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): BlockSlotId =
   ## Retrieve the canonical block at the given slot, or the last block that
-  ## comes before - similar to atSlot, but without the linear scan
+  ## comes before - similar to atSlot, but without the linear scan - may hit
+  ## the database to look up early indices.
   if slot == dag.genesis.slot:
     return dag.genesis.bid.atSlot(slot)
 
   if slot >= dag.tail.slot:
     return dag.getBlockAtSlot(slot).toBlockSlotId()
 
-  var pos = slot.int
-  while pos >= dag.backfill.slot.int:
-    if not dag.backfillBlocks[pos].isZero:
-      return BlockId(root: dag.backfillBlocks[pos], slot: Slot(pos)).atSlot(slot)
-    pos -= 1
+  var pos = slot
+  while pos >= dag.backfill.slot:
+    let root = dag.db.finalizedBlocks.get(pos)
+
+    if root.isSome():
+      return BlockId(root: root.get(), slot: pos).atSlot(slot)
+
+    doAssert pos > dag.backfill.slot, "We should have returned the backfill"
+
+    pos = pos - 1
 
   BlockSlotId() # not backfilled yet, and not genesis
 
 proc getBlockId*(dag: ChainDAGRef, root: Eth2Digest): Opt[BlockId] =
+  ## Look up block id by root in history - useful for turning a root into a
+  ## slot - may hit the database, may return blocks that have since become
+  ## unviable - use `getBlockIdAtSlot` to check that the block is still viable
+  ## if used in a sensitive context
   block: # If we have a BlockRef, this is the fastest way to get a block id
     let blck = dag.getBlockRef(root)
     if blck.isOk():
       return ok(blck.get().bid)
 
-  block: # Otherwise, we might have a summary in the database
+  block: # We might have a summary in the database
     let summary = dag.db.getBeaconBlockSummary(root)
     if summary.isOk():
       return ok(BlockId(root: root, slot: summary.get().slot))
@@ -498,25 +494,18 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # Backfills are blocks that we have in the database, but can't construct a
   # state for without replaying from genesis
   var
-    backfillBlocks = newSeq[Eth2Digest](tailRef.slot.int)
-    # This is where we'll start backfilling, worst case - we might refine this
-    # while loading blocks, in case backfilling has happened already
-    backfill = withBlck(tailBlock): blck.message.toBeaconBlockSummary()
     # The most recent block that we load from the finalized blocks table
     midRef: BlockRef
-    backRoot: Option[Eth2Digest]
 
   # Start by loading basic block information about finalized blocks - this
   # generally goes from genesis (or the earliest backfilled block) all the way
   # to the latest block finalized in the `head` history - we have to be careful
   # though, versions prior to 1.7.0 did not store finalized blocks in the
   # database, and / or the application might have crashed between the head and
-  # finalized blocks updates
+  # finalized blocks updates.
   for slot, root in db.finalizedBlocks:
     if slot < tailRef.slot:
-      backfillBlocks[slot.int] = root
-      if backRoot.isNone():
-        backRoot = some(root)
+      discard # TODO don't load this range at all from the database
     elif slot == tailRef.slot:
       if root != tailRef.root:
         fatal "Finalized blocks do not meet with tail, database corrupt?",
@@ -541,10 +530,14 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   var
     headRef: BlockRef
     curRef: BlockRef
+    finalizedBlocks = newSeq[Eth2Digest](
+      if midRef == nil: tailRef.slot.int + 1
+      else: 0
+    )
 
-  # Now load the part from head to finalized (going backwards) - if we loaded
-  # any finalized blocks, we should hit the last of them while loading this
-  # history
+  # Load the part from head going backwards - if we found any entries in the
+  # finalized block table, we'll stop at `midRef`, otherwise we'll keep going
+  # as far as we can find headers and fill in the finalized blocks from tail
   for blck in db.getAncestorSummaries(headRoot):
     if midRef != nil and blck.summary.slot <= midRef.slot:
       if midRef.slot != blck.summary.slot or midRef.root != blck.root:
@@ -567,9 +560,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       break
 
     if blck.summary.slot < tailRef.slot:
-      backfillBlocks[blck.summary.slot.int] = blck.root
-      if backRoot.isNone():
-        backfill = blck.summary
+      doAssert midRef == nil,
+        "If we loaded any blocks from the finalized slot table, they should have included tailRef"
+      finalizedBlocks[blck.summary.slot.int] = blck.root
     elif blck.summary.slot == tailRef.slot:
       if curRef == nil:
         curRef = tailRef
@@ -577,6 +570,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       else:
         link(tailRef, curRef)
         curRef = curRef.parent
+
+      if midRef == nil:
+        finalizedBlocks[blck.summary.slot.int] = blck.root
     else:
       let newRef = BlockRef.init(blck.root, blck.summary.slot)
       if curRef == nil:
@@ -588,9 +584,23 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
       trace "Populating block dag", key = curRef.root, val = curRef
 
-  if backRoot.isSome():
-    backfill = db.getBeaconBlockSummary(backRoot.get()).expect(
-      "Backfill block must have a summary")
+  if finalizedBlocks.len > 0 and not db.db.readOnly: # TODO abstraction leak
+    db.withManyWrites:
+      for i, root in finalizedBlocks.mpairs:
+        if root.isZero: continue
+
+        db.finalizedBlocks.insert(Slot(i), root)
+
+  let backfill = block:
+    let backfillSlot = db.finalizedBlocks.low.expect("tail at least")
+    if backfillSlot < tailRef.slot:
+      let backfillRoot = db.finalizedBlocks.get(backfillSlot).expect(
+        "low to be loadable")
+
+      db.getBeaconBlockSummary(backfillRoot).expect(
+        "Backfill block must have a summary")
+    else:
+      withBlck(tailBlock): blck.message.toBeaconBlockSummary()
 
   let summariesTick = Moment.now()
 
@@ -683,8 +693,6 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     cfg,
     getStateField(dag.headState.data, genesis_validators_root))
 
-  swap(dag.backfillBlocks, backfillBlocks) # avoid allocating a full copy
-
   let forkVersions =
     [cfg.GENESIS_FORK_VERSION, cfg.ALTAIR_FORK_VERSION,
      cfg.BELLATRIX_FORK_VERSION, cfg.SHARDING_FORK_VERSION]
@@ -732,7 +740,12 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     dag.finalizedHead = tmp.atSlot(finalizedSlot)
 
   block: # Set up tail -> finalizedHead
-    dag.finalizedBlocks.setLen((dag.finalizedHead.slot - dag.tail.slot).int + 1)
+    # Room for all finalized blocks from the tail onwards
+    let n = (dag.finalizedHead.slot - dag.tail.slot).int + 1
+
+    # Make room for some more blocks to avoid an instant reallocation
+    dag.finalizedBlocks = newSeqOfCap[BlockRef](int(n * 3 / 2))
+    dag.finalizedBlocks.setLen(n)
 
     var tmp = dag.finalizedHead.blck
     while not isNil(tmp):

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -374,6 +374,12 @@ suite "chain DAG finalization tests" & preset():
 
     assign(tmpState[], dag.headState.data)
 
+    # skip slots so we can test gappy getBlockAtSlot
+    check process_slots(
+      defaultRuntimeConfig, tmpState[],
+      getStateField(tmpState[], slot) + 2.uint64,
+      cache, info, {}).isOk()
+
     for i in 0 ..< (SLOTS_PER_EPOCH * 6):
       if i == 1:
         # There are 2 heads now because of the fork at slot 1
@@ -392,12 +398,15 @@ suite "chain DAG finalization tests" & preset():
     check:
       dag.heads.len() == 1
       dag.getBlockAtSlot(0.Slot) == BlockSlot(blck: dag.genesis, slot: 0.Slot)
+      dag.getBlockAtSlot(2.Slot) ==
+        BlockSlot(blck: dag.getBlockAtSlot(1.Slot).blck, slot: 2.Slot)
+
       dag.getBlockAtSlot(dag.head.slot) == BlockSlot(
         blck: dag.head, slot: dag.head.slot.Slot)
       dag.getBlockAtSlot(dag.head.slot + 1) == BlockSlot(
         blck: dag.head, slot: dag.head.slot.Slot + 1)
 
-      not dag.containsForkBlock(dag.getBlockAtSlot(1.Slot).blck.root)
+      not dag.containsForkBlock(dag.getBlockAtSlot(5.Slot).blck.root)
       dag.containsForkBlock(dag.finalizedHead.blck.root)
 
     check:

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -713,6 +713,8 @@ suite "Backfill":
       # No epochref for pre-tail epochs
       dag.getEpochRef(dag.tail, dag.tail.slot.epoch - 1, true).isErr()
 
+      dag.backfill == tailBlock.phase0Data.message.toBeaconBlockSummary()
+
     var
       badBlock = blocks[^2].phase0Data
     badBlock.signature = blocks[^3].phase0Data.signature
@@ -737,6 +739,8 @@ suite "Backfill":
       dag.getBlockIdAtSlot(dag.tail.slot - 1) ==
         blocks[^2].toBlockId().atSlot()
       dag.getBlockIdAtSlot(dag.tail.slot - 2) == BlockSlotId()
+
+      dag.backfill == blocks[^2].phase0Data.message.toBeaconBlockSummary()
 
     check:
       dag.addBackfillBlock(blocks[^3].phase0Data).isOk()
@@ -766,6 +770,7 @@ suite "Backfill":
 
     check:
       dag.addBackfillBlock(blocks[^2].phase0Data).isOk()
+      dag.backfill == blocks[^2].phase0Data.message.toBeaconBlockSummary()
 
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init())
@@ -782,4 +787,4 @@ suite "Backfill":
       dag2.getBlockIdAtSlot(dag.tail.slot - 1) ==
         blocks[^2].toBlockId().atSlot()
       dag2.getBlockIdAtSlot(dag.tail.slot - 2) == BlockSlotId()
-      dag2.backfill.slot == blocks[^2].toBlockId().slot
+      dag2.backfill == blocks[^2].phase0Data.message.toBeaconBlockSummary()


### PR DESCRIPTION
This PR names and documents the concept of the archive: a range of slots
for which we have degraded functionality in terms of historical access -
in particular:

* we don't support rewinding to states in this range
* we don't keep an in-memory representation of the block dag

The archive de-facto exists in a trusted-node-synced node, but this PR
gives it a name and drops the in-memory digest index.

In order to satisfy `GetBlocksByRange` requests, we ensure that we have
blocks for the entire archive period via backfill. Future versions may
relax this further, adding a "pre-archive" period that is fully pruned.

During by-slot searches in the archive (both for libp2p and rest
requests), an extra database lookup is used to covert the given `slot`
to a `root` - future versions will avoid this using era files which
natively are indexed by `slot`. That said, the lookup is quite
fast compared to the actual block loading given how trivial the table
is - it's hard to measure, even.

A collateral benefit of this PR is that checkpoint-synced nodes will see
100-200MB memory usage savings, thanks to the dropped in-memory cache -
future pruning work will bring this benefit to full nodes as well.

* document chaindag storage architecture and assumptions
* look up parent using block id instead of full block in clearance
(future-proofing the code against a future in which blocks come from era
files)
* simplify finalized block init, always writing the backfill portion to
db at startup (to ensure lookups work as expected)
* preallocate some extra memory for finalized blocks, to avoid immediate
realloc