### PR TITLE
integrate light client into beacon node

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -14,7 +14,7 @@ import
   chronos, json_rpc/servers/httpserver, presto,
 
   # Local modules
-  "."/[beacon_clock, beacon_chain_db, conf],
+  "."/[beacon_clock, beacon_chain_db, conf, light_client],
   ./gossip_processing/[eth2_processor, block_processor, consensus_manager],
   ./networking/eth2_network,
   ./eth1/eth1_monitor,
@@ -27,9 +27,10 @@ import
   ./rpc/state_ttl_cache
 
 export
-  osproc, chronos, httpserver, presto, action_tracker, beacon_clock,
-  beacon_chain_db, conf, attestation_pool, sync_committee_msg_pool,
-  validator_pool, eth2_network, eth1_monitor, request_manager, sync_manager,
+  osproc, chronos, httpserver, presto, action_tracker,
+  beacon_clock, beacon_chain_db, conf, light_client,
+  attestation_pool, sync_committee_msg_pool, validator_pool,
+  eth2_network, eth1_monitor, request_manager, sync_manager,
   eth2_processor, blockchain_dag, block_quarantine, base, exit_pool,
   validator_monitor, consensus_manager
 
@@ -44,6 +45,7 @@ type
     db*: BeaconChainDB
     config*: BeaconNodeConf
     attachedValidators*: ref ValidatorPool
+    lightClient*: LightClient
     dag*: ChainDAGRef
     quarantine*: ref Quarantine
     attestationPool*: ref AttestationPool

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -33,18 +33,18 @@ proc initLightClient*(
     node.network, rng, config, cfg,
     forkDigests, getBeaconTime, genesis_validators_root)
 
-  if config.lightClientEnable.get:
+  if config.lightClientEnable:
     lightClient.trustedBlockRoot = config.lightClientTrustedBlockRoot
 
   elif config.lightClientTrustedBlockRoot.isSome:
     warn "Ignoring `lightClientTrustedBlockRoot`, light client not enabled",
-      lightClientEnable = config.lightClientEnable.get,
+      lightClientEnable = config.lightClientEnable,
       lightClientTrustedBlockRoot = config.lightClientTrustedBlockRoot
 
   node.lightClient = lightClient
 
 proc startLightClient*(node: BeaconNode) =
-  if not node.config.lightClientEnable.get:
+  if not node.config.lightClientEnable:
     return
 
   node.lightClient.start()
@@ -54,7 +54,7 @@ proc installLightClientMessageValidators*(node: BeaconNode) =
     if node.config.serveLightClientData.get:
       # Process gossip using both full node and light client
       node.processor
-    elif node.config.lightClientEnable.get:
+    elif node.config.lightClientEnable:
       # Only process gossip using light client
       nil
     else:
