### PR TITLE
Revert "Polish, remove beta warning for validator monitor"

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -390,7 +390,7 @@ proc createAndSendAttestation(node: BeaconNode,
       wallTime = node.beaconClock.now()
       delay = wallTime - attestationData.slot.attestation_deadline()
 
-    info "Attestation sent",
+    notice "Attestation sent",
       attestation = shortLog(attestation), validator = shortLog(validator),
       delay, subnet_id
 
@@ -990,7 +990,7 @@ proc sendAggregatedAttestations(
     let
       subnet_id = compute_subnet_for_attestation(
         committees_per_slot, slot, data.committee_index)
-    info "Aggregated attestation sent",
+    notice "Aggregated attestation sent",
       aggregate = shortLog(signedAP.message.aggregate),
       aggregator_index = signedAP.message.aggregator_index,
       signature = shortLog(signedAP.signature),
@@ -1225,7 +1225,7 @@ proc sendAttestation*(node: BeaconNode,
     wallTime = node.processor.getCurrentBeaconTime()
     delay = wallTime - attestation.data.slot.attestation_deadline()
 
-  info "Attestation sent",
+  notice "Attestation sent",
     attestation = shortLog(attestation), delay, subnet_id
 
   beacon_attestation_sent_delay.observe(delay.toFloatSeconds())
@@ -1242,7 +1242,7 @@ proc sendAggregateAndProof*(node: BeaconNode,
     if res.isGoodForSending:
       node.network.broadcastAggregateAndProof(proof)
 
-      info "Aggregated attestation sent",
+      notice "Aggregated attestation sent",
         attestation = shortLog(proof.message.aggregate),
         aggregator_index = proof.message.aggregator_index,
         signature = shortLog(proof.signature)

--- a/docs/the_nimbus_book/src/validator-monitor.md
+++ b/docs/the_nimbus_book/src/validator-monitor.md
@@ -1,6 +1,6 @@
 # Validator monitoring
 
-> **Note:** This feature is available from `v1.7.0` onwards
+> ⚠️ This feature is currently in BETA - implementation details such as metric names and counters may change in response to community feedback.
 
 The validator monitoring feature allows for tracking the life-cycle and performance of one or more validators in detail.
 


### PR DESCRIPTION
A few more fixes are needed before removing beta:

* auto-monitor should be on by default
* totals should be on by default to prevent metrics explosions on large servers

Reverts status-im/nimbus-eth2#3531