### PR TITLE
Refactor and optimize sync logs.

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -65,6 +65,7 @@ type
     avgSyncSpeed*: float
     syncStatus*: string
     direction: SyncQueueKind
+    ident*: string
 
   SyncMoment* = object
     stamp*: chronos.Moment
@@ -116,7 +117,8 @@ proc newSyncManager*[A, B](pool: PeerPool[A, B],
                            blockVerifier: BlockVerifier,
                            maxHeadAge = uint64(SLOTS_PER_EPOCH * 1),
                            chunkSize = uint64(SLOTS_PER_EPOCH),
-                           toleranceValue = uint64(1)
+                           toleranceValue = uint64(1),
+                           ident = "main"
                            ): SyncManager[A, B] =
   let (getFirstSlot, getLastSlot, getSafeSlot) = case direction
   of SyncQueueKind.Forward:
@@ -137,7 +139,8 @@ proc newSyncManager*[A, B](pool: PeerPool[A, B],
     chunkSize: chunkSize,
     blockVerifier: blockVerifier,
     notInSyncEvent: newAsyncEvent(),
-    direction: direction
+    direction: direction,
+    ident: ident
   )
   res.initQueue()
   res
@@ -145,11 +148,18 @@ proc newSyncManager*[A, B](pool: PeerPool[A, B],
 proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
                       req: SyncRequest): Future[BeaconBlocksRes] {.async.} =
   mixin beaconBlocksByRange, getScore, `==`
+
+  logScope:
+    peer = peer
+    peer_score = peer.getScore()
+    peer_speed = peer.netKbps()
+    sync_ident = man.ident
+    direction = man.direction
+    topics = "syncman"
+
   doAssert(not(req.isEmpty()), "Request must not be empty!")
-  debug "Requesting blocks from peer", peer = peer,
-        slot = req.slot, slot_count = req.count, step = req.step,
-        peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-        direction = man.direction, topics = "syncman"
+  debug "Requesting blocks from peer", slot = req.slot,
+        slot_count = req.count, step = req.step
   try:
     let res =
       if peer.useSyncV2():
@@ -160,24 +170,18 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
             blcks.mapIt(newClone(ForkedSignedBeaconBlock.init(it))))
 
     if res.isErr():
-      debug "Error, while reading getBlocks response",
-              peer = peer, slot = req.slot, count = req.count,
-              step = req.step, peer_speed = peer.netKbps(),
-              direction = man.direction, topics = "syncman",
-              error = $res.error()
+      debug "Error, while reading getBlocks response", slot = req.slot,
+             count = req.count, step = req.step, error = $res.error()
       return
     return res
   except CancelledError:
-    debug "Interrupt, while waiting getBlocks response", peer = peer,
-          slot = req.slot, slot_count = req.count, step = req.step,
-          peer_speed = peer.netKbps(), direction = man.direction,
-          topics = "syncman"
+    debug "Interrupt, while waiting getBlocks response", slot = req.slot,
+          slot_count = req.count, step = req.step
     return
   except CatchableError as exc:
-    debug "Error, while waiting getBlocks response", peer = peer,
-          slot = req.slot, slot_count = req.count, step = req.step,
-          errName = exc.name, errMsg = exc.msg, peer_speed = peer.netKbps(),
-          direction = man.direction, topics = "syncman"
+    debug "Error, while waiting getBlocks response", slot = req.slot,
+          slot_count = req.count, step = req.step, errName = exc.name,
+          errMsg = exc.msg
     return
 
 proc remainingSlots(man: SyncManager): uint64 =
@@ -187,6 +191,15 @@ proc remainingSlots(man: SyncManager): uint64 =
     man.getFirstSlot() - man.getLastSlot()
 
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
+  logScope:
+    peer = peer
+    peer_score = peer.getScore()
+    peer_speed = peer.netKbps()
+    index = index
+    sync_ident = man.ident
+    direction = man.direction
+    topics = "syncman"
+
   var
     headSlot = man.getLocalHeadSlot()
     wallSlot = man.getLocalWallSlot()
@@ -194,10 +207,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
 
   block: # Check that peer status is recent and relevant
     debug "Peer's syncing status", wall_clock_slot = wallSlot,
-          remote_head_slot = peerSlot, local_head_slot = headSlot,
-          peer_score = peer.getScore(), peer = peer, index = index,
-          peer_speed = peer.netKbps(), direction = man.direction,
-          topics = "syncman"
+          remote_head_slot = peerSlot, local_head_slot = headSlot
 
     let
       peerStatusAge = Moment.now() - peer.state(BeaconSync).statusLastTime
