### PR TITLE
use v1.1.10 CL spec test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -53,7 +53,7 @@ export
 # Eventually, we could also differentiate between user/tainted data and
 # internal state that's gone through sanity checks already.
 
-const SPEC_VERSION* = "1.1.9"
+const SPEC_VERSION* = "1.1.10"
 ## Spec version we're aiming to be compatible with, right now
 
 const


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.1.10
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.1.10

No changes in non-tests code, aside from spec version string that's used in a few places.