### PR TITLE
refactor fork consistency checking and gate compilation on it

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -665,32 +665,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            serveLightClientData = false,
            importLightClientData = ImportLightClientData.None,
            vanityLogs = default(VanityLogs)): ChainDAGRef =
-  # TODO move fork version sanity checking elsewhere?
-
-  # TODO re-add cfg.CAPELLA_FORK_VERSION once eth-clients repos include it and
-  # fix SHARDING_FORK_VERSION to be its new FORK_VERSION. Until then make sure
-  # that it will never actually use the Capella fork.
-  doAssert cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH
-
-  let forkVersions =
-    [cfg.GENESIS_FORK_VERSION, cfg.ALTAIR_FORK_VERSION,
-     cfg.BELLATRIX_FORK_VERSION, cfg.SHARDING_FORK_VERSION]
-  for i in 0 ..< forkVersions.len:
-    for j in i+1 ..< forkVersions.len:
-      doAssert forkVersions[i] != forkVersions[j]
-
-  template assertForkEpochOrder(
-      firstForkEpoch: Epoch, secondForkEpoch: Epoch) =
-    doAssert firstForkEpoch <= secondForkEpoch
-
-    # TODO https://github.com/ethereum/consensus-specs/issues/2902 multiple
-    # fork transitions per epoch don't work in a well-defined way.
-    doAssert firstForkEpoch < secondForkEpoch or
-             firstForkEpoch in [GENESIS_EPOCH, FAR_FUTURE_EPOCH]
-
-  assertForkEpochOrder(cfg.ALTAIR_FORK_EPOCH, cfg.BELLATRIX_FORK_EPOCH)
-  assertForkEpochOrder(cfg.BELLATRIX_FORK_EPOCH, cfg.CAPELLA_FORK_EPOCH)
-  assertForkEpochOrder(cfg.CAPELLA_FORK_EPOCH, cfg.SHARDING_FORK_EPOCH)
+  cfg.checkForkConsistency()
 
   doAssert updateFlags in [{}, {verifyFinalization}],
     "Other flags not supported in ChainDAG"

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -240,6 +240,9 @@ when not defined(gnosisChainBinary):
       mainnetMetadata* = eth2Network("shared/mainnet", mainnet)
       praterMetadata* = eth2Network("shared/prater", goerli)
       ropstenMetadata = mergeTestnet("ropsten-beacon-chain", ropsten)
+    static:
+      for network in [mainnetMetadata, praterMetadata, ropstenMetadata]:
+        checkForkConsistency(network.cfg)
 
   proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata {.raises: [Defect, IOError].} =
     template loadRuntimeMetadata: auto =
@@ -283,6 +286,8 @@ else:
   const
     gnosisMetadata* = loadCompileTimeNetworkMetadata(
       currentSourcePath.parentDir.replace('\\', '/') & "/../../media/gnosis")
+
+  static: checkForkConsistency(gnosisMetadata.cfg)
 
   proc checkNetworkParameterUse*(eth2Network: Option[string]) =
     # Support `gnosis-chain` as network name which was used in v22.3


### PR DESCRIPTION
This adds, effectively, tests, though it organizes them as some in-line compile-time checks to accommodate the Gnosis network definitions.