### PR TITLE
update `kiln` networks dir

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -76,7 +76,7 @@ type
 
 const
   eth2NetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/eth2-networks"
-  mergeNetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/merge-networks"
+  mergeNetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/merge-testnets"
 
 proc readBootstrapNodes*(path: string): seq[string] {.raises: [IOError, Defect].} =
   # Read a list of ENR values from a YAML file containing a flat list of entries


### PR DESCRIPTION
The `--network=kiln` parameter does not seem to work properly.
The merge networks repo is cloned to `vendor/merge-testnets`,
but the code refers to `vendor/merge-networks`.
The two directories are aligned in hopes to fix this problem.