### PR TITLE
serve light client data on `prater` by default

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -429,15 +429,13 @@ type
       serveLightClientData* {.
         hidden
         desc: "BETA: Serve data for enabling light clients to stay in sync with the network"
-        defaultValue: false
-        name: "serve-light-client-data"}: bool
+        name: "serve-light-client-data"}: Option[bool]
 
       importLightClientData* {.
         hidden
         desc: "BETA: Which classes of light client data to import. " &
               "Must be one of: none, only-new, full (slow startup), on-demand (may miss validator duties)"
-        defaultValue: ImportLightClientData.None
-        name: "import-light-client-data"}: ImportLightClientData
+        name: "import-light-client-data"}: Option[ImportLightClientData]
 
       inProcessValidators* {.
         desc: "Disable the push model (the beacon node tells a signing process with the private keys of the validators what to sign and when) and load the validators in the beacon node itself"

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1456,7 +1456,7 @@ proc new*(T: type Eth2Node, config: BeaconNodeConf, runtimeCfg: RuntimeConfig,
       node.protocolStates[proto.index] = proto.networkStateInitializer(node)
 
     for msg in proto.messages:
-      if msg.isLightClientRequest and not config.serveLightClientData:
+      if msg.isLightClientRequest and not config.serveLightClientData.get:
         continue
       if msg.protocolMounter != nil:
         msg.protocolMounter node

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -166,14 +166,14 @@ proc loadChainDag(
       if config.verifyFinalization: {verifyFinalization}
       else: {}
     onOptimisticLightClientUpdateCb =
-      if config.serveLightClientData: onOptimisticLightClientUpdate
+      if config.serveLightClientData.get: onOptimisticLightClientUpdate
       else: nil
     dag = ChainDAGRef.init(
       cfg, db, validatorMonitor, chainDagFlags, config.eraDir,
       onBlockAdded, onHeadChanged, onChainReorg,
       onOptimisticLCUpdateCb = onOptimisticLightClientUpdateCb,
-      serveLightClientData = config.serveLightClientData,
-      importLightClientData = config.importLightClientData)
+      serveLightClientData = config.serveLightClientData.get,
+      importLightClientData = config.importLightClientData.get)
     databaseGenesisValidatorsRoot =
       getStateField(dag.headState, genesis_validators_root)
 
@@ -851,7 +851,7 @@ proc addAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest, slot: Sl
 
   node.network.updateSyncnetsMetadata(currentSyncCommitteeSubnets)
 
-  if node.config.serveLightClientData:
+  if node.config.serveLightClientData.get:
     node.network.subscribe(
       getOptimisticLightClientUpdateTopic(forkDigest), basicParams)
 
@@ -866,7 +866,7 @@ proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.network.unsubscribe(
     getSyncCommitteeContributionAndProofTopic(forkDigest))
 
-  if node.config.serveLightClientData:
+  if node.config.serveLightClientData.get:
     node.network.unsubscribe(getOptimisticLightClientUpdateTopic(forkDigest))
 
 proc trackCurrentSyncCommitteeTopics(node: BeaconNode, slot: Slot) =
@@ -1386,7 +1386,7 @@ proc installMessageValidators(node: BeaconNode) =
     node.network.addValidator(
       getOptimisticLightClientUpdateTopic(digest),
       proc(msg: OptimisticLightClientUpdate): ValidationResult =
-        if node.config.serveLightClientData:
+        if node.config.serveLightClientData.get:
           toValidationResult(
             node.processor[].optimisticLightClientUpdateValidator(
               MsgSource.gossip, msg))
@@ -1707,6 +1707,21 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
+  if config.serveLightClientData.isNone:
+    if metadata.configDefaults.serveLightClientData:
+      info "Applying network config default",
+        serveLightClientData = metadata.configDefaults.serveLightClientData,
+        eth2Network = config.eth2Network
+    config.serveLightClientData =
+      some metadata.configDefaults.serveLightClientData
+  if config.importLightClientData.isNone:
+    if metadata.configDefaults.importLightClientData !=
+        ImportLightClientData.None:
+      info "Applying network config default",
+        importLightClientData = metadata.configDefaults.importLightClientData,
+        eth2Network = config.eth2Network
+    config.importLightClientData =
+      some metadata.configDefaults.importLightClientData
 
   let node = BeaconNode.init(
     metadata.cfg,

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1155,7 +1155,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
   handleAttestations(node, head, slot)
   handleSyncCommitteeMessages(node, head, slot)
 
-  if node.config.serveLightClientData and didSubmitBlock:
+  if node.config.serveLightClientData.get and didSubmitBlock:
     let cutoff = node.beaconClock.fromNow(
       slot.optimistic_light_client_update_time())
     if cutoff.inFuture:
@@ -1327,7 +1327,7 @@ proc sendBeaconBlock*(node: BeaconNode, forked: ForkedSignedBeaconBlock
           blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
           signature = shortLog(blck.signature)
 
-        if node.config.serveLightClientData:
+        if node.config.serveLightClientData.get:
           # The optimistic light client update is sent with a delay because it
           # only validates once the new block has been processed by the peers.
           # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#block-proposal

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -154,6 +154,8 @@ proc startSingleNodeNetwork =
     "--keymanager-address=127.0.0.1",
     "--keymanager-port=" & $keymanagerPort,
     "--keymanager-token-file=" & tokenFilePath,
+    "--serve-light-client-data=off",
+    "--import-light-client-data=none",
     "--doppelganger-detection=off"], it))
 
   let metadata = loadEth2NetworkMetadata(dataDir)


### PR DESCRIPTION
Applies a `prater` testnet specific config default to serve light client
data on that network.