### PR TITLE
Bump libp2p

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1900,7 +1900,7 @@ proc createEth2Node*(rng: ref BrHmacDrbgContext,
 
   let altairPrefix = "/eth2/" & $forkDigests.altair
 
-  func msgIdProvider(m: messages.Message): seq[byte] =
+  func msgIdProvider(m: messages.Message): Result[seq[byte], ValidationResult] =
     template topic: untyped =
       if m.topicIDs.len > 0: m.topicIDs[0] else: ""
 
@@ -1908,9 +1908,9 @@ proc createEth2Node*(rng: ref BrHmacDrbgContext,
       # This doesn't have to be a tight bound, just enough to avoid denial of
       # service attacks.
       let decoded = snappy.decode(m.data, maxGossipMaxSize())
-      gossipId(decoded, altairPrefix, topic, true)
+      ok(gossipId(decoded, altairPrefix, topic, true))
     except CatchableError:
-      gossipId(m.data, altairPrefix, topic, false)
+      ok(gossipId(m.data, altairPrefix, topic, false))
 
   let
     params = GossipSubParams(


### PR DESCRIPTION
This bump includes:
- https://github.com/status-im/nim-libp2p/pull/652: strictExceptions compatibility
- https://github.com/status-im/nim-libp2p/pull/627: prevent the issue we had with the committee subscription a while ago to happen again
- https://github.com/status-im/nim-libp2p/pull/644: small gossip sub peer scoring fix
- https://github.com/status-im/nim-libp2p/pull/690: closes #3336
- https://github.com/status-im/nim-libp2p/pull/688: allow msgIdProvider gossip sub to fail, which stops the message processing earlier
- https://github.com/status-im/nim-libp2p/pull/696: Needed for #3346