### PR TITLE
improve panda display

### DIFF
--- a/beacon_chain/consensus_object_pools/vanity_logs/pandas.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/pandas.nim
@@ -17,9 +17,9 @@ type
 
 # Created by http://beatscribe.com/ (beatscribe#1008 on Discord)
 # These need to be the main body of the log not to be reformatted or escaped.
-proc mono🐼()  = notice "text-version.txt".staticRead
-proc color🐼() = notice "color-version.ans".staticRead
-proc blink🐼() = notice "blink-version.ans".staticRead
+proc mono🐼()  = notice "\n" & "text-version.txt".staticRead
+proc color🐼() = notice "\n" & "color-version.ans".staticRead
+proc blink🐼() = notice "\n" & "blink-version.ans".staticRead
 
 func getPandas*(stdoutKind: StdoutLogKind): VanityLogs =
   case stdoutKind


### PR DESCRIPTION
tiny part of https://github.com/status-im/nimbus-eth2/pull/3730 to try to isolate Linux i386 Nim 1.2 under-or-overflow build error