### PR TITLE
tns: checkpoint wal periodically while backfilling

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1836,6 +1836,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
     withState(state[]):
       dag.db.putState(state)
+      dag.db.checkpoint()
 
       state_root = state.root
 

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -73,6 +73,8 @@ proc doTrustedNodeSync*(
 
   let
     db = BeaconChainDB.new(databaseDir, inMemory = false)
+  defer:
+    db.close()
 
   var
     dbCache = DbCache(summaries: db.loadSummaries())
@@ -391,6 +393,9 @@ proc doTrustedNodeSync*(
           continue
 
         gets[int(i mod gets.lenu64)] = downloadBlock(slot)
+
+      if i mod 1024 == 0:
+        db.checkpoint() # Transfer stuff from wal periodically
     true
   else:
     notice "Database initialized, historical blocks will be backfilled when starting the node",


### PR DESCRIPTION
Witout this, we end up with a massive .wal file that needs to be
checkpointed on first startup (which takes a few minutes) - it's much
more efficient to do smaller checkpoints, it turns out.