### PR TITLE
cap number of threads for --num-threads=0

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -352,7 +352,8 @@ proc init*(T: type BeaconNode,
       fatal "The number of threads --numThreads cannot be negative."
       quit 1
     elif config.numThreads == 0:
-      taskpool = TaskpoolPtr.new()
+      # TODO nim-taskpools only supports up to 255 threads
+      taskpool = TaskpoolPtr.new(numThreads = min(countProcessors(), 255))
     else:
       taskpool = TaskpoolPtr.new(numThreads = config.numThreads)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -352,8 +352,7 @@ proc init*(T: type BeaconNode,
       fatal "The number of threads --numThreads cannot be negative."
       quit 1
     elif config.numThreads == 0:
-      # TODO nim-taskpools only supports up to 255 threads
-      taskpool = TaskpoolPtr.new(numThreads = min(countProcessors(), 255))
+      taskpool = TaskpoolPtr.new(numThreads = min(countProcessors(), 16))
     else:
       taskpool = TaskpoolPtr.new(numThreads = config.numThreads)
 


### PR DESCRIPTION
Kind of a kludge, and depends on the non-exported constant `TP_MaxWorkers` in
https://github.com/status-im/nim-taskpools/blob/b31b891f114cf8704728116435efc5a2f9c2a719/taskpools/sparsesets.nim#L14-L15

It's a mitigation, though, to assertion on startup when running `--num-threads=0` with a >= 256-core machine, which doesn't depend on any changes in `nim-taskpools`, for the assertion in:
```nim
func allocate*(s: var SparseSet, capacity: SomeInteger) {.inline.} =
  preCondition: capacity <= TP_MaxWorkers
```

The same assertion could fire if someone manually requests `--num-threads=256` or higher manually, but that's something someone would have to have manually set up to begin with. It seems worse in many ways to silently run, but not with the settings the user manually configured, in the non-`--num-threads=0` case, whereas the 0 case just has to do something reasonable.