### PR TITLE
keep proposer boosting permanently enabled

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -493,9 +493,9 @@ type
         defaultValue: false
         name: "validator-monitor-totals" }: bool
 
-      proposerBoosting* {.
+      proposerBoostingNoEffect* {.
         hidden
-        desc: "Enable proposer boosting; temporary option feature gate (debugging; option may be removed without warning)",
+        desc: "No-op stub; may be removed without warning",
         defaultValue: false
         name: "proposer-boosting-debug" }: bool
 

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -86,17 +86,13 @@ declareGauge attestation_pool_block_attestation_packing_time,
 
 proc init*(T: type AttestationPool, dag: ChainDAGRef,
            quarantine: ref Quarantine,
-           onAttestation: OnAttestationCallback = nil,
-           proposerBoosting: bool = false): T =
+           onAttestation: OnAttestationCallback = nil): T =
   ## Initialize an AttestationPool from the dag `headState`
   ## The `finalized_root` works around the finalized_checkpoint of the genesis block
   ## holding a zero_root.
   let finalizedEpochRef = dag.getFinalizedEpochRef()
 
-  var forkChoice = ForkChoice.init(
-    finalizedEpochRef,
-    dag.finalizedHead.blck,
-    proposerBoosting)
+  var forkChoice = ForkChoice.init(finalizedEpochRef, dag.finalizedHead.blck)
 
   # Feed fork choice with unfinalized history - during startup, block pool only
   # keeps track of a single history so we just need to follow it

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -51,19 +51,14 @@ logScope:
 
 func init*(T: type ForkChoiceBackend,
            justifiedCheckpoint: Checkpoint,
-           finalizedCheckpoint: Checkpoint,
-           useProposerBoosting: bool): T =
-  T(
-    proto_array: ProtoArray.init(
+           finalizedCheckpoint: Checkpoint): T =
+  T(proto_array: ProtoArray.init(
       justifiedCheckpoint,
-      finalizedCheckpoint),
-    proposer_boosting: useProposerBoosting
-  )
+      finalizedCheckpoint))
 
 proc init*(T: type ForkChoice,
            epochRef: EpochRef,
-           blck: BlockRef,
-           proposerBoosting: bool): T =
+           blck: BlockRef): T =
   ## Initialize a fork choice context for a finalized state - in the finalized
   ## state, the justified and finalized checkpoints are the same, so only one
   ## is used here
@@ -80,7 +75,7 @@ proc init*(T: type ForkChoice,
 
   ForkChoice(
     backend: ForkChoiceBackend.init(
-      best_justified, finalized, proposerBoosting),
+      best_justified, finalized),
     checkpoints: Checkpoints(
       justified: justified,
       finalized: finalized,
@@ -413,7 +408,7 @@ func find_head*(
   # Apply score changes
   ? self.proto_array.applyScoreChanges(
     deltas, justifiedCheckpoint, finalizedCheckpoint,
-    justified_state_balances, proposer_boost_root, self.proposer_boosting
+    justified_state_balances, proposer_boost_root
   )
 
   self.balances = justified_state_balances

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -130,7 +130,6 @@ type
     proto_array*: ProtoArray
     votes*: seq[VoteTracker]
     balances*: seq[Gwei]
-    proposer_boosting*: bool
 
   QueuedAttestation* = object
     slot*: Slot

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -249,8 +249,7 @@ proc initFullNode(
     quarantine = newClone(
       Quarantine.init())
     attestationPool = newClone(
-      AttestationPool.init(
-        dag, quarantine, onAttestationReceived, config.proposerBoosting))
+      AttestationPool.init(dag, quarantine, onAttestationReceived))
     syncCommitteeMsgPool = newClone(
       SyncCommitteeMsgPool.init(rng, onSyncContribution))
     exitPool = newClone(

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -100,7 +100,6 @@ proc initialLoad(
     fkChoice = newClone(ForkChoice.init(
       dag.getFinalizedEpochRef(),
       dag.finalizedHead.blck,
-      true
     ))
 
   (dag, fkChoice)

--- a/tests/fork_choice/scenarios/ffg_01.nim
+++ b/tests/fork_choice/scenarios/ffg_01.nim
@@ -14,8 +14,7 @@ func setup_finality_01(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   # Initialize the fork choice context
   result.fork_choice = ForkChoiceBackend.init(
     justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    true # use proposer boosting, though the proposer boost root not set
+    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(0))
   )
 
   # ----------------------------------

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -14,8 +14,7 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   # Initialize the fork choice context
   result.fork_choice = ForkChoiceBackend.init(
     justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    true # use proposer boosting, though the proposer boost root not set
+    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
   )
 
   # ----------------------------------

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -15,8 +15,7 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   # We start with epoch 0 fully finalized to avoid epoch 0 special cases.
   result.fork_choice = ForkChoiceBackend.init(
     justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    true # use proposer boosting, though the proposer boost root not set
+    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
   )
 
   # ----------------------------------

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -15,8 +15,7 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # We start with epoch 0 fully finalized to avoid epoch 0 special cases.
   result.fork_choice = ForkChoiceBackend.init(
     justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    true # use proposer boosting, though the proposer boost root not set
+    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
   )
 
   # ----------------------------------

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -448,6 +448,8 @@ suite "Attestation pool processing" & preset():
     check:
       head == b10Add[]
 
+    # Add a block too late to be timely enough to be proposer-boosted, which
+    # would otherwise cause it to be selected as head
     let
       b11 = makeTestBlock(state[], cache,
         graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -457,7 +459,8 @@ suite "Attestation pool processing" & preset():
           epochRef: EpochRef):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, signedBlock.message,
+          blckRef.slot.start_beacon_time + SECONDS_PER_SLOT.int64.seconds)
 
       bc1 = get_beacon_committee(
         state[], getStateField(state[], slot) - 1, 1.CommitteeIndex,


### PR DESCRIPTION
Part of the consensus specs which, until recently, few CL clients had enabled in general, by default, on mainnet.

Probably don't merge until after shortly after next release, to get in early in the release cycle.

The setting will disappear too, as soon as the devops required for it have been configured for the Nimbus fleet. Keeping the setting detaches this PR from that aspect.