### PR TITLE
kiln beacon node

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -442,14 +442,14 @@ proc new*(T: type BeaconChainDB,
     blocks = [
       kvStore db.openKvStore("blocks").expectDb(),
       kvStore db.openKvStore("altair_blocks").expectDb(),
-      kvStore db.openKvStore("merge_blocks").expectDb()]
+      kvStore db.openKvStore("bellatrix_blocks").expectDb()]
 
     stateRoots = kvStore db.openKvStore("state_roots", true).expectDb()
 
     statesNoVal = [
       kvStore db.openKvStore("state_no_validators2").expectDb(),
       kvStore db.openKvStore("altair_state_no_validators").expectDb(),
-      kvStore db.openKvStore("merge_state_no_validators").expectDb()]
+      kvStore db.openKvStore("bellatrix_state_no_validators").expectDb()]
 
     stateDiffs = kvStore db.openKvStore("state_diffs").expectDb()
     summaries = kvStore db.openKvStore("beacon_block_summaries", true).expectDb()

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -442,14 +442,14 @@ proc new*(T: type BeaconChainDB,
     blocks = [
       kvStore db.openKvStore("blocks").expectDb(),
       kvStore db.openKvStore("altair_blocks").expectDb(),
-      kvStore db.openKvStore("bellatrix_blocks").expectDb()]
+      kvStore db.openKvStore("merge_blocks").expectDb()]
 
     stateRoots = kvStore db.openKvStore("state_roots", true).expectDb()
 
     statesNoVal = [
       kvStore db.openKvStore("state_no_validators2").expectDb(),
       kvStore db.openKvStore("altair_state_no_validators").expectDb(),
-      kvStore db.openKvStore("bellatrix_state_no_validators").expectDb()]
+      kvStore db.openKvStore("merge_state_no_validators").expectDb()]
 
     stateDiffs = kvStore db.openKvStore("state_diffs").expectDb()
     summaries = kvStore db.openKvStore("beacon_block_summaries", true).expectDb()

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -721,7 +721,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # Load head -> finalized, or all summaries in case the finalized block table
   # hasn't been written yet
   for blck in db.getAncestorSummaries(head.root):
-    let newRef = BlockRef.init(blck.root, blck.summary.slot)
+    let newRef = BlockRef.init(
+      blck.root, default(Eth2Digest), blck.summary.slot)
     if headRef == nil:
       doAssert blck.root == head.root
       headRef = newRef

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -14,13 +14,13 @@ import
   chronos, json, metrics, chronicles/timings, stint/endians2,
   web3, web3/ethtypes as web3Types, web3/ethhexstrings, web3/engine_api,
   eth/common/eth_types,
-  eth/async_utils, stew/[byteutils, shims/hashes],
+  eth/async_utils, stew/[byteutils, objects, shims/hashes],
   # Local modules:
   ../spec/[eth2_merkleization, forks, helpers],
   ../spec/datatypes/[base, phase0, bellatrix],
   ../networking/network_metadata,
   ../consensus_object_pools/block_pools_types,
-  ".."/[beacon_chain_db, beacon_node_status],
+  ".."/[beacon_chain_db, beacon_node_status, beacon_clock],
   ./merkle_minimal
 
 export
@@ -109,7 +109,7 @@ type
     forcePolling: bool
     jwtSecret: seq[byte]
 
-    dataProvider: Web3DataProviderRef
+    dataProvider*: Web3DataProviderRef  # TODO evidently not meant for export
     latestEth1Block: Option[FullBlockId]
 
     depositsChain: Eth1Chain
@@ -296,7 +296,7 @@ func is_candidate_block(cfg: RuntimeConfig,
 func asEth2Digest*(x: BlockHash): Eth2Digest =
   Eth2Digest(data: array[32, byte](x))
 
-template asBlockHash(x: Eth2Digest): BlockHash =
+template asBlockHash*(x: Eth2Digest): BlockHash =
   BlockHash(x.data)
 
 func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV1):
