### PR TITLE
use snappy-framed format for compressing bellatrix+ database entries

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -478,12 +478,22 @@ proc getBlock*(
 proc getBlockSSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
   # Load the SSZ-encoded data of a block into `bytes`, overwriting the existing
   # content
-  # careful: there are two snappy encodings in use, with and without framing!
-  # Returns true if the block is found, false if not
   let fork = dag.cfg.blockForkAtEpoch(bid.slot.epoch)
   dag.db.getBlockSSZ(bid.root, bytes, fork) or
     (bid.slot <= dag.finalizedHead.slot and
       getBlockSSZ(
+        dag.era, getStateField(dag.headState, historical_roots).asSeq,
+        bid.slot, bytes).isOk)
+
+proc getBlockSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
+  # Load the snappy-frame-compressed ("SZ") SSZ-encoded data of a block into
+  # `bytes`, overwriting the existing content
+  # careful: there are two snappy encodings in use, with and without framing!
+  # Returns true if the block is found, false if not
+  let fork = dag.cfg.blockForkAtEpoch(bid.slot.epoch)
+  dag.db.getBlockSZ(bid.root, bytes, fork) or
+    (bid.slot <= dag.finalizedHead.slot and
+      getBlockSZ(
         dag.era, getStateField(dag.headState, historical_roots).asSeq,
         bid.slot, bytes).isOk)
 

--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -243,11 +243,11 @@ proc init*(T: type EraGroup, f: IoHandle, startSlot: Option[Slot]): Result[T, st
         else: 0
   ))))
 
-proc update*(g: var EraGroup, f: IoHandle, slot: Slot, sszBytes: openArray[byte]): Result[void, string] =
+proc update*(g: var EraGroup, f: IoHandle, slot: Slot, szBytes: openArray[byte]): Result[void, string] =
   doAssert slot >= g.slotIndex.startSlot
   g.slotIndex.offsets[int(slot - g.slotIndex.startSlot)] =
     try:
-      ? f.appendRecord(SnappyBeaconBlock, framingFormatCompress(sszBytes))
+      ? f.appendRecord(SnappyBeaconBlock, szBytes)
     except CatchableError as e: raiseAssert e.msg # TODO fix snappy
 
   ok()

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -487,7 +487,7 @@ proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
         withTimer(timers[tBlocks]):
           var blocks: array[SLOTS_PER_HISTORICAL_ROOT.int, BlockId]
           for i in dag.getBlockRange(firstSlot.get(), 1, blocks)..<blocks.len:
-            if dag.getBlockSSZ(blocks[i], tmp):
+            if dag.getBlockSZ(blocks[i], tmp):
               group.update(e2, blocks[i].slot, tmp).get()
 
       withTimer(timers[tState]):

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -14,7 +14,7 @@ import
   ../beacon_chain/spec/[beaconstate, forks, state_transition],
   ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
   ../beacon_chain/consensus_object_pools/blockchain_dag,
-  eth/db/kvstore,
+  eth/db/kvstore, snappy/framing,
   # test utilies
   ./testutil, ./testdbutil, ./testblockutil, ./teststateutil
 
@@ -100,7 +100,7 @@ suite "Beacon chain DB" & preset():
 
     db.putBlock(signedBlock)
 
-    var tmp: seq[byte]
+    var tmp, tmp2: seq[byte]
     check:
       db.containsBlock(root)
       db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
@@ -108,7 +108,9 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, phase0.TrustedSignedBeaconBlock).get() == signedBlock
       db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
+      db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
+      tmp2 == framingFormatCompress(tmp)
 
     db.delBlock(root)
     check:
@@ -118,6 +120,7 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, phase0.TrustedSignedBeaconBlock).isErr()
       not db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
+      not db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
 
     db.putStateRoot(root, signedBlock.message.slot, root)
     var root2 = root
@@ -139,7 +142,7 @@ suite "Beacon chain DB" & preset():
 
     db.putBlock(signedBlock)
 
-    var tmp: seq[byte]
+    var tmp, tmp2: seq[byte]
     check:
       db.containsBlock(root)
       not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
@@ -147,7 +150,9 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, altair.TrustedSignedBeaconBlock).get() == signedBlock
       db.getBlockSSZ(root, tmp, altair.TrustedSignedBeaconBlock)
+      db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
+      tmp2 == framingFormatCompress(tmp)
 
     db.delBlock(root)
     check:
@@ -157,6 +162,7 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, altair.TrustedSignedBeaconBlock).isErr()
       not db.getBlockSSZ(root, tmp, altair.TrustedSignedBeaconBlock)
+      not db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
 
     db.putStateRoot(root, signedBlock.message.slot, root)
     var root2 = root
@@ -178,7 +184,7 @@ suite "Beacon chain DB" & preset():
 
     db.putBlock(signedBlock)
 
-    var tmp: seq[byte]
+    var tmp, tmp2: seq[byte]
     check:
       db.containsBlock(root)
       not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
@@ -186,7 +192,9 @@ suite "Beacon chain DB" & preset():
       db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, bellatrix.TrustedSignedBeaconBlock).get() == signedBlock
       db.getBlockSSZ(root, tmp, bellatrix.TrustedSignedBeaconBlock)
+      db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
+      tmp2 == framingFormatCompress(tmp)
 
     db.delBlock(root)
     check:
@@ -196,6 +204,7 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
       db.getBlock(root, bellatrix.TrustedSignedBeaconBlock).isErr()
       not db.getBlockSSZ(root, tmp, bellatrix.TrustedSignedBeaconBlock)
+      not db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
 
     db.putStateRoot(root, signedBlock.message.slot, root)
     var root2 = root


### PR DESCRIPTION
`.era` files and Req/Resp protocols use framed formats - aligning the
database with these makes for less recompression work overall as gossip
is sent only once while req/resp repeats (potentially) - this also
allows efficient pruning-to-era where snappy-recompression is the major
cycle thief.