### PR TITLE
MEV REST serialization and call signatures

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -10,6 +10,7 @@ import stew/[assign2, results, base10, byteutils], presto/common,
        json_serialization/std/[options, net, sets]
 import ".."/[eth2_ssz_serialization, forks, keystore],
        ".."/datatypes/[phase0, altair, bellatrix],
+       ".."/mev/bellatrix_mev,
        ".."/../validators/slashing_protection_common,
        "."/[rest_types, rest_keymanager_types]
 import nimcrypto/utils as ncrutils
@@ -54,6 +55,8 @@ type
     phase0.SignedBeaconBlock |
     altair.SignedBeaconBlock |
     bellatrix.SignedBeaconBlock |
+    SignedBlindedBeaconBlock |
+    SignedValidatorRegistrationV1 |
     SignedVoluntaryExit |
     Web3SignerRequest |
     KeystoresAndSlashingProtection |

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -17,9 +17,10 @@ import
   std/[json, typetraits],
   stew/base10, web3/ethtypes,
   ".."/forks,
-  ".."/datatypes/[phase0, altair, bellatrix]
+  ".."/datatypes/[phase0, altair, bellatrix],
+  ".."/mev/bellatrix_mev
 
-export forks, phase0, altair, bellatrix
+export forks, phase0, altair, bellatrix, bellatrix_mev
 
 const
   # https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/states/validator_balances.yaml#L17
@@ -534,6 +535,7 @@ type
   GetEpochCommitteesResponse* = DataEnclosedObject[seq[RestBeaconStatesCommittees]]
   GetForkScheduleResponse* = DataEnclosedObject[seq[Fork]]
   GetGenesisResponse* = DataEnclosedObject[RestGenesis]
+  GetHeaderResponse* = DataEnclosedObject[SignedBuilderBid]
   GetNetworkIdentityResponse* = DataEnclosedObject[RestNetworkIdentity]
   GetPeerCountResponse* = DataMetaEnclosedObject[RestPeerCount]
   GetPeerResponse* = DataMetaEnclosedObject[RestNodePeer]
@@ -559,6 +561,7 @@ type
   ProduceBlockResponse* = DataEnclosedObject[phase0.BeaconBlock]
   ProduceBlockResponseV2* = ForkedBeaconBlock
   ProduceSyncCommitteeContributionResponse* = DataEnclosedObject[SyncCommitteeContribution]
+  SubmitBlindedBlockResponse* = DataEnclosedObject[SignedBuilderBid]
 
 func `==`*(a, b: RestValidatorIndex): bool =
   uint64(a) == uint64(b)

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -10,43 +10,30 @@ import ".."/datatypes/[altair, bellatrix]
 {.push raises: [Defect].}
 
 type
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#validatorregistrationv1
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#validatorregistrationv1
   ValidatorRegistrationV1 = object
     fee_recipient*: ExecutionAddress
     gas_limit*: uint64
     timestamp*: uint64
     pubkey*: ValidatorPubKey
 
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#signedvalidatorregistrationv1
-  SignedValidatorRegistrationV1 = object
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#signedvalidatorregistrationv1
+  SignedValidatorRegistrationV1* = object
     message*: ValidatorRegistrationV1
     signature*: ValidatorSig
 
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#builderbid
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#builderbid
   BuilderBid = object
     header*: ExecutionPayloadHeader
     value*: Eth2Digest   # uint256
     pubkey*: ValidatorPubKey
 
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#signedbuilderbid
-  SignedBuilderBid = object
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#signedbuilderbid
+  SignedBuilderBid* = object
     message*: BuilderBid
     signature*: ValidatorSig
 
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#signedblindedbeaconblock
-  SignedBlindedBeaconBlock = object
-    message*: BlindedBeaconBlock
-    signature*: ValidatorSig
-
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#blindedbeaconblock
-  BlindedBeaconBlock = object
-    slot*: Slot
-    proposer_index*: uint64
-    parent_root*: Eth2Digest
-    state_root*: Eth2Digest
-    body*: BlindedBeaconBlockBody
-
-  # https://github.com/lightclient/builder-specs/blob/b286dbae3e9d065c63df687a90cb9e9b1687519a/specs/README.md#blindedbeaconblockbody
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#blindedbeaconblockbody
   BlindedBeaconBlockBody = object
     randao_reveal*: ValidatorSig
     eth1_data*: Eth1Data
