### PR TITLE
fix handling of multiple fork transitions per epoch

### DIFF
--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -4,19 +4,6 @@ import common, api
 
 logScope: service = "fork_service"
 
-proc validateForkSchedule(forks: openArray[Fork]): bool {.raises: [Defect].} =
-  # Check if `forks` list is linked list.
-  var current_version = forks[0].current_version
-  for index, item in forks:
-    if index > 0:
-      if item.previous_version != current_version:
-        return false
-    else:
-      if item.previous_version != item.current_version:
-        return false
-    current_version = item.current_version
-  true
-
 proc sortForks(forks: openArray[Fork]): Result[seq[Fork], cstring] {.
      raises: [Defect].} =
   proc cmp(x, y: Fork): int {.closure.} =
@@ -27,10 +14,8 @@ proc sortForks(forks: openArray[Fork]): Result[seq[Fork], cstring] {.
   if len(forks) == 0:
     return err("Empty fork schedule")
 
-  let sortedForks = sorted(forks, cmp)
-  if not(validateForkSchedule(sortedForks)):
-    return err("Invalid fork schedule")
-  ok(sortedForks)
+  # TODO validity and correct handling of multiple forks per epoch unspecified
+  ok(sorted(forks, cmp))
 
 proc pollForFork(vc: ValidatorClientRef) {.async.} =
   let sres = vc.getCurrentSlot()


### PR DESCRIPTION
`validateForkSchedule` over-validates in the case where `ALTAIR_FORK_EPOCH == BELLATRIX_FORK_EPOCH`. https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/fork.md#upgrading-the-state specifies
```python
        fork=Fork(
            previous_version=pre.fork.current_version,
            current_version=BELLATRIX_FORK_VERSION,
            epoch=epoch,
        ),
```
and since one has to conceptually upgrade state from phase 0 to Altair to Bellatrix, and https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/fork.md#upgrading-the-state creates the Altair fork via
```python
        fork=Fork(
            previous_version=pre.fork.current_version,
            current_version=ALTAIR_FORK_VERSION,
            epoch=epoch,
        ),
```
this implies that `previous_version` in a Bellatrix state will either be (in a test scenario where it starts with Bellatrix) `BELLATRIX_FORK_VERSION`, or in a non-test scenario, `ALTAIR_FORK_VERSION`.

When `ALTAIR_FORK_EPOCH == BELLATRIX_FORK_EPOCH`, therefore, one runs `upgrade_to_bellatrix(upgrade_to_altair(preState))` conceptually, and the fork schedule will look something like:
1. (`previous_version`: `GENESIS_FORK_VERSION`, `current_version`: `GENESIS_FORK_VERSION`, `epoch`: `ALTAIR_FORK_EPOCH`)
2. (`previous_version`: `ALTAIR_FORK_VERSION`, `current_version`: `BELLATRIX_FORK_VERSION`, `epoch`: `BELLATRIX_FORK_EPOCH`)

The Bellatrix consensus spec fork tests confirm that this is the intended interpretation empirically and have a `postState` that looks like
> (`previous_version`: `ALTAIR_FORK_VERSION`, `current_version`: `BELLATRIX_FORK_VERSION`, `epoch`: `BELLATRIX_FORK_EPOCH`)

even when `ALTAIR_FORK_EPOCH == BELLATRIX_FORK_EPOCH == 0`, i.e. there was never any observable moment in beacon chain-time where the `previous_version` Altair fork was ever externally observable.

The fork schedule doesn't, therefore, one-to-one match the state fork linked list version chain the same and can and does skip fork versions entirely.

There's another odd side-effect of this: anything slightly in the past, such as incorporating attestations even a slot or two old, because problematic at just around this threshold, exactly because of the lack of overlap of these fork versions in a linked-list fashion. The failure mode, and it's unclear it's a bug in Nimbus per se, is that attestations near the end of a fork time period get signed with `GENESIS_FORK_VERSION` but then by the time they're incorporated into a block and verified, `GENESIS_FORK_VERSION` is neither `previous_version` nor `current_version`. Therefore, the `get_domain` (https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#get_domain) algorithm does not suffice:
```python
def get_domain(state: BeaconState, domain_type: DomainType, epoch: Epoch=None) -> Domain:
    """
    Return the signature domain (fork version concatenated with domain type) of a message.
    """
    epoch = get_current_epoch(state) if epoch is None else epoch
    fork_version = state.fork.previous_version if epoch < state.fork.epoch else state.fork.current_version
    return compute_domain(domain_type, fork_version, state.genesis_validators_root)
```
There's no way to access the correct `fork_version` to verify the message, because there's no overlap in `fork_version`s between `Fork`s, but rather this noncontiguous cutover. In Nimbus, https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#is_valid_indexed_attestation catches this first, because
```python
    domain = get_domain(state, DOMAIN_BEACON_ATTESTER, indexed_attestation.data.target.epoch)
```
only knows about `fork_version`s in `state`, but not the `fork_version` which created the attestation.

It would be possible for Nimbus to correctly handle these by refactoring things to use the `forkAtEpoch` helper rather than trust `BeaconState.fork`, but that would violate the spec as written for not much gain, currently, so leaving that alone.