### PR TITLE
update to pre-release light client sync protocol

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -799,13 +799,19 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 35/35 Fail: 0/35 Skip: 0/35
+## EF - Altair - Sync protocol - Light client [Preset: mainnet]
+```diff
+  All tests                                                                                  Skip
+```
+OK: 0/1 Fail: 0/1 Skip: 1/1
 ## EF - Altair - Unittests - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
++ test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1209,4 +1215,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1034/1035 Fail: 0/1035 Skip: 1/1035
+OK: 1035/1037 Fail: 0/1037 Skip: 2/1037

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -840,13 +840,19 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 35/35 Fail: 0/35 Skip: 0/35
+## EF - Altair - Sync protocol - Light client [Preset: minimal]
+```diff
+  All tests                                                                                  Skip
+```
+OK: 0/1 Fail: 0/1 Skip: 1/1
 ## EF - Altair - Unittests - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
 + process_light_client_update_timeout                                                        OK
++ test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1286,4 +1292,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1084/1104 Fail: 0/1104 Skip: 20/1104
+OK: 1085/1106 Fail: 0/1106 Skip: 21/1106

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -24,6 +24,10 @@
 
 {.push raises: [Defect].}
 
+# References to `vFuture` refer to the pre-release proposal of the libp2p based
+# light client sync protocol. Conflicting release versions are not in use.
+# https://github.com/ethereum/consensus-specs/pull/2802
+
 import
   std/[typetraits, sets, hashes],
   chronicles,
@@ -51,13 +55,14 @@ const
   TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE* = 16
   SYNC_COMMITTEE_SUBNET_COUNT* = 4
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#constants
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#constants
   # All of these indices are rooted in `BeaconState`.
   # The first member (`genesis_time`) is 32, subsequent members +1 each.
   # If there are ever more than 32 members in `BeaconState`, indices change!
   # `FINALIZED_ROOT_INDEX` is one layer deeper, i.e., `52 * 2 + 1`.
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/ssz/merkle-proofs.md
   FINALIZED_ROOT_INDEX* = 105.GeneralizedIndex # `finalized_checkpoint` > `root`
