### PR TITLE
add support for `ResourceUnavailable` p2p error

### DIFF
--- a/beacon_chain/networking/faststreams_backend.nim
+++ b/beacon_chain/networking/faststreams_backend.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -112,7 +112,7 @@ proc readResponseChunk(s: AsyncInputStream,
 
   let responseCode = ResponseCode responseCodeByte
   case responseCode:
-  of InvalidRequest, ServerError:
+  of InvalidRequest, ServerError, ResourceUnavailable:
     let errorMsgChunk = await readChunkPayload(s, noSnappy, string)
     let errorMsg = if errorMsgChunk.isOk: errorMsgChunk.value
                    else: return err(errorMsgChunk.error)

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -148,7 +148,7 @@ proc readResponseChunk(conn: Connection, peer: Peer,
 
     let responseCode = ResponseCode responseCodeByte
     case responseCode:
-    of InvalidRequest, ServerError:
+    of InvalidRequest, ServerError, ResourceUnavailable:
       let
         errorMsgChunk = await readChunkPayload(conn, peer, ErrorMsg)
         errorMsg = if errorMsgChunk.isOk: errorMsgChunk.value


### PR DESCRIPTION
The `p2p-interface.md` spec defines a `ResourceUnavailable` error to
return in situations where data that exists on the network is locally
unavailable, e.g., when a block within `MIN_EPOCHS_FOR_BLOCK_REQUESTS`
is requested by `BeaconBlocksByRange` but cannot be provided. This patch
adds support for that additional error code.