### PR TITLE
Grafana: aggregats/slot in fleets like in local Grafana [skip ci]

### DIFF
--- a/grafana/metrics.status.im.json
+++ b/grafana/metrics.status.im.json
@@ -1728,6 +1728,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "exemplar": true,
           "expr": "rate(beacon_attestations_received_total{instance=\"${instance}\",container=\"${container}\"}[$__rate_interval]) * 12",
           "interval": "",
           "legendFormat": "received",
@@ -1739,14 +1740,6 @@
           "interval": "",
           "legendFormat": "sent",
           "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(beacon_aggregates_received_total{instance=\"${instance}\",container=\"${container}\"}[$__rate_interval]) * 12",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "aggregates",
-          "refId": "C"
         }
       ],
       "timeFrom": null,
@@ -1869,6 +1862,93 @@
           "options": {}
         }
       ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "pluginVersion": "8.0.4",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(beacon_aggregates_received_total{instance=\"${instance}\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "received",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "aggregates/slot (${instance})",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Locally:

![image](https://user-images.githubusercontent.com/22738317/158988098-9074e62b-09e7-4731-a416-ba4f721ce40b.png)


Fleet

![image](https://user-images.githubusercontent.com/22738317/158988137-ebc4fc45-96ad-42e6-ab63-8bbccfd62538.png)

In the fleet aggregates/slot are in the same graph as attestations/slot and have a completely different scale than attestations/slot (potentially because of the new changes to seen aggregates #3439) but they are the main source of CPU consumption and should be highlighted.

Warning: tested locally, not in the fleet, i'm not sure how to test Grafana updates for the fleet to avoid losing the whole monitoring (at the very least on type and version incompatibilities)