### PR TITLE
fix Nim 1.6 build deprecation warnings

### DIFF
--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -155,11 +155,11 @@ func addUnviable*(quarantine: var Quarantine, root: Eth2Digest) =
 
     for k in toRemove:
       quarantine.orphans.del k
-      quarantine.unviable.add(k[0], ())
+      quarantine.unviable[k[0]] = ()
 
     toRemove.setLen(0)
 
-  quarantine.unviable.add(root, ())
+  quarantine.unviable[root] = ()
 
 func cleanupOrphans(quarantine: var Quarantine, finalizedSlot: Slot) =
   var toDel: seq[(Eth2Digest, ValidatorSig)]
@@ -201,7 +201,7 @@ func addOrphan*(
   let parent_root = getForkedBlockField(signedBlock, parent_root)
 
   if parent_root in quarantine.unviable:
-    quarantine.unviable.add(signedBlock.root, ())
+    quarantine.unviable[signedBlock.root] = ()
     return true
 
   # Even if the quarantine is full, we need to schedule its parent for


### PR DESCRIPTION
This fixes 3 warnings, each of which individually appears 10 times in a full (`make test && make`) build:
```
beacon_chain/consensus_object_pools/block_quarantine.nim(158, 27) Warning: Deprecated since v1.4; it was more confusing than useful, use `[]=`; add is deprecated [Deprecated]
beacon_chain/consensus_object_pools/block_quarantine.nim(162, 23) Warning: Deprecated since v1.4; it was more confusing than useful, use `[]=`; add is deprecated [Deprecated]
beacon_chain/consensus_object_pools/block_quarantine.nim(204, 25) Warning: Deprecated since v1.4; it was more confusing than useful, use `[]=`; add is deprecated [Deprecated]
```
`add` and `[]=` aren't identical, but in this case, `[]=` is better anyway, since it can't add duplicate blocks.