### PR TITLE
allow `SyncCommitteePeriod` as libp2p params

### DIFF
--- a/beacon_chain/spec/ssz_codec.nim
+++ b/beacon_chain/spec/ssz_codec.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -17,7 +17,7 @@ export codec, base, typetraits
 
 # Coding and decoding of SSZ to spec-specific types
 
-template toSszType*(v: Slot|Epoch): auto = uint64(v)
+template toSszType*(v: Slot|Epoch|SyncCommitteePeriod): auto = uint64(v)
 template toSszType*(v: BlsCurveType): auto = toRaw(v)
 template toSszType*(v: ForkDigest|GraffitiBytes): auto = distinctBase(v)
 template toSszType*(v: Version): auto = distinctBase(v)
@@ -32,6 +32,9 @@ template fromSszBytes*(T: type Slot, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
 template fromSszBytes*(T: type Epoch, bytes: openArray[byte]): T =
+  T fromSszBytes(uint64, bytes)
+
+template fromSszBytes*(T: type SyncCommitteePeriod, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
 func fromSszBytes*(T: type ForkDigest, bytes: openArray[byte]): T {.raisesssz.} =


### PR DESCRIPTION
Adds a converter to allow using `SyncCommitteePeriod` as parameter for
libp2p messages (used in pre-release light client sync protocol).