### PR TITLE
document and clean up `ValidatorIndex` usage

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -676,7 +676,12 @@ proc validateAggregate*(
   # [REJECT] The aggregator's validator index is within the committee -- i.e.
   # aggregate_and_proof.aggregator_index in get_beacon_committee(state,
   # aggregate.data.slot, aggregate.data.index).
-  if aggregate_and_proof.aggregator_index.ValidatorIndex notin
+
+  let aggregator_index =
+    ValidatorIndex.init(aggregate_and_proof.aggregator_index).valueOr:
+      return checkedReject("Aggregate: invalid aggregator index")
+
+  if aggregator_index notin
       get_beacon_committee(epochRef, slot, committee_index):
     return checkedReject("Aggregate: aggregator's validator index not in committee")
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -963,9 +963,10 @@ func get_sync_committee_cache*(
     s.incl(pk)
 
   var pubkeyIndices: Table[ValidatorPubKey, ValidatorIndex]
-  for i, v in state.validators:
-    if v.pubkey in s:
-      pubkeyIndices[v.pubkey] = i.ValidatorIndex
+  for vidx in state.validators.vindices:
+    let pubkey = state.validators[vidx].pubkey
+    if pubkey in s:
+      pubkeyIndices[pubkey] = vidx
 
   var res: SyncCommitteeCache
   try:

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -5,17 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# This file contains data types that are part of the spec and thus subject to
-# serialization and spec updates.
-#
-# The spec folder in general contains code that has been hoisted from the
-# specification and that follows the spec as closely as possible, so as to make
-# it easy to keep up-to-date.
-#
-# These datatypes are used as specifications for serialization - thus should not
-# be altered outside of what the spec says. Likewise, they should not be made
-# `ref` - this can be achieved by wrapping them in higher-level
-# types / composition
+# Types specific to altair (ie known to have changed across hard forks) - see
+# `base` for types and guidelines common across forks
 
 # TODO Careful, not nil analysis is broken / incomplete and the semantics will
 #      likely change in future versions of the language:
@@ -106,43 +97,43 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#synccommitteemessage
   SyncCommitteeMessage* = object
-    slot*: Slot ##\
-    ## Slot to which this contribution pertains
+    slot*: Slot
+      ## Slot to which this contribution pertains
 
-    beacon_block_root*: Eth2Digest ##\
-    ## Block root for this signature
+    beacon_block_root*: Eth2Digest
+      ## Block root for this signature
 
-    validator_index*: uint64 ##\
-    ## Index of the validator that produced this signature
+    validator_index*: uint64 # `ValidatorIndex` after validation
+      ## Index of the validator that produced this signature
 
-    signature*: ValidatorSig ##\
-    ## Signature by the validator over the block root of `slot`
+    signature*: ValidatorSig
+      ## Signature by the validator over the block root of `slot`
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#synccommitteecontribution
   SyncCommitteeAggregationBits* =
     BitArray[SYNC_SUBCOMMITTEE_SIZE]
 
   SyncCommitteeContribution* = object
-    slot*: Slot ##\
-    ## Slot to which this contribution pertains
+    slot*: Slot
+      ## Slot to which this contribution pertains
 
-    beacon_block_root*: Eth2Digest ##\
-    ## Block root for this contribution
+    beacon_block_root*: Eth2Digest
+      ## Block root for this contribution
 
-    subcommittee_index*: uint64 ##\
-    ## The subcommittee this contribution pertains to out of the broader sync
-    ## committee
+    subcommittee_index*: uint64 # `SyncSubcommitteeIndex` after validation
+      ## The subcommittee this contribution pertains to out of the broader sync
+      ## committee
 
-    aggregation_bits*: SyncCommitteeAggregationBits ##\
-    ## A bit is set if a signature from the validator at the corresponding
-    ## index in the subcommittee is present in the aggregate `signature`.
+    aggregation_bits*: SyncCommitteeAggregationBits
+      ## A bit is set if a signature from the validator at the corresponding
+      ## index in the subcommittee is present in the aggregate `signature`.
 
-    signature*: ValidatorSig  ##\
-    ## Signature by the validator(s) over the block root of `slot`
+    signature*: ValidatorSig
+      ## Signature by the validator(s) over the block root of `slot`
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#contributionandproof
   ContributionAndProof* = object
-    aggregator_index*: uint64
+    aggregator_index*: uint64 # `ValidatorIndex` after validation
     contribution*: SyncCommitteeContribution
     selection_proof*: ValidatorSig
 
@@ -154,27 +145,29 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#syncaggregatorselectiondata
   SyncAggregatorSelectionData* = object
     slot*: Slot
-    subcommittee_index*: uint64
+    subcommittee_index*: uint64 #  # `SyncSubcommitteeIndex` after validation
 
   ### Modified/overloaded
 
   # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientbootstrap
   LightClientBootstrap* = object
-    # The requested beacon block header
     header*: BeaconBlockHeader
+      ## The requested beacon block header
 
-    # Current sync committee corresponding to `header`
     current_sync_committee*: SyncCommittee
+      ## Current sync committee corresponding to `header`
+
     current_sync_committee_branch*:
       array[log2trunc(CURRENT_SYNC_COMMITTEE_INDEX), Eth2Digest]
 
   # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientupdate
   LightClientUpdate* = object
-    # The beacon block header that is attested to by the sync committee
     attested_header*: BeaconBlockHeader
+      ## The beacon block header that is attested to by the sync committee
 
-    # Next sync committee corresponding to `attested_header`
     next_sync_committee*: SyncCommittee
+      ## Next sync committee corresponding to `attested_header`,
+      ## if signature is from current sync committee
     next_sync_committee_branch*:
       array[log2trunc(NEXT_SYNC_COMMITTEE_INDEX), Eth2Digest]
 
@@ -183,10 +176,9 @@ type
     finality_branch*:
       array[log2trunc(FINALIZED_ROOT_INDEX), Eth2Digest]
 
-    # Sync committee aggregate signature
     sync_aggregate*: SyncAggregate
-    # Slot at which the aggregate signature was created (untrusted)
     signature_slot*: Slot
+      ## Slot at which the aggregate signature was created (untrusted)
 
   # https://github.com/ethereum/consensus-specs/blob/vFuture/specs/altair/sync-protocol.md#lightclientfinalityupdate
   LightClientFinalityUpdate* = object
@@ -231,22 +223,22 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/sync-protocol.md#lightclientstore
   LightClientStore* = object
-    finalized_header*: BeaconBlockHeader ##\
-    ## Beacon block header that is finalized
+    finalized_header*: BeaconBlockHeader
+      ## Beacon block header that is finalized
 
-    # Sync committees corresponding to the header
     current_sync_committee*: SyncCommittee
+      ## Sync committees corresponding to the header
     next_sync_committee*: SyncCommittee
 
-    best_valid_update*: Option[LightClientUpdate] ##\
-    ## Best available header to switch finalized head to if we see nothing else
+    best_valid_update*: Option[LightClientUpdate]
+      ## Best available header to switch finalized head to if we see nothing else
 
-    optimistic_header*: BeaconBlockHeader ##\
-    ## Most recent available reasonably-safe header
+    optimistic_header*: BeaconBlockHeader
+      ## Most recent available reasonably-safe header
 
-    # Max number of active participants in a sync committee (used to calculate
-    # safety threshold)
     previous_max_active_participants*: uint64
+      ## Max number of active participants in a sync committee (used to compute
+      ## safety threshold)
     current_max_active_participants*: uint64
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/beacon-chain.md#beaconstate
@@ -258,11 +250,11 @@ type
     fork*: Fork
 
     # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+    latest_block_header*: BeaconBlockHeader
+      ## `latest_block_header.state_root == ZERO_HASH` temporarily
 
-    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
 
     state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
     historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
@@ -275,14 +267,14 @@ type
 
     # Registry
     validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
 
     # Slashings
-    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]
+      ## Per-epoch sums of slashed effective balances
 
     # Participation
     previous_epoch_participation*: EpochParticipationFlags
@@ -291,8 +283,8 @@ type
     # Finality
     justification_bits*: JustificationBits
 
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
+    previous_justified_checkpoint*: Checkpoint
+      ## Previous epoch snapshot
 
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
@@ -343,27 +335,28 @@ type
     ## is formed.
 
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: BeaconBlockBody
 
   SigVerifiedBeaconBlock* = object
     ## A BeaconBlock that contains verified signatures
     ## but that has not been verified for state transition
+
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: SigVerifiedBeaconBlockBody
 
@@ -385,19 +378,19 @@ type
     ##      then, the type must be manually kept compatible with its untrusted
     ##      cousin.
     slot*: Slot
-    proposer_index*: uint64
-    parent_root*: Eth2Digest ##\
-    state_root*: Eth2Digest ##\
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
     body*: TrustedBeaconBlockBody
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
     randao_reveal*: ValidatorSig
-    eth1_data*: Eth1Data ##\
-    ## Eth1 data vote
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
 
-    graffiti*: GraffitiBytes ##\
-    ## Arbitrary data
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
@@ -531,7 +524,7 @@ type
       List[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Represent in full
-    balances*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Mod-increment
     randao_mix*: Eth2Digest

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -145,7 +145,7 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/altair/validator.md#syncaggregatorselectiondata
   SyncAggregatorSelectionData* = object
     slot*: Slot
-    subcommittee_index*: uint64 #  # `SyncSubcommitteeIndex` after validation
+    subcommittee_index*: uint64 # `SyncSubcommitteeIndex` after validation
 
   ### Modified/overloaded
 

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -5,6 +5,9 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+# Types specific to bellatrix (ie known to have changed across hard forks) - see
+# `base` for types and guidelines common across forks
+
 # TODO Careful, not nil analysis is broken / incomplete and the semantics will
 #      likely change in future versions of the language:
 #      https://github.com/nim-lang/RFCs/issues/250
@@ -99,11 +102,11 @@ type
     fork*: Fork
 
     # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+    latest_block_header*: BeaconBlockHeader
+      ## `latest_block_header.state_root == ZERO_HASH` temporarily
 
-    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
 
     state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
     historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
@@ -116,14 +119,14 @@ type
 
     # Registry
     validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
 
     # Slashings
-    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]
+      ## Per-epoch sums of slashed effective balances
 
     # Participation
     previous_epoch_participation*: EpochParticipationFlags
@@ -132,8 +135,8 @@ type
     # Finality
     justification_bits*: JustificationBits
 
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
+    previous_justified_checkpoint*: Checkpoint
+      ## Previous epoch snapshot
 
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
@@ -167,13 +170,13 @@ type
     ## is formed.
 
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: BeaconBlockBody
 
@@ -181,13 +184,13 @@ type
     ## A BeaconBlock that contains verified signatures
     ## but that has not been verified for state transition
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: SigVerifiedBeaconBlockBody
 
@@ -209,19 +212,19 @@ type
     ##      then, the type must be manually kept compatible with its untrusted
     ##      cousin.
     slot*: Slot
-    proposer_index*: uint64
-    parent_root*: Eth2Digest ##\
-    state_root*: Eth2Digest ##\
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
     body*: TrustedBeaconBlockBody
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
     randao_reveal*: ValidatorSig
-    eth1_data*: Eth1Data ##\
-    ## Eth1 data vote
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
 
-    graffiti*: GraffitiBytes ##\
-    ## Arbitrary data
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
@@ -247,11 +250,11 @@ type
     ##
     ## The block state transition has NOT been verified
     randao_reveal*: ValidatorSig
-    eth1_data*: Eth1Data ##\
-    ## Eth1 data vote
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
 
-    graffiti*: GraffitiBytes ##\
-    ## Arbitrary data
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
@@ -267,11 +270,11 @@ type
   TrustedBeaconBlockBody* = object
     ## A full verified block
     randao_reveal*: TrustedSig
-    eth1_data*: Eth1Data ##\
-    ## Eth1 data vote
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
 
-    graffiti*: GraffitiBytes ##\
-    ## Arbitrary data
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -5,17 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# This file contains data types that are part of the spec and thus subject to
-# serialization and spec updates.
-#
-# The spec folder in general contains code that has been hoisted from the
-# specification and that follows the spec as closely as possible, so as to make
-# it easy to keep up-to-date.
-#
-# These datatypes are used as specifications for serialization - thus should not
-# be altered outside of what the spec says. Likewise, they should not be made
-# `ref` - this can be achieved by wrapping them in higher-level
-# types / composition
+# Types specific to phase0 (ie known to have changed across hard forks) - see
+# `base` for types and guidelines common across forks
 
 # TODO Careful, not nil analysis is broken / incomplete and the semantics will
 #      likely change in future versions of the language:
@@ -40,11 +31,11 @@ type
     fork*: Fork
 
     # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+    latest_block_header*: BeaconBlockHeader
+      ## `latest_block_header.state_root == ZERO_HASH` temporarily
 
-    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
 
     state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
     historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
@@ -57,14 +48,14 @@ type
 
     # Registry
     validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
 
     # Slashings
-    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]
+      ## Per-epoch sums of slashed effective balances
 
     # Attestations
     previous_epoch_attestations*:
