### PR TITLE
consensus specs v1.2.0-rc.1

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -744,8 +744,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - add_to_activation_queue [Preset: mainnet]                               OK
 + Registry updates - ejection [Preset: mainnet]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Altair - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -901,8 +902,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - add_to_activation_queue [Preset: mainnet]                               OK
 + Registry updates - ejection [Preset: mainnet]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Bellatrix - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -962,6 +964,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 ## EF - ForkChoice [Preset: mainnet]
 ```diff
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
+  ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        Skip
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
 + ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
@@ -972,7 +975,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 + ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               OK
 + ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
 ```
-OK: 9/10 Fail: 0/10 Skip: 1/10
+OK: 9/11 Fail: 0/11 Skip: 2/11
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1025,8 +1028,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - add_to_activation_queue [Preset: mainnet]                               OK
 + Registry updates - ejection [Preset: mainnet]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
+OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Phase 0 - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -1220,4 +1224,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1035/1038 Fail: 0/1038 Skip: 3/1038
+OK: 1038/1042 Fail: 0/1042 Skip: 4/1042

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -776,8 +776,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection [Preset: minimal]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: minimal]                         OK
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
+OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -948,8 +949,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection [Preset: minimal]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: minimal]                         OK
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
+OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -1018,6 +1020,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
 ## EF - ForkChoice [Preset: minimal]
 ```diff
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        Skip
+  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/filtered_block_tree          Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/genesis                      Skip
   ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  Skip
@@ -1038,7 +1041,7 @@ OK: 38/38 Fail: 0/38 Skip: 0/38
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               Skip
   ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo Skip
 ```
-OK: 0/20 Fail: 0/20 Skip: 20/20
+OK: 0/21 Fail: 0/21 Skip: 21/21
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1095,8 +1098,9 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection [Preset: minimal]                                              OK
 + Registry updates - ejection_past_churn_limit_min [Preset: minimal]                         OK
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
++ Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
+OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Phase 0 - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -1297,4 +1301,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1085/1107 Fail: 0/1107 Skip: 22/1107
+OK: 1088/1111 Fail: 0/1111 Skip: 23/1111

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -105,7 +105,7 @@ func init*(T: type ProtoArray,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#configuration
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#get_latest_attesting_balance
-const PROPOSER_SCORE_BOOST* = 70
+const PROPOSER_SCORE_BOOST* = 40
 func calculateProposerBoost(validatorBalances: openArray[Gwei]): int64 =
   var
     total_balance: uint64

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.1.10"
+const SPEC_VERSION* = "1.2.0-rc.1"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -126,7 +126,8 @@ func clear_epoch_from_cache(cache: var StateCache, epoch: Epoch) =
 proc advance_slot(
     cfg: RuntimeConfig,
     state: var ForkyBeaconState, previous_slot_state_root: Eth2Digest,
-    flags: UpdateFlags, cache: var StateCache, info: var ForkyEpochInfo) =
+    flags: UpdateFlags, cache: var StateCache, info: var ForkyEpochInfo):
+    Result[void, cstring] =
   # Do the per-slot and potentially the per-epoch processing, then bump the
   # slot number - we've now arrived at the slot state on top of which a block
   # optionally can be applied.
