### PR TITLE
error handling for local testnet REST query

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -727,9 +727,16 @@ done
 # light clients
 if [ "$LC_NODES" -ge "1" ]; then
   echo "Waiting for Altair finalization"
-  ALTAIR_FORK_EPOCH="$(
-    "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/config/spec" | \
-      "${JQ_BINARY}" -r '.data.ALTAIR_FORK_EPOCH')"
+  while :; do
+    ALTAIR_FORK_EPOCH="$(
+      "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/config/spec" | \
+        "${JQ_BINARY}" -r '.data.ALTAIR_FORK_EPOCH')"
+    if [ "${ALTAIR_FORK_EPOCH}" -eq "${ALTAIR_FORK_EPOCH}" ]; then # check for number
+      break
+    fi
+    echo "ALTAIR_FORK_EPOCH: ${ALTAIR_FORK_EPOCH}"
+    sleep 1
+  done
   while :; do
     CURRENT_FORK_EPOCH="$(
       "${CURL_BINARY}" -s "http://localhost:${BASE_REST_PORT}/eth/v1/beacon/states/finalized/fork" | \


### PR DESCRIPTION
When querying `ALTAIR_FORK_EPOCH` fails, the `launch_local_testnet`
script got stuck because comparing `CURRENT_FORK_EPOCH` against it
would keep failing with `[: : integer expression expected`.
Querying `ALTAIR_FORK_EPOCH` is now retried until a number is returned.