### PR TITLE
update to latest light client libp2p protocol

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -265,11 +265,11 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Light client processor [Preset: mainnet]
 ```diff
 + Duplicate bootstrap [Preset: mainnet]                                                      OK
-+ Forced update [Preset: mainnet]                                                            OK
 + Invalid bootstrap [Preset: mainnet]                                                        OK
++ Missing bootstrap (finality update) [Preset: mainnet]                                      OK
 + Missing bootstrap (optimistic update) [Preset: mainnet]                                    OK
 + Missing bootstrap (update) [Preset: mainnet]                                               OK
-+ Standard sync [Preset: mainnet]                                                            OK
++ Sync [Preset: mainnet]                                                                     OK
 ```
 OK: 6/6 Fail: 0/6 Skip: 0/6
 ## ListKeys requests [Preset: mainnet]

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -804,6 +804,11 @@ OK: 35/35 Fail: 0/35 Skip: 0/35
   All tests                                                                                  Skip
 ```
 OK: 0/1 Fail: 0/1 Skip: 1/1
+## EF - Altair - Sync protocol - Update ranking [Preset: mainnet]
+```diff
+  All tests                                                                                  Skip
+```
+OK: 0/1 Fail: 0/1 Skip: 1/1
 ## EF - Altair - Unittests - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -1215,4 +1220,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1035/1037 Fail: 0/1037 Skip: 2/1037
+OK: 1035/1038 Fail: 0/1038 Skip: 3/1038

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -845,6 +845,11 @@ OK: 35/35 Fail: 0/35 Skip: 0/35
   All tests                                                                                  Skip
 ```
 OK: 0/1 Fail: 0/1 Skip: 1/1
+## EF - Altair - Sync protocol - Update ranking [Preset: minimal]
+```diff
+  All tests                                                                                  Skip
+```
+OK: 0/1 Fail: 0/1 Skip: 1/1
 ## EF - Altair - Unittests - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -1292,4 +1297,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1085/1106 Fail: 0/1106 Skip: 21/1106
+OK: 1085/1107 Fail: 0/1107 Skip: 22/1107

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -50,6 +50,7 @@ type
     quarantine*: ref Quarantine
     attestationPool*: ref AttestationPool
     syncCommitteeMsgPool*: ref SyncCommitteeMsgPool
+    lightClientPool*: ref LightClientPool
     exitPool*: ref ExitPool
     eth1Monitor*: Eth1Monitor
     rpcServer*: RpcServer

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -216,8 +216,10 @@ type
       ## On beacon chain reorganization
     onFinHappened*: OnFinalizedCallback
       ## On finalization callback
-    onOptimisticLightClientUpdate*: OnOptimisticLightClientUpdateCallback
-      ## On `OptimisticLightClientUpdate` updated callback
+    onLightClientFinalityUpdate*: OnLightClientFinalityUpdateCallback
+      ## On new `LightClientFinalityUpdate` callback
+    onLightClientOptimisticUpdate*: OnLightClientOptimisticUpdateCallback
+      ## On new `LightClientOptimisticUpdate` callback
 
     headSyncCommittees*: SyncCommitteeCache
       ## A cache of the sync committees, as they appear in the head state -

--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -13,13 +13,16 @@
 import
   # Status libraries
   stew/bitops2,
+  chronos,
   # Beacon chain internals
   ../spec/datatypes/altair,
   ./block_dag
 
 type
-  OnOptimisticLightClientUpdateCallback* =
-    proc(data: OptimisticLightClientUpdate) {.gcsafe, raises: [Defect].}
+  OnLightClientFinalityUpdateCallback* =
+    proc(data: altair.LightClientFinalityUpdate) {.gcsafe, raises: [Defect].}
+  OnLightClientOptimisticUpdateCallback* =
+    proc(data: altair.LightClientOptimisticUpdate) {.gcsafe, raises: [Defect].}
 
   ImportLightClientData* {.pure.} = enum
     ## Controls which classes of light client data are imported.
@@ -30,18 +33,17 @@ type
     Full = "full"
       ## Import light client data for entire weak subjectivity period.
     OnDemand = "on-demand"