@@ -216,26 +226,19 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
         await sleepAsync(StatusExpirationTime div 2 - peerStatusAge)
 
       trace "Updating peer's status information", wall_clock_slot = wallSlot,
-            remote_head_slot = peerSlot, local_head_slot = headSlot,
-            peer = peer, peer_score = peer.getScore(), index = index,
-            peer_speed = peer.netKbps(), direction = man.direction,
-            topics = "syncman"
+            remote_head_slot = peerSlot, local_head_slot = headSlot
 
       try:
         let res = await peer.updateStatus()
         if not(res):
           peer.updateScore(PeerScoreNoStatus)
-          debug "Failed to get remote peer's status, exiting", peer = peer,
-                peer_score = peer.getScore(), peer_head_slot = peerSlot,
-                peer_speed = peer.netKbps(), index = index,
-                direction = man.direction, topics = "syncman"
+          debug "Failed to get remote peer's status, exiting",
+                peer_head_slot = peerSlot
+
           return
       except CatchableError as exc:
         debug "Unexpected exception while updating peer's status",
-              peer = peer, peer_score = peer.getScore(),
-              peer_head_slot = peerSlot, peer_speed = peer.netKbps(),
-              index = index, errMsg = exc.msg, direction = man.direction,
-              topics = "syncman"
+              peer_head_slot = peerSlot, errName = exc.name, errMsg = exc.msg
         return
 
       let newPeerSlot = peer.getHeadSlot()
@@ -243,16 +246,11 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
         peer.updateScore(PeerScoreStaleStatus)
         debug "Peer's status information is stale",
               wall_clock_slot = wallSlot, remote_old_head_slot = peerSlot,
-              local_head_slot = headSlot, remote_new_head_slot = newPeerSlot,
-              peer = peer, peer_score = peer.getScore(), index = index,
-              peer_speed = peer.netKbps(), direction = man.direction,
-              topics = "syncman"
+              local_head_slot = headSlot, remote_new_head_slot = newPeerSlot
       else:
         debug "Peer's status information updated", wall_clock_slot = wallSlot,
               remote_old_head_slot = peerSlot, local_head_slot = headSlot,
-              remote_new_head_slot = newPeerSlot, peer = peer,
-              peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-              index = index, direction = man.direction, topics = "syncman"
+              remote_new_head_slot = newPeerSlot
         peer.updateScore(PeerScoreGoodStatus)
         peerSlot = newPeerSlot
 
@@ -268,26 +266,17 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
 
       warn "Peer reports a head newer than our wall clock - clock out of sync?",
             wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
-            local_head_slot = headSlot, peer = peer, index = index,
-            tolerance_value = man.toleranceValue, peer_speed = peer.netKbps(),
-            peer_score = peer.getScore(), direction = man.direction,
-            topics = "syncman"
+            local_head_slot = headSlot, tolerance_value = man.toleranceValue
       return
 
   if man.remainingSlots() <= man.maxHeadAge:
     case man.direction
     of SyncQueueKind.Forward:
       info "We are in sync with network", wall_clock_slot = wallSlot,
-            remote_head_slot = peerSlot, local_head_slot = headSlot,
-            peer = peer, peer_score = peer.getScore(), index = index,
-            peer_speed = peer.netKbps(), direction = man.direction,
-            topics = "syncman"
+            remote_head_slot = peerSlot, local_head_slot = headSlot
     of SyncQueueKind.Backward:
       info "Backfill complete", wall_clock_slot = wallSlot,
-            remote_head_slot = peerSlot, local_head_slot = headSlot,
-            peer = peer, peer_score = peer.getScore(), index = index,
-            peer_speed = peer.netKbps(), direction = man.direction,
-            topics = "syncman"
+            remote_head_slot = peerSlot, local_head_slot = headSlot
 
     # We clear SyncManager's `notInSyncEvent` so all the workers will become
     # sleeping soon.
@@ -310,10 +299,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     debug "Peer's head slot is lower then local head slot",
           wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
           local_last_slot = man.getLastSlot(),
-          local_first_slot = man.getFirstSlot(), peer = peer,
-          peer_score = peer.getScore(),
-          peer_speed = peer.netKbps(), index = index,
-          direction = man.direction, topics = "syncman"
+          local_first_slot = man.getFirstSlot()
     peer.updateScore(PeerScoreUseless)
     return
 
