### PR TITLE
increase Jenkins timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,7 +97,7 @@ def runStages(nodeDir) {
 parallel(
 	"Linux": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 4, unit: 'HOURS') {
+			timeout(time: 5, unit: 'HOURS') {
 				node("linux") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
 						runStages("linux")
@@ -108,7 +108,7 @@ parallel(
 	},
 	"macOS (AMD64)": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 4, unit: 'HOURS') {
+			timeout(time: 5, unit: 'HOURS') {
 				node("macos && x86_64") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 						runStages("macos_amd64")
@@ -119,7 +119,7 @@ parallel(
 	},
 	"macOS (ARM64)": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 4, unit: 'HOURS') {
+			timeout(time: 5, unit: 'HOURS') {
 				node("macos && arm64") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 						runStages("macos_arm64")


### PR DESCRIPTION
In theory, it's a nice stopgap to prevent things from running forever. However, it counts queued time, during which the CI for a branch isn't running at all, against that branch. While I'm sure there were some arguments for this design, the effect is that it semi-regularly cancels perfectly well-running Jenkins CI jobs as a result of their having been queued for too long.

This has the opposite effect as one might hope: since they still need to run eventually, it increases total Jenkins CI work. To the extent that the Jenkins jobs take longer than ideal, well, they might. But randomly cutting them off just means they need to be rerun, and machine time spent on first run was wasted. Counterproductive regardless of typical ranges of intention.

The previous PR of this sort increased the timeout from 3 hours to 4 hours. This one increases it to 5 hours.