### PR TITLE
Fix /eth/v1/node/syncing

### DIFF
--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -1,5 +1,4 @@
 import
-  std/[sequtils],
   stew/[byteutils, results],
   chronicles,
   eth/p2p/discoveryv5/enr,
@@ -254,7 +253,15 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Node/getSyncingStatus
   router.api(MethodGet, "/eth/v1/node/syncing") do () -> RestApiResponse:
-    return RestApiResponse.jsonResponse(node.syncManager.getInfo())
+    let
+      wallSlot = node.beaconClock.now().slotOrZero()
+      headSlot = node.dag.head.slot
+      distance = wallSlot - headSlot
+      info = RestSyncInfo(
+        head_slot: headSlot, sync_distance: distance,
+        is_syncing: distance != 0'u64
+      )
+    return RestApiResponse.jsonResponse(info)
 
   # https://ethereum.github.io/beacon-APIs/#/Node/getHealth
   router.api(MethodGet, "/eth/v1/node/health") do () -> RestApiResponse:

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -259,7 +259,11 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
       distance = wallSlot - headSlot
       info = RestSyncInfo(
         head_slot: headSlot, sync_distance: distance,
-        is_syncing: distance != 0'u64
+        is_syncing:
+          if isNil(node.syncManager):
+            false
+          else:
+            node.syncManager.inProgress
       )
     return RestApiResponse.jsonResponse(info)
 

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -658,14 +658,3 @@ proc syncLoop[A, B](man: SyncManager[A, B]) {.async.} =
 proc start*[A, B](man: SyncManager[A, B]) =
   ## Starts SyncManager's main loop.
   man.syncFut = man.syncLoop()
-
-proc getInfo*[A, B](man: SyncManager[A, B]): RestSyncInfo =
-  ## Returns current synchronization information for RPC call.
-  let wallSlot = man.getLocalWallSlot()
-  let headSlot = man.getLocalHeadSlot()
-  let sync_distance = wallSlot - headSlot
-  RestSyncInfo(
-    head_slot: headSlot,
-    sync_distance: sync_distance,
-    is_syncing: man.inProgress
-  )

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -7,7 +7,7 @@
 
 {.push raises: [Defect].}
 
-import std/[options, heapqueue, tables, strutils, sequtils, math, algorithm]
+import std/[options, heapqueue, tables, strutils, sequtils, math]
 import stew/[results, base10], chronos, chronicles
 import
   ../spec/datatypes/[base, phase0, altair],


### PR DESCRIPTION
Fix REST server `/eth/v1/node/syncing` call to return proper values even if SyncManager is not running.