### PR TITLE
Historical state reindex for trusted node sync

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -690,6 +690,10 @@ type
         defaultValue: true
         name: "backfill"}: bool
 
+      reindex* {.
+        desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
+        defaultValue: false}: bool
+
   ValidatorClientConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1888,10 +1888,10 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
     if slot == dag.tail.slot:
       link(midRef, dag.tail)
-      dag.tail = midRef
       break
 
     let next = BlockRef.init(root, slot)
+
     link(midRef, next)
     midRef = next
 
@@ -1899,6 +1899,9 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
   dag.finalizedBlocks = finBlocks
   dag.tail = dag.genesis
+
+  # Without setting to nil here, there's a GC crash (!) in tests
+  midRef = nil
 
   if junk.len > 0:
     info "Dropping redundant states", junk

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1796,7 +1796,8 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
   var
     canonical = newSeq[Eth2Digest](
-      dag.finalizedHead.slot.epoch div EPOCHS_PER_STATE_SNAPSHOT)
+      (dag.finalizedHead.slot.epoch) div
+      EPOCHS_PER_STATE_SNAPSHOT)
     junk: seq[((Slot, Eth2Digest), Eth2Digest)]
 
   for k, v in roots:
@@ -1816,8 +1817,8 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
     if not dag.db.containsState(v):
       continue # If it's not in the database..
-
     canonical[k[0].epoch div EPOCHS_PER_STATE_SNAPSHOT] = v
+    doAssert k[0].epoch div EPOCHS_PER_STATE_SNAPSHOT < canonical.lenu64
 
   let
     state = (ref ForkedHashedBeaconState)()
@@ -1899,9 +1900,6 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
   dag.finalizedBlocks = finBlocks
   dag.tail = dag.genesis
-
-  # Without setting to nil here, there's a GC crash (!) in tests
-  midRef = nil
 
   if junk.len > 0:
     info "Dropping redundant states", junk

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1916,7 +1916,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
   dag.tail = dag.genesis
 
   if junk.len > 0:
-    info "Dropping redundant states", junk
+    info "Dropping redundant states", states = junk.len
 
     for i in junk:
       dag.db.delState(i[1])

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1796,7 +1796,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
   var
     canonical = newSeq[Eth2Digest](
-      (dag.finalizedHead.slot.epoch) div
+      (dag.finalizedHead.slot.epoch + EPOCHS_PER_STATE_SNAPSHOT - 1) div
       EPOCHS_PER_STATE_SNAPSHOT)
     junk: seq[((Slot, Eth2Digest), Eth2Digest)]
 
@@ -1817,8 +1817,8 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
     if not dag.db.containsState(v):
       continue # If it's not in the database..
+
     canonical[k[0].epoch div EPOCHS_PER_STATE_SNAPSHOT] = v
-    doAssert k[0].epoch div EPOCHS_PER_STATE_SNAPSHOT < canonical.lenu64
 
   let
     state = (ref ForkedHashedBeaconState)()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1819,6 +1819,7 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [Defect, CatchableEr
       config.trustedNodeUrl,
       config.blockId,
       config.backfillBlocks,
+      config.reindex,
       genesis)
 
 {.pop.} # TODO moduletests exceptions

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -14,7 +14,7 @@ It is possibly to use trusted node sync with a third-party API provider -- see [
 
 ## Perform a trusted node sync
 
-> **Tip:** Make sure to replace `http://localhost:5052` in the commands below with the appropriate endpoint for you. `http://localhost:5052` is the endpoint exposed by Nimbus but this is not consistent across all clients. For example, if your trusted node is a [Prysm node](https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api#performing-requests-against-a-local-prysm-node), it exposes `127.0.0.1:3500` by default. Which means you would run the commands below with 
+> **Tip:** Make sure to replace `http://localhost:5052` in the commands below with the appropriate endpoint for you. `http://localhost:5052` is the endpoint exposed by Nimbus but this is not consistent across all clients. For example, if your trusted node is a [Prysm node](https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api#performing-requests-against-a-local-prysm-node), it exposes `127.0.0.1:3500` by default. Which means you would run the commands below with
 >
 > `--trusted-node-url=http://127.0.0.1:3500`
 
@@ -37,8 +37,6 @@ build/nimbus_beacon_node trustedNodeSync --network:prater \
  --data-dir=build/data/shared_prater_0  \
  --trusted-node-url=http://localhost:5052
 ```
-
-
 
 > **Note:**
 > Because trusted node sync by default copies all blocks via REST, if you use a third-party service to sync from, you may hit API limits. If this happens to you, you may need to use the `--backfill` option to [delay the backfill of the block history](./trusted-node-sync.md#delay-block-history-backfill).
@@ -64,7 +62,6 @@ The `head` root is also printed in the log output at regular intervals.
 > ```
 
 
-
 ## Advanced
 
 ### Delay block history backfill
@@ -72,6 +69,8 @@ The `head` root is also printed in the log output at regular intervals.
 By default, both the state and the full block history will be downloaded from the trusted node.
 
 It is possible to get started more quickly by delaying the backfill of the block history using the `--backfill=false` parameter. In this case, the beacon node will first sync to the current head so that it can start performing its duties, then backfill the blocks from the network.
+
+You can also resume the trusted node backfill at any time by simply running the trusted node sync command again.
 
 > **Warning:** While backfilling blocks, your node will not be able to answer historical requests or sync requests. This might lead to you being de-scored, and eventually disconnected, by your peers.
 
@@ -97,6 +96,10 @@ curl -o block.32000.ssz -H 'Accept: application/octet-stream' http://localhost:5
 build/nimbus_beacon_node --data-dir:trusted --finalized-checkpoint-block=block.32000.ssz --finalized-checkpoint-state=state.32000.ssz
 ```
 
-## Caveats
+## Recreate historical state access indices
 
-A node synced using trusted node sync will not be able to serve historical requests via the Beacon API from before the checkpoint. Future versions will resolve this issue.
+When performing checkpoint sync, the historical state data from the time before the checkpoint is not available. To recreate the indices and caches necessary for historical state access, run trusted node sync with the `--reindex` flag - this can be done on an already-synced node as well, in which case the process will simply resume where it left off:
+
+```
+build/nimbus_beacon_node trustedNodeSync --reindex=true
+```

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -766,6 +766,11 @@ suite "Backfill":
 
       dag.backfill.slot == GENESIS_SLOT
 
+    dag.rebuildIndex()
+
+    check:
+      dag.getFinalizedEpochRef() != nil
+
   test "reload backfill position":
     let
       tailBlock = blocks[^1]


### PR DESCRIPTION
When performing trusted node sync, historical access is limited to
states after the checkpoint.

Reindexing restores full historical access by replaying historical
blocks against the state and storing snapshots in the database.

The process can be initiated or resumed at any point in time.