### PR TITLE
libp2p light client gossip validation

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -814,6 +814,10 @@ proc addAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest, slot: Sl
 
   node.network.updateSyncnetsMetadata(currentSyncCommitteeSubnets)
 
+  if node.config.serveLightClientData:
+    node.network.subscribe(
+      getOptimisticLightClientUpdateTopic(forkDigest), basicParams)
+
 proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removePhase0MessageHandlers(forkDigest)
 
@@ -824,6 +828,9 @@ proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
 
   node.network.unsubscribe(
     getSyncCommitteeContributionAndProofTopic(forkDigest))
+
+  if node.config.serveLightClientData:
+    node.network.unsubscribe(getOptimisticLightClientUpdateTopic(forkDigest))
 
 proc trackCurrentSyncCommitteeTopics(node: BeaconNode, slot: Slot) =
   # Unlike trackNextSyncCommitteeTopics, just snap to the currently correct
@@ -1322,6 +1329,21 @@ proc installMessageValidators(node: BeaconNode) =
 
   installSyncCommitteeeValidators(node.dag.forkDigests.altair)
   installSyncCommitteeeValidators(node.dag.forkDigests.bellatrix)
+
+  template installOptimisticLightClientUpdateValidator(digest: auto) =
+    node.network.addValidator(
+      getOptimisticLightClientUpdateTopic(digest),
+      proc(msg: OptimisticLightClientUpdate): ValidationResult =
+        if node.config.serveLightClientData:
+          toValidationResult(
+            node.processor[].optimisticLightClientUpdateValidator(
+              MsgSource.gossip, msg))
+        else:
+          debug "Ignoring optimistic light client update: Feature disabled"
+          ValidationResult.Ignore)
+
+  installOptimisticLightClientUpdateValidator(node.dag.forkDigests.altair)
+  installOptimisticLightClientUpdateValidator(node.dag.forkDigests.bellatrix)
 
 proc stop(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -7,6 +7,10 @@
 
 {.push raises: [Defect].}
 
+# References to `vFuture` refer to the pre-release proposal of the libp2p based
+# light client sync protocol. Conflicting release versions are not in use.
+# https://github.com/ethereum/consensus-specs/pull/2802
+
 import
   "."/[helpers, forks],
   "."/datatypes/base
@@ -93,6 +97,11 @@ func getSyncCommitteeTopic*(forkDigest: ForkDigest,
 func getSyncCommitteeContributionAndProofTopic*(forkDigest: ForkDigest): string =
   ## For subscribing and unsubscribing to/from a subnet.
   eth2Prefix(forkDigest) & "sync_committee_contribution_and_proof/ssz_snappy"
+
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#optimistic_light_client_update
+func getOptimisticLightClientUpdateTopic*(forkDigest: ForkDigest): string =
+  ## For broadcasting or obtaining the latest `OptimisticLightClientUpdate`.
+  eth2Prefix(forkDigest) & "optimistic_light_client_update_v0/ssz_snappy"
 
 func getENRForkID*(cfg: RuntimeConfig,
                    epoch: Epoch,


### PR DESCRIPTION
When `--serve-light-client-data` is specified, provides stability on the
`optimistic_light_client_update` GossipSub topic.