### PR TITLE
update to latest light client spec

### DIFF
--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -302,6 +302,8 @@ func apply_light_client_update(
     didProgress = true
   if active_header.slot > store.finalized_header.slot:
     store.finalized_header = active_header
+    if store.finalized_header.slot > store.optimistic_header.slot:
+      store.optimistic_header = store.finalized_header
     didProgress = true
   didProgress
 


### PR DESCRIPTION
Adds the additional check to ensure `optimistic_header` is always after
`finalized_header` in `LightClientStore`, as introduced to the spec in
https://github.com/ethereum/consensus-specs/pull/2814