### PR TITLE
Bugfix: Don't include invalid deposits in block proposals

### DIFF
--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -128,7 +128,7 @@ proc is_valid_indexed_attestation*(
     return err("is_valid_indexed_attestation: no attesting indices")
 
   # Verify aggregate signature
-  if not (skipBlsValidation in flags or attestation.signature is TrustedSig):
+  if not (flags.shouldSkipBls or attestation.signature is TrustedSig):
     var
       pubkeys = newSeqOfCap[CookedPubKey](sigs)
     for index in get_attesting_indices(

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -20,19 +20,33 @@
 
 type
   UpdateFlag* = enum
-    skipBlsValidation ##\
-    ## Skip verification of BLS signatures in block processing.
-    ## Predominantly intended for use in testing, e.g. to allow extra coverage.
-    ## Also useful to avoid unnecessary work when replaying known, good blocks.
-    skipStateRootValidation ##\
-    ## Skip verification of block state root.
+    skipBlsValidation
+      ## Skip verification of BLS signatures in block processing.
+      ## Predominantly intended for use in testing, e.g. to allow extra coverage.
+      ## Also useful to avoid unnecessary work when replaying known, good blocks.
+
+    skipStateRootValidation
+      ## Skip verification of block state root.
+
     verifyFinalization
-    slotProcessed ##\
-    ## Allow blocks to be applied to states with the same slot number as the
-    ## block which is what happens when `process_block` is called separately
-    skipLastStateRootCalculation ##\
-    ## When process_slots() is being called as part of a state_transition(),
-    ## the hash_tree_root() from the block will fill in the state.root so it
-    ## should skip calculating that last state root.
+
+    slotProcessed
+      ## Allow blocks to be applied to states with the same slot number as the
+      ## block which is what happens when `process_block` is called separately
+
+    skipLastStateRootCalculation
+      ## When process_slots() is being called as part of a state_transition(),
+      ## the hash_tree_root() from the block will fill in the state.root so it
+      ## should skip calculating that last state root.
+
+    localOrigin
+      ## The block or attestation has local origin which allows us to skip some
+      ## of the validation checks (e.g. we don't need to check our own signature).
+      ## Please note that this is also used to skip over third party signatures
+      ## because these are validated before entering the various pools that we
+      ## use as inputs when building blocks.
 
   UpdateFlags* = set[UpdateFlag]
+
+template shouldSkipBls*(flags: UpdateFlags): bool =
+  {skipBlsValidation, localOrigin} * flags != {}

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -424,7 +424,7 @@ proc is_valid_indexed_attestation*(
     return err("indexed attestation: indices not sorted and unique")
 
   # Verify aggregate signature
-  if not (skipBlsValidation in flags or indexed_attestation.signature is TrustedSig):
+  if not (flags.shouldSkipBls or indexed_attestation.signature is TrustedSig):
     let pubkeys = mapIt(
       indexed_attestation.attesting_indices, state.validators[it].pubkey)
     if not verify_attestation_signature(
@@ -483,7 +483,7 @@ proc is_valid_indexed_attestation*(
     return err("is_valid_indexed_attestation: no attesting indices")
 
   # Verify aggregate signature
-  if not (skipBlsValidation in flags or attestation.signature is TrustedSig):
+  if not (flags.shouldSkipBls or attestation.signature is TrustedSig):
     var
       pubkeys = newSeqOfCap[ValidatorPubKey](sigs)
     for index in get_attesting_indices(

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -214,7 +214,7 @@ proc state_transition_block_aux(
   # by the block proposer. Every actor in the network will update its state
   # according to the contents of this block - but first they will validate
   # that the block is sane.
-  if skipBlsValidation notin flags:
+  if not flags.shouldSkipBls:
     ? verify_block_signature(state.data, signedBlock)
 
   trace "state_transition: processing block, signature passed",
@@ -342,7 +342,7 @@ proc makeBeaconBlock*(
                                 randao_reveal, eth1_data, graffiti, attestations, deposits,
                                 exits, sync_aggregate, execution_payload)
 
-  let res = process_block(cfg, state.data, blck, {skipBlsValidation}, cache)
+  let res = process_block(cfg, state.data, blck, {localOrigin}, cache)
 
   if res.isErr:
     rollback(state)
@@ -407,7 +407,7 @@ proc makeBeaconBlock*(
                                 randao_reveal, eth1_data, graffiti, attestations, deposits,
                                 exits, sync_aggregate, execution_payload)
 
-  let res = process_block(cfg, state.data, blck, {skipBlsValidation}, cache)
+  let res = process_block(cfg, state.data, blck, {localOrigin}, cache)
 
   if res.isErr:
     rollback(state)
@@ -473,7 +473,7 @@ proc makeBeaconBlock*(
                                 randao_reveal, eth1_data, graffiti, attestations, deposits,
                                 exits, sync_aggregate, execution_payload)
 
-  let res = process_block(cfg, state.data, blck, {skipBlsValidation}, cache)
+  let res = process_block(cfg, state.data, blck, {localOrigin}, cache)
 
   if res.isErr:
     rollback(state)
@@ -514,7 +514,7 @@ proc makeBeaconBlock*(
                            exits, sync_aggregate, executionPayload))
 
     let res = process_block(cfg, state.`kind Data`.data, blck.`kind Data`,
-                            {skipBlsValidation}, cache)
+                            {localOrigin}, cache)
 
     if res.isErr:
       rollback(state)


### PR DESCRIPTION
This would result in our block being rejected (orphaned) in the network.
See the provided comments in `process_deposit` for more details.