### PR TITLE
--stop-at-synced-epoch

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -261,11 +261,13 @@ type
         name: "verify-finalization" }: bool
 
       stopAtEpoch* {.
+        hidden
         desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "stop-at-epoch" }: uint64
 
       stopAtSyncedEpoch* {.
+        hidden
         desc: "The synced epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "stop-at-synced-epoch" }: uint64

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -261,9 +261,14 @@ type
         name: "verify-finalization" }: bool
 
       stopAtEpoch* {.
-        desc: "A positive epoch selects the epoch at which to stop"
+        desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "stop-at-epoch" }: uint64
+
+      stopAtSyncedEpoch* {.
+        desc: "The synced epoch at which to exit the program. (for testing purposes)"
+        defaultValue: 0
+        name: "stop-at-synced-epoch" }: uint64
 
       metricsEnabled* {.
         desc: "Enable the metrics server"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1118,6 +1118,10 @@ proc onSecond(node: BeaconNode) =
   # Nim GC metrics (for the main thread)
   updateThreadMetrics()
 
+  if node.config.stopAtSyncedEpoch != 0 and node.dag.head.slot.epoch >= node.config.stopAtSyncedEpoch:
+    notice "Shutting down after having reached the target synced epoch"
+    bnStatus = BeaconNodeStatus.Stopping
+
 proc runOnSecondLoop(node: BeaconNode) {.async.} =
   let sleepTime = chronos.seconds(1)
   const nanosecondsIn1s = float(chronos.seconds(1).nanoseconds)


### PR DESCRIPTION
This allows benchmarking the initial sync (only forward sync, 1s error margin). Might be useful in CI, with a timeout, as a sanity check.