@@ -58,3 +45,20 @@ type
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
     sync_aggregate*: SyncAggregate
     execution_payload_header*: ExecutionPayloadHeader
+
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#blindedbeaconblock
+  BlindedBeaconBlock* = object
+    slot*: Slot
+    proposer_index*: uint64
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
+    body*: BlindedBeaconBlockBody
+
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#signedblindedbeaconblock
+  SignedBlindedBeaconBlock* = object
+    message*: BlindedBeaconBlock
+    signature*: ValidatorSig
+
+const
+  # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#signing
+  DOMAIN_MEV* = DomainType([byte 0x00, 0x00, 0x00, 0x01])

--- a/beacon_chain/spec/mev/rest_bellatrix_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_bellatrix_mev_calls.nim
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
+
+import
+  chronos, presto/client,
+  ".."/eth2_apis/[rest_types, eth2_rest_serialization]
+
+export chronos, client, rest_types, eth2_rest_serialization
+
+proc registerValidators*(body: SignedValidatorRegistrationV1
+                        ): RestPlainResponse {.
+     rest, endpoint: "/eth/v1/builder/validators",
+     meth: MethodPost.}
+  ## https://github.com/ethereum/builder-specs/blob/v0.0.0/apis/builder/validators.yaml
+
+proc getHeader*(slot: Slot,
+                parent_hash: Eth2Digest,
+                pubkey: ValidatorPubKey
+               ): RestResponse[GetHeaderResponse] {.
+     rest, endpoint: "/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}",
+     meth: MethodGet.}
+  ## https://github.com/ethereum/builder-specs/blob/v0.0.0/apis/builder/header.yaml
+
+proc submitBlindedBlock*(body: SignedBlindedBeaconBlock
+                        ): RestResponse[SubmitBlindedBlockResponse] {.
+     rest, endpoint: "/eth/v1/builder/blinded_blocks",
+     meth: MethodPost.}
+  ## https://github.com/ethereum/builder-specs/blob/v0.0.0/apis/builder/blinded_blocks.yaml
+
+proc checkBuilderStatus*(): RestPlainResponse {.
+     rest, endpoint: "/eth/v1/builder/status",
+     meth: MethodGet.}
+  ## https://github.com/ethereum/builder-specs/blob/v0.0.0/apis/builder/status.yaml

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -17,7 +17,8 @@
 ## functions.
 
 import
-  ./datatypes/[phase0, altair, bellatrix], ./helpers, ./eth2_merkleization
+  ./datatypes/[phase0, altair, bellatrix], ./mev/bellatrix_mev, ./helpers,
+  ./eth2_merkleization
 
 export phase0, altair
 
@@ -86,7 +87,9 @@ proc verify_epoch_signature*(
 
 func compute_block_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    blck: Eth2Digest | SomeForkyBeaconBlock | BeaconBlockHeader): Eth2Digest =
+    blck: Eth2Digest | SomeForkyBeaconBlock | BeaconBlockHeader |
+          # https://github.com/ethereum/builder-specs/blob/v0.0.0/specs/README.md#signing
+          BlindedBeaconBlock): Eth2Digest =
   let
     epoch = epoch(slot)
     domain = get_domain(
@@ -316,7 +319,7 @@ proc get_contribution_and_proof_signature*(
 
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#aggregation-selection
-proc is_sync_committee_aggregator*(signature: ValidatorSig): bool =
+func is_sync_committee_aggregator*(signature: ValidatorSig): bool =
   let
     signatureDigest = eth2digest(signature.blob)
     modulo = max(1'u64, (SYNC_COMMITTEE_SIZE div SYNC_COMMITTEE_SUBNET_COUNT) div TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -1,8 +1,15 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import
   std/[json, typetraits],
-  unittest2, stew/byteutils, json_serialization,
+  unittest2, json_serialization,
   blscurve, eth/keys, libp2p/crypto/crypto as lcrypto,
   nimcrypto/utils as ncrutils,
   ../beacon_chain/spec/[crypto, keystore],


### PR DESCRIPTION
This corresponds to the first standardized version (0.0.0).

There's not yet a fully ready mock endpoint against which to test it, but that should be within a day or two.

https://ethereum.github.io/builder-specs/ is a browsable version of these APIs.