### PR TITLE
disallow non-(genesis, far-future) equal transition epochs

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -673,8 +673,18 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     for j in i+1 ..< forkVersions.len:
       doAssert forkVersions[i] != forkVersions[j]
 
-  doAssert cfg.ALTAIR_FORK_EPOCH <= cfg.BELLATRIX_FORK_EPOCH
-  doAssert cfg.BELLATRIX_FORK_EPOCH <= cfg.SHARDING_FORK_EPOCH
+  template assertForkEpochOrder(
+      firstForkEpoch: Epoch, secondForkEpoch: Epoch) =
+    doAssert firstForkEpoch <= secondForkEpoch
+
+    # TODO https://github.com/ethereum/consensus-specs/issues/2902 multiple
+    # fork transitions per epoch don't work in a well-defined way.
+    doAssert firstForkEpoch < secondForkEpoch or
+             firstForkEpoch in [GENESIS_EPOCH, FAR_FUTURE_EPOCH]
+
+  assertForkEpochOrder(cfg.ALTAIR_FORK_EPOCH, cfg.BELLATRIX_FORK_EPOCH)
+  assertForkEpochorder(cfg.BELLATRIX_FORK_EPOCH, cfg.SHARDING_FORK_EPOCH)
+
   doAssert updateFlags in [{}, {verifyFinalization}],
     "Other flags not supported in ChainDAG"
 

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -618,6 +618,8 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
       missingParentSlot: Option[Slot]
 
       # compiler segfault if this is moved into the for loop, at time of writing
+      # TODO this does segfault in 1.2 but not 1.6, so remove workaround when 1.2
+      # is dropped.
       res: Result[void, BlockError]
 
     for blk in sq.blocks(item):


### PR DESCRIPTION
An alternative approach to https://github.com/status-im/nimbus-eth2/pull/3649 in some sense, though arguably complementary.

That turns out to be not per se just a Nimbus bug, and it's not clear it's worth trying to perfect handling of a scenario the protocol itself doesn't permit without pitfalls and which doesn't occur in any in-the-wild testnet (excepting empheral Hive-like or other local or temporary testnets people might construct, but not mainnet, Prater, Kiln, Ropsten, any of the Goerli/Mainnet shadow forks, etc).