### PR TITLE
serve light client data in CI / dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ define CONNECT_TO_NETWORK_IN_DEV_MODE
 		--network=$(1) $(3) $(GOERLI_TESTNETS_PARAMS) \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_$(1)_$(NODE_ID) \
+		--serve-light-client-data=1 --import-light-client-data=only-new \
 		--dump $(NODE_PARAMS)
 endef
 

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -597,6 +597,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     ${STOP_AT_EPOCH_FLAG} \
     --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
+    --serve-light-client-data=1 --import-light-client-data=only-new \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &
 


### PR DESCRIPTION
Adjust config for CI / dev builds to serve light client data by default:
`--serve-light-client-data=1 --import-light-client-data=only-new`