### PR TITLE
allow sync using light client protocol

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -252,6 +252,12 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + [SCRYPT] Network Keystore encryption                                                       OK
 ```
 OK: 9/9 Fail: 0/9 Skip: 0/9
+## Light client [Preset: mainnet]
+```diff
++ Light client sync                                                                          OK
++ Pre-Altair                                                                                 OK
+```
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## ListKeys requests [Preset: mainnet]
 ```diff
 + Correct token provided [Preset: mainnet]                                                   OK
@@ -512,4 +518,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 282/286 Fail: 0/286 Skip: 4/286
+OK: 284/288 Fail: 0/288 Skip: 4/288

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -414,7 +414,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SyncQueue#Forward] getRewindPoint() test                                                  OK
 + [SyncQueue] checkResponse() test                                                           OK
 + [SyncQueue] contains() test                                                                OK
-+ [SyncQueue] getLastNonEmptySlot() test                                                     OK
++ [SyncQueue] getLastNonEmptyKey() test                                                      OK
 + [SyncQueue] hasEndGap() test                                                               OK
 ```
 OK: 19/19 Fail: 0/19 Skip: 0/19

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -803,9 +803,10 @@ OK: 35/35 Fail: 0/35 Skip: 0/35
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
++ test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1209,4 +1210,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1034/1035 Fail: 0/1035 Skip: 1/1035
+OK: 1035/1036 Fail: 0/1036 Skip: 1/1036

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -403,9 +403,10 @@ ConsensusSpecPreset-minimal
 + fork_random_large_validator_set                                                            OK
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
++ light_client_sync                                                                          OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 402/402 Fail: 0/402 Skip: 0/402
+OK: 403/403 Fail: 0/403 Skip: 0/403
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -844,9 +845,10 @@ OK: 35/35 Fail: 0/35 Skip: 0/35
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
++ test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1286,4 +1288,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1084/1104 Fail: 0/1104 Skip: 20/1104
+OK: 1086/1106 Fail: 0/1106 Skip: 20/1106

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -59,8 +59,8 @@ type
     eventBus*: AsyncEventBus
     vcProcess*: Process
     requestManager*: RequestManager
-    syncManager*: SyncManager[Peer, PeerID]
-    backfiller*: SyncManager[Peer, PeerID]
+    syncManager*: BeaconBlocksSyncManager[Peer, PeerID]
+    backfiller*: BeaconBlocksSyncManager[Peer, PeerID]
     genesisSnapshotContent*: string
     actionTracker*: ActionTracker
     processor*: ref Eth2Processor

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -24,6 +24,9 @@ import
   ./validators/slashing_protection_common,
   ./filepath
 
+from consensus_object_pools/block_pools_types_light_client
+  import ImportLightClientData
+
 export
   uri, nat, enr,
   defaultEth2TcpPort, enabledLogLevel, ValidIpAddress,
@@ -390,6 +393,19 @@ type
       keymanagerTokenFile* {.
         desc: "A file specifying the authorizition token required for accessing the keymanager API"
         name: "keymanager-token-file" }: Option[InputFile]
+
+      serveLightClientData* {.
+        hidden
+        desc: "BETA: Serve data for enabling light clients to stay in sync with the network"
+        defaultValue: false
+        name: "serve-light-client-data"}: bool
+
+      importLightClientData* {.
+        hidden
+        desc: "BETA: Which classes of light client data to import. " &
+              "Must be one of: none, only-new, full (slow startup), on-demand (may miss validator duties)"
+        defaultValue: ImportLightClientData.None
+        name: "import-light-client-data"}: ImportLightClientData
 
       inProcessValidators* {.
         desc: "Disable the push model (the beacon node tells a signing process with the private keys of the validators what to sign and when) and load the validators in the beacon node itself"

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -238,6 +238,17 @@ type
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" }: Option[Checkpoint]
 
+      lightClientTrustedBlockRoot* {.
+        hidden
+        desc: "BETA: Recent trusted finalized block root for accelerating sync using the light client protocol."
+        name: "light-client-trusted-block-root" }: Option[Eth2Digest]
+
+      lightClientStateNodeUrl* {.
+        hidden
+        desc: "BETA: URL of the REST API (with Debug endpoint) to sync initial state from."
+        defaultValue: "http://localhost:5052"
+        name: "light-client-state-node-url" }: string
+
       finalizedCheckpointState* {.
         desc: "SSZ file specifying a recent finalized state"
         name: "finalized-checkpoint-state" }: Option[InputFile]
@@ -863,6 +874,13 @@ proc createDumpDirs*(config: BeaconNodeConf) =
     let resOut = secureCreatePath(config.dumpDirOutgoing)
     if resOut.isErr():
       warn "Could not create dump directory", path = config.dumpDirOutgoing
+
+func parseCmdArg*(T: type Eth2Digest, input: TaintedString): T
+                 {.raises: [ValueError, Defect].} =
+  Eth2Digest.fromHex(input)
+
+func completeCmdArg*(T: type Eth2Digest, input: TaintedString): seq[string] =
+  return @[]
 
 func parseCmdArg*(T: type GraffitiBytes, input: TaintedString): T
                  {.raises: [ValueError, Defect].} =

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -11,7 +11,7 @@ import
   chronicles,
   stew/[assign2, results],
   ../spec/[forks, signatures, signatures_batch, state_transition],
-  "."/[block_dag, blockchain_dag]
+  "."/[block_dag, blockchain_dag, blockchain_dag_light_client]
 
 export results, signatures_batch, block_dag, blockchain_dag
 
@@ -83,6 +83,9 @@ proc addResolvedHeadBlock(
     stateDataDur, sigVerifyDur, stateVerifyDur,
     putBlockDur = putBlockTick - startTick,
     epochRefDur = epochRefTick - putBlockTick
+
+  # Update light client data
+  dag.processNewBlockForLightClient(state, trustedBlock, parent)
 
   # Notify others of the new block before processing the quarantine, such that
   # notifications for parents happens before those of the children

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -57,6 +57,12 @@ type
       ## Slot time for this BlockSlot which may differ from blck.slot when time
       ## has advanced without blocks
 
+func hash*(bid: BlockId): Hash =
+  var h: Hash = 0
+  h = h !& hash(bid.root)
+  h = h !& hash(bid.slot)
+  !$h
+
 template root*(blck: BlockRef): Eth2Digest = blck.bid.root
 template slot*(blck: BlockRef): Slot = blck.bid.slot
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -17,11 +17,11 @@ import
   ../spec/datatypes/[phase0, altair, bellatrix],
   ".."/beacon_chain_db,
   ../validators/validator_monitor,
-  ./block_dag
+  ./block_dag, block_pools_types_light_client
 
 export
   options, sets, tables, hashes, helpers, beacon_chain_db, block_dag,
-  validator_monitor
+  block_pools_types_light_client, validator_monitor
 
 # ChainDAG and types related to forming a DAG of blocks, keeping track of their
 # relationships and allowing various forms of lookups
@@ -148,6 +148,12 @@ type
 
     cfg*: RuntimeConfig
 
+    serveLightClientData*: bool
+      ## Whether to make local light client data available.
+
+    importLightClientData*: ImportLightClientData
+      ## Which classes of light client data to import.
+
     epochRefs*: array[32, EpochRef]
       ## Cached information about a particular epoch ending with the given
       ## block - we limit the number of held EpochRefs to put a cap on
@@ -159,6 +165,14 @@ type
       ## value with other components which don't have access to the
       ## full ChainDAG.
 
+    # -----------------------------------
+    # Data to enable light clients to stay in sync with the network
+
+    lightClientDb*: LightClientDatabase
+
+    # -----------------------------------
+    # Callbacks
+
     onBlockAdded*: OnBlockCallback
       ## On block added callback
     onHeadChanged*: OnHeadCallback
@@ -167,6 +181,8 @@ type
       ## On beacon chain reorganization
     onFinHappened*: OnFinalizedCallback
       ## On finalization callback
+    onOptimisticLightClientUpdate*: OnOptimisticLightClientUpdateCallback
+      ## On `OptimisticLightClientUpdate` updated callback
 
     headSyncCommittees*: SyncCommitteeCache
       ## A cache of the sync committees, as they appear in the head state -

--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -1,0 +1,85 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import
+  # Status libraries
+  stew/bitops2,
+  # Beacon chain internals
+  ../spec/datatypes/altair,
+  ./block_dag
+
+type
+  OnOptimisticLightClientUpdateCallback* =
+    proc(data: OptimisticLightClientUpdate) {.gcsafe, raises: [Defect].}
+
+  ImportLightClientData* {.pure.} = enum
+    ## Controls which classes of light client data are imported.
+    None = "none"
+      ## Import no light client data.
+    OnlyNew = "only-new"
+      ## Import only new light client data (new non-finalized blocks).
+    Full = "full"
+      ## Import light client data for entire weak subjectivity period.
+    OnDemand = "on-demand"
+      ## No precompute of historic data. Is slow and may miss validator duties.
+
+  CachedLightClientData* = object
+    ## Cached data from historical non-finalized states to improve speed when
+    ## creating future `LightClientUpdate` and `LightClientBootstrap` instances.
+    current_sync_committee_branch*:
+      array[log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+
+    next_sync_committee_branch*:
+      array[log2trunc(altair.NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+
+    finalized_bid*: BlockId
+    finality_branch*:
+      array[log2trunc(altair.FINALIZED_ROOT_INDEX), Eth2Digest]
+
+  CachedLightClientBootstrap* = object
+    ## Cached data from historical finalized epoch boundary blocks to improve
+    ## speed when creating future `LightClientBootstrap` instances.
+    current_sync_committee_branch*:
+      array[log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+
+  LightClientDatabase* = object
+    cachedData*: Table[BlockId, CachedLightClientData]
+      ## Cached data for creating future `LightClientUpdate` instances.
+      ## Key is the block ID of which the post state was used to get the data.
+      ## Data is stored for the most recent 4 finalized checkpoints, as well as
+      ## for all non-finalized blocks.
+
+    cachedBootstrap*: Table[Slot, CachedLightClientBootstrap]
+      ## Cached data for creating future `LightClientBootstrap` instances.
+      ## Key is the block slot of which the post state was used to get the data.
+      ## Data is stored for finalized epoch boundary blocks.
+
+    latestCheckpoints*: array[4, Checkpoint]
+      ## Keeps track of the latest four `finalized_checkpoint` references
+      ## leading to `finalizedHead`. Used to prune `cachedData`.
+      ## Non-finalized states may only refer to these checkpoints.
+
+    lastCheckpointIndex*: int
+      ## Last index that was modified in `latestCheckpoints`.
+
+    bestUpdates*: Table[SyncCommitteePeriod, altair.LightClientUpdate]
+      ## Stores the `LightClientUpdate` with the most `sync_committee_bits` per
+      ## `SyncCommitteePeriod`. Updates with a finality proof have precedence.
+
+    pendingBestUpdates*:
+      Table[(SyncCommitteePeriod, Eth2Digest), altair.LightClientUpdate]
+      ## Same as `bestUpdates`, but for `SyncCommitteePeriod` with
+      ## `next_sync_committee` that are not finalized. Key is `(period,
+      ## hash_tree_root(current_sync_committee | next_sync_committee)`.
+
+    latestUpdate*: altair.LightClientUpdate
+      ## Tracks the `LightClientUpdate` for the latest slot. This may be older
+      ## than head for empty slots or if not signed by sync committee.
+
+    optimisticUpdate*: OptimisticLightClientUpdate
+      ## Tracks the `OptimisticLightClientUpdate` for the latest slot. This may
+      ## be older than head for empty slots or if not signed by sync committee.

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -463,10 +463,10 @@ export
   blockchain_dag_light_client.getLightClientBootstrap
 
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
-           validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
+           validatorMonitor: ref ValidatorMonitor,
+           updateFlags: UpdateFlags, forkDigests: ref ForkDigests = nil,
            onBlockCb: OnBlockCallback = nil, onHeadCb: OnHeadCallback = nil,
-           onReorgCb: OnReorgCallback = nil,
-           onFinCb: OnFinalizedCallback = nil,
+           onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
            onOptimisticLCUpdateCb: OnOptimisticLightClientUpdateCallback = nil,
            serveLightClientData = false,
            importLightClientData = ImportLightClientData.None
@@ -655,9 +655,12 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # db state is likely a epoch boundary state which is what we want for epochs
   assign(dag.epochRefState, dag.headState)
 
-  dag.forkDigests = newClone ForkDigests.init(
-    cfg,
-    getStateField(dag.headState.data, genesis_validators_root))
+  dag.forkDigests =
+    if forkDigests == nil:
+      newClone ForkDigests.init(
+        cfg, getStateField(dag.headState.data, genesis_validators_root))
+    else:
+      forkDigests
 
   swap(dag.backfillBlocks, backfillBlocks) # avoid allocating a full copy
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -1,0 +1,919 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  # Standard library
+  std/[algorithm, sequtils],
+  # Status libraries
+  stew/[bitops2, objects],
+  chronos,
+  # Beacon chain internals
+  ../spec/datatypes/[phase0, altair, bellatrix],
+  "."/[block_pools_types, blockchain_dag]
+
+logScope: topics = "chaindag"
+
+type
+  HashedBeaconStateWithSyncCommittee =
+    bellatrix.HashedBeaconState |
+    altair.HashedBeaconState
+
+  TrustedSignedBeaconBlockWithSyncAggregate =
+    bellatrix.TrustedSignedBeaconBlock |
+    altair.TrustedSignedBeaconBlock
+
+func fromBlock(
+    T: type BeaconBlockHeader,
+    blck: ForkyTrustedSignedBeaconBlock): T =
+  ## Reduce a given full block to just its `BeaconBlockHeader`.
+  BeaconBlockHeader(
+    slot: blck.message.slot,
+    proposer_index: blck.message.proposer_index,
+    parent_root: blck.message.parent_root,
+    state_root: blck.message.state_root,
+    body_root: blck.message.body.hash_tree_root())
+
+func fromBlock(
+    T: type BeaconBlockHeader,
+    blck: ForkedTrustedSignedBeaconBlock): T =
+  ## Reduce a given full block to just its `BeaconBlockHeader`.
+  withBlck(blck):
+    BeaconBlockHeader.fromBlock(blck)
+
+template nextEpochBoundarySlot(slot: Slot): Slot =
+  ## Compute the first possible epoch boundary state slot of a `Checkpoint`
+  ## referring to a block at given slot.
+  (slot + (SLOTS_PER_EPOCH - 1)).epoch.start_slot
+
+func computeEarliestLightClientSlot*(dag: ChainDAGRef): Slot =
+  ## Compute the earliest slot for which light client data is retained.
+  let
+    altairStartSlot = dag.cfg.ALTAIR_FORK_EPOCH.start_slot
+    currentSlot = getStateField(dag.headState.data, slot)
+  if currentSlot < altairStartSlot:
+    return altairStartSlot
+
+  let
+    MIN_EPOCHS_FOR_BLOCK_REQUESTS =
+      dag.cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY +
+      dag.cfg.CHURN_LIMIT_QUOTIENT div 2
+    MIN_SLOTS_FOR_BLOCK_REQUESTS =
+      MIN_EPOCHS_FOR_BLOCK_REQUESTS * SLOTS_PER_EPOCH
+    minSlot = max(altairStartSlot, dag.tail.slot)
+  if currentSlot - minSlot < MIN_SLOTS_FOR_BLOCK_REQUESTS:
+    return minSlot
+
+  let earliestSlot = currentSlot - MIN_SLOTS_FOR_BLOCK_REQUESTS
+  max(earliestSlot.sync_committee_period.start_slot, minSlot)
+
+proc currentSyncCommitteeForPeriod(
+    dag: ChainDAGRef,
+    tmpState: ref StateData,
+    period: SyncCommitteePeriod): SyncCommittee =
+  ## Fetch a `SyncCommittee` for a given sync committee period.
+  ## For non-finalized periods, follow the chain as selected by fork choice.
+  let earliestSlot = dag.computeEarliestLightClientSlot
+  doAssert period >= earliestSlot.sync_committee_period
+  let
+    periodStartSlot = period.start_slot
+    syncCommitteeSlot = max(periodStartSlot, earliestSlot)
+  dag.withUpdatedState(tmpState[], dag.getBlockAtSlot(syncCommitteeSlot)) do:
+    withState(stateData.data):
+      when stateFork >= BeaconStateFork.Altair:
+        state.data.current_sync_committee
+      else: raiseAssert "Unreachable"
+  do: raiseAssert "Unreachable"
+
+template syncCommitteeRoot(
+    state: HashedBeaconStateWithSyncCommittee): Eth2Digest =
+  ## Compute a root to uniquely identify `current_sync_committee` and
+  ## `next_sync_committee`.
+  withEth2Hash:
+    h.update state.data.current_sync_committee.hash_tree_root().data
+    h.update state.data.next_sync_committee.hash_tree_root().data
+
+proc syncCommitteeRootForPeriod(
+    dag: ChainDAGRef,
+    tmpState: ref StateData,
+    period: SyncCommitteePeriod): Eth2Digest =
+  ## Compute a root to uniquely identify `current_sync_committee` and
+  ## `next_sync_committee` for a given sync committee period.
+  ## For non-finalized periods, follow the chain as selected by fork choice.
+  let earliestSlot = dag.computeEarliestLightClientSlot
+  doAssert period >= earliestSlot.sync_committee_period
+  let
+    periodStartSlot = period.start_slot
+    syncCommitteeSlot = max(periodStartSlot, earliestSlot)
+  dag.withUpdatedState(tmpState[], dag.getBlockAtSlot(syncCommitteeSlot)) do:
+    withState(stateData.data):
+      when stateFork >= BeaconStateFork.Altair:
+        state.syncCommitteeRoot
+      else: raiseAssert "Unreachable"
+  do: raiseAssert "Unreachable"
+
+proc getLightClientData(
+    dag: ChainDAGRef,
+    bid: BlockId): CachedLightClientData =
+  ## Fetch cached light client data about a given block.
+  ## Data must be cached (`cacheLightClientData`) before calling this function.
+  try: dag.lightClientDb.cachedData[bid]
+  except KeyError: raiseAssert "Unreachable"
+
+template getLightClientData(
+    dag: ChainDAGRef,
+    blck: BlockRef): CachedLightClientData =
+  getLightClientData(dag, blck.bid)
+
+proc cacheLightClientData*(
+    dag: ChainDAGRef,
+    state: HashedBeaconStateWithSyncCommittee,
+    blck: TrustedSignedBeaconBlockWithSyncAggregate,
+    isNew = true) =
+  ## Cache data for a given block and its post-state to speed up creating future
+  ## `LightClientUpdate` and `LightClientBootstrap` instances that refer to this
+  ## block and state.
+  let startTick = Moment.now()
+
+  var current_sync_committee_branch {.noinit.}:
+    array[log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+  state.data.build_proof(
+    altair.CURRENT_SYNC_COMMITTEE_INDEX, current_sync_committee_branch)
+
+  var next_sync_committee_branch {.noinit.}:
+    array[log2trunc(altair.NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+  state.data.build_proof(
+    altair.NEXT_SYNC_COMMITTEE_INDEX, next_sync_committee_branch)
+
+  var finality_branch {.noinit.}:
+    array[log2trunc(altair.FINALIZED_ROOT_INDEX), Eth2Digest]
+  state.data.build_proof(
+    altair.FINALIZED_ROOT_INDEX, finality_branch)
+
+  template finalized_checkpoint(): auto = state.data.finalized_checkpoint
+  let
+    bid =
+      BlockId(root: blck.root, slot: blck.message.slot)
+    finalized_bid =
+      dag.getBlockIdAtSlot(finalized_checkpoint.epoch.start_slot).bid
+  if dag.lightClientDb.cachedData.hasKeyOrPut(
+      bid,
+      CachedLightClientData(
+        current_sync_committee_branch:
+          current_sync_committee_branch,
+        next_sync_committee_branch:
+          next_sync_committee_branch,
+        finalized_bid:
+          finalized_bid,
+        finality_branch:
+          finality_branch)):
+    doAssert false, "Redundant `cacheLightClientData` call"
+
+  let endTick = Moment.now()
+  if isNew and endTick - startTick > chronos.milliseconds(30):
+    debug "Caching light client data took longer than usual",
+      root = blck.root, slot = blck.message.slot,
+      createDur = endTick - startTick
+
+proc deleteLightClientData*(dag: ChainDAGRef, bid: BlockId) =
+  ## Delete cached light client data for a given block. This needs to be called
+  ## when a block becomes unreachable due to finalization of a different fork.
+  if dag.importLightClientData == ImportLightClientData.None:
+    return
+
+  dag.lightClientDb.cachedData.del bid
+
+template lazy_header(name: untyped): untyped {.dirty.} =
+  ## `createLightClientUpdates` helper to lazily load a known block header.
+  var `name ptr`: ptr[BeaconBlockHeader]
+  template `assign name`(target: var BeaconBlockHeader,
+                         bid: BlockId | BlockRef): untyped =
+    if `name ptr` != nil:
+      target = `name ptr`[]
+    else:
+      target = BeaconBlockHeader.fromBlock(
+        when bid is BlockID:
+          dag.getForkedBlock(bid).get
+        else:
+          dag.getForkedBlock(bid))
+      `name ptr` = addr target
+
+template lazy_data(name: untyped): untyped {.dirty.} =
+  ## `createLightClientUpdates` helper to lazily load cached light client state.
+  var `name` {.noinit.}: CachedLightClientData
+  `name`.finalized_bid.slot = FAR_FUTURE_SLOT
+  template `load name`(bid: BlockId | BlockRef): untyped =
+    if `name`.finalized_bid.slot == FAR_FUTURE_SLOT:
+      `name` = dag.getLightClientData(bid)
+
+proc createLightClientUpdates(
+    dag: ChainDAGRef,
+    state: HashedBeaconStateWithSyncCommittee,
+    blck: TrustedSignedBeaconBlockWithSyncAggregate,
+    parent: BlockRef) =
+  ## Create `LightClientUpdate` and `OptimisticLightClientUpdate` instances for
+  ## a given block and its post-state, and keep track of best / latest ones.
+  ## Data about the parent block's post-state and its `finalized_checkpoint`'s
+  ## block's post-state needs to be cached (`cacheLightClientData`) before
+  ## calling this function.
+  let startTick = Moment.now()
+
+  # Parent needs to be known to continue
+  if parent == nil:
+    return
+
+  # Verify sync committee has sufficient participants
+  template sync_aggregate(): auto = blck.message.body.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
+  if num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    return
+
+  # Verify attested block (parent) is recent enough and that state is available
+  let
+    earliest_slot = dag.computeEarliestLightClientSlot
+    attested_slot = parent.slot
+  if attested_slot < earliest_slot:
+    return
+
+  # Verify signature does not skip a sync committee period
+  let
+    signature_slot = blck.message.slot
+    signature_period = signature_slot.sync_committee_period
+    attested_period = attested_slot.sync_committee_period
+  if signature_period > attested_period + 1:
+    return
+
+  # Update to new `OptimisticLightClientUpdate` if it attests to a later slot
+  lazy_header(attested_header)
+  template optimistic_update(): auto = dag.lightClientDb.optimisticUpdate
+  if attested_slot > optimistic_update.attested_header.slot:
+    optimistic_update.attested_header
+      .assign_attested_header(parent)
+    optimistic_update.sync_aggregate =
+      isomorphicCast[SyncAggregate](sync_aggregate)
+    optimistic_update.fork_version =
+      state.data.fork.current_version
+    optimistic_update.is_signed_by_next_sync_committee =
+      signature_period == attested_period + 1
+    if dag.onOptimisticLightClientUpdate != nil:
+      dag.onOptimisticLightClientUpdate(optimistic_update)
+
+  # Update to new latest `LightClientUpdate` if it attests to a later slot
+  lazy_data(attested_data)
+  lazy_data(finalized_data)
+  lazy_header(finalized_header)
+  template latest_update(): auto = dag.lightClientDb.latestUpdate
+  if attested_slot > latest_update.attested_header.slot:
+    latest_update.attested_header
+      .assign_attested_header(parent)
+    latest_update.sync_aggregate =
+      isomorphicCast[SyncAggregate](sync_aggregate)
+    latest_update.fork_version =
+      state.data.fork.current_version
+
+    load_attested_data(parent)
+    let finalized_slot = attested_data.finalized_bid.slot
+    if finalized_slot + UPDATE_TIMEOUT < attested_slot or
+        finalized_slot < earliest_slot:
+      latest_update.finalized_header = BeaconBlockHeader()
+      latest_update.finality_branch.fill(Eth2Digest())
+      if signature_period == attested_period + 1:
+        latest_update.next_sync_committee = SyncCommittee()
+        latest_update.next_sync_committee_branch.fill(Eth2Digest())
+      else:
+        latest_update.next_sync_committee =
+          state.data.next_sync_committee
+        latest_update.next_sync_committee_branch =
+          attested_data.next_sync_committee_branch
+    else:
+      latest_update.finalized_header
+        .assign_finalized_header(attested_data.finalized_bid)
+      latest_update.finality_branch =
+        attested_data.finality_branch
+      if signature_period == finalized_slot.sync_committee_period + 1:
+        latest_update.next_sync_committee = SyncCommittee()
+        latest_update.next_sync_committee_branch.fill(Eth2Digest())
+      else:
+        load_finalized_data(attested_data.finalized_bid)
+        latest_update.next_sync_committee =
+          state.data.next_sync_committee
+        latest_update.next_sync_committee_branch =
+          finalized_data.next_sync_committee_branch
+
+  # Update best `LightClientUpdate` for current period if it improved
+  if signature_period == attested_period:
+    let isNextSyncCommitteeFinalized =
+      signature_period.start_slot <= dag.finalizedHead.slot
+    var best_update =
+      if isNextSyncCommitteeFinalized:
+        dag.lightClientDb.bestUpdates.getOrDefault(signature_period)
+      else:
+        let key = (signature_period, state.syncCommitteeRoot)
+        dag.lightClientDb.pendingBestUpdates.getOrDefault(key)
+
+    type Verdict = enum
+      unknown
+      new_update_is_worse
+      new_update_is_better
+    var verdict = unknown
+
+    # If no best update has been recorded, new update is better
+    template best_sync_aggregate(): auto = best_update.sync_aggregate
+    let best_num_active_participants =
+      countOnes(best_sync_aggregate.sync_committee_bits).uint64
+    if best_num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+      verdict = new_update_is_better
+    else:
+      # If finality changes, the finalized update is better
+      template finalized_period_at_signature(): auto =
+        state.data.finalized_checkpoint.epoch.sync_committee_period
+      template best_attested_slot(): auto =
+        best_update.attested_header.slot
+      if best_update.finality_branch.isZeroMemory:
+        if (attested_slot > dag.finalizedHead.slot or
+            attested_slot > best_attested_slot) and
+            signature_period == finalized_period_at_signature:
+          load_attested_data(parent)
+          let finalized_slot = attested_data.finalized_bid.slot
+          if signature_period == finalized_slot.sync_committee_period and
+              finalized_slot >= earliest_slot:
+            verdict = new_update_is_better
+      elif attested_slot > dag.finalizedHead.slot or
+          attested_slot < best_attested_slot:
+        if signature_period == finalized_period_at_signature:
+          load_attested_data(parent)
+          let finalized_slot = attested_data.finalized_bid.slot
+          if signature_period != finalized_slot.sync_committee_period or
+              finalized_slot < earliest_slot:
+            verdict = new_update_is_worse
+        else:
+          verdict = new_update_is_worse
+      if verdict == unknown:
+        # If participation changes, higher participation is better
+        if num_active_participants < best_num_active_participants:
+          verdict = new_update_is_worse
+        elif num_active_participants > best_num_active_participants:
+          verdict = new_update_is_better
+        else:
+          # Older updates are better
+          if attested_slot >= best_attested_slot:
+            verdict = new_update_is_worse
+          else:
+            verdict = new_update_is_better
+
+    if verdict == new_update_is_better:
+      best_update.attested_header
+        .assign_attested_header(parent)
+      best_update.sync_aggregate =
+        isomorphicCast[SyncAggregate](sync_aggregate)
+      best_update.fork_version =
+        state.data.fork.current_version
+
+      load_attested_data(parent)
+      let finalized_slot = attested_data.finalized_bid.slot
+      if signature_period != finalized_slot.sync_committee_period or
+          finalized_slot < earliest_slot:
+        best_update.finalized_header = BeaconBlockHeader()
+        best_update.finality_branch.fill(Eth2Digest())
+        best_update.next_sync_committee =
+          state.data.next_sync_committee
+        best_update.next_sync_committee_branch =
+          attested_data.next_sync_committee_branch
+      else:
+        best_update.finalized_header
+          .assign_finalized_header(attested_data.finalized_bid)
+        best_update.finality_branch =
+          attested_data.finality_branch
+        load_finalized_data(attested_data.finalized_bid)
+        best_update.next_sync_committee =
+          state.data.next_sync_committee
+        best_update.next_sync_committee_branch =
+          finalized_data.next_sync_committee_branch
+
+      if isNextSyncCommitteeFinalized:
+        dag.lightClientDb.bestUpdates[signature_period] = best_update
+        debug "Best `LightClientUpdate` improved",
+          period = signature_period, update = best_update
+      else:
+        let key = (signature_period, state.syncCommitteeRoot)
+        dag.lightClientDb.pendingBestUpdates[key] = best_update
+        debug "Best `LightClientUpdate` improved",
+          period = key, update = best_update
+
+  let endTick = Moment.now()
+  if endTick - startTick > chronos.milliseconds(100):
+    debug "`LightClientUpdate` creation took longer than usual",
+      root = dag.head.root, slot = dag.head.slot,
+      createDur = endTick - startTick
+
+proc processNewBlockForLightClient*(
+    dag: ChainDAGRef,
+    state: StateData,
+    signedBlock: ForkyTrustedSignedBeaconBlock,
+    parent: BlockRef) =
+  ## Update light client data with information from a new block.
+  if dag.importLightClientData == ImportLightClientData.None:
+    return
+  if signedBlock.message.slot < dag.computeEarliestLightClientSlot:
+    return
+
+  when signedBlock is bellatrix.TrustedSignedBeaconBlock:
+    dag.cacheLightClientData(state.data.bellatrixData, signedBlock)
+    dag.createLightClientUpdates(state.data.bellatrixData, signedBlock, parent)
+  elif signedBlock is altair.TrustedSignedBeaconBlock:
+    dag.cacheLightClientData(state.data.altairData, signedBlock)
+    dag.createLightClientUpdates(state.data.altairData, signedBlock, parent)
+  elif signedBlock is phase0.TrustedSignedBeaconBlock:
+    discard
+  else:
+    {.error: "Unreachable".}
+
+proc processHeadChangeForLightClient*(dag: ChainDAGRef) =
+  ## Update light client data to account for a new head block.
+  ## Note that `dag.finalizedHead` is not yet updated when this is called.
+  if dag.importLightClientData == ImportLightClientData.None:
+    return
+  if dag.head.slot < dag.computeEarliestLightClientSlot:
+    return
+
+  let headPeriod = dag.head.slot.sync_committee_period
+  if headPeriod.start_slot > dag.finalizedHead.slot:
+    let finalizedPeriod = dag.finalizedHead.slot.sync_committee_period
+    if headPeriod > finalizedPeriod + 1:
+      var tmpState = assignClone(dag.headState)
+      for period in finalizedPeriod + 1 ..< headPeriod:
+        let key = (period, dag.syncCommitteeRootForPeriod(tmpState, period))
+        dag.lightClientDb.bestUpdates[period] =
+          dag.lightClientDb.pendingBestUpdates.getOrDefault(key)
+    withState(dag.headState.data):
+      when stateFork >= BeaconStateFork.Altair:
+        let key = (headPeriod, state.syncCommitteeRoot)
+        dag.lightClientDb.bestUpdates[headPeriod] =
+          dag.lightClientDb.pendingBestUpdates.getOrDefault(key)
+      else: raiseAssert "Unreachable"
+
+proc processFinalizationForLightClient*(dag: ChainDAGRef) =
+  ## Prune cached data that is no longer useful for creating future
+  ## `LightClientUpdate` and `LightClientBootstrap` instances.
+  ## This needs to be called whenever `finalized_checkpoint` changes.
+  if dag.importLightClientData == ImportLightClientData.None:
+    return
+  let
+    altairStartSlot = dag.cfg.ALTAIR_FORK_EPOCH.start_slot
+    finalizedSlot = dag.finalizedHead.slot
+  if finalizedSlot < altairStartSlot:
+    return
+  let earliestSlot = dag.computeEarliestLightClientSlot
+
+  # Keep track of latest four finalized checkpoints
+  let
+    lastIndex = dag.lightClientDb.lastCheckpointIndex
+    lastCheckpoint = addr dag.lightClientDb.latestCheckpoints[lastIndex]
+  if dag.finalizedHead.slot.epoch != lastCheckpoint.epoch or
+      dag.finalizedHead.blck.root != lastCheckpoint.root:
+    let
+      nextIndex = (lastIndex + 1) mod dag.lightClientDb.latestCheckpoints.len
+      nextCheckpoint = addr dag.lightClientDb.latestCheckpoints[nextIndex]
+    nextCheckpoint[].epoch = dag.finalizedHead.slot.epoch
+    nextCheckpoint[].root = dag.finalizedHead.blck.root
+    dag.lightClientDb.lastCheckpointIndex = nextIndex
+
+    # Cache `LightClientBootstrap` for newly finalized epoch boundary blocks.
+    # Epoch boundary blocks are the block for the initial slot of an epoch,
+    # or the most recent block if no block was proposed at that slot
+    let lowSlot = max(lastCheckpoint.epoch.start_slot, earliestSlot)
+    var boundarySlot = dag.finalizedHead.slot
+    while boundarySlot >= lowSlot:
+      let blck = dag.getBlockAtSlot(boundarySlot).blck
+      if blck.slot >= lowSlot:
+        dag.lightClientDb.cachedBootstrap[blck.slot] =
+          CachedLightClientBootstrap(
+            current_sync_committee_branch:
+              dag.getLightClientData(blck.bid).current_sync_committee_branch)
+      boundarySlot = blck.slot.nextEpochBoundarySlot
+      if boundarySlot < SLOTS_PER_EPOCH:
+        break
+      boundarySlot -= SLOTS_PER_EPOCH
+
+  # Prune light client data that is no longer relevant,
+  # i.e., can no longer be referred to by future updates, or is too old
+  var bidsToDelete: seq[BlockId]
+  for bid, data in dag.lightClientDb.cachedData:
+    if bid.slot >= earliestSlot:
+      if bid.slot >= finalizedSlot:
+        continue
+      if dag.lightClientDb.latestCheckpoints.anyIt(bid.root == it.root):
+        continue
+    bidsToDelete.add bid
+  for bid in bidsToDelete:
+    dag.lightClientDb.cachedData.del bid
+
+  # Prune bootstrap data that is no longer relevant
+  var slotsToDelete: seq[Slot]
+  for slot in dag.lightClientDb.cachedBootstrap.keys:
+    if slot < earliestSlot:
+      slotsToDelete.add slot
+  for slot in slotsToDelete:
+    dag.lightClientDb.cachedBootstrap.del slot
+
+  # Prune best `LightClientUpdate` that are no longer relevant
+  let earliestPeriod = earliestSlot.sync_committee_period
+  var periodsToDelete: seq[SyncCommitteePeriod]
+  for period in dag.lightClientDb.bestUpdates.keys:
+    if period < earliestPeriod:
+      periodsToDelete.add period
+  for period in periodsToDelete:
+    dag.lightClientDb.bestUpdates.del period
+
+  # Prune best `LightClientUpdate` referring to non-finalized sync committees
+  # that are no longer relevant, i.e., orphaned or too old
+  let finalizedPeriod = finalizedSlot.sync_committee_period
+  var keysToDelete: seq[(SyncCommitteePeriod, Eth2Digest)]
+  for (period, syncCommitteeRoot) in dag.lightClientDb.pendingBestUpdates.keys:
+    if period <= finalizedPeriod:
+      keysToDelete.add (period, syncCommitteeRoot)
+  for key in keysToDelete:
+    dag.lightClientDb.pendingBestUpdates.del key
+
+proc initBestLightClientUpdateForPeriod(
+    dag: ChainDAGRef, period: SyncCommitteePeriod) =
+  ## Compute and cache the `LightClientUpdate` with the most sync committee
+  ## signatures (i.e., participation) for a given sync committee period.
+  let periodStartSlot = period.start_slot
+  if periodStartSlot > dag.finalizedHead.slot:
+    return
+  let
+    earliestSlot = dag.computeEarliestLightClientSlot
+    periodEndSlot = periodStartSlot + SLOTS_PER_SYNC_COMMITTEE_PERIOD - 1
+  if periodEndSlot < earliestSlot:
+    return
+  if dag.lightClientDb.bestUpdates.hasKey(period):
+    return
+  let startTick = Moment.now()
+  debug "Computing best `LightClientUpdate`", period
+  defer:
+    let endTick = Moment.now()
+    debug "Best `LightClientUpdate` computed",
+      period, update = dag.lightClientDb.bestUpdates.getOrDefault(period),
+      computeDur = endTick - startTick
+
+  proc maxParticipantsBlock(highBlck: BlockRef, lowSlot: Slot): BlockRef =
+    ## Determine the earliest block with most sync committee signatures among
+    ## ancestors of `highBlck` with at least `lowSlot` as parent block slot.
+    ## Return `nil` if no block with `MIN_SYNC_COMMITTEE_PARTICIPANTS` is found.
+    var
+      maxParticipants = 0
+      maxBlockRef: BlockRef
+      blockRef = highBlck
+    while blockRef.parent != nil and blockRef.parent.slot >= lowSlot:
+      let numParticipants =
+        withBlck(dag.getForkedBlock(blockRef)):
+          when stateFork >= BeaconStateFork.Altair:
+            countOnes(blck.message.body.sync_aggregate.sync_committee_bits)
+          else: raiseAssert "Unreachable"
+      if numParticipants >= maxParticipants:
+        maxParticipants = numParticipants
+        maxBlockRef = blockRef
+      blockRef = blockRef.parent
+    if maxParticipants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+      maxBlockRef = nil
+    maxBlockRef
+
+  # Determine the block in the period with highest sync committee participation
+  let
+    lowSlot = max(periodStartSlot, earliestSlot)
+    highSlot = min(periodEndSlot, dag.finalizedHead.blck.slot)
+    highBlck = dag.getBlockAtSlot(highSlot).blck
+    bestNonFinalizedRef = maxParticipantsBlock(highBlck, lowSlot)
+  if bestNonFinalizedRef == nil:
+    dag.lightClientDb.bestUpdates[period] = default(altair.LightClientUpdate)
+    return
+
+  # The block with highest participation may refer to a `finalized_checkpoint`
+  # in a different sync committee period. If that is the case, search for a
+  # later block with a `finalized_checkpoint` within the given sync committee
+  # period, despite it having a lower sync committee participation
+  var
+    tmpState = assignClone(dag.headState)
+    bestFinalizedRef = bestNonFinalizedRef
+    finalizedBlck {.noinit.}: BlockRef
+  while bestFinalizedRef != nil:
+    let
+      finalizedEpoch = block:
+        dag.withUpdatedState(tmpState[], bestFinalizedRef.parent.atSlot) do:
+          withState(stateData.data):
+            when stateFork >= BeaconStateFork.Altair:
+              state.data.finalized_checkpoint.epoch
+            else: raiseAssert "Unreachable"
+        do: raiseAssert "Unreachable"
+      finalizedEpochStartSlot = finalizedEpoch.start_slot
+    if finalizedEpochStartSlot >= lowSlot:
+      finalizedBlck = dag.getBlockAtSlot(finalizedEpochStartSlot).blck
+      if finalizedBlck.slot >= lowSlot:
+        break
+    bestFinalizedRef = maxParticipantsBlock(highBlck, bestFinalizedRef.slot + 1)
+
+  # If a finalized block has been found within the sync commitee period,
+  # create a `LightClientUpdate` for that one. Otherwise, create a non-finalized
+  # `LightClientUpdate`
+  var update {.noinit.}: LightClientUpdate
+  if bestFinalizedRef != nil:
+    # Fill data from attested block
+    dag.withUpdatedState(tmpState[], bestFinalizedRef.parent.atSlot) do:
+      let bdata = dag.getForkedBlock(blck)
+      withStateAndBlck(stateData.data, bdata):
+        when stateFork >= BeaconStateFork.Altair:
+          update.attested_header =
+            BeaconBlockHeader.fromBlock(blck)
+          state.data.build_proof(
+            altair.FINALIZED_ROOT_INDEX, update.finality_branch)
+        else: raiseAssert "Unreachable"
+    do: raiseAssert "Unreachable"
+
+    # Fill data from signature block
+    let bdata = dag.getForkedBlock(bestFinalizedRef)
+    withBlck(bdata):
+      when stateFork >= BeaconStateFork.Altair:
+        update.sync_aggregate =
+          isomorphicCast[SyncAggregate](blck.message.body.sync_aggregate)
+      else: raiseAssert "Unreachable"
+    update.fork_version =
+      dag.cfg.forkAtEpoch(bestFinalizedRef.slot.epoch).current_version
+
+    # Fill data from finalized block
+    dag.withUpdatedState(tmpState[], finalizedBlck.atSlot) do:
+      let bdata = dag.getForkedBlock(blck)
+      withStateAndBlck(stateData.data, bdata):
+        when stateFork >= BeaconStateFork.Altair:
+          update.next_sync_committee =
+            state.data.next_sync_committee
+          state.data.build_proof(
+            altair.NEXT_SYNC_COMMITTEE_INDEX, update.next_sync_committee_branch)
+          update.finalized_header =
+            BeaconBlockHeader.fromBlock(blck)
+        else: raiseAssert "Unreachable"
+    do: raiseAssert "Unreachable"
+  else:
+    # Fill data from attested block
+    dag.withUpdatedState(tmpState[], bestNonFinalizedRef.parent.atSlot) do:
+      let bdata = dag.getForkedBlock(blck)
+      withStateAndBlck(stateData.data, bdata):
+        when stateFork >= BeaconStateFork.Altair:
+          update.attested_header =
+            BeaconBlockHeader.fromBlock(blck)
+          update.next_sync_committee =
+            state.data.next_sync_committee
+          state.data.build_proof(
+            altair.NEXT_SYNC_COMMITTEE_INDEX, update.next_sync_committee_branch)
+          update.finalized_header = BeaconBlockHeader()
+          update.finality_branch.fill(Eth2Digest())
+        else: raiseAssert "Unreachable"
+    do: raiseAssert "Unreachable"
+
+    # Fill data from signature block
+    let bdata = dag.getForkedBlock(bestNonFinalizedRef)
+    withBlck(bdata):
+      when stateFork >= BeaconStateFork.Altair:
+        update.sync_aggregate =
+          isomorphicCast[SyncAggregate](blck.message.body.sync_aggregate)
+      else: raiseAssert "Unreachable"
+    update.fork_version =
+      dag.cfg.forkAtEpoch(bestNonFinalizedRef.slot.epoch).current_version
+  dag.lightClientDb.bestUpdates[period] = update
+
+proc initLightClientBootstrapForPeriod(
+    dag: ChainDAGRef,
+    period: SyncCommitteePeriod) =
+  ## Compute and cache `LightClientBootstrap` data for all epoch boundary blocks
+  ## within a given sync committee period.
+  let periodStartSlot = period.start_slot
+  if periodStartSlot > dag.finalizedHead.slot:
+    return
+  let
+    earliestSlot = dag.computeEarliestLightClientSlot
+    periodEndSlot = periodStartSlot + SLOTS_PER_SYNC_COMMITTEE_PERIOD - 1
+  if periodEndSlot < earliestSlot:
+    return
+
+  let startTick = Moment.now()
+  debug "Caching `LightClientBootstrap` data", period
+  defer:
+    let endTick = Moment.now()
+    debug "`LightClientBootstrap` data cached", period,
+      cacheDur = endTick - startTick
+
+  let
+    lowSlot = max(periodStartSlot, earliestSlot)
+    highSlot = min(periodEndSlot, dag.finalizedHead.blck.slot)
+    lowBoundarySlot = lowSlot.nextEpochBoundarySlot
+    highBoundarySlot = highSlot.nextEpochBoundarySlot
+  var
+    tmpState = assignClone(dag.headState)
+    tmpCache: StateCache
+    nextBoundarySlot = lowBoundarySlot
+  while nextBoundarySlot <= highBoundarySlot:
+    let
+      blck = dag.getBlockAtSlot(nextBoundarySlot).blck
+      boundarySlot = blck.slot.nextEpochBoundarySlot
+    if boundarySlot == nextBoundarySlot and
+        blck.slot >= lowSlot and blck.slot <= highSlot and
+        not dag.lightClientDb.cachedBootstrap.hasKey(blck.slot):
+      var cachedBootstrap {.noinit.}: CachedLightClientBootstrap
+      doAssert dag.updateStateData(
+        tmpState[], blck.atSlot, save = false, tmpCache)
+      withStateVars(tmpState[]):
+        withState(stateData.data):
+          when stateFork >= BeaconStateFork.Altair:
+            state.data.build_proof(
+              altair.CURRENT_SYNC_COMMITTEE_INDEX,
+              cachedBootstrap.current_sync_committee_branch)
+          else: raiseAssert "Unreachable"
+      dag.lightClientDb.cachedBootstrap[blck.slot] = cachedBootstrap
+    nextBoundarySlot += SLOTS_PER_EPOCH
+
+proc initLightClientDb*(dag: ChainDAGRef) =
+  ## Initialize cached light client data
+  if dag.importLightClientData == ImportLightClientData.None:
+    return
+  let earliestSlot = dag.computeEarliestLightClientSlot
+  if dag.head.slot < earliestSlot:
+    return
+
+  let
+    finalizedSlot = dag.finalizedHead.slot
+    finalizedPeriod = finalizedSlot.sync_committee_period
+  dag.initBestLightClientUpdateForPeriod(finalizedPeriod)
+
+  let lightClientStartTick = Moment.now()
+  debug "Initializing cached light client data"
+
+  # Build lists of block to process.
+  # As it is slow to load states in descending order,
+  # first build a todo list, then process them in ascending order
+  let lowSlot = max(finalizedSlot, dag.computeEarliestLightClientSlot)
+  var
+    blocksBetween = newSeqOfCap[BlockRef](dag.head.slot - lowSlot + 1)
+    blockRef = dag.head
+  while blockRef.slot > lowSlot:
+    blocksBetween.add blockRef
+    blockRef = blockRef.parent
+  blocksBetween.add blockRef
+
+  # Process blocks (reuses `dag.headState`, but restores it to the current head)
+  var
+    tmpState = assignClone(dag.headState)
+    tmpCache, cache: StateCache
+    oldCheckpoint: Checkpoint
+    checkpointIndex = 0
+  for i in countdown(blocksBetween.high, blocksBetween.low):
+    blockRef = blocksBetween[i]
+    doAssert dag.updateStateData(
+      dag.headState, blockRef.atSlot(blockRef.slot), save = false, cache)
+    withStateVars(dag.headState):
+      let bdata = dag.getForkedBlock(blck)
+      withStateAndBlck(stateData.data, bdata):
+        when stateFork >= BeaconStateFork.Altair:
+          # Cache data for `LightClientUpdate` of descendant blocks
+          dag.cacheLightClientData(state, blck, isNew = false)
+
+          # Cache data for the block's `finalized_checkpoint`.
+          # The `finalized_checkpoint` may refer to:
+          # 1. `finalizedHead.blck -> finalized_checkpoint`
+          #    This may happen when there were skipped slots.
+          # 2. `finalizedHead -> finalized_checkpoint`
+          # 3. One epoch boundary that got justified then finalized
+          #    between `finalizedHead -> finalized_checkpoint`
+          #    and `finalizedHead`
+          # 4. `finalizedHead`
+          let checkpoint = state.data.finalized_checkpoint
+          if checkpoint != oldCheckpoint:
+            oldCheckpoint = checkpoint
+            doAssert checkpointIndex < dag.lightClientDb.latestCheckpoints.len
+            dag.lightClientDb.latestCheckpoints[checkpointIndex] = checkpoint
+            dag.lightClientDb.lastCheckpointIndex = checkpointIndex
+            inc checkpointIndex
+
+            # Save new checkpoint block using `tmpState` (avoid replay after it)
+            if checkpoint.root != dag.finalizedHead.blck.root:
+              let cpRef =
+                dag.getBlockAtSlot(checkpoint.epoch.start_slot).blck
+              if cpRef != nil and cpRef.slot >= earliestSlot:
+                assert cpRef.bid.root == checkpoint.root
+                doAssert dag.updateStateData(
+                  tmpState[], cpRef.atSlot, save = false, tmpCache)
+                withStateVars(tmpState[]):
+                  let bdata = dag.getForkedBlock(blck)
+                  withStateAndBlck(stateData.data, bdata):
+                    when stateFork >= BeaconStateFork.Altair:
+                      dag.cacheLightClientData(state, blck, isNew = false)
+                    else: raiseAssert "Unreachable"
+
+          # Create `LightClientUpdate` for non-finalized blocks.
+          if blockRef.slot > finalizedSlot:
+            dag.createLightClientUpdates(state, blck, blockRef.parent)
+        else: raiseAssert "Unreachable"
+
+  let lightClientEndTick = Moment.now()
+  debug "Initialized cached light client data",
+    initDur = lightClientEndTick - lightClientStartTick
+
+  # Import historic data
+  if dag.importLightClientData == ImportLightClientData.Full:
+    let
+      earliestSlot = dag.computeEarliestLightClientSlot
+      earliestPeriod = earliestSlot.sync_committee_period
+    for period in earliestPeriod ..< finalizedPeriod:
+      dag.initBestLightClientUpdateForPeriod(period)
+      dag.initLightClientBootstrapForPeriod(period)
+    dag.initLightClientBootstrapForPeriod(finalizedPeriod)
+
+proc getBestLightClientUpdateForPeriod*(
+    dag: ChainDAGRef,
+    period: SyncCommitteePeriod): Option[altair.LightClientUpdate] =
+  if not dag.serveLightClientData:
+    return none(altair.LightClientUpdate)
+
+  if dag.importLightClientData == ImportLightClientData.OnDemand:
+    dag.initBestLightClientUpdateForPeriod(period)
+  result = some(dag.lightClientDb.bestUpdates.getOrDefault(period))
+  let numParticipants = countOnes(result.get.sync_aggregate.sync_committee_bits)
+  if numParticipants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    result = none(altair.LightClientUpdate)
+
+proc getLatestLightClientUpdate*(
+    dag: ChainDAGRef): Option[altair.LightClientUpdate] =
+  if not dag.serveLightClientData:
+    return none(altair.LightClientUpdate)
+
+  result = some(dag.lightClientDb.latestUpdate)
+  let numParticipants = countOnes(result.get.sync_aggregate.sync_committee_bits)
+  if numParticipants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    result = none(altair.LightClientUpdate)
+
+proc getOptimisticLightClientUpdate*(
+    dag: ChainDAGRef): Option[OptimisticLightClientUpdate] =
+  if not dag.serveLightClientData:
+    return none(OptimisticLightClientUpdate)
+
+  result = some(dag.lightClientDb.optimisticUpdate)
+  let numParticipants = countOnes(result.get.sync_aggregate.sync_committee_bits)
+  if numParticipants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    result = none(OptimisticLightClientUpdate)
+
+proc getLightClientBootstrap*(
+    dag: ChainDAGRef,
+    blockRoot: Eth2Digest): Option[altair.LightClientBootstrap] =
+  if not dag.serveLightClientData:
+    return none(altair.LightClientBootstrap)
+
+  let blck = dag.getForkedBlock(blockRoot)
+  if blck.isErr:
+    debug "`LightClientBootstrap` unavailable: Block not found", blockRoot
+    return none(altair.LightClientBootstrap)
+
+  withBlck(blck.get):
+    let slot = blck.message.slot
+    when stateFork >= BeaconStateFork.Altair:
+      let earliestSlot = dag.computeEarliestLightClientSlot
+      if slot < earliestSlot:
+        debug "`LightClientBootstrap` unavailable: Block too old", slot
+        return none(altair.LightClientBootstrap)
+      if slot > dag.finalizedHead.blck.slot:
+        debug "`LightClientBootstrap` unavailable: Not finalized", blockRoot
+        return none(altair.LightClientBootstrap)
+      var cachedBootstrap =
+        dag.lightClientDb.cachedBootstrap.getOrDefault(slot)
+      if cachedBootstrap.current_sync_committee_branch.isZeroMemory:
+        if dag.importLightClientData == ImportLightClientData.OnDemand:
+          var tmpState = assignClone(dag.headState)
+          dag.withUpdatedState(tmpState[], dag.getBlockAtSlot(slot)) do:
+            withState(stateData.data):
+              when stateFork >= BeaconStateFork.Altair:
+                state.data.build_proof(
+                  altair.CURRENT_SYNC_COMMITTEE_INDEX,
+                  cachedBootstrap.current_sync_committee_branch)
+              else: raiseAssert "Unreachable"
+          do: raiseAssert "Unreachable"
+          dag.lightClientDb.cachedBootstrap[slot] = cachedBootstrap
+        else:
+          debug "`LightClientBootstrap` unavailable: Data not cached", slot
+          return none(altair.LightClientBootstrap)
+
+      var tmpState = assignClone(dag.headState)
+      var bootstrap {.noinit.}: altair.LightClientBootstrap
+      bootstrap.header =
+        BeaconBlockHeader.fromBlock(blck)
+      bootstrap.current_sync_committee =
+        dag.currentSyncCommitteeForPeriod(tmpState, slot.sync_committee_period)
+      bootstrap.current_sync_committee_branch =
+        cachedBootstrap.current_sync_committee_branch
+      return some(bootstrap)
+    else:
+      debug "`LightClientBootstrap` unavailable: Block before Altair", slot
+      return none(altair.LightClientBootstrap)

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -58,6 +58,10 @@ declareCounter beacon_sync_committee_contributions_received,
   "Number of valid sync committee contributions processed by this node"
 declareCounter beacon_sync_committee_contributions_dropped,
   "Number of invalid sync committee contributions dropped by this node", labels = ["reason"]
+declareCounter beacon_optimistic_light_client_updates_received,
+  "Number of valid optimistic light client updates processed by this node"
+declareCounter beacon_optimistic_light_client_updates_dropped,
+  "Number of invalid optimistic light client updates dropped by this node", labels = ["reason"]
 
 const delayBuckets = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, Inf]
 
@@ -529,3 +533,23 @@ proc contributionValidator*(
     beacon_sync_committee_contributions_dropped.inc(1, [$v.error[0]])
 
     err(v.error())
+
+proc optimisticLightClientUpdateValidator*(
+    self: var Eth2Processor, src: MsgSource,
+    optimistic_update: OptimisticLightClientUpdate
+): Result[void, ValidationError] =
+  logScope:
+    optimistic_update
+
+  debug "Optimistic light client update received"
+
+  let v = self.dag.validateOptimisticLightClientUpdate(optimistic_update)
+  if v.isOk():
+    trace "Optimistic light client update validated"
+
+    beacon_optimistic_light_client_updates_received.inc()
+  else:
+    debug "Dropping optimistic light client update", error = v.error
+    beacon_optimistic_light_client_updates_dropped.inc(1, [$v.error[0]])
+
+  v

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -1,0 +1,275 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  stew/objects,
+  chronos, metrics,
+  ../spec/datatypes/altair,
+  ../spec/light_client_sync,
+  ../consensus_object_pools/block_pools_types,
+  ".."/[beacon_clock],
+  ../sszdump
+
+# Light Client Processor
+# ------------------------------------------------------------------------------
+# The light client processor moves light client objects
+# from "Incoming" to "Consensus verified"
+
+declareHistogram light_client_store_object_duration_seconds,
+  "storeObject() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
+
+type
+  DidInitializeStoreCallback* =
+    proc() {.gcsafe, raises: [Defect].}
+
+  LightClientProcessor* = object
+    ## This manages the processing of received light client objects
+    ##
+    ## from:
+    ## - Gossip (`OptimisticLightClientUpdate`)
+    ## - SyncManager (`BestLightClientUpdatesByRange`)
+    ## - LightClientManager (`GetLatestLightClientUpdate`,
+    ##   `GetOptimisticLightClientUpdate`, `GetLightClientBootstrap`)
+    ##
+    ## are then consensus-verified and added to:
+    ## - `LightClientStore`
+    ##
+    ## The processor will also attempt to force-update the light client state
+    ## if no update seems to be available on the network that is signed by a
+    ## supermajority of sync committee members and has a finality proof.
+
+    # Config
+    # ----------------------------------------------------------------
+    dumpEnabled: bool
+    dumpDirInvalid: string
+    dumpDirIncoming: string
+
+    # Consumer
+    # ----------------------------------------------------------------
+    store: ref Option[LightClientStore]
+    getBeaconTime*: GetBeaconTimeFn
+    didInitializeStoreCallback: DidInitializeStoreCallback
+
+    cfg: RuntimeConfig
+    genesisValidatorsRoot: Eth2Digest
+    trustedBlockRoot: Eth2Digest
+
+    lastProgressTick: BeaconTime # Moment when last update made progress
+    lastDuplicateTick: BeaconTime # Moment when last duplicate update received
+    numDuplicatesSinceProgress: int # Number of duplicates since last progress
+
+const
+  # These constants have been chosen empirically and are not backed by spec
+  duplicateRateLimit = chronos.seconds(5) # Rate limit for counting duplicates
+  duplicateCountDelay = chronos.minutes(15) # Delay to start counting duplicates
+  minForceUpdateDelay = chronos.minutes(30) # Minimum delay until forced-update
+  minForceUpdateDuplicates = 100 # Minimum duplicates until forced-update
+
+# Initialization
+# ------------------------------------------------------------------------------
+
+proc new*(
+    T: type LightClientProcessor,
+    dumpEnabled: bool,
+    dumpDirInvalid, dumpDirIncoming: string,
+    cfg: RuntimeConfig,
+    genesisValidatorsRoot, trustedBlockRoot: Eth2Digest,
+    store: ref Option[LightClientStore],
+    getBeaconTime: GetBeaconTimeFn,
+    didInitializeStoreCallback: DidInitializeStoreCallback = nil
+): ref LightClientProcessor =
+  (ref LightClientProcessor)(
+    dumpEnabled: dumpEnabled,
+    dumpDirInvalid: dumpDirInvalid,
+    dumpDirIncoming: dumpDirIncoming,
+    store: store,
+    getBeaconTime: getBeaconTime,
+    didInitializeStoreCallback: didInitializeStoreCallback,
+    cfg: cfg,
+    genesisValidatorsRoot: genesisValidatorsRoot,
+    trustedBlockRoot: trustedBlockRoot
+  )
+
+# Storage
+# ------------------------------------------------------------------------------
+
+proc dumpInvalidObject(
+    self: LightClientProcessor,
+    obj: SomeLightClientObject) =
+  if self.dumpEnabled:
+    dump(self.dumpDirInvalid, obj)
+
+proc dumpObject[T](
+    self: LightClientProcessor,
+    obj: SomeLightClientObject,
+    res: Result[T, BlockError]) =
+  if self.dumpEnabled and res.isErr:
+    case res.error
+    of BlockError.Invalid:
+      self.dumpInvalidObject(obj)
+    of BlockError.MissingParent:
+      dump(self.dumpDirIncoming, obj)
+    else:
+      discard
+
+proc tryForceUpdate(
+    self: var LightClientProcessor,
+    wallTime: BeaconTime) =
+  ## Try to force-update to the next sync committee period.
+  let
+    wallSlot = wallTime.slotOrZero()
+    store = self.store
+
+  if store[].isSome:
+    case store[].get.process_slot_for_light_client_store(wallSlot)
+    of NoUpdate:
+      discard
+    of UpdatedWithoutSupermajority:
+      warn "Light client force-update without supermajority",
+        localHeadSlot = store[].get.optimistic_header.slot,
+        finalized = store[].get.finalized_header
+    of UpdatedWithoutFinalityProof:
+      warn "Light client force-update without finality proof",
+        localHeadSlot = store[].get.optimistic_header.slot,
+        finalized = store[].get.finalized_header
+
+proc storeObject*(
+    self: var LightClientProcessor,
+    src: MsgSource, wallTime: BeaconTime,
+    obj: SomeLightClientObject): Result[void, BlockError] =
+  ## storeObject is the main entry point for unvalidated light client objects -
+  ## all untrusted objects pass through here. When storing an object, we will
+  ## update the LightClientStore accordingly
+  let
+    startTick = Moment.now()
+    wallSlot = wallTime.slotOrZero()
+    store = self.store
+
+    res =
+      when obj is altair.LightClientBootstrap:
+        if store[].isSome:
+          err(BlockError.Duplicate)
+        else:
+          let initRes = initialize_light_client_store(
+            self.trustedBlockRoot, obj)
+          if initRes.isErr:
+            err(initRes.error)
+          else:
+            store[] = some(initRes.get)
+            ok()
+      elif obj is altair.LightClientUpdate:
+        if store[].isNone:
+          err(BlockError.MissingParent)
+        else:
+          store[].get.process_light_client_update(
+            obj, wallSlot, self.cfg, self.genesisValidatorsRoot,
+            allowForceUpdate = false)
+      elif obj is altair.OptimisticLightClientUpdate:
+        if store[].isNone:
+          err(BlockError.MissingParent)
+        else:
+          store[].get.process_optimistic_light_client_update(
+            obj, wallSlot, self.cfg, self.genesisValidatorsRoot)
+
+  self.dumpObject(obj, res)
+
+  if res.isErr:
+    when obj is altair.LightClientUpdate:
+      if store[].isSome and store[].get.best_valid_update.isSome:
+        # `best_valid_update` gets set when no supermajority / finality proof
+        # is available. In that case, we will wait for a better update.
+        # If none is made available within reasonable time, the light client
+        # is force-updated using the best known data to ensure sync progress.
+        case res.error
+        of BlockError.Duplicate:
+          if wallTime > self.lastDuplicateTick + duplicateRateLimit:
+            if self.numDuplicatesSinceProgress < minForceUpdateDuplicates:
+              let
+                finalized_period =
+                  store[].get.finalized_header.slot.sync_committee_period
+                update_period =
+                  obj.get_active_header.slot.sync_committee_period
+                is_next_sync_committee_known =
+                  not store[].get.next_sync_committee.isZeroMemory
+                update_can_advance_period =
+                  if is_next_sync_committee_known:
+                    update_period == finalized_period + 1
+                  else:
+                    update_period == finalized_period
+              if update_can_advance_period:
+                self.lastDuplicateTick = wallTime
+                inc self.numDuplicatesSinceProgress
+            if self.numDuplicatesSinceProgress >= minForceUpdateDuplicates and
+                wallTime > self.lastProgressTick + minForceUpdateDelay:
+              self.tryForceUpdate(wallTime)
+              self.lastProgressTick = wallTime
+              self.lastDuplicateTick = wallTime + duplicateCountDelay
+              self.numDuplicatesSinceProgress = 0
+        else: discard
+
+    return res
+
+  when obj is altair.LightClientBootstrap | altair.LightClientUpdate:
+    self.lastProgressTick = wallTime
+    self.lastDuplicateTick = wallTime + duplicateCountDelay
+    self.numDuplicatesSinceProgress = 0
+
+  let
+    storeObjectTick = Moment.now()
+    storeObjectDur = storeObjectTick - startTick
+
+  light_client_store_object_duration_seconds.observe(
+    storeObjectDur.toFloatSeconds())
+
+  let objSlot =
+    when obj is altair.LightClientBootstrap:
+      obj.header.slot
+    else:
+      obj.attested_header.slot
+  debug "Light client object processed", kind = typeof(obj).name,
+    localHeadSlot = store[].get.optimistic_header.slot,
+    objectSlot = objSlot,
+    storeObjectDur
+
+  when obj is altair.LightClientBootstrap:
+    if self.didInitializeStoreCallback != nil:
+      self.didInitializeStoreCallback()
+
+  res
+
+# Enqueue
+# ------------------------------------------------------------------------------
+
+proc addObject*(
+    self: var LightClientProcessor,
+    src: MsgSource,
+    obj: SomeLightClientObject,
+    resfut: Future[Result[void, BlockError]] = nil) =
+  ## Enqueue a Gossip-validated light client object for consensus verification
+  # Backpressure:
+  #   Only one object is validated at any time -
+  #   Light client objects are always "fast" to process
+  # Producers:
+  # - Gossip (`OptimisticLightClientUpdate`)
+  # - SyncManager (`BestLightClientUpdatesByRange`)
+  # - LightClientManager (`GetLatestLightClientUpdate`,
+  #   `GetOptimisticLightClientUpdate`, `GetLightClientBootstrap`)
+
+  let
+    wallTime = self.getBeaconTime()
+    (afterGenesis, wallSlot) = wallTime.toSlot()
+
+  if not afterGenesis:
+    error "Processing light client object before genesis, clock turned back?"
+    quit 1
+
+  let res = self.storeObject(src, wallTime, obj)
+
+  if resFut != nil:
+    resFut.complete(res)

--- a/beacon_chain/networking/faststreams_backend.nim
+++ b/beacon_chain/networking/faststreams_backend.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -112,7 +112,7 @@ proc readResponseChunk(s: AsyncInputStream,
 
   let responseCode = ResponseCode responseCodeByte
   case responseCode:
-  of InvalidRequest, ServerError:
+  of InvalidRequest, ServerError, ResourceUnavailable:
     let errorMsgChunk = await readChunkPayload(s, noSnappy, string)
     let errorMsg = if errorMsgChunk.isOk: errorMsgChunk.value
                    else: return err(errorMsgChunk.error)

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -148,7 +148,7 @@ proc readResponseChunk(conn: Connection, peer: Peer,
 
     let responseCode = ResponseCode responseCodeByte
     case responseCode:
-    of InvalidRequest, ServerError:
+    of InvalidRequest, ServerError, ResourceUnavailable:
       let errorMsgChunk = await readChunkPayload(conn, peer, ErrorMsg)
       let errorMsg = if errorMsgChunk.isOk: errorMsgChunk.value
                      else: return err(errorMsgChunk.error)

--- a/beacon_chain/networking/peer_scores.nim
+++ b/beacon_chain/networking/peer_scores.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -18,7 +18,7 @@ const
     ## This peer is sending malformed or nonsensical data
 
   PeerScoreHeadTooNew* = -100
-    ## The peer reports a head newer than our wall clock slot
+    ## The peer reports a head newer than our wall clock
   PeerScoreNoStatus* = -100
     ## Peer did not answer `status` request.
   PeerScoreStaleStatus* = -50
@@ -28,18 +28,18 @@ const
   PeerScoreGoodStatus* = 50
     ## Peer's `status` answer is fine.
   PeerScoreNoBlocks* = -100
-    ## Peer did not respond in time on `blocksByRange` request.
+    ## Peer did not respond in time to `ByRange` request.
   PeerScoreGoodBlocks* = 100
-    ## Peer's `blocksByRange` answer is fine.
+    ## Peer's `ByRange` answer is fine.
   PeerScoreBadBlocks* = -1000
-    ## Peer's response contains incorrect blocks.
+    ## Peer's response contains incorrect values.
   PeerScoreBadResponse* = -1000
     ## Peer's response is not in requested range.
   PeerScoreMissingBlocks* = -25
-    ## Peer response contains too many empty blocks - this can happen either
+    ## Peer response contains too many empty values - this can happen either
     ## because a long reorg happened or the peer is falsely trying to convince
     ## us that a long reorg happened.
-    ## Peer's `blocksByRange` answer is fine.
+    ## Peer's `ByRange` answer is fine.
   PeerScoreUnviableFork* = -200
-    ## Peer responded with blocks from an unviable fork - are they on a
+    ## Peer responded with values from an unviable fork - are they on a
     ## different chain?

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -490,11 +490,11 @@ proc init*(T: type BeaconNode,
       blockProcessor, validatorMonitor, dag, attestationPool, exitPool,
       validatorPool, syncCommitteeMsgPool, quarantine, rng, getBeaconTime,
       taskpool)
-    syncManager = newSyncManager[Peer, PeerID](
+    syncManager = newBeaconBlocksSyncManager[Peer, PeerID](
       network.peerPool, SyncQueueKind.Forward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       dag.tail.slot, blockVerifier)
-    backfiller = newSyncManager[Peer, PeerID](
+    backfiller = newBeaconBlocksSyncManager[Peer, PeerID](
       network.peerPool, SyncQueueKind.Backward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       dag.backfill.slot, blockVerifier, maxHeadAge = 0)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1,3 +1,4 @@
+# beacon_chain
 # Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -157,6 +158,8 @@ proc init*(T: type BeaconNode,
       eventBus.emit("finalization", data)
   proc onSyncContribution(data: SignedContributionAndProof) =
     eventBus.emit("sync-contribution-and-proof", data)
+  proc onOptimisticLightClientUpdate(data: OptimisticLightClientUpdate) =
+    discard
 
   if config.finalizedCheckpointState.isSome:
     let checkpointStatePath = config.finalizedCheckpointState.get.string
@@ -321,11 +324,17 @@ proc init*(T: type BeaconNode,
   info "Loading block DAG from database", path = config.databaseDir
 
   let
-    chainDagFlags = if config.verifyFinalization: {verifyFinalization}
-                     else: {}
+    chainDagFlags =
+      if config.verifyFinalization: {verifyFinalization}
+      else: {}
+    onOptimisticLightClientUpdateCb =
+      if config.serveLightClientData: onOptimisticLightClientUpdate
+      else: nil
     dag = ChainDAGRef.init(
       cfg, db, validatorMonitor, chainDagFlags, onBlockAdded, onHeadChanged,
-      onChainReorg)
+      onChainReorg, onOptimisticLCUpdateCb = onOptimisticLightClientUpdateCb,
+      serveLightClientData = config.serveLightClientData,
+      importLightClientData = config.importLightClientData)
     quarantine = newClone(Quarantine.init())
     databaseGenesisValidatorsRoot =
       getStateField(dag.headState.data, genesis_validators_root)

--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -1,3 +1,4 @@
+# beacon_chain
 # Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -16,13 +17,19 @@ logScope: topics = "rest_config"
 
 proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
   let
+    cfg =
+      case node.kind
+      of BeaconNodeKind.Light:
+        addr node.cfg
+      of BeaconNodeKind.Full:
+        addr node.dag.cfg
     cachedForkSchedule =
-      RestApiResponse.prepareJsonResponse(getForkSchedule(node.dag.cfg))
+      RestApiResponse.prepareJsonResponse(getForkSchedule(cfg[]))
     cachedConfigSpec =
       RestApiResponse.prepareJsonResponse(
         (
           # https://github.com/ethereum/consensus-specs/blob/v1.0.1/configs/mainnet/phase0.yaml
-          CONFIG_NAME: node.dag.cfg.name(),
+          CONFIG_NAME: cfg[].name(),
 
           # https://github.com/ethereum/consensus-specs/blob/v1.1.3/presets/mainnet/phase0.yaml
           MAX_COMMITTEES_PER_SLOT:
@@ -108,57 +115,57 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
           # https://github.com/ethereum/consensus-specs/blob/v1.1.3/configs/mainnet.yaml
           PRESET_BASE:
-            node.dag.cfg.PRESET_BASE,
+            cfg[].PRESET_BASE,
           TERMINAL_TOTAL_DIFFICULTY:
-            toString(node.dag.cfg.TERMINAL_TOTAL_DIFFICULTY),
+            toString(cfg[].TERMINAL_TOTAL_DIFFICULTY),
           TERMINAL_BLOCK_HASH:
-            $node.dag.cfg.TERMINAL_BLOCK_HASH,
+            $cfg[].TERMINAL_BLOCK_HASH,
           MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:
-            Base10.toString(node.dag.cfg.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT),
+            Base10.toString(cfg[].MIN_GENESIS_ACTIVE_VALIDATOR_COUNT),
           MIN_GENESIS_TIME:
-            Base10.toString(node.dag.cfg.MIN_GENESIS_TIME),
+            Base10.toString(cfg[].MIN_GENESIS_TIME),
           GENESIS_FORK_VERSION:
-            "0x" & $node.dag.cfg.GENESIS_FORK_VERSION,
+            "0x" & $cfg[].GENESIS_FORK_VERSION,
           GENESIS_DELAY:
-            Base10.toString(node.dag.cfg.GENESIS_DELAY),
+            Base10.toString(cfg[].GENESIS_DELAY),
           ALTAIR_FORK_VERSION:
-            "0x" & $node.dag.cfg.ALTAIR_FORK_VERSION,
+            "0x" & $cfg[].ALTAIR_FORK_VERSION,
           ALTAIR_FORK_EPOCH:
-            Base10.toString(uint64(node.dag.cfg.ALTAIR_FORK_EPOCH)),
+            Base10.toString(uint64(cfg[].ALTAIR_FORK_EPOCH)),
           BELLATRIX_FORK_VERSION:
-            "0x" & $node.dag.cfg.BELLATRIX_FORK_VERSION,
-          BELLATRIX_FORK_EPOCH:
-            Base10.toString(uint64(node.dag.cfg.BELLATRIX_FORK_EPOCH)),
+            "0x" & $cfg[].BELLATRIX_FORK_VERSION,
+          MERGE_FORK_EPOCH:
+            Base10.toString(uint64(cfg[].BELLATRIX_FORK_EPOCH)),
           SHARDING_FORK_VERSION:
-            "0x" & $node.dag.cfg.SHARDING_FORK_VERSION,
+            "0x" & $cfg[].SHARDING_FORK_VERSION,
           SHARDING_FORK_EPOCH:
-            Base10.toString(uint64(node.dag.cfg.SHARDING_FORK_EPOCH)),
+            Base10.toString(uint64(cfg[].SHARDING_FORK_EPOCH)),
           SECONDS_PER_SLOT:
             Base10.toString(SECONDS_PER_SLOT),
           SECONDS_PER_ETH1_BLOCK:
-            Base10.toString(node.dag.cfg.SECONDS_PER_ETH1_BLOCK),
+            Base10.toString(cfg[].SECONDS_PER_ETH1_BLOCK),
           MIN_VALIDATOR_WITHDRAWABILITY_DELAY:
-            Base10.toString(node.dag.cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
+            Base10.toString(cfg[].MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
           SHARD_COMMITTEE_PERIOD:
-            Base10.toString(node.dag.cfg.SHARD_COMMITTEE_PERIOD),
+            Base10.toString(cfg[].SHARD_COMMITTEE_PERIOD),
           ETH1_FOLLOW_DISTANCE:
-            Base10.toString(node.dag.cfg.ETH1_FOLLOW_DISTANCE),
+            Base10.toString(cfg[].ETH1_FOLLOW_DISTANCE),
           INACTIVITY_SCORE_BIAS:
-            Base10.toString(node.dag.cfg.INACTIVITY_SCORE_BIAS),
+            Base10.toString(cfg[].INACTIVITY_SCORE_BIAS),
           INACTIVITY_SCORE_RECOVERY_RATE:
-            Base10.toString(node.dag.cfg.INACTIVITY_SCORE_RECOVERY_RATE),
+            Base10.toString(cfg[].INACTIVITY_SCORE_RECOVERY_RATE),
           EJECTION_BALANCE:
-            Base10.toString(node.dag.cfg.EJECTION_BALANCE),
+            Base10.toString(cfg[].EJECTION_BALANCE),
           MIN_PER_EPOCH_CHURN_LIMIT:
-            Base10.toString(node.dag.cfg.MIN_PER_EPOCH_CHURN_LIMIT),
+            Base10.toString(cfg[].MIN_PER_EPOCH_CHURN_LIMIT),
           CHURN_LIMIT_QUOTIENT:
-            Base10.toString(node.dag.cfg.CHURN_LIMIT_QUOTIENT),
+            Base10.toString(cfg[].CHURN_LIMIT_QUOTIENT),
           DEPOSIT_CHAIN_ID:
-            Base10.toString(node.dag.cfg.DEPOSIT_CHAIN_ID),
+            Base10.toString(cfg[].DEPOSIT_CHAIN_ID),
           DEPOSIT_NETWORK_ID:
-            Base10.toString(node.dag.cfg.DEPOSIT_NETWORK_ID),
+            Base10.toString(cfg[].DEPOSIT_NETWORK_ID),
           DEPOSIT_CONTRACT_ADDRESS:
-            $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS,
+            $cfg[].DEPOSIT_CONTRACT_ADDRESS,
 
           # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#constants
           # GENESIS_SLOT
@@ -238,8 +245,8 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
     cachedDepositContract =
       RestApiResponse.prepareJsonResponse(
         (
-          chain_id: $node.dag.cfg.DEPOSIT_CHAIN_ID,
-          address: $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS
+          chain_id: $cfg[].DEPOSIT_CHAIN_ID,
+          address: $cfg[].DEPOSIT_CONTRACT_ADDRESS
         )
       )
 

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -20,6 +20,9 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/eth/v1/debug/beacon/states/{state_id}") do (
     state_id: StateIdent) -> RestApiResponse:
+    if node.kind != BeaconNodeKind.Full:
+      return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
+
     let bslot =
       block:
         if state_id.isErr():
@@ -55,6 +58,9 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet,
              "/eth/v2/debug/beacon/states/{state_id}") do (
     state_id: StateIdent) -> RestApiResponse:
+    if node.kind != BeaconNodeKind.Full:
+      return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
+
     let bslot =
       block:
         if state_id.isErr():
@@ -86,6 +92,9 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Debug/getDebugChainHeads
   router.api(MethodGet,
              "/eth/v1/debug/beacon/heads") do () -> RestApiResponse:
+    if node.kind != BeaconNodeKind.Full:
+      return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
+
     return RestApiResponse.jsonResponse(
       node.dag.heads.mapIt((root: it.root, slot: it.slot))
     )

--- a/beacon_chain/rpc/rpc_config_api.nim
+++ b/beacon_chain/rpc/rpc_config_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,7 +13,8 @@ import
   chronicles,
   ../beacon_node,
   ../eth1/eth1_monitor,
-  ../spec/forks
+  ../spec/forks,
+  ./rpc_utils
 
 logScope: topics = "configapi"
 
@@ -23,9 +24,19 @@ type
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Defect, CatchableError].} =
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:
+    if node.kind != BeaconNodeKind.Full:
+      raiseBeaconNodeInSyncError()
+
     return @[getStateField(node.dag.headState.data, fork)]
 
   rpcServer.rpc("get_v1_config_spec") do () -> JsonNode:
+    let cfg =
+      case node.kind
+      of BeaconNodeKind.Light:
+        addr node.cfg
+      of BeaconNodeKind.Full:
+        addr node.dag.cfg
+
     return %*{
       # Note: This is intentionally only returning v1.0 config values.
       # Please use the REST API /eth/v1/config/spec to retrieve the full config.
@@ -33,33 +44,32 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "MAX_COMMITTEES_PER_SLOT": $MAX_COMMITTEES_PER_SLOT,
       "TARGET_COMMITTEE_SIZE": $TARGET_COMMITTEE_SIZE,
       "MAX_VALIDATORS_PER_COMMITTEE": $MAX_VALIDATORS_PER_COMMITTEE,
-      "MIN_PER_EPOCH_CHURN_LIMIT": $node.dag.cfg.MIN_PER_EPOCH_CHURN_LIMIT,
-      "CHURN_LIMIT_QUOTIENT": $node.dag.cfg.CHURN_LIMIT_QUOTIENT,
+      "MIN_PER_EPOCH_CHURN_LIMIT": $cfg[].MIN_PER_EPOCH_CHURN_LIMIT,
+      "CHURN_LIMIT_QUOTIENT": $cfg[].CHURN_LIMIT_QUOTIENT,
       "SHUFFLE_ROUND_COUNT": $SHUFFLE_ROUND_COUNT,
       "MIN_GENESIS_ACTIVE_VALIDATOR_COUNT":
-        $node.dag.cfg.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
-      "MIN_GENESIS_TIME": $node.dag.cfg.MIN_GENESIS_TIME,
+        $cfg[].MIN_GENESIS_ACTIVE_VALIDATOR_COUNT,
+      "MIN_GENESIS_TIME": $cfg[].MIN_GENESIS_TIME,
       "HYSTERESIS_QUOTIENT": $HYSTERESIS_QUOTIENT,
       "HYSTERESIS_DOWNWARD_MULTIPLIER": $HYSTERESIS_DOWNWARD_MULTIPLIER,
       "HYSTERESIS_UPWARD_MULTIPLIER": $HYSTERESIS_UPWARD_MULTIPLIER,
       "SAFE_SLOTS_TO_UPDATE_JUSTIFIED": $SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
-      "ETH1_FOLLOW_DISTANCE": $node.dag.cfg.ETH1_FOLLOW_DISTANCE,
+      "ETH1_FOLLOW_DISTANCE": $cfg[].ETH1_FOLLOW_DISTANCE,
       "TARGET_AGGREGATORS_PER_COMMITTEE": $TARGET_AGGREGATORS_PER_COMMITTEE,
       "RANDOM_SUBNETS_PER_VALIDATOR": $RANDOM_SUBNETS_PER_VALIDATOR,
       "EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION":
         $EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION,
-      "SECONDS_PER_ETH1_BLOCK": $node.dag.cfg.SECONDS_PER_ETH1_BLOCK,
-      "DEPOSIT_CHAIN_ID": $node.dag.cfg.DEPOSIT_CHAIN_ID,
-      "DEPOSIT_NETWORK_ID": $node.dag.cfg.DEPOSIT_NETWORK_ID,
-      "DEPOSIT_CONTRACT_ADDRESS": $node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS,
+      "SECONDS_PER_ETH1_BLOCK": $cfg[].SECONDS_PER_ETH1_BLOCK,
+      "DEPOSIT_CHAIN_ID": $cfg[].DEPOSIT_CHAIN_ID,
+      "DEPOSIT_NETWORK_ID": $cfg[].DEPOSIT_NETWORK_ID,
+      "DEPOSIT_CONTRACT_ADDRESS": $cfg[].DEPOSIT_CONTRACT_ADDRESS,
       "MIN_DEPOSIT_AMOUNT": $MIN_DEPOSIT_AMOUNT,
       "MAX_EFFECTIVE_BALANCE": $MAX_EFFECTIVE_BALANCE,
-      "EJECTION_BALANCE": $node.dag.cfg.EJECTION_BALANCE,
+      "EJECTION_BALANCE": $cfg[].EJECTION_BALANCE,
       "EFFECTIVE_BALANCE_INCREMENT": $EFFECTIVE_BALANCE_INCREMENT,
-      "GENESIS_FORK_VERSION":
-        "0x" & $node.dag.cfg.GENESIS_FORK_VERSION,
+      "GENESIS_FORK_VERSION": "0x" & $cfg[].GENESIS_FORK_VERSION,
       "BLS_WITHDRAWAL_PREFIX": to0xHex([BLS_WITHDRAWAL_PREFIX]),
-      "GENESIS_DELAY": $node.dag.cfg.GENESIS_DELAY,
+      "GENESIS_DELAY": $cfg[].GENESIS_DELAY,
       "SECONDS_PER_SLOT": $SECONDS_PER_SLOT,
       "MIN_ATTESTATION_INCLUSION_DELAY": $MIN_ATTESTATION_INCLUSION_DELAY,
       "SLOTS_PER_EPOCH": $SLOTS_PER_EPOCH,
@@ -68,8 +78,8 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       "EPOCHS_PER_ETH1_VOTING_PERIOD": $EPOCHS_PER_ETH1_VOTING_PERIOD,
       "SLOTS_PER_HISTORICAL_ROOT": $SLOTS_PER_HISTORICAL_ROOT,
       "MIN_VALIDATOR_WITHDRAWABILITY_DELAY":
-        $node.dag.cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
-      "SHARD_COMMITTEE_PERIOD": $node.dag.cfg.SHARD_COMMITTEE_PERIOD,
+        $cfg[].MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+      "SHARD_COMMITTEE_PERIOD": $cfg[].SHARD_COMMITTEE_PERIOD,
       "MIN_EPOCHS_TO_INACTIVITY_PENALTY": $MIN_EPOCHS_TO_INACTIVITY_PENALTY,
       "EPOCHS_PER_HISTORICAL_VECTOR": $EPOCHS_PER_HISTORICAL_VECTOR,
       "EPOCHS_PER_SLASHINGS_VECTOR": $EPOCHS_PER_SLASHINGS_VECTOR,
@@ -103,7 +113,14 @@ proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     }
 
   rpcServer.rpc("get_v1_config_deposit_contract") do () -> JsonNode:
+    let cfg =
+      case node.kind
+      of BeaconNodeKind.Light:
+        addr node.cfg
+      of BeaconNodeKind.Full:
+        addr node.dag.cfg
+
     return %*{
-      "chain_id": $node.dag.cfg.DEPOSIT_CHAIN_ID,
-      "address": node.dag.cfg.DEPOSIT_CONTRACT_ADDRESS
+      "chain_id": $cfg[].DEPOSIT_CHAIN_ID,
+      "address": cfg[].DEPOSIT_CONTRACT_ADDRESS
     }

--- a/beacon_chain/rpc/rpc_debug_api.nim
+++ b/beacon_chain/rpc/rpc_debug_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -25,6 +25,9 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Defect, CatchableError].} =
   rpcServer.rpc("get_v1_debug_beacon_states_stateId") do (
       stateId: string) -> phase0.BeaconState:
+    if node.kind != BeaconNodeKind.Full:
+      raiseBeaconNodeInSyncError()
+
     withStateForStateId(stateId):
       if stateData.data.kind == BeaconStateFork.Phase0:
         return stateData.data.phase0Data.data
@@ -32,4 +35,7 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         raiseNoAltairSupport()
 
   rpcServer.rpc("get_v1_debug_beacon_heads") do () -> seq[tuple[root: Eth2Digest, slot: Slot]]:
+    if node.kind != BeaconNodeKind.Full:
+      raiseBeaconNodeInSyncError()
+
     return node.dag.heads.mapIt((it.root, it.slot))

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -21,6 +21,10 @@ export forks, rpc_types, eth2_json_rpc_serialization, blockchain_dag
 template raiseNoAltairSupport*() =
   raise (ref ValueError)(msg:
     "The JSON-RPC interface does not support certain Altair operations due to changes in block structure - see https://nimbus.guide/rest-api.html for full altair support")
+
+from rest_constants import BeaconNodeInSyncError
+template raiseBeaconNodeInSyncError*() =
+  raise (ref CatchableError)(msg: BeaconNodeInSyncError)
 
 template withStateForStateId*(stateId: string, body: untyped): untyped =
   let

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -146,6 +146,9 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/validator.md#broadcast-sync-committee-contribution
   syncContributionSlotOffset* = TimeDiff(nanoseconds:
     NANOSECONDS_PER_SLOT.int64  * 2 div INTERVALS_PER_SLOT)
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#block-proposal
+  optimisticLightClientUpdateSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64 div INTERVALS_PER_SLOT)
 
 func toFloatSeconds*(t: TimeDiff): float =
   float(t.nanoseconds) / 1_000_000_000.0
@@ -167,6 +170,8 @@ func sync_committee_message_deadline*(s: Slot): BeaconTime =
   s.start_beacon_time + syncCommitteeMessageSlotOffset
 func sync_contribution_deadline*(s: Slot): BeaconTime =
   s.start_beacon_time + syncContributionSlotOffset
+func optimistic_light_client_update_deadline*(s: Slot): BeaconTime =
+  s.start_beacon_time + optimisticLightClientUpdateSlotOffset
 
 func slotOrZero*(time: BeaconTime): Slot =
   let exSlot = time.toSlot

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -236,6 +236,13 @@ template start_epoch*(period: SyncCommitteePeriod): Epoch =
   if period >= maxPeriod: FAR_FUTURE_EPOCH
   else: Epoch(period * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
 
+template start_slot*(period: SyncCommitteePeriod): Slot =
+  ## Return the start slot of ``period``.
+  const maxPeriod = SyncCommitteePeriod(
+    FAR_FUTURE_EPOCH div EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+  if period >= maxPeriod: FAR_FUTURE_SLOT
+  else: Slot(period * SLOTS_PER_SYNC_COMMITTEE_PERIOD)
+
 func `$`*(t: BeaconTime): string =
   if t.ns_since_genesis >= 0:
     $(timer.nanoseconds(t.ns_since_genesis))

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -27,7 +27,7 @@
 import
   std/[typetraits, sets, hashes],
   chronicles,
-  stew/[assign2, bitops2],
+  stew/[assign2, bitops2, objects],
   "."/[base, phase0]
 
 export base, sets
@@ -608,6 +608,16 @@ chronicles.formatIt SignedContributionAndProof: shortLog(it)
 
 template hash*(x: LightClientUpdate): Hash =
   hash(x.header)
+
+func shortLog*(v: LightClientUpdate): auto =
+  (
+    attested: shortLog(v.attested_header),
+    finalized: shortLog(v.finalized_header),
+    sync_committee_participants: countOnes(v.sync_aggregate.sync_committee_bits),
+    is_signed_by_next: v.next_sync_committee.isZeroMemory
+  )
+
+chronicles.formatIt LightClientUpdate: it.shortLog
 
 func clear*(info: var EpochInfo) =
   info.validators.setLen(0)

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -619,6 +619,15 @@ func shortLog*(v: LightClientUpdate): auto =
 
 chronicles.formatIt LightClientUpdate: it.shortLog
 
+func shortLog*(v: OptimisticLightClientUpdate): auto =
+  (
+    attested_header: shortLog(v.attested_header),
+    num_active_participants: countOnes(v.sync_aggregate.sync_committee_bits),
+    is_signed_by_next: v.is_signed_by_next_sync_committee
+  )
+
+chronicles.formatIt OptimisticLightClientUpdate: it.shortLog
+
 func clear*(info: var EpochInfo) =
   info.validators.setLen(0)
   info.balances = UnslashedParticipatingBalances()

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -51,9 +51,15 @@ const
   TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE* = 16
   SYNC_COMMITTEE_SUBNET_COUNT* = 4
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/setup.py#L478-L479
-  FINALIZED_ROOT_INDEX* = 105.GeneralizedIndex
-  NEXT_SYNC_COMMITTEE_INDEX* = 55.GeneralizedIndex
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#constants
+  # All of these indices are rooted in `BeaconState`.
+  # The first member (`genesis_time`) is 32, subsequent members +1 each.
+  # If there are ever more than 32 members in `BeaconState`, indices change!
+  # `FINALIZED_ROOT_INDEX` is one layer deeper, i.e., `52 * 2 + 1`.
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/ssz/merkle-proofs.md 
+  FINALIZED_ROOT_INDEX* = 105.GeneralizedIndex # `finalized_checkpoint` > `root`
+  CURRENT_SYNC_COMMITTEE_INDEX* = 54.GeneralizedIndex # `current_sync_committee`
+  NEXT_SYNC_COMMITTEE_INDEX* = 55.GeneralizedIndex # `next_sync_committee`
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/beacon-chain.md#participation-flag-indices
   TIMELY_SOURCE_FLAG_INDEX* = 0
@@ -152,12 +158,23 @@ type
 
   ### Modified/overloaded
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#lightclientbootstrap
+  LightClientBootstrap* = object
+    header*: BeaconBlockHeader ##\
+    ## The requested beacon block header
+
+    # Current sync committee corresponding to the requested header
+    current_sync_committee*: SyncCommittee
+    current_sync_committee_branch*:
+      array[log2trunc(CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+
   # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#lightclientupdate
   LightClientUpdate* = object
     attested_header*: BeaconBlockHeader ##\
     ## The beacon block header that is attested to by the sync committee
 
-    # Next sync committee corresponding to the active header
+    # Next sync committee corresponding to the active header,
+    # if signature is from current sync committee
     next_sync_committee*: SyncCommittee
     next_sync_committee_branch*:
       array[log2trunc(NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
@@ -171,6 +188,20 @@ type
 
     fork_version*: Version ##\
     ## Fork version for the aggregate signature
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#optimisticlightclientupdate
+  OptimisticLightClientUpdate* = object
+    attested_header*: BeaconBlockHeader ##\
+    ## The beacon block header that is attested to by the sync committee
+
+    sync_aggregate*: SyncAggregate ##\
+    ## Sync committee aggregate signature
+
+    fork_version*: Version ##\
+    ## Fork version for the aggregate signature
+
+    is_signed_by_next_sync_committee*: bool ##\
+    ## Whether the signature was produced by `attested_header`'s next sync committee
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#lightclientstore
   LightClientStore* = object

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -56,7 +56,7 @@ const
   # The first member (`genesis_time`) is 32, subsequent members +1 each.
   # If there are ever more than 32 members in `BeaconState`, indices change!
   # `FINALIZED_ROOT_INDEX` is one layer deeper, i.e., `52 * 2 + 1`.
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/ssz/merkle-proofs.md 
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/ssz/merkle-proofs.md
   FINALIZED_ROOT_INDEX* = 105.GeneralizedIndex # `finalized_checkpoint` > `root`
   CURRENT_SYNC_COMMITTEE_INDEX* = 54.GeneralizedIndex # `current_sync_committee`
   NEXT_SYNC_COMMITTEE_INDEX* = 55.GeneralizedIndex # `next_sync_committee`
@@ -202,6 +202,11 @@ type
 
     is_signed_by_next_sync_committee*: bool ##\
     ## Whether the signature was produced by `attested_header`'s next sync committee
+
+  SomeLightClientObject* =
+    LightClientBootstrap |
+    LightClientUpdate |
+    OptimisticLightClientUpdate
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#lightclientstore
   LightClientStore* = object
@@ -608,6 +613,11 @@ chronicles.formatIt SignedContributionAndProof: shortLog(it)
 
 template hash*(x: LightClientUpdate): Hash =
   hash(x.header)
+
+func shortLog*(v: LightClientBootstrap): auto =
+  (
+    header: shortLog(v.header)
+  )
 
 func shortLog*(v: LightClientUpdate): auto =
   (

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -1,10 +1,35 @@
+# beacon_chain
+# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   stew/[bitops2, objects],
   datatypes/altair,
   helpers
 
+func period_contains_fork_version(
+    cfg: RuntimeConfig,
+    period: SyncCommitteePeriod,
+    fork_version: Version): bool =
+  ## Determine whether a given `fork_version` is used during a given `period`.
+  let
+    periodStartEpoch = period.start_epoch
+    periodEndEpoch = periodStartEpoch + EPOCHS_PER_SYNC_COMMITTEE_PERIOD - 1
+  return
+    if fork_version == cfg.BELLATRIX_FORK_VERSION:
+      periodEndEpoch >= cfg.BELLATRIX_FORK_EPOCH
+    elif fork_version == cfg.ALTAIR_FORK_VERSION:
+      periodStartEpoch < cfg.BELLATRIX_FORK_EPOCH and
+      cfg.BELLATRIX_FORK_EPOCH != cfg.ALTAIR_FORK_EPOCH and
+      periodEndEpoch >= cfg.ALTAIR_FORK_EPOCH
+    else:
+      false
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#get_active_header
-func get_active_header(update: LightClientUpdate): BeaconBlockHeader =
+func get_active_header(update: altair.LightClientUpdate): BeaconBlockHeader =
   # The "active header" is the header that the update is trying to convince
   # us to accept. If a finalized header is present, it's the finalized
   # header, otherwise it's the attested header
@@ -13,86 +38,6 @@ func get_active_header(update: LightClientUpdate): BeaconBlockHeader =
   else:
     update.attested_header
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#validate_light_client_update
-proc validate_light_client_update*(store: LightClientStore,
-                                   update: LightClientUpdate,
-                                   current_slot: Slot,
-                                   genesis_validators_root: Eth2Digest): bool =
-  # Verify update slot is larger than slot of current best finalized header
-  let active_header = get_active_header(update)
-  if not (current_slot >= active_header.slot and
-          active_header.slot > store.finalized_header.slot):
-    return false
-
-  # Verify update does not skip a sync committee period
-  let
-    finalized_period = sync_committee_period(store.finalized_header.slot)
-    update_period = sync_committee_period(active_header.slot)
-
-  if update_period notin [finalized_period, finalized_period + 1]:
-    return false
-
-  # Verify that the `finalized_header`, if present, actually is the finalized
-  # header saved in the state of the `attested header`
-  if update.finalized_header.isZeroMemory:
-    if not update.finality_branch.isZeroMemory:
-      return false
-  else:
-    if not is_valid_merkle_branch(hash_tree_root(update.finalized_header),
-                                  update.finality_branch,
-                                  log2trunc(FINALIZED_ROOT_INDEX),
-                                  get_subtree_index(FINALIZED_ROOT_INDEX),
-                                  update.attested_header.state_root):
-      return false
-
-  # Verify update next sync committee if the update period incremented
-  # TODO: Use a view type instead of `unsafeAddr`
-  let sync_committee = if update_period == finalized_period:
-    if not update.next_sync_committee_branch.isZeroMemory:
-      return false
-    unsafeAddr store.current_sync_committee
-  else:
-    if not is_valid_merkle_branch(hash_tree_root(update.next_sync_committee),
-                                  update.next_sync_committee_branch,
-                                  log2trunc(NEXT_SYNC_COMMITTEE_INDEX),
-                                  get_subtree_index(NEXT_SYNC_COMMITTEE_INDEX),
-                                  active_header.state_root):
-      return false
-    unsafeAddr store.next_sync_committee
-
-  template sync_aggregate(): auto = update.sync_aggregate
-  let sync_committee_participants_count = countOnes(sync_aggregate.sync_committee_bits)
-
-  # Verify sync committee has sufficient participants
-  if sync_committee_participants_count < MIN_SYNC_COMMITTEE_PARTICIPANTS:
-    return false
-
-  # Verify sync committee aggregate signature
-  # participant_pubkeys = [pubkey for (bit, pubkey) in zip(sync_aggregate.sync_committee_bits, sync_committee.pubkeys) if bit]
-  var participant_pubkeys = newSeqOfCap[ValidatorPubKey](sync_committee_participants_count)
-  for idx, bit in sync_aggregate.sync_committee_bits:
-    if bit:
-      participant_pubkeys.add(sync_committee.pubkeys[idx])
-
-  let domain = compute_domain(
-    DOMAIN_SYNC_COMMITTEE, update.fork_version, genesis_validators_root)
-  let signing_root = compute_signing_root(update.attested_header, domain)
-
-  blsFastAggregateVerify(
-    participant_pubkeys, signing_root.data, sync_aggregate.sync_committee_signature)
-
-# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#apply_light_client_update
-func apply_light_client_update(
-    store: var LightClientStore, update: LightClientUpdate) =
-  let
-    active_header = get_active_header(update)
-    finalized_period = sync_committee_period(store.finalized_header.slot)
-    update_period = sync_committee_period(active_header.slot)
-  if update_period == finalized_period + 1:
-    store.current_sync_committee = store.next_sync_committee
-    store.next_sync_committee = update.next_sync_committee
-  store.finalized_header = active_header
-
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#get_safety_threshold
 func get_safety_threshold(store: LightClientStore): uint64 =
   max(
@@ -100,42 +45,321 @@ func get_safety_threshold(store: LightClientStore): uint64 =
     store.current_max_active_participants
   ) div 2
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#process_light_client_update
-proc process_light_client_update*(store: var LightClientStore,
-                                  update: LightClientUpdate,
-                                  current_slot: Slot,
-                                  genesis_validators_root: Eth2Digest): bool =
-  if not validate_light_client_update(
-      store, update, current_slot, genesis_validators_root):
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#initialize_light_client_store
+func initialize_light_client_store*(
+    trusted_block_root: Eth2Digest,
+    bootstrap: altair.LightClientBootstrap): Opt[LightClientStore] =
+  if hash_tree_root(bootstrap.header) != trusted_block_root:
+    return err()
+
+  if not is_valid_merkle_branch(
+      hash_tree_root(bootstrap.current_sync_committee),
+      bootstrap.current_sync_committee_branch,
+      log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX),
+      get_subtree_index(altair.CURRENT_SYNC_COMMITTEE_INDEX),
+      bootstrap.header.state_root):
+    return err()
+
+  return ok(LightClientStore(
+    finalized_header: bootstrap.header,
+    current_sync_committee: bootstrap.current_sync_committee,
+    optimistic_header: bootstrap.header))
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#validate_light_client_update
+proc validate_light_client_update*(
+    store: LightClientStore,
+    update: altair.LightClientUpdate,
+    current_slot: Slot,
+    cfg: RuntimeConfig,
+    genesis_validators_root: Eth2Digest): bool =
+  # Verify sync committee has sufficient participants
+  template sync_aggregate(): auto = update.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
+  if num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
     return false
 
+  # Determine update header
+  template attested_header(): auto = update.attested_header
+  if current_slot < attested_header.slot:
+    return false
+  let active_header = get_active_header(update)
+  if attested_header.slot < active_header.slot:
+    return false
+
+  # Verify update is relevant
+  let is_next_sync_committee_known = not store.next_sync_committee.isZeroMemory
+  if is_next_sync_committee_known:
+    if active_header.slot < store.finalized_header.slot:
+      return false
+    if active_header.slot == store.finalized_header.slot:
+      if attested_header.slot <= store.optimistic_header.slot:
+        return false
+
+  # Verify update does not skip a sync committee period
   let
-    sync_committee_bits = update.sync_aggregate.sync_committee_bits
-    sum_sync_committee_bits = countOnes(sync_committee_bits)
+    finalized_period = store.finalized_header.slot.sync_committee_period
+    update_period = active_header.slot.sync_committee_period
+  if update_period notin [finalized_period, finalized_period + 1]:
+    return false
+  let
+    is_signed_by_next_sync_committee =
+      update.next_sync_committee.isZeroMemory
+    signature_period =
+      if is_signed_by_next_sync_committee:
+        update_period + 1
+      else:
+        update_period
+    current_period = current_slot.sync_committee_period
+  if current_period < signature_period:
+    return false
+  if is_next_sync_committee_known:
+    if signature_period notin [finalized_period, finalized_period + 1]:
+      return false
+  else:
+    if signature_period != finalized_period:
+      return false
 
-  # Update the best update in case we have to force-update to it if the
-  # timeout elapses
-  if  store.best_valid_update.isNone or
-      sum_sync_committee_bits > countOnes(
-        store.best_valid_update.get.sync_aggregate.sync_committee_bits):
-    store.best_valid_update = some(update)
+  # Verify fork version is acceptable
+  template fork_version(): auto = update.fork_version
+  if not cfg.period_contains_fork_version(signature_period, fork_version):
+    return false
 
-  # Track the maximum number of active participants in the committee signatures
-  store.current_max_active_participants = max(
-    store.current_max_active_participants,
-    sum_sync_committee_bits.uint64,
-  )
+  # Verify that the `finalized_header`, if present, actually is the finalized
+  # header saved in the state of the `attested_header`
+  if update.finalized_header.isZeroMemory:
+    if not update.finality_branch.isZeroMemory:
+      return false
+  else:
+    if not is_valid_merkle_branch(
+        hash_tree_root(update.finalized_header),
+        update.finality_branch,
+        log2trunc(altair.FINALIZED_ROOT_INDEX),
+        get_subtree_index(altair.FINALIZED_ROOT_INDEX),
+        update.attested_header.state_root):
+      return false
+
+  # Verify that the `next_sync_committee`, if present, actually is the
+  # next sync committee saved in the state of the `active_header`
+  if is_signed_by_next_sync_committee:
+    if not update.next_sync_committee_branch.isZeroMemory:
+      return false
+  else:
+    if update_period == finalized_period and is_next_sync_committee_known:
+      if update.next_sync_committee != store.next_sync_committee:
+        return false
+    if not is_valid_merkle_branch(
+        hash_tree_root(update.next_sync_committee),
+        update.next_sync_committee_branch,
+        log2trunc(altair.NEXT_SYNC_COMMITTEE_INDEX),
+        get_subtree_index(altair.NEXT_SYNC_COMMITTEE_INDEX),
+        active_header.state_root):
+      return false
+
+  # Verify sync committee aggregate signature
+  let sync_committee =
+    if signature_period == finalized_period:
+      unsafeAddr store.current_sync_committee
+    else:
+      unsafeAddr store.next_sync_committee
+  var participant_pubkeys =
+    newSeqOfCap[ValidatorPubKey](num_active_participants)
+  for idx, bit in sync_aggregate.sync_committee_bits:
+    if bit:
+      participant_pubkeys.add(sync_committee.pubkeys[idx])
+  let
+    domain = compute_domain(DOMAIN_SYNC_COMMITTEE,
+                            fork_version,
+                            genesis_validators_root)
+    signing_root = compute_signing_root(attested_header, domain)
+  if not blsFastAggregateVerify(participant_pubkeys,
+                                signing_root.data,
+                                sync_aggregate.sync_committee_signature):
+    return false
+
+  true
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#validate_optimistic_light_client_update
+proc validate_optimistic_light_client_update*(
+    store: LightClientStore,
+    optimistic_update: OptimisticLightClientUpdate,
+    current_slot: Slot,
+    cfg: RuntimeConfig,
+    genesis_validators_root: Eth2Digest): bool =
+  # Verify sync committee has sufficient participants
+  template sync_aggregate(): auto = optimistic_update.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
+  if num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    return false
+
+  # Determine update header
+  template attested_header(): auto = optimistic_update.attested_header
+  if current_slot < attested_header.slot:
+    return false
+  template active_header(): auto = attested_header
+
+  # Verify update is relevant
+  if attested_header.slot <= store.optimistic_header.slot:
+    return false
+
+  # Verify update does not skip a sync committee period
+  let
+    finalized_period = store.finalized_header.slot.sync_committee_period
+    update_period = active_header.slot.sync_committee_period
+  if update_period notin [finalized_period, finalized_period + 1]:
+    return false
+  let
+    is_signed_by_next_sync_committee =
+      optimistic_update.is_signed_by_next_sync_committee
+    signature_period =
+      if is_signed_by_next_sync_committee:
+        update_period + 1
+      else:
+        update_period
+    current_period = current_slot.sync_committee_period
+  if current_period < signature_period:
+    return false
+  let is_next_sync_committee_known = not store.next_sync_committee.isZeroMemory
+  if is_next_sync_committee_known:
+    if signature_period notin [finalized_period, finalized_period + 1]:
+      return false
+  else:
+    if signature_period != finalized_period:
+      return false
+
+  # Verify fork version is acceptable
+  template fork_version(): auto = optimistic_update.fork_version
+  if not cfg.period_contains_fork_version(signature_period, fork_version):
+    return false
+
+  # Verify sync committee aggregate signature
+  let sync_committee =
+    if signature_period == finalized_period:
+      unsafeAddr store.current_sync_committee
+    else:
+      unsafeAddr store.next_sync_committee
+  var participant_pubkeys =
+    newSeqOfCap[ValidatorPubKey](num_active_participants)
+  for idx, bit in sync_aggregate.sync_committee_bits:
+    if bit:
+      participant_pubkeys.add(sync_committee.pubkeys[idx])
+  let
+    domain = compute_domain(DOMAIN_SYNC_COMMITTEE,
+                            fork_version,
+                            genesis_validators_root)
+    signing_root = compute_signing_root(attested_header, domain)
+  if not blsFastAggregateVerify(participant_pubkeys,
+                                signing_root.data,
+                                sync_aggregate.sync_committee_signature):
+    return false
+
+  true
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#apply_light_client_update
+func apply_light_client_update(
+    store: var LightClientStore,
+    update: altair.LightClientUpdate) =
+  let
+    active_header = get_active_header(update)
+    finalized_period = store.finalized_header.slot.sync_committee_period
+    update_period = active_header.slot.sync_committee_period
+  if store.next_sync_committee.isZeroMemory:
+    assert update_period == finalized_period
+    store.next_sync_committee = update.next_sync_committee
+  elif update_period == finalized_period + 1:
+    store.previous_max_active_participants =
+      store.current_max_active_participants
+    store.current_max_active_participants = 0
+    store.current_sync_committee = store.next_sync_committee
+    store.next_sync_committee = update.next_sync_committee
+    assert not store.next_sync_committee.isZeroMemory
+  if active_header.slot > store.finalized_header.slot:
+    store.finalized_header = active_header
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#apply_optimistic_light_client_header
+func apply_optimistic_light_client_header(
+    store: var LightClientStore,
+    attested_header: BeaconBlockHeader,
+    num_active_participants: uint64) =
+  if store.current_max_active_participants < num_active_participants:
+    store.current_max_active_participants = num_active_participants
+
+  if num_active_participants > get_safety_threshold(store) and
+      attested_header.slot > store.optimistic_header.slot:
+    store.optimistic_header = attested_header
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#process_slot_for_light_client_store
+func process_slot_for_light_client_store*(
+    store: var LightClientStore,
+    current_slot: Slot) =
+  if store.best_valid_update.isSome and
+      current_slot > store.finalized_header.slot + UPDATE_TIMEOUT:
+    apply_light_client_update(store, store.best_valid_update.get)
+    store.best_valid_update = none(altair.LightClientUpdate)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#process_light_client_update
+proc process_light_client_update*(
+    store: var LightClientStore,
+    update: altair.LightClientUpdate,
+    current_slot: Slot,
+    cfg: RuntimeConfig,
+    genesis_validators_root: Eth2Digest,
+    allowForceUpdate = true): bool =
+  if not validate_light_client_update(
+      store, update, current_slot, cfg, genesis_validators_root):
+    return false
+
+  template sync_aggregate(): auto = update.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
 
   # Update the optimistic header
-  if  sum_sync_committee_bits.uint64 > get_safety_threshold(store) and
-      update.attested_header.slot > store.optimistic_header.slot:
-    store.optimistic_header = update.attested_header
+  apply_optimistic_light_client_header(
+    store, update.attested_header, num_active_participants)
+
+  # Update the best update in case we have to force-update to it
+  # if the timeout elapses
+  let best_active_participants =
+    if store.best_valid_update.isNone:
+      0.uint64
+    else:
+      template best_sync_aggregate(): auto =
+        store.best_valid_update.get.sync_aggregate
+      countOnes(best_sync_aggregate.sync_committee_bits).uint64
+  if num_active_participants > best_active_participants:
+    store.best_valid_update = some(update)
 
   # Update finalized header
-  if  sum_sync_committee_bits * 3 >= len(sync_committee_bits) * 2 and
+  if num_active_participants * 3 >= static(sync_committee_bits.len * 2) and
       not update.finalized_header.isZeroMemory:
     # Normal update through 2/3 threshold
     apply_light_client_update(store, update)
-    store.best_valid_update = none(LightClientUpdate)
+    store.best_valid_update = none(altair.LightClientUpdate)
+  else:
+    if allowForceUpdate:
+      # Force-update to best update if the timeout elapsed
+      process_slot_for_light_client_store(store, current_slot)
+
+  true
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#process_light_client_update
+proc process_optimistic_light_client_update*(
+    store: var LightClientStore,
+    optimistic_update: OptimisticLightClientUpdate,
+    current_slot: Slot,
+    cfg: RuntimeConfig,
+    genesis_validators_root: Eth2Digest): bool =
+  if not validate_optimistic_light_client_update(
+      store, optimistic_update, current_slot, cfg, genesis_validators_root):
+    return false
+
+  template sync_aggregate(): auto = optimistic_update.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
+
+  # Update the optimistic header
+  apply_optimistic_light_client_header(
+    store, optimistic_update.attested_header, num_active_participants)
 
   true

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -94,6 +94,11 @@ func getSyncCommitteeContributionAndProofTopic*(forkDigest: ForkDigest): string 
   ## For subscribing and unsubscribing to/from a subnet.
   eth2Prefix(forkDigest) & "sync_committee_contribution_and_proof/ssz_snappy"
 
+# https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/sync-protocol.md#optimistic_light_client_update
+func getOptimisticLightClientUpdateTopic*(forkDigest: ForkDigest): string =
+  ## For broadcasting the latest `OptimisticLightClientUpdate` to light clients.
+  eth2Prefix(forkDigest) & "optimistic_light_client_update/ssz_snappy"
+
 func getENRForkID*(cfg: RuntimeConfig,
                    epoch: Epoch,
                    genesis_validators_root: Eth2Digest): ENRForkID =

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -132,7 +132,7 @@ func getDiscoveryForkID*(cfg: RuntimeConfig,
       next_fork_epoch: FAR_FUTURE_EPOCH)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/altair/p2p-interface.md#transitioning-the-gossip
-func getTargetGossipState*(
+func getTargetGossipForks*(
     epoch, ALTAIR_FORK_EPOCH, BELLATRIX_FORK_EPOCH: Epoch, isBehind: bool):
     set[BeaconStateFork] =
   if isBehind:

--- a/beacon_chain/spec/ssz_codec.nim
+++ b/beacon_chain/spec/ssz_codec.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -17,7 +17,7 @@ export codec, base, typetraits
 
 # Coding and decoding of SSZ to spec-specific types
 
-template toSszType*(v: Slot|Epoch): auto = uint64(v)
+template toSszType*(v: Slot|Epoch|SyncCommitteePeriod): auto = uint64(v)
 template toSszType*(v: BlsCurveType): auto = toRaw(v)
 template toSszType*(v: ForkDigest|GraffitiBytes): auto = distinctBase(v)
 template toSszType*(v: Version): auto = distinctBase(v)
@@ -32,6 +32,9 @@ template fromSszBytes*(T: type Slot, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
 template fromSszBytes*(T: type Epoch, bytes: openArray[byte]): T =
+  T fromSszBytes(uint64, bytes)
+
+template fromSszBytes*(T: type SyncCommitteePeriod, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
 func fromSszBytes*(T: type ForkDigest, bytes: openArray[byte]): T {.raisesssz.} =

--- a/beacon_chain/sszdump.nim
+++ b/beacon_chain/sszdump.nim
@@ -46,3 +46,38 @@ proc dump*(dir: string, v: ForkyHashedBeaconState) =
 proc dump*(dir: string, v: SyncCommitteeMessage, validator: ValidatorPubKey) =
   logErrors:
     SSZ.saveFile(dir / &"sync-committee-msg-{v.slot}-{shortLog(validator)}.ssz", v)
+
+proc dump*(dir: string, v: altair.LightClientBootstrap) =
+  logErrors:
+    let
+      prefix = "bootstrap"
+      slot = v.header.slot
+      blck = shortLog(v.header.hash_tree_root())
+      root = shortLog(v.hash_tree_root())
+    SSZ.saveFile(
+      dir / &"{prefix}-{slot}-{blck}-{root}.ssz", v)
+
+proc dump*(dir: string, v: altair.LightClientUpdate) =
+  logErrors:
+    let
+      prefix = "update"
+      attestedSlot = v.attested_header.slot
+      attestedBlck = shortLog(v.attested_header.hash_tree_root())
+      suffix =
+        if v.finalized_header.slot != 0.Slot:
+          "f"
+        else:
+          "o"
+      root = shortLog(v.hash_tree_root())
+    SSZ.saveFile(
+      dir / &"{prefix}-{attestedSlot}-{attestedBlck}-{suffix}-{root}.ssz", v)
+
+proc dump*(dir: string, v: altair.OptimisticLightClientUpdate) =
+  logErrors:
+    let
+      prefix = "optimistic-update"
+      attestedSlot = v.attested_header.slot
+      attestedBlck = shortLog(v.attested_header.hash_tree_root())
+      root = shortLog(v.hash_tree_root())
+    SSZ.saveFile(
+      dir / &"{prefix}-{attestedSlot}-{attestedBlck}-{root}.ssz", v)

--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -1,0 +1,268 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import chronos, chronicles
+import
+  eth/p2p/discoveryv5/random2,
+  ../spec/datatypes/[altair],
+  ../networking/eth2_network,
+  "."/sync_protocol, "."/sync_manager
+
+logScope:
+  topics = "lcman"
+
+type
+  Nothing = object
+  LightClientEndpoint[K, V] =
+    (K, V) # https://github.com/nim-lang/Nim/issues/19531
+  LatestLightClientUpdateEndpoint =
+    LightClientEndpoint[Nothing, altair.LightClientUpdate]
+  OptimisticLightClientUpdateEndpoint =
+    LightClientEndpoint[Nothing, altair.OptimisticLightClientUpdate]
+  LightClientBootstrapEndpoint =
+    LightClientEndpoint[Eth2Digest, altair.LightClientBootstrap]
+
+  ValueVerifier[V] =
+    proc(v: V): Future[Result[void, BlockError]] {.gcsafe, raises: [Defect].}
+  LightClientBootstrapVerifier* =
+    ValueVerifier[altair.LightClientBootstrap]
+  LightClientUpdateVerifier* =
+    ValueVerifier[altair.LightClientUpdate]
+  OptimisticLightClientUpdateVerifier* =
+    ValueVerifier[altair.OptimisticLightClientUpdate]
+
+  CanApplyLatestLightClientUpdatesCallback* =
+    proc(): bool {.gcsafe, raises: [Defect].}
+
+  LightClientManager* = object
+    network: Eth2Node
+    rng: ref BrHmacDrbgContext
+    bootstrapVerifier: LightClientBootstrapVerifier
+    updateVerifier: LightClientUpdateVerifier
+    optimisticUpdateVerifier: OptimisticLightClientUpdateVerifier
+    canApplyLatestUpdates: CanApplyLatestLightClientUpdatesCallback
+    loopFuture: Future[void]
+
+func init*(
+    T: type LightClientManager,
+    network: Eth2Node,
+    rng: ref BrHmacDrbgContext,
+    bootstrapVerifier: LightClientBootstrapVerifier,
+    updateVerifier: LightClientUpdateVerifier,
+    optimisticUpdateVerifier: OptimisticLightClientUpdateVerifier,
+    canApplyLatestUpdatesCallback: CanApplyLatestLightClientUpdatesCallback
+): LightClientManager =
+  ## Initialize light client manager.
+  LightClientManager(
+    network: network,
+    rng: rng,
+    bootstrapVerifier: bootstrapVerifier,
+    updateVerifier: updateVerifier,
+    optimisticUpdateVerifier: optimisticUpdateVerifier,
+    canApplyLatestUpdates: canApplyLatestUpdatesCallback
+  )
+
+proc doRequest(
+    e: typedesc[LightClientBootstrapEndpoint],
+    peer: Peer,
+    blockRoot: Eth2Digest
+): Future[NetRes[altair.LightClientBootstrap]] {.
+    raises: [Defect, IOError].} =
+  peer.lightClientBootstrap(blockRoot)
+
+proc doRequest(
+    e: typedesc[LatestLightClientUpdateEndpoint],
+    peer: Peer
+): Future[NetRes[altair.LightClientUpdate]] {.
+    raises: [Defect, IOError].} =
+  peer.latestLightClientUpdate()
+
+proc doRequest(
+    e: typedesc[OptimisticLightClientUpdateEndpoint],
+    peer: Peer
+): Future[NetRes[altair.OptimisticLightClientUpdate]] {.
+    raises: [Defect, IOError].} =
+  peer.optimisticLightClientUpdate()
+
+template valueVerifier[E](
+    self: LightClientManager,
+    e: typedesc[E]
+): ValueVerifier[E.V] =
+  when E.V is altair.LightClientBootstrap:
+    self.bootstrapVerifier
+  elif E.V is altair.LightClientUpdate:
+    self.updateVerifier
+  elif E.V is altair.OptimisticLightClientUpdate:
+    self.optimisticUpdateVerifier
+  else: static: doAssert false
+
+proc workerTask[E](
+    self: LightClientManager,
+    e: typedesc[E],
+    key: E.K
+): Future[bool] {.async.} =
+  var
+    peer: Peer
+    didProgress = false
+  try:
+    peer = await self.network.peerPool.acquire()
+    let value =
+      when E.K is Nothing:
+        await E.doRequest(peer)
+      else:
+        await E.doRequest(peer, key)
+    if value.isOk:
+      let
+        val = value.get
+        res = await self.valueVerifier(E)(val)
+      if res.isErr:
+        case res.error
+        of BlockError.MissingParent:
+          # Ignore, may have lost sync and require other request to progress
+          discard
+        of BlockError.Duplicate:
+          # Ignore, a concurrent request may have fulfilled this already
+          when E.V is altair.LightClientBootstrap:
+            didProgress = true
+          else:
+            discard
+        of BlockError.UnviableFork:
+          # Descore, peer is on an incompatible fork version
+          notice "Received value from an unviable fork", value = val.shortLog,
+            endpoint = E.name, peer, peer_score = peer.getScore()
+          peer.updateScore(PeerScoreUnviableFork)
+        of BlockError.Invalid:
+          # Descore, received data is malformed
+          warn "Received invalid value", value = val.shortLog,
+            endpoint = E.name, peer, peer_score = peer.getScore()
+          peer.updateScore(PeerScoreBadBlocks)
+      else:
+        # Reward, peer returned something useful
+        peer.updateScore(PeerScoreGoodBlocks)
+        didProgress = true
+    else:
+      peer.updateScore(PeerScoreNoBlocks)
+      debug "Failed to receive value on request", value,
+        endpoint = E.name, peer, peer_score = peer.getScore()
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    peer.updateScore(PeerScoreNoBlocks)
+    debug "Unexpected exception while receiving value", exc = exc.msg,
+      endpoint = E.name, peer, peer_score = peer.getScore()
+    raise exc
+  finally:
+    if peer != nil:
+      self.network.peerPool.release(peer)
+  return didProgress
+
+proc fulfill[E](
+    self: LightClientManager,
+    e: typedesc[E],
+    key: E.K
+): Future[bool] {.async.} =
+  let start = SyncMoment.now(0)
+
+  const PARALLEL_REQUESTS = 2
+  var workers: array[PARALLEL_REQUESTS, Future[bool]]
+
+  # Start concurrent workers
+  for i in 0 ..< workers.len:
+    try:
+      workers[i] = self.workerTask(e, key)
+    except CatchableError as exc:
+      for j in 0 ..< i:
+        if not workers[j].finished:
+          workers[j].cancel()
+      return false
+
+  # Wait for any worker to report progress,
+  # or for all workers to finish
+  proc cancelAll() =
+    for i in 0 ..< workers.len:
+      if not workers[i].finished:
+        workers[i].cancel()
+
+  var anyDidProgress = false
+  proc handleFinishedWorker(future: pointer) =
+    try:
+      let didProgress = cast[Future[bool]](future).read()
+      if didProgress:
+        anyDidProgress = true
+        cancelAll()
+    except CatchableError as exc:
+      cancelAll()
+
+  for i in 0 ..< workers.len:
+    workers[i].addCallback(handleFinishedWorker)
+  await allFutures(workers)
+
+  return anyDidProgress
+
+template fulfill[E](
+    self: LightClientManager,
+    e: typedesc[E]
+): Future[bool] =
+  self.fulfill(e, Nothing())
+
+proc loop(
+    self: LightClientManager,
+    trustedBlockRoot: Option[Eth2Digest]) {.async.} =
+  # Obtain bootstrap data if a trusted block root is supplied
+  if trustedBlockRoot.isSome:
+    while true:
+      if await self.fulfill(LightClientBootstrapEndpoint, trustedBlockRoot.get):
+        break
+      await sleepAsync(chronos.seconds(60))
+
+  while true:
+    # While we are out of sync, latest values will not apply
+    while not self.canApplyLatestUpdates():
+      await sleepAsync(chronos.seconds(2))
+
+    # Fetch 1 `OptimisticLightClientUpdate` to avoid waiting for gossip
+    try:
+      discard await self.fulfill(OptimisticLightClientUpdateEndpoint)
+    except CatchableError as exc:
+      raise exc
+
+    # Periodically fetch `LightClientUpdate` to advance sync committee period
+    var nextFetchTick = Moment.now()
+    while self.canApplyLatestUpdates():
+      if Moment.now() > nextFetchTick:
+        const SECONDS_PER_PERIOD =
+          SLOTS_PER_SYNC_COMMITTEE_PERIOD * SECONDS_PER_SLOT
+        let
+          didProgress = await self.fulfill(LatestLightClientUpdateEndpoint)
+          delaySeconds =
+            if didProgress:
+              const
+                minDelaySeconds = SECONDS_PER_PERIOD div 8
+                jitterSeconds = SECONDS_PER_PERIOD div 4
+              (minDelaySeconds + self.rng[].rand(jitterSeconds).uint64).int64
+            else:
+              const
+                minDelaySeconds = SECONDS_PER_PERIOD div 64
+                jitterSeconds = SECONDS_PER_PERIOD div 32
+              (minDelaySeconds + self.rng[].rand(jitterSeconds).uint64).int64
+        nextFetchTick = Moment.fromNow(chronos.seconds(delaySeconds))
+      await sleepAsync(chronos.seconds(2))
+
+proc start*(
+    self: var LightClientManager,
+    trustedBlockRoot: Option[Eth2Digest]) =
+  ## Start light client manager's loop.
+  doAssert self.loopFuture == nil
+  self.loopFuture = self.loop(trustedBlockRoot)
+
+proc stop*(self: var LightClientManager) =
+  ## Stop light client manager's loop.
+  if self.loopFuture != nil:
+    self.loopFuture.cancel()
+    self.loopFuture = nil

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -30,6 +30,7 @@ import # Unit test
   ./test_helpers,
   ./test_honest_validator,
   ./test_interop,
+  ./test_light_client,
   ./test_message_signatures,
   ./test_peer_pool,
   ./test_spec,

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -18,5 +18,6 @@ import
   ./test_fixture_sanity_slots,
   ./test_fixture_ssz_consensus_objects,
   ./test_fixture_state_transition_epoch,
+  ./test_fixture_sync_protocol_light_client_sync,
   ./test_fixture_sync_protocol,
   ./test_fixture_transition

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -151,7 +151,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
-      res
+      res.isOk
       store.current_max_active_participants > 0
       store.optimistic_header == update.attested_header
       store.finalized_header == pre_store_finalized_header
@@ -219,7 +219,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
-      res
+      res.isOk
       store.current_max_active_participants > 0
       store.optimistic_header == update.attested_header
       store.finalized_header == pre_store_finalized_header
@@ -287,7 +287,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
-      res
+      res.isOk
       store.previous_max_active_participants > 0
       store.optimistic_header == update.attested_header
       store.finalized_header == update.attested_header
@@ -385,7 +385,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
-      res
+      res.isOk
       store.current_max_active_participants > 0
       store.optimistic_header == update.attested_header
       store.finalized_header == update.finalized_header

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
@@ -1,0 +1,136 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Standard library
+  std/[json, os, streams],
+  # Status libraries
+  stew/bitops2,
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/light_client_sync,
+  ../../../beacon_chain/spec/datatypes/altair,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils
+
+const TestsDir =
+  SszTestsDir/const_preset/"altair"/"sync_protocol"/"light_client_sync"/"pyspec_tests"
+
+type
+  TestMeta = object
+    genesis_validators_root: string
+    trusted_block_root: string
+
+  TestStepKind {.pure.} = enum
+    ProcessSlot
+    ProcessUpdate
+    ProcessOptimisticUpdate
+
+  TestStep = object
+    case kind: TestStepKind
+    of TestStepKind.ProcessSlot:
+      discard
+    of TestStepKind.ProcessUpdate:
+      update: altair.LightClientUpdate
+    of TestStepKind.ProcessOptimisticUpdate:
+      optimistic_update: OptimisticLightClientUpdate
+    current_slot: Slot
+
+proc loadSteps(path: string): seq[TestStep] =
+  let stepsYAML = readFile(path/"steps.yaml")
+  let steps = yaml.loadToJson(stepsYAML)
+
+  result = @[]
+  for step in steps[0]:
+    if step.hasKey"process_slot":
+      let s = step["process_slot"]
+      result.add TestStep(kind: TestStepKind.ProcessSlot,
+                          current_slot: s["current_slot"].getInt().Slot)
+    elif step.hasKey"process_update":
+      let
+        s = step["process_update"]
+        filename = s["update"].getStr()
+        update = parseTest(path/filename & ".ssz_snappy", SSZ,
+                           altair.LightClientUpdate)
+      result.add TestStep(kind: TestStepKind.ProcessUpdate,
+                          update: update,
+                          current_slot: s["current_slot"].getInt().Slot)
+    elif step.hasKey"process_optimistic_update":
+      let
+        s = step["process_optimistic_update"]
+        filename = s["optimistic_update"].getStr()
+        optimistic_update = parseTest(path/filename & ".ssz_snappy", SSZ,
+                                      OptimisticLightClientUpdate)
+      result.add TestStep(kind: TestStepKind.ProcessOptimisticUpdate,
+                          optimistic_update: optimistic_update,
+                          current_slot: s["current_slot"].getInt().Slot)
+    else:
+      doAssert false, "Unreachable: " & $step
+
+proc runTest(identifier: string) =
+  let testDir = TestsDir / identifier
+
+  proc `testImpl _ sync_protocol_light_client_sync _ identifier`() =
+    test identifier:
+      let
+        meta = block:
+          var s = openFileStream(testDir/"meta.yaml")
+          defer: close(s)
+          var res: TestMeta
+          yaml.load(s, res)
+          res
+        genesis_validators_root =
+          Eth2Digest.fromHex(meta.genesis_validators_root)
+        trusted_block_root =
+          Eth2Digest.fromHex(meta.trusted_block_root)
+
+        bootstrap = parseTest(testDir/"bootstrap.ssz_snappy", SSZ,
+                              altair.LightClientBootstrap)
+        steps = loadSteps(testDir)
+
+        expected_finalized_header =
+          parseTest(testDir/"expected_finalized_header.ssz_snappy", SSZ,
+                    BeaconBlockHeader)
+        expected_optimistic_header =
+          parseTest(testDir/"expected_optimistic_header.ssz_snappy", SSZ,
+                    BeaconBlockHeader)
+
+      var cfg = defaultRuntimeConfig
+      cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+
+      var store =
+        initialize_light_client_store(trusted_block_root, bootstrap).get
+
+      for step in steps:
+        case step.kind
+        of TestStepKind.ProcessSlot:
+          process_slot_for_light_client_store(
+            store, step.current_slot)
+        of TestStepKind.ProcessUpdate:
+          let res = process_light_client_update(
+            store, step.update, step.current_slot,
+            cfg, genesis_validators_root)
+          check res
+        of TestStepKind.ProcessOptimisticUpdate:
+          let res = process_optimistic_light_client_update(
+            store, step.optimistic_update, step.current_slot,
+            cfg, genesis_validators_root)
+          check res
+
+      check:
+        store.finalized_header == expected_finalized_header
+        store.optimistic_header == expected_optimistic_header
+
+  `testImpl _ sync_protocol_light_client_sync _ identifier`()
+
+suite "EF - Altair - Sync protocol - Light client" & preset():
+  for kind, path in walkDir(TestsDir, relative = true, checkDir = true):
+    runTest(path)

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
@@ -118,12 +118,12 @@ proc runTest(identifier: string) =
           let res = process_light_client_update(
             store, step.update, step.current_slot,
             cfg, genesis_validators_root)
-          check res
+          check res.isOk
         of TestStepKind.ProcessOptimisticUpdate:
           let res = process_optimistic_light_client_update(
             store, step.optimistic_update, step.current_slot,
             cfg, genesis_validators_root)
-          check res
+          check res.isOk
 
       check:
         store.finalized_header == expected_finalized_header

--- a/tests/test_gossip_transition.nim
+++ b/tests/test_gossip_transition.nim
@@ -5,60 +5,60 @@ import
   ./testutil,
   ../beacon_chain/spec/[forks, network]
 
-template getTargetGossipState(a, b, c: int, isBehind: bool): auto =
-  getTargetGossipState(a.Epoch, b.Epoch, c.Epoch, isBehind)
+template getTargetGossipForks(a, b, c: int, isBehind: bool): auto =
+  getTargetGossipForks(a.Epoch, b.Epoch, c.Epoch, isBehind)
 
 suite "Gossip fork transition":
   test "Gossip fork transition":
     check:
-      getTargetGossipState(0, 0, 0, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(0, 0, 2, false) == {BeaconStateFork.Altair}
-      getTargetGossipState(0, 1, 2, false) == {BeaconStateFork.Phase0, BeaconStateFork.Altair}
-      getTargetGossipState(0, 2, 3, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(0, 2, 5, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(0, 3, 4, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(0, 3, 5, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(0, 4, 4, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(0, 4, 5, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(1, 0, 1, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(1, 0, 5, false) == {BeaconStateFork.Altair}
-      getTargetGossipState(1, 1, 4, false) == {BeaconStateFork.Altair}
-      getTargetGossipState(2, 0, 2, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(2, 2, 3, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
-      getTargetGossipState(2, 2, 4, false) == {BeaconStateFork.Altair}
-      getTargetGossipState(2, 3, 4, false) == {BeaconStateFork.Phase0, BeaconStateFork.Altair}
-      getTargetGossipState(2, 3, 5,  true) == {}
-      getTargetGossipState(2, 5, 5, false) == {BeaconStateFork.Phase0}
-      getTargetGossipState(3, 0, 2, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 0, 3, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 0, 5, false) == {BeaconStateFork.Altair}
-      getTargetGossipState(3, 1, 2, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 1, 1, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 1, 3, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 1, 5,  true) == {}
-      getTargetGossipState(3, 1, 4, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 2, 3, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 3, 4, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
-      getTargetGossipState(3, 3, 4,  true) == {}
-      getTargetGossipState(3, 4, 4, false) == {BeaconStateFork.Phase0, BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 0, 0, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 0, 1, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 1, 1, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 1, 3, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 2, 4, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 3, 4, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 4, 4, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 5, 5, false) == {BeaconStateFork.Phase0, BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 0, 0, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 0, 2, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 0, 4, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 0, 5, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 0, 5,  true) == {}
-      getTargetGossipState(5, 1, 5, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 2, 2, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 2, 4,  true) == {}
-      getTargetGossipState(5, 3, 4, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 3, 5, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(5, 5, 5, false) == {BeaconStateFork.Bellatrix}
-      getTargetGossipState(2, 0, 3, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
-      getTargetGossipState(4, 1, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(0, 0, 0, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(0, 0, 2, false) == {BeaconStateFork.Altair}
+      getTargetGossipForks(0, 1, 2, false) == {BeaconStateFork.Phase0, BeaconStateFork.Altair}
+      getTargetGossipForks(0, 2, 3, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(0, 2, 5, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(0, 3, 4, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(0, 3, 5, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(0, 4, 4, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(0, 4, 5, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(1, 0, 1, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(1, 0, 5, false) == {BeaconStateFork.Altair}
+      getTargetGossipForks(1, 1, 4, false) == {BeaconStateFork.Altair}
+      getTargetGossipForks(2, 0, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(2, 2, 3, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(2, 2, 4, false) == {BeaconStateFork.Altair}
+      getTargetGossipForks(2, 3, 4, false) == {BeaconStateFork.Phase0, BeaconStateFork.Altair}
+      getTargetGossipForks(2, 3, 5,  true) == {}
+      getTargetGossipForks(2, 5, 5, false) == {BeaconStateFork.Phase0}
+      getTargetGossipForks(3, 0, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 0, 3, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 0, 5, false) == {BeaconStateFork.Altair}
+      getTargetGossipForks(3, 1, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 1, 1, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 1, 3, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 1, 5,  true) == {}
+      getTargetGossipForks(3, 1, 4, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 2, 3, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 3, 4, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(3, 3, 4,  true) == {}
+      getTargetGossipForks(3, 4, 4, false) == {BeaconStateFork.Phase0, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 0, 0, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 0, 1, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 1, 1, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 1, 3, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 2, 4, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 3, 4, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 4, 4, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 5, 5, false) == {BeaconStateFork.Phase0, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 0, 0, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 0, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 0, 4, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 0, 5, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 0, 5,  true) == {}
+      getTargetGossipForks(5, 1, 5, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 2, 2, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 2, 4,  true) == {}
+      getTargetGossipForks(5, 3, 4, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 3, 5, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(5, 5, 5, false) == {BeaconStateFork.Bellatrix}
+      getTargetGossipForks(2, 0, 3, false) == {BeaconStateFork.Altair, BeaconStateFork.Bellatrix}
+      getTargetGossipForks(4, 1, 2, false) == {BeaconStateFork.Bellatrix}

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -1,0 +1,158 @@
+# beacon_chain
+# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+import
+  # Status libraries
+  chronicles, eth/keys, stew/objects, taskpools,
+  # Beacon chain internals
+  ../beacon_chain/consensus_object_pools/
+    [block_clearance, block_quarantine, blockchain_dag],
+  ../beacon_chain/spec/[forks, helpers, light_client_sync, state_transition],
+  # Test utilities
+  ./testutil, ./testdbutil
+
+suite "Light client" & preset():
+  let
+    cfg = block:
+      var res = defaultRuntimeConfig
+      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH + 1
+      res
+    altairStartSlot = cfg.ALTAIR_FORK_EPOCH.start_slot
+
+  proc advanceToSlot(
+      dag: ChainDAGRef,
+      targetSlot: Slot,
+      verifier: var BatchVerifier,
+      quarantine: var Quarantine,
+      attested = true,
+      syncCommitteeRatio = 0.75) =
+    var cache: StateCache
+    const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
+    while true:
+      var slot = getStateField(dag.headState.data, slot)
+      doAssert targetSlot >= slot
+      if targetSlot == slot: break
+
+      # When there is a large jump, skip to the end of the current period,
+      # create blocks for a few epochs to finalize it, then proceed
+      let
+        nextPeriod = slot.sync_committee_period + 1
+        periodEpoch = nextPeriod.start_epoch
+        periodSlot = periodEpoch.start_slot
+        checkpointSlot = periodSlot - maxAttestedSlotsPerPeriod
+      if targetSlot > checkpointSlot:
+        var info: ForkedEpochInfo
+        doAssert process_slots(cfg, dag.headState.data, checkpointSlot,
+                               cache, info, flags = {}).isOk()
+        slot = checkpointSlot
+
+      # Create blocks for final few epochs
+      let blocks = min(targetSlot - slot, maxAttestedSlotsPerPeriod)
+      for blck in makeTestBlocks(dag.headState.data, cache, blocks.int,
+                                 attested, syncCommitteeRatio, cfg):
+        let added =
+          case blck.kind
+          of BeaconBlockFork.Phase0:
+            const nilCallback = OnPhase0BlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
+          of BeaconBlockFork.Altair:
+            const nilCallback = OnAltairBlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.altairData, nilCallback)
+          of BeaconBlockFork.Bellatrix:
+            const nilCallback = OnBellatrixBlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+        check: added.isOk()
+        dag.updateHead(added[], quarantine)
+
+  setup:
+    const num_validators = SLOTS_PER_EPOCH
+    let
+      validatorMonitor = newClone(ValidatorMonitor.init())
+      dag = ChainDAGRef.init(
+        cfg, makeTestDB(num_validators), validatorMonitor, {},
+        serveLightClientData = true,
+        importLightClientData = ImportLightClientData.OnlyNew)
+      quarantine = newClone(Quarantine.init())
+      taskpool = TaskPool.new()
+    var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+
+  test "Pre-Altair":
+    # Genesis
+    check:
+      dag.headState.data.kind == BeaconStateFork.Phase0
+      dag.getBestLightClientUpdateForPeriod(0.SyncCommitteePeriod).isNone
+      dag.getLatestLightClientUpdate.isNone
+
+    # Advance to last slot before Altair
+    dag.advanceToSlot(altairStartSlot - 1, verifier, quarantine[])
+    check:
+      dag.headState.data.kind == BeaconStateFork.Phase0
+      dag.getBestLightClientUpdateForPeriod(0.SyncCommitteePeriod).isNone
+      dag.getLatestLightClientUpdate.isNone
+
+    # Advance to Altair
+    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+    check:
+      dag.headState.data.kind == BeaconStateFork.Altair
+      dag.getBestLightClientUpdateForPeriod(0.SyncCommitteePeriod).isNone
+      dag.getLatestLightClientUpdate.isNone
+
+  test "Light client sync":
+    # Advance to Altair
+    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+
+    # Track trusted checkpoint for light client
+    let
+      genesis_validators_root = dag.genesisValidatorsRoot
+      trusted_block_root = dag.headState.blck.root
+
+    # Advance to target slot
+    const
+      headPeriod = 2.SyncCommitteePeriod
+      periodEpoch = headPeriod.start_epoch
+      headSlot = (periodEpoch + 2).start_slot + 5
+    dag.advanceToSlot(headSlot, verifier, quarantine[])
+    let currentSlot = getStateField(dag.headState.data, slot)
+
+    # Initialize light client store
+    let bootstrap = dag.getLightClientBootstrap(trusted_block_root)
+    check bootstrap.isSome
+    var storeRes = initialize_light_client_store(
+      trusted_block_root, bootstrap.get)
+    check storeRes.isSome
+    template store(): auto = storeRes.get
+
+    # Sync to latest sync committee period
+    while store.finalized_header.slot.sync_committee_period + 1 < headPeriod:
+      let
+        period =
+          if store.next_sync_committee.isZeroMemory:
+            store.finalized_header.slot.sync_committee_period
+          else:
+            store.finalized_header.slot.sync_committee_period + 1
+        bestUpdate = dag.getBestLightClientUpdateForPeriod(period)
+        res = process_light_client_update(
+          store, bestUpdate.get, currentSlot, cfg, genesis_validators_root)
+      check:
+        bestUpdate.isSome
+        bestUpdate.get.finalized_header.slot.sync_committee_period == period
+        res
+        store.finalized_header == bestUpdate.get.finalized_header
+
+    # Sync to latest update
+    let
+      latestUpdate = dag.getLatestLightClientUpdate
+      res = process_light_client_update(
+        store, latestUpdate.get, currentSlot, cfg, genesis_validators_root)
+    check:
+      latestUpdate.isSome
+      latestUpdate.get.attested_header.slot == dag.headState.blck.parent.slot
+      res
+      store.finalized_header == latestUpdate.get.finalized_header
+      store.optimistic_header == latestUpdate.get.attested_header


### PR DESCRIPTION
Adds the `--trust-sync-committee` launch option to use the light client
sync protocol for obtaining the latest finalized head. Then, instead of
regularly syncing forward, sync backwards to skip most block validation.
`--trusted-block-root` can be used to initialize the light client; when
not specified, regular sync is used until the light client obtains info
about new sync committees from the network to jump to latest wall slot.