@@ -332,22 +318,18 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     # To avoid endless loop we going to wait for RESP_TIMEOUT time here.
     # This time is enough for all pending requests to finish and it is also
     # enough for main sync loop to clear ``notInSyncEvent``.
-    debug "Empty request received from queue, exiting", peer = peer,
+    debug "Empty request received from queue, exiting",
           local_head_slot = headSlot, remote_head_slot = peerSlot,
           queue_input_slot = man.queue.inpSlot,
           queue_output_slot = man.queue.outSlot,
-          queue_last_slot = man.queue.finalSlot,
-          peer_speed = peer.netKbps(), peer_score = peer.getScore(),
-          index = index, direction = man.direction, topics = "syncman"
+          queue_last_slot = man.queue.finalSlot
     await sleepAsync(RESP_TIMEOUT)
     return
 
   debug "Creating new request for peer", wall_clock_slot = wallSlot,
         remote_head_slot = peerSlot, local_head_slot = headSlot,
         request_slot = req.slot, request_count = req.count,
-        request_step = req.step, peer = peer, peer_speed = peer.netKbps(),
-        peer_score = peer.getScore(), index = index,
-        direction = man.direction, topics = "syncman"
+        request_step = req.step
 
   man.workers[index].status = SyncWorkerStatus.Downloading
 
@@ -358,19 +340,14 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       let smap = getShortMap(req, data)
       debug "Received blocks on request", blocks_count = len(data),
             blocks_map = smap, request_slot = req.slot,
-            request_count = req.count, request_step = req.step,
-            peer = peer, peer_score = peer.getScore(),
-            peer_speed = peer.netKbps(), index = index,
-            direction = man.direction, topics = "syncman"
+            request_count = req.count, request_step = req.step
 
       if not(checkResponse(req, data)):
         peer.updateScore(PeerScoreBadResponse)
         warn "Received blocks sequence is not in requested range",
              blocks_count = len(data), blocks_map = smap,
              request_slot = req.slot, request_count = req.count,
-             request_step = req.step, peer = peer,
-             peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-             index = index, direction = man.direction, topics = "syncman"
+             request_step = req.step
         return
 
       # Scoring will happen in `syncUpdate`.
@@ -382,25 +359,25 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       man.queue.push(req)
       debug "Failed to receive blocks on request",
             request_slot = req.slot, request_count = req.count,
-            request_step = req.step, peer = peer, index = index,
-            peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-            direction = man.direction, topics = "syncman"
+            request_step = req.step
       return
 
   except CatchableError as exc:
     debug "Unexpected exception while receiving blocks",
           request_slot = req.slot, request_count = req.count,
-          request_step = req.step, peer = peer, index = index,
-          peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-          errName = exc.name, errMsg = exc.msg, direction = man.direction,
-          topics = "syncman"
+          request_step = req.step, errName = exc.name, errMsg = exc.msg
     return
 
 proc syncWorker[A, B](man: SyncManager[A, B], index: int) {.async.} =
   mixin getKey, getScore, getHeadSlot
 
-  debug "Starting syncing worker", index = index, direction = man.direction,
-                                   topics = "syncman"
+  logScope:
+    index = index
+    sync_ident = man.ident
+    direction = man.direction
+    topics = "syncman"
+
+  debug "Starting syncing worker"
 
   while true:
     var peer: A = nil
@@ -420,16 +397,14 @@ proc syncWorker[A, B](man: SyncManager[A, B], index: int) {.async.} =
         true
       except CatchableError as exc:
         debug "Unexpected exception in sync worker",
-              peer = peer, index = index,
-              peer_score = peer.getScore(), peer_speed = peer.netKbps(),
-              errName = exc.name, errMsg = exc.msg, direction = man.direction,
-              topics = "syncman"
+              peer = peer, peer_score = peer.getScore(),
+              peer_speed = peer.netKbps(),
+              errName = exc.name, errMsg = exc.msg
         true
     if doBreak:
       break
 
