### PR TITLE
validate `fork_version` as light client

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -142,7 +142,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         sync_aggregate: sync_aggregate,
         fork_version: state.fork.current_version)
       res = process_light_client_update(
-        store, update, signature_slot, state.genesis_validators_root)
+        store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
       res
@@ -206,7 +206,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         sync_aggregate: sync_aggregate,
         fork_version: state.fork.current_version)
       res = process_light_client_update(
-        store, update, signature_slot, state.genesis_validators_root)
+        store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
       res
@@ -297,7 +297,7 @@ suite "EF - Altair - Unittests - Sync protocol" & preset():
         sync_aggregate: sync_aggregate,
         fork_version: state.fork.current_version)
       res = process_light_client_update(
-        store, update, signature_slot, state.genesis_validators_root)
+        store, update, signature_slot, cfg, state.genesis_validators_root)
 
     check:
       res


### PR DESCRIPTION
The spec does not provide code for validating the `fork_version` field
of `LightClientUpdate`. However, we can use our own logic for additional
validation of that field. The spec's python test suite sets up states
that do not follow the fork schedule (e.g., that use Altair fork version
before Altair fork epoch), which complicates upstreaming this as code.