### PR TITLE
update light client server for DAG failure modes

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -79,7 +79,7 @@ proc addResolvedHeadBlock(
     epochRefDur = epochRefTick - putBlockTick
 
   # Update light client data
-  dag.processNewBlockForLightClient(state, trustedBlock, parent)
+  dag.processNewBlockForLightClient(state, trustedBlock, parent.bid)
 
   # Notify others of the new block before processing the quarantine, such that
   # notifications for parents happens before those of the children

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -125,7 +125,7 @@ suite "Light client" & preset():
 
     # Initialize light client store
     let bootstrap = dag.getLightClientBootstrap(trusted_block_root)
-    check bootstrap.isSome
+    check bootstrap.isOk
     var storeRes = initialize_light_client_store(
       trusted_block_root, bootstrap.get)
     check storeRes.isOk

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -95,7 +95,7 @@ suite "Light client processor" & preset():
 
   test "Standard sync" & preset():
     let bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
-    check bootstrap.isSome
+    check bootstrap.isOk
     setTimeToSlot(bootstrap.get.header.slot)
     res = processor[].storeObject(
       MsgSource.gossip, getBeaconTime(), bootstrap.get)
@@ -117,7 +117,7 @@ suite "Light client processor" & preset():
 
   test "Forced update" & preset():
     let bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
-    check bootstrap.isSome
+    check bootstrap.isOk
     setTimeToSlot(bootstrap.get.header.slot)
     res = processor[].storeObject(
       MsgSource.gossip, getBeaconTime(), bootstrap.get)
@@ -196,7 +196,7 @@ suite "Light client processor" & preset():
 
   test "Invalid bootstrap" & preset():
     var bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
-    check bootstrap.isSome
+    check bootstrap.isOk
     bootstrap.get.header.slot.inc()
     setTimeToSlot(bootstrap.get.header.slot)
     res = processor[].storeObject(
@@ -208,7 +208,7 @@ suite "Light client processor" & preset():
 
   test "Duplicate bootstrap" & preset():
     let bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
-    check bootstrap.isSome
+    check bootstrap.isOk
     setTimeToSlot(bootstrap.get.header.slot)
     res = processor[].storeObject(
       MsgSource.gossip, getBeaconTime(), bootstrap.get)


### PR DESCRIPTION
Gracefully handles the new failure modes recently introduced to the DAG
as part of https://github.com/status-im/nimbus-eth2/pull/3513
Data that is deemed to exist but fails to load leads to an error log to
avoid suppressing logic errors accidentally. In `verifyFinalization`
mode, the assertions remain active.