### PR TITLE
Windows: give up stack traces for 66% better performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
             base-devel
             git
             mingw-w64-i686-toolchain
+            mingw-w64-i686-cmake
 
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
@@ -109,6 +110,7 @@ jobs:
             base-devel
             git
             mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
 
       - name: Restore Nim DLLs dependencies (Windows) from cache
         if: runner.os == 'Windows'
@@ -163,6 +165,7 @@ jobs:
           fi
 
           ncpu=""
+          make_cmd="make"
           case '${{ runner.os }}' in
           'Linux')
             ncpu=$(nproc)
@@ -172,14 +175,16 @@ jobs:
             ;;
           'Windows')
             ncpu=${NUMBER_OF_PROCESSORS}
+            make_cmd="mingw32-make"
             ;;
           esac
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
+          echo "make_cmd=${make_cmd}" >> $GITHUB_ENV
 
       - name: Build Nim and Nimbus dependencies
         run: |
-          make -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
+          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
           ./env.sh nim --version
 
       - name: Get latest fixtures commit hash
@@ -206,17 +211,17 @@ jobs:
 
       - name: Smoke test the Beacon Node and Validator Client with all tracing enabled
         run: |
-          make -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client
+          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client
 
       - name: Build all tools
         run: |
-          make -j ${ncpu} NIM_COMMIT=${{ matrix.branch }}
+          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }}
           # The Windows image runs out of disk space, so make some room
           rm -rf nimcache
 
       - name: Run tests
         run: |
-          make -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test
+          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test
 
       # The upload creates a combined report that gets posted as a comment on the PR
       # https://github.com/EnricoMi/publish-unit-test-result-action

--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,6 @@ all: | $(TOOLS) libnfuzz.so libnfuzz.a
 # must be included after the default target
 -include $(BUILD_SYSTEM_DIR)/makefiles/targets.mk
 
-ifeq ($(OS), Windows_NT)
-  # libbacktrace/libunwind is disabled on Windows.
-  USE_LIBBACKTRACE := 0
-endif
-
 DEPOSITS_DELAY := 0
 
 #- "--define:release" cannot be added to "config.nims"
@@ -131,8 +126,7 @@ DEPOSITS_DELAY := 0
 NIM_PARAMS += -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,prysm,teku
 
 ifeq ($(USE_LIBBACKTRACE), 0)
-# Blame Jacek for the lack of line numbers in your stack traces ;-)
-NIM_PARAMS += --stacktrace:on --excessiveStackTrace:on --linetrace:off -d:disable_libbacktrace
+NIM_PARAMS += -d:disable_libbacktrace
 endif
 
 deps: | deps-common nat-libs build/generate_makefile

--- a/config.nims
+++ b/config.nims
@@ -130,10 +130,7 @@ switch("define", "withoutPCRE")
 
 switch("import", "testutils/moduletests")
 
-const useLibStackTrace = not defined(windows) and
-                         not defined(disable_libbacktrace)
-
-when useLibStackTrace:
+when not defined(disable_libbacktrace):
   --define:nimStackTraceOverride
   switch("import", "libbacktrace")
 else:

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -53,6 +53,9 @@ if [[ "${PLATFORM}" == "Windows_amd64" ]]; then
   # undefined symbols, so we're forced to use g++ as a linker wrapper.
   # For some reason, macOS's Clang doesn't need this trick, nor do native (and
   # newer) Mingw-w64 toolchains on Windows.
+  #
+  # nim-blscurve's Windows SSSE3 detection doesn't work when cross-compiling,
+  # so we enable it here.
   make \
     -j$(nproc) \
     CC="${CC}" \
@@ -60,7 +63,7 @@ if [[ "${PLATFORM}" == "Windows_amd64" ]]; then
     CXXFLAGS="${CXXFLAGS} -D__STDC_FORMAT_MACROS -D_WIN32_WINNT=0x0600" \
     USE_VENDORED_LIBUNWIND=1 \
     LOG_LEVEL="TRACE" \
-    NIMFLAGS="${NIMFLAGS_COMMON} --os:windows --gcc.exe=${CC} --gcc.linkerexe=${CXX} --passL:-static" \
+    NIMFLAGS="${NIMFLAGS_COMMON} --os:windows --gcc.exe=${CC} --gcc.linkerexe=${CXX} --passL:-static -d:BLSTuseSSSE3=1" \
     ${BINARIES}
 elif [[ "${PLATFORM}" == "Linux_arm32v7" ]]; then
   CC="arm-linux-gnueabihf-gcc"


### PR DESCRIPTION
See: https://github.com/status-im/nimbus-eth2/issues/3453

TODO: make libbacktrace/libunwind work in MSYS2, to get those stack traces back.