### PR TITLE
add `start_slot` overload for sync periods

### DIFF
--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -231,10 +231,18 @@ template is_sync_committee_period*(epoch: Epoch): bool =
   epoch.since_sync_committee_period_start() == 0
 
 template start_epoch*(period: SyncCommitteePeriod): Epoch =
+  ## Return the start epoch of ``period``.
   const maxPeriod = SyncCommitteePeriod(
     FAR_FUTURE_EPOCH div EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
   if period >= maxPeriod: FAR_FUTURE_EPOCH
   else: Epoch(period * EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+
+template start_slot*(period: SyncCommitteePeriod): Slot =
+  ## Return the start slot of ``period``.
+  const maxPeriod = SyncCommitteePeriod(
+    FAR_FUTURE_SLOT div SLOTS_PER_SYNC_COMMITTEE_PERIOD)
+  if period >= maxPeriod: FAR_FUTURE_SLOT
+  else: Slot(period * SLOTS_PER_SYNC_COMMITTEE_PERIOD)
 
 func `$`*(t: BeaconTime): string =
   if t.ns_since_genesis >= 0:

--- a/tests/test_beacon_time.nim
+++ b/tests/test_beacon_time.nim
@@ -1,11 +1,15 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import
   unittest2,
-
   ../beacon_chain/spec/beacon_time
-
-{.used.}
 
 suite "Beacon time":
   test "basics":
@@ -19,9 +23,11 @@ suite "Beacon time":
 
       # Roundtrip far times we treat these as "Infinitiy"
       FAR_FUTURE_SLOT.epoch.start_slot() == FAR_FUTURE_SLOT
+      FAR_FUTURE_SLOT.sync_committee_period.start_slot() == FAR_FUTURE_SLOT
       FAR_FUTURE_EPOCH.start_slot().epoch() == FAR_FUTURE_EPOCH
       FAR_FUTURE_SLOT.start_beacon_time().slotOrZero() == FAR_FUTURE_SLOT
       FAR_FUTURE_PERIOD.start_epoch().sync_committee_period() == FAR_FUTURE_PERIOD
+      FAR_FUTURE_PERIOD.start_slot().sync_committee_period() == FAR_FUTURE_PERIOD
 
       BeaconTime(ns_since_genesis: -10000000000).slotOrZero == Slot(0)
       Slot(5).since_epoch_start() == 5
@@ -35,6 +41,9 @@ suite "Beacon time":
 
       Epoch(3).start_slot.is_epoch()
       SyncCommitteePeriod(5).start_epoch().is_sync_committee_period()
+      SyncCommitteePeriod(5).start_slot().is_sync_committee_period()
 
       Epoch(5).start_slot.sync_committee_period ==
         Epoch(5).sync_committee_period
+      SyncCommitteePeriod(5).start_slot.sync_committee_period ==
+        SyncCommitteePeriod(5)


### PR DESCRIPTION
Adds a `start_slot` overload for `SyncCommitteePeriod` as a shortcut for
`period.start_epoch.start_slot`.