@@ -75,8 +66,8 @@ type
     # Finality
     justification_bits*: JustificationBits
 
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
+    previous_justified_checkpoint*: Checkpoint
+      ## Previous epoch snapshot
 
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
@@ -100,13 +91,13 @@ type
     ## is formed.
 
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: BeaconBlockBody
 
@@ -119,13 +110,13 @@ type
     ## A BeaconBlock that contains verified signatures
     ## but that has not been verified for state transition
     slot*: Slot
-    proposer_index*: uint64
+    proposer_index*: uint64 # `ValidatorIndex` after validation
 
-    parent_root*: Eth2Digest ##\
-    ## Root hash of the previous block
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
 
-    state_root*: Eth2Digest ##\
-    ## The state root, _after_ this block has been processed
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
 
     body*: SigVerifiedBeaconBlockBody
 
@@ -147,9 +138,9 @@ type
     ##      then, the type must be manually kept compatible with its untrusted
     ##      cousin.
     slot*: Slot
-    proposer_index*: uint64
-    parent_root*: Eth2Digest ##\
-    state_root*: Eth2Digest ##\
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
     body*: TrustedBeaconBlockBody
 
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/beacon-chain.md#beaconblockbody

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -360,22 +360,22 @@ func is_withdrawable_validator*(validator: Validator, epoch: Epoch): bool =
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/beacon-chain.md#get_active_validator_indices
 iterator get_active_validator_indices*(state: ForkyBeaconState, epoch: Epoch):
     ValidatorIndex =
