### PR TITLE
Revert "bump nim-stew to remove pragma disabling checks"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,18 +213,18 @@ jobs:
         run: |
           if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
             # hide the CI failure in GitHub's UI
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client || true
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client || true
           else
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE nimbus_beacon_node nimbus_validator_client
           fi
 
       - name: Build all tools
         run: |
           if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
             # hide the CI failure in GitHub's UI
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} || true
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} || true
           else
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }}
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }}
           fi
           # The Windows image runs out of disk space, so make some room
           rm -rf nimcache
@@ -233,9 +233,9 @@ jobs:
         run: |
           if [[ "${{ matrix.branch }}" == "version-1-6" ]]; then
             # hide the CI failure in GitHub's UI
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test || true
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test || true
           else
-            ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test
+            ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} DISABLE_TEST_FIXTURES_SCRIPT=1 test
           fi
 
       # The upload creates a combined report that gets posted as a comment on the PR


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#3555

Hopefully not necessary to merge -- more a diagnostic to figure out whether
```
Error: unhandled exception: 'jwtSecret' is not accessible using discriminant 'cmd' of type 'BeaconNodeConf' [FieldError]
```
in CI on various Nim 1.2 (but not Nim 1.6) platforms, both GitHub Actions and Jenkins really is somehow fallout from this `nim-stew` bump (a bit odd), the `V=1` change (also odd), or is just coincidental timing.