### PR TITLE
launch_local_testnet.sh: Lighthouse VC nodes

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -614,6 +614,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
       ./build/${LH_BINARY} vc \
         --debug-level "debug" \
         --logfile-max-number 0 \
+        --log-format "JSON" \
         --validators-dir "${VALIDATOR_DATA_DIR}" \
         --secrets-dir "${VALIDATOR_DATA_DIR}/secrets" \
         --beacon-nodes "http://127.0.0.1:$((BASE_REST_PORT + NUM_NODE))" \


### PR DESCRIPTION
Using LH VC nodes:
`./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --disable-htop --lighthouse-vc-nodes 2 -- --verify-finalization --discv5:no`

For the next runs, do yourself a favour and add `--reuse-binaries` before `--`. They'll be built once more, because they've just been deleted.

Problems so far:
- missing REST API call (non-fatal): `{"lvl":"DBG","ts":"2022-03-09 11:52:54.994+01:00","msg":"Request is not part of API","topics":"beacnde","peer":"127.0.0.1:57826","meth":"GET","uri":"/lighthouse/staking"}`
- ~~a more serious looking one, on the LH VC side: `Mar 09 12:06:21.019 CRIT Error during attestation routine        slot: 65, committee_index: 0, error: "All endpoints failed http://127.0.0.1:7500/ => Unavailable(Offline), http://127.0.0.1:7500/ => Unavailable(Offline)", service: attestation`~~ (BN was offline due to the assertion failure)
- BN assertion failure:

```text
{"lvl":"DBG","ts":"2022-03-09 12:06:17.328+01:00","msg":"batch crypto - failure, falling back","topics":"gossip_checks","items":1}
../csu/libc-start.c(409)
../sysdeps/nptl/libc_start_call_main.h(58)
/mnt/sde1/storage/nimbus-eth2/vendor/nim-json-rpc/json_rpc/client.nim(381) main
/mnt/sde1/storage/nimbus-eth2/vendor/nim-json-rpc/json_rpc/client.nim(374) NimMain
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1930) main
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1799) handleStartUpCmd
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1644) doRunBeaconNode
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1456) start
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1400) run
/mnt/sde1/storage/nimbus-eth2/vendor/nim-chronos/chronos/asyncloop.nim(279) poll
/mnt/sde1/storage/nimbus-eth2/vendor/nim-chronos/chronos/asyncfutures2.nim(365) futureContinue
/mnt/sde1/storage/nimbus-eth2/beacon_chain/gossip_processing/gossip_validation.nim(170) validateAttestation
/mnt/sde1/storage/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/assertions.nim(22) raiseAssert
/mnt/sde1/storage/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(49) sysFatal
[[reraised from:
../csu/libc-start.c(409)
../sysdeps/nptl/libc_start_call_main.h(58)
/mnt/sde1/storage/nimbus-eth2/vendor/nim-json-rpc/json_rpc/client.nim(381) main
/mnt/sde1/storage/nimbus-eth2/vendor/nim-json-rpc/json_rpc/client.nim(374) NimMain
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1930) main
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1799) handleStartUpCmd
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1644) doRunBeaconNode
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1456) start
/mnt/sde1/storage/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1400) run
/mnt/sde1/storage/nimbus-eth2/vendor/nim-chronos/chronos/asyncloop.nim(279) poll
/mnt/sde1/storage/nimbus-eth2/vendor/nim-chronos/chronos/asyncfutures2.nim(387) futureContinue
]]
Error: unhandled exception: Attestation: invalid signature [AssertionError]
```