### PR TITLE
Rpc pubkey

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -360,6 +360,8 @@ func fromHex*(T: type BlsCurveType, hexStr: string): BlsResult[T] {.inline.} =
 func `==`*(a, b: ValidatorPubKey | ValidatorSig): bool =
   equalMem(unsafeAddr a.blob[0], unsafeAddr b.blob[0], sizeof(a.blob))
 
+func `==`*(a, b: ValidatorPrivKey): bool {.error: "Secret keys should stay secret".}
+
 # Hashing
 # ----------------------------------------------------------------------
 


### PR DESCRIPTION
This centralizes all crypto handling in crypto.nim instead of having it sprawled out.

In particular, for REST and RPC, pubkeys are supplied by users and due to lazy validation, those are unchecked (no check that they are infnity, on curve or in subgroup).
Fortunately:
1. We require the endpoint to be exposed only to trusted services (either local or in a safe network)
2. All codepaths in REST and RPC compares the pubkey with the known one from the Ethereum Beacon State, hence invalid keys cannot slip in.

Alternative: since RPC is scheduled for deprecation, we can also deleted the related files instead of merging this PR.

Regarding REST, validators pubkeys go through ValidatorIdent and/or `node.restKeysCache` and those are compared to the known validators key before use so no issue there: 

https://github.com/status-im/nimbus-eth2/blob/13b264d509d48909bb354f85b879f22641723509/beacon_chain/rpc/rest_beacon_api.nim#L339-L362

Closes #1715