### PR TITLE
enable multithreading by default (10-20% faster sync)

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -191,8 +191,8 @@ type
       name: "slashing-db-kind" }: SlashingDbKind
 
     numThreads* {.
-      defaultValue: 1,
-      desc: "Number of worker threads (set this to 0 to use as many threads as there are CPU cores available)"
+      defaultValue: 0,
+      desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
       name: "num-threads" }: int
 
     case cmd* {.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -36,8 +36,8 @@ The following options are available:
      --insecure-netkey-password  Use pre-generated INSECURE password for network private key file [=false].
      --agent-string            Node agent string which is used as identifier in network [=nimbus].
      --subscribe-all-subnets   Subscribe to all subnet topics when gossiping [=false].
-     --num-threads             Number of worker threads (set this to 0 to use as many threads as there are CPU
-                               cores available) [=1].
+     --num-threads             Number of worker threads ("0" = use as many threads as there are CPU cores
+                               available) [=0].
  -b, --bootstrap-node          Specifies one or more bootstrap nodes to use when connecting to the network.
      --bootstrap-file          Specifies a line-delimited file of bootstrap Ethereum network addresses.
      --listen-address          Listening address for the Ethereum LibP2P and Discovery v5 traffic [=0.0.0.0].


### PR DESCRIPTION
Rough benchmarking with: `rm -rf build/data/shared_mainnet_0; time ./run-mainnet-beacon-node.sh --web3-url="wss://mainnet.infura.io/ws/v3/${API_TOKEN}" --metrics --metrics-port=8008 --enr-auto-update --doppelganger-detection=off --num-threads=${NUM_THREADS} --stop-at-synced-epoch=100`

```text
--num-threads=8

real	1m28.981s
real	1m26.053s
real	1m28.969s
real	1m30.038s
real	1m35.041s

--num-treads=4

real	1m30.962s
real	1m35.034s
real	1m38.018s
real	1m31.063s
real	1m39.157s

--num-treads=2

real	1m51.949s
real	1m40.074s
real	1m37.180s
real	1m40.123s
real	1m41.047s

--num-threads=1

real	1m55.136s
real	1m57.015s
real	1m56.067s
real	1m55.031s
real	1m52.030s
```

There is no danger of overloading all CPU cores on a low-end machine. Here's the CPU usage for 8, 4, 2 and 1 thread:

![Screenshot 2022-03-14 at 12-42-01 NBC local testnet sim (all nodes) - Grafana](https://user-images.githubusercontent.com/495550/158178538-0931d01f-ddc8-4472-96ee-620f19c8cb21.png)
