### PR TITLE
avoid unnecessary recompression in block protocol

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -888,7 +888,7 @@ proc getBlockSZ*(
       snappy.decode(data, maxDecompressedDbRecordSize))
     except CatchableError: success = false
   db.blocks[BeaconBlockFork.Phase0].get(key.data, decode).expectDb() and success or
-    db.v0.getPhase0BlockSSZ(key, data)
+    db.v0.getPhase0BlockSZ(key, data)
 
 proc getBlockSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -824,6 +824,17 @@ proc getPhase0BlockSSZ(
   db.backend.get(subkey(phase0.SignedBeaconBlock, key), decode).expectDb() and
     success
 
+proc getPhase0BlockSZ(
+    db: BeaconChainDBV0, key: Eth2Digest, data: var seq[byte]): bool =
+  let dataPtr = addr data # Short-lived
+  var success = true
+  proc decode(data: openArray[byte]) =
+    try: dataPtr[] = snappy.encodeFramed(
+      snappy.decode(data, maxDecompressedDbRecordSize))
+    except CatchableError: success = false
+  db.backend.get(subkey(phase0.SignedBeaconBlock, key), decode).expectDb() and
+    success
+
 # SSZ implementations are separate so as to avoid unnecessary data copies
 proc getBlockSSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -538,7 +538,8 @@ proc writeChunkSZ*(
     uncompressedLen: uint64, payloadSZ: openArray[byte],
     contextBytes: openArray[byte] = []): Future[void] =
   # max 10 bytes varint length + 1 byte response code + data
-  var output = memoryOutput(payloadSZ.len + contextBytes.len + 11)
+  const numOverheadBytes = sizeof(byte) + Leb128.maxLen(typeof(uncompressedLen))
+  var output = memoryOutput(payloadSZ.len + contextBytes.len + numOverheadBytes)
   try:
     if responseCode.isSome:
       output.write byte(responseCode.get)

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -537,6 +537,7 @@ proc writeChunkSZ*(
     conn: Connection, responseCode: Option[ResponseCode],
     uncompressedLen: uint64, payloadSZ: openArray[byte],
     contextBytes: openArray[byte] = []): Future[void] =
+  # max 10 bytes varint length + 1 byte response code + data
   var output = memoryOutput(payloadSZ.len + contextBytes.len + 11)
   try:
     if responseCode.isSome:

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -394,7 +394,7 @@ p2pProtocol BeaconSync(version = 1,
       bytes: seq[byte]
 
     for i in startIndex..endIndex:
-      if dag.getBlockSSZ(blocks[i], bytes):
+      if dag.getBlockSZ(blocks[i], bytes):
         let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
           warn "Cannot read block size, database corrupt?",
             bytes = bytes.len(), blck = shortLog(blocks[i])
@@ -450,7 +450,7 @@ p2pProtocol BeaconSync(version = 1,
         blockRef = dag.getBlockRef(blockRoots[i]).valueOr:
           continue
 
-      if dag.getBlockSSZ(blockRef.bid, bytes):
+      if dag.getBlockSZ(blockRef.bid, bytes):
         let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
           warn "Cannot read block size, database corrupt?",
             bytes = bytes.len(), blck = shortLog(blockRef)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -111,6 +111,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
       tmp2 == encodeFramed(tmp)
+      uncompressedLenFramed(tmp2).isSome
 
     db.delBlock(root)
     check:
@@ -153,6 +154,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
       tmp2 == encodeFramed(tmp)
+      uncompressedLenFramed(tmp2).isSome
 
     db.delBlock(root)
     check:
@@ -195,6 +197,7 @@ suite "Beacon chain DB" & preset():
       db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
       tmp == SSZ.encode(signedBlock)
       tmp2 == encodeFramed(tmp)
+      uncompressedLenFramed(tmp2).isSome
 
     db.delBlock(root)
     check:


### PR DESCRIPTION
Blocks can be sent straight from compressed data sources