### PR TITLE
preparations for persisting light client data

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -539,6 +539,12 @@ func isNextSyncCommitteeFinalized*(
   else:
     true
 
+func firstNonFinalizedPeriod*(dag: ChainDAGRef): SyncCommitteePeriod =
+  if dag.finalizedHead.slot >= dag.cfg.ALTAIR_FORK_EPOCH.start_slot:
+    dag.finalizedHead.slot.sync_committee_period + 1
+  else:
+    dag.cfg.ALTAIR_FORK_EPOCH.sync_committee_period
+
 proc updateBeaconMetrics(
     state: ForkedHashedBeaconState, bid: BlockId, cache: var StateCache) =
   # https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#additional-metrics

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -540,6 +540,16 @@ proc currentSyncCommitteeForPeriod*(
       else: err()
   do: err()
 
+func isNextSyncCommitteeFinalized*(
+    dag: ChainDAGRef, period: SyncCommitteePeriod): bool =
+  let finalizedSlot = dag.finalizedHead.slot
+  if finalizedSlot < period.start_slot:
+    false
+  elif finalizedSlot < dag.cfg.ALTAIR_FORK_EPOCH.start_slot:
+    false # Fork epoch not necessarily tied to sync committee period boundary
+  else:
+    true
+
 proc updateBeaconMetrics(
     state: ForkedHashedBeaconState, bid: BlockId, cache: var StateCache) =
   # https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#additional-metrics

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -526,12 +526,12 @@ proc currentSyncCommitteeForPeriod*(
     period: SyncCommitteePeriod): Opt[SyncCommittee] =
   ## Fetch a `SyncCommittee` for a given sync committee period.
   ## For non-finalized periods, follow the chain as selected by fork choice.
-  let earliestSlot = max(dag.tail.slot, dag.cfg.ALTAIR_FORK_EPOCH.start_slot)
-  if period < earliestSlot.sync_committee_period:
+  let lowSlot = max(dag.tail.slot, dag.cfg.ALTAIR_FORK_EPOCH.start_slot)
+  if period < lowSlot.sync_committee_period:
     return err()
   let
     periodStartSlot = period.start_slot
-    syncCommitteeSlot = max(periodStartSlot, earliestSlot)
+    syncCommitteeSlot = max(periodStartSlot, lowSlot)
     bsi = ? dag.getBlockIdAtSlot(syncCommitteeSlot)
   dag.withUpdatedState(tmpState, bsi) do:
     withState(state):

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -454,7 +454,7 @@ proc processFinalizationForLightClient*(
   # Prune light client data that is no longer referrable by future updates
   var bidsToDelete: seq[BlockId]
   for bid, data in dag.lightClientCache.data:
-    if bid.slot >= finalizedSlot:
+    if bid.slot >= dag.finalizedHead.blck.slot:
       continue
     bidsToDelete.add bid
   for bid in bidsToDelete:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -67,12 +67,12 @@ proc updateExistingState(
   ok
 
 template withUpdatedExistingState(
-    dag: ChainDAGRef, state: var ForkedHashedBeaconState,
+    dag: ChainDAGRef, stateParam: var ForkedHashedBeaconState,
     bsiParam: BlockSlotId, okBody: untyped, failureBody: untyped): untyped =
   ## Wrapper around `withUpdatedState` for states expected to exist.
   block:
     let bsi = bsiParam
-    dag.withUpdatedState(state, bsiParam) do:
+    dag.withUpdatedState(stateParam, bsiParam) do:
       okBody
     do:
       error "State failed to load unexpectedly", bsi, tail = dag.tail.slot

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -109,12 +109,12 @@ proc syncCommitteeRootForPeriod(
   ## Compute a root to uniquely identify `current_sync_committee` and
   ## `next_sync_committee` for a given sync committee period.
   ## For non-finalized periods, follow the chain as selected by fork choice.
-  let earliestSlot = max(dag.tail.slot, dag.cfg.ALTAIR_FORK_EPOCH.start_slot)
-  if period < earliestSlot.sync_committee_period:
+  let lowSlot = max(dag.tail.slot, dag.cfg.ALTAIR_FORK_EPOCH.start_slot)
+  if period < lowSlot.sync_committee_period:
     return err()
   let
     periodStartSlot = period.start_slot
-    syncCommitteeSlot = max(periodStartSlot, earliestSlot)
+    syncCommitteeSlot = max(periodStartSlot, lowSlot)
     bsi = ? dag.getExistingBlockIdAtSlot(syncCommitteeSlot)
   dag.withUpdatedExistingState(tmpState, bsi) do:
     withState(state):

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -209,7 +209,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
         dag.handleUnexpectedLightClientError(bid.slot)
         `name _ ok` = false
       else:
-        target = bdata.get.toBeaconBlockHeader
+        target = bdata.get.toBeaconBlockHeader()
         `name _ ptr` = addr target
     `name _ ok`
 
@@ -664,7 +664,7 @@ proc initLightClientUpdateForPeriod(
       return
     withStateAndBlck(state, bdata):
       when stateFork >= BeaconStateFork.Altair:
-        update.attested_header = blck.toBeaconBlockHeader
+        update.attested_header = blck.toBeaconBlockHeader()
         update.next_sync_committee = state.data.next_sync_committee
         state.data.build_proof(
           altair.NEXT_SYNC_COMMITTEE_INDEX,
@@ -686,7 +686,7 @@ proc initLightClientUpdateForPeriod(
       dag.handleUnexpectedLightClientError(finalizedBid.slot)
       return
     withBlck(bdata):
-      update.finalized_header = blck.toBeaconBlockHeader
+      update.finalized_header = blck.toBeaconBlockHeader()
   let bdata = dag.getExistingForkedBlock(signatureBid).valueOr:
     dag.handleUnexpectedLightClientError(signatureBid.slot)
     return
@@ -822,7 +822,7 @@ proc getLightClientBootstrap*(
       var tmpState = assignClone(dag.headState)
       var bootstrap {.noinit.}: altair.LightClientBootstrap
       bootstrap.header =
-        blck.toBeaconBlockHeader
+        blck.toBeaconBlockHeader()
       bootstrap.current_sync_committee =
         ? dag.existingCurrentSyncCommitteeForPeriod(tmpState[], period)
       bootstrap.current_sync_committee_branch =

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -199,8 +199,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
   var
     `name _ ptr`: ptr[BeaconBlockHeader]
     `name _ ok` = true
-  template `assign _ name`(target: var BeaconBlockHeader,
-                           bid: BlockId): bool =
+  template `assign _ name`(target: var BeaconBlockHeader, bid: BlockId): bool =
     if `name _ ptr` != nil:
       target = `name _ ptr`[]
     elif `name _ ok`:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -168,7 +168,6 @@ proc deleteLightClientData*(dag: ChainDAGRef, bid: BlockId) =
   dag.lightClientCache.data.del bid
 
 func handleUnexpectedLightClientError(dag: ChainDAGRef, buggedSlot: Slot) =
-  ## Light client data is expected to be available from `earliestSlot` onward.
   ## If there is an unexpected error, adjust `importTailSlot` to keep track of
   ## section for which complete light client data is available, and to avoid
   ## failed lookups of cached light client data.

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -720,9 +720,15 @@ done
 # light clients
 if [ "$LC_NODES" -ge "1" ]; then
   echo "Waiting for Altair finalization"
-  ALTAIR_FORK_EPOCH="$(
-    "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/config/spec" | \
-      "${JQ_BINARY}" -r '.data.ALTAIR_FORK_EPOCH')"
+  while :; do
+    ALTAIR_FORK_EPOCH="$(
+      "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/config/spec" | \
+        "${JQ_BINARY}" -r '.data.ALTAIR_FORK_EPOCH')"
+    if [ "${ALTAIR_FORK_EPOCH}" -eq "${ALTAIR_FORK_EPOCH}" ]; then # is number
+      break
+    fi
+    sleep 1
+  done
   while :; do
     CURRENT_FORK_EPOCH="$(
       "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/beacon/states/finalized/fork" | \


### PR DESCRIPTION
When switching the light client data in-memory cache to a database,
additional failure points are introduced due to possible inconsistencies
that are introduced into the DB out-of-band. These additional failure
points are handled as preparation to the move to persistence.
Also includes fixes related to theoretic edge cases in initial period,
and some minor cleanups, e.g., `asSigned` vs `isomorphicCast`.