### PR TITLE
fcU on syncing newPayload syncing response

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -453,7 +453,8 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
         blck.resfut.complete(Result[void, BlockError].err(BlockError.Invalid))
       continue
 
-    if  executionPayloadStatus == PayloadExecutionStatus.accepted and
+    if  executionPayloadStatus in
+          [PayloadExecutionStatus.accepted, PayloadExecutionStatus.syncing] and
         hasExecutionPayload:
       # The EL client doesn't know here whether the payload is valid, because,
       # for example, in Geth's case, its parent isn't known. When Geth logs an
@@ -481,7 +482,7 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
       # cause a sync deadlock unless the EL can be convinced to sync back, or
       # the CL is rather more open-endedly optimistic (potentially for entire
       # weak subjectivity periods) than seems optimal.
-      debug "runQueueProcessingLoop: execution payload accepted",
+      debug "runQueueProcessingLoop: execution payload accepted or syncing",
         executionPayloadStatus
 
       await self.runForkchoiceUpdated(


### PR DESCRIPTION
`SYNCING` simply means
> the payload extends the canonical chain and requisite data for its validation is missing

(https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.8/src/engine/specification.md#specification)
without a `forkchoiceUpdated`, the EL might never actually sync to get the requisite missing data.