-  debug "Sync worker stopped", index = index, direction = man.direction,
-                               topics = "syncman"
+  debug "Sync worker stopped"
 
 proc getWorkersStats[A, B](man: SyncManager[A, B]): tuple[map: string,
                                                           sleeping: int,
@@ -465,6 +440,12 @@ proc getWorkersStats[A, B](man: SyncManager[A, B]): tuple[map: string,
   (map, sleeping, waiting, pending)
 
 proc guardTask[A, B](man: SyncManager[A, B]) {.async.} =
+  logScope:
+    index = index
+    sync_ident = man.ident
+    direction = man.direction
+    topics = "syncman"
+
   var pending: array[SyncWorkersCount, Future[void]]
 
   # Starting all the synchronization workers.
@@ -479,11 +460,9 @@ proc guardTask[A, B](man: SyncManager[A, B]) {.async.} =
     let index = pending.find(failFuture)
     if failFuture.failed():
       warn "Synchronization worker stopped working unexpectedly with an error",
-            index = index, errMsg = failFuture.error.msg,
-            direction = man.direction
+            errName = failFuture.error.name, errMsg = failFuture.error.msg
     else:
-      warn "Synchronization worker stopped working unexpectedly without error",
-            index = index, direction = man.direction
+      warn "Synchronization worker stopped working unexpectedly without error"
 
     let future = syncWorker[A, B](man, index)
     man.workers[index].future = future
@@ -516,13 +495,17 @@ proc toTimeLeftString*(d: Duration): string =
     res
 
 proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
+  logScope:
+    sync_ident = man.ident
+    direction = man.direction
+    topics = "syncman"
+
   mixin getKey, getScore
   var pauseTime = 0
 
   var guardTaskFut = man.guardTask()
 
-  debug "Synchronization loop started", topics = "syncman",
-        direction = man.direction
+  debug "Synchronization loop started"
 
   proc averageSpeedTask() {.async.} =
     while true:
@@ -568,8 +551,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
           pending_workers_count = pending,
           wall_head_slot = wallSlot, local_head_slot = headSlot,
           pause_time = $chronos.seconds(pauseTime),
-          avg_sync_speed = man.avgSyncSpeed, ins_sync_speed = man.insSyncSpeed,
-          direction = man.direction, topics = "syncman"
+          avg_sync_speed = man.avgSyncSpeed, ins_sync_speed = man.insSyncSpeed
 
     let
       pivot = man.progressPivot
@@ -607,8 +589,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
               wall_head_slot = wallSlot, local_head_slot = headSlot,
               difference = (wallSlot - headSlot), max_head_age = man.maxHeadAge,
               sleeping_workers_count = sleeping,
-              waiting_workers_count = waiting, pending_workers_count = pending,
-              direction = man.direction, topics = "syncman"
+              waiting_workers_count = waiting, pending_workers_count = pending
         # We already synced, so we should reset all the pending workers from
         # any state they have.
         man.queue.clearAndWakeup()
@@ -621,14 +602,12 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
             debug "Forward synchronization process finished, sleeping",
                   wall_head_slot = wallSlot, local_head_slot = headSlot,
                   difference = (wallSlot - headSlot),
-                  max_head_age = man.maxHeadAge, direction = man.direction,
-                  topics = "syncman"
+                  max_head_age = man.maxHeadAge
           else:
             debug "Synchronization loop sleeping", wall_head_slot = wallSlot,
                   local_head_slot = headSlot,
                   difference = (wallSlot - headSlot),
-                  max_head_age = man.maxHeadAge, direction = man.direction,
-                  topics = "syncman"
+                  max_head_age = man.maxHeadAge
         of SyncQueueKind.Backward:
           # Backward syncing is going to be executed only once, so we exit loop
           # and stop all pending tasks which belongs to this instance (sync
@@ -652,8 +631,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
           debug "Backward synchronization process finished, exiting",
                 wall_head_slot = wallSlot, local_head_slot = headSlot,
                 backfill_slot = man.getLastSlot(),
-                max_head_age = man.maxHeadAge, direction = man.direction,
-                topics = "syncman"
+                max_head_age = man.maxHeadAge
           break
     else:
       if not(man.notInSyncEvent.isSet()):
@@ -666,8 +644,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
                 period = man.maxHeadAge, wall_head_slot = wallSlot,
                 local_head_slot = headSlot,
                 missing_slots = man.remainingSlots(),
-                progress = float(man.queue.progress()),
-                topics = "syncman"
+                progress = float(man.queue.progress())
       else:
         man.notInSyncEvent.fire()
         man.inProgress = true

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -150,7 +150,6 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
   mixin beaconBlocksByRange, getScore, `==`
 
   logScope:
-    peer = peer
     peer_score = peer.getScore()
     peer_speed = peer.netKbps()
     sync_ident = man.ident
@@ -158,8 +157,7 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
     topics = "syncman"
 
   doAssert(not(req.isEmpty()), "Request must not be empty!")
-  debug "Requesting blocks from peer", slot = req.slot,
-        slot_count = req.count, step = req.step
+  debug "Requesting blocks from peer", request = req
   try:
     let res =
       if peer.useSyncV2():
@@ -170,18 +168,16 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
             blcks.mapIt(newClone(ForkedSignedBeaconBlock.init(it))))
 
     if res.isErr():
-      debug "Error, while reading getBlocks response", slot = req.slot,
-             count = req.count, step = req.step, error = $res.error()
+      debug "Error, while reading getBlocks response", request = req,
+             error = $res.error()
       return
     return res
   except CancelledError:
-    debug "Interrupt, while waiting getBlocks response", slot = req.slot,
-          slot_count = req.count, step = req.step
+    debug "Interrupt, while waiting getBlocks response", request = req
     return
   except CatchableError as exc:
-    debug "Error, while waiting getBlocks response", slot = req.slot,
-          slot_count = req.count, step = req.step, errName = exc.name,
-          errMsg = exc.msg
+    debug "Error, while waiting getBlocks response", request = req,
+          errName = exc.name, errMsg = exc.msg
     return
 
 proc remainingSlots(man: SyncManager): uint64 =
@@ -192,12 +188,10 @@ proc remainingSlots(man: SyncManager): uint64 =
 
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
   logScope:
-    peer = peer
     peer_score = peer.getScore()
     peer_speed = peer.netKbps()
     index = index
     sync_ident = man.ident
-    direction = man.direction
     topics = "syncman"
 
   var
@@ -206,6 +200,10 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     peerSlot = peer.getHeadSlot()
 
   block: # Check that peer status is recent and relevant
+    logScope:
+      peer = peer
+      direction = man.direction
+
     debug "Peer's syncing status", wall_clock_slot = wallSlot,
           remote_head_slot = peerSlot, local_head_slot = headSlot
 
@@ -270,6 +268,10 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       return
 
   if man.remainingSlots() <= man.maxHeadAge:
+    logScope:
+      peer = peer
+      direction = man.direction
+
     case man.direction
     of SyncQueueKind.Forward:
       info "We are in sync with network", wall_clock_slot = wallSlot,
@@ -296,10 +298,11 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     # Right now we decreasing peer's score a bit, so it will not be
     # disconnected due to low peer's score, but new fresh peers could replace
     # peers with low latest head.
-    debug "Peer's head slot is lower then local head slot",
+    debug "Peer's head slot is lower then local head slot", peer = peer,
           wall_clock_slot = wallSlot, remote_head_slot = peerSlot,
           local_last_slot = man.getLastSlot(),
-          local_first_slot = man.getFirstSlot()
+          local_first_slot = man.getFirstSlot(),
+          direction = man.direction
     peer.updateScore(PeerScoreUseless)
     return
 
@@ -318,18 +321,17 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     # To avoid endless loop we going to wait for RESP_TIMEOUT time here.
     # This time is enough for all pending requests to finish and it is also
     # enough for main sync loop to clear ``notInSyncEvent``.
-    debug "Empty request received from queue, exiting",
+    debug "Empty request received from queue, exiting", peer = peer,
           local_head_slot = headSlot, remote_head_slot = peerSlot,
           queue_input_slot = man.queue.inpSlot,
           queue_output_slot = man.queue.outSlot,
-          queue_last_slot = man.queue.finalSlot
+          queue_last_slot = man.queue.finalSlot, direction = man.direction
     await sleepAsync(RESP_TIMEOUT)
     return
 
   debug "Creating new request for peer", wall_clock_slot = wallSlot,
         remote_head_slot = peerSlot, local_head_slot = headSlot,
-        request_slot = req.slot, request_count = req.count,
-        request_step = req.step
+        request = req
 
   man.workers[index].status = SyncWorkerStatus.Downloading
 
@@ -339,15 +341,13 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       let data = blocks.get()
       let smap = getShortMap(req, data)
       debug "Received blocks on request", blocks_count = len(data),
-            blocks_map = smap, request_slot = req.slot,
-            request_count = req.count, request_step = req.step
+            blocks_map = smap, request = req
 
       if not(checkResponse(req, data)):
         peer.updateScore(PeerScoreBadResponse)
         warn "Received blocks sequence is not in requested range",
              blocks_count = len(data), blocks_map = smap,
-             request_slot = req.slot, request_count = req.count,
-             request_step = req.step
+             request = req
         return
 
       # Scoring will happen in `syncUpdate`.
@@ -357,15 +357,12 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
     else:
       peer.updateScore(PeerScoreNoBlocks)
       man.queue.push(req)
-      debug "Failed to receive blocks on request",
-            request_slot = req.slot, request_count = req.count,
-            request_step = req.step
+      debug "Failed to receive blocks on request", request = req
       return
 
   except CatchableError as exc:
-    debug "Unexpected exception while receiving blocks",
-          request_slot = req.slot, request_count = req.count,
-          request_step = req.step, errName = exc.name, errMsg = exc.msg
+    debug "Unexpected exception while receiving blocks", request = req,
+          errName = exc.name, errMsg = exc.msg
     return
 
 proc syncWorker[A, B](man: SyncManager[A, B], index: int) {.async.} =

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -79,8 +79,7 @@ chronicles.formatIt SyncQueueKind: toLowerAscii($it)
 
 template shortLog*[T](req: SyncRequest[T]): string =
   Base10.toString(uint64(req.slot)) & ":" &
-  Base10.toString(req.count) & ":" &
-  Base10.toString(req.step) & "@" &
+  Base10.toString(req.count) & "@" &
   Base10.toString(req.index)
 
 chronicles.expandIt SyncRequest:

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -667,17 +667,16 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
         of SyncQueueKind.Forward:
           if safeSlot < req.slot:
             let rewindSlot = sq.getRewindPoint(failSlot, safeSlot)
-            warn "Unexpected missing parent, rewind happens", request = req,
-                 rewind_to_slot = rewindSlot,
-                 rewind_epoch_count = sq.rewind.get().epochCount,
-                 rewind_fail_slot = failSlot, finalized_slot = safeSlot,
+            warn "Unexpected missing parent, rewind happens",
+                 request = req, rewind_to_slot = rewindSlot,
+                 rewind_point = sq.rewind, finalized_slot = safeSlot,
                  blocks_count = len(item.data),
                  blocks_map = getShortMap(req, item.data)
             resetSlot = some(rewindSlot)
             req.item.updateScore(PeerScoreMissingBlocks)
           else:
             error "Unexpected missing parent at finalized epoch slot",
-                  request = req, to_slot = safeSlot,
+                  request = req, rewind_to_slot = safeSlot,
                   blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data)
             req.item.updateScore(PeerScoreBadBlocks)
