### PR TITLE
engine API alpha.7 -> alpha.8 and a few remaining v1.1.9 to v1.1.10 CL spec URL updates

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -501,15 +501,15 @@ type
         defaultValue: false
         name: "proposer-boosting-debug" }: bool
 
-      # https://github.com/ethereum/consensus-specs/blob/v1.1.9/sync/optimistic.md#fork-choice-poisoning
+      # https://github.com/ethereum/consensus-specs/blob/v1.1.10/sync/optimistic.md#fork-choice-poisoning
       safeSlotsToImportOptimistically* {.
         hidden
         desc: "Modify SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY"
-        # https://github.com/ethereum/consensus-specs/blob/v1.1.9/sync/optimistic.md#constants
+        # https://github.com/ethereum/consensus-specs/blob/v1.1.10/sync/optimistic.md#constants
         defaultValue: 128
         name: "safe-slots-to-import-optimistically" }: uint64
 
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/authentication.md#key-distribution
+      # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/authentication.md#key-distribution
       jwtSecret* {.
         hidden
         desc: "A file containing the hex-encoded 256 bit secret key to be used for verifying/generating jwt tokens"

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -78,7 +78,7 @@ type
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/fork-choice.md#powblock
+  # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/fork-choice.md#powblock
   PowBlock* = object
     block_hash*: Eth2Digest
     parent_hash*: Eth2Digest

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -20,7 +20,7 @@ proc base64urlEncode(x: auto): string =
   base64.encode(x, safe = true).replace("=", "")
 
 func getIatToken*(time: uint64): JsonNode =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/authentication.md#jwt-claims
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/authentication.md#jwt-claims
   # "Required: iat (issued-at) claim. The EL SHOULD only accept iat timestamps
   # which are within +-5 seconds from the current time."
   #
@@ -32,7 +32,7 @@ func getIatToken*(time: uint64): JsonNode =
   %* {"iat": time}
 
 proc getSignedToken*(key: openArray[byte], payload: string): string =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/authentication.md#jwt-specifications
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/authentication.md#jwt-specifications
   # "The EL MUST support at least the following alg: HMAC + SHA256 (HS256)"
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
@@ -65,7 +65,7 @@ proc checkJwtSecret*(
     # hex-encoded secret as a jwt.hex file on the filesystem. This file can
     # then be used to provision the counterpart client.
     #
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.7/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/authentication.md#key-distribution
     const jwtSecretFilename = "jwt.hex"
     let jwtSecretPath = dataDir / jwtSecretFilename
 

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -43,7 +43,7 @@ func sign_block(state: ForkyBeaconState, blck: var ForkySignedBeaconBlock) =
     blck.root,
     privkey).toValidatorSig()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.9/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py#L1-L31
+# https://github.com/ethereum/consensus-specs/blob/v1.1.10/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py#L1-L31
 func build_empty_execution_payload(state: bellatrix.BeaconState): ExecutionPayload =
   ## Assuming a pre-state of the same slot, build a valid ExecutionPayload
   ## without any transactions.


### PR DESCRIPTION
All Nim source file comments, no non-comments. No semantic changes.