### PR TITLE
fix light client data pruning

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1247,13 +1247,14 @@ proc pruneBlocksDAG(dag: ChainDAGRef) =
 
     var cur = head.atSlot()
     while not cur.blck.isAncestorOf(dag.finalizedHead.blck):
-      # Update light client data
-      dag.deleteLightClientData(cur.blck.bid)
 
       # TODO: should we move that disk I/O to `onSlotEnd`
       dag.delState(cur.toBlockSlotId().expect("not nil"))
 
       if cur.isProposed():
+        # Update light client data
+        dag.deleteLightClientData(cur.blck.bid)
+
         dag.forkBlocks.excl(KeyedBlockRef.init(cur.blck))
         dag.db.delBlock(cur.blck.root)
 


### PR DESCRIPTION
When eliminating orphaned forks, light client data about blocks was also
deleted when the orphaned fork was referring to a state several slots
after the block. Linking light client data pruning with block deletion
instead of state deletion fixes this problem. Light client data always
refers to blocks and their immediate post-state.