### PR TITLE
Support for distributed keystores with multiple remotes based on threshold signatures

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -234,6 +234,14 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Mocked start private key                                                                   OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
+## Key spliting
+```diff
++ k < n                                                                                      OK
++ k == n                                                                                     OK
++ k == n == 100                                                                              OK
++ single share                                                                               OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## KeyStorage testing suite
 ```diff
 + Pbkdf2 errors                                                                              OK
@@ -313,6 +321,13 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + deletePeer() test                                                                          OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
+## Remove keystore testing suite
+```diff
++ vesion 1                                                                                   OK
++ vesion 2 many remotes                                                                      OK
++ vesion 2 single remote                                                                     OK
+```
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Slashing Interchange tests  [Preset: mainnet]
 ```diff
 + Slashing test: duplicate_pubkey_not_slashable.json                                         OK
@@ -529,4 +544,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 1/1 Fail: 0/1 Skip: 0/1
 
 ---TOTAL---
-OK: 294/299 Fail: 0/299 Skip: 5/299
+OK: 301/306 Fail: 0/306 Skip: 5/306

--- a/Makefile
+++ b/Makefile
@@ -359,9 +359,10 @@ define MAKE_DEPOSIT
 
 	build/deposit_contract sendDeposits \
 		$(2) \
-		--deposit-contract=$$(cat vendor/eth2-network/shared/$(1)/deposit_contract.txt) \
+		--deposit-contract=$$(cat vendor/eth2-networks/shared/$(1)/deposit_contract.txt) \
 		--deposits-file=nbc-$(1)-deposits.json \
 		--min-delay=$(DEPOSITS_DELAY) \
+		--max-delay=$(DEPOSITS_DELAY) \
 		--ask-for-key
 endef
 

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -391,7 +391,9 @@ proc doDeposits*(config: BeaconNodeConf, rng: var BrHmacDrbgContext) {.
       walletPath.wallet.nextAccount,
       config.totalDeposits,
       config.outValidatorsDir,
-      config.outSecretsDir)
+      config.outSecretsDir,
+      @[], 0, 0,
+      KeystoreMode.Fast)
 
     if deposits.isErr:
       fatal "Failed to generate deposits", err = deposits.error

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -181,7 +181,7 @@ template errorResponse(code: HttpCode, message: string): RestApiResponse =
   RestApiResponse.response("{\"error\": \"" & message & "\"}", code)
 
 template signatureResponse(code: HttpCode, signature: string): RestApiResponse =
-  RestApiResponse.response("{\"signature\": \"0x" & signature & "\"}", code)
+  RestApiResponse.response("{\"signature\": \"0x" & signature & "\"}", code, "application/json")
 
 proc installApiHandlers*(node: SigningNode) =
   var router = node.router()

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -81,6 +81,9 @@ proc initValidators(vc: ValidatorClientRef): Future[bool] {.async.} =
     if pubkey in duplicates:
       error "Duplicate validator's key found", validator_pubkey = pubkey
       return false
+    elif keystore.kind == KeystoreKind.Remote:
+      info "Remote validator client was skipped", validator_pubkey = pubkey
+      continue
     else:
       duplicates.add(pubkey)
       vc.attachedValidators.addLocalValidator(keystore)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -58,7 +58,8 @@ type
     Web3SignerRequest |
     KeystoresAndSlashingProtection |
     DeleteKeystoresBody |
-    ImportRemoteKeystoresBody
+    ImportRemoteKeystoresBody |
+    ImportDistributedKeystoresBody
 
   EncodeArrays* =
     seq[ValidatorIndex] |
@@ -77,6 +78,7 @@ type
     GetBlockV2Response |
     GetKeystoresResponse |
     GetRemoteKeystoresResponse |
+    GetDistributedKeystoresResponse |
     GetStateV2Response |
     GetStateForkResponse |
     ProduceBlockResponseV2 |
@@ -1214,6 +1216,7 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconStat
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: Web3SignerRequest) {.
      raises: [IOError, Defect].} =
+  writer.beginRecord()
   case value.kind
   of Web3SignerRequestKind.AggregationSlot:
     doAssert(value.forkInfo.isSome(),
@@ -1302,6 +1305,7 @@ proc writeValue*(writer: var JsonWriter[RestJson],
       writer.writeField("signingRoot", value.signingRoot)
     writer.writeField("contribution_and_proof",
                       value.syncCommitteeContributionAndProof)
+  writer.endRecord()
 
 proc readValue*(reader: var JsonReader[RestJson],
                 value: var Web3SignerRequest) {.
@@ -1359,7 +1363,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       signingRoot = some(reader.readValue(Eth2Digest))
     of "aggregation_slot", "aggregate_and_proof", "block", "beacon_block",
        "randao_reveal", "voluntary_exit", "sync_committee_message",
-       "sync_aggregator_selection_data", "contribution_and_proof":
+       "sync_aggregator_selection_data", "contribution_and_proof", "attestation":
       if data.isSome():
         reader.raiseUnexpectedField("Multiple data fields found",
                                     "Web3SignerRequest")

--- a/beacon_chain/spec/eth2_apis/rest_keymanager_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_keymanager_calls.nim
@@ -69,6 +69,20 @@ proc deleteRemoteKeysPlain*(body: DeleteKeystoresBody): RestPlainResponse {.
      meth: MethodDelete.}
   ## https://ethereum.github.io/keymanager-APIs/#/Remote%20Key%20Manager/DeleteRemoteKeys
 
+proc listRemoteDistributedKeysPlain*(): RestPlainResponse {.
+     rest, endpoint: "/eth/v1/remotekeys/distributed",
+     meth: MethodGet.}
+
+proc importRemoteDistributedKeysPlain*(body: ImportDistributedKeystoresBody
+                           ): RestPlainResponse {.
+     rest, endpoint: "/eth/v1/remotekeys/distributed",
+     meth: MethodPost.}
+
+proc deleteRemoteDistributedKeysPlain*(body: DeleteKeystoresBody): RestPlainResponse {.
+     rest, endpoint: "/eth/v1/remotekeys/distributed",
+     meth: MethodDelete.}
+
+
 proc listRemoteKeys*(client: RestClientRef,
                      token: string): Future[GetRemoteKeystoresResponse] {.
      async.} =

--- a/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
@@ -13,6 +13,11 @@ type
     pubkey*: ValidatorPubKey
     url*: HttpHostUri
 
+  DistributedKeystoreInfo* = object
+    threshold*: int
+    pubkey*: ValidatorPubKey
+    remotes*: seq[RemoteSignerInfo]
+
   RequestItemStatus* = object
     status*: string
     message*: string
@@ -31,8 +36,14 @@ type
   GetRemoteKeystoresResponse* = object
     data*: seq[RemoteKeystoreInfo]
 
+  GetDistributedKeystoresResponse* = object
+    data*: seq[DistributedKeystoreInfo]
+
   ImportRemoteKeystoresBody* = object
     remote_keys*: seq[RemoteKeystoreInfo]
+
+  ImportDistributedKeystoresBody* = object
+    remote_keys*: seq[DistributedKeystoreInfo]
 
   PostKeystoresResponse* = object
     data*: seq[RequestItemStatus]

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -40,6 +40,8 @@ import # Unit test
   ./test_sync_committee_pool,
   ./test_sync_manager,
   ./test_zero_signature,
+  ./test_key_splitting,
+  ./test_remote_keystore,
   ./fork_choice/tests_fork_choice,
   ./consensus_spec/all_tests as consensus_all_tests,
   ./slashing_protection/test_fixtures,

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -1,0 +1,83 @@
+{.used.}
+
+import
+  std/[json, typetraits, sequtils],
+  unittest2, eth/keys, stew/byteutils,
+  ../beacon_chain/spec/[crypto, keystore],
+  ./testutil
+
+func sign(secrets: seq[SecretShare], message: seq[byte]): seq[SignatureShare] =
+  let msg = message
+  return secrets.mapIt(it.key.blsSign(message).toSignatureShare(it.id))
+
+suite "Key spliting":
+  let
+    privateKey = ValidatorPrivKey.init("0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
+    pubKey = privateKey.toPubKey.toPubKey
+    password = string.fromBytes hexToSeqByte("7465737470617373776f7264f09f9491")
+    salt = hexToSeqByte "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
+    iv = hexToSeqByte "264daa3f303d7259501c93d997d84fe6"
+    rng = keys.newRng()
+
+  var msg = newSeq[byte](32)
+  brHmacDrbgGenerate(rng[], msg)
+
+  test "single share":
+    let maybeShares = generateSecretShares(privateKey, rng[], 1, 1)
+    check maybeShares.isOk
+    let shares = maybeShares.get
+    check shares.len == 1
+    let signs = shares.sign(msg)
+    let recovered = signs.recoverSignature()
+    check pubKey.blsVerify(msg, recovered)
+    check pubKey.confirmShares(shares, rng[])
+
+  test "k < n":
+    let maybeShares = generateSecretShares(privateKey, rng[], 2, 3)
+    doAssert maybeShares.isOk
+    let shares = maybeShares.get
+    check shares.len == 3
+    let signs = shares.sign(msg)
+
+    var invalidShare = shares[2]
+    invalidShare.id = 1000 # 1000 is an arbitrary wrong value
+
+    check pubKey.blsVerify(msg, signs.recoverSignature())
+    check pubKey.blsVerify(msg, @[signs[0], signs[1]].recoverSignature())
+    check pubKey.blsVerify(msg, @[signs[1], signs[2]].recoverSignature())
+    check pubKey.blsVerify(msg, @[signs[2], signs[0]].recoverSignature())
+    check not pubKey.blsVerify(msg, @[signs[0]].recoverSignature())
+    check pubKey.confirmShares(shares, rng[])
+    check pubKey.confirmShares(@[shares[0], shares[1]], rng[])
+    check pubKey.confirmShares(@[shares[1], shares[2]], rng[])
+    check pubKey.confirmShares(@[shares[2], shares[0]], rng[])
+    check pubKey.confirmShares(@[shares[0], shares[2]], rng[])
+    check not pubKey.confirmShares(@[shares[0]], rng[])
+    check not pubKey.confirmShares(@[shares[1]], rng[])
+    check not pubKey.confirmShares(@[shares[2]], rng[])
+    check not pubKey.confirmShares(@[invalidShare], rng[])
+    check not pubKey.confirmShares(@[shares[0], invalidShare], rng[])
+    check not pubKey.confirmShares(@[shares[1], invalidShare], rng[])
+    check not pubKey.confirmShares(@[shares[2], invalidShare], rng[])
+
+  test "k == n":
+    let maybeShares = generateSecretShares(privateKey, rng[], 3, 3)
+    check maybeShares.isOk
+    let shares = maybeShares.get
+    check shares.len == 3
+    let signs = shares.sign(msg)
+    let recovered = signs.recoverSignature()
+    check pubKey.blsVerify(msg, recovered)
+    check not pubKey.blsVerify(msg, @[signs[0]].recoverSignature())
+    check not pubKey.blsVerify(msg, @[signs[0], signs[1]].recoverSignature())
+    check pubKey.confirmShares(shares, rng[])
+
+  test "k == n == 100":
+    let maybeShares = generateSecretShares(privateKey, rng[], 100, 100)
+    check maybeShares.isOk
+    let shares = maybeShares.get
+    check shares.len == 100
+    let signs = shares.sign(msg)
+    let recovered = signs.recoverSignature()
+    check pubKey.blsVerify(msg, recovered)
+    check pubKey.confirmShares(shares, rng[])

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -102,6 +102,9 @@ proc startSingleNodeNetwork {.raises: [CatchableError, Defect].} =
     0, simulationDepositsCount,
     validatorsDir,
     secretsDir,
+    @[],
+    0,
+    0,
     KeystoreMode.Fast)
 
   if deposits.isErr:
@@ -213,7 +216,7 @@ proc listRemoteValidators(validatorsDir,
     for el in listLoadableKeystores(validatorsDir, secretsDir, true,
                                     {KeystoreKind.Remote}):
       validators.add RemoteKeystoreInfo(pubkey: el.pubkey,
-                                        url: el.remoteUrl)
+                                        url: el.remotes[0].url)
 
   except OSError as err:
     error "Failure to list the validator directories",

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -1,0 +1,81 @@
+{.used.}
+
+import
+  std/[json, typetraits],
+  unittest2, stew/byteutils, json_serialization,
+  blscurve, eth/keys, libp2p/crypto/crypto as lcrypto,
+  nimcrypto/utils as ncrutils,
+  ../beacon_chain/spec/[crypto, keystore],
+  ./testutil
+
+suite "Remove keystore testing suite":
+  test "vesion 1" :
+    let remoteKeyStores = """{
+      "version": 1,
+      "pubkey": "0x8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c",
+      "remote": "http://127.0.0.1:6000",
+      "type": "web3signer"
+    }"""
+    let keystore = Json.decode(remoteKeyStores, RemoteKeystore)
+    check keystore.pubkey.toHex == "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
+    check keystore.remotes.len == 1
+    check $keystore.remotes[0].url == "http://127.0.0.1:6000"
+    check keystore.remotes[0].id == 0
+    check keystore.remotes[0].pubkey.toHex == "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
+
+  test "vesion 2 single remote":
+    let remoteKeyStores = """{
+      "version": 2,
+      "pubkey": "0x8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c",
+      "remotes": [
+        {
+          "url": "http://127.0.0.1:6000",
+          "pubkey": "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
+        }
+      ],
+      "type": "web3signer"
+    }"""
+    let keystore = Json.decode(remoteKeyStores, RemoteKeystore)
+    check keystore.pubkey.toHex == "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
+    check keystore.remotes.len == 1
+    check $keystore.remotes[0].url == "http://127.0.0.1:6000"
+    check keystore.remotes[0].id == 0
+    check keystore.remotes[0].pubkey.toHex == "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
+
+  test "vesion 2 many remotes" :
+    let remoteKeyStores = """{
+      "version": 2,
+      "pubkey": "0x8ebc7291df2a671326de83471a4feeb759cc842caa59aa92065e3508baa7e50513bc49a79ff4387c8ef747764f364b6f",
+      "remotes": [
+        {
+          "url": "http://127.0.0.1:6000",
+          "id": 1,
+          "pubkey": "95313b967bcd761175dbc2a5685c16b1a73000e66f9622eca080cb0428dd3db61f7377b32b1fd27f3bdbdf2b554e7f87"
+        },
+        {
+          "url": "http://127.0.0.1:6001",
+          "id": 2,
+          "pubkey": "8b8c115d19a9bdacfc7af9c8e8fc1353af54b63b0e772a641499cac9b6ea5cb1b3479cfa52ebc98ba5afe07a06c06238"
+        },
+        {
+          "url": "http://127.0.0.1:6002",
+          "id": 3,
+          "pubkey": "8f5f9e305e7fcbde94182747f5ecec573d1786e8320a920347a74c0ff5e70f12ca22607c98fdc8dbe71161db59e0ac9d"
+        }
+      ],
+      "threshold": 2,
+      "type": "web3signer"
+    }"""
+    let keystore = Json.decode(remoteKeyStores, RemoteKeystore)
+    check keystore.pubkey.toHex == "8ebc7291df2a671326de83471a4feeb759cc842caa59aa92065e3508baa7e50513bc49a79ff4387c8ef747764f364b6f"
+    check keystore.remotes.len == 3
+    check $keystore.remotes[0].url == "http://127.0.0.1:6000"
+    check $keystore.remotes[1].url == "http://127.0.0.1:6001"
+    check $keystore.remotes[2].url == "http://127.0.0.1:6002"
+    check keystore.remotes[0].id == 1
+    check keystore.remotes[1].id == 2
+    check keystore.remotes[2].id == 3
+    check keystore.remotes[0].pubkey.toHex == "95313b967bcd761175dbc2a5685c16b1a73000e66f9622eca080cb0428dd3db61f7377b32b1fd27f3bdbdf2b554e7f87"
+    check keystore.remotes[1].pubkey.toHex == "8b8c115d19a9bdacfc7af9c8e8fc1353af54b63b0e772a641499cac9b6ea5cb1b3479cfa52ebc98ba5afe07a06c06238"
+    check keystore.remotes[2].pubkey.toHex == "8f5f9e305e7fcbde94182747f5ecec573d1786e8320a920347a74c0ff5e70f12ca22607c98fdc8dbe71161db59e0ac9d"
+    check keystore.threshold == 2


### PR DESCRIPTION
Other fixes:

* Fix bit rot in the `make prater-dev-deposit` target.
* Correct content-type in the responses of the Nimbus signing node
* Invalid JSON payload was being sent in the web3signer requests