### PR TITLE
enable `styleCheck:usages`

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1159,7 +1159,7 @@ proc loadStateRoots*(db: BeaconChainDB): Table[(Slot, Eth2Digest), Eth2Digest] =
   ## mean we also have a state (and vice versa)!
   var state_roots = initTable[(Slot, Eth2Digest), Eth2Digest](1024)
 
-  discard db.state_roots.find([], proc(k, v: openArray[byte]) =
+  discard db.stateRoots.find([], proc(k, v: openArray[byte]) =
     if k.len() == 40 and v.len() == 32:
       # For legacy reasons, the first byte of the slot is not part of the slot
       # but rather a subkey identifier - see subkey

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -59,8 +59,8 @@ type
     eventBus*: AsyncEventBus
     vcProcess*: Process
     requestManager*: RequestManager
-    syncManager*: SyncManager[Peer, PeerID]
-    backfiller*: SyncManager[Peer, PeerID]
+    syncManager*: SyncManager[Peer, PeerId]
+    backfiller*: SyncManager[Peer, PeerId]
     genesisSnapshotContent*: string
     actionTracker*: ActionTracker
     processor*: ref Eth2Processor

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -379,7 +379,7 @@ proc addAttestation*(pool: var AttestationPool,
     pool.onAttestationAdded(attestation)
 
 func covers*(
-    pool: var AttestationPool, data: Attestationdata,
+    pool: var AttestationPool, data: AttestationData,
     bits: CommitteeValidatorsBits): bool =
   ## Return true iff the given attestation already is fully covered by one of
   ## the existing aggregates, making it redundant

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -367,6 +367,6 @@ proc addBackfillBlock*(
   let putBlockTick = Moment.now
   debug "Block backfilled",
     sigVerifyDur = sigVerifyTick - startTick,
-    putBlockDur = putBlocktick - sigVerifyTick
+    putBlockDur = putBlockTick - sigVerifyTick
 
   ok()

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -506,7 +506,7 @@ proc getForkedBlock*(
     type T = type(blck)
     blck = getBlock(dag, bid, T).valueOr:
         getBlock(
-            dag.era, getStateField(dag.headState, historicalRoots).asSeq,
+            dag.era, getStateField(dag.headState, historical_roots).asSeq,
             bid.slot, Opt[Eth2Digest].ok(bid.root), T).valueOr:
           result.err()
           return
@@ -792,7 +792,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of BeaconStateFork.Phase0: genesisFork(cfg)
       of BeaconStateFork.Altair: altairFork(cfg)
       of BeaconStateFork.Bellatrix: bellatrixFork(cfg)
-    statefork = getStateField(dag.headState, fork)
+    stateFork = getStateField(dag.headState, fork)
 
   if stateFork != configFork:
     error "State from database does not match network, check --network parameter",
@@ -954,7 +954,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   dag
 
-template genesisValidatorsRoot*(dag: ChainDAGRef): Eth2Digest =
+template genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
   getStateField(dag.headState, genesis_validators_root)
 
 func getEpochRef*(
@@ -1050,7 +1050,7 @@ proc getFinalizedEpochRef*(dag: ChainDAGRef): EpochRef =
 func stateCheckpoint*(dag: ChainDAGRef, bsi: BlockSlotId): BlockSlotId =
   ## The first ancestor BlockSlot that is a state checkpoint
   var bsi = bsi
-  while not dag.isStateCheckPoint(bsi):
+  while not dag.isStateCheckpoint(bsi):
     if bsi.isProposed:
       bsi.bid = dag.parent(bsi.bid).valueOr:
         break

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -229,7 +229,7 @@ proc deleteLightClientData*(dag: ChainDAGRef, bid: BlockId) =
 template lazy_header(name: untyped): untyped {.dirty.} =
   ## `createLightClientUpdates` helper to lazily load a known block header.
   var `name ptr`: ptr[BeaconBlockHeader]
-  template `assign name`(target: var BeaconBlockHeader,
+  template `assign _ name`(target: var BeaconBlockHeader,
                          bid: BlockId): untyped =
     if `name ptr` != nil:
       target = `name ptr`[]
@@ -243,7 +243,7 @@ template lazy_data(name: untyped): untyped {.dirty.} =
   ## `createLightClientUpdates` helper to lazily load cached light client state.
   var `name` {.noinit.}: CachedLightClientData
   `name`.finalized_bid.slot = FAR_FUTURE_SLOT
-  template `load name`(bid: BlockId): untyped =
+  template `load _ name`(bid: BlockId): untyped =
     if `name`.finalized_bid.slot == FAR_FUTURE_SLOT:
       `name` = dag.getLightClientData(bid)
 

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -19,7 +19,7 @@ proc getSignedExitMessage(config: BeaconNodeConf,
                           exitAtEpoch: Epoch,
                           validatorIdx: uint64 ,
                           fork: Fork,
-                          genesisValidatorsRoot: Eth2Digest): SignedVoluntaryExit =
+                          genesis_validators_root: Eth2Digest): SignedVoluntaryExit =
   let
     validatorsDir = config.validatorsDir
     keystoreDir = validatorsDir / validatorKeyAsStr
@@ -48,7 +48,7 @@ proc getSignedExitMessage(config: BeaconNodeConf,
   signedExit.signature =
     block:
       let key = signingItem.get.privateKey
-      get_voluntary_exit_signature(fork, genesisValidatorsRoot,
+      get_voluntary_exit_signature(fork, genesis_validators_root,
                                    signedExit.message, key).toValidatorSig()
 
   signedExit
@@ -153,7 +153,7 @@ proc rpcValidatorExit(config: BeaconNodeConf) {.async.} =
     fatal "Failed to obtain the fork id of the head state", err = err.msg
     quit 1
 
-  let genesisValidatorsRoot = try:
+  let genesis_validators_root = try:
     (await rpcClient.get_v1_beacon_genesis()).genesis_validators_root
   except CatchableError as err:
     fatal "Failed to obtain the genesis validators root of the network",
@@ -167,7 +167,7 @@ proc rpcValidatorExit(config: BeaconNodeConf) {.async.} =
                                       exitAtEpoch,
                                       validatorIdx,
                                       fork,
-                                      genesisValidatorsRoot)
+                                      genesis_validators_root)
 
   try:
     let choice = askForExitConfirmation()
@@ -281,14 +281,14 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
     quit 1
 
   let
-    genesisValidatorsRoot = genesis.genesis_validators_root
+    genesis_validators_root = genesis.genesis_validators_root
     validatorKeyAsStr = "0x" & $validator.pubkey
     signedExit = getSignedExitMessage(config,
                                       validatorKeyAsStr,
                                       exitAtEpoch,
                                       validatorIdx,
                                       fork,
-                                      genesisValidatorsRoot)
+                                      genesis_validators_root)
 
   try:
     let choice = askForExitConfirmation()

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -204,7 +204,6 @@ proc getPartialState(
   #      performs
   var tmp: seq[byte]
   if (let e = db.getStateSSZ(historical_roots, slot, tmp); e.isErr):
-    debugecho e.error()
     return false
 
   static: doAssert isFixedSize(PartialBeaconState)
@@ -243,7 +242,7 @@ iterator getBlockIds*(
 proc new*(
     T: type EraDB, cfg: RuntimeConfig, path: string,
     genesis_validators_root: Eth2Digest): EraDB =
-  EraDb(cfg: cfg, path: path, genesis_validators_root: genesis_validators_root)
+  EraDB(cfg: cfg, path: path, genesis_validators_root: genesis_validators_root)
 
 when isMainModule:
   # Testing EraDB gets messy because of the large amounts of data involved:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -336,7 +336,7 @@ func asEngineExecutionPayload*(executionPayload: bellatrix.ExecutionPayload):
 
   engine_api.ExecutionPayloadV1(
     parentHash: executionPayload.parent_hash.asBlockHash,
-    feeRecipient: Address(executionPayload.feeRecipient.data),
+    feeRecipient: Address(executionPayload.fee_recipient.data),
     stateRoot: executionPayload.state_root.asBlockHash,
     receiptsRoot: executionPayload.receipts_root.asBlockHash,
     logsBloom:
@@ -362,7 +362,7 @@ template findBlock(chain: Eth1Chain, eth1Data: Eth1Data): Eth1Block =
   getOrDefault(chain.blocksByHash, asBlockHash(eth1Data.block_hash), nil)
 
 func makeSuccessorWithoutDeposits(existingBlock: Eth1Block,
-                                  successor: BlockObject): ETh1Block =
+                                  successor: BlockObject): Eth1Block =
   result = Eth1Block(
     number: Eth1BlockNumber successor.number,
     timestamp: Eth1BlockTimestamp successor.timestamp,
@@ -409,11 +409,9 @@ template awaitWithRetries*[T](lazyFutExpr: Future[T],
     if not f.finished:
       await cancelAndWait(f)
     elif f.failed:
-      if f.error[] of Defect:
-        raise f.error
-      else:
-        debug "Web3 request failed", req = reqType, err = f.error.msg
-        inc failed_web3_requests
+      static: doAssert f.error of CatchableError
+      debug "Web3 request failed", req = reqType, err = f.error.msg
+      inc failed_web3_requests
     else:
       break
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -190,8 +190,8 @@ func applyScoreChanges*(self: var ProtoArray,
     # the delta by the new score amount.
     #
     # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#get_latest_attesting_balance
-    if  useProposerBoost and (not proposer_boost_root.isZero) and
-        proposer_boost_root == node.root:
+    if  useProposerBoost and (not proposerBoostRoot.isZero) and
+        proposerBoostRoot == node.root:
       proposerBoostScore = calculateProposerBoost(newBalances)
       if  nodeDelta >= 0 and
           high(Delta) - nodeDelta < self.previousProposerBoostScore:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -285,8 +285,8 @@ proc addBlock*(
       # because there are no state rewinds to deal with
       let res = self.storeBackfillBlock(blck)
 
-      if resFut != nil:
-        resFut.complete(res)
+      if resfut != nil:
+        resfut.complete(res)
       return
 
   try:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -697,7 +697,7 @@ proc validateAggregate*(
   let deferredCrypto = batchCrypto
                 .scheduleAggregateChecks(
                   fork, genesis_validators_root,
-                  signed_aggregate_and_proof, epochRef, attesting_indices
+                  signedAggregateAndProof, epochRef, attesting_indices
                 )
   if deferredCrypto.isErr():
     return checkedReject(deferredCrypto.error)
@@ -881,7 +881,7 @@ proc validateSyncCommitteeMessage*(
   let
     epoch = msg.slot.epoch
     fork = dag.forkAtEpoch(epoch)
-    genesisValidatorsRoot = dag.genesisValidatorsRoot
+    genesis_validators_root = dag.genesis_validators_root
     senderPubKey = dag.validatorKey(msg.validator_index)
 
   if senderPubKey.isNone():
@@ -967,7 +967,7 @@ proc validateContribution*(
   let
     epoch = msg.message.contribution.slot.epoch
     fork = dag.forkAtEpoch(epoch)
-    genesis_validators_root = dag.genesisValidatorsRoot
+    genesis_validators_root = dag.genesis_validators_root
 
   if msg.message.contribution.aggregation_bits.countOnes() == 0:
     # [REJECT] The contribution has participants

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -61,7 +61,7 @@ type
     didInitializeStoreCallback: DidInitializeStoreCallback
 
     cfg: RuntimeConfig
-    genesisValidatorsRoot: Eth2Digest
+    genesis_validators_root: Eth2Digest
     trustedBlockRoot: Eth2Digest
 
     lastProgressTick: BeaconTime # Moment when last update made progress
@@ -83,7 +83,7 @@ proc new*(
     dumpEnabled: bool,
     dumpDirInvalid, dumpDirIncoming: string,
     cfg: RuntimeConfig,
-    genesisValidatorsRoot, trustedBlockRoot: Eth2Digest,
+    genesis_validators_root, trustedBlockRoot: Eth2Digest,
     store: ref Option[LightClientStore],
     getBeaconTime: GetBeaconTimeFn,
     didInitializeStoreCallback: DidInitializeStoreCallback = nil
@@ -96,7 +96,7 @@ proc new*(
     getBeaconTime: getBeaconTime,
     didInitializeStoreCallback: didInitializeStoreCallback,
     cfg: cfg,
-    genesisValidatorsRoot: genesisValidatorsRoot,
+    genesis_validators_root: genesis_validators_root,
     trustedBlockRoot: trustedBlockRoot
   )
 
@@ -172,14 +172,14 @@ proc storeObject*(
           err(BlockError.MissingParent)
         else:
           store[].get.process_light_client_update(
-            obj, wallSlot, self.cfg, self.genesisValidatorsRoot,
+            obj, wallSlot, self.cfg, self.genesis_validators_root,
             allowForceUpdate = false)
       elif obj is altair.OptimisticLightClientUpdate:
         if store[].isNone:
           err(BlockError.MissingParent)
         else:
           store[].get.process_optimistic_light_client_update(
-            obj, wallSlot, self.cfg, self.genesisValidatorsRoot)
+            obj, wallSlot, self.cfg, self.genesis_validators_root)
 
   self.dumpObject(obj, res)
 

--- a/beacon_chain/interop.nim
+++ b/beacon_chain/interop.nim
@@ -52,5 +52,5 @@ func makeDeposit*(
     pubkey: pubkey,
     withdrawal_credentials: makeWithdrawalCredentials(pubkey))
 
-  if skipBLSValidation notin flags:
+  if skipBlsValidation notin flags:
     result.signature = preset.get_deposit_signature(result, privkey).toValidatorSig()

--- a/beacon_chain/networking/libp2p_json_serialization.nim
+++ b/beacon_chain/networking/libp2p_json_serialization.nim
@@ -10,13 +10,13 @@
 import libp2p/[peerid, multiaddress], json_serialization
 export json_serialization
 
-proc writeValue*(writer: var JsonWriter, value: PeerID) {.
+proc writeValue*(writer: var JsonWriter, value: PeerId) {.
     raises: [Defect, IOError].} =
   writer.writeValue $value
 
-proc readValue*(reader: var JsonReader, value: var PeerID) {.
+proc readValue*(reader: var JsonReader, value: var PeerId) {.
     raises: [Defect, IOError, SerializationError].} =
-  let res = PeerID.init reader.readValue(string)
+  let res = PeerId.init reader.readValue(string)
   if res.isOk:
     value = res.get()
   else:

--- a/beacon_chain/nim.cfg
+++ b/beacon_chain/nim.cfg
@@ -2,3 +2,8 @@
 -d:"libp2p_pki_schemes=secp256k1"
 
 -d:chronosStrictException
+--styleCheck:usages
+--styleCheck:hint
+--hint[XDeclaredButNotUsed]:off
+--hint[ConvFromXtoItselfNotNeeded]:off
+--hint[Processing]:off

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -222,7 +222,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           cooked = get_slot_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot,
+            forkInfo.genesis_validators_root,
             request.aggregationSlot.slot, validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -230,7 +230,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           cooked = get_aggregate_and_proof_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, request.aggregateAndProof,
+            forkInfo.genesis_validators_root, request.aggregateAndProof,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -238,7 +238,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           cooked = get_attestation_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, request.attestation,
+            forkInfo.genesis_validators_root, request.attestation,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -248,7 +248,7 @@ proc installApiHandlers*(node: SigningNode) =
           blck = request.blck
           blockRoot = hash_tree_root(blck)
           cooked = get_block_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, blck.slot, blockRoot,
+            forkInfo.genesis_validators_root, blck.slot, blockRoot,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -260,7 +260,7 @@ proc installApiHandlers*(node: SigningNode) =
           cooked =
             withBlck(forked):
               get_block_signature(forkInfo.fork,
-                forkInfo.genesisValidatorsRoot, blck.slot, blockRoot,
+                forkInfo.genesis_validators_root, blck.slot, blockRoot,
                 validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -277,7 +277,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           cooked = get_epoch_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, request.randaoReveal.epoch,
+            forkInfo.genesis_validators_root, request.randaoReveal.epoch,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -285,7 +285,7 @@ proc installApiHandlers*(node: SigningNode) =
         let
           forkInfo = request.forkInfo.get()
           cooked = get_voluntary_exit_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, request.voluntaryExit,
+            forkInfo.genesis_validators_root, request.voluntaryExit,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -294,7 +294,7 @@ proc installApiHandlers*(node: SigningNode) =
           forkInfo = request.forkInfo.get()
           msg = request.syncCommitteeMessage
           cooked = get_sync_committee_message_signature(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, msg.slot, msg.beaconBlockRoot,
+            forkInfo.genesis_validators_root, msg.slot, msg.beaconBlockRoot,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -303,7 +303,7 @@ proc installApiHandlers*(node: SigningNode) =
           forkInfo = request.forkInfo.get()
           msg = request.syncAggregatorSelectionData
           cooked = get_sync_committee_selection_proof(forkInfo.fork,
-            forkInfo.genesisValidatorsRoot, msg.slot, msg.subcommittee_index,
+            forkInfo.genesis_validators_root, msg.slot, msg.subcommittee_index,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)
@@ -312,7 +312,7 @@ proc installApiHandlers*(node: SigningNode) =
           forkInfo = request.forkInfo.get()
           msg = request.syncCommitteeContributionAndProof
           cooked = get_contribution_and_proof_signature(
-            forkInfo.fork, forkInfo.genesisValidatorsRoot, msg,
+            forkInfo.fork, forkInfo.genesis_validators_root, msg,
             validator.data.privateKey)
           signature = cooked.toValidatorSig().toHex()
         signatureResponse(Http200, signature)

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -52,7 +52,7 @@ type
     state*: string
 
   RestPubSubPeer* = object
-    peerId*: PeerID
+    peerId*: PeerId
     score*: float64
     iWantBudget*: int
     iHaveBudget*: int
@@ -67,14 +67,14 @@ type
     agent*: string
 
   RestPeerStats* = object
-    peerId*: PeerID
+    peerId*: PeerId
     null*: bool
     connected*: bool
     expire*: string
     score*: float64
 
   RestPeerStatus* = object
-    peerId*: PeerID
+    peerId*: PeerId
     connected*: bool
 
 proc toInfo(node: BeaconNode, peerId: PeerId): RestPeerInfo =
@@ -146,7 +146,7 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   router.api(MethodGet, "/nimbus/v1/network/ids") do (
     ) -> RestApiResponse:
-    var res: seq[PeerID]
+    var res: seq[PeerId]
     for peerId, peer in node.network.peerPool:
       res.add(peerId)
     return RestApiResponse.jsonResponse((peerids: res))
@@ -273,7 +273,7 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
           var peers: seq[RestPubSubPeer]
           let backoff = node.network.pubsub.backingOff.getOrDefault(topic)
           for peer in v:
-            peers.add(peer.toNode(backOff.getOrDefault(peer.peerId)))
+            peers.add(peer.toNode(backoff.getOrDefault(peer.peerId)))
           res.add((topic: topic, peers: peers))
         res
     let meshPeers =
@@ -283,14 +283,14 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
           var peers: seq[RestPubSubPeer]
           let backoff = node.network.pubsub.backingOff.getOrDefault(topic)
           for peer in v:
-            peers.add(peer.toNode(backOff.getOrDefault(peer.peerId)))
+            peers.add(peer.toNode(backoff.getOrDefault(peer.peerId)))
           res.add((topic: topic, peers: peers))
         res
     let colocationPeers =
       block:
-        var res: seq[tuple[address: string, peerids: seq[PeerID]]]
+        var res: seq[tuple[address: string, peerids: seq[PeerId]]]
         for k, v in node.network.pubsub.peersInIP:
-          var peerids: seq[PeerID]
+          var peerids: seq[PeerId]
           for id in v:
             peerids.add(id)
           res.add(($k, peerids))

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -104,7 +104,7 @@ proc getDiscoveryAddresses(node: BeaconNode): Option[seq[string]] =
   if respa.isErr():
     return none[seq[string]]()
   let pa = respa.get()
-  let mpa = MultiAddress.init(multicodec("p2p"), pa.peerId)
+  let mpa = MultiAddress.init(multiCodec("p2p"), pa.peerId)
   if mpa.isErr():
     return none[seq[string]]()
   var addresses = newSeqOfCap[string](len(pa.addrs))
@@ -116,7 +116,7 @@ proc getDiscoveryAddresses(node: BeaconNode): Option[seq[string]] =
 
 proc getP2PAddresses(node: BeaconNode): Option[seq[string]] =
   let pinfo = node.network.switch.peerInfo
-  let mpa = MultiAddress.init(multicodec("p2p"), pinfo.peerId)
+  let mpa = MultiAddress.init(multiCodec("p2p"), pinfo.peerId)
   if mpa.isErr():
     return none[seq[string]]()
   var addresses = newSeqOfCap[string](len(pinfo.addrs))
@@ -152,7 +152,7 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
     return RestApiResponse.jsonResponse(
       (
         peer_id: $node.network.peerId(),
-        enr: node.network.enrRecord().toUri(),
+        enr: node.network.enrRecord().toURI(),
         p2p_addresses: p2pAddresses,
         discovery_addresses: discoveryAddresses,
         metadata: (
@@ -196,7 +196,7 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
          (peer.direction in directionMask):
         let peer = (
           peer_id: $peer.peerId,
-          enr: if peer.enr.isSome(): peer.enr.get().toUri() else: "",
+          enr: if peer.enr.isSome(): peer.enr.get().toURI() else: "",
           last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
           state: peer.connectionState.toString(),
           direction: peer.direction.toString(),
@@ -225,7 +225,7 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Node/getPeer
   router.api(MethodGet, "/eth/v1/node/peers/{peer_id}") do (
-    peer_id: PeerID) -> RestApiResponse:
+    peer_id: PeerId) -> RestApiResponse:
     let peer =
       block:
         if peer_id.isErr():
@@ -238,7 +238,7 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
     return RestApiResponse.jsonResponse(
       (
         peer_id: $peer.peerId,
-        enr: if peer.enr.isSome(): peer.enr.get().toUri() else: "",
+        enr: if peer.enr.isSome(): peer.enr.get().toURI() else: "",
         last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
         state: peer.connectionState.toString(),
         direction: peer.direction.toString(),

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -15,7 +15,7 @@ type
   ValidatorIndexError* {.pure.} = enum
     UnsupportedValue, TooHighValue
 
-func match(data: openarray[char], charset: set[char]): int =
+func match(data: openArray[char], charset: set[char]): int =
   for ch in data:
     if ch notin charset:
       return 1

--- a/beacon_chain/rpc/rpc_beacon_api.nim
+++ b/beacon_chain/rpc/rpc_beacon_api.nim
@@ -60,7 +60,7 @@ proc createIdQuery(ids: openArray[string]): Result[ValidatorQuery, cstring] =
 
   for item in ids:
     if item.startsWith("0x"):
-      let pubkey = ? ValidatorPubkey.fromHex(item)
+      let pubkey = ? ValidatorPubKey.fromHex(item)
       res.keyset.incl(pubkey)
     else:
       var tmp: uint64

--- a/beacon_chain/rpc/rpc_nimbus_api.nim
+++ b/beacon_chain/rpc/rpc_nimbus_api.nim
@@ -170,7 +170,7 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       var peers = newJArray()
       let backoff = node.network.pubsub.backingOff.getOrDefault(topic)
       for peer in v:
-        peers.add(peer.toNode(backOff.getOrDefault(peer.peerId)))
+        peers.add(peer.toNode(backoff.getOrDefault(peer.peerId)))
 
       gossipsub.add(topic, peers)
 
@@ -181,7 +181,7 @@ proc installNimbusApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       var peers = newJArray()
       let backoff = node.network.pubsub.backingOff.getOrDefault(topic)
       for peer in v:
-        peers.add(peer.toNode(backOff.getOrDefault(peer.peerId)))
+        peers.add(peer.toNode(backoff.getOrDefault(peer.peerId)))
 
       mesh.add(topic, peers)
 

--- a/beacon_chain/rpc/rpc_node_api.nim
+++ b/beacon_chain/rpc/rpc_node_api.nim
@@ -128,7 +128,7 @@ proc getDiscoveryAddresses(node: BeaconNode): Option[seq[string]] =
   if respa.isErr():
     return none[seq[string]]()
   let pa = respa.get()
-  let mpa = MultiAddress.init(multicodec("p2p"), pa.peerId)
+  let mpa = MultiAddress.init(multiCodec("p2p"), pa.peerId)
   if mpa.isErr():
     return none[seq[string]]()
   var addresses = newSeqOfCap[string](len(pa.addrs))
@@ -140,7 +140,7 @@ proc getDiscoveryAddresses(node: BeaconNode): Option[seq[string]] =
 
 proc getP2PAddresses(node: BeaconNode): Option[seq[string]] =
   let pinfo = node.network.switch.peerInfo
-  let mpa = MultiAddress.init(multicodec("p2p"), pinfo.peerId)
+  let mpa = MultiAddress.init(multiCodec("p2p"), pinfo.peerId)
   if mpa.isErr():
     return none[seq[string]]()
   var addresses = newSeqOfCap[string](len(pinfo.addrs))
@@ -171,7 +171,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     return (
       peer_id: $node.network.peerId(),
-      enr: node.network.enrRecord().toUri(),
+      enr: node.network.enrRecord().toURI(),
       p2p_addresses: p2pAddresses,
       discovery_addresses: discoveryAddresses,
       metadata: (node.network.metadata.seq_number,
@@ -193,7 +193,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
       if (peer.connectionState in states) and (peer.direction in dirs):
         let resPeer = (
           peer_id: $peer.peerId,
-          enr: if peer.enr.isSome(): peer.enr.get().toUri() else: "",
+          enr: if peer.enr.isSome(): peer.enr.get().toURI() else: "",
           last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
           state: peer.connectionState.toString(),
           direction: peer.direction.toString(),
@@ -221,7 +221,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
   rpcServer.rpc("get_v1_node_peers_peerId") do (
     peer_id: string) -> RpcNodePeer:
-    let pres = PeerID.init(peer_id)
+    let pres = PeerId.init(peer_id)
     if pres.isErr():
       raise newException(CatchableError,
                          "The peer ID supplied could not be parsed")
@@ -232,7 +232,7 @@ proc installNodeApiHandlers*(rpcServer: RpcServer, node: BeaconNode) {.
 
     return (
       peer_id: $peer.peerId,
-      enr: if peer.enr.isSome(): peer.enr.get().toUri() else: "",
+      enr: if peer.enr.isSome(): peer.enr.get().toURI() else: "",
       last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
       state: peer.connectionState.toString(),
       direction: peer.direction.toString(),

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -401,9 +401,9 @@ type
     # serialized. They're represented in memory to allow in-place SSZ reading
     # and writing compatibly with the full Validator object.
 
-    pubkey* {.dontserialize.}: ValidatorPubKey
+    pubkey* {.dontSerialize.}: ValidatorPubKey
 
-    withdrawal_credentials* {.dontserialize.}: Eth2Digest ##\
+    withdrawal_credentials* {.dontSerialize.}: Eth2Digest ##\
     ## Commitment to pubkey for withdrawals and transfers
 
     effective_balance*: uint64 ##\
@@ -908,7 +908,7 @@ func prune*(cache: var StateCache, epoch: Epoch) =
   block:
     for k in cache.shuffled_active_validator_indices.keys:
       if k < pruneEpoch:
-        drops.add prune_epoch.start_slot
+        drops.add pruneEpoch.start_slot
     for drop in drops:
       cache.shuffled_active_validator_indices.del drop.epoch
     drops.setLen(0)

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -37,14 +37,14 @@ proc getSignedToken*(key: openArray[byte], payload: string): string =
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
   const jwsProtectedHeader =
-    base64url_encode($ %* {"typ": "JWT", "alg": "HS256"}) & "."
+    base64urlEncode($ %* {"typ": "JWT", "alg": "HS256"}) & "."
   # In theory, std/json might change how it encodes, and it doesn't per-se
   # matter but can also simply specify the base64-encoded form directly if
   # useful, since it's never checked here on its own.
   static: doAssert jwsProtectedHeader == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
   let signingInput = jwsProtectedHeader & base64urlEncode(payload)
 
-  signingInput & "." & base64_urlencode(sha256.hmac(key, signingInput).data)
+  signingInput & "." & base64urlEncode(sha256.hmac(key, signingInput).data)
 
 proc getSignedIatToken*(key: openArray[byte], time: int64): string =
   getSignedToken(key, $getIatToken(time))

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -271,7 +271,7 @@ proc jsonError*(t: typedesc[RestApiResponse], status: HttpCode = Http200,
 
 proc jsonError*(t: typedesc[RestApiResponse], status: HttpCode = Http200,
                 msg: string = "",
-                stacktraces: openarray[string]): RestApiResponse =
+                stacktraces: openArray[string]): RestApiResponse =
   let data =
     block:
       var default: string
@@ -326,7 +326,7 @@ proc sszResponse*(t: typedesc[RestApiResponse], data: auto): RestApiResponse =
         default
   RestApiResponse.response(res, Http200, "application/octet-stream")
 
-template hexOriginal(data: openarray[byte]): string =
+template hexOriginal(data: openArray[byte]): string =
   to0xHex(data)
 
 proc decodeJsonString*[T](t: typedesc[T],
@@ -920,7 +920,7 @@ proc readValue*(reader: var JsonReader[RestJson],
                                     "RestPublishedBeaconBlock")
       proposer_index = some(reader.readValue(uint64))
     of "parent_root":
-      if parentRoot.isSome():
+      if parent_root.isSome():
         reader.raiseUnexpectedField("Multiple `parent_root` fields found",
                                     "RestPublishedBeaconBlock")
       parent_root = some(reader.readValue(Eth2Digest))
@@ -1941,7 +1941,7 @@ proc encodeBytes*[T: EncodeArrays](value: T,
   else:
     err("Content-Type not supported")
 
-proc decodeBytes*[T: DecodeTypes](t: typedesc[T], value: openarray[byte],
+proc decodeBytes*[T: DecodeTypes](t: typedesc[T], value: openArray[byte],
                                   contentType: string): RestResult[T] =
   const isExtensibleType = t is ExtensibleDecodeTypes
   case contentType
@@ -1953,7 +1953,7 @@ proc decodeBytes*[T: DecodeTypes](t: typedesc[T], value: openarray[byte],
   else:
     err("Content-Type not supported")
 
-proc decodeBytes*[T: SszDecodeTypes](t: typedesc[T], value: openarray[byte],
+proc decodeBytes*[T: SszDecodeTypes](t: typedesc[T], value: openArray[byte],
                                      contentType: string, updateRoot = true): RestResult[T] =
   case contentType
   of "application/octet-stream":
@@ -2066,7 +2066,7 @@ proc encodeString*(value: PeerDirectKind): Result[string, cstring] =
   of PeerDirectKind.Outbound:
     ok("outbound")
 
-proc encodeString*(peerid: PeerID): Result[string, cstring] =
+proc encodeString*(peerid: PeerId): Result[string, cstring] =
   ok($peerid)
 
 proc decodeString*(t: typedesc[EventTopic],
@@ -2211,9 +2211,9 @@ proc decodeString*(t: typedesc[ValidatorIdent],
     ok(ValidatorIdent(kind: ValidatorQueryKind.Index,
                       index: RestValidatorIndex(res)))
 
-proc decodeString*(t: typedesc[PeerID],
-                   value: string): Result[PeerID, cstring] =
-  PeerID.init(value)
+proc decodeString*(t: typedesc[PeerId],
+                   value: string): Result[PeerId, cstring] =
+  PeerId.init(value)
 
 proc decodeString*(t: typedesc[CommitteeIndex],
                    value: string): Result[CommitteeIndex, cstring] =

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -435,8 +435,7 @@ type
 
   Web3SignerForkInfo* = object
     fork*: Fork
-    genesisValidatorsRoot* {.
-      serializedFieldName: "genesis_validators_root".}: Eth2Digest
+    genesis_validators_root*: Eth2Digest
 
   Web3SignerAggregationSlotData* = object
     slot*: Slot
@@ -593,65 +592,65 @@ func init*(t: typedesc[RestValidatorBalance], index: ValidatorIndex,
   RestValidatorBalance(index: index, balance: Base10.toString(balance))
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: Slot,
+           genesis_validators_root: Eth2Digest, data: Slot,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.AggregationSlot,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     aggregationSlot: Web3SignerAggregationSlotData(slot: data)
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: AggregateAndProof,
+           genesis_validators_root: Eth2Digest, data: AggregateAndProof,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.AggregateAndProof,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     aggregateAndProof: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: AttestationData,
+           genesis_validators_root: Eth2Digest, data: AttestationData,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.Attestation,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     attestation: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: phase0.BeaconBlock,
+           genesis_validators_root: Eth2Digest, data: phase0.BeaconBlock,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.Block,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     blck: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: ForkedBeaconBlock,
+           genesis_validators_root: Eth2Digest, data: ForkedBeaconBlock,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.BlockV2,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     beaconBlock: data
@@ -673,39 +672,39 @@ func init*(t: typedesc[Web3SignerRequest], genesisForkVersion: Version,
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: Epoch,
+           genesis_validators_root: Eth2Digest, data: Epoch,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.RandaoReveal,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     randaoReveal: Web3SignerRandaoRevealData(epoch: data)
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, data: VoluntaryExit,
+           genesis_validators_root: Eth2Digest, data: VoluntaryExit,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.VoluntaryExit,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     voluntaryExit: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest, blockRoot: Eth2Digest,
+           genesis_validators_root: Eth2Digest, blockRoot: Eth2Digest,
            slot: Slot, signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.SyncCommitteeMessage,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     syncCommitteeMessage: Web3SignerSyncCommitteeMessageData(
@@ -714,28 +713,28 @@ func init*(t: typedesc[Web3SignerRequest], fork: Fork,
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest,
+           genesis_validators_root: Eth2Digest,
            data: SyncAggregatorSelectionData,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.SyncCommitteeSelectionProof,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     syncAggregatorSelectionData: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesisValidatorsRoot: Eth2Digest,
+           genesis_validators_root: Eth2Digest,
            data: ContributionAndProof,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.SyncCommitteeContributionAndProof,
     forkInfo: some(Web3SignerForkInfo(
-      fork: fork, genesisValidatorsRoot: genesisValidatorsRoot
+      fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
     syncCommitteeContributionAndProof: data

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -566,16 +566,16 @@ func compute_fork_digest*(current_version: Version,
 
 func init*(T: type ForkDigests,
            cfg: RuntimeConfig,
-           genesisValidatorsRoot: Eth2Digest): T =
+           genesis_validators_root: Eth2Digest): T =
   T(
     phase0:
-      compute_fork_digest(cfg.GENESIS_FORK_VERSION, genesisValidatorsRoot),
+      compute_fork_digest(cfg.GENESIS_FORK_VERSION, genesis_validators_root),
     altair:
-      compute_fork_digest(cfg.ALTAIR_FORK_VERSION, genesisValidatorsRoot),
+      compute_fork_digest(cfg.ALTAIR_FORK_VERSION, genesis_validators_root),
     bellatrix:
-      compute_fork_digest(cfg.BELLATRIX_FORK_VERSION, genesisValidatorsRoot),
+      compute_fork_digest(cfg.BELLATRIX_FORK_VERSION, genesis_validators_root),
     sharding:
-      compute_fork_digest(cfg.SHARDING_FORK_VERSION, genesisValidatorsRoot),
+      compute_fork_digest(cfg.SHARDING_FORK_VERSION, genesis_validators_root),
   )
 
 func toBlockId*(blck: SomeForkySignedBeaconBlock): BlockId =

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -29,7 +29,7 @@ import nimcrypto/utils as ncrutils
 export
   results, burnMem, writeValue, readValue
 
-{.localPassC: "-fno-lto".} # no LTO for crypto
+{.localPassc: "-fno-lto".} # no LTO for crypto
 
 type
   KeystoreMode* = enum
@@ -61,7 +61,7 @@ type
 
   Cipher* = object
     case function*: CipherFunctionKind
-    of aes128ctrCipher:
+    of aes128CtrCipher:
       params*: Aes128CtrParams
     message*: CipherBytes
 
@@ -293,7 +293,7 @@ static:
 
 func validateKeyPath*(path: string): Result[KeyPath, cstring] =
   var digitCount: int
-  var number: BiggestUint
+  var number: BiggestUInt
   try:
     for elem in path.string.split("/"):
       # TODO: doesn't "m" have to be the first character and is it the only
@@ -675,7 +675,7 @@ func scrypt(password: openArray[char], salt: openArray[byte],
   discard scrypt(password, salt, N, r, p, xyv, b, result)
 
 func areValid(params: Pbkdf2Params): bool =
-  if params.c == 0 or params.dkLen < 32 or params.salt.bytes.len == 0:
+  if params.c == 0 or params.dklen < 32 or params.salt.bytes.len == 0:
     return false
 
   # https://www.ietf.org/rfc/rfc2898.txt
@@ -875,7 +875,7 @@ proc createNetKeystore*(kdfKind: KdfKind,
 
 proc createKeystore*(kdfKind: KdfKind,
                      rng: var BrHmacDrbgContext,
-                     privKey: ValidatorPrivkey,
+                     privKey: ValidatorPrivKey,
                      password = KeystorePass.init "",
                      path = KeyPath "",
                      description = "",

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -193,7 +193,7 @@ func getSyncSubnets*(
     syncCommittee: SyncCommittee): SyncnetBits =
   var res: SyncnetBits
   for i, pubkey in syncCommittee.pubkeys:
-    if not nodeHasPubKey(pubkey):
+    if not nodeHasPubkey(pubkey):
       continue
 
     # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#broadcast-sync-committee-message

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -49,7 +49,7 @@ func get_slot_signature*(
   let signing_root = compute_slot_signing_root(
     fork, genesis_validators_root, slot)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_slot_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
@@ -73,7 +73,7 @@ func get_epoch_signature*(
   let signing_root = compute_epoch_signing_root(
     fork, genesis_validators_root, epoch)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
@@ -100,7 +100,7 @@ func get_block_signature*(
   let signing_root = compute_block_signing_root(
     fork, genesis_validators_root, slot, root)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_block_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
@@ -125,11 +125,11 @@ func compute_aggregate_and_proof_signing_root*(
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/validator.md#broadcast-aggregate
 func get_aggregate_and_proof_signature*(fork: Fork, genesis_validators_root: Eth2Digest,
                                         aggregate_and_proof: AggregateAndProof,
-                                        privKey: ValidatorPrivKey): CookedSig =
+                                        privkey: ValidatorPrivKey): CookedSig =
   let signing_root = compute_aggregate_and_proof_signing_root(
     fork, genesis_validators_root, aggregate_and_proof)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_aggregate_and_proof_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
@@ -158,7 +158,7 @@ func get_attestation_signature*(
   let signing_root = compute_attestation_signing_root(
     fork, genesis_validators_root, attestation_data)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_attestation_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,
@@ -185,7 +185,7 @@ func get_deposit_signature*(preset: RuntimeConfig,
   let signing_root = compute_deposit_signing_root(
     preset.GENESIS_FORK_VERSION, deposit.getDepositMessage())
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 func get_deposit_signature*(message: DepositMessage, version: Version,
                             privkey: ValidatorPrivKey): CookedSig =
@@ -218,7 +218,7 @@ func get_voluntary_exit_signature*(
   let signing_root = compute_voluntary_exit_signing_root(
     fork, genesis_validators_root, voluntary_exit)
 
-  blsSign(privKey, signing_root.data)
+  blsSign(privkey, signing_root.data)
 
 proc verify_voluntary_exit_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest,

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -25,7 +25,7 @@ import
 export results, altair, phase0, taskpools, bearssl, signatures
 
 type
-  TaskPoolPtr* = TaskPool
+  TaskPoolPtr* = Taskpool
 
   BatchVerifier* = object
     sigVerifCache*: BatchedBLSVerifierCache ##\

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -340,7 +340,7 @@ proc makeBeaconBlock*(
 
   var blck = partialBeaconBlock(cfg, state, proposer_index,
                                 randao_reveal, eth1_data, graffiti, attestations, deposits,
-                                exits, sync_aggregate, executionPayload)
+                                exits, sync_aggregate, execution_payload)
 
   let res = process_block(cfg, state.data, blck, {skipBlsValidation}, cache)
 

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -572,7 +572,7 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
       )
 
     # Update status string
-    man.syncStatus = timeLeft.toTimeLeftString() & " (" &
+    man.syncStatus = timeleft.toTimeLeftString() & " (" &
                     (done * 100).formatBiggestFloat(ffDecimal, 2) & "%) " &
                     man.avgSyncSpeed.formatBiggestFloat(ffDecimal, 4) &
                     "slots/s (" & map & ":" & currentSlot & ")"

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -586,9 +586,9 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
         else:
           some(sq.readyQueue.pop())
       of SyncQueueKind.Backward:
-        let maxSlot = sq.readyQueue[0].request.slot +
+        let maxslot = sq.readyQueue[0].request.slot +
                       (sq.readyQueue[0].request.count - 1'u64)
-        if sq.outSlot > maxSlot:
+        if sq.outSlot > maxslot:
           none[SyncResult[T]]()
         else:
           some(sq.readyQueue.pop())
@@ -820,10 +820,10 @@ proc pop*[T](sq: SyncQueue[T], maxslot: Slot, item: T): SyncRequest[T] =
   ## Create new request according to current SyncQueue parameters.
   sq.handlePotentialSafeSlotAdvancement()
   while len(sq.debtsQueue) > 0:
-    if maxSlot < sq.debtsQueue[0].slot:
+    if maxslot < sq.debtsQueue[0].slot:
       # Peer's latest slot is less than starting request's slot.
       return SyncRequest.empty(sq.kind, T)
-    if maxSlot < sq.debtsQueue[0].lastSlot():
+    if maxslot < sq.debtsQueue[0].lastSlot():
       # Peer's latest slot is less than finishing request's slot.
       return SyncRequest.empty(sq.kind, T)
     var sr = sq.debtsQueue.pop()
@@ -837,7 +837,7 @@ proc pop*[T](sq: SyncQueue[T], maxslot: Slot, item: T): SyncRequest[T] =
 
   case sq.kind
   of SyncQueueKind.Forward:
-    if maxSlot < sq.inpSlot:
+    if maxslot < sq.inpSlot:
       # Peer's latest slot is less than queue's input slot.
       return SyncRequest.empty(sq.kind, T)
     if sq.inpSlot > sq.finalSlot:
@@ -862,7 +862,7 @@ proc pop*[T](sq: SyncQueue[T], maxslot: Slot, item: T): SyncRequest[T] =
           (baseSlot - count, count)
         else:
           (baseSlot - sq.chunkSize, sq.chunkSize)
-    if (maxSlot + 1'u64) < slot + count:
+    if (maxslot + 1'u64) < slot + count:
       # Peer's latest slot is less than queue's input slot.
       return SyncRequest.empty(sq.kind, T)
     var sr = SyncRequest.init(sq.kind, slot, count, item)

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -108,7 +108,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
           error_name = exc.name, error_msg = exc.msg
 
 proc proposeBlock(vc: ValidatorClientRef, slot: Slot,
-                  proposerKey: ValidatorPubkey) {.async.} =
+                  proposerKey: ValidatorPubKey) {.async.} =
   let (inFuture, timeToSleep) = vc.beaconClock.fromNow(slot)
   try:
     if inFuture:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -156,7 +156,7 @@ proc init*(t: typedesc[DutyAndProof], epoch: Epoch, dependentRoot: Eth2Digest,
                slotSig: slotSig)
 
 proc init*(t: typedesc[ProposedData], epoch: Epoch, dependentRoot: Eth2Digest,
-           data: openarray[ProposerTask]): ProposedData =
+           data: openArray[ProposerTask]): ProposedData =
   ProposedData(epoch: epoch, dependentRoot: dependentRoot, duties: @data)
 
 proc getCurrentSlot*(vc: ValidatorClientRef): Option[Slot] =
@@ -231,7 +231,7 @@ proc getDelay*(vc: ValidatorClientRef, deadline: BeaconTime): TimeDiff =
   vc.beaconClock.now() - deadline
 
 proc getValidator*(vc: ValidatorClientRef,
-                   key: ValidatorPubkey): Option[AttachedValidator] =
+                   key: ValidatorPubKey): Option[AttachedValidator] =
   let validator = vc.attachedValidators.getValidator(key)
   if isNil(validator):
     warn "Validator not in pool anymore", validator = shortLog(validator)

--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -4,7 +4,7 @@ import common, api
 
 logScope: service = "fork_service"
 
-proc validateForkSchedule(forks: openarray[Fork]): bool {.raises: [Defect].} =
+proc validateForkSchedule(forks: openArray[Fork]): bool {.raises: [Defect].} =
   # Check if `forks` list is linked list.
   var current_version = forks[0].current_version
   for index, item in forks.pairs():
@@ -17,7 +17,7 @@ proc validateForkSchedule(forks: openarray[Fork]): bool {.raises: [Defect].} =
     current_version = item.current_version
   true
 
-proc sortForks(forks: openarray[Fork]): Result[seq[Fork], cstring] {.
+proc sortForks(forks: openArray[Fork]): Result[seq[Fork], cstring] {.
      raises: [Defect].} =
   proc cmp(x, y: Fork): int {.closure.} =
     if uint64(x.epoch) == uint64(y.epoch): return 0

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -90,7 +90,7 @@ proc init*(
 
   if requiresMigration:
     fatal "The slashing database predates Altair hardfork from October 2021." &
-      " You can migrate to the new DB format using Nimbus 1.6.0" & 
+      " You can migrate to the new DB format using Nimbus 1.6.0" &
       " for a few minutes at https://github.com/status-im/nimbus-eth2/releases/tag/v1.6.0" &
       " until the messages \"Migrating local validators slashing DB from v1 to v2\"" &
       " and \"Slashing DB migration successful.\""
@@ -206,7 +206,7 @@ proc registerAttestation*(
 
 proc pruneBlocks*(
        db: SlashingProtectionDB,
-       validator: ValidatorPubkey,
+       validator: ValidatorPubKey,
        newMinSlot: Slot) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import to ensure
@@ -220,7 +220,7 @@ proc pruneBlocks*(
 
 proc pruneAttestations*(
        db: SlashingProtectionDB,
-       validator: ValidatorPubkey,
+       validator: ValidatorPubKey,
        newMinSourceEpoch: int64,
        newMinTargetEpoch: int64) =
   ## Prune all blocks from a validator before the specified newMinSlot

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -225,7 +225,7 @@ proc writeValue*(w: var JsonWriter, a: SlotString or EpochString)
 proc readValue*(r: var JsonReader, a: var (SlotString or EpochString))
                {.raises: [SerializationError, IOError, Defect].} =
   try:
-    a = (typeof a)(r.readValue(string).parseBiggestUint())
+    a = (typeof a)(r.readValue(string).parseBiggestUInt())
   except ValueError:
     raiseUnexpectedValue(r, "Integer in a string expected")
 
@@ -361,7 +361,7 @@ proc importInterchangeV5Impl*(
     # (the last before the earliest) the minEpochViolation check stays consistent.
     var maxValidSourceEpochSeen = -1
     var maxValidTargetEpochSeen = -1
-    
+
     if dbSource.isSome():
       maxValidSourceEpochSeen = int dbSource.get()
     if dbTarget.isSome():
@@ -384,7 +384,7 @@ proc importInterchangeV5Impl*(
 
     # See formal proof https://github.com/michaelsproul/slashing-proofs
     # of synthetic attestation
-    if not(maxValidSourceEpochSeen < maxValidTargetEpochSeen) and 
+    if not(maxValidSourceEpochSeen < maxValidTargetEpochSeen) and
        not(maxValidSourceEpochSeen == 0 and maxValidTargetEpochSeen == 0):
       # Special-case genesis (Slashing prot is deactivated anyway)
       warn "Invalid attestation(s), source epochs should be less than target epochs, skipping import",
@@ -393,7 +393,7 @@ proc importInterchangeV5Impl*(
         maxValidTargetEpochSeen = maxValidTargetEpochSeen
       result = siPartial
       continue
-  
+
     db.registerSyntheticAttestation(
       parsedKey,
       Epoch maxValidSourceEpochSeen,

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -422,7 +422,7 @@ proc forkchoice_updated(state: bellatrix.BeaconState,
                         finalized_block_hash: Eth2Digest,
                         fee_recipient: ethtypes.Address,
                         execution_engine: Eth1Monitor):
-                        Future[Option[bellatrix.PayloadId]] {.async.} =
+                        Future[Option[bellatrix.PayloadID]] {.async.} =
   const web3Timeout = 3.seconds
 
   let
@@ -439,9 +439,9 @@ proc forkchoice_updated(state: bellatrix.BeaconState,
     payloadId = forkchoiceResponse.payloadId
 
   return if payloadId.isSome:
-    some(bellatrix.PayloadId(payloadId.get))
+    some(bellatrix.PayloadID(payloadId.get))
   else:
-    none(bellatrix.PayloadId)
+    none(bellatrix.PayloadID)
 
 proc makeBeaconBlockForHeadAndSlot*(node: BeaconNode,
                                     randao_reveal: ValidatorSig,
@@ -705,11 +705,11 @@ proc createAndSendSyncCommitteeMessage(node: BeaconNode,
   try:
     let
       fork = node.dag.forkAtEpoch(slot.epoch)
-      genesisValidatorsRoot = node.dag.genesisValidatorsRoot
+      genesis_validators_root = node.dag.genesis_validators_root
       msg =
         block:
           let res = await signSyncCommitteeMessage(validator, fork,
-                                                   genesisValidatorsRoot,
+                                                   genesis_validators_root,
                                                    slot, head.root)
           if res.isErr():
             error "Unable to sign committee message using remote signer",
@@ -781,7 +781,7 @@ proc signAndSendContribution(node: BeaconNode,
 
     let res = await validator.sign(
       msg, node.dag.forkAtEpoch(contribution.slot.epoch),
-      node.dag.genesisValidatorsRoot)
+      node.dag.genesis_validators_root)
 
     if res.isErr():
       error "Unable to sign sync committee contribution usign remote signer",
@@ -801,7 +801,7 @@ proc handleSyncCommitteeContributions(node: BeaconNode,
   # TODO Use a view type to avoid the copy
   let
     fork = node.dag.forkAtEpoch(slot.epoch)
-    genesisValidatorsRoot = node.dag.genesisValidatorsRoot
+    genesis_validators_root = node.dag.genesis_validators_root
     syncCommittee = node.dag.syncCommitteeParticipants(slot + 1)
 
   type
@@ -827,7 +827,7 @@ proc handleSyncCommitteeContributions(node: BeaconNode,
           subcommitteeIdx: subcommitteeIdx)
 
         selectionProofs.add validator.getSyncCommitteeSelectionProof(
-          fork, genesisValidatorsRoot, slot, subcommitteeIdx.asUInt64)
+          fork, genesis_validators_root, slot, subcommitteeIdx.asUInt64)
 
     await allFutures(selectionProofs)
 

--- a/docs/the_auditors_handbook/src/02.2.5_arrays_openarrays_strings_cstring.md
+++ b/docs/the_auditors_handbook/src/02.2.5_arrays_openarrays_strings_cstring.md
@@ -9,9 +9,9 @@ TODO
 Openarray are a parameter-only type that represent a (pointer, length) pair.
 In other languages they are also known as slices, ranges, views, spans.
 
-_The name openarray is inherited from Pascal, Oberon and Modula 2_
+_The name openArray is inherited from Pascal, Oberon and Modula 2_
 
-Arrays and sequences are implictily converted to openarray.
+Arrays and sequences are implictily converted to openArray.
 
 The compiler has a limited form of escape analysis to prevent capturing openarrays in closures
 or returning them.

--- a/ncli/nim.cfg
+++ b/ncli/nim.cfg
@@ -1,2 +1,10 @@
-hints:off
 -u:metrics
+
+-d:"libp2p_pki_schemes=secp256k1"
+
+-d:chronosStrictException
+--styleCheck:usages
+--styleCheck:hint
+--hint[XDeclaredButNotUsed]:off
+--hint[ConvFromXtoItselfNotNeeded]:off
+--hint[Processing]:off

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -265,6 +265,8 @@ proc getTestRules(conf: RestTesterConf): Result[seq[JsonNode], cstring] =
       fatal "JSON processing error while reading rules file",
             error_msg = exc.msg, filename = conf.rulesFilename
       return err("Unable to parse json")
+    except Exception as exc:
+      raiseAssert exc.msg
 
   let elems = node.getElems()
   if len(elems) == 0:
@@ -727,13 +729,15 @@ proc validateHeaders(resp: HttpResponseHeader, expect: HeadersExpect): bool =
           return false
     true
 
-proc jsonBody(body: openarray[byte]): Result[JsonNode, cstring] =
+proc jsonBody(body: openArray[byte]): Result[JsonNode, cstring] =
   var sbody = cast[string](@body)
   let res =
     try:
       parseJson(sbody)
     except CatchableError as exc:
       return err("Unable to parse json")
+    except Exception as exc:
+      raiseAssert exc.msg
   ok(res)
 
 proc getPath(jobj: JsonNode, path: seq[string]): Result[JsonNode, cstring] =
@@ -784,7 +788,7 @@ proc structCmp(j1, j2: JsonNode, strict: bool): bool =
   else:
     true
 
-proc validateBody(body: openarray[byte], expect: BodyExpect): bool =
+proc validateBody(body: openArray[byte], expect: BodyExpect): bool =
   if len(expect.items) == 0:
     true
   else:

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -150,7 +150,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
 
     let
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
-      genesis_validators_root = dag.genesisValidatorsRoot
+      genesis_validators_root = dag.genesis_validators_root
       fork = dag.forkAtEpoch(slot.epoch)
       messagesTime = slot.attestation_deadline()
       contributionsTime = slot.sync_contribution_deadline()

--- a/research/block_sim.nim.cfg
+++ b/research/block_sim.nim.cfg
@@ -1,2 +1,1 @@
--u:metrics
 -d:"chronicles_sinks=json[file(block_sim.log)]"

--- a/research/nim.cfg
+++ b/research/nim.cfg
@@ -1,0 +1,10 @@
+-u:metrics
+
+-d:"libp2p_pki_schemes=secp256k1"
+
+-d:chronosStrictException
+--styleCheck:usages
+--styleCheck:hint
+--hint[XDeclaredButNotUsed]:off
+--hint[ConvFromXtoItselfNotNeeded]:off
+--hint[Processing]:off

--- a/research/stack_sizes.nim.cfg
+++ b/research/stack_sizes.nim.cfg
@@ -1,1 +1,0 @@
--u:metrics

--- a/research/state_sim.nim.cfg
+++ b/research/state_sim.nim.cfg
@@ -1,1 +1,0 @@
--u:metrics

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,2 +1,9 @@
 # Use only `secp256k1` public key cryptography as an identity in LibP2P.
 -d:"libp2p_pki_schemes=secp256k1"
+
+-d:chronosStrictException
+--styleCheck:usages
+--styleCheck:hint
+--hint[XDeclaredButNotUsed]:off
+--hint[ConvFromXtoItselfNotNeeded]:off
+--hint[Processing]:off

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -14,7 +14,7 @@ proc new(T: type Eth2DiscoveryProtocol,
     bindPort: Port, bindIp: ValidIpAddress,
     enrFields: openArray[(string, seq[byte])] = [],
     rng: ref BrHmacDrbgContext):
-    T {.raises: [Exception, Defect].} =
+    T {.raises: [CatchableError, Defect].} =
 
   newProtocol(pk, enrIp, enrTcpPort, enrUdpPort, enrFields,
     bindPort = bindPort, bindIp = bindIp, rng = rng)

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -44,7 +44,7 @@ let
   cfg = defaultRuntimeConfig
   validatorDirRes = secureCreatePath(testValidatorsDir)
 
-proc namesEqual(a, b: openarray[string]): bool =
+proc namesEqual(a, b: openArray[string]): bool =
   sorted(a) == sorted(b)
 
 when not defined(windows):

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -82,7 +82,7 @@ suite "Light client" & preset():
         serveLightClientData = true,
         importLightClientData = ImportLightClientData.OnlyNew)
       quarantine = newClone(Quarantine.init())
-      taskpool = TaskPool.new()
+      taskpool = Taskpool.new()
     var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
 
   test "Pre-Altair":
@@ -112,7 +112,7 @@ suite "Light client" & preset():
 
     # Track trusted checkpoint for light client
     let
-      genesis_validators_root = dag.genesisValidatorsRoot
+      genesis_validators_root = dag.genesis_validators_root
       trusted_block_root = dag.head.root
 
     # Advance to target slot

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -33,7 +33,7 @@ suite "Light client processor" & preset():
       serveLightClientData = true,
       importLightClientData = ImportLightClientData.OnlyNew)
     quarantine = newClone(Quarantine.init())
-    taskpool = TaskPool.new()
+    taskpool = Taskpool.new()
   var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
 
   var cache: StateCache
@@ -56,7 +56,7 @@ suite "Light client processor" & preset():
 
   addBlocks(SLOTS_PER_EPOCH, 0.75)
   let
-    genesisValidatorsRoot = dag.genesisValidatorsRoot
+    genesis_validators_root = dag.genesis_validators_root
     trustedBlockRoot = dag.head.root
 
   const
@@ -89,7 +89,7 @@ suite "Light client processor" & preset():
     let store = (ref Option[LightClientStore])()
     var
       processor = LightClientProcessor.new(
-        false, "", "", cfg, genesisValidatorsRoot, trustedBlockRoot,
+        false, "", "", cfg, genesis_validators_root, trustedBlockRoot,
         store, getBeaconTime, didInitializeStore)
       res: Result[void, BlockError]
 

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -7,7 +7,7 @@ import
   ../beacon_chain/consensus_object_pools/sync_committee_msg_pool,
   ./testblockutil
 
-func aggregate(sigs: openarray[CookedSig]): CookedSig =
+func aggregate(sigs: openArray[CookedSig]): CookedSig =
   var agg {.noinit.}: AggregateSignature
   agg.init sigs[0]
   for i in 1 ..< sigs.len:
@@ -45,7 +45,7 @@ suite "Sync committee pool":
   test "Aggregating votes":
     let
       fork = altairFork(defaultRuntimeConfig)
-      genesisValidatorsRoot = eth2digest(@[5.byte, 6, 7])
+      genesis_validators_root = eth2digest(@[5.byte, 6, 7])
 
       privkey1 = MockPrivKeys[1.ValidatorIndex]
       privkey2 = MockPrivKeys[2.ValidatorIndex]
@@ -64,13 +64,13 @@ suite "Sync committee pool":
       subcommittee2 = SyncSubcommitteeIndex(1)
 
       sig1 = get_sync_committee_message_signature(
-        fork, genesisValidatorsRoot, root1Slot, root1, privkey1)
+        fork, genesis_validators_root, root1Slot, root1, privkey1)
       sig2 = get_sync_committee_message_signature(
-        fork, genesisValidatorsRoot, root2Slot, root2, privkey1)
+        fork, genesis_validators_root, root2Slot, root2, privkey1)
       sig3 = get_sync_committee_message_signature(
-        fork, genesisValidatorsRoot, root3Slot, root3, privkey1)
+        fork, genesis_validators_root, root3Slot, root3, privkey1)
       sig4 = get_sync_committee_message_signature(
-        fork, genesisValidatorsRoot, root3Slot, root2, privkey1)
+        fork, genesis_validators_root, root3Slot, root2, privkey1)
 
     # Inserting sync committee messages
     #


### PR DESCRIPTION
Some upstream repos still need fixes, but this gets us close enough that
style hints can be enabled by default.

In general, "canonical" spellings are preferred even if they violate
nep-1 - this applies in particular to spec-related stuff like
`genesis_validators_root` which appears throughout the codebase.