### PR TITLE
Improve the compatibility with various Web3Signer versions and configurations

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -662,9 +662,9 @@ proc readValue*(
       reader, "Expected a valid hex string with " & $value.len() & " bytes")
 
 ## ForkedBeaconBlock
-proc readValue*(reader: var JsonReader[RestJson],
-                value: var ForkedBeaconBlock) {.
-     raises: [IOError, SerializationError, Defect].} =
+proc readValue*[BlockType: Web3SignerForkedBeaconBlock|ForkedBeaconBlock](
+    reader: var JsonReader[RestJson],
+    value: var BlockType) {.raises: [IOError, SerializationError, Defect].} =
   var
     version: Option[BeaconBlockFork]
     data: Option[JsonString]
@@ -677,17 +677,17 @@ proc readValue*(reader: var JsonReader[RestJson],
                                     "ForkedBeaconBlock")
       let vres = reader.readValue(string)
       case vres
-      of "phase0":
+      of "PHASE0", "phase0":
         version = some(BeaconBlockFork.Phase0)
-      of "altair":
+      of "ALTAIR", "altair":
         version = some(BeaconBlockFork.Altair)
-      of "bellatrix":
+      of "BELLATRIX", "bellatrix":
         version = some(BeaconBlockFork.Bellatrix)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
-    of "data":
+    of "block", "block_header", "data":
       if data.isSome():
-        reader.raiseUnexpectedField("Multiple data fields found",
+        reader.raiseUnexpectedField("Multiple block or block_header fields found",
                                     "ForkedBeaconBlock")
       data = some(reader.readValue(JsonString))
     else:
@@ -708,7 +708,7 @@ proc readValue*(reader: var JsonReader[RestJson],
         none[phase0.BeaconBlock]()
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect phase0 block format")
-    value = ForkedBeaconBlock.init(res.get())
+    value = ForkedBeaconBlock.init(res.get()).BlockType
   of BeaconBlockFork.Altair:
     let res =
       try:
@@ -718,7 +718,7 @@ proc readValue*(reader: var JsonReader[RestJson],
         none[altair.BeaconBlock]()
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect altair block format")
-    value = ForkedBeaconBlock.init(res.get())
+    value = ForkedBeaconBlock.init(res.get()).BlockType
   of BeaconBlockFork.Bellatrix:
     let res =
       try:
@@ -728,20 +728,29 @@ proc readValue*(reader: var JsonReader[RestJson],
         none[bellatrix.BeaconBlock]()
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect bellatrix block format")
-    value = ForkedBeaconBlock.init(res.get())
+    value = ForkedBeaconBlock.init(res.get()).BlockType
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedBeaconBlock) {.
-     raises: [IOError, Defect].} =
+
+proc writeValue*[BlockType: Web3SignerForkedBeaconBlock|ForkedBeaconBlock](
+    writer: var JsonWriter[RestJson],
+    value: BlockType) {.raises: [IOError, Defect].} =
+
+  template forkIdentifier(id: string): auto =
+    when BlockType is ForkedBeaconBlock:
+      id
+    else:
+      (static toUpperAscii id)
+
   writer.beginRecord()
   case value.kind
   of BeaconBlockFork.Phase0:
-    writer.writeField("version", "phase0")
+    writer.writeField("version", forkIdentifier "phase0")
     writer.writeField("data", value.phase0Data)
   of BeaconBlockFork.Altair:
-    writer.writeField("version", "altair")
+    writer.writeField("version", forkIdentifier "altair")
     writer.writeField("data", value.altairData)
   of BeaconBlockFork.Bellatrix:
-    writer.writeField("version", "bellatrix")
+    writer.writeField("version", forkIdentifier "bellatrix")
     writer.writeField("data", value.bellatrixData)
   writer.endRecord()
 
@@ -1449,7 +1458,7 @@ proc readValue*(reader: var JsonReader[RestJson],
         reader.raiseUnexpectedValue("Field `fork_info` is missing")
       let data =
         block:
-          let res = decodeJsonString(ForkedBeaconBlock, data.get(), true)
+          let res = decodeJsonString(Web3SignerForkedBeaconBlock, data.get(), true)
           if res.isErr():
             reader.raiseUnexpectedValue(
               "Incorrect field `beacon_block` format")

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -488,7 +488,7 @@ type
         serializedFieldName: "block".}: phase0.BeaconBlock
     of Web3SignerRequestKind.BlockV2:
       beaconBlock* {.
-        serializedFieldName: "beacon_block".}: ForkedBeaconBlock
+        serializedFieldName: "beacon_block".}: Web3SignerForkedBeaconBlock
     of Web3SignerRequestKind.Deposit:
       deposit*: Web3SignerDepositData
     of Web3SignerRequestKind.RandaoReveal:
@@ -655,7 +655,7 @@ func init*(t: typedesc[Web3SignerRequest], fork: Fork,
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
-           genesis_validators_root: Eth2Digest, data: ForkedBeaconBlock,
+           genesis_validators_root: Eth2Digest, data: Web3SignerForkedBeaconBlock,
            signingRoot: Option[Eth2Digest] = none[Eth2Digest]()
           ): Web3SignerRequest =
   Web3SignerRequest(

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -107,6 +107,8 @@ type
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
 
+  Web3SignerForkedBeaconBlock* {.borrow: `.`} = distinct ForkedBeaconBlock
+
   ForkedTrustedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:     phase0.TrustedBeaconBlock
@@ -345,8 +347,8 @@ template asTrusted*(x: ForkedSignedBeaconBlock): ForkedTrustedSignedBeaconBlock 
   isomorphicCast[ForkedTrustedSignedBeaconBlock](x)
 
 template withBlck*(
-    x: ForkedBeaconBlock | ForkedSignedBeaconBlock |
-       ForkedTrustedSignedBeaconBlock,
+    x: ForkedBeaconBlock | Web3SignerForkedBeaconBlock |
+    ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock,
     body: untyped): untyped =
   case x.kind
   of BeaconBlockFork.Phase0:
@@ -367,6 +369,8 @@ func proposer_index*(x: ForkedBeaconBlock): uint64 =
 
 func hash_tree_root*(x: ForkedBeaconBlock): Eth2Digest =
   withBlck(x): hash_tree_root(blck)
+
+func hash_tree_root*(x: Web3SignerForkedBeaconBlock): Eth2Digest {.borrow.}
 
 template getForkedBlockField*(x: ForkedSignedBeaconBlock | ForkedTrustedSignedBeaconBlock, y: untyped): untyped =
   # unsafeAddr avoids a copy of the field in some cases

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -205,7 +205,7 @@ proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
                               genesis_validators_root: Eth2Digest,
                               blck: ForkedBeaconBlock): Future[SignatureResult]
                              {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, blck)
+  let request = Web3SignerRequest.init(fork, genesis_validators_root, blck.Web3SignerForkedBeaconBlock)
   debug "Signing block proposal using remote signer",
         validator = shortLog(v)
   return await v.signData(request)


### PR DESCRIPTION
* Some Web3Signer versions insist on replying with text/plain messages
* When reading blocks, the Web3Signer uses upper-case fork identifiers
  instead of lower-case identifies like the Beacon API.