### PR TITLE
exists{Dir,File} -> {dir,file}Exists; rm unused imports

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -31,7 +31,7 @@
 import
   std/[typetraits, sets, hashes],
   chronicles,
-  stew/[assign2, bitops2, objects],
+  stew/[bitops2, objects],
   "."/[base, phase0]
 
 export base, sets
@@ -547,7 +547,7 @@ chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
 template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
   a[i.asInt]
 
-template `[]`*(arr: array[SYNC_COMMITTEE_SIZE, any] | seq;
+template `[]`*(arr: array[SYNC_COMMITTEE_SIZE, auto] | seq;
                idx: IndexInSyncCommittee): auto =
   arr[int idx]
 

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -13,7 +13,7 @@
 {.push raises: [Defect].}
 
 import
-  stew/[assign2, byteutils],
+  stew/byteutils,
   json_serialization,
   ssz_serialization/types as sszTypes,
   ../digest,

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -484,10 +484,10 @@ proc removeValidatorFiles*(validatorsDir, secretsDir, keyName: string,
         keystoreDir / RemoteKeystoreFileName
     secretFile = secretsDir / keyName
 
-  if not(existsDir(keystoreDir)):
+  if not(dirExists(keystoreDir)):
     return ok(RemoveValidatorStatus.notFound)
 
-  if not(existsFile(keystoreFile)):
+  if not(fileExists(keystoreFile)):
     return ok(RemoveValidatorStatus.notFound)
 
   case kind
@@ -498,7 +498,7 @@ proc removeValidatorFiles*(validatorsDir, secretsDir, keyName: string,
         return err("Could not remove keystore file")
     block:
       let res = io2.removeFile(secretFile)
-      if res.isErr() and existsFile(secretFile):
+      if res.isErr() and fileExists(secretFile):
         return err("Could not remove password file")
     # We remove folder with all subfolders and files inside.
     try:
@@ -555,9 +555,9 @@ proc existsKeystore*(keystoreDir: string, keyKind: KeystoreKind): bool {.
      raises: [Defect].} =
   case keyKind
   of KeystoreKind.Local:
-    existsFile(keystoreDir / KeystoreFileName)
+    fileExists(keystoreDir / KeystoreFileName)
   of KeystoreKind.Remote:
-    existsFile(keystoreDir / RemoteKeystoreFileName)
+    fileExists(keystoreDir / RemoteKeystoreFileName)
 
 proc existsKeystore*(keystoreDir: string,
                      keysMask: set[KeystoreKind]): bool {.raises: [Defect].} =
@@ -796,10 +796,10 @@ proc saveKeystore*(rng: var BrHmacDrbgContext,
     keystoreDir = validatorsDir / keyName
     keystoreFile = keystoreDir / KeystoreFileName
 
-  if existsDir(keystoreDir):
+  if dirExists(keystoreDir):
     return err(KeystoreGenerationError(kind: DuplicateKeystoreDir,
       error: "Keystore directory already exists"))
-  if existsFile(keystoreFile):
+  if fileExists(keystoreFile):
     return err(KeystoreGenerationError(kind: DuplicateKeystoreFile,
       error: "Keystore file already exists"))
 
@@ -839,10 +839,10 @@ proc saveKeystore*(validatorsDir: string,
       pubkey: publicKey, remote: url, flags: flags
     )
 
-  if existsDir(keystoreDir):
+  if dirExists(keystoreDir):
     return err(KeystoreGenerationError(kind: DuplicateKeystoreDir,
       error: "Keystore directory already exists"))
-  if existsFile(keystoreFile):
+  if fileExists(keystoreFile):
     return err(KeystoreGenerationError(kind: DuplicateKeystoreFile,
       error: "Keystore file already exists"))
 

--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -46,7 +46,7 @@ proc runTest[T, U](
 
   proc testImpl() =
     let prefix =
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         "[Valid]   "
       else:
         "[Invalid] "
@@ -57,7 +57,7 @@ proc runTest[T, U](
       let done = applyProc(
         preState[], parseTest(testDir/(applyFile & ".ssz_snappy"), SSZ, T))
 
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(testDir/"post.ssz_snappy", SSZ, altair.BeaconState))
 

--- a/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/altair/test_fixture_sanity_blocks.nim
@@ -27,7 +27,7 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   proc `testImpl _ blck _ testName`() =
     let
-      hasPostState = existsFile(testPath/"post.ssz_snappy")
+      hasPostState = fileExists(testPath/"post.ssz_snappy")
       prefix = if hasPostState: "[Valid]   " else: "[Invalid] "
 
     test prefix & testName & " - " & unitTestName & preset():

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -79,7 +79,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # ----------------------------------------------------------------
 
 suite "EF - Altair - SSZ consensus objects " & preset():
-  doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
+  doAssert dirExists(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -47,7 +47,7 @@ proc runTest[T, U](
 
   proc testImpl() =
     let prefix =
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         "[Valid]   "
       else:
         "[Invalid] "
@@ -58,7 +58,7 @@ proc runTest[T, U](
       let done = applyProc(
         preState[], parseTest(testDir/(applyFile & ".ssz_snappy"), SSZ, T))
 
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(
             testDir/"post.ssz_snappy", SSZ, bellatrix.BeaconState))

--- a/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_sanity_blocks.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[os, sequtils, strutils],
+  std/[os, sequtils],
   # Nimble
   chronicles,
   # Beacon chain internals
@@ -30,7 +30,7 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   proc `testImpl _ blck _ testName`() =
     let
-      hasPostState = existsFile(testPath/"post.ssz_snappy")
+      hasPostState = fileExists(testPath/"post.ssz_snappy")
       prefix = if hasPostState: "[Valid]   " else: "[Invalid] "
 
     test prefix & testName & " - " & unitTestName & preset():

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -79,7 +79,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # ----------------------------------------------------------------
 
 suite "EF - Bellatrix - SSZ consensus objects " & preset():
-  doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
+  doAssert dirExists(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 

--- a/tests/consensus_spec/consensus_spec_tests_preset.nim
+++ b/tests/consensus_spec/consensus_spec_tests_preset.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  chronicles,
   ../testutil
 
 # Tests that depend on `mainnet` vs `minimal` compile-time configuration

--- a/tests/consensus_spec/phase0/test_fixture_operations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations.nim
@@ -44,7 +44,7 @@ proc runTest[T, U](
 
   proc testImpl() =
     let prefix =
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         "[Valid]   "
       else:
         "[Invalid] "
@@ -55,7 +55,7 @@ proc runTest[T, U](
       let done = applyProc(
         preState[], parseTest(testDir/(applyFile & ".ssz_snappy"), SSZ, T))
 
-      if existsFile(testDir/"post.ssz_snappy"):
+      if fileExists(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(testDir/"post.ssz_snappy", SSZ, phase0.BeaconState))
 

--- a/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/phase0/test_fixture_sanity_blocks.nim
@@ -27,7 +27,7 @@ proc runTest(testName, testDir, unitTestName: string) =
 
   proc `testImpl _ blck _ testName`() =
     let
-      hasPostState = existsFile(testPath/"post.ssz_snappy")
+      hasPostState = fileExists(testPath/"post.ssz_snappy")
       prefix = if hasPostState: "[Valid]   " else: "[Invalid] "
 
     test prefix & testName & " - " & unitTestName & preset():

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -79,7 +79,7 @@ proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
 # ----------------------------------------------------------------
 
 suite "EF - Phase 0 - SSZ consensus objects " & preset():
-  doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
+  doAssert dirExists(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -246,7 +246,7 @@ proc sszCheck(baseDir, sszType, sszSubType: string) =
 # ------------------------------------------------------------------------
 
 suite "EF - SSZ generic types":
-  doAssert existsDir(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
+  doAssert dirExists(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
   for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
     doAssert pathKind == pcDir
 


### PR DESCRIPTION
https://nim-lang.org/docs/os.html#existsDir.t%2Cvarargs%5Buntyped%5D and https://nim-lang.org/docs/os.html#existsFile.t%2Cvarargs%5Buntyped%5D in Nim 1.6 mean that one sees many
```
Warning: use dirExists; existsDir is deprecated [Deprecated]
```
and
```
Warning: use fileExists; existsFile is deprecated [Deprecated]
```
in Nim 1.6 `nimbus-eth2` builds.

The non-deprecated functions already exist in Nim 1.2, so use them.