### PR TITLE
remove `nim-protobuf-serialization`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -138,11 +138,6 @@
 	url = https://github.com/status-im/nim-snappy.git
 	ignore = untracked
 	branch = master
-[submodule "vendor/nim-protobuf-serialization"]
-	path = vendor/nim-protobuf-serialization
-	url = https://github.com/status-im/nim-protobuf-serialization.git
-	ignore = untracked
-	branch = master
 [submodule "vendor/asynctools"]
 	path = vendor/asynctools
 	url = https://github.com/cheatfate/asynctools.git


### PR DESCRIPTION
tests don't compile in the nimbus-eth2 environment due to missing
dependencies, and the project itself is not used within nimbus-eth2

The project is also broken with bounds checking.