### PR TITLE
relax `BlockRef` database assumptions

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -138,8 +138,9 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
         else:
           epochRef = dag.getEpochRef(blckRef, blckRef.slot.epoch, false).expect(
             "Getting an EpochRef should always work for non-finalized blocks")
-
-          withBlck(dag.getForkedBlock(blckRef)):
+          let blck = dag.getForkedBlock(blckRef.bid).expect(
+              "Should be able to load initial fork choice blocks")
+          withBlck(blck):
             forkChoice.process_block(
               dag, epochRef, blckRef, blck.message,
               blckRef.slot.start_beacon_time)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -198,7 +198,7 @@ func toBlockSlotId*(bs: BlockSlot): BlockSlotId =
 
 func isProposed*(bid: BlockId, slot: Slot): bool =
   ## Return true if `bid` was proposed in the given slot
-  bid.slot == slot
+  bid.slot == slot and not bid.root.isZero
 
 func isProposed*(blck: BlockRef, slot: Slot): bool =
   ## Return true if `blck` was proposed in the given slot

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -68,7 +68,6 @@ template withStateVars*(
   template stateRoot(): Eth2Digest {.inject, used.} =
     getStateRoot(stateDataInternal.data)
   template blck(): BlockRef {.inject, used.} = stateDataInternal.blck
-  template root(): Eth2Digest {.inject, used.} = stateDataInternal.data.root
 
   body
 
@@ -428,11 +427,6 @@ proc getForkedBlock*(
     blck = getBlock(dag, bid, T).valueOr:
       result.err()
       return
-
-proc getForkedBlock*(
-    dag: ChainDAGRef, blck: BlockRef): ForkedTrustedSignedBeaconBlock =
-  dag.getForkedBlock(blck.bid).expect(
-    "BlockRef block should always load, database corrupt?")
 
 proc getForkedBlock*(
     dag: ChainDAGRef, root: Eth2Digest): Opt[ForkedTrustedSignedBeaconBlock] =
@@ -1220,7 +1214,6 @@ proc updateStateData*(
       found,
       assignDur,
       replayDur
-
   elif ancestors.len > 0:
     debug "State replayed",
       blocks = ancestors.len,

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -159,11 +159,14 @@ proc getForkedBlockFromBlockId(
     raises: [Defect, CatchableError].} =
   case blockId:
     of "head":
-      node.dag.getForkedBlock(node.dag.head)
+      node.dag.getForkedBlock(node.dag.head.bid).valueOr:
+        raise newException(CatchableError, "Block not found")
     of "genesis":
-      node.dag.getForkedBlock(node.dag.genesis)
+      node.dag.getForkedBlock(node.dag.genesis.bid).valueOr:
+        raise newException(CatchableError, "Block not found")
     of "finalized":
-      node.dag.getForkedBlock(node.dag.finalizedHead.blck)
+      node.dag.getForkedBlock(node.dag.finalizedHead.blck.bid).valueOr:
+        raise newException(CatchableError, "Block not found")
     else:
       if blockId.startsWith("0x"):
         let

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -956,7 +956,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
         clear cache
 
   for bi in 0 ..< blockRefs.len:
-    let forkedBlock = dag.getForkedBlock(blockRefs[blockRefs.len - bi - 1])
+    let forkedBlock = dag.getForkedBlock(blockRefs[blockRefs.len - bi - 1].bid).get()
     withBlck(forkedBlock):
       processSlots(blck.message.slot, {skipLastStateRootCalculation})
 

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -83,10 +83,14 @@ suite "BlockSlot and helpers":
 
   test "parent sanity":
     let
+      root = block:
+        var d: Eth2Digest
+        d.data[0] = 1
+        d
       s0 = BlockRef(bid: BlockId(slot: Slot(0)))
       s00 = BlockSlot(blck: s0, slot: Slot(0))
       s01 = BlockSlot(blck: s0, slot: Slot(1))
-      s2 = BlockRef(bid: BlockId(slot: Slot(2)), parent: s0)
+      s2 = BlockRef(bid: BlockId(slot: Slot(2), root: root), parent: s0)
       s22 = BlockSlot(blck: s2, slot: Slot(2))
       s24 = BlockSlot(blck: s2, slot: Slot(4))
 

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -541,7 +541,7 @@ suite "chain DAG finalization tests" & preset():
         assign(tmpStateData[], dag.headState)
         check:
           dag.updateStateData(tmpStateData[], cur.atSlot(cur.slot), false, cache)
-          dag.getForkedBlock(cur).phase0Data.message.state_root ==
+          dag.getForkedBlock(cur.bid).get().phase0Data.message.state_root ==
             getStateRoot(tmpStateData[].data)
           getStateRoot(tmpStateData[].data) == hash_tree_root(
             tmpStateData[].data.phase0Data.data)


### PR DESCRIPTION
* remove `getForkedBlock(BlockRef)` which assumes block data exists but
doesn't support archive/backfilled blocks
* fix REST `/eth/v1/beacon/headers` request not returning
archive/backfilled blocks
* avoid re-encoding in REST block SSZ requests (using `getBlockSSZ`)