@@ -137,10 +138,12 @@ proc advance_slot(
   let is_epoch_transition = (state.slot + 1).is_epoch
   if is_epoch_transition:
     # Note: Genesis epoch = 0, no need to test if before Genesis
-    process_epoch(cfg, state, flags, cache, info)
+    ? process_epoch(cfg, state, flags, cache, info)
     clear_epoch_from_cache(cache, (state.slot + 1).epoch)
 
   state.slot += 1
+
+  ok()
 
 func noRollback*(state: var phase0.HashedBeaconState) =
   trace "Skipping rollback of broken phase 0 state"
@@ -192,8 +195,7 @@ proc process_slots*(
   while getStateField(state, slot) < slot:
     withState(state):
       withEpochInfo(state.data, info):
-        advance_slot(
-          cfg, state.data, state.root, flags, cache, info)
+        ? advance_slot(cfg, state.data, state.root, flags, cache, info)
 
       if skipLastStateRootCalculation notin flags or
           state.data.slot < slot:

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -178,7 +178,7 @@ proc process_proposer_slashing*(
     cache: var StateCache):
     Result[void, cstring] =
   let proposer_index = ? check_proposer_slashing(state, proposer_slashing, flags)
-  slash_validator(cfg, state, proposer_index, cache)
+  ? slash_validator(cfg, state, proposer_index, cache)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#is_slashable_attestation_data
@@ -247,7 +247,7 @@ proc process_attester_slashing*(
     ? check_attester_slashing(state, attester_slashing, flags)
 
   for index in slashed_attesters:
-    slash_validator(cfg, state, index, cache)
+    ? slash_validator(cfg, state, index, cache)
 
   ok()
 
@@ -376,7 +376,7 @@ proc process_voluntary_exit*(
     cache: var StateCache): Result[void, cstring] =
   let exited_validator =
     ? check_voluntary_exit(cfg, state, signed_voluntary_exit, flags)
-  initiate_validator_exit(cfg, state, exited_validator, cache)
+  ? initiate_validator_exit(cfg, state, exited_validator, cache)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#operations

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -798,7 +798,8 @@ func process_rewards_and_penalties(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#registry-updates
 func process_registry_updates*(
-    cfg: RuntimeConfig, state: var ForkyBeaconState, cache: var StateCache) =
+    cfg: RuntimeConfig, state: var ForkyBeaconState, cache: var StateCache):
+    Result[void, cstring] =
   ## Process activation eligibility and ejections
 
   # Make visible, e.g.,
@@ -823,7 +824,7 @@ func process_registry_updates*(
 
     if is_active_validator(state.validators.asSeq()[vidx], get_current_epoch(state)) and
         state.validators.asSeq()[vidx].effective_balance <= cfg.EJECTION_BALANCE:
-      initiate_validator_exit(cfg, state, vidx, cache)
+      ? initiate_validator_exit(cfg, state, vidx, cache)
 
   ## Queue validators eligible for activation and not dequeued for activation
   var activation_queue : seq[tuple[a: Epoch, b: ValidatorIndex]] = @[]
@@ -845,6 +846,8 @@ func process_registry_updates*(
       (_, vidx) = epoch_and_index
     state.validators[vidx].activation_epoch =
       compute_activation_exit_epoch(get_current_epoch(state))
+
+  ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#slashings
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/beacon-chain.md#slashings
@@ -1034,7 +1037,7 @@ func process_inactivity_updates*(
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#epoch-processing
 proc process_epoch*(
     cfg: RuntimeConfig, state: var phase0.BeaconState, flags: UpdateFlags,
-    cache: var StateCache, info: var phase0.EpochInfo) =
+    cache: var StateCache, info: var phase0.EpochInfo): Result[void, cstring] =
   let currentEpoch = get_current_epoch(state)
   trace "process_epoch",
     current_epoch = currentEpoch
@@ -1054,7 +1057,7 @@ proc process_epoch*(
     doAssert state.finalized_checkpoint.epoch + 3 >= currentEpoch
 
   process_rewards_and_penalties(state, info)
-  process_registry_updates(cfg, state, cache)
+  ? process_registry_updates(cfg, state, cache)
   process_slashings(state, info.balances.current_epoch)
   process_eth1_data_reset(state)
   process_effective_balance_updates(state)
@@ -1062,6 +1065,8 @@ proc process_epoch*(
   process_randao_mixes_reset(state)
   process_historical_roots_update(state)
   process_participation_record_updates(state)
+
+  ok()
 
 func init*(
     info: var altair.EpochInfo,
@@ -1087,8 +1092,8 @@ func init*(
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/beacon-chain.md#epoch-processing
 proc process_epoch*(
     cfg: RuntimeConfig, state: var (altair.BeaconState | bellatrix.BeaconState),
-    flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo)
-    =
+    flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
+    Result[void, cstring] =
   let currentEpoch = get_current_epoch(state)
   trace "process_epoch",
     current_epoch = currentEpoch
@@ -1114,21 +1119,17 @@ proc process_epoch*(
   process_rewards_and_penalties(cfg, state, info)
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#registry-updates
-  process_registry_updates(cfg, state, cache)
+  ? process_registry_updates(cfg, state, cache)
 
   # https://github.com/ethereum/consensus-specs/blob/v1.0.1/specs/phase0/beacon-chain.md#slashings
   process_slashings(state, info.balances.current_epoch)
 
   process_eth1_data_reset(state)
-
   process_effective_balance_updates(state)
-
   process_slashings_reset(state)
-
   process_randao_mixes_reset(state)
-
   process_historical_roots_update(state)
-
   process_participation_flag_updates(state)  # [New in Altair]
-
   process_sync_committee_updates(state)  # [New in Altair]
+
+  ok()

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -32,17 +32,17 @@ template runSuite(
         # BeaconState objects are stored on the heap to avoid stack overflow
         type T = altair.BeaconState
         let preState {.inject.} = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
-        let postState = newClone(parseTest(testDir/"post.ssz_snappy", SSZ, T))
         var cache {.inject, used.} = StateCache()
         template state: untyped {.inject, used.} = preState[]
         template cfg: untyped {.inject, used.} = defaultRuntimeConfig
 
-        transitionProc
-
-        check:
-          hash_tree_root(preState[]) == hash_tree_root(postState[])
-
-        reportDiff(preState, postState)
+        if transitionProc.isOk:
+          let postState =
+            newClone(parseTest(testDir/"post.ssz_snappy", SSZ, T))
+          check: hash_tree_root(preState[]) == hash_tree_root(postState[])
+          reportDiff(preState, postState)
+        else:
+          check: not fileExists(testDir/"post.ssz_snappy")
 
 # Justification & Finalization
 # ---------------------------------------------------------------
@@ -51,6 +51,7 @@ const JustificationFinalizationDir = RootDir/"justification_and_finalization"/"p
 runSuite(JustificationFinalizationDir, "Justification & Finalization"):
   let info = altair.EpochInfo.init(state)
   process_justification_and_finalization(state, info.balances)
+  Result[void, cstring].ok()
 
 # Inactivity updates
 # ---------------------------------------------------------------
@@ -59,6 +60,7 @@ const InactivityDir = RootDir/"inactivity_updates"/"pyspec_tests"
 runSuite(InactivityDir, "Inactivity"):
   let info = altair.EpochInfo.init(state)
   process_inactivity_updates(cfg, state, info)
+  Result[void, cstring].ok()
 
 # Rewards & Penalties
 # ---------------------------------------------------------------
@@ -79,6 +81,7 @@ const SlashingsDir = RootDir/"slashings"/"pyspec_tests"
 runSuite(SlashingsDir, "Slashings"):
   let info = altair.EpochInfo.init(state)
   process_slashings(state, info.balances.current_epoch)
+  Result[void, cstring].ok()
 
 # Eth1 data reset
 # ---------------------------------------------------------------
@@ -86,6 +89,7 @@ runSuite(SlashingsDir, "Slashings"):
 const Eth1DataResetDir = RootDir/"eth1_data_reset/"/"pyspec_tests"
 runSuite(Eth1DataResetDir, "Eth1 data reset"):
   process_eth1_data_reset(state)
+  Result[void, cstring].ok()
 
 # Effective balance updates
 # ---------------------------------------------------------------
@@ -93,6 +97,7 @@ runSuite(Eth1DataResetDir, "Eth1 data reset"):
 const EffectiveBalanceUpdatesDir = RootDir/"effective_balance_updates"/"pyspec_tests"
 runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates"):
   process_effective_balance_updates(state)
+  Result[void, cstring].ok()
 
 # Slashings reset
 # ---------------------------------------------------------------
@@ -100,6 +105,7 @@ runSuite(EffectiveBalanceUpdatesDir, "Effective balance updates"):
 const SlashingsResetDir = RootDir/"slashings_reset"/"pyspec_tests"
 runSuite(SlashingsResetDir, "Slashings reset"):
   process_slashings_reset(state)
+  Result[void, cstring].ok()
 
 # RANDAO mixes reset
 # ---------------------------------------------------------------
@@ -107,6 +113,7 @@ runSuite(SlashingsResetDir, "Slashings reset"):
 const RandaoMixesResetDir = RootDir/"randao_mixes_reset"/"pyspec_tests"
 runSuite(RandaoMixesResetDir, "RANDAO mixes reset"):
   process_randao_mixes_reset(state)
+  Result[void, cstring].ok()
 
 # Historical roots update
 # ---------------------------------------------------------------
@@ -114,6 +121,7 @@ runSuite(RandaoMixesResetDir, "RANDAO mixes reset"):
 const HistoricalRootsUpdateDir = RootDir/"historical_roots_update"/"pyspec_tests"
 runSuite(HistoricalRootsUpdateDir, "Historical roots update"):
   process_historical_roots_update(state)
+  Result[void, cstring].ok()
 
 # Participation flag updates
 # ---------------------------------------------------------------
@@ -121,10 +129,16 @@ runSuite(HistoricalRootsUpdateDir, "Historical roots update"):
 const ParticipationFlagDir = RootDir/"participation_flag_updates"/"pyspec_tests"
 runSuite(ParticipationFlagDir, "Participation flag updates"):
   process_participation_flag_updates(state)
+  Result[void, cstring].ok()
 
 # Sync committee updates
 # ---------------------------------------------------------------
 
+# These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-runSuite(SyncCommitteeDir, "Sync committee updates"):
-  process_sync_committee_updates(state)
+when const_preset == "minimal":
+  runSuite(SyncCommitteeDir, "Sync committee updates"):
+    process_sync_committee_updates(state)
+    Result[void, cstring].ok()
+else:
+  doAssert not dirExists(SyncCommitteeDir)

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_light_client_sync.nim
@@ -139,6 +139,6 @@ suite "EF - Altair - Sync protocol - Light client" & preset():
     # `make test` from `nimbus-eth2` to ensure that the regular test vectors
     # have been downloaded and extracted, then proceed from `nimbus-eth2` with:
     # $ rsync -r ../consensus-spec-tests/tests/ \
-    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.1.10/
+    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.2.0-rc.1/
     test "All tests":
       skip()

--- a/tests/consensus_spec/altair/test_fixture_sync_protocol_update_ranking.nim
+++ b/tests/consensus_spec/altair/test_fixture_sync_protocol_update_ranking.nim
@@ -83,6 +83,6 @@ suite "EF - Altair - Sync protocol - Update ranking" & preset():
     # `make test` from `nimbus-eth2` to ensure that the regular test vectors
     # have been downloaded and extracted, then proceed from `nimbus-eth2` with:
     # $ rsync -r ../consensus-spec-tests/tests/ \
-    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.1.10/
+    #   ../nimbus-eth2/vendor/nim-eth2-scenarios/tests-v1.2.0-rc.1/
     test "All tests":
       skip()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -329,6 +329,7 @@ suite "EF - ForkChoice" & preset():
     # test: tests/fork_choice/scenarios/no_votes.nim
     #       "Ensure the head is still 4 whilst the justified epoch is 0."
     "on_block_future_block",
+    "discard_equivocations" # TODO
   ]
 
   for fork in [BeaconBlockFork.Phase0]: # TODO: init ChainDAG from Merge/Altair


### PR DESCRIPTION
`discard_equivocations` should be implemented, but people want their 40% proposer boost, and this gets that without breaking mainnet compat and with an EF CL spec test suite for it too, so I consider `discard_equivocations` outside the scope of this PR.