### PR TITLE
standardize on upcoming/specified engine API timeouts

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -32,8 +32,6 @@ export sszdump, signatures_batch
 declareHistogram beacon_store_block_duration_seconds,
   "storeBlock() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
 
-const web3Timeout = 4.seconds
-
 type
   BlockEntry* = object
     blck*: ForkedSignedBeaconBlock
@@ -349,7 +347,7 @@ proc runForkchoiceUpdated(
     discard awaitWithTimeout(
       forkchoiceUpdated(
         self.consensusManager.eth1Monitor, headBlockRoot, finalizedBlockRoot),
-      web3Timeout):
+      FORKCHOICEUPDATED_TIMEOUT):
         debug "runForkChoiceUpdated: forkchoiceUpdated timed out"
         default(ForkchoiceUpdatedResponse)
   except CatchableError as err:
@@ -386,7 +384,7 @@ proc newExecutionPayload*(
         awaitWithTimeout(
             eth1Monitor.newPayload(
               executionPayload.asEngineExecutionPayload),
-            web3Timeout):
+            NEWPAYLOAD_TIMEOUT):
           info "newPayload: newPayload timed out"
           PayloadStatusV1(status: PayloadExecutionStatus.syncing)
       payloadStatus = payloadResponse.status

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -25,6 +25,12 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/beacon-chain.md#transition-settings
   TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH* = FAR_FUTURE_EPOCH
 
+  # https://github.com/ethereum/execution-apis/blob/2c3dffa1ad301a5b1d46212e1bd65e918265cd6f/src/engine/specification.md#request-1
+  FORKCHOICEUPDATED_TIMEOUT* = 8.seconds
+
+  # https://github.com/ethereum/execution-apis/blob/2c3dffa1ad301a5b1d46212e1bd65e918265cd6f/src/engine/specification.md#request
+  NEWPAYLOAD_TIMEOUT* = 8.seconds
+
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -1,8 +1,15 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import
   std/[json, typetraits],
-  unittest2, stew/byteutils, json_serialization,
+  unittest2, json_serialization,
   blscurve, eth/keys, libp2p/crypto/crypto as lcrypto,
   nimcrypto/utils as ncrutils,
   ../beacon_chain/spec/[crypto, keystore],


### PR DESCRIPTION
alpha.8 doesn't specify these, but the next version of the engine API will.