### PR TITLE
mitigate Eth1Monitor being nil in merge scenario

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -449,7 +449,7 @@ proc getPayload*(p: Eth1Monitor,
                  payloadId: bellatrix.PayloadID): Future[engine_api.ExecutionPayloadV1] =
   # Eth1 monitor can recycle connections without (external) warning; at least,
   # don't crash.
-  if p.dataProvider.isNil:
+  if p.isNil or p.dataProvider.isNil:
     var epr: Future[engine_api.ExecutionPayloadV1]
     epr.complete(default(engine_api.ExecutionPayloadV1))
     return epr
@@ -472,7 +472,7 @@ proc forkchoiceUpdated*(p: Eth1Monitor,
                         Future[engine_api.ForkchoiceUpdatedResponse] =
   # Eth1 monitor can recycle connections without (external) warning; at least,
   # don't crash.
-  if p.dataProvider.isNil:
+  if p.isNil or p.dataProvider.isNil:
     var fcuR: Future[engine_api.ForkchoiceUpdatedResponse]
     fcuR.complete(engine_api.ForkchoiceUpdatedResponse(
       payloadStatus: PayloadStatusV1(status: PayloadExecutionStatus.syncing)))
@@ -498,7 +498,7 @@ proc forkchoiceUpdated*(p: Eth1Monitor,
                         Future[engine_api.ForkchoiceUpdatedResponse] =
   # Eth1 monitor can recycle connections without (external) warning; at least,
   # don't crash.
-  if p.dataProvider.isNil:
+  if p.isNil or p.dataProvider.isNil:
     var fcuR: Future[engine_api.ForkchoiceUpdatedResponse]
     fcuR.complete(engine_api.ForkchoiceUpdatedResponse(
       payloadStatus: PayloadStatusV1(status: PayloadExecutionStatus.syncing)))


### PR DESCRIPTION
Mitigate https://github.com/status-im/nimbus-eth2/issues/3597 for example.

It's still not clear how these are happening -- when there aren't validators assigned, it might, but then it should never be calling `getPayload` either. The `dataProvider` might not exist, or the connection might be being recycled, but how `Eth1Monitor` itself just is `nil` when it's set up once needs further investigation.

Some instances of these crashes have been traced to incorrect setup -- wrong web3 URL, etc -- which caused the Eth1 monitor init to abort. But that `getPayload` crash doesn't look like that.

But, at least it shouldn't crash.