@@ -445,15 +445,37 @@ proc getBlockByNumber*(p: Web3DataProviderRef,
 
 proc getPayload*(p: Web3DataProviderRef,
                  payloadId: bellatrix.PayloadID): Future[engine_api.ExecutionPayloadV1] =
+  # Eth1 monitor can recycle connections without (external) warning; at least,
+  # don't crash.
+  if p.isNil:
+    var epr: Future[engine_api.ExecutionPayloadV1]
+    epr.complete(default(engine_api.ExecutionPayloadV1))
+    return epr
+
   p.web3.provider.engine_getPayloadV1(FixedBytes[8] payloadId)
 
 proc newPayload*(p: Web3DataProviderRef,
                  payload: engine_api.ExecutionPayloadV1): Future[PayloadStatusV1] =
+  # Eth1 monitor can recycle connections without (external) warning; at least,
+  # don't crash.
+  if p.isNil:
+    var epr: Future[PayloadStatusV1]
+    epr.complete(PayloadStatusV1(status: PayloadExecutionStatus.syncing))
+    return epr
+
   p.web3.provider.engine_newPayloadV1(payload)
 
 proc forkchoiceUpdated*(p: Web3DataProviderRef,
                         headBlock, finalizedBlock: Eth2Digest):
                         Future[engine_api.ForkchoiceUpdatedResponse] =
+  # Eth1 monitor can recycle connections without (external) warning; at least,
+  # don't crash.
+  if p.isNil:
+    var fcuR: Future[engine_api.ForkchoiceUpdatedResponse]
+    fcuR.complete(engine_api.ForkchoiceUpdatedResponse(
+      payloadStatus: PayloadStatusV1(status: PayloadExecutionStatus.syncing)))
+    return fcuR
+
   p.web3.provider.engine_forkchoiceUpdatedV1(
     ForkchoiceStateV1(
       headBlockHash: headBlock.asBlockHash,
@@ -472,6 +494,14 @@ proc forkchoiceUpdated*(p: Web3DataProviderRef,
                         randomData: array[32, byte],
                         suggestedFeeRecipient: Eth1Address):
                         Future[engine_api.ForkchoiceUpdatedResponse] =
+  # Eth1 monitor can recycle connections without (external) warning; at least,
+  # don't crash.
+  if p.isNil:
+    var fcuR: Future[engine_api.ForkchoiceUpdatedResponse]
+    fcuR.complete(engine_api.ForkchoiceUpdatedResponse(
+      payloadStatus: PayloadStatusV1(status: PayloadExecutionStatus.syncing)))
+    return fcuR
+
   p.web3.provider.engine_forkchoiceUpdatedV1(
     ForkchoiceStateV1(
       headBlockHash: headBlock.asBlockHash,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -11,13 +11,16 @@ import
   std/math,
   stew/results,
   chronicles, chronos, metrics,
-  ../spec/datatypes/[phase0, altair],
+  eth/async_utils,
+  web3/engine_api_types,
+  ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/[forks, signatures_batch],
   ../consensus_object_pools/[
     attestation_pool, block_clearance, blockchain_dag, block_quarantine,
     spec_cache],
+  ../eth1/eth1_monitor,
   ./consensus_manager,
-  ".."/[beacon_clock],
+  ../beacon_clock,
   ../sszdump
 
 export sszdump, signatures_batch
@@ -28,6 +31,8 @@ export sszdump, signatures_batch
 
 declareHistogram beacon_store_block_duration_seconds,
   "storeBlock() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
+
+const web3Timeout = 650.milliseconds
 
 type
   BlockEntry* = object
@@ -69,10 +74,16 @@ type
     # ----------------------------------------------------------------
     consensusManager: ref ConsensusManager
       ## Blockchain DAG, AttestationPool and Quarantine
+      ## Blockchain DAG, AttestationPool, Quarantine, and Eth1Manager
     validatorMonitor: ref ValidatorMonitor
     getBeaconTime: GetBeaconTimeFn
 
     verifier: BatchVerifier
+
+proc addBlock*(
+    self: var BlockProcessor, src: MsgSource, blck: ForkedSignedBeaconBlock,
+    resfut: Future[Result[void, BlockError]] = nil,
+    validationDur = Duration())
 
 # Initialization
 # ------------------------------------------------------------------------------
@@ -311,6 +322,67 @@ proc processBlock(self: var BlockProcessor, entry: BlockEntry) =
       if res.isOk(): Result[void, BlockError].ok()
       else: Result[void, BlockError].err(res.error()))
 
+proc runForkchoiceUpdated(
+    self: ref BlockProcessor, headBlockRoot, finalizedBlockRoot: Eth2Digest)
+    {.async.} =
+  if headBlockRoot.isZero or finalizedBlockRoot.isZero:
+    return
+
+  try:
+    # Minimize window for Eth1 monitor to shut down connection
+    await self.consensusManager.eth1Monitor.ensureDataProvider()
+
+    debug "runForkChoiceUpdated: running forkchoiceUpdated",
+      headBlockRoot,
+      finalizedBlockRoot
+
+    discard awaitWithTimeout(
+      forkchoiceUpdated(
+        self.consensusManager.eth1Monitor.dataProvider, headBlockRoot,
+        finalizedBlockRoot),
+      web3Timeout):
+        info "runForkChoiceUpdated: forkchoiceUpdated timed out"
+        default(ForkchoiceUpdatedResponse)
+  except CatchableError as err:
+    info "runForkChoiceUpdated: forkchoiceUpdated failed",
+      err = err.msg
+    discard
+
+proc newExecutionPayload(
+    web3Provider: auto, executionPayload: bellatrix.ExecutionPayload):
+    Future[PayloadExecutionStatus] {.async.} =
+  debug "newPayload: inserting block into execution engine",
+    parentHash = executionPayload.parent_hash,
+    blockHash = executionPayload.block_hash,
+    stateRoot = shortLog(executionPayload.state_root),
+    receiptsRoot = shortLog(executionPayload.receipts_root),
+    prevRandao = shortLog(executionPayload.prev_randao),
+    blockNumber = executionPayload.block_number,
+    gasLimit = executionPayload.gas_limit,
+    gasUsed = executionPayload.gas_used,
+    timestamp = executionPayload.timestamp,
+    extraDataLen = executionPayload.extra_data.len,
+    blockHash = executionPayload.block_hash,
+    baseFeePerGas =
+      UInt256.fromBytesLE(executionPayload.base_fee_per_gas.data),
+    numTransactions = executionPayload.transactions.len
+
+  try:
+    let
+      payloadResponse =
+        awaitWithTimeout(
+            web3Provider.newPayload(
+              executionPayload.asEngineExecutionPayload),
+            web3Timeout):
+          info "newPayload: newExecutionPayload timed out"
+          PayloadStatusV1(status: PayloadExecutionStatus.syncing)
+      payloadStatus = payloadResponse.status
+
+    return payloadStatus
+  except CatchableError as err:
+    info "newExecutionPayload failed", msg = err.msg
+    return PayloadExecutionStatus.syncing
+
 proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
   while true:
     # Cooperative concurrency: one block per loop iteration - because
@@ -324,6 +396,64 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
       # larger network reads when under load.
       idleTimeout = 10.milliseconds
 
+      defaultBellatrixPayload = default(bellatrix.ExecutionPayload)
+
     discard await idleAsync().withTimeout(idleTimeout)
 
-    self[].processBlock(await self[].blockQueue.popFirst())
+    let
+      blck = await self[].blockQueue.popFirst()
+      hasExecutionPayload = blck.blck.kind >= BeaconBlockFork.Bellatrix
+      executionPayloadStatus =
+        if  hasExecutionPayload and
+            # Allow local testnets to run without requiring an execution layer
+            blck.blck.bellatrixData.message.body.execution_payload !=
+              defaultBellatrixPayload:
+          try:
+            # Minimize window for Eth1 monitor to shut down connection
+            await self.consensusManager.eth1Monitor.ensureDataProvider()
+
+            await newExecutionPayload(
+              self.consensusManager.eth1Monitor.dataProvider,
+              blck.blck.bellatrixData.message.body.execution_payload)
+          except CatchableError as err:
+            info "runQueueProcessingLoop: newExecutionPayload failed",
+              err = err.msg
+            PayloadExecutionStatus.syncing
+        else:
+          # Vacuously
+          PayloadExecutionStatus.valid
+
+    if executionPayloadStatus in [
+        PayloadExecutionStatus.invalid,
+        PayloadExecutionStatus.invalid_block_hash,
+        PayloadExecutionStatus.invalid_terminal_block]:
+      info "runQueueProcessingLoop: execution payload invalid",
+        executionPayloadStatus
+      if not blck.resfut.isNil:
+        blck.resfut.complete(Result[void, BlockError].err(BlockError.Invalid))
+      continue
+
+    if executionPayloadStatus == PayloadExecutionStatus.valid:
+      self[].processBlock(blck)
+    else:
+      # Every non-nil future must be completed here, but don't want to process
+      # the block any further in CL terms. Also don't want to specify Invalid,
+      # as if it gets here, it's something more like MissingParent (except, on
+      # the EL side).
+      if not blck.resfut.isNil:
+        blck.resfut.complete(
+          Result[void, BlockError].err(BlockError.MissingParent))
+
+    if  executionPayloadStatus == PayloadExecutionStatus.valid and
+        hasExecutionPayload:
+      let
+        headBlockRoot = self.consensusManager.dag.head.executionBlockRoot
+
+        finalizedBlockRoot =
+          if not isZero(
+              self.consensusManager.dag.finalizedHead.blck.executionBlockRoot):
+            self.consensusManager.dag.finalizedHead.blck.executionBlockRoot
+          else:
+            default(Eth2Digest)
+
+      await self.runForkchoiceUpdated(headBlockRoot, finalizedBlockRoot)

--- a/beacon_chain/gossip_processing/consensus_manager.nim
+++ b/beacon_chain/gossip_processing/consensus_manager.nim
@@ -10,7 +10,8 @@
 import
   chronicles, chronos,
   ../spec/datatypes/base,
-  ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool]
+  ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
+  ../eth1/eth1_monitor
 
 # TODO: Move to "consensus_object_pools" folder
 
@@ -28,18 +29,24 @@ type
     # ----------------------------------------------------------------
     quarantine*: ref Quarantine
 
+    # Execution layer integration
+    # ----------------------------------------------------------------
+    eth1Monitor*: Eth1Monitor
+
 # Initialization
 # ------------------------------------------------------------------------------
 
 func new*(T: type ConsensusManager,
           dag: ChainDAGRef,
           attestationPool: ref AttestationPool,
-          quarantine: ref Quarantine
+          quarantine: ref Quarantine,
+          eth1Monitor: Eth1Monitor
          ): ref ConsensusManager =
   (ref ConsensusManager)(
     dag: dag,
     attestationPool: attestationPool,
-    quarantine: quarantine
+    quarantine: quarantine,
+    eth1Monitor: eth1Monitor
   )
 
 # Consensus Management

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -256,7 +256,7 @@ proc initFullNode(
     exitPool = newClone(
       ExitPool.init(dag, onVoluntaryExitAdded))
     consensusManager = ConsensusManager.new(
-      dag, attestationPool, quarantine)
+      dag, attestationPool, quarantine, node.eth1Monitor)
     blockProcessor = BlockProcessor.new(
       config.dumpEnabled, config.dumpDirInvalid, config.dumpDirIncoming,
       rng, taskpool, consensusManager, node.validatorMonitor, getBeaconTime)

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -83,14 +83,16 @@ proc checkJwtSecret*(
 
   try:
     let lines = readLines(jwtSecret.get, 1)
-    if lines.len > 0 and lines[0].startswith("0x"):
+    if lines.len > 0:
+      # Secret JWT key is parsed in constant time using nimcrypto:
+      # https://github.com/cheatfate/nimcrypto/pull/44
       let secret = utils.fromHex(lines[0])
       if secret.len >= MIN_SECRET_LEN:
         ok(secret)
       else:
         err("JWT secret not at least 256 bits")
     else:
-      err("no 0x-prefixed hex string found")
+      err("no hex string found")
   except IOError:
     err("couldn't open specified JWT secret file")
   except ValueError:

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -17,6 +17,7 @@ import
   ../beacon_chain/gossip_processing/[block_processor, consensus_manager],
   ../beacon_chain/consensus_object_pools/[
     attestation_pool, blockchain_dag, block_quarantine, block_clearance],
+  ../beacon_chain/eth1/eth1_monitor,
   ./testutil, ./testdbutil, ./testblockutil
 
 proc pruneAtFinalization(dag: ChainDAGRef) =
@@ -33,7 +34,9 @@ suite "Block processor" & preset():
       verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
       quarantine = newClone(Quarantine.init())
       attestationPool = newClone(AttestationPool.init(dag, quarantine))
-      consensusManager = ConsensusManager.new(dag, attestationPool, quarantine)
+      eth1Monitor = new Eth1Monitor
+      consensusManager = ConsensusManager.new(
+        dag, attestationPool, quarantine, eth1Monitor)
       state = newClone(dag.headState)
       cache = StateCache()
       b1 = addTestBlock(state[], cache).phase0Data


### PR DESCRIPTION
Non-goals: block proposing or JWT support. Attesting should work, but I wouldn't consider it not working a blocker for this PR. Becaue of lack of JWT support, using the Geth configuration at https://notes.ethereum.org/@launchpad/kiln for example, one needs to use `--web3-url=ws://127.0.0.1:8546`. For example, I'm using a script:
```sh
#!/usr/bin/env sh
set -eu
nimbus-eth2/build/nimbus_beacon_node \
    --network=merge-testnets/kiln \
    --web3-url=ws://127.0.0.1:8546
    --rest \
    --metrics \
    --log-level=DEBUG \
    --terminal-total-difficulty-override=20000000000000 \
    --jwt-secret="/tmp/jwtsecret"
```
which is a copy/paste of the launchpad example, but `s/8551/8546/`.

It does function as a beacon node following Kiln and avoids nontrivial changes to the Eth1 monitor; in particular, it does not track do anything with transition total difficulty. It detects The Merge simply by when non-empty `ExecutionPayload`s appear, which is enough for its purpose.

Its initial form is a bit of a dump of a subset of the code in `kiln-dev-auth`, and needs cleanup, but since the goal is to merge this in a reasonably timely way, leaving it as non-draft.