### PR TITLE
remove Jenkins caching

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,19 +20,15 @@ def runStages(nodeDir) {
 				sh "git submodule update --init --recursive"
 			}
 
-			cache(maxCacheSize: 250, caches: [
-				[$class: "ArbitraryFileCache", excludes: "", includes: "**/*", path: "${WORKSPACE}/${nodeDir}/jsonTestsCache"]
-			]) {
-				stage("Preparations") {
-					sh """#!/bin/bash
-					set -e
-					# macOS shows scary warnings if there are old libraries and object files laying around
-					make clean
-					# to allow the following parallel stages
-					make -j${env.NPROC} QUICK_AND_DIRTY_COMPILER=1 update
-					./scripts/setup_scenarios.sh jsonTestsCache
-					"""
-				}
+			stage("Preparations") {
+				sh """#!/bin/bash
+				set -e
+				# macOS shows scary warnings if there are old libraries and object files laying around
+				make clean
+				# to allow the following parallel stages
+				make -j${env.NPROC} QUICK_AND_DIRTY_COMPILER=1 update
+				./scripts/setup_scenarios.sh
+				"""
 			}
 
 			stage("Tools") {


### PR DESCRIPTION
Since Jenkins was updated to incorporate https://issues.jenkins.io/browse/JENKINS-67173 in version 2.326, it's been showing
```
Failed to deserialize response to UserRequest:hudson.FilePath$Exists@582d9fa5: java.lang.SecurityException: Sending hudson.FilePath$Exists from agent to controller is prohibited.

See https://www.jenkins.io/redirect/security-144 for more details
```
In general, Jenkins plugins need to have been updated to this. However, https://plugins.jenkins.io/jobcacher/ hasn't been updated in 5 years, and certainly not for a security fix from a few months ago. This incompatibility between the post-security-fix Jenkins and the non-updated Job Cacher plugin means that the workaround that https://www.jenkins.io/redirect/security-144 suggests doesn't exist anymore.

There might be an alternative caching plugin, or approach, but in the meantime, disable Jenkins caching for the Nim compiler.
