### PR TITLE
Snappy revamp

### DIFF
--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -6,8 +6,7 @@
 
 import
   std/os,
-  stew/results,
-  snappy/framing,
+  stew/results, snappy,
   ../ncli/e2store,
   ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/forks,
@@ -118,7 +117,7 @@ proc getBlockSSZ*(
   ? db.getBlockSZ(historical_roots, slot, tmp)
 
   try:
-    bytes = framingFormatUncompress(tmp)
+    bytes = decodeFramed(tmp)
     ok()
   except CatchableError as exc:
     err(exc.msg)
@@ -172,7 +171,7 @@ proc getStateSSZ*(
   ? db.getStateSZ(historical_roots, slot, tmp)
 
   try:
-    bytes = framingFormatUncompress(tmp)
+    bytes = decodeFramed(tmp)
     ok()
   except CatchableError as exc:
     err(exc.msg)

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -15,7 +15,7 @@ import
   stew/[leb128, endians2, results, byteutils, io2, bitops2], bearssl,
   stew/shims/net as stewNet,
   stew/shims/[macros],
-  faststreams/[inputs, outputs, buffers], snappy, snappy/framing,
+  faststreams/[inputs, outputs, buffers], snappy, snappy/faststreams,
   json_serialization, json_serialization/std/[net, sets, options],
   chronos, chronicles, metrics,
   libp2p/[switch, peerinfo, multiaddress, multicodec, crypto/crypto,
@@ -548,7 +548,7 @@ proc writeChunk*(conn: Connection,
 
     output.write toBytes(payload.lenu64, Leb128).toOpenArray()
 
-    framingFormatCompress(output, payload)
+    compressFramed(payload, output)
   except IOError as exc:
     raiseAssert exc.msg # memoryOutput shouldn't raise
   conn.write(output.getOutput)

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -60,14 +60,14 @@ proc uncompressFramedStream*(conn: Connection,
       if dataLen < 4:
         return err "Snappy frame size too low to contain CRC checksum"
 
-      if output.len - written - 4 < dataLen:
+      if output.len - written < dataLen - 4:
         return err "Too much data"
 
       let crc = uint32.fromBytesLE frameData.toOpenArray(0, 3)
       if maskedCrc(frameData.toOpenArray(4, dataLen - 1)) != crc:
         return err "Snappy content CRC checksum failed"
 
-      output[written..<written + dataLen] = frameData.toOpenArray(4, dataLen-1)
+      output[written..<written + dataLen - 4] = frameData.toOpenArray(4, dataLen-1)
 
     elif id < 0x80:
       # Reserved unskippable chunks (chunk types 0x02-0x7f)

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -35,8 +35,11 @@ proc uncompressFramedStream*(conn: Connection,
 
     let (id, dataLen) = decodeFrameHeader(frameHeader)
 
-    if dataLen.uint64 > maxCompressedFrameDataLen.uint64:
-      return err "invalid snappy frame length"
+    if dataLen > frameData.len:
+      # In theory, compressed frames could be bigger and still result in a
+      # valid, small snappy frame, but this would mean they are not getting
+      # compressed correctly
+      return err "Snappy frame too big"
 
     if dataLen > 0:
       try:

--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -3,7 +3,7 @@
 import
   std/strformat,
   stew/[arrayops, endians2, io2, results],
-  snappy, snappy/framing,
+  snappy,
   ../beacon_chain/spec/[beacon_time, forks],
   ../beacon_chain/spec/eth2_ssz_serialization
 
@@ -89,10 +89,7 @@ proc appendRecord*(f: IoHandle, typ: Type, data: openArray[byte]): Result[int64,
   ok(start)
 
 proc toCompressedBytes(item: auto): seq[byte] =
-  try:
-    framingFormatCompress(SSZ.encode(item))
-  except CatchableError as exc:
-    raiseAssert exc.msg # shouldn't happen
+  snappy.encodeFramed(SSZ.encode(item))
 
 proc appendRecord*(f: IoHandle, v: ForkyTrustedSignedBeaconBlock): Result[int64, string] =
   f.appendRecord(SnappyBeaconBlock, toCompressedBytes(v))

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -7,7 +7,7 @@
 
 import
   std/[os, stats, strformat, tables],
-  snappy, snappy/framing,
+  snappy,
   chronicles, confutils, stew/[byteutils, io2], eth/db/kvstore_sqlite3,
   ../beacon_chain/networking/network_metadata,
   ../beacon_chain/[beacon_chain_db],
@@ -536,7 +536,7 @@ proc cmdImportEra(conf: DbConf, cfg: RuntimeConfig) =
 
       if header.typ == SnappyBeaconBlock:
         withTimer(timers[tBlock]):
-          let uncompressed = framingFormatUncompress(data)
+          let uncompressed = decodeFramed(data)
           let blck = try: readSszForkedSignedBeaconBlock(cfg, uncompressed)
           except CatchableError as exc:
             error "Invalid snappy block", msg = exc.msg, file
@@ -547,7 +547,7 @@ proc cmdImportEra(conf: DbConf, cfg: RuntimeConfig) =
         blocks += 1
       elif header.typ == SnappyBeaconState:
         withTimer(timers[tState]):
-          let uncompressed = framingFormatUncompress(data)
+          let uncompressed = decodeFramed(data)
           let state = try: newClone(
             readSszForkedHashedBeaconState(cfg, uncompressed))
           except CatchableError as exc:

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -14,7 +14,7 @@ import
   ../beacon_chain/spec/[beaconstate, forks, state_transition],
   ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
   ../beacon_chain/consensus_object_pools/blockchain_dag,
-  eth/db/kvstore, snappy/framing,
+  eth/db/kvstore,
   # test utilies
   ./testutil, ./testdbutil, ./testblockutil, ./teststateutil
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -9,7 +9,7 @@
 
 import
   std/[algorithm, options, sequtils],
-  unittest2,
+  unittest2, snappy,
   ../beacon_chain/[beacon_chain_db, interop],
   ../beacon_chain/spec/[beaconstate, forks, state_transition],
   ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
@@ -110,7 +110,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
       db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
-      tmp2 == framingFormatCompress(tmp)
+      tmp2 == encodeFramed(tmp)
 
     db.delBlock(root)
     check:
@@ -152,7 +152,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSSZ(root, tmp, altair.TrustedSignedBeaconBlock)
       db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
-      tmp2 == framingFormatCompress(tmp)
+      tmp2 == encodeFramed(tmp)
 
     db.delBlock(root)
     check:
@@ -194,7 +194,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSSZ(root, tmp, bellatrix.TrustedSignedBeaconBlock)
       db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
-      tmp2 == framingFormatCompress(tmp)
+      tmp2 == encodeFramed(tmp)
 
     db.delBlock(root)
     check:


### PR DESCRIPTION
This PR makes the necessary adjustments to deal with the revamped snappy
API.

In practical terms for nimbus-eth2, there are performance increases to
gossip processing, database reading and writing as well as era file
processing. Exporting `.era` files for example, a snappy-heavy
operation, almost halves in total processing time:

Pre:

```
     Average,       StdDev,          Min,          Max,      Samples,         Test
      39.088,        8.735,       23.619,       53.301,           50, tState
     237.079,       46.692,      165.620,      355.481,           49, tBlocks
```

Post:

```
All time are ms
     Average,       StdDev,          Min,          Max,      Samples,         Test
      25.350,        5.303,       15.351,       41.856,           50, tState
     141.238,       24.164,       99.990,      199.329,           49, tBlocks
```