### PR TITLE
ensure MAX_CHUNK_SIZE usage consistent in sync_protocol

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -614,10 +614,10 @@ when useNativeSnappy:
 else:
   include libp2p_streams_backend
 
-func maxChunkSize(t: typedesc[bellatrix.SignedBeaconBlock]): uint32 =
+func maxChunkSize*(t: typedesc[bellatrix.SignedBeaconBlock]): uint32 =
   MAX_CHUNK_SIZE_BELLATRIX
 
-func maxChunkSize(t: typedesc): uint32 =
+func maxChunkSize*(t: typedesc): uint32 =
   MAX_CHUNK_SIZE
 
 proc makeEth2Request(peer: Peer, protocolId: string, requestBytes: Bytes,

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -69,6 +69,11 @@ type
 
   BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS]
 
+template readChunkPayload*(
+    conn: Connection, peer: Peer, MsgType: type ForkySignedBeaconBlock):
+    Future[NetRes[MsgType]] =
+  readChunkPayload(conn, peer, maxChunkSize(MsgType), MsgType)
+
 proc readChunkPayload*(
     conn: Connection, peer: Peer, maxChunkSize: uint32,
     MsgType: type (ref ForkedSignedBeaconBlock)):
@@ -82,22 +87,19 @@ proc readChunkPayload*(
   # Ignores maxChunkSize; needs to be consistent formal parameters,
   # but this function is where that's determined.
   if contextBytes == peer.network.forkDigests.phase0:
-    let res = await readChunkPayload(
-      conn, peer, MAX_CHUNK_SIZE, phase0.SignedBeaconBlock)
+    let res = await readChunkPayload(conn, peer, phase0.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:
       return err(res.error)
   elif contextBytes == peer.network.forkDigests.altair:
-    let res = await readChunkPayload(
-      conn, peer, MAX_CHUNK_SIZE, altair.SignedBeaconBlock)
+    let res = await readChunkPayload(conn, peer, altair.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:
       return err(res.error)
   elif contextBytes == peer.network.forkDigests.bellatrix:
-    let res = await readChunkPayload(
-      conn, peer, MAX_CHUNK_SIZE_BELLATRIX, bellatrix.SignedBeaconBlock)
+    let res = await readChunkPayload(conn, peer, bellatrix.SignedBeaconBlock)
     if res.isOk:
       return ok newClone(ForkedSignedBeaconBlock.init(res.get))
     else:


### PR DESCRIPTION
Ideally, this wrapper function could/would be moved to `eth2_network`, and `maxChunkSize` not exported from there, but this at least ensures consistency within `sync_protocol` and use of `maxChunkSize` uniformly.

Attempts to move it to `eth2_network` thus far (using templates, the async machinery, not-the-async-machinery, procs/funcs, explicitly re-exporting from `sync_protocol` to make it indististinguishable despite that being in principle not necessary, `type` vs `typedesc`, using `ForkySignedBeaconBlock` vs some other more explicit representation, etc) all just result in one `sync_protocol` `readChunkPayload` not finding the `eth2_network` one, so this is a compromise.