-  for idx in 0..<state.validators.len:
-    if is_active_validator(state.validators[idx], epoch):
-      yield idx.ValidatorIndex
+  for vidx in state.validators.vindices:
+    if is_active_validator(state.validators[vidx], epoch):
+      yield vidx
 
 func get_active_validator_indices*(state: ForkyBeaconState, epoch: Epoch):
     seq[ValidatorIndex] =
   ## Return the sequence of active validator indices at ``epoch``.
   var res = newSeqOfCap[ValidatorIndex](state.validators.len)
-  for idx in get_active_validator_indices(state, epoch):
-    res.add idx
+  for vidx in get_active_validator_indices(state, epoch):
+    res.add vidx
   res
 
 func get_active_validator_indices_len*(state: ForkyBeaconState, epoch: Epoch):
     uint64 =
-  for idx in 0..<state.validators.len:
-    if is_active_validator(state.validators[idx], epoch):
+  for vidx in state.validators.vindices:
+    if is_active_validator(state.validators[vidx], epoch):
       inc result
 
 func get_active_validator_indices_len*(

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -664,11 +664,10 @@ iterator get_flag_index_deltas*(
       info, flag_index)
     active_increments = get_active_increments(info)
 
-  for index in 0 ..< state.validators.len:
-    if not is_eligible_validator(info.validators[index]):
+  for vidx in state.validators.vindices:
+    if not is_eligible_validator(info.validators[vidx]):
       continue
 
-    template vidx: ValidatorIndex = index.ValidatorIndex
     let base_reward = get_base_reward_increment(state, vidx, base_reward_per_increment)
     yield
       if is_unslashed_participating_index(
@@ -705,16 +704,15 @@ iterator get_inactivity_penalty_deltas*(
       cfg.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_ALTAIR
     previous_epoch = get_previous_epoch(state)
 
-  for index in 0 ..< state.validators.len:
-    if not is_eligible_validator(info.validators[index]):
+  for vidx in state.validators.vindices:
+    if not is_eligible_validator(info.validators[vidx]):
       continue
 
-    template vidx: untyped = index.ValidatorIndex
     if not is_unslashed_participating_index(
         state, TIMELY_TARGET_FLAG_INDEX, previous_epoch, vidx):
       let
-        penalty_numerator = state.validators[index].effective_balance *
-          state.inactivity_scores[index]
+        penalty_numerator = state.validators[vidx].effective_balance *
+          state.inactivity_scores[vidx]
       yield (vidx, Gwei(penalty_numerator div penalty_denominator))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/beacon-chain.md#modified-get_inactivity_penalty_deltas
@@ -729,16 +727,15 @@ iterator get_inactivity_penalty_deltas*(
       cfg.INACTIVITY_SCORE_BIAS * INACTIVITY_PENALTY_QUOTIENT_BELLATRIX
     previous_epoch = get_previous_epoch(state)
 
-  for index in 0 ..< state.validators.len:
-    if not is_eligible_validator(info.validators[index]):
+  for vidx in state.validators.vindices:
+    if not is_eligible_validator(info.validators[vidx]):
       continue
 
-    template vidx: untyped = index.ValidatorIndex
     if not is_unslashed_participating_index(
         state, TIMELY_TARGET_FLAG_INDEX, previous_epoch, vidx):
       let
-        penalty_numerator = state.validators[index].effective_balance *
-          state.inactivity_scores[index]
+        penalty_numerator = state.validators[vidx].effective_balance *
+          state.inactivity_scores[vidx]
       yield (vidx, Gwei(penalty_numerator div penalty_denominator))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/beacon-chain.md#rewards-and-penalties-1
@@ -819,22 +816,22 @@ func process_registry_updates*(
   # the current epoch, 1 + MAX_SEED_LOOKAHEAD epochs ahead. Thus caches
   # remain valid for this epoch through though this function along with
   # the rest of the epoch transition.
-  for index in 0..<state.validators.len():
-    if is_eligible_for_activation_queue(state.validators.asSeq()[index]):
-      state.validators[index].activation_eligibility_epoch =
+  for vidx in state.validators.vindices:
+    if is_eligible_for_activation_queue(state.validators.asSeq()[vidx]):
+      state.validators[vidx].activation_eligibility_epoch =
         get_current_epoch(state) + 1
 
-    if is_active_validator(state.validators.asSeq()[index], get_current_epoch(state)) and
-        state.validators.asSeq()[index].effective_balance <= cfg.EJECTION_BALANCE:
-      initiate_validator_exit(cfg, state, index.ValidatorIndex, cache)
+    if is_active_validator(state.validators.asSeq()[vidx], get_current_epoch(state)) and
+        state.validators.asSeq()[vidx].effective_balance <= cfg.EJECTION_BALANCE:
+      initiate_validator_exit(cfg, state, vidx, cache)
 
   ## Queue validators eligible for activation and not dequeued for activation
-  var activation_queue : seq[tuple[a: Epoch, b: int]] = @[]
-  for index in 0..<state.validators.len():
-    let validator = unsafeAddr state.validators.asSeq()[index]
+  var activation_queue : seq[tuple[a: Epoch, b: ValidatorIndex]] = @[]
+  for vidx in state.validators.vindices:
+    let validator = unsafeAddr state.validators.asSeq()[vidx]
     if is_eligible_for_activation(state, validator[]):
       activation_queue.add (
-        validator[].activation_eligibility_epoch, index)
+        validator[].activation_eligibility_epoch, vidx)
 
   activation_queue.sort(system.cmp)
 
@@ -845,8 +842,8 @@ func process_registry_updates*(
     if i.uint64 >= churn_limit:
       break
     let
-      (_, index) = epoch_and_index
-    state.validators[index].activation_epoch =
+      (_, vidx) = epoch_and_index
+    state.validators[vidx].activation_epoch =
       compute_activation_exit_epoch(get_current_epoch(state))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/beacon-chain.md#slashings
@@ -895,12 +892,12 @@ func process_slashings*(state: var ForkyBeaconState, total_balance: Gwei) =
     adjusted_total_slashing_balance = get_adjusted_total_slashing_balance(
       state, total_balance)
 
-  for index in 0..<state.validators.len:
-    let validator = unsafeAddr state.validators.asSeq()[index]
+  for vidx in state.validators.vindices:
+    let validator = unsafeAddr state.validators.asSeq()[vidx]
     if slashing_penalty_applies(validator[], epoch):
       let penalty = validator[].get_slashing_penalty(
         adjusted_total_slashing_balance, total_balance)
-      decrease_balance(state, index.ValidatorIndex, penalty)
+      decrease_balance(state, vidx, penalty)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/beacon-chain.md#eth1-data-votes-updates
 func process_eth1_data_reset*(state: var ForkyBeaconState) =

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -41,7 +41,7 @@ type
     currentEpochParticipation: EpochParticipationFlags
     previousEpochParticipation: EpochParticipationFlags
 
-  PubkeyToIndexTable = Table[ValidatorPubKey, int]
+  PubkeyToIndexTable = Table[ValidatorPubKey, ValidatorIndex]
 
   AuxiliaryState* = object
     epochParticipationFlags: ParticipationFlags
@@ -340,12 +340,13 @@ proc collectFromDeposits(
       let pubkey = deposit.data.pubkey
       let amount = deposit.data.amount
       var index = findValidatorIndex(state.data, pubkey)
-      if index == -1:
-        index = pubkeyToIndex.getOrDefault(pubkey, -1)
-      if index != -1:
-        rewardsAndPenalties[index].deposits += amount
+      if index.isNone:
+        if pubkey in pubkeyToIndex:
+          index = Opt[ValidatorIndex].ok(pubkeyToIndex[pubkey])
+      if index.isSome:
+        rewardsAndPenalties[index.get()].deposits += amount
       elif verify_deposit_signature(cfg, deposit.data):
-        pubkeyToIndex[pubkey] = rewardsAndPenalties.len
+        pubkeyToIndex[pubkey] = ValidatorIndex(rewardsAndPenalties.len)
         rewardsAndPenalties.add(
           RewardsAndPenalties(deposits: amount))
 


### PR DESCRIPTION
* document static vs dynamic range checking requirements
* add `vindices` iterator to iterate over valid validator indices in a
state
* clean up spec comments in general