### PR TITLE
catch wrong-fork-blocks earlier

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -94,7 +94,7 @@ proc addResolvedHeadBlock(
   blockRef
 
 proc checkStateTransition(
-       dag: ChainDAGRef, signedBlock: SomeForkySignedBeaconBlock,
+       dag: ChainDAGRef, signedBlock: ForkySigVerifiedSignedBeaconBlock,
        cache: var StateCache): Result[void, BlockError] =
   ## Ensure block can be applied on a state
   func restore(v: var ForkedHashedBeaconState) =

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -226,13 +226,22 @@ template init*(T: type ForkedTrustedSignedBeaconBlock, blck: altair.TrustedSigne
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: bellatrix.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Bellatrix,  bellatrixData: blck)
 
-template toFork*[T: phase0.TrustedSignedBeaconBlock](
+template toFork*[T:
+    phase0.SignedBeaconBlock |
+    phase0.SigVerifiedSignedBeaconBlock |
+    phase0.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Phase0
-template toFork*[T: altair.TrustedSignedBeaconBlock](
+template toFork*[T:
+    altair.SignedBeaconBlock |
+    altair.SigVerifiedSignedBeaconBlock |
+    altair.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Altair
-template toFork*[T: bellatrix.TrustedSignedBeaconBlock](
+template toFork*[T:
+    bellatrix.SignedBeaconBlock |
+    bellatrix.SigVerifiedSignedBeaconBlock |
+    bellatrix.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Bellatrix
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -250,11 +250,11 @@ proc state_transition_block*(
   ## before the state has been updated, `rollback` will not be called.
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
 
-  # Ensure state_transition_block()-only callers trigger this
-  maybeUpgradeStateToAltair(cfg, state)
-
   let res = withState(state):
-    state_transition_block_aux(cfg, state, signedBlock, cache, flags)
+    when stateFork.toBeaconBlockFork() == type(signedBlock).toFork:
+      state_transition_block_aux(cfg, state, signedBlock, cache, flags)
+    else:
+      err("State/block fork mismatch")
 
   if res.isErr():
     rollback(state)


### PR DESCRIPTION
Can't apply a phase0 block to a later phase state and vice versa.

Since instantiation has been a topic, pre/post c file size:

```
424K	@mspec@sstate_transition.nim.c
892K	@mspec@sstate_transition_block.nim.c
```

```
288K	@mspec@sstate_transition.nim.c
880K	@mspec@sstate_transition_block.nim.c
```