@@ -701,15 +700,13 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
           await sq.resetWait(resetSlot)
           case sq.kind
           of SyncQueueKind.Forward:
-            debug "Rewind to slot was happened", reset_slot = reset_slot.get(),
+            debug "Rewind to slot has happened", reset_slot = resetSlot.get(),
                   queue_input_slot = sq.inpSlot, queue_output_slot = sq.outSlot,
-                  rewind_epoch_count = sq.rewind.get().epochCount,
-                  rewind_fail_slot = sq.rewind.get().failSlot,
-                  reset_slot = resetSlot, direction = sq.kind
+                  rewind_point = sq.rewind, direction = sq.kind
           of SyncQueueKind.Backward:
-            debug "Rewind to slot was happened", reset_slot = reset_slot.get(),
+            debug "Rewind to slot has happened", reset_slot = resetSlot.get(),
                   queue_input_slot = sq.inpSlot, queue_output_slot = sq.outSlot,
-                  reset_slot = resetSlot, direction = sq.kind
+                  direction = sq.kind
 
       break
 

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -14,6 +14,9 @@ type
 proc `$`(peer: SomeTPeer): string =
   "SomeTPeer"
 
+template shortLog(peer: SomeTPeer): string =
+  $peer
+
 proc updateScore(peer: SomeTPeer, score: int) =
   discard
 


### PR DESCRIPTION
Integrates @cheatfate's refactorings and optimizations of the sync manager / sync queue logs as well as the introduction of `shortLog(SyncRequest)` from #3420 

On top of these integrations, adds a few minor logging improvements:
- Fixes a typo (`was happened` -> `has happened`)
- Avoids passing `reset_slot` argument to log statement multiple times
- Uses same `rewind_to_slot` label when logging in both sync directions
- Consistent rewind point logging