+  CURRENT_SYNC_COMMITTEE_INDEX* = 54.GeneralizedIndex # `current_sync_committee`
   NEXT_SYNC_COMMITTEE_INDEX* = 55.GeneralizedIndex # `next_sync_committee`
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/beacon-chain.md#participation-flag-indices
@@ -157,12 +162,23 @@ type
 
   ### Modified/overloaded
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#lightclientupdate
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientbootstrap
+  LightClientBootstrap* = object
+    header*: BeaconBlockHeader ##\
+    ## The requested beacon block header
+
+    # Current sync committee corresponding to the requested header
+    current_sync_committee*: SyncCommittee
+    current_sync_committee_branch*:
+      array[log2trunc(CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientupdate
   LightClientUpdate* = object
     attested_header*: BeaconBlockHeader ##\
     ## The beacon block header that is attested to by the sync committee
 
-    # Next sync committee corresponding to the active header
+    # Next sync committee corresponding to the active header,
+    # if signature is from current sync committee
     next_sync_committee*: SyncCommittee
     next_sync_committee_branch*:
       array[log2trunc(NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
@@ -176,6 +192,20 @@ type
 
     fork_version*: Version ##\
     ## Fork version for the aggregate signature
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#optimisticlightclientupdate
+  OptimisticLightClientUpdate* = object
+    attested_header*: BeaconBlockHeader ##\
+    ## The beacon block header that is attested to by the sync committee
+
+    sync_aggregate*: SyncAggregate ##\
+    ## Sync committee aggregate signature
+
+    fork_version*: Version ##\
+    ## Fork version for the aggregate signature
+
+    is_signed_by_next_sync_committee*: bool ##\
+    ## Whether the signature was produced by `attested_header`'s next sync committee
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#lightclientstore
   LightClientStore* = object

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -18,5 +18,6 @@ import
   ./test_fixture_sanity_slots,
   ./test_fixture_ssz_consensus_objects,
   ./test_fixture_state_transition_epoch,
+  ./test_fixture_sync_protocol_light_client_sync,
   ./test_fixture_sync_protocol,
   ./test_fixture_transition

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
@@ -1,0 +1,161 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+# This implements the pre-release proposal of the libp2p based light client sync
+# protocol. See https://github.com/ethereum/consensus-specs/pull/2802
+
+import
+  # Standard library
+  std/[json, os, streams],
+  # Status libraries
+  stew/bitops2,
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/light_client_sync,
+  ../../../beacon_chain/spec/datatypes/altair,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils
+
+const TestsDir =
+  SszTestsDir/const_preset/"altair"/"sync_protocol"/"light_client_sync"/"pyspec_tests"
+
+type
+  TestMeta = object
+    genesis_validators_root: string
+    trusted_block_root: string
+
+  TestStepKind {.pure.} = enum
+    ProcessSlot
+    ProcessUpdate
+    ProcessOptimisticUpdate
+
+  TestStep = object
+    case kind: TestStepKind
+    of TestStepKind.ProcessSlot:
+      discard
+    of TestStepKind.ProcessUpdate:
+      update: altair.LightClientUpdate
+    of TestStepKind.ProcessOptimisticUpdate:
+      optimistic_update: OptimisticLightClientUpdate
+    current_slot: Slot
+
+proc loadSteps(path: string): seq[TestStep] =
+  let stepsYAML = readFile(path/"steps.yaml")
+  let steps = yaml.loadToJson(stepsYAML)
+
+  result = @[]
+  for step in steps[0]:
+    if step.hasKey"process_slot":
+      let s = step["process_slot"]
+      result.add TestStep(kind: TestStepKind.ProcessSlot,
+                          current_slot: s["current_slot"].getInt().Slot)
+    elif step.hasKey"process_update":
+      let
+        s = step["process_update"]
+        filename = s["update"].getStr()
+        update = parseTest(path/filename & ".ssz_snappy", SSZ,
+                           altair.LightClientUpdate)
+      result.add TestStep(kind: TestStepKind.ProcessUpdate,
+                          update: update,
+                          current_slot: s["current_slot"].getInt().Slot)
+    elif step.hasKey"process_optimistic_update":
+      let
+        s = step["process_optimistic_update"]
+        filename = s["optimistic_update"].getStr()
+        optimistic_update = parseTest(path/filename & ".ssz_snappy", SSZ,
+                                      OptimisticLightClientUpdate)
+      result.add TestStep(kind: TestStepKind.ProcessOptimisticUpdate,
+                          optimistic_update: optimistic_update,
+                          current_slot: s["current_slot"].getInt().Slot)
+    else:
+      doAssert false, "Unreachable: " & $step
+
+proc runTest(identifier: string) =
+  let testDir = TestsDir / identifier
+
+  proc `testImpl _ sync_protocol_light_client_sync _ identifier`() =
+    test identifier:
+      let
+        meta = block:
+          var s = openFileStream(testDir/"meta.yaml")
+          defer: close(s)
+          var res: TestMeta
+          yaml.load(s, res)
+          res
+        genesis_validators_root =
+          Eth2Digest.fromHex(meta.genesis_validators_root)
+        trusted_block_root =
+          Eth2Digest.fromHex(meta.trusted_block_root)
+
+        bootstrap = parseTest(testDir/"bootstrap.ssz_snappy", SSZ,
+                              altair.LightClientBootstrap)
+        steps = loadSteps(testDir)
+
+        expected_finalized_header =
+          parseTest(testDir/"expected_finalized_header.ssz_snappy", SSZ,
+                    BeaconBlockHeader)
+        expected_optimistic_header =
+          parseTest(testDir/"expected_optimistic_header.ssz_snappy", SSZ,
+                    BeaconBlockHeader)
+
+      var cfg = defaultRuntimeConfig
+      cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+
+      var store =
+        initialize_light_client_store(trusted_block_root, bootstrap).get
+
+      for step in steps:
+        case step.kind
+        of TestStepKind.ProcessSlot:
+          process_slot_for_light_client_store(
+            store, step.current_slot)
+        of TestStepKind.ProcessUpdate:
+          let res = process_light_client_update(
+            store, step.update, step.current_slot,
+            cfg, genesis_validators_root)
+          check res
+        of TestStepKind.ProcessOptimisticUpdate:
+          let res = process_optimistic_light_client_update(
+            store, step.optimistic_update, step.current_slot,
+            cfg, genesis_validators_root)
+          check res
+
+      check:
+        store.finalized_header == expected_finalized_header
+        store.optimistic_header == expected_optimistic_header
+
+  `testImpl _ sync_protocol_light_client_sync _ identifier`()
+
+suite "EF - Altair - Sync protocol - Light client" & preset():
+  try:
+    for kind, path in walkDir(TestsDir, relative = true, checkDir = true):
+      runTest(path)
+  except OSError:
+    # These tests are for the pre-release proposal of the libp2p based light
+    # client sync protocol. Corresponding test vectors need manual integration.
+    # https://github.com/ethereum/consensus-specs/pull/2802
+    #
+    # To locally integrate the test vectors, clone the pre-release spec repo
+    # at latest commit of https://github.com/ethereum/consensus-specs/pull/2802
+    # and place it next to the `nimbus-eth2` repo, so that `nimbus-eth2` and
+    # `consensus-specs` are in the same directory.
+    #
+    # To generate the additional test vectors, from `consensus-specs`:
+    # $ rm -rf ../consensus-spec-tests && \
+    #   doctoc specs && make lint && make gen_sync_protocol
+    #
+    # To integrate the additional test vectors into `nimbus-eth2`, first run
+    # `make test` from `nimbus-eth2` to ensure that the regular test vectors
+    # have been downloaded and extracted, then proceed from `nimbus-eth2` with:
+    # $ rsync -r ../consensus-spec-tests/tests/ \
+    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.1.10/
+    test "All tests":
+      skip()


### PR DESCRIPTION
This adopts the spec sections of the pre-release proposal of the libp2p
based light client sync protocol, and also adds a test runner for the
new accompanying tests. While the release version of the light client
sync protocol contains conflicting definitions, it is currently unused,
and the code specific to the pre-release proposal is marked as such.
See https://github.com/ethereum/consensus-specs/pull/2802