### PR TITLE
don't write `node-metadata.json` on startup

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1717,9 +1717,11 @@ proc doCreateTestnet*(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.rais
 
   let bootstrapFile = config.outputBootstrapFile.string
   if bootstrapFile.len > 0:
+    type MetaData = altair.MetaData
     let
       networkKeys = getPersistentNetKeys(rng, config)
-      netMetadata = getPersistentNetMetadata(config)
+
+      netMetadata = MetaData()
       forkId = getENRForkID(
         cfg,
         initialState[].slot.epoch,


### PR DESCRIPTION
This file is not actually used / useful - should metadata persistence
support be added in the future, it needs to be done with a new file such
that downgrades, that have the TODO logic unimplemented, don't break.