### PR TITLE
Polish, remove beta warning for validator monitor

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -390,7 +390,7 @@ proc createAndSendAttestation(node: BeaconNode,
       wallTime = node.beaconClock.now()
       delay = wallTime - attestationData.slot.attestation_deadline()
 
-    notice "Attestation sent",
+    info "Attestation sent",
       attestation = shortLog(attestation), validator = shortLog(validator),
       delay, subnet_id
 
@@ -990,7 +990,7 @@ proc sendAggregatedAttestations(
     let
       subnet_id = compute_subnet_for_attestation(
         committees_per_slot, slot, data.committee_index)
-    notice "Aggregated attestation sent",
+    info "Aggregated attestation sent",
       aggregate = shortLog(signedAP.message.aggregate),
       aggregator_index = signedAP.message.aggregator_index,
       signature = shortLog(signedAP.signature),
@@ -1225,7 +1225,7 @@ proc sendAttestation*(node: BeaconNode,
     wallTime = node.processor.getCurrentBeaconTime()
     delay = wallTime - attestation.data.slot.attestation_deadline()
 
-  notice "Attestation sent",
+  info "Attestation sent",
     attestation = shortLog(attestation), delay, subnet_id
 
   beacon_attestation_sent_delay.observe(delay.toFloatSeconds())
@@ -1242,7 +1242,7 @@ proc sendAggregateAndProof*(node: BeaconNode,
     if res.isGoodForSending:
       node.network.broadcastAggregateAndProof(proof)
 
-      notice "Aggregated attestation sent",
+      info "Aggregated attestation sent",
         attestation = shortLog(proof.message.aggregate),
         aggregator_index = proof.message.aggregator_index,
         signature = shortLog(proof.signature)

--- a/docs/the_nimbus_book/src/validator-monitor.md
+++ b/docs/the_nimbus_book/src/validator-monitor.md
@@ -1,6 +1,6 @@
 # Validator monitoring
 
-> ⚠️ This feature is currently in BETA - implementation details such as metric names and counters may change in response to community feedback.
+> **Note:** This feature is available from `v1.7.0` onwards
 
 The validator monitoring feature allows for tracking the life-cycle and performance of one or more validators in detail.
 


### PR DESCRIPTION
Validator monitoring improves logging by giving more specific monitoring
information, and can now be seen as complete.

Previously, logging has focused on "Attestation sent" messages which
carry little informational value when things go wrong, and are overly
aggressive when everything works as expected (sending attestations is
the norm).

* lower "Attestation sent" log to `INFO`
* lower "Previous epoch attestation missing" to `NOTICE` for easier
filtering
* add delay logging to validator monitor logs
* simplify delay logging code post-`BeaconTime`
* mark 1.7.0 as the start of the validator monitor feature - previous
versions had significant bugs in totals mode