### PR TITLE
remove StateData

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -67,7 +67,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + getBlockRef returns none for missing blocks                                                OK
 + loading tail block works [Preset: mainnet]                                                 OK
 + updateHead updates head and headState [Preset: mainnet]                                    OK
-+ updateStateData sanity [Preset: mainnet]                                                   OK
++ updateState sanity [Preset: mainnet]                                                       OK
 ```
 OK: 6/6 Fail: 0/6 Skip: 0/6
 ## Block processor [Preset: mainnet]

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -664,7 +664,7 @@ proc putState*(db: BeaconChainDB, key: Eth2Digest, value: ForkyBeaconState) =
 
 proc putState*(db: BeaconChainDB, state: ForkyHashedBeaconState) =
   db.withManyWrites:
-    db.putStateRoot(state.latest_block_root(), state.data.slot, state.root)
+    db.putStateRoot(state.latest_block_root, state.data.slot, state.root)
     db.putState(state.root, state.data)
 
 # For testing rollback

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -149,9 +149,8 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
 
   info "Fork choice initialized",
     justified_epoch = getStateField(
-      dag.headState.data, current_justified_checkpoint).epoch,
-    finalized_epoch = getStateField(
-      dag.headState.data, finalized_checkpoint).epoch,
+      dag.headState, current_justified_checkpoint).epoch,
+    finalized_epoch = getStateField(dag.headState, finalized_checkpoint).epoch,
     finalized_root = shortLog(dag.finalizedHead.blck.root)
 
   T(

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -140,6 +140,9 @@ type
       ## go - the tail block is unique in that its parent is set to `nil`, even
       ## in the case where an earlier genesis block exists.
 
+    head*: BlockRef
+      ## The most recently known head, as chosen by fork choice
+
     backfill*: BeaconBlockSummary
       ## The backfill points to the oldest block with an unbroken ancestry from
       ## dag.tail - when backfilling, we'll move backwards in time starting
@@ -162,17 +165,19 @@ type
     # -----------------------------------
     # Rewinder - Mutable state processing
 
-    headState*: StateData
+    headState*: ForkedHashedBeaconState
       ## State given by the head block - must only be updated in `updateHead` -
       ## always matches dag.head
 
-    epochRefState*: StateData
+    epochRefState*: ForkedHashedBeaconState
       ## State used to produce epochRef instances - must only be used in
       ## `getEpochRef`
 
-    clearanceState*: StateData
+    clearanceState*: ForkedHashedBeaconState
       ## Cached state used during block clearance - must only be used in
       ## clearance module
+    clearanceBlck*: BlockRef
+      ## The latest block that was applied to the clearance state
 
     updateFlags*: UpdateFlags
 
@@ -248,12 +253,6 @@ type
 
     # balances, as used in fork choice
     effective_balances_bytes*: seq[byte]
-
-  StateData* = object
-    data*: ForkedHashedBeaconState
-
-    blck*: BlockRef
-    ## The block associated with the state found in data
 
   # TODO when Nim 1.2 support is dropped, make these generic. 1.2 generates
   # invalid C code, which gcc refuses to compile. Example test case:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -42,7 +42,7 @@ func computeEarliestLightClientSlot*(dag: ChainDAGRef): Slot =
     minSupportedSlot = max(
       dag.cfg.ALTAIR_FORK_EPOCH.start_slot,
       dag.lightClientCache.importTailSlot)
-    currentSlot = getStateField(dag.headState.data, slot)
+    currentSlot = getStateField(dag.headState, slot)
   if currentSlot < minSupportedSlot:
     return minSupportedSlot
 
@@ -61,7 +61,7 @@ func computeEarliestLightClientSlot*(dag: ChainDAGRef): Slot =
 
 proc currentSyncCommitteeForPeriod(
     dag: ChainDAGRef,
-    tmpState: var StateData,
+    tmpState: var ForkedHashedBeaconState,
     period: SyncCommitteePeriod): SyncCommittee =
   ## Fetch a `SyncCommittee` for a given sync committee period.
   ## For non-finalized periods, follow the chain as selected by fork choice.
@@ -74,7 +74,7 @@ proc currentSyncCommitteeForPeriod(
     # data for the period
     bs = dag.getBlockAtSlot(syncCommitteeSlot).expect("TODO")
   dag.withUpdatedState(tmpState, bs) do:
-    withState(stateData.data):
+    withState(state):
       when stateFork >= BeaconStateFork.Altair:
         state.data.current_sync_committee
       else: raiseAssert "Unreachable"
@@ -90,7 +90,7 @@ template syncCommitteeRoot(
 
 proc syncCommitteeRootForPeriod(
     dag: ChainDAGRef,
-    tmpState: var StateData,
+    tmpState: var ForkedHashedBeaconState,
     period: SyncCommitteePeriod): Eth2Digest =
   ## Compute a root to uniquely identify `current_sync_committee` and
   ## `next_sync_committee` for a given sync committee period.
@@ -102,7 +102,7 @@ proc syncCommitteeRootForPeriod(
     syncCommitteeSlot = max(periodStartSlot, earliestSlot)
     bs = dag.getBlockAtSlot(syncCommitteeSlot).expect("TODO")
   dag.withUpdatedState(tmpState, bs) do:
-    withState(stateData.data):
+    withState(state):
       when stateFork >= BeaconStateFork.Altair:
         state.syncCommitteeRoot
       else: raiseAssert "Unreachable"
@@ -391,7 +391,7 @@ proc createLightClientUpdates(
 
 proc processNewBlockForLightClient*(
     dag: ChainDAGRef,
-    state: StateData,
+    state: ForkedHashedBeaconState,
     signedBlock: ForkyTrustedSignedBeaconBlock,
     parent: BlockRef) =
   ## Update light client data with information from a new block.
@@ -401,11 +401,11 @@ proc processNewBlockForLightClient*(
     return
 
   when signedBlock is bellatrix.TrustedSignedBeaconBlock:
-    dag.cacheLightClientData(state.data.bellatrixData, signedBlock)
-    dag.createLightClientUpdates(state.data.bellatrixData, signedBlock, parent)
+    dag.cacheLightClientData(state.bellatrixData, signedBlock)
+    dag.createLightClientUpdates(state.bellatrixData, signedBlock, parent)
   elif signedBlock is altair.TrustedSignedBeaconBlock:
-    dag.cacheLightClientData(state.data.altairData, signedBlock)
-    dag.createLightClientUpdates(state.data.altairData, signedBlock, parent)
+    dag.cacheLightClientData(state.altairData, signedBlock)
+    dag.createLightClientUpdates(state.altairData, signedBlock, parent)
   elif signedBlock is phase0.TrustedSignedBeaconBlock:
     discard
   else:
@@ -428,7 +428,7 @@ proc processHeadChangeForLightClient*(dag: ChainDAGRef) =
         let key = (period, dag.syncCommitteeRootForPeriod(tmpState[], period))
         dag.lightClientCache.bestUpdates[period] =
           dag.lightClientCache.pendingBestUpdates.getOrDefault(key)
-    withState(dag.headState.data):
+    withState(dag.headState):
       when stateFork >= BeaconStateFork.Altair:
         let key = (headPeriod, state.syncCommitteeRoot)
         dag.lightClientCache.bestUpdates[headPeriod] =
@@ -586,7 +586,7 @@ proc initBestLightClientUpdateForPeriod(
     let
       finalizedEpoch = block:
         dag.withUpdatedState(tmpState[], bestFinalizedRef.parent.atSlot) do:
-          withState(stateData.data):
+          withState(state):
             when stateFork >= BeaconStateFork.Altair:
               state.data.finalized_checkpoint.epoch
             else: raiseAssert "Unreachable"
@@ -607,7 +607,7 @@ proc initBestLightClientUpdateForPeriod(
     # Fill data from attested block
     dag.withUpdatedState(tmpState[], bestFinalizedRef.parent.atSlot) do:
       let bdata = dag.getForkedBlock(blck.bid).get
-      withStateAndBlck(stateData.data, bdata):
+      withStateAndBlck(state, bdata):
         when stateFork >= BeaconStateFork.Altair:
           update.attested_header =
             blck.toBeaconBlockHeader
@@ -629,7 +629,7 @@ proc initBestLightClientUpdateForPeriod(
     # Fill data from finalized block
     dag.withUpdatedState(tmpState[], finalizedBlck.atSlot) do:
       let bdata = dag.getForkedBlock(blck.bid).get
-      withStateAndBlck(stateData.data, bdata):
+      withStateAndBlck(state, bdata):
         when stateFork >= BeaconStateFork.Altair:
           update.next_sync_committee =
             state.data.next_sync_committee
@@ -643,7 +643,7 @@ proc initBestLightClientUpdateForPeriod(
     # Fill data from attested block
     dag.withUpdatedState(tmpState[], bestNonFinalizedRef.parent.atSlot) do:
       let bdata = dag.getForkedBlock(blck.bid).get
-      withStateAndBlck(stateData.data, bdata):
+      withStateAndBlck(state, bdata):
         when stateFork >= BeaconStateFork.Altair:
           update.attested_header =
             blck.toBeaconBlockHeader
@@ -705,10 +705,10 @@ proc initLightClientBootstrapForPeriod(
         blck.slot >= lowSlot and blck.slot <= highSlot and
         not dag.lightClientCache.bootstrap.hasKey(blck.slot):
       var cachedBootstrap {.noinit.}: CachedLightClientBootstrap
-      doAssert dag.updateStateData(
+      doAssert dag.updateState(
         tmpState[], blck.atSlot, save = false, tmpCache)
       withStateVars(tmpState[]):
-        withState(stateData.data):
+        withState(state):
           when stateFork >= BeaconStateFork.Altair:
             state.data.build_proof(
               altair.CURRENT_SYNC_COMMITTEE_INDEX,
@@ -756,11 +756,11 @@ proc initLightClientCache*(dag: ChainDAGRef) =
     cpIndex = 0
   for i in countdown(blocksBetween.high, blocksBetween.low):
     blockRef = blocksBetween[i]
-    doAssert dag.updateStateData(
+    doAssert dag.updateState(
       dag.headState, blockRef.atSlot(blockRef.slot), save = false, cache)
     withStateVars(dag.headState):
-      let bdata = dag.getForkedBlock(blck.bid).get
-      withStateAndBlck(stateData.data, bdata):
+      let bdata = dag.getForkedBlock(dag.head.bid).get
+      withStateAndBlck(state, bdata):
         when stateFork >= BeaconStateFork.Altair:
           # Cache data for `LightClientUpdate` of descendant blocks
           dag.cacheLightClientData(state, blck, isNew = false)
@@ -791,11 +791,11 @@ proc initLightClientCache*(dag: ChainDAGRef) =
                 dag.getBlockAtSlot(checkpoint.epoch.start_slot).expect("TODO").blck
               if cpRef != nil and cpRef.slot >= earliestSlot:
                 assert cpRef.bid.root == checkpoint.root
-                doAssert dag.updateStateData(
+                doAssert dag.updateState(
                   tmpState[], cpRef.atSlot, save = false, tmpCache)
                 withStateVars(tmpState[]):
-                  let bdata = dag.getForkedBlock(blck.bid).get
-                  withStateAndBlck(stateData.data, bdata):
+                  let bdata = dag.getForkedBlock(cpRef.bid).get
+                  withStateAndBlck(state, bdata):
                     when stateFork >= BeaconStateFork.Altair:
                       dag.cacheLightClientData(state, blck, isNew = false)
                     else: raiseAssert "Unreachable"
@@ -880,7 +880,7 @@ proc getLightClientBootstrap*(
         if dag.importLightClientData == ImportLightClientData.OnDemand:
           var tmpState = assignClone(dag.headState)
           dag.withUpdatedState(tmpState[], dag.getBlockAtSlot(slot).expect("TODO")) do:
-            withState(stateData.data):
+            withState(state):
               when stateFork >= BeaconStateFork.Altair:
                 state.data.build_proof(
                   altair.CURRENT_SYNC_COMMITTEE_INDEX,

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -757,9 +757,9 @@ proc initLightClientCache*(dag: ChainDAGRef) =
   for i in countdown(blocksBetween.high, blocksBetween.low):
     blockRef = blocksBetween[i]
     doAssert dag.updateState(
-      dag.headState, blockRef.atSlot(blockRef.slot), save = false, cache)
+      dag.headState, blockRef.atSlot(), save = false, cache)
     withStateVars(dag.headState):
-      let bdata = dag.getForkedBlock(dag.head.bid).get
+      let bdata = dag.getForkedBlock(blockRef.bid).get
       withStateAndBlck(state, bdata):
         when stateFork >= BeaconStateFork.Altair:
           # Cache data for `LightClientUpdate` of descendant blocks

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -191,7 +191,7 @@ proc storeBlock*(
         vm[].registerAttestationInBlock(attestation.data, validator_index,
           trustedBlock.message)
 
-    withState(dag[].clearanceState.data):
+    withState(dag[].clearanceState):
       when stateFork >= BeaconStateFork.Altair and
           Trusted isnot phase0.TrustedSignedBeaconBlock: # altair+
         for i in trustedBlock.message.body.sync_aggregate.sync_committee_bits.oneIndices():

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -39,12 +39,12 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res.get()
     node.withStateForBlockSlot(bslot):
       return
-        case stateData.data.kind
+        case state.kind
         of BeaconStateFork.Phase0:
           if contentType == sszMediaType:
-            RestApiResponse.sszResponse(stateData.data.phase0Data.data)
+            RestApiResponse.sszResponse(state.phase0Data.data)
           elif contentType == jsonMediaType:
-            RestApiResponse.jsonResponse(stateData.data.phase0Data.data)
+            RestApiResponse.jsonResponse(state.phase0Data.data)
           else:
             RestApiResponse.jsonError(Http500, InvalidAcceptError)
         of BeaconStateFork.Altair, BeaconStateFork.Bellatrix:
@@ -75,9 +75,9 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
     node.withStateForBlockSlot(bslot):
       return
         if contentType == jsonMediaType:
-          RestApiResponse.jsonResponsePlain(stateData.data)
+          RestApiResponse.jsonResponsePlain(state)
         elif contentType == sszMediaType:
-          withState(stateData.data):
+          withState(state):
             RestApiResponse.sszResponse(state.data)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -118,9 +118,9 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api(MethodGet, "/nimbus/v1/chain/head") do() -> RestApiResponse:
     let
       head = node.dag.head
-      finalized = getStateField(node.dag.headState.data, finalized_checkpoint)
+      finalized = getStateField(node.dag.headState, finalized_checkpoint)
       justified =
-        getStateField(node.dag.headState.data, current_justified_checkpoint)
+        getStateField(node.dag.headState, current_justified_checkpoint)
     return RestApiResponse.jsonResponse(
       (
         head_slot: head.slot,
@@ -232,7 +232,7 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
     let proposalState = assignClone(node.dag.headState)
     node.dag.withUpdatedState(proposalState[], head.atSlot(wallSlot)) do:
       return RestApiResponse.jsonResponse(
-        node.getBlockProposalEth1Data(stateData.data))
+        node.getBlockProposalEth1Data(state))
     do:
       return RestApiResponse.jsonError(Http400, PrunedStateError)
 

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -175,9 +175,9 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Defect, CatchableError].} =
   rpcServer.rpc("get_v1_beacon_genesis") do () -> RpcBeaconGenesis:
     return (
-      genesis_time: getStateField(node.dag.headState.data, genesis_time),
+      genesis_time: getStateField(node.dag.headState, genesis_time),
       genesis_validators_root:
-        getStateField(node.dag.headState.data, genesis_validators_root),
+        getStateField(node.dag.headState, genesis_validators_root),
       genesis_fork_version: node.dag.cfg.GENESIS_FORK_VERSION
     )
 
@@ -187,23 +187,23 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
   rpcServer.rpc("get_v1_beacon_states_fork") do (stateId: string) -> Fork:
     withStateForStateId(stateId):
-      return getStateField(stateData.data, fork)
+      return getStateField(state, fork)
 
   rpcServer.rpc("get_v1_beacon_states_finality_checkpoints") do (
       stateId: string) -> RpcBeaconStatesFinalityCheckpoints:
     withStateForStateId(stateId):
       return (previous_justified:
-                getStateField(stateData.data, previous_justified_checkpoint),
+                getStateField(state, previous_justified_checkpoint),
               current_justified:
-                getStateField(stateData.data, current_justified_checkpoint),
-              finalized: getStateField(stateData.data, finalized_checkpoint))
+                getStateField(state, current_justified_checkpoint),
+              finalized: getStateField(state, finalized_checkpoint))
 
   rpcServer.rpc("get_v1_beacon_states_stateId_validators") do (
       stateId: string, validatorIds: Option[seq[string]],
       status: Option[seq[string]]) -> seq[RpcBeaconStatesValidators]:
     var vquery: ValidatorQuery
     var squery: StatusQuery
-    let current_epoch = getStateField(node.dag.headState.data, slot).epoch
+    let current_epoch = getStateField(node.dag.headState, slot).epoch
 
     template statusCheck(status, statusQuery, vstatus, current_epoch): bool =
       if status.isNone():
@@ -230,7 +230,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         vquery = vqres.get()
 
       if validatorIds.isNone():
-        for index, validator in getStateField(stateData.data, validators).pairs():
+        for index, validator in getStateField(state, validators).pairs():
           let sres = validator.getStatus(current_epoch)
           if sres.isOk:
             let vstatus = sres.get()
@@ -240,11 +240,11 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
               res.add((validator: validator,
                        index: uint64(index),
                        status: vstatus,
-                       balance: getStateField(stateData.data, balances).asSeq()[index]))
+                       balance: getStateField(state, balances).asSeq()[index]))
       else:
         for index in vquery.ids:
-          if index < lenu64(getStateField(stateData.data, validators)):
-            let validator = getStateField(stateData.data, validators).asSeq()[index]
+          if index < lenu64(getStateField(state, validators)):
+            let validator = getStateField(state, validators).asSeq()[index]
             let sres = validator.getStatus(current_epoch)
             if sres.isOk:
               let vstatus = sres.get()
@@ -255,9 +255,9 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
                 res.add((validator: validator,
                          index: uint64(index),
                          status: vstatus,
-                         balance: getStateField(stateData.data, balances).asSeq()[index]))
+                         balance: getStateField(state, balances).asSeq()[index]))
 
-        for index, validator in getStateField(stateData.data, validators).pairs():
+        for index, validator in getStateField(state, validators).pairs():
           if validator.pubkey in vquery.keyset:
             let sres = validator.getStatus(current_epoch)
             if sres.isOk:
@@ -268,12 +268,12 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
                 res.add((validator: validator,
                          index: uint64(index),
                          status: vstatus,
-                         balance: getStateField(stateData.data, balances).asSeq()[index]))
+                         balance: getStateField(state, balances).asSeq()[index]))
     return res
 
   rpcServer.rpc("get_v1_beacon_states_stateId_validators_validatorId") do (
       stateId: string, validatorId: string) -> RpcBeaconStatesValidators:
-    let current_epoch = getStateField(node.dag.headState.data, slot).epoch
+    let current_epoch = getStateField(node.dag.headState, slot).epoch
     let vqres = createIdQuery([validatorId])
     if vqres.isErr:
       raise newException(CatchableError, $vqres.error)
@@ -282,23 +282,23 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     withStateForStateId(stateId):
       if len(vquery.ids) > 0:
         let index = vquery.ids[0]
-        if index < lenu64(getStateField(stateData.data, validators)):
-          let validator = getStateField(stateData.data, validators).asSeq()[index]
+        if index < lenu64(getStateField(state, validators)):
+          let validator = getStateField(state, validators).asSeq()[index]
           let sres = validator.getStatus(current_epoch)
           if sres.isOk:
             return (validator: validator, index: uint64(index),
                     status: sres.get(),
-                    balance: getStateField(stateData.data, balances).asSeq()[index])
+                    balance: getStateField(state, balances).asSeq()[index])
           else:
             raise newException(CatchableError, "Incorrect validator's state")
       else:
-        for index, validator in getStateField(stateData.data, validators).pairs():
+        for index, validator in getStateField(state, validators).pairs():
           if validator.pubkey in vquery.keyset:
             let sres = validator.getStatus(current_epoch)
             if sres.isOk:
               return (validator: validator, index: uint64(index),
                       status: sres.get(),
-                      balance: getStateField(stateData.data, balances).asSeq()[index])
+                      balance: getStateField(state, balances).asSeq()[index])
             else:
               raise newException(CatchableError, "Incorrect validator's state")
 
@@ -308,7 +308,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     var res: seq[RpcBalance]
     withStateForStateId(stateId):
       if validatorsId.isNone():
-        for index, value in getStateField(stateData.data, balances).pairs():
+        for index, value in getStateField(state, balances).pairs():
           let balance = (index: uint64(index), balance: value)
           res.add(balance)
       else:
@@ -318,17 +318,17 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
         var vquery = vqres.get()
         for index in vquery.ids:
-          if index < lenu64(getStateField(stateData.data, validators)):
-            let validator = getStateField(stateData.data, validators).asSeq()[index]
+          if index < lenu64(getStateField(state, validators)):
+            let validator = getStateField(state, validators).asSeq()[index]
             vquery.keyset.excl(validator.pubkey)
             let balance = (index: uint64(index),
-                           balance: getStateField(stateData.data, balances).asSeq()[index])
+                           balance: getStateField(state, balances).asSeq()[index])
             res.add(balance)
 
-        for index, validator in getStateField(stateData.data, validators).pairs():
+        for index, validator in getStateField(state, validators).pairs():
           if validator.pubkey in vquery.keyset:
             let balance = (index: uint64(index),
-                           balance: getStateField(stateData.data, balances).asSeq()[index])
+                           balance: getStateField(state, balances).asSeq()[index])
             res.add(balance)
     return res
 
@@ -339,12 +339,12 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       proc getCommittee(slot: Slot,
                         index: CommitteeIndex): RpcBeaconStatesCommittees =
         let vals = get_beacon_committee(
-          stateData.data, slot, index, cache).mapIt(it.uint64)
+          state, slot, index, cache).mapIt(it.uint64)
         return (index: index.uint64, slot: slot.uint64, validators: vals)
 
       proc forSlot(slot: Slot, res: var seq[RpcBeaconStatesCommittees]) =
         let committees_per_slot =
-          get_committee_count_per_slot(stateData.data, slot.epoch, cache)
+          get_committee_count_per_slot(state, slot.epoch, cache)
 
         if index.isNone:
           for committee_index in get_committee_indices(committees_per_slot):
@@ -359,7 +359,7 @@ proc installBeaconApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
       let qepoch =
         if epoch.isNone:
-          epoch(getStateField(stateData.data, slot))
+          epoch(getStateField(state, slot))
         else:
           Epoch(epoch.get())
 

--- a/beacon_chain/rpc/rpc_config_api.nim
+++ b/beacon_chain/rpc/rpc_config_api.nim
@@ -23,7 +23,7 @@ type
 proc installConfigApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
     raises: [Defect, CatchableError].} =
   rpcServer.rpc("get_v1_config_fork_schedule") do () -> seq[Fork]:
-    return @[getStateField(node.dag.headState.data, fork)]
+    return @[getStateField(node.dag.headState, fork)]
 
   rpcServer.rpc("get_v1_config_spec") do () -> JsonNode:
     return %*{

--- a/beacon_chain/rpc/rpc_debug_api.nim
+++ b/beacon_chain/rpc/rpc_debug_api.nim
@@ -26,8 +26,8 @@ proc installDebugApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
   rpcServer.rpc("get_v1_debug_beacon_states_stateId") do (
       stateId: string) -> phase0.BeaconState:
     withStateForStateId(stateId):
-      if stateData.data.kind == BeaconStateFork.Phase0:
-        return stateData.data.phase0Data.data
+      if state.kind == BeaconStateFork.Phase0:
+        return state.phase0Data.data
       else:
         raiseNoAltairSupport()
 

--- a/beacon_chain/rpc/rpc_nimbus_api.nim
+++ b/beacon_chain/rpc/rpc_nimbus_api.nim
@@ -47,9 +47,9 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
   rpcServer.rpc("getChainHead") do () -> JsonNode:
     let
       head = node.dag.head
-      finalized = getStateField(node.dag.headState.data, finalized_checkpoint)
+      finalized = getStateField(node.dag.headState, finalized_checkpoint)
       justified =
-        getStateField(node.dag.headState.data, current_justified_checkpoint)
+        getStateField(node.dag.headState, current_justified_checkpoint)
     return %* {
       "head_slot": head.slot,
       "head_block_root": head.root.data.toHex(),
@@ -109,7 +109,7 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     let proposalState = assignClone(node.dag.headState)
     node.dag.withUpdatedState(proposalState[], head.atSlot(wallSlot)):
-      return node.getBlockProposalEth1Data(stateData.data)
+      return node.getBlockProposalEth1Data(state)
     do:
       raise (ref CatchableError)(msg: "Trying to access pruned state")
 

--- a/beacon_chain/rpc/rpc_utils.nim
+++ b/beacon_chain/rpc/rpc_utils.nim
@@ -26,8 +26,8 @@ template withStateForStateId*(stateId: string, body: untyped): untyped =
   let
     bs = node.stateIdToBlockSlot(stateId)
 
-  template isState(state: StateData): bool =
-    state.blck.atSlot(getStateField(state.data, slot)) == bs
+  template isState(state: ForkedHashedBeaconState): bool =
+    state.matches_block_slot(bs.blck.root, bs.slot)
 
   if isState(node.dag.headState):
     withStateVars(node.dag.headState):
@@ -94,12 +94,12 @@ proc stateIdToBlockSlot*(node: BeaconNode, stateId: string): BlockSlot {.raises:
     node.dag.finalizedHead
   of "justified":
     node.dag.head.atEpochStart(
-      getStateField(node.dag.headState.data, current_justified_checkpoint).epoch)
+      getStateField(node.dag.headState, current_justified_checkpoint).epoch)
   else:
     if stateId.startsWith("0x"):
       let stateRoot = parseRoot(stateId)
-      if stateRoot == getStateRoot(node.dag.headState.data):
-        node.dag.headState.blck.atSlot()
+      if stateRoot == getStateRoot(node.dag.headState):
+        node.dag.head.atSlot()
       else:
         # We don't have a state root -> BlockSlot mapping
         raise (ref ValueError)(msg: "State not found")

--- a/beacon_chain/rpc/rpc_validator_api.nim
+++ b/beacon_chain/rpc/rpc_validator_api.nim
@@ -146,8 +146,8 @@ proc installValidatorApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
         "Slot requested not in current or next wall-slot epoch")
 
     if not verify_slot_signature(
-        getStateField(node.dag.headState.data, fork),
-        getStateField(node.dag.headState.data, genesis_validators_root),
+        getStateField(node.dag.headState, fork),
+        getStateField(node.dag.headState, genesis_validators_root),
         slot, validator_pubkey, slot_signature):
       raise newException(CatchableError,
         "Invalid slot signature")

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -305,7 +305,7 @@ template partialBeaconBlock(
   phase0.BeaconBlock(
     slot: state.data.slot,
     proposer_index: proposer_index.uint64,
-    parent_root: state.latest_block_root(),
+    parent_root: state.latest_block_root,
     body: phase0.BeaconBlockBody(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
@@ -369,7 +369,7 @@ template partialBeaconBlock(
   altair.BeaconBlock(
     slot: state.data.slot,
     proposer_index: proposer_index.uint64,
-    parent_root: state.latest_block_root(),
+    parent_root: state.latest_block_root,
     body: altair.BeaconBlockBody(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
@@ -434,7 +434,7 @@ template partialBeaconBlock(
   bellatrix.BeaconBlock(
     slot: state.data.slot,
     proposer_index: proposer_index.uint64,
-    parent_root: state.latest_block_root(),
+    parent_root: state.latest_block_root,
     body: bellatrix.BeaconBlockBody(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -66,7 +66,7 @@ cli do(validatorsDir: string, secretsDir: string,
       warn "Unkownn validator", pubkey
 
   var
-    blockRoot = withState(state[]): state.latest_block_root()
+    blockRoot = withState(state[]): state.latest_block_root
     cache: StateCache
     info: ForkedEpochInfo
     aggregates: seq[Attestation]

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol.nim
@@ -65,7 +65,7 @@ proc block_for_next_slot(
 
   let attestations =
     if withAttestations:
-      let block_root = withState(forked): state.latest_block_root()
+      let block_root = withState(forked): state.latest_block_root
       makeFullAttestations(forked, block_root, state.slot, cache)
     else:
       @[]

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -162,12 +162,12 @@ proc stepOnBlock(
        dag: ChainDagRef,
        fkChoice: ref ForkChoice,
        verifier: var BatchVerifier,
-       state: var StateData,
+       state: var ForkedHashedBeaconState,
        stateCache: var StateCache,
        signedBlock: ForkySignedBeaconBlock,
        time: BeaconTime): Result[BlockRef, BlockError] =
   # 1. Move state to proper slot.
-  doAssert dag.updateStateData(
+  doAssert dag.updateState(
     state,
     dag.head.atSlot(time.slotOrZero),
     save = false,

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -82,7 +82,7 @@ suite "Attestation pool processing" & preset():
       bc0 = get_beacon_committee(
         state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation = makeAttestation(
-        state[], state[].latest_block_root(), bc0[0], cache)
+        state[], state[].latest_block_root, bc0[0], cache)
 
     pool[].addAttestation(
       attestation, @[bc0[0]], attestation.loadSig,
@@ -194,14 +194,14 @@ suite "Attestation pool processing" & preset():
 
     var
       att0 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[0], cache)
+        state[], state[].latest_block_root, bc0[0], cache)
       att0x = att0
       att1 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[1], cache)
+        state[], state[].latest_block_root, bc0[1], cache)
       att2 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[2], cache)
+        state[], state[].latest_block_root, bc0[2], cache)
       att3 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[3], cache)
+        state[], state[].latest_block_root, bc0[3], cache)
 
     # Both attestations include member 2 but neither is a subset of the other
     att0.combine(att2)
@@ -288,7 +288,7 @@ suite "Attestation pool processing" & preset():
       bc0 = get_beacon_committee(
         state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[0], cache)
+        state[], state[].latest_block_root, bc0[0], cache)
 
     check:
       process_slots(
@@ -299,7 +299,7 @@ suite "Attestation pool processing" & preset():
       bc1 = get_beacon_committee(state[],
         getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation1 = makeAttestation(
-        state[], state[].latest_block_root(), bc1[0], cache)
+        state[], state[].latest_block_root, bc1[0], cache)
 
     # test reverse order
     pool[].addAttestation(
@@ -321,9 +321,9 @@ suite "Attestation pool processing" & preset():
       bc0 = get_beacon_committee(
         state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation0 =
-        makeAttestation(state[], state[].latest_block_root(), bc0[0], cache)
+        makeAttestation(state[], state[].latest_block_root, bc0[0], cache)
       attestation1 =
-        makeAttestation(state[], state[].latest_block_root(), bc0[1], cache)
+        makeAttestation(state[], state[].latest_block_root, bc0[1], cache)
 
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
@@ -350,9 +350,9 @@ suite "Attestation pool processing" & preset():
       bc0 = get_beacon_committee(
         state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[0], cache)
+        state[], state[].latest_block_root, bc0[0], cache)
       attestation1 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[1], cache)
+        state[], state[].latest_block_root, bc0[1], cache)
 
     attestation0.combine(attestation1)
 
@@ -380,9 +380,9 @@ suite "Attestation pool processing" & preset():
       bc0 = get_beacon_committee(state[],
         getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation0 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[0], cache)
+        state[], state[].latest_block_root, bc0[0], cache)
       attestation1 = makeAttestation(
-        state[], state[].latest_block_root(), bc0[1], cache)
+        state[], state[].latest_block_root, bc0[1], cache)
 
     attestation0.combine(attestation1)
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -73,15 +73,16 @@ suite "Attestation pool processing" & preset():
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:
       process_slots(
-        dag.cfg, state.data, getStateField(state.data, slot) + 1, cache, info,
+        dag.cfg, state[], getStateField(state[], slot) + 1, cache, info,
         {}).isOk()
 
   test "Can add and retrieve simple attestations" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      attestation = makeAttestation(state[].data, state.blck.root, bc0[0], cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation = makeAttestation(
+        state[], state[].latest_block_root(), bc0[0], cache)
 
     pool[].addAttestation(
       attestation, @[bc0[0]], attestation.loadSig,
@@ -104,11 +105,11 @@ suite "Attestation pool processing" & preset():
         none(Slot), some(CommitteeIndex(attestation.data.index + 1)))) == []
 
       process_slots(
-        defaultRuntimeConfig, state.data,
-        getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        defaultRuntimeConfig, state[],
+        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
         info, {}).isOk()
 
-    let attestations = pool[].getAttestationsForBlock(state.data, cache)
+    let attestations = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       attestations.len == 1
@@ -116,40 +117,40 @@ suite "Attestation pool processing" & preset():
 
     let
       root1 = addTestBlock(
-        state.data, cache, attestations = attestations,
+        state[], cache, attestations = attestations,
         nextSlot = false).phase0Data.root
       bc1 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      att1 = makeAttestation(state[].data, root1, bc1[0], cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      att1 = makeAttestation(state[], root1, bc1[0], cache)
 
     check:
-      withState(state.data): state.latest_block_root == root1
+      withState(state[]): state.latest_block_root == root1
 
       process_slots(
-        defaultRuntimeConfig, state.data,
-        getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        defaultRuntimeConfig, state[],
+        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
         info, {}).isOk()
 
-      withState(state.data): state.latest_block_root == root1
+      withState(state[]): state.latest_block_root == root1
 
     check:
       # shouldn't include already-included attestations
-      pool[].getAttestationsForBlock(state.data, cache) == []
+      pool[].getAttestationsForBlock(state[], cache) == []
 
     pool[].addAttestation(
       att1, @[bc1[0]], att1.loadSig, att1.data.slot.start_beacon_time)
 
     check:
       # but new ones should go in
-      pool[].getAttestationsForBlock(state.data, cache).len() == 1
+      pool[].getAttestationsForBlock(state[], cache).len() == 1
 
     let
-      att2 = makeAttestation(state[].data, root1, bc1[1], cache)
+      att2 = makeAttestation(state[], root1, bc1[1], cache)
     pool[].addAttestation(
       att2, @[bc1[1]], att2.loadSig, att2.data.slot.start_beacon_time)
 
     let
-      combined = pool[].getAttestationsForBlock(state.data, cache)
+      combined = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       # New attestations should be combined with old attestations
@@ -162,18 +163,18 @@ suite "Attestation pool processing" & preset():
 
     check:
       # readding the combined attestation shouldn't have an effect
-      pool[].getAttestationsForBlock(state.data, cache).len() == 1
+      pool[].getAttestationsForBlock(state[], cache).len() == 1
 
     let
       # Someone votes for a different root
-      att3 = makeAttestation(state[].data, Eth2Digest(), bc1[2], cache)
+      att3 = makeAttestation(state[], Eth2Digest(), bc1[2], cache)
     pool[].addAttestation(
       att3, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 
     check:
       # We should now get both attestations for the block, but the aggregate
       # should be the one with the most votes
-      pool[].getAttestationsForBlock(state.data, cache).len() == 2
+      pool[].getAttestationsForBlock(state[], cache).len() == 2
       pool[].getAggregatedAttestation(2.Slot, 0.CommitteeIndex).
         get().aggregation_bits.countOnes() == 2
       pool[].getAggregatedAttestation(2.Slot, hash_tree_root(att2.data)).
@@ -181,7 +182,7 @@ suite "Attestation pool processing" & preset():
 
     let
       # Someone votes for a different root
-      att4 = makeAttestation(state[].data, Eth2Digest(), bc1[2], cache)
+      att4 = makeAttestation(state[], Eth2Digest(), bc1[2], cache)
     pool[].addAttestation(
       att4, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 
@@ -189,14 +190,18 @@ suite "Attestation pool processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
 
     var
-      att0 = makeAttestation(state[].data, state.blck.root, bc0[0], cache)
+      att0 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[0], cache)
       att0x = att0
-      att1 = makeAttestation(state[].data, state.blck.root, bc0[1], cache)
-      att2 = makeAttestation(state[].data, state.blck.root, bc0[2], cache)
-      att3 = makeAttestation(state[].data, state.blck.root, bc0[3], cache)
+      att1 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[1], cache)
+      att2 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[2], cache)
+      att3 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[3], cache)
 
     # Both attestations include member 2 but neither is a subset of the other
     att0.combine(att2)
@@ -212,13 +217,13 @@ suite "Attestation pool processing" & preset():
 
     check:
       process_slots(
-        defaultRuntimeConfig, state.data,
-        getStateField(state.data, slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        defaultRuntimeConfig, state[],
+        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
         info, {}).isOk()
 
     check:
       pool[].covers(att0.data, att0.aggregation_bits)
-      pool[].getAttestationsForBlock(state.data, cache).len() == 2
+      pool[].getAttestationsForBlock(state[], cache).len() == 2
       # Can get either aggregate here, random!
       pool[].getAggregatedAttestation(1.Slot, 0.CommitteeIndex).isSome()
 
@@ -227,7 +232,7 @@ suite "Attestation pool processing" & preset():
       att3, @[bc0[3]], att3.loadSig, att3.data.slot.start_beacon_time)
 
     block:
-      let attestations = pool[].getAttestationsForBlock(state.data, cache)
+      let attestations = pool[].getAttestationsForBlock(state[], cache)
       check:
         attestations.len() == 2
         attestations[0].aggregation_bits.countOnes() == 3
@@ -240,7 +245,7 @@ suite "Attestation pool processing" & preset():
       att0x, @[bc0[0]], att0x.loadSig, att0x.data.slot.start_beacon_time)
 
     block:
-      let attestations = pool[].getAttestationsForBlock(state.data, cache)
+      let attestations = pool[].getAttestationsForBlock(state[], cache)
       check:
         attestations.len() == 1
         attestations[0].aggregation_bits.countOnes() == 4
@@ -253,46 +258,48 @@ suite "Attestation pool processing" & preset():
       root.data[0..<8] = toBytesBE(i.uint64)
       let
         bc0 = get_beacon_committee(
-          state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
+          state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
 
       for j in 0..<bc0.len():
         root.data[8..<16] = toBytesBE(j.uint64)
-        let att = makeAttestation(state[].data, root, bc0[j], cache)
+        let att = makeAttestation(state[], root, bc0[j], cache)
         pool[].addAttestation(
           att, @[bc0[j]], att.loadSig, att.data.slot.start_beacon_time)
         inc attestations
 
       check:
         process_slots(
-          defaultRuntimeConfig, state.data,
-          getStateField(state.data, slot) + 1, cache, info, {}).isOk()
+          defaultRuntimeConfig, state[],
+          getStateField(state[], slot) + 1, cache, info, {}).isOk()
 
     doAssert attestations.uint64 > MAX_ATTESTATIONS,
       "6*SLOTS_PER_EPOCH validators > 128 mainnet MAX_ATTESTATIONS"
     check:
       # Fill block with attestations
-      pool[].getAttestationsForBlock(state.data, cache).lenu64() ==
+      pool[].getAttestationsForBlock(state[], cache).lenu64() ==
         MAX_ATTESTATIONS
       pool[].getAggregatedAttestation(
-        getStateField(state.data, slot) - 1, 0.CommitteeIndex).isSome()
+        getStateField(state[], slot) - 1, 0.CommitteeIndex).isSome()
 
   test "Attestations may arrive in any order" & preset():
     var cache = StateCache()
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      attestation0 = makeAttestation(state[].data, state.blck.root, bc0[0], cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[0], cache)
 
     check:
       process_slots(
-        defaultRuntimeConfig, state.data, getStateField(state.data, slot) + 1,
+        defaultRuntimeConfig, state[], getStateField(state[], slot) + 1,
         cache, info, {}).isOk()
 
     let
-      bc1 = get_beacon_committee(state[].data,
-        getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      attestation1 = makeAttestation(state[].data, state.blck.root, bc1[0], cache)
+      bc1 = get_beacon_committee(state[],
+        getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation1 = makeAttestation(
+        state[], state[].latest_block_root(), bc1[0], cache)
 
     # test reverse order
     pool[].addAttestation(
@@ -302,7 +309,7 @@ suite "Attestation pool processing" & preset():
       attestation0, @[bc0[0]], attestation0.loadSig,
       attestation0.data.slot.start_beacon_time)
 
-    let attestations = pool[].getAttestationsForBlock(state.data, cache)
+    let attestations = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       attestations.len == 1
@@ -312,11 +319,11 @@ suite "Attestation pool processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
       attestation0 =
-        makeAttestation(state[].data, state.blck.root, bc0[0], cache)
+        makeAttestation(state[], state[].latest_block_root(), bc0[0], cache)
       attestation1 =
-        makeAttestation(state[].data, state.blck.root, bc0[1], cache)
+        makeAttestation(state[], state[].latest_block_root(), bc0[1], cache)
 
     pool[].addAttestation(
       attestation0, @[bc0[0]], attestation0.loadSig,
@@ -327,10 +334,10 @@ suite "Attestation pool processing" & preset():
 
     check:
       process_slots(
-        defaultRuntimeConfig, state.data,
+        defaultRuntimeConfig, state[],
         MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {}).isOk()
 
-    let attestations = pool[].getAttestationsForBlock(state.data, cache)
+    let attestations = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       attestations.len == 1
@@ -341,11 +348,11 @@ suite "Attestation pool processing" & preset():
     var
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      attestation0 =
-        makeAttestation(state[].data, state.blck.root, bc0[0], cache)
-      attestation1 =
-        makeAttestation(state[].data, state.blck.root, bc0[1], cache)
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[0], cache)
+      attestation1 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[1], cache)
 
     attestation0.combine(attestation1)
 
@@ -358,10 +365,10 @@ suite "Attestation pool processing" & preset():
 
     check:
       process_slots(
-        defaultRuntimeConfig, state.data,
+        defaultRuntimeConfig, state[],
         MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {}).isOk()
 
-    let attestations = pool[].getAttestationsForBlock(state.data, cache)
+    let attestations = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       attestations.len == 1
@@ -370,12 +377,12 @@ suite "Attestation pool processing" & preset():
     var cache = StateCache()
     var
       # Create an attestation for slot 1!
-      bc0 = get_beacon_committee(state[].data,
-        getStateField(state.data, slot), 0.CommitteeIndex, cache)
-      attestation0 =
-        makeAttestation(state[].data, state.blck.root, bc0[0], cache)
-      attestation1 =
-        makeAttestation(state[].data, state.blck.root, bc0[1], cache)
+      bc0 = get_beacon_committee(state[],
+        getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation0 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[0], cache)
+      attestation1 = makeAttestation(
+        state[], state[].latest_block_root(), bc0[1], cache)
 
     attestation0.combine(attestation1)
 
@@ -388,10 +395,10 @@ suite "Attestation pool processing" & preset():
 
     check:
       process_slots(
-        defaultRuntimeConfig, state.data,
+        defaultRuntimeConfig, state[],
         MIN_ATTESTATION_INCLUSION_DELAY.Slot + 1, cache, info, {}).isOk()
 
-    let attestations = pool[].getAttestationsForBlock(state.data, cache)
+    let attestations = pool[].getAttestationsForBlock(state[], cache)
 
     check:
       attestations.len == 1
@@ -399,7 +406,7 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns latest block with no attestations":
     var cache = StateCache()
     let
-      b1 = addTestBlock(state.data, cache).phase0Data
+      b1 = addTestBlock(state[], cache).phase0Data
       b1Add = dag.addHeadBlock(verifier, b1) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -412,7 +419,7 @@ suite "Attestation pool processing" & preset():
       head == b1Add[]
 
     let
-      b2 = addTestBlock(state.data, cache).phase0Data
+      b2 = addTestBlock(state[], cache).phase0Data
       b2Add = dag.addHeadBlock(verifier, b2) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -428,7 +435,7 @@ suite "Attestation pool processing" & preset():
   test "Fork choice returns block with attestation":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, cache).phase0Data
+      b10 = makeTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -442,7 +449,7 @@ suite "Attestation pool processing" & preset():
       head == b10Add[]
 
     let
-      b11 = makeTestBlock(state.data, cache,
+      b11 = makeTestBlock(state[], cache,
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
       ).phase0Data
       b11Add = dag.addHeadBlock(verifier, b11) do (
@@ -453,9 +460,9 @@ suite "Attestation pool processing" & preset():
           epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
 
       bc1 = get_beacon_committee(
-        state[].data, getStateField(state.data, slot) - 1, 1.CommitteeIndex,
+        state[], getStateField(state[], slot) - 1, 1.CommitteeIndex,
         cache)
-      attestation0 = makeAttestation(state[].data, b10.root, bc1[0], cache)
+      attestation0 = makeAttestation(state[], b10.root, bc1[0], cache)
 
     pool[].addAttestation(
       attestation0, @[bc1[0]], attestation0.loadSig,
@@ -468,8 +475,8 @@ suite "Attestation pool processing" & preset():
       head2 == b10Add[]
 
     let
-      attestation1 = makeAttestation(state[].data, b11.root, bc1[1], cache)
-      attestation2 = makeAttestation(state[].data, b11.root, bc1[2], cache)
+      attestation1 = makeAttestation(state[], b11.root, bc1[1], cache)
+      attestation2 = makeAttestation(state[], b11.root, bc1[2], cache)
     pool[].addAttestation(
       attestation1, @[bc1[1]], attestation1.loadSig,
       attestation1.data.slot.start_beacon_time)
@@ -494,7 +501,7 @@ suite "Attestation pool processing" & preset():
   test "Trying to add a block twice tags the second as an error":
     var cache = StateCache()
     let
-      b10 = makeTestBlock(state.data, cache).phase0Data
+      b10 = makeTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -525,7 +532,7 @@ suite "Attestation pool processing" & preset():
     dag.updateFlags.incl {skipBLSValidation}
     var cache = StateCache()
     let
-      b10 = addTestBlock(state.data, cache).phase0Data
+      b10 = addTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
           epochRef: EpochRef):
@@ -547,10 +554,10 @@ suite "Attestation pool processing" & preset():
     for epoch in 0 ..< 5:
       let start_slot = start_slot(Epoch epoch)
       let committees_per_slot =
-        get_committee_count_per_slot(state[].data, Epoch epoch, cache)
+        get_committee_count_per_slot(state[], Epoch epoch, cache)
       for slot in start_slot ..< start_slot + SLOTS_PER_EPOCH:
         let new_block = addTestBlock(
-          state.data, cache, attestations = attestations).phase0Data
+          state[], cache, attestations = attestations).phase0Data
 
         let blockRef = dag.addHeadBlock(verifier, new_block) do (
             blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
@@ -567,7 +574,7 @@ suite "Attestation pool processing" & preset():
         attestations.setlen(0)
         for committee_index in get_committee_indices(committees_per_slot):
           let committee = get_beacon_committee(
-            state[].data, getStateField(state.data, slot), committee_index,
+            state[], getStateField(state[], slot), committee_index,
             cache)
 
           # Create a bitfield filled with the given count per attestation,
@@ -578,8 +585,7 @@ suite "Attestation pool processing" & preset():
 
           attestations.add Attestation(
             aggregation_bits: aggregation_bits,
-            data: makeAttestationData(
-              state[].data, getStateField(state.data, slot),
+            data: makeAttestationData(state[], getStateField(state[], slot),
               committee_index, blockRef.get().root)
             # signature: ValidatorSig()
           )

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -68,7 +68,7 @@ proc getTestStates(stateFork: BeaconStateFork): auto =
     db = makeTestDB(SLOTS_PER_EPOCH)
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
-  var testStates = getTestStates(dag.headState.data, stateFork)
+  var testStates = getTestStates(dag.headState, stateFork)
 
   # Ensure transitions beyond just adding validators and increasing slots
   sort(testStates) do (x, y: ref ForkedHashedBeaconState) -> int:
@@ -338,7 +338,7 @@ suite "Beacon chain DB" & preset():
     let restoreAddr = addr dag.headState
 
     func restore() =
-      assign(state[], restoreAddr[].data)
+      assign(state[], restoreAddr[])
 
     check:
       state[].phase0Data.data.slot == 10.Slot
@@ -361,7 +361,7 @@ suite "Beacon chain DB" & preset():
     let restoreAddr = addr dag.headState
 
     func restore() =
-      assign(state[], restoreAddr[].data)
+      assign(state[], restoreAddr[])
 
     check:
       state[].altairData.data.slot == 10.Slot
@@ -387,7 +387,7 @@ suite "Beacon chain DB" & preset():
     let restoreAddr = addr dag.headState
 
     func restore() =
-      assign(state[], restoreAddr[].data)
+      assign(state[], restoreAddr[])
 
     check:
       state[].bellatrixData.data.slot == 10.Slot

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -34,7 +34,7 @@ suite "Block processor" & preset():
       quarantine = newClone(Quarantine.init())
       attestationPool = newClone(AttestationPool.init(dag, quarantine))
       consensusManager = ConsensusManager.new(dag, attestationPool, quarantine)
-      state = newClone(dag.headState.data)
+      state = newClone(dag.headState)
       cache = StateCache()
       b1 = addTestBlock(state[], cache).phase0Data
       b2 = addTestBlock(state[], cache).phase0Data
@@ -92,7 +92,7 @@ suite "Block processor" & preset():
     check:
       # ensure we loaded the correct head state
       dag2.head.root == b2.root
-      getStateRoot(dag2.headState.data) == b2.message.state_root
+      getStateRoot(dag2.headState) == b2.message.state_root
       dag2.getBlockRef(b1.root).isSome()
       dag2.getBlockRef(b2.root).isSome()
       dag2.heads.len == 1

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -580,7 +580,7 @@ suite "Old database versions" & preset():
 
     # preInit a database to a v1.0.12 state
     db.putStateRoot(
-      genState[].latest_block_root(), genState[].data.slot, genState[].root)
+      genState[].latest_block_root, genState[].data.slot, genState[].root)
     db.putStateV0(genState[].root, genState[].data)
 
     db.putBlockV0(genBlock)

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -34,7 +34,7 @@ suite "Exit pool testing suite":
 
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
-      withState(dag.headState.data):
+      withState(dag.headState):
         check:
           pool[].getBeaconBlockExits(state.data).proposer_slashings.lenu64 ==
             min(i + 1, MAX_PROPOSER_SLASHINGS)
@@ -54,7 +54,7 @@ suite "Exit pool testing suite":
 
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
-      withState(dag.headState.data):
+      withState(dag.headState):
         check:
           pool[].getBeaconBlockExits(state.data).attester_slashings.lenu64 ==
             min(i + 1, MAX_ATTESTER_SLASHINGS)
@@ -70,7 +70,7 @@ suite "Exit pool testing suite":
 
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
-      withState(dag.headState.data):
+      withState(dag.headState):
         check:
           pool[].getBeaconBlockExits(state.data).voluntary_exits.lenu64 ==
             min(i + 1, MAX_VOLUNTARY_EXITS)

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -53,17 +53,17 @@ suite "Beacon state" & preset():
       info: ForkedEpochInfo
 
     check: # Works for genesis block
-      state[].phase0Data.latest_block_root() == genBlock.root
+      state[].phase0Data.latest_block_root == genBlock.root
       process_slots(cfg, state[], Slot 1, cache, info, {}).isOk()
-      state[].phase0Data.latest_block_root() == genBlock.root
+      state[].phase0Data.latest_block_root == genBlock.root
 
     let blck = addTestBlock(
       state[], cache, nextSlot = false, flags = {skipBlsValidation}).phase0Data
 
     check: # Works for random blocks
-      state[].phase0Data.latest_block_root() == blck.root
+      state[].phase0Data.latest_block_root == blck.root
       process_slots(cfg, state[], Slot 2, cache, info, {}).isOk()
-      state[].phase0Data.latest_block_root() == blck.root
+      state[].phase0Data.latest_block_root == blck.root
 
   test "get_beacon_proposer_index":
     var

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -27,7 +27,7 @@ suite "state diff tests" & preset():
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
 
   test "random slot differences" & preset():
-    let testStates = getTestStates(dag.headState.data, BeaconStateFork.Altair)
+    let testStates = getTestStates(dag.headState, BeaconStateFork.Altair)
 
     for i in 0 ..< testStates.len:
       for j in (i+1) ..< testStates.len:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -402,7 +402,7 @@ iterator makeTestBlocks*(
     state = assignClone(state)
   for _ in 0..<blocks:
     let
-      parent_root = withState(state[]): state.latest_block_root()
+      parent_root = withState(state[]): state.latest_block_root
       attestations =
         if attested:
           makeFullAttestations(


### PR DESCRIPTION
One more step on the journey to reduce `BlockRef` usage across the
codebase - this one gets rid of `StateData` whose job was to keep track
of which block was last assigned to a state - these duties have now been
taken over by `latest_block_root`, a fairly recent addition that
computes this block root from state data (at a small cost that should be
insignificant)

99% mechanical change.