@@ -76,7 +76,7 @@ proc updateLightClientGossipStatus*(
   node.lightClient.updateGossipStatus(slot, some isBehind)
 
 proc updateLightClientFromDag*(node: BeaconNode) =
-  if not node.config.lightClientEnable.get:
+  if not node.config.lightClientEnable:
     return
   if node.config.lightClientTrustedBlockRoot.isSome:
     return

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -80,7 +80,7 @@ proc updateLightClientFromDag*(node: BeaconNode) =
   let
     dagHead = node.dag.finalizedHead
     dagPeriod = dagHead.slot.sync_committee_period
-  if dagHead.slot.epoch < node.dag.cfg.ALTAIR_FORK_EPOCH:
+  if dagHead.slot < node.dag.cfg.ALTAIR_FORK_EPOCH.start_slot:
     return
 
   let lcHeader = node.lightClient.finalizedHeader

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -1,0 +1,99 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+# This implements the pre-release proposal of the libp2p based light client sync
+# protocol. See https://github.com/ethereum/consensus-specs/pull/2802
+
+import
+  chronicles,
+  ./beacon_node
+
+logScope: topics = "beacnde"
+
+proc initLightClient*(
+    node: BeaconNode,
+    rng: ref BrHmacDrbgContext,
+    cfg: RuntimeConfig,
+    forkDigests: ref ForkDigests,
+    getBeaconTime: GetBeaconTimeFn,
+    genesis_validators_root: Eth2Digest) =
+  template config(): auto = node.config
+
+  let lightClient = createLightClient(
+    node.network, rng, config, cfg,
+    forkDigests, getBeaconTime, genesis_validators_root)
+
+  if config.lightClientEnable.get:
+    lightClient.trustedBlockRoot = config.lightClientTrustedBlockRoot
+
+  elif config.lightClientTrustedBlockRoot.isSome:
+    warn "Ignoring `lightClientTrustedBlockRoot`, light client not enabled",
+      lightClientEnable = config.lightClientEnable.get,
+      lightClientTrustedBlockRoot = config.lightClientTrustedBlockRoot
+
+  node.lightClient = lightClient
+
+proc startLightClient*(node: BeaconNode) =
+  if not node.config.lightClientEnable.get:
+    return
+
+  node.lightClient.start()
+
+proc installLightClientMessageValidators*(node: BeaconNode) =
+  let eth2Processor =
+    if node.config.serveLightClientData.get:
+      # Process gossip using both full node and light client
+      node.processor
+    elif node.config.lightClientEnable.get:
+      # Only process gossip using light client
+      nil
+    else:
+      # Light client topics will never be subscribed to, no validators needed
+      return
+
+  node.lightClient.installMessageValidators(eth2Processor)
+
+proc updateLightClientGossipStatus*(
+    node: BeaconNode, slot: Slot, dagIsBehind: bool) =
+  let isBehind =
+    if node.config.serveLightClientData.get:
+      # Forward DAG's readiness to handle light client gossip
+      dagIsBehind
+    else:
+      # Full node is not interested in gossip
+      true
+
+  node.lightClient.updateGossipStatus(slot, some isBehind)
+
+proc updateLightClientFromDag*(node: BeaconNode) =
+  if not node.config.lightClientEnable.get:
+    return
+  if node.config.lightClientTrustedBlockRoot.isSome:
+    return
+
+  let
+    dagHead = node.dag.finalizedHead
+    dagPeriod = dagHead.slot.sync_committee_period
+  if dagHead.slot.epoch < node.dag.cfg.ALTAIR_FORK_EPOCH:
+    return
+
+  let lcHeader = node.lightClient.finalizedHeader
+  if lcHeader.isSome:
+    if dagPeriod <= lcHeader.get.slot.sync_committee_period:
+      return
+
+  let
+    bdata = node.dag.getForkedBlock(dagHead.blck.bid).valueOr:
+      return
+    header = bdata.toBeaconBlockHeader
+    current_sync_committee = block:
+      var tmpState = assignClone(node.dag.headState)
+      node.dag.currentSyncCommitteeForPeriod(tmpState[], dagPeriod).valueOr:
+        return
+  node.lightClient.resetToFinalizedHeader(header, current_sync_committee)

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -33,18 +33,18 @@ proc initLightClient*(
     node.network, rng, config, cfg,
     forkDigests, getBeaconTime, genesis_validators_root)
 
-  if config.lightClientEnable:
+  if config.lightClientEnable.get:
     lightClient.trustedBlockRoot = config.lightClientTrustedBlockRoot
 
   elif config.lightClientTrustedBlockRoot.isSome:
     warn "Ignoring `lightClientTrustedBlockRoot`, light client not enabled",
-      lightClientEnable = config.lightClientEnable,
+      lightClientEnable = config.lightClientEnable.get,
       lightClientTrustedBlockRoot = config.lightClientTrustedBlockRoot
 
   node.lightClient = lightClient
 
 proc startLightClient*(node: BeaconNode) =
-  if not node.config.lightClientEnable:
+  if not node.config.lightClientEnable.get:
     return
 
   node.lightClient.start()
@@ -54,7 +54,7 @@ proc installLightClientMessageValidators*(node: BeaconNode) =
     if node.config.serveLightClientData.get:
       # Process gossip using both full node and light client
       node.processor
-    elif node.config.lightClientEnable:
+    elif node.config.lightClientEnable.get:
       # Only process gossip using light client
       nil
     else:
@@ -76,7 +76,7 @@ proc updateLightClientGossipStatus*(
   node.lightClient.updateGossipStatus(slot, some isBehind)
 
 proc updateLightClientFromDag*(node: BeaconNode) =
-  if not node.config.lightClientEnable:
+  if not node.config.lightClientEnable.get:
     return
   if node.config.lightClientTrustedBlockRoot.isSome:
     return

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -25,6 +25,10 @@ proc initLightClient*(
     genesis_validators_root: Eth2Digest) =
   template config(): auto = node.config
 
+  # Creating a light client is not dependent on `lightClientEnable`
+  # because the light client module also handles gossip subscriptions
+  # for broadcasting light client data as a server.
+
   let lightClient = createLightClient(
     node.network, rng, config, cfg,
     forkDigests, getBeaconTime, genesis_validators_root)

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -269,8 +269,7 @@ type
       lightClientEnable* {.
         hidden
         desc: "BETA: Accelerate sync using light client."
-        defaultValue: false
-        name: "light-client-enable" .}: bool
+        name: "light-client-enable" .}: Option[bool]
 
       lightClientTrustedBlockRoot* {.
         hidden

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -266,6 +266,16 @@ type
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" }: Option[Checkpoint]
 
+      lightClientEnable* {.
+        hidden
+        desc: "BETA: Accelerate sync using light client."
+        name: "light-client-enable" .}: Option[bool]
+
+      lightClientTrustedBlockRoot* {.
+        hidden
+        desc: "BETA: Recent trusted finalized block root to initialize light client from."
+        name: "light-client-trusted-block-root" }: Option[Eth2Digest]
+
       finalizedCheckpointState* {.
         desc: "SSZ file specifying a recent finalized state"
         name: "finalized-checkpoint-state" }: Option[InputFile]
@@ -903,6 +913,13 @@ proc createDumpDirs*(config: BeaconNodeConf) =
     if (let res = secureCreatePath(config.dumpDirOutgoing); res.isErr):
       warn "Could not create dump directory",
         path = config.dumpDirOutgoing, err = ioErrorMsg(res.error)
+
+func parseCmdArg*(T: type Eth2Digest, input: string): T
+                 {.raises: [ValueError, Defect].} =
+  Eth2Digest.fromHex(input)
+
+func completeCmdArg*(T: type Eth2Digest, input: string): seq[string] =
+  return @[]
 
 func parseCmdArg*(T: type GraffitiBytes, input: string): T
                  {.raises: [ValueError, Defect].} =

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -269,7 +269,8 @@ type
       lightClientEnable* {.
         hidden
         desc: "BETA: Accelerate sync using light client."
-        name: "light-client-enable" .}: Option[bool]
+        defaultValue: false
+        name: "light-client-enable" .}: bool
 
       lightClientTrustedBlockRoot* {.
         hidden

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -122,10 +122,3 @@ type LightClientConf* = object
     desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
     defaultValue: 0
     name: "stop-at-epoch" }: uint64
-
-func parseCmdArg*(T: type Eth2Digest, input: string): T
-                 {.raises: [ValueError, Defect].} =
-  Eth2Digest.fromHex(input)
-
-func completeCmdArg*(T: type Eth2Digest, input: string): seq[string] =
-  return @[]

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -113,24 +113,16 @@ proc getExistingForkedBlock*(
     doAssert verifyFinalization notin dag.updateFlags
   bdata
 
-proc currentSyncCommitteeForPeriod(
+proc existingCurrentSyncCommitteeForPeriod(
     dag: ChainDAGRef,
     tmpState: var ForkedHashedBeaconState,
     period: SyncCommitteePeriod): Opt[SyncCommittee] =
-  ## Fetch a `SyncCommittee` for a given sync committee period.
-  ## For non-finalized periods, follow the chain as selected by fork choice.
-  let earliestSlot = dag.computeEarliestLightClientSlot
-  doAssert period >= earliestSlot.sync_committee_period
-  let
-    periodStartSlot = period.start_slot
-    syncCommitteeSlot = max(periodStartSlot, earliestSlot)
-    bsi = ? dag.getExistingBlockIdAtSlot(syncCommitteeSlot)
-  dag.withUpdatedExistingState(tmpState, bsi) do:
-    withState(state):
-      when stateFork >= BeaconStateFork.Altair:
-        ok state.data.current_sync_committee
-      else: raiseAssert "Unreachable"
-  do: err()
+  ## Wrapper around `currentSyncCommitteeForPeriod` for states known to exist.
+  let syncCommittee = dag.currentSyncCommitteeForPeriod(tmpState, period)
+  if syncCommittee.isErr:
+    error "Current sync committee failed to load unexpectedly",
+      period, tail = dag.tail.slot
+  syncCommittee
 
 template syncCommitteeRoot(
     state: HashedBeaconStateWithSyncCommittee): Eth2Digest =
@@ -795,7 +787,7 @@ proc getLightClientBootstrap*(
       bootstrap.header =
         blck.toBeaconBlockHeader
       bootstrap.current_sync_committee =
-        ? dag.currentSyncCommitteeForPeriod(tmpState[], period)
+        ? dag.existingCurrentSyncCommitteeForPeriod(tmpState[], period)
       bootstrap.current_sync_committee_branch =
         cachedBootstrap.current_sync_committee_branch
       return ok bootstrap

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -122,6 +122,7 @@ proc existingCurrentSyncCommitteeForPeriod(
   if syncCommittee.isErr:
     error "Current sync committee failed to load unexpectedly",
       period, tail = dag.tail.slot
+    doAssert verifyFinalization notin dag.updateFlags
   syncCommittee
 
 template syncCommitteeRoot(

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -332,10 +332,15 @@ proc updateGossipStatus*(
       let forkDigest = lightClient.forkDigests[].atStateFork(gossipFork)
       lightClient.network.unsubscribe(
         getLightClientFinalityUpdateTopic(forkDigest))
+      lightClient.network.unsubscribe(
+        getLightClientOptimisticUpdateTopic(forkDigest))
 
   for gossipFork in newGossipForks:
     if gossipFork >= BeaconStateFork.Altair:
       let forkDigest = lightClient.forkDigests[].atStateFork(gossipFork)
+      lightClient.network.subscribe(
+        getLightClientFinalityUpdateTopic(forkDigest),
+        lightClientTopicParams)
       lightClient.network.subscribe(
         getLightClientOptimisticUpdateTopic(forkDigest),
         lightClientTopicParams)

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -43,6 +43,7 @@ type
 
   Eth2NetworkConfigDefaults* = object
     ## Network specific config defaults
+    lightClientEnable*: bool
     serveLightClientData*: bool
     importLightClientData*: ImportLightClientData
 
@@ -191,6 +192,8 @@ proc loadEth2NetworkMetadata*(path: string, eth1Network = none(Eth1Network)): Et
 
       configDefaults =
         Eth2NetworkConfigDefaults(
+          lightClientEnable:
+            false, # Only produces debug logs so far
           serveLightClientData:
             shouldSupportLightClient,
           importLightClientData:

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -43,6 +43,7 @@ type
 
   Eth2NetworkConfigDefaults* = object
     ## Network specific config defaults
+    lightClientEnable*: bool
     serveLightClientData*: bool
     importLightClientData*: ImportLightClientData
 
@@ -164,7 +165,7 @@ proc loadEth2NetworkMetadata*(path: string, eth1Network = none(Eth1Network)): Et
       else:
         ""
 
-      enableLightClientData =
+      shouldSupportLightClient =
         if genesisData.len >= 40:
           # SSZ processing at compile time does not work well.
           #
@@ -191,10 +192,12 @@ proc loadEth2NetworkMetadata*(path: string, eth1Network = none(Eth1Network)): Et
 
       configDefaults =
         Eth2NetworkConfigDefaults(
+          lightClientEnable:
+            false, # Only produces debug logs so far
           serveLightClientData:
-            enableLightClientData,
+            shouldSupportLightClient,
           importLightClientData:
-            if enableLightClientData:
+            if shouldSupportLightClient:
               ImportLightClientData.OnlyNew
             else:
               ImportLightClientData.None

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -43,7 +43,6 @@ type
 
   Eth2NetworkConfigDefaults* = object
     ## Network specific config defaults
-    lightClientEnable*: bool
     serveLightClientData*: bool
     importLightClientData*: ImportLightClientData
 
@@ -192,8 +191,6 @@ proc loadEth2NetworkMetadata*(path: string, eth1Network = none(Eth1Network)): Et
 
       configDefaults =
         Eth2NetworkConfigDefaults(
-          lightClientEnable:
-            false, # Only produces debug logs so far
           serveLightClientData:
             shouldSupportLightClient,
           importLightClientData:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1704,7 +1704,6 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
           `field` = metadata.configDefaults.`field`
       config.`field` = some metadata.configDefaults.`field`
 
-  applyConfigDefault(lightClientEnable)
   applyConfigDefault(serveLightClientData)
   applyConfigDefault(importLightClientData)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1706,6 +1706,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
           `field` = metadata.configDefaults.`field`
       config.`field` = some metadata.configDefaults.`field`
 
+  applyConfigDefault(lightClientEnable)
   applyConfigDefault(serveLightClientData)
   applyConfigDefault(importLightClientData)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -19,8 +19,8 @@ import
   ./spec/[engine_authentication, weak_subjectivity],
   ./validators/[keystore_management, validator_duties],
   "."/[
-    beacon_node, deposits, interop, nimbus_binary_common, statusbar,
-    trusted_node_sync, wallets]
+    beacon_node, beacon_node_light_client, deposits, interop,
+    nimbus_binary_common, statusbar, trusted_node_sync, wallets]
 
 when defined(posix):
   import system/ansi_c
@@ -237,6 +237,7 @@ proc initFullNode(
         discard trackFinalizedState(eth1Monitor,
                                     finalizedEpochRef.eth1_data,
                                     finalizedEpochRef.eth1_deposit_index)
+      node.updateLightClientFromDag()
       eventBus.emit("finalization", data)
 
   func getLocalHeadSlot(): Slot =
@@ -664,7 +665,7 @@ proc init*(T: type BeaconNode,
       else:
         nil
 
-  var node = BeaconNode(
+  let node = BeaconNode(
     nickname: nickname,
     graffitiBytes: if config.graffiti.isSome: config.graffiti.get
                    else: defaultGraffitiBytes(),
@@ -682,9 +683,10 @@ proc init*(T: type BeaconNode,
     gossipState: {},
     beaconClock: beaconClock,
     validatorMonitor: validatorMonitor,
-    stateTtlCache: stateTtlCache
-  )
+    stateTtlCache: stateTtlCache)
 
+  node.initLightClient(
+    rng, cfg, dag.forkDigests, getBeaconTime, dag.genesis_validators_root)
   node.initFullNode(
     rng, dag, taskpool, getBeaconTime)
 
@@ -870,12 +872,6 @@ proc addAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest, slot: Sl
 
   node.network.updateSyncnetsMetadata(currentSyncCommitteeSubnets)
 
-  if node.config.serveLightClientData.get:
-    node.network.subscribe(
-      getLightClientFinalityUpdateTopic(forkDigest), basicParams)
-    node.network.subscribe(
-      getLightClientOptimisticUpdateTopic(forkDigest), basicParams)
-
 proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removePhase0MessageHandlers(forkDigest)
 
@@ -886,12 +882,6 @@ proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
 
   node.network.unsubscribe(
     getSyncCommitteeContributionAndProofTopic(forkDigest))
-
-  if node.config.serveLightClientData.get:
-    node.network.unsubscribe(
-      getLightClientFinalityUpdateTopic(forkDigest))
-    node.network.unsubscribe(
-      getLightClientOptimisticUpdateTopic(forkDigest))
 
 proc trackCurrentSyncCommitteeTopics(node: BeaconNode, slot: Slot) =
   # Unlike trackNextSyncCommitteeTopics, just snap to the currently correct
@@ -1009,12 +999,14 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     headDistance =
       if slot > head.slot: (slot - head.slot).uint64
       else: 0'u64
+    isBehind =
+      headDistance > TOPIC_SUBSCRIBE_THRESHOLD_SLOTS + HYSTERESIS_BUFFER
     targetGossipState =
       getTargetGossipState(
         slot.epoch,
         node.dag.cfg.ALTAIR_FORK_EPOCH,
         node.dag.cfg.BELLATRIX_FORK_EPOCH,
-        headDistance > TOPIC_SUBSCRIBE_THRESHOLD_SLOTS + HYSTERESIS_BUFFER)
+        isBehind)
 
   doAssert targetGossipState.card <= 2
 
@@ -1089,6 +1081,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
 
   node.gossipState = targetGossipState
   node.updateAttestationSubnetHandlers(slot)
+  node.updateLightClientGossipStatus(slot, isBehind)
 
 proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
@@ -1393,29 +1386,7 @@ proc installMessageValidators(node: BeaconNode) =
   installSyncCommitteeeValidators(forkDigests.altair)
   installSyncCommitteeeValidators(forkDigests.bellatrix)
 
-  template installLightClientDataValidators(digest: auto) =
-    node.network.addValidator(
-      getLightClientFinalityUpdateTopic(digest),
-      proc(msg: altair.LightClientFinalityUpdate): ValidationResult =
-        if node.config.serveLightClientData.get:
-          toValidationResult(
-            node.processor[].lightClientFinalityUpdateValidator(
-              MsgSource.gossip, msg))
-        else:
-          ValidationResult.Ignore)
-
-    node.network.addValidator(
-      getLightClientOptimisticUpdateTopic(digest),
-      proc(msg: altair.LightClientOptimisticUpdate): ValidationResult =
-        if node.config.serveLightClientData.get:
-          toValidationResult(
-            node.processor[].lightClientOptimisticUpdateValidator(
-              MsgSource.gossip, msg))
-        else:
-          ValidationResult.Ignore)
-
-  installLightClientDataValidators(forkDigests.altair)
-  installLightClientDataValidators(forkDigests.bellatrix)
+  node.installLightClientMessageValidators()
 
 proc stop(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping
@@ -1462,6 +1433,7 @@ proc run(node: BeaconNode) {.raises: [Defect, CatchableError].} =
     wallTime = node.beaconClock.now()
     wallSlot = wallTime.slotOrZero()
 
+  node.startLightClient()
   node.requestManager.start()
   node.syncManager.start()
 
@@ -1723,21 +1695,18 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
-  if config.serveLightClientData.isNone:
-    if metadata.configDefaults.serveLightClientData:
-      info "Applying network config default",
-        serveLightClientData = metadata.configDefaults.serveLightClientData,
-        eth2Network = config.eth2Network
-    config.serveLightClientData =
-      some metadata.configDefaults.serveLightClientData
-  if config.importLightClientData.isNone:
-    if metadata.configDefaults.importLightClientData !=
-        ImportLightClientData.None:
-      info "Applying network config default",
-        importLightClientData = metadata.configDefaults.importLightClientData,
-        eth2Network = config.eth2Network
-    config.importLightClientData =
-      some metadata.configDefaults.importLightClientData
+
+  template applyConfigDefault(field: untyped): untyped =
+    if config.`field`.isNone:
+      if not metadata.configDefaults.`field`.isZeroMemory:
+        info "Applying network config default",
+          eth2Network = config.eth2Network,
+          `field` = metadata.configDefaults.`field`
+      config.`field` = some metadata.configDefaults.`field`
+
+  applyConfigDefault(lightClientEnable)
+  applyConfigDefault(serveLightClientData)
+  applyConfigDefault(importLightClientData)
 
   let node = BeaconNode.init(
     metadata.cfg,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -690,6 +690,8 @@ proc init*(T: type BeaconNode,
   node.initFullNode(
     rng, dag, taskpool, getBeaconTime)
 
+  node.updateLightClientFromDag()
+
   node
 
 func verifyFinalization(node: BeaconNode, slot: Slot) =

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -159,7 +159,6 @@ proc startSingleNodeNetwork {.raises: [CatchableError, Defect].} =
     "--keymanager-address=127.0.0.1",
     "--keymanager-port=" & $keymanagerPort,
     "--keymanager-token-file=" & tokenFilePath,
-    "--light-client-enable=off",
     "--serve-light-client-data=off",
     "--import-light-client-data=none",
     "--doppelganger-detection=off"], it))

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -159,6 +159,7 @@ proc startSingleNodeNetwork {.raises: [CatchableError, Defect].} =
     "--keymanager-address=127.0.0.1",
     "--keymanager-port=" & $keymanagerPort,
     "--keymanager-token-file=" & tokenFilePath,
+    "--light-client-enable=off",
     "--serve-light-client-data=off",
     "--import-light-client-data=none",
     "--doppelganger-detection=off"], it))


### PR DESCRIPTION
Adds a `LightClient` instance to the beacon node as preparation to
accelerate syncing in the future (optimistic sync).

- `--light-client-enable` turns on the feature
- `--light-client-trusted-block-root` configures block to start from

If no block root is configured, light client tracks DAG `finalizedHead`.