### PR TITLE
stylecheck fixes

### DIFF
--- a/beacon_chain/eth1/deposit_contract.nim
+++ b/beacon_chain/eth1/deposit_contract.nim
@@ -165,7 +165,7 @@ proc sendDeposits*(deposits: seq[LaunchPadDeposit],
     while true:
       try:
         let tx = depositContract.deposit(
-          Bytes48(dp.pubKey.toRaw()),
+          Bytes48(dp.pubkey.toRaw()),
           Bytes32(dp.withdrawal_credentials.data),
           Bytes96(dp.signature.toRaw()),
           FixedBytes[32](hash_tree_root(dp).data))
@@ -195,7 +195,7 @@ proc main() {.async.} =
   if conf.cmd == StartUpCommand.generateSimulationDeposits:
     let
       mnemonic = generateMnemonic(rng[])
-      seed = getSeed(mnemonic, KeyStorePass.init "")
+      seed = getSeed(mnemonic, KeystorePass.init "")
       cfg = getRuntimeConfig(conf.eth2Network)
 
     if (let res = secureCreatePath(string conf.outValidatorsDir); res.isErr):

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -305,8 +305,8 @@ template asBlockHash*(x: Eth2Digest): BlockHash =
 
 func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV1):
     bellatrix.ExecutionPayload =
-  template getTransaction(t: TypedTransaction): bellatrix.Transaction =
-    bellatrix.Transaction.init(t.distinctBase)
+  template getTransaction(tt: TypedTransaction): bellatrix.Transaction =
+    bellatrix.Transaction.init(tt.distinctBase)
 
   bellatrix.ExecutionPayload(
     parent_hash: rpcExecutionPayload.parentHash.asEth2Digest,
@@ -331,8 +331,8 @@ func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV1):
 
 func asEngineExecutionPayload*(executionPayload: bellatrix.ExecutionPayload):
     ExecutionPayloadV1 =
-  template getTypedTransaction(t: bellatrix.Transaction): TypedTransaction =
-    TypedTransaction(t.distinctBase)
+  template getTypedTransaction(tt: bellatrix.Transaction): TypedTransaction =
+    TypedTransaction(tt.distinctBase)
 
   engine_api.ExecutionPayloadV1(
     parentHash: executionPayload.parent_hash.asBlockHash,

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -246,7 +246,7 @@ proc collectEpochRewardsAndPenalties*(
           state, base_reward, active_increments,
           unslashed_participating_increment,
           PARTICIPATION_FLAG_WEIGHTS[flag_index].uint64,
-          finalityDelay)
+          finality_delay)
 
       case flag_index
       of TIMELY_SOURCE_FLAG_INDEX:

--- a/ncli/validator_db_aggregator.nim
+++ b/ncli/validator_db_aggregator.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[os, strutils, streams, parsecsv],
   stew/[io2, byteutils], chronicles, confutils, snappy,
@@ -158,7 +165,7 @@ proc addValidatorData*(aggregator: var ValidatorDbAggregator,
   else:
     aggregator.aggregatedRewardsAndPenalties[index] += rp
     inc aggregator.participationEpochsCount[index]
-    if rp.inclusionDelay.isSome:
+    if rp.inclusion_delay.isSome:
       inc aggregator.inclusionDelaysCount[index]
 
 proc advanceEpochs*(aggregator: var ValidatorDbAggregator, epoch: Epoch,

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -33,7 +33,7 @@ template findIt*(s: openArray, predicate: untyped): int =
 
 proc findValidator(validators: seq[Validator], pubKey: ValidatorPubKey):
     Option[ValidatorIndex] =
-  let idx = validators.findIt(it.pubKey == pubKey)
+  let idx = validators.findIt(it.pubkey == pubKey)
   if idx == -1:
     none(ValidatorIndex)
   else:
@@ -254,7 +254,7 @@ cli do(validatorsDir: string, secretsDir: string,
             else:
               agg = AggregateSignature.init(sig)
               inited = true
-            sync_aggregate.sync_committee_bits.setBit(i)
+            syncAggregate.sync_committee_bits.setBit(i)
 
         if inited:
-          sync_aggregate.sync_committee_signature = finish(agg).toValidatorSig()
+          syncAggregate.sync_committee_signature = finish(agg).toValidatorSig()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -84,7 +84,7 @@ proc initialLoad(
   let signedBlock = ForkedSignedBeaconBlock.init(phase0.SignedBeaconBlock(
         message: blk,
         # signature: - unused as it's trusted
-        root: hashTreeRoot(blk)
+        root: hash_tree_root(blk)
       ))
 
   ChainDAGRef.preInit(

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -221,7 +221,7 @@ proc sszCheck(baseDir, sszType, sszSubType: string) =
   of "bitlist": checkBitList(sszSubType, dir, expectedHash)
   of "containers":
     var name: string
-    let wasMatched = scanf(sszSubtype, "$+_", name)
+    let wasMatched = scanf(sszSubType, "$+_", name)
     doAssert wasMatched
     case name
     of "SingleFieldTestStruct": checkBasic(SingleFieldTestStruct, dir, expectedHash)

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -175,7 +175,7 @@ suite "Light client" & preset():
     # Initialize new DAG from checkpoint
     let cpDb = BeaconChainDB.new("", inMemory = true)
     ChainDAGRef.preInit(
-      cpDB, genesisState[],
+      cpDb, genesisState[],
       dag.headState, dag.getForkedBlock(dag.head.bid).get)
     let cpDag = ChainDAGRef.init(
       cfg, cpDb, validatorMonitor, {},


### PR DESCRIPTION
- `pubKey` to `pubkey`
- `KeyStorePass` to `KeystorePass`
- `finalityDelay` to `finality_delay`
- `inclusionDelay` to `inclusion_delay`
- `sync_aggregate` to `syncAggregate`
- `hashTreeRoot` to `hash_tree_root`

There are a handful remaining, but they're a bit more nuanced -- typically, overlap in a single-letter variable name which is used at least once both uppercase and lowercase (`F` and `f`), a situation where there's a slightly less trivial coexistence of both forms (`startSlot` and `start_slot`; and `blockHash` and `block_hash`), etc. Worth dealing with in a separate PR for clarity.