### PR TITLE
use MAX_CHUNK_SIZE_BELLATRIX for signed Bellatrix blocks

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1971,8 +1971,7 @@ template gossipMaxSize(T: untyped): uint32 =
          T is altair.SignedBeaconBlock:
       GOSSIP_MAX_SIZE
     else:
-      echo T
-      {.fatal: "unknown type".}
+      {.fatal: "unknown type " & name(T).}
   static: doAssert maxSize <= maxGossipMaxSize()
   maxSize.uint32
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -614,6 +614,12 @@ when useNativeSnappy:
 else:
   include libp2p_streams_backend
 
+func maxChunkSize(t: typedesc[bellatrix.SignedBeaconBlock]): uint32 =
+  MAX_CHUNK_SIZE_BELLATRIX
+
+func maxChunkSize(t: typedesc): uint32 =
+  MAX_CHUNK_SIZE
+
 proc makeEth2Request(peer: Peer, protocolId: string, requestBytes: Bytes,
                      ResponseMsg: type,
                      timeout: Duration): Future[NetRes[ResponseMsg]]
@@ -635,7 +641,7 @@ proc makeEth2Request(peer: Peer, protocolId: string, requestBytes: Bytes,
     # Read the response
     return
       await readResponse(when useNativeSnappy: libp2pInput(stream) else: stream,
-                         peer, ResponseMsg, timeout)
+                         peer, maxChunkSize(ResponseMsg), ResponseMsg, timeout)
   finally:
     await stream.closeWithEOF()
 
@@ -787,8 +793,10 @@ proc handleIncomingStream(network: Eth2Node,
       NetRes[MsgRec].ok default(MsgRec)
     else:
       try:
-        awaitWithTimeout(readChunkPayload(s, peer, MsgRec), deadline):
-          returnInvalidRequest(errorMsgLit "Request full data not sent in time")
+        awaitWithTimeout(
+          readChunkPayload(s, peer, maxChunkSize(MsgRec), MsgRec), deadline):
+            returnInvalidRequest(
+              errorMsgLit "Request full data not sent in time")
 
       except SerializationError as err:
         returnInvalidRequest err.formatMsg("msg")
@@ -1963,6 +1971,7 @@ template gossipMaxSize(T: untyped): uint32 =
          T is altair.SignedBeaconBlock:
       GOSSIP_MAX_SIZE
     else:
+      echo T
       {.fatal: "unknown type".}
   static: doAssert maxSize <= maxGossipMaxSize()
   maxSize.uint32

--- a/beacon_chain/networking/faststreams_backend.nim
+++ b/beacon_chain/networking/faststreams_backend.nim
@@ -86,6 +86,8 @@ proc readSszValue(s: AsyncInputStream,
 proc readChunkPayload(s: AsyncInputStream,
                       noSnappy: bool,
                       MsgType: type): Future[NetRes[MsgType]] {.async.} =
+  # TODO this needs to sometimes be MAX_CHUNK_SIZE_BELLATRIX, for at least
+  # bellatrix.SignedBeaconBlock
   let prefix = await readSizePrefix(s, MAX_CHUNK_SIZE)
   let size = if prefix.isOk: prefix.value.int
              else: return err(prefix.error)

--- a/beacon_chain/networking/libp2p_streams_backend.nim
+++ b/beacon_chain/networking/libp2p_streams_backend.nim
@@ -113,7 +113,7 @@ proc readChunkPayload*(conn: Connection, peer: Peer,
     except InvalidVarintError:
       return neterr UnexpectedEOF
 
-  if size > MAX_CHUNK_SIZE:
+  if size > maxChunkSize:
     return neterr SizePrefixOverflow
   if size == 0:
     return neterr ZeroSizePrefix

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -29,7 +29,7 @@ import nimcrypto/utils as ncrutils
 export
   results, burnMem, writeValue, readValue
 
-{.localPassC: "-fno-lto".} # no LTO for crypto
+{.localPassc: "-fno-lto".} # no LTO for crypto
 
 type
   KeystoreMode* = enum

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -70,7 +70,8 @@ type
   BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS]
 
 proc readChunkPayload*(
-    conn: Connection, peer: Peer, MsgType: type (ref ForkedSignedBeaconBlock)):
+    conn: Connection, peer: Peer, maxChunkSize: uint32,
+    MsgType: type (ref ForkedSignedBeaconBlock)):
     Future[NetRes[MsgType]] {.async.} =
   var contextBytes: ForkDigest
   try:
@@ -78,20 +79,25 @@ proc readChunkPayload*(
   except CatchableError:
     return neterr UnexpectedEOF
 
+  # Ignores maxChunkSize; needs to be consistent formal parameters,
+  # but this function is where that's determined.
   if contextBytes == peer.network.forkDigests.phase0:
-    let res = await readChunkPayload(conn, peer, phase0.SignedBeaconBlock)
+    let res = await readChunkPayload(
+      conn, peer, MAX_CHUNK_SIZE, phase0.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:
       return err(res.error)
   elif contextBytes == peer.network.forkDigests.altair:
-    let res = await readChunkPayload(conn, peer, altair.SignedBeaconBlock)
+    let res = await readChunkPayload(
+      conn, peer, MAX_CHUNK_SIZE, altair.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:
       return err(res.error)
   elif contextBytes == peer.network.forkDigests.bellatrix:
-    let res = await readChunkPayload(conn, peer, bellatrix.SignedBeaconBlock)
+    let res = await readChunkPayload(
+      conn, peer, MAX_CHUNK_SIZE_BELLATRIX, bellatrix.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -26,7 +26,7 @@ export
 when defined(windows):
   import stew/[windows/acl]
 
-{.localPassC: "-fno-lto".} # no LTO for crypto
+{.localPassc: "-fno-lto".} # no LTO for crypto
 
 const
   KeystoreFileName* = "keystore.json"

--- a/config.nims
+++ b/config.nims
@@ -181,7 +181,7 @@ switch("warning", "LockLevel:off")
 # ############################################################
 
 # This applies per-file compiler flags to C files
-# which do not support {.localPassC: "-fno-lto".}
+# which do not support {.localPassc: "-fno-lto".}
 # Unfortunately this is filename based instead of path-based
 # Assumes GCC
 


### PR DESCRIPTION
The faststreams backend has relevant code, but it's a `TODO` because
```
$ make NIMFLAGS="-d:snappy_implementation=native" nimbus_beacon_node 
Building: build/nimbus_beacon_node
nimbus-eth2/beacon_chain/networking/faststreams_backend.nim(26, 46) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/networking/faststreams_backend.nim(27, 21) template/generic instantiation of `fsTranslateErrors` from here
nimbus-eth2/beacon_chain/networking/faststreams_backend.nim(28, 11) Error: undeclared identifier: 'safeClose'
make: *** [Makefile:256: nimbus_beacon_node] Error 1
```