-      ## No precompute of historic data. Is slow and may miss validator duties.
+      ## Don't precompute historic data. Slow, may miss validator duties.
 
   CachedLightClientData* = object
     ## Cached data from historical non-finalized states to improve speed when
     ## creating future `LightClientUpdate` and `LightClientBootstrap` instances.
     current_sync_committee_branch*:
       array[log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
-
     next_sync_committee_branch*:
       array[log2trunc(altair.NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
 
-    finalized_bid*: BlockId
+    finalized_slot*: Slot
     finality_branch*:
       array[log2trunc(altair.FINALIZED_ROOT_INDEX), Eth2Digest]
 
@@ -55,40 +57,44 @@ type
     data*: Table[BlockId, CachedLightClientData]
       ## Cached data for creating future `LightClientUpdate` instances.
       ## Key is the block ID of which the post state was used to get the data.
-      ## Data is stored for the most recent 4 finalized checkpoints, as well as
-      ## for all non-finalized blocks.
+      ## Data stored for the finalized head block and all non-finalized blocks.
 
     bootstrap*: Table[Slot, CachedLightClientBootstrap]
       ## Cached data for creating future `LightClientBootstrap` instances.
       ## Key is the block slot of which the post state was used to get the data.
-      ## Data is stored for finalized epoch boundary blocks.
+      ## Data stored for all finalized epoch boundary blocks.
 
-    latestCheckpoints*: array[4, Checkpoint]
-      ## Keeps track of the latest four `finalized_checkpoint` references
-      ## leading to `finalizedHead`. Used to prune `data`.
-      ## Non-finalized states may only refer to these checkpoints.
-
-    lastCheckpointIndex*: int
-      ## Last index that was modified in `latestCheckpoints`.
-
-    bestUpdates*: Table[SyncCommitteePeriod, altair.LightClientUpdate]
+    best*: Table[SyncCommitteePeriod, altair.LightClientUpdate]
       ## Stores the `LightClientUpdate` with the most `sync_committee_bits` per
-      ## `SyncCommitteePeriod`. Updates with a finality proof have precedence.
+      ## `SyncCommitteePeriod`. Sync committee finality gives precedence.
 
-    pendingBestUpdates*:
+    pendingBest*:
       Table[(SyncCommitteePeriod, Eth2Digest), altair.LightClientUpdate]
-      ## Same as `bestUpdates`, but for `SyncCommitteePeriod` with
-      ## `next_sync_committee` that are not finalized. Key is `(period,
+      ## Same as `best`, but for `SyncCommitteePeriod` with not yet finalized
+      ## `next_sync_committee`. Key is `(attested_period,
       ## hash_tree_root(current_sync_committee | next_sync_committee)`.
 
-    latestUpdate*: altair.LightClientUpdate
-      ## Tracks the `LightClientUpdate` for the latest slot. This may be older
-      ## than head for empty slots or if not signed by sync committee.
-
-    optimisticUpdate*: OptimisticLightClientUpdate
-      ## Tracks the `OptimisticLightClientUpdate` for the latest slot. This may
-      ## be older than head for empty slots or if not signed by sync committee.
+    latest*: altair.LightClientFinalityUpdate
+      ## Tracks light client data for the latest slot that was signed by
+      ## at least `MIN_SYNC_COMMITTEE_PARTICIPANTS`. May be older than head.
 
     importTailSlot*: Slot
-      ## The earliest slot for which light client data is collected.
-      ## Only relevant for `ImportLightClientData.OnlyNew`.
+      ## The earliest slot for which light client data is imported.
+
+    latestForwardedFinalitySlot*: Slot
+      ## Latest finality update that was forwarded on libp2p gossip.
+      ## Tracks `finality_update.finalized_header.slot`.
+
+    latestForwardedOptimisticSlot*: Slot
+      ## Latest optimistic update that was forwarded on libp2p gossip.
+      ## Tracks `optimistic_update.attested_header.slot`.
+
+    latestBroadcastedSlot*: Slot
+      ## Latest slot for which updates were broadcasted on libp2p gossip.
+      ## Tracks `update.signature_slot`.
+
+    broadcastGossipFut*: Future[void]
+      ## Task to broadcast libp2p gossip. Started when a sync committee message
+      ## is sent. Tracked separately from `handleValidatorDuties` to catch the
+      ## case where `node.attachedValidators[].count == 0` at function start,
+      ## and then a sync committee message gets sent from a remote VC via REST.

--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -13,7 +13,6 @@
 import
   # Status libraries
   stew/bitops2,
-  chronos,
   # Beacon chain internals
   ../spec/datatypes/altair,
   ./block_dag
@@ -80,21 +79,3 @@ type
 
     importTailSlot*: Slot
       ## The earliest slot for which light client data is imported.
-
-    latestForwardedFinalitySlot*: Slot
-      ## Latest finality update that was forwarded on libp2p gossip.
-      ## Tracks `finality_update.finalized_header.slot`.
-
-    latestForwardedOptimisticSlot*: Slot
-      ## Latest optimistic update that was forwarded on libp2p gossip.
-      ## Tracks `optimistic_update.attested_header.slot`.
-
-    latestBroadcastedSlot*: Slot
-      ## Latest slot for which updates were broadcasted on libp2p gossip.
-      ## Tracks `update.signature_slot`.
-
-    broadcastGossipFut*: Future[void]
-      ## Task to broadcast libp2p gossip. Started when a sync committee message
-      ## is sent. Tracked separately from `handleValidatorDuties` to catch the
-      ## case where `node.attachedValidators[].count == 0` at function start,
-      ## and then a sync committee message gets sent from a remote VC via REST.

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1032,19 +1032,58 @@ proc validateContribution*(
 
   return ok((sig, participants))
 
-# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#optimistic_light_client_update
-proc validateOptimisticLightClientUpdate*(
-    dag: ChainDAGRef, optimistic_update: OptimisticLightClientUpdate):
-    Result[void, ValidationError] =
-  template local_update(): auto = dag.lightClientCache.optimisticUpdate
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_finality_update
+proc validateLightClientFinalityUpdate*(
+    dag: ChainDAGRef,
+    finality_update: altair.LightClientFinalityUpdate,
+    wallTime: BeaconTime): Result[void, ValidationError] =
+  let finalized_slot = finality_update.finalized_header.slot
+  if finalized_slot <= dag.lightClientCache.latestForwardedFinalitySlot:
+    # [IGNORE] No other `finality_update` with a lower or equal
+    # `finalized_header.slot` was already forwarded on the network.
+    return errIgnore("LightClientFinalityUpdate: slot already forwarded")
 
-  if optimistic_update != local_update:
-    # [IGNORE] The optimistic update is not attesting to the latest block's
-    # parent block.
-    if optimistic_update.attested_header != local_update.attested_header:
-      return errIgnore("OptimisticLightClientUpdate: not attesting to latest")
+  let
+    signature_slot = finality_update.signature_slot
+    currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    forwardTime = signature_slot.light_client_finality_update_time
+  if currentTime < forwardTime:
+    # [IGNORE] The `finality_update` is received after the block at
+    # `signature_slot` was given enough time to propagate through the network.
+    return errIgnore("LightClientFinalityUpdate: received too early")
 
-    # [REJECT] The optimistic update does not match the expected value.
-    return errReject("OptimisticLightClientUpdate: not matching expected value")
+  if finality_update != dag.lightClientCache.latest:
+    # [IGNORE] The received `finality_update` matches the locally computed one
+    # exactly.
+    return errIgnore("LightClientFinalityUpdate: not matching local")
 
+  dag.lightClientCache.latestForwardedFinalitySlot = finalized_slot
+  ok()
+
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_optimistic_update
+proc validateLightClientOptimisticUpdate*(
+    dag: ChainDAGRef,
+    optimistic_update: altair.LightClientOptimisticUpdate,
+    wallTime: BeaconTime): Result[void, ValidationError] =
+  let attested_slot = optimistic_update.attested_header.slot
+  if attested_slot <= dag.lightClientCache.latestForwardedOptimisticSlot:
+    # [IGNORE] No other `optimistic_update` with a lower or equal
+    # `attested_header.slot` was already forwarded on the network.
+    return errIgnore("LightClientOptimisticUpdate: slot already forwarded")
+
+  let
+    signature_slot = optimistic_update.signature_slot
+    currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    forwardTime = signature_slot.light_client_optimistic_update_time
+  if currentTime < forwardTime:
+    # [IGNORE] The `optimistic_update` is received after the block at
+    # `signature_slot` was given enough time to propagate through the network.
+    return errIgnore("LightClientOptimisticUpdate: received too early")
+
+  if not optimistic_update.matches(dag.lightClientCache.latest):
+    # [IGNORE] The received `optimistic_update` matches the locally computed one
+    # exactly.
+    return errIgnore("LightClientOptimisticUpdate: not matching local")
+
+  dag.lightClientCache.latestForwardedOptimisticSlot = attested_slot
   ok()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -258,6 +258,8 @@ proc initFullNode(
       AttestationPool.init(dag, quarantine, onAttestationReceived))
     syncCommitteeMsgPool = newClone(
       SyncCommitteeMsgPool.init(rng, onSyncContribution))
+    lightClientPool = newClone(
+      LightClientPool())
     exitPool = newClone(
       ExitPool.init(dag, onVoluntaryExitAdded))
     consensusManager = ConsensusManager.new(
@@ -277,8 +279,8 @@ proc initFullNode(
     processor = Eth2Processor.new(
       config.doppelgangerDetection,
       blockProcessor, node.validatorMonitor, dag, attestationPool, exitPool,
-      node.attachedValidators, syncCommitteeMsgPool, quarantine, rng,
-      getBeaconTime, taskpool)
+      node.attachedValidators, syncCommitteeMsgPool, lightClientPool,
+      quarantine, rng, getBeaconTime, taskpool)
     syncManager = newSyncManager[Peer, PeerId](
       node.network.peerPool, SyncQueueKind.Forward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -296,6 +296,7 @@ proc initFullNode(
   node.quarantine = quarantine
   node.attestationPool = attestationPool
   node.syncCommitteeMsgPool = syncCommitteeMsgPool
+  node.lightClientPool = lightClientPool
   node.exitPool = exitPool
   node.processor = processor
   node.blockProcessor = blockProcessor

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -158,20 +158,26 @@ proc loadChainDag(
     eventBus.emit("head-change", data)
   proc onChainReorg(data: ReorgInfoObject) =
     eventBus.emit("chain-reorg", data)
-  proc onOptimisticLightClientUpdate(data: OptimisticLightClientUpdate) =
+  proc onLightClientFinalityUpdate(data: altair.LightClientFinalityUpdate) =
+    discard
+  proc onLightClientOptimisticUpdate(data: altair.LightClientOptimisticUpdate) =
     discard
 
   let
     chainDagFlags =
       if config.verifyFinalization: {verifyFinalization}
       else: {}
-    onOptimisticLightClientUpdateCb =
-      if config.serveLightClientData.get: onOptimisticLightClientUpdate
+    onLightClientFinalityUpdateCb =
+      if config.serveLightClientData.get: onLightClientFinalityUpdate
+      else: nil
+    onLightClientOptimisticUpdateCb =
+      if config.serveLightClientData.get: onLightClientOptimisticUpdate
       else: nil
     dag = ChainDAGRef.init(
       cfg, db, validatorMonitor, chainDagFlags, config.eraDir,
       onBlockAdded, onHeadChanged, onChainReorg,
-      onOptimisticLCUpdateCb = onOptimisticLightClientUpdateCb,
+      onLCFinalityUpdateCb = onLightClientFinalityUpdateCb,
+      onLCOptimisticUpdateCb = onLightClientOptimisticUpdateCb,
       serveLightClientData = config.serveLightClientData.get,
       importLightClientData = config.importLightClientData.get)
     databaseGenesisValidatorsRoot =
@@ -865,7 +871,9 @@ proc addAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest, slot: Sl
 
   if node.config.serveLightClientData.get:
     node.network.subscribe(
-      getOptimisticLightClientUpdateTopic(forkDigest), basicParams)
+      getLightClientFinalityUpdateTopic(forkDigest), basicParams)
+    node.network.subscribe(
+      getLightClientOptimisticUpdateTopic(forkDigest), basicParams)
 
 proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removePhase0MessageHandlers(forkDigest)
@@ -879,7 +887,10 @@ proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
     getSyncCommitteeContributionAndProofTopic(forkDigest))
 
   if node.config.serveLightClientData.get:
-    node.network.unsubscribe(getOptimisticLightClientUpdateTopic(forkDigest))
+    node.network.unsubscribe(
+      getLightClientFinalityUpdateTopic(forkDigest))
+    node.network.unsubscribe(
+      getLightClientOptimisticUpdateTopic(forkDigest))
 
 proc trackCurrentSyncCommitteeTopics(node: BeaconNode, slot: Slot) =
   # Unlike trackNextSyncCommitteeTopics, just snap to the currently correct
@@ -1394,20 +1405,29 @@ proc installMessageValidators(node: BeaconNode) =
   installSyncCommitteeeValidators(forkDigests.altair)
   installSyncCommitteeeValidators(forkDigests.bellatrix)
 
-  template installOptimisticLightClientUpdateValidator(digest: auto) =
+  template installLightClientDataValidators(digest: auto) =
     node.network.addValidator(
-      getOptimisticLightClientUpdateTopic(digest),
-      proc(msg: OptimisticLightClientUpdate): ValidationResult =
+      getLightClientFinalityUpdateTopic(digest),
+      proc(msg: altair.LightClientFinalityUpdate): ValidationResult =
         if node.config.serveLightClientData.get:
           toValidationResult(
-            node.processor[].optimisticLightClientUpdateValidator(
+            node.processor[].lightClientFinalityUpdateValidator(
               MsgSource.gossip, msg))
         else:
-          debug "Ignoring optimistic light client update: Feature disabled"
           ValidationResult.Ignore)
 
-  installOptimisticLightClientUpdateValidator(forkDigests.altair)
-  installOptimisticLightClientUpdateValidator(forkDigests.bellatrix)
+    node.network.addValidator(
+      getLightClientOptimisticUpdateTopic(digest),
+      proc(msg: altair.LightClientOptimisticUpdate): ValidationResult =
+        if node.config.serveLightClientData.get:
+          toValidationResult(
+            node.processor[].lightClientOptimisticUpdateValidator(
+              MsgSource.gossip, msg))
+        else:
+          ValidationResult.Ignore)
+
+  installLightClientDataValidators(forkDigests.altair)
+  installLightClientDataValidators(forkDigests.bellatrix)
 
 proc stop(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Stopping

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -150,8 +150,11 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#broadcast-sync-committee-contribution
   syncContributionSlotOffset* = TimeDiff(nanoseconds:
     NANOSECONDS_PER_SLOT.int64  * 2 div INTERVALS_PER_SLOT)
-  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#block-proposal
-  optimisticLightClientUpdateSlotOffset* = TimeDiff(nanoseconds:
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_finality_update
+  lightClientFinalityUpdateSlotOffset* = TimeDiff(nanoseconds:
+    NANOSECONDS_PER_SLOT.int64 div INTERVALS_PER_SLOT)
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_optimistic_update
+  lightClientOptimisticUpdateSlotOffset* = TimeDiff(nanoseconds:
     NANOSECONDS_PER_SLOT.int64 div INTERVALS_PER_SLOT)
 
 func toFloatSeconds*(t: TimeDiff): float =
@@ -174,8 +177,10 @@ func sync_committee_message_deadline*(s: Slot): BeaconTime =
   s.start_beacon_time + syncCommitteeMessageSlotOffset
 func sync_contribution_deadline*(s: Slot): BeaconTime =
   s.start_beacon_time + syncContributionSlotOffset
-func optimistic_light_client_update_time*(s: Slot): BeaconTime =
-  s.start_beacon_time + optimisticLightClientUpdateSlotOffset
+func light_client_finality_update_time*(s: Slot): BeaconTime =
+  s.start_beacon_time + lightClientFinalityUpdateSlotOffset
+func light_client_optimistic_update_time*(s: Slot): BeaconTime =
+  s.start_beacon_time + lightClientOptimisticUpdateSlotOffset
 
 func slotOrZero*(time: BeaconTime): Slot =
   let exSlot = time.toSlot

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -328,15 +328,26 @@ func stateForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconStateFork =
     doAssert BeaconStateFork.Altair    > BeaconStateFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.BELLATRIX_FORK_EPOCH:  BeaconStateFork.Bellatrix
-  elif epoch >= cfg.ALTAIR_FORK_EPOCH: BeaconStateFork.Altair
-  else:                                BeaconStateFork.Phase0
+  if   epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconStateFork.Bellatrix
+  elif epoch >= cfg.ALTAIR_FORK_EPOCH:    BeaconStateFork.Altair
+  else:                                   BeaconStateFork.Phase0
 
 func blockForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconBlockFork =
   ## Return the current fork for the given epoch.
-  if   epoch >= cfg.BELLATRIX_FORK_EPOCH:  BeaconBlockFork.Bellatrix
-  elif epoch >= cfg.ALTAIR_FORK_EPOCH: BeaconBlockFork.Altair
-  else:                                BeaconBlockFork.Phase0
+  if   epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconBlockFork.Bellatrix
+  elif epoch >= cfg.ALTAIR_FORK_EPOCH:    BeaconBlockFork.Altair
+  else:                                   BeaconBlockFork.Phase0
+
+func stateForkForDigest*(
+    forkDigests: ForkDigests, forkDigest: ForkDigest): Opt[BeaconStateFork] =
+  if   forkDigest == forkDigests.bellatrix:
+    ok BeaconStateFork.Bellatrix
+  elif forkDigest == forkDigests.altair:
+    ok BeaconStateFork.Altair
+  elif forkDigest == forkDigests.phase0:
+    ok BeaconStateFork.Phase0
+  else:
+    err()
 
 template asSigned*(x: ForkedTrustedSignedBeaconBlock): ForkedSignedBeaconBlock =
   isomorphicCast[ForkedSignedBeaconBlock](x)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -9,11 +9,15 @@
 
 {.push raises: [Defect].}
 
+# References to `vFuture` refer to the pre-release proposal of the libp2p based
+# light client sync protocol. Conflicting release versions are not in use.
+# https://github.com/ethereum/consensus-specs/pull/2802
+
 import
   # Standard lib
   std/[algorithm, math, sequtils, sets, tables],
   # Status libraries
-  stew/[bitops2, byteutils, endians2],
+  stew/[bitops2, byteutils, endians2, objects],
   chronicles,
   # Internal
   ./datatypes/[phase0, altair, bellatrix],
@@ -475,10 +479,118 @@ func has_flag*(flags: ParticipationFlags, flag_index: int): bool =
   let flag = ParticipationFlags(1'u8 shl flag_index)
   (flags and flag) == flag
 
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#is_sync_committee_update
+template is_sync_committee_update*(update: SomeLightClientUpdate): bool =
+  when update is SomeLightClientUpdateWithSyncCommittee:
+    not isZeroMemory(update.next_sync_committee_branch)
+  else:
+    false
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#get_active_header
+template is_finality_update*(update: SomeLightClientUpdate): bool =
+  when update is SomeLightClientUpdateWithFinality:
+    not isZeroMemory(update.finality_branch)
+  else:
+    false
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#get_subtree_index
 func get_subtree_index*(idx: GeneralizedIndex): uint64 =
   doAssert idx > 0
   uint64(idx mod (type(idx)(1) shl log2trunc(idx)))
+
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#is_next_sync_committee_known
+template is_next_sync_committee_known*(store: LightClientStore): bool =
+  not isZeroMemory(store.next_sync_committee)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#get_safety_threshold
+func get_safety_threshold*(store: LightClientStore): uint64 =
+  max(
+    store.previous_max_active_participants,
+    store.current_max_active_participants
+  ) div 2
+
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#is_better_update
+type LightClientUpdateMetadata* = object
+  attested_slot*, finalized_slot*, signature_slot*: Slot
+  has_sync_committee*, has_finality*: bool
+  num_active_participants*: uint64
+
+func toMeta*(update: SomeLightClientUpdate): LightClientUpdateMetadata =
+  var meta {.noinit.}: LightClientUpdateMetadata
+  meta.attested_slot =
+    update.attested_header.slot
+  meta.finalized_slot =
+    when update is SomeLightClientUpdateWithFinality:
+      update.finalized_header.slot
+    else:
+      0.Slot
+  meta.signature_slot =
+    update.signature_slot
+  meta.has_sync_committee =
+    when update is SomeLightClientUpdateWithSyncCommittee:
+      not update.next_sync_committee_branch.isZeroMemory
+    else:
+      false
+  meta.has_finality =
+    when update is SomeLightClientUpdateWithFinality:
+      not update.finality_branch.isZeroMemory
+    else:
+      false
+  meta.num_active_participants =
+    countOnes(update.sync_aggregate.sync_committee_bits).uint64
+  meta
+
+func is_better_data*(new_meta, old_meta: LightClientUpdateMetadata): bool =
+  # Compare supermajority (> 2/3) sync committee participation
+  const max_active_participants = SYNC_COMMITTEE_SIZE.uint64
+  let
+    new_has_supermajority =
+      new_meta.num_active_participants * 3 >= max_active_participants * 2
+    old_has_supermajority =
+      old_meta.num_active_participants * 3 >= max_active_participants * 2
+  if new_has_supermajority != old_has_supermajority:
+    return new_has_supermajority > old_has_supermajority
+  if not new_has_supermajority:
+    if new_meta.num_active_participants != old_meta.num_active_participants:
+      return new_meta.num_active_participants > old_meta.num_active_participants
+
+  # Compare presence of relevant sync committee
+  let
+    new_has_relevant_sync_committee = new_meta.has_sync_committee and
+      new_meta.attested_slot.sync_committee_period ==
+      new_meta.signature_slot.sync_committee_period
+    old_has_relevant_sync_committee = old_meta.has_sync_committee and
+      old_meta.attested_slot.sync_committee_period ==
+      old_meta.signature_slot.sync_committee_period
+  if new_has_relevant_sync_committee != old_has_relevant_sync_committee:
+    return new_has_relevant_sync_committee > old_has_relevant_sync_committee
+
+  # Compare indication of any finality
+  if new_meta.has_finality != old_meta.has_finality:
+    return new_meta.has_finality > old_meta.has_finality
+
+  # Compare sync committee finality
+  if new_meta.has_finality:
+    let
+      new_has_sync_committee_finality =
+        new_meta.finalized_slot.sync_committee_period ==
+        new_meta.attested_slot.sync_committee_period
+      old_has_sync_committee_finality =
+        old_meta.finalized_slot.sync_committee_period ==
+        old_meta.attested_slot.sync_committee_period
+    if new_has_sync_committee_finality != old_has_sync_committee_finality:
+      return new_has_sync_committee_finality > old_has_sync_committee_finality
+
+  # Tiebreaker 1: Sync committee participation beyond supermajority
+  if new_meta.num_active_participants != old_meta.num_active_participants:
+    return new_meta.num_active_participants > old_meta.num_active_participants
+
+  # Tiebreaker 2: Prefer older data (fewer changes to best data)
+  new_meta.attested_slot < old_meta.attested_slot
+
+template is_better_update*[A, B: SomeLightClientUpdate](
+    new_update: A, old_update: B): bool =
+  is_better_data(toMeta(new_update), toMeta(old_update))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
 func is_merge_transition_complete*(state: bellatrix.BeaconState): bool =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -523,7 +523,7 @@ func toMeta*(update: SomeLightClientUpdate): LightClientUpdateMetadata =
     when update is SomeLightClientUpdateWithFinality:
       update.finalized_header.slot
     else:
-      0.Slot
+      GENESIS_SLOT
   meta.signature_slot =
     update.signature_slot
   meta.has_sync_committee =

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -98,10 +98,15 @@ func getSyncCommitteeContributionAndProofTopic*(forkDigest: ForkDigest): string 
   ## For subscribing and unsubscribing to/from a subnet.
   eth2Prefix(forkDigest) & "sync_committee_contribution_and_proof/ssz_snappy"
 
-# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#optimistic_light_client_update
-func getOptimisticLightClientUpdateTopic*(forkDigest: ForkDigest): string =
-  ## For broadcasting or obtaining the latest `OptimisticLightClientUpdate`.
-  eth2Prefix(forkDigest) & "optimistic_light_client_update_v0/ssz_snappy"
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_finality_update
+func getLightClientFinalityUpdateTopic*(forkDigest: ForkDigest): string =
+  ## For broadcasting or obtaining the latest `LightClientFinalityUpdate`.
+  eth2Prefix(forkDigest) & "light_client_finality_update_v0/ssz_snappy"
+
+# https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#light_client_optimistic_update
+func getLightClientOptimisticUpdateTopic*(forkDigest: ForkDigest): string =
+  ## For broadcasting or obtaining the latest `LightClientOptimisticUpdate`.
+  eth2Prefix(forkDigest) & "light_client_optimistic_update_v0/ssz_snappy"
 
 func getENRForkID*(cfg: RuntimeConfig,
                    epoch: Epoch,

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -26,16 +26,19 @@ logScope:
 
 const
   MAX_REQUEST_BLOCKS = 1024
-  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#configuration
-  MAX_REQUEST_LIGHT_CLIENT_UPDATES = 128
-
   blockByRootLookupCost = allowedOpsPerSecondCost(50)
   blockResponseCost = allowedOpsPerSecondCost(100)
   blockByRangeLookupCost = allowedOpsPerSecondCost(20)
-  lightClientUpdateResponseCost = allowedOpsPerSecondCost(100)
-  lightClientUpdateByRangeLookupCost = allowedOpsPerSecondCost(20)
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#configuration
+  MAX_REQUEST_LIGHT_CLIENT_UPDATES = 128
+  lightClientEmptyResponseCost = allowedOpsPerSecondCost(50)
   lightClientBootstrapLookupCost = allowedOpsPerSecondCost(5)
   lightClientBootstrapResponseCost = allowedOpsPerSecondCost(100)
+  lightClientUpdateResponseCost = allowedOpsPerSecondCost(100)
+  lightClientUpdateByRangeLookupCost = allowedOpsPerSecondCost(20)
+  lightClientFinalityUpdateResponseCost = allowedOpsPerSecondCost(100)
+  lightClientOptimisticUpdateResponseCost = allowedOpsPerSecondCost(100)
 
 type
   StatusMsg* = object
@@ -107,6 +110,29 @@ proc readChunkPayload*(
       return err(res.error)
   else:
     return neterr InvalidContextBytes
+
+proc readChunkPayload*(
+    conn: Connection, peer: Peer, maxChunkSize: uint32,
+    MsgType: type SomeLightClientObject):
+    Future[NetRes[MsgType]] {.async.} =
+  var contextBytes: ForkDigest
+  try:
+    await conn.readExactly(addr contextBytes, sizeof contextBytes)
+  except CatchableError:
+    return neterr UnexpectedEOF
+  let stateFork =
+    peer.network.forkDigests[].stateForkForDigest(contextBytes).valueOr:
+      return neterr InvalidContextBytes
+
+  let res =
+    if stateFork >= BeaconStateFork.Altair:
+      await readChunkPayload(conn, peer, maxChunkSize, MsgType)
+    else:
+      doAssert stateFork == BeaconStateFork.Phase0
+      return neterr InvalidContextBytes
+  if res.isErr:
+    return err(res.error)
+  return ok res.get
 
 func shortLog*(s: StatusMsg): auto =
   (
@@ -476,91 +502,6 @@ p2pProtocol BeaconSync(version = 1,
     debug "Block root request done",
       peer, roots = blockRoots.len, count, found
 
-  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#bestlightclientupdatesbyrange
-  proc bestLightClientUpdatesByRange(
-      peer: Peer,
-      startPeriod: SyncCommitteePeriod,
-      reqCount: uint64,
-      response: MultipleChunksResponse[altair.LightClientUpdate])
-      {.async, libp2pProtocol("best_light_client_updates_by_range", 0,
-                              isLightClientRequest = true).} =
-    trace "Received LC updates by range request", peer, startPeriod, reqCount
-    if reqCount == 0'u64:
-      raise newException(InvalidInputsError, "Empty range requested")
-    let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
-
-    let
-      headPeriod = dag.head.slot.sync_committee_period
-      # Limit number of updates in response
-      maxSupportedCount =
-        if startPeriod > headPeriod:
-          0'u64
-        else:
-          min(headPeriod + 1 - startPeriod, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
-      count = min(reqCount, maxSupportedCount)
-      onePastPeriod = startPeriod + count
-
-    peer.updateRequestQuota(count.float * lightClientUpdateByRangeLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
-    var found = 0
-    for period in startPeriod..<onePastPeriod:
-      let update = dag.getBestLightClientUpdateForPeriod(period)
-      if update.isSome:
-        await response.write(update.get)
-        inc found
-
-    peer.updateRequestQuota(found.float * lightClientUpdateResponseCost)
-
-    debug "LC updates by range request done", peer, startPeriod, count, found
-
-    if found == 0 and count > 0:
-      raise newException(ResourceUnavailableError,
-                         "No light client update available")
-
-  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#getlatestlightclientupdate
-  proc latestLightClientUpdate(
-      peer: Peer,
-      response: SingleChunkResponse[altair.LightClientUpdate])
-      {.async, libp2pProtocol("latest_light_client_update", 0,
-                              isLightClientRequest = true).} =
-    trace "Received latest LC update request", peer
-    let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
-
-    peer.awaitNonNegativeRequestQuota()
-
-    let update = dag.getLatestLightClientUpdate
-    if update.isSome:
-      await response.send(update.get)
-    else:
-      raise newException(ResourceUnavailableError,
-                         "No light client update available")
-
-    peer.updateRequestQuota(lightClientUpdateResponseCost)
-
-  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#getoptimisticlightclientupdate
-  proc optimisticLightClientUpdate(
-      peer: Peer,
-      response: SingleChunkResponse[OptimisticLightClientUpdate])
-      {.async, libp2pProtocol("optimistic_light_client_update", 0,
-                              isLightClientRequest = true).} =
-    trace "Received optimistic LC update request", peer
-    let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
-
-    peer.awaitNonNegativeRequestQuota()
-
-    let optimistic_update = dag.getOptimisticLightClientUpdate
-    if optimistic_update.isSome:
-      await response.send(optimistic_update.get)
-    else:
-      raise newException(ResourceUnavailableError,
-                         "No optimistic light client update available")
-
-    peer.updateRequestQuota(lightClientUpdateResponseCost)
-
   # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#getlightclientbootstrap
   proc lightClientBootstrap(
       peer: Peer,
@@ -577,12 +518,108 @@ p2pProtocol BeaconSync(version = 1,
 
     let bootstrap = dag.getLightClientBootstrap(blockRoot)
     if bootstrap.isOk:
-      await response.send(bootstrap.get)
+      let
+        contextSlot = bootstrap.get.header.slot
+        contextBytes = dag.forkDigestAtEpoch(contextSlot.epoch).data
+      await response.send(bootstrap.get, contextBytes)
     else:
-      raise newException(ResourceUnavailableError,
-                         "No light client bootstrap available")
+      peer.updateRequestQuota(lightClientEmptyResponseCost)
+      raise newException(
+        ResourceUnavailableError, "LC bootstrap unavailable")
 
     peer.updateRequestQuota(lightClientBootstrapResponseCost)
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientupdatesbyrange
+  proc lightClientUpdatesByRange(
+      peer: Peer,
+      startPeriod: SyncCommitteePeriod,
+      reqCount: uint64,
+      response: MultipleChunksResponse[altair.LightClientUpdate])
+      {.async, libp2pProtocol("light_client_updates_by_range", 0,
+                              isLightClientRequest = true).} =
+    trace "Received LC updates by range request", peer, startPeriod, reqCount
+    let dag = peer.networkState.dag
+    doAssert dag.serveLightClientData
+
+    let
+      headPeriod = dag.head.slot.sync_committee_period
+      # Limit number of updates in response
+      maxSupportedCount =
+        if startPeriod > headPeriod:
+          0'u64
+        else:
+          min(headPeriod + 1 - startPeriod, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
+      count = min(reqCount, maxSupportedCount)
+      onePastPeriod = startPeriod + count
+    if count == 0:
+      peer.updateRequestQuota(lightClientEmptyResponseCost)
+
+    peer.updateRequestQuota(count.float * lightClientUpdateByRangeLookupCost)
+    peer.awaitNonNegativeRequestQuota()
+
+    var found = 0
+    for period in startPeriod..<onePastPeriod:
+      let update = dag.getLightClientUpdateForPeriod(period)
+      if update.isSome:
+        let
+          contextSlot = update.get.attested_header.slot
+          contextBytes = dag.forkDigestAtEpoch(contextSlot.epoch).data
+        await response.write(update.get, contextBytes)
+        inc found
+
+    peer.updateRequestQuota(found.float * lightClientUpdateResponseCost)
+
+    debug "LC updates by range request done", peer, startPeriod, count, found
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#getlightclientfinalityupdate
+  proc lightClientFinalityUpdate(
+      peer: Peer,
+      response: SingleChunkResponse[altair.LightClientFinalityUpdate])
+      {.async, libp2pProtocol("light_client_finality_update", 0,
+                              isLightClientRequest = true).} =
+    trace "Received LC finality update request", peer
+    let dag = peer.networkState.dag
+    doAssert dag.serveLightClientData
+
+    peer.awaitNonNegativeRequestQuota()
+
+    let finality_update = dag.getLightClientFinalityUpdate
+    if finality_update.isSome:
+      let
+        contextSlot = finality_update.get.attested_header.slot
+        contextBytes = dag.forkDigestAtEpoch(contextSlot.epoch).data
+      await response.send(finality_update.get, contextBytes)
+    else:
+      peer.updateRequestQuota(lightClientEmptyResponseCost)
+      raise newException(ResourceUnavailableError,
+                         "LC finality update available")
+
+    peer.updateRequestQuota(lightClientFinalityUpdateResponseCost)
+
+  # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#getlightclientoptimisticupdate
+  proc lightClientOptimisticUpdate(
+      peer: Peer,
+      response: SingleChunkResponse[altair.LightClientOptimisticUpdate])
+      {.async, libp2pProtocol("light_client_optimistic_update", 0,
+                              isLightClientRequest = true).} =
+    trace "Received LC optimistic update request", peer
+    let dag = peer.networkState.dag
+    doAssert dag.serveLightClientData
+
+    peer.awaitNonNegativeRequestQuota()
+
+    let optimistic_update = dag.getLightClientOptimisticUpdate
+    if optimistic_update.isSome:
+      let
+        contextSlot = optimistic_update.get.attested_header.slot
+        contextBytes = dag.forkDigestAtEpoch(contextSlot.epoch).data
+      await response.send(optimistic_update.get, contextBytes)
+    else:
+      peer.updateRequestQuota(lightClientEmptyResponseCost)
+      raise newException(ResourceUnavailableError,
+                         "LC optimistic update available")
+
+    peer.updateRequestQuota(lightClientOptimisticUpdateResponseCost)
 
   proc goodbye(peer: Peer,
                reason: uint64)

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -64,6 +64,12 @@ declareHistogram beacon_sync_committee_message_sent_delay,
   "Time(s) between slot start and sync committee message sent moment",
   buckets = delayBuckets
 
+declareCounter beacon_light_client_finality_updates_sent,
+  "Number of LC finality updates sent by this peer"
+
+declareCounter beacon_light_client_optimistic_updates_sent,
+  "Number of LC optimistic updates sent by this peer"
+
 declareCounter beacon_blocks_proposed,
   "Number of beacon chain blocks sent by this peer"
 
@@ -239,7 +245,57 @@ proc sendAttestation*(
         error = res.error()
       err(res.error()[1])
 
-proc sendSyncCommitteeMessage*(
+proc handleLightClientUpdates(node: BeaconNode, slot: Slot) {.async.} =
+  static: doAssert lightClientFinalityUpdateSlotOffset ==
+    lightClientOptimisticUpdateSlotOffset
+  let sendTime = node.beaconClock.fromNow(
+    slot.light_client_finality_update_time())
+  if sendTime.inFuture:
+    debug "Waiting to send LC updates", slot, delay = shortLog(sendTime.offset)
+    await sleepAsync(sendTime.offset)
+
+  template latest(): auto = node.dag.lightClientCache.latest
+  let signature_slot = latest.signature_slot
+  if slot != signature_slot:
+    return
+
+  template sync_aggregate(): auto = latest.sync_aggregate
+  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
+  let num_active_participants = countOnes(sync_committee_bits).uint64
+  if num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
+    return
+
+  let finalized_slot = latest.finalized_header.slot
+  if finalized_slot > node.dag.lightClientCache.latestForwardedFinalitySlot:
+    template msg(): auto = latest
+    node.network.broadcastLightClientFinalityUpdate(msg)
+    node.dag.lightClientCache.latestForwardedFinalitySlot = finalized_slot
+    beacon_light_client_finality_updates_sent.inc()
+    notice "LC finality update sent", message = shortLog(msg)
+
+  let attested_slot = latest.attested_header.slot
+  if attested_slot > node.dag.lightClientCache.latestForwardedOptimisticSlot:
+    let msg = latest.toOptimistic
+    node.network.broadcastLightClientOptimisticUpdate(msg)
+    node.dag.lightClientCache.latestForwardedOptimisticSlot = attested_slot
+    beacon_light_client_optimistic_updates_sent.inc()
+    notice "LC optimistic update sent", message = shortLog(msg)
+
+proc scheduleSendingLightClientUpdates(node: BeaconNode, slot: Slot) =
+  if not node.config.serveLightClientData.get:
+    return
+  if node.dag.lightClientCache.broadcastGossipFut != nil:
+    return
+  if slot <= node.dag.lightClientCache.latestBroadcastedSlot:
+    return
+  node.dag.lightClientCache.latestBroadcastedSlot = slot
+
+  template fut(): auto = node.dag.lightClientCache.broadcastGossipFut
+  fut = node.handleLightClientUpdates(slot)
+  fut.addCallback do (p: pointer) {.gcsafe.}:
+    fut = nil
+
+proc sendSyncCommitteeMessage(
     node: BeaconNode, msg: SyncCommitteeMessage,
     subcommitteeIdx: SyncSubcommitteeIndex,
     checkSignature: bool): Future[SendResult] {.async.} =
@@ -254,6 +310,7 @@ proc sendSyncCommitteeMessage*(
     if res.isGoodForSending:
       node.network.broadcastSyncCommitteeMessage(msg, subcommitteeIdx)
       beacon_sync_committee_messages_sent.inc()
+      node.scheduleSendingLightClientUpdates(msg.slot)
       SendResult.ok()
     else:
       notice "Sync committee message failed validation",
@@ -826,19 +883,6 @@ proc handleSyncCommitteeMessages(node: BeaconNode, head: BlockRef, slot: Slot) =
       asyncSpawn createAndSendSyncCommitteeMessage(node, slot, validator,
                                                    subcommitteeIdx, head)
 
-proc handleOptimisticLightClientUpdates(
-    node: BeaconNode, head: BlockRef, slot: Slot) =
-  if slot < node.dag.cfg.ALTAIR_FORK_EPOCH.start_slot():
-    return
-  doAssert head.parent != nil, "Newly proposed block lacks parent reference"
-  let msg = node.dag.lightClientCache.optimisticUpdate
-  if msg.attested_header.slot != head.parent.bid.slot:
-    notice "No optimistic light client update for proposed block",
-      slot = slot, block_root = shortLog(head.root)
-    return
-  node.network.broadcastOptimisticLightClientUpdate(msg)
-  notice "Sent optimistic light client update", message = shortLog(msg)
-
 proc signAndSendContribution(node: BeaconNode,
                              validator: AttachedValidator,
                              contribution: SyncCommitteeContribution,
@@ -1227,16 +1271,6 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
   handleAttestations(node, head, slot)
   handleSyncCommitteeMessages(node, head, slot)
 
-  if node.config.serveLightClientData.get and didSubmitBlock:
-    let cutoff = node.beaconClock.fromNow(
-      slot.optimistic_light_client_update_time())
-    if cutoff.inFuture:
-      debug "Waiting to send optimistic light client update",
-        head = shortLog(head),
-        optimisticLightClientUpdateCutoff = shortLog(cutoff.offset)
-      await sleepAsync(cutoff.offset)
-    handleOptimisticLightClientUpdates(node, head, slot)
-
   updateValidatorMetrics(node) # the important stuff is done, update the vanity numbers
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/validator.md#broadcast-aggregate
@@ -1393,31 +1427,11 @@ proc sendBeaconBlock*(node: BeaconNode, forked: ForkedSignedBeaconBlock
         notice "Block published",
           blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
           signature = shortLog(blck.signature)
-
-        if node.config.serveLightClientData.get:
-          # The optimistic light client update is sent with a delay because it
-          # only validates once the new block has been processed by the peers.
-          # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#block-proposal
-          proc publishOptimisticLightClientUpdate() {.async.} =
-            let cutoff = node.beaconClock.fromNow(
-              wallTime.slotOrZero.optimistic_light_client_update_time())
-            if cutoff.inFuture:
-              debug "Waiting to publish optimistic light client update",
-                blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
-                signature = shortLog(blck.signature),
-                optimisticLightClientUpdateCutoff = shortLog(cutoff.offset)
-              await sleepAsync(cutoff.offset)
-            handleOptimisticLightClientUpdates(
-              node, newBlockRef.get, wallTime.slotOrZero)
-
-          asyncSpawn publishOptimisticLightClientUpdate()
-
         true
       else:
         warn "Unable to add proposed block to block pool",
           blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
           signature = shortLog(blck.signature), err = newBlockRef.error()
-
         false
   return SendBlockResult.ok(accepted)
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -60,7 +60,7 @@ func gauss(r: var Rand; mu = 0.0; sigma = 1.0): float =
 cli do(slots = SLOTS_PER_EPOCH * 6,
        validators = SLOTS_PER_EPOCH * 400, # One per shard is minimum
        attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
-       syncCommitteeRatio {.desc: "ratio of validators that perform sync committee actions in each round"} = 0.75,
+       syncCommitteeRatio {.desc: "ratio of validators that perform sync committee actions in each round"} = 0.82,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):
   let

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -19,5 +19,6 @@ import
   ./test_fixture_ssz_consensus_objects,
   ./test_fixture_state_transition_epoch,
   ./test_fixture_sync_protocol_light_client_sync,
+  ./test_fixture_sync_protocol_update_ranking,
   ./test_fixture_sync_protocol,
   ./test_fixture_transition

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -114,7 +114,14 @@ suite "EF - Altair - SSZ consensus objects " & preset():
           of "ForkData": checkSSZ(ForkData, path, hash)
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
-          of "LightClientUpdate": checkSSZ(LightClientUpdate, path, hash)
+          of "LightClientBootstrap":
+            checkSSZ(LightClientBootstrap, path, hash)
+          of "LightClientUpdate":
+            discard # Modified - checkSSZ(LightClientUpdate, path, hash)
+          of "LightClientFinalityUpdate":
+            checkSSZ(LightClientFinalityUpdate, path, hash)
+          of "LightClientOptimisticUpdate":
+            checkSSZ(LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
           of "SignedAggregateAndProof":

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_update_ranking.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_update_ranking.nim
@@ -1,0 +1,88 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.used.}
+
+# This implements the pre-release proposal of the libp2p based light client sync
+# protocol. See https://github.com/ethereum/consensus-specs/pull/2802
+
+import
+  # Standard library
+  std/[algorithm, os, streams],
+  # Status libraries
+  stew/base10,
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/helpers,
+  ../../../beacon_chain/spec/datatypes/altair,
+  # Test utilities
+  ../../testutil,
+  ../fixtures_utils
+
+const TestsDir =
+  SszTestsDir/const_preset/"altair"/"sync_protocol"/"update_ranking"/"pyspec_tests"
+
+type
+  TestMeta = object
+    updates_count: uint64
+
+proc runTest(identifier: string) =
+  let testDir = TestsDir / identifier
+
+  proc `testImpl _ sync_protocol_update_ranking _ identifier`() =
+    test identifier:
+      let meta = block:
+        var s = openFileStream(testDir/"meta.yaml")
+        defer: close(s)
+        var res: TestMeta
+        yaml.load(s, res)
+        res
+
+      var updates = newSeqOfCap[altair.LightClientUpdate](meta.updates_count)
+      for i in 0 ..< meta.updates_count:
+        updates.add parseTest(
+          testDir/"updates_" & Base10.toString(i) & ".ssz_snappy",
+          SSZ, altair.LightClientUpdate)
+
+      proc cmp(a, b: altair.LightClientUpdate): int =
+        if a.is_better_update(b):
+          check: not b.is_better_update(a)
+          -1
+        elif b.is_better_update(a):
+          1
+        else:
+          0
+      check: updates.isSorted(cmp)
+
+  `testImpl _ sync_protocol_update_ranking _ identifier`()
+
+suite "EF - Altair - Sync protocol - Update ranking" & preset():
+  try:
+    for kind, path in walkDir(TestsDir, relative = true, checkDir = true):
+      runTest(path)
+  except OSError:
+    # These tests are for the pre-release proposal of the libp2p based light
+    # client sync protocol. Corresponding test vectors need manual integration.
+    # https://github.com/ethereum/consensus-specs/pull/2802
+    #
+    # To locally integrate the test vectors, clone the pre-release spec repo
+    # at latest commit of https://github.com/ethereum/consensus-specs/pull/2802
+    # and place it next to the `nimbus-eth2` repo, so that `nimbus-eth2` and
+    # `consensus-specs` are in the same directory.
+    #
+    # To generate the additional test vectors, from `consensus-specs`:
+    # $ rm -rf ../consensus-spec-tests && \
+    #   doctoc specs && make lint && make gen_sync_protocol
+    #
+    # To integrate the additional test vectors into `nimbus-eth2`, first run
+    # `make test` from `nimbus-eth2` to ensure that the regular test vectors
+    # have been downloaded and extracted, then proceed from `nimbus-eth2` with:
+    # $ rsync -r ../consensus-spec-tests/tests/ \
+    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.1.10/
+    test "All tests":
+      skip()

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -117,7 +117,14 @@ suite "EF - Bellatrix - SSZ consensus objects " & preset():
           of "ForkData": checkSSZ(ForkData, path, hash)
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
-          of "LightClientUpdate": checkSSZ(LightClientUpdate, path, hash)
+          of "LightClientBootstrap":
+            checkSSZ(LightClientBootstrap, path, hash)
+          of "LightClientUpdate":
+            discard # Modified - checkSSZ(LightClientUpdate, path, hash)
+          of "LightClientFinalityUpdate":
+            checkSSZ(LightClientFinalityUpdate, path, hash)
+          of "LightClientOptimisticUpdate":
+            checkSSZ(LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import
@@ -17,6 +24,8 @@ suite "Honest validator":
       getAttesterSlashingsTopic(forkDigest) == "/eth2/00000000/attester_slashing/ssz_snappy"
       getAggregateAndProofsTopic(forkDigest) == "/eth2/00000000/beacon_aggregate_and_proof/ssz_snappy"
       getSyncCommitteeContributionAndProofTopic(forkDigest) == "/eth2/00000000/sync_committee_contribution_and_proof/ssz_snappy"
+      getLightClientFinalityUpdateTopic(forkDigest) == "/eth2/00000000/light_client_finality_update_v0/ssz_snappy"
+      getLightClientOptimisticUpdateTopic(forkDigest) == "/eth2/00000000/light_client_optimistic_update_v0/ssz_snappy"
 
   test "Mainnet attestation topics":
     check:

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -71,7 +71,7 @@ suite "Light client processor" & preset():
                            cache, info, flags = {}).isOk()
     let syncCommitteeRatio =
       if period > lastPeriodWithSupermajority:
-        0.52
+        0.62
       else:
         0.82
     addBlocks(numFilledEpochsPerPeriod * SLOTS_PER_EPOCH, syncCommitteeRatio)

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -171,10 +171,9 @@ suite "Light client processor" & preset():
     if res.isOk:
       check:
         store[].isSome
-        if finalityUpdate.get.finalized_header.slot > previousFinalized.slot:
-          store[].get.finalized_header == finalityUpdate.get.finalized_header
-        else:
-          store[].get.finalized_header == previousFinalized
+        store[].get.finalized_header == previousFinalized
+        store[].get.best_valid_update.isSome
+        store[].get.best_valid_update.get.matches(finalityUpdate.get)
         store[].get.optimistic_header == finalityUpdate.get.attested_header
     else:
       check res.error == BlockError.Duplicate

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -54,7 +54,7 @@ suite "Light client processor" & preset():
       doAssert added.isOk()
       dag.updateHead(added[], quarantine[])
 
-  addBlocks(SLOTS_PER_EPOCH, 0.75)
+  addBlocks(SLOTS_PER_EPOCH, 0.82)
   let
     genesis_validators_root = dag.genesis_validators_root
     trustedBlockRoot = dag.head.root
@@ -71,9 +71,9 @@ suite "Light client processor" & preset():
                            cache, info, flags = {}).isOk()
     let syncCommitteeRatio =
       if period > lastPeriodWithSupermajority:
-        0.25
+        0.52
       else:
-        0.75
+        0.82
     addBlocks(numFilledEpochsPerPeriod * SLOTS_PER_EPOCH, syncCommitteeRatio)
 
   setup:
@@ -93,7 +93,7 @@ suite "Light client processor" & preset():
         store, getBeaconTime, didInitializeStore)
       res: Result[void, BlockError]
 
-  test "Standard sync" & preset():
+  test "Sync" & preset():
     let bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
     check bootstrap.isOk
     setTimeToSlot(bootstrap.get.header.slot)
@@ -104,63 +104,34 @@ suite "Light client processor" & preset():
       numDidInitializeStoreCalls == 1
 
     for period in lowPeriod .. lastPeriodWithSupermajority:
-      let update = dag.getBestLightClientUpdateForPeriod(period)
+      let update = dag.getLightClientUpdateForPeriod(period)
       check update.isSome
-      setTimeToSlot(update.get.attested_header.slot + 1)
+      setTimeToSlot(update.get.signature_slot)
       res = processor[].storeObject(
         MsgSource.gossip, getBeaconTime(), update.get)
       check:
         res.isOk
         store[].isSome
-        store[].get.finalized_header == update.get.finalized_header
-        store[].get.optimistic_header == update.get.attested_header
-
-  test "Forced update" & preset():
-    let bootstrap = dag.getLightClientBootstrap(trustedBlockRoot)
-    check bootstrap.isOk
-    setTimeToSlot(bootstrap.get.header.slot)
-    res = processor[].storeObject(
-      MsgSource.gossip, getBeaconTime(), bootstrap.get)
-    check:
-      res.isOk
-      numDidInitializeStoreCalls == 1
-
-    for period in lowPeriod .. lastPeriodWithSupermajority:
-      let update = dag.getBestLightClientUpdateForPeriod(period)
-      check update.isSome
-      setTimeToSlot(update.get.attested_header.slot + 1)
-      res = processor[].storeObject(
-        MsgSource.gossip, getBeaconTime(), update.get)
-      check:
-        res.isOk
-        store[].isSome
-        store[].get.finalized_header == update.get.finalized_header
+        if update.get.finalized_header.slot > bootstrap.get.header.slot:
+          store[].get.finalized_header == update.get.finalized_header
+        else:
+          store[].get.finalized_header == bootstrap.get.header
         store[].get.optimistic_header == update.get.attested_header
 
     for period in lastPeriodWithSupermajority + 1 .. highPeriod:
-      let update = dag.getBestLightClientUpdateForPeriod(period)
+      let update = dag.getLightClientUpdateForPeriod(period)
       check update.isSome
-      setTimeToSlot(update.get.attested_header.slot + 1)
-      res = processor[].storeObject(
-        MsgSource.gossip, getBeaconTime(), update.get)
-      check:
-        res.isOk
-        store[].isSome
-        store[].get.best_valid_update.isSome
-        store[].get.best_valid_update.get == update.get
+      setTimeToSlot(update.get.signature_slot)
 
-      res = processor[].storeObject(
-        MsgSource.gossip, getBeaconTime(), update.get)
-      check:
-        res.isErr
-        res.error == BlockError.Duplicate
-        store[].isSome
-        store[].get.best_valid_update.isSome
-        store[].get.best_valid_update.get == update.get
-      time += chronos.minutes(15)
+      for i in 0 ..< 2:
+        res = processor[].storeObject(
+          MsgSource.gossip, getBeaconTime(), update.get)
+        check:
+          res.isOk
+          store[].isSome
+          store[].get.best_valid_update.isSome
+          store[].get.best_valid_update.get == update.get
 
-      for _ in 0 ..< 150:
-        time += chronos.seconds(5)
         res = processor[].storeObject(
           MsgSource.gossip, getBeaconTime(), update.get)
         check:
@@ -169,27 +140,48 @@ suite "Light client processor" & preset():
           store[].isSome
           store[].get.best_valid_update.isSome
           store[].get.best_valid_update.get == update.get
+        time += chronos.minutes(15)
 
-      time += chronos.minutes(15)
+        for _ in 0 ..< 150:
+          time += chronos.seconds(5)
+          res = processor[].storeObject(
+            MsgSource.gossip, getBeaconTime(), update.get)
+          check:
+            res.isErr
+            res.error == BlockError.Duplicate
+            store[].isSome
+            store[].get.best_valid_update.isSome
+            store[].get.best_valid_update.get == update.get
 
-      res = processor[].storeObject(
-        MsgSource.gossip, getBeaconTime(), update.get)
-      check:
-        res.isErr
-        res.error == BlockError.Duplicate
-        store[].isSome
-        store[].get.best_valid_update.isNone
-        store[].get.finalized_header == update.get.finalized_header
+        time += chronos.minutes(15)
 
-    let optimisticUpdate = dag.getOptimisticLightClientUpdate()
-    check optimisticUpdate.isSome
-    setTimeToSlot(optimisticUpdate.get.attested_header.slot + 1)
+        res = processor[].storeObject(
+          MsgSource.gossip, getBeaconTime(), update.get)
+        check:
+          res.isErr
+          res.error == BlockError.Duplicate
+          store[].isSome
+          store[].get.best_valid_update.isNone
+        if store[].get.finalized_header == update.get.attested_header:
+          break
+        check: store[].get.finalized_header == update.get.finalized_header
+      check: store[].get.finalized_header == update.get.attested_header
+
+    let
+      previousFinalized = store[].get.finalized_header
+      finalityUpdate = dag.getLightClientFinalityUpdate()
+    check finalityUpdate.isSome
+    setTimeToSlot(finalityUpdate.get.signature_slot)
     res = processor[].storeObject(
-      MsgSource.gossip, getBeaconTime(), optimisticUpdate.get)
+      MsgSource.gossip, getBeaconTime(), finalityUpdate.get)
     if res.isOk:
       check:
         store[].isSome
-        store[].get.optimistic_header == optimisticUpdate.get.attested_header
+        if finalityUpdate.get.finalized_header.slot > previousFinalized.slot:
+          store[].get.finalized_header == finalityUpdate.get.finalized_header
+        else:
+          store[].get.finalized_header == previousFinalized
+        store[].get.optimistic_header == finalityUpdate.get.attested_header
     else:
       check res.error == BlockError.Duplicate
     check numDidInitializeStoreCalls == 1
@@ -223,9 +215,9 @@ suite "Light client processor" & preset():
       numDidInitializeStoreCalls == 1
 
   test "Missing bootstrap (update)" & preset():
-    let update = dag.getBestLightClientUpdateForPeriod(lowPeriod)
+    let update = dag.getLightClientUpdateForPeriod(lowPeriod)
     check update.isSome
-    setTimeToSlot(update.get.attested_header.slot + 1)
+    setTimeToSlot(update.get.signature_slot)
     res = processor[].storeObject(
       MsgSource.gossip, getBeaconTime(), update.get)
     check:
@@ -233,10 +225,21 @@ suite "Light client processor" & preset():
       res.error == BlockError.MissingParent
       numDidInitializeStoreCalls == 0
 
+  test "Missing bootstrap (finality update)" & preset():
+    let finalityUpdate = dag.getLightClientFinalityUpdate()
+    check finalityUpdate.isSome
+    setTimeToSlot(finalityUpdate.get.signature_slot)
+    res = processor[].storeObject(
+      MsgSource.gossip, getBeaconTime(), finalityUpdate.get)
+    check:
+      res.isErr
+      res.error == BlockError.MissingParent
+      numDidInitializeStoreCalls == 0
+
   test "Missing bootstrap (optimistic update)" & preset():
-    let optimisticUpdate = dag.getOptimisticLightClientUpdate()
+    let optimisticUpdate = dag.getLightClientOptimisticUpdate()
     check optimisticUpdate.isSome
-    setTimeToSlot(optimisticUpdate.get.attested_header.slot + 1)
+    setTimeToSlot(optimisticUpdate.get.signature_slot)
     res = processor[].storeObject(
       MsgSource.gossip, getBeaconTime(), optimisticUpdate.get)
     check:


### PR DESCRIPTION
Incorporates the latest changes to the light client sync protocol based
on Devconnect AMS feedback. Note that this breaks compatibility with the
previous prototype, due to changes to data structures and endpoints.
See https://github.com/ethereum/consensus-specs/pull/2802

Due to the amount of changes, it is best to review the heavily edited
files from scratch (likewise, for the spec).