### PR TITLE
REST parameter defaults

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -638,9 +638,9 @@ type
 
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
-          defaultValue: defaultBeaconNode
+          defaultValue: resolveTAddress(defaultBeaconNode)
           defaultValueDesc: "http://127.0.0.1:5052"
-          name: "rest-url" }: Option[Uri]
+          name: "rest-url" }: string
 
     of BNStartUpCmd.record:
       case recordCmd* {.command.}: RecordCmd

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -46,6 +46,7 @@ const
   defaultListenAddress* = (static ValidIpAddress.init("0.0.0.0"))
   defaultAdminListenAddress* = (static ValidIpAddress.init("127.0.0.1"))
   defaultSigningNodeRequestTimeout* = 60
+  defaultBeaconNode* = "http://127.0.0.1:" & $DefaultEth2RestPort
 
 when defined(windows):
   {.pragma: windowsOnly.}
@@ -637,6 +638,8 @@ type
 
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
+          defaultValue: defaultBeaconNode
+          defaultValueDesc: "http://127.0.0.1:5052"
           name: "rest-url" }: Option[Uri]
 
     of BNStartUpCmd.record:
@@ -696,7 +699,8 @@ type
     of BNStartUpCmd.trustedNodeSync:
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
-        defaultValue: "http://localhost:5052"
+        defaultValue: defaultBeaconNode
+        defaultValueDesc: "http://127.0.0.1:5052"
         name: "trusted-node-url"
       .}: string
 
@@ -788,6 +792,8 @@ type
 
     beaconNodes* {.
       desc: "URL addresses to one or more beacon node HTTP REST APIs",
+      defaultValue: @[defaultBeaconNode]
+      defaultValueDesc: "http://127.0.0.1:5052"
       name: "beacon-node" }: seq[string]
 
   SigningNodeConf* = object

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -638,7 +638,7 @@ type
 
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
-          defaultValue: resolveTAddress(defaultBeaconNode)
+          defaultValue: defaultBeaconNode
           defaultValueDesc: "http://127.0.0.1:5052"
           name: "rest-url" }: string
 

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -110,22 +110,7 @@ proc askForExitConfirmation(): ClientExitAction =
 
 proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   let
-    address = if isNone(config.restUrlForExit):
-      resolveTAddress("127.0.0.1", Port(DefaultEth2RestPort))[0]
-    else:
-      let taseq = try:
-        resolveTAddress($config.restUrlForExit.get().hostname &
-                        ":" &
-                        $config.restUrlForExit.get().port)
-      except CatchableError as err:
-        fatal "Failed to resolve address", err = err.msg
-        quit 1
-      if len(taseq) == 1:
-        taseq[0]
-      else:
-        taseq[1]
-
-    client = RestClientRef.new(address)
+    client = RestClientRef.new(config.restUrlForExit)
 
     stateIdHead = StateIdent(kind: StateQueryKind.Named,
                              value: StateIdentType.Head)

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -110,7 +110,8 @@ proc askForExitConfirmation(): ClientExitAction =
 
 proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   let
-    client = RestClientRef.new(config.restUrlForExit)
+    client = RestClientRef.new(config.restUrlForExit).valueOr:
+      raise (ref RestError)(msg: $error)
 
     stateIdHead = StateIdent(kind: StateQueryKind.Named,
                              value: StateIdentType.Head)

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -184,6 +184,7 @@ programMain:
       servers
 
   if len(beaconNodes) == 0:
+    # This should not happen, thanks to defaults in `conf.nim`
     fatal "Not enough beacon nodes in command line"
     quit 1
 

--- a/docs/the_nimbus_book/src/voluntary-exit.md
+++ b/docs/the_nimbus_book/src/voluntary-exit.md
@@ -1,15 +1,18 @@
 # Perform a voluntary exit
 
+Voluntary exits allow validators to permanently stop performing their duties, and eventually recover the deposit.
+
+Exits are subject to a wait period that depends on the length of the exit queue. While a validator is exiting, it still must perform its duties in order not to lose funds to inactivity penalities.
+
 > ⚠️  Voluntary exits are **irreversible**. You won't be able to validate again with the same key. And you won't be able to withdraw your stake until the Eth1 and Eth2 merge. *Note that voluntary exits won't be processed if the chain isn't finalising.*
 
-To perform a voluntary exit, make sure your beacon node is running with the `--rpc`option enabled (e.g. `./run-mainnet-beacon-node.sh --rpc`), then run:
-
+To perform a voluntary exit, make sure your beacon node is running with the `--rest`option enabled (e.g. `./run-mainnet-beacon-node.sh --rest`), then run:
 
 **Prater**
 
 ```
-build/nimbus_beacon_node deposits exit \ 
- --validator=<VALIDATOR_PUBLIC_KEY> \ 
+build/nimbus_beacon_node deposits exit \
+ --validator=<VALIDATOR_PUBLIC_KEY> \
  --data-dir=build/data/shared_prater_0
 ```
 
@@ -17,7 +20,7 @@ build/nimbus_beacon_node deposits exit \
 **Mainnet**
 
 ```
-build/nimbus_beacon_node deposits exit \ 
+build/nimbus_beacon_node deposits exit \
  --validator=<VALIDATOR_PUBLIC_KEY> \
  --data-dir=build/data/shared_mainnet_0
 ```
@@ -26,6 +29,6 @@ build/nimbus_beacon_node deposits exit \
 
 ## `rest-url` parameter
 
-As of `v1.7.0` the `deposits exit` command can accept a `--rest-url` parameter. This means you can issue exits with any [REST API](./rest-api.md) compatible beacon node 
+> **Note:** This feature is available from `v1.7.0` onwards - earlier versions relied on the now removed [JSON-RPC API](./api.md).
 
-
+The `--rest-url` parameter can be used to point the exit command to a specific node for publishing the request, as long as it's compatible with the [REST API](./rest-api.md).


### PR DESCRIPTION
* add default BN for VC
* unify "default" beacon node across commands
* clean up validator exit docs