### PR TITLE
rename light client config parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,8 +310,8 @@ define CONNECT_TO_NETWORK_IN_DEV_MODE
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_$(1)_$(NODE_ID) \
 		--light-client-enable=on \
-		--serve-light-client-data=on \
-		--import-light-client-data=only-new \
+		--light-client-data-serve=on \
+		--light-client-data-import-mode=only-new \
 		--dump $(NODE_PARAMS)
 endef
 

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -98,7 +98,7 @@ proc startLightClient*(node: BeaconNode) =
 
 proc installLightClientMessageValidators*(node: BeaconNode) =
   let eth2Processor =
-    if node.config.serveLightClientData.get:
+    if node.config.lightClientDataServe.get:
       # Process gossip using both full node and light client
       node.processor
     elif node.config.lightClientEnable.get:
@@ -113,7 +113,7 @@ proc installLightClientMessageValidators*(node: BeaconNode) =
 proc updateLightClientGossipStatus*(
     node: BeaconNode, slot: Slot, dagIsBehind: bool) =
   let isBehind =
-    if node.config.serveLightClientData.get:
+    if node.config.lightClientDataServe.get:
       # Forward DAG's readiness to handle light client gossip
       dagIsBehind
     else:

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -29,7 +29,7 @@ import
   ./filepath
 
 from consensus_object_pools/block_pools_types_light_client
-  import ImportLightClientData
+  import LightClientDataImportMode
 
 export
   uri, nat, enr,
@@ -445,16 +445,16 @@ type
         desc: "A file specifying the authorization token required for accessing the keymanager API"
         name: "keymanager-token-file" }: Option[InputFile]
 
-      serveLightClientData* {.
+      lightClientDataServe* {.
         hidden
         desc: "BETA: Serve data for enabling light clients to stay in sync with the network"
-        name: "serve-light-client-data"}: Option[bool]
+        name: "light-client-data-serve"}: Option[bool]
 
-      importLightClientData* {.
+      lightClientDataImportMode* {.
         hidden
         desc: "BETA: Which classes of light client data to import. " &
               "Must be one of: none, only-new, full (slow startup), on-demand (may miss validator duties)"
-        name: "import-light-client-data"}: Option[ImportLightClientData]
+        name: "light-client-data-import-mode"}: Option[LightClientDataImportMode]
 
       inProcessValidators* {.
         desc: "Disable the push model (the beacon node tells a signing process with the private keys of the validators what to sign and when) and load the validators in the beacon node itself"

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -185,10 +185,10 @@ type
 
     cfg*: RuntimeConfig
 
-    serveLightClientData*: bool
+    lightClientDataServe*: bool
       ## Whether to make local light client data available or not
 
-    importLightClientData*: ImportLightClientData
+    lightClientDataImportMode*: LightClientDataImportMode
       ## Which classes of light client data to import
 
     epochRefs*: array[32, EpochRef]

--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -23,7 +23,7 @@ type
   OnLightClientOptimisticUpdateCallback* =
     proc(data: altair.LightClientOptimisticUpdate) {.gcsafe, raises: [Defect].}
 
-  ImportLightClientData* {.pure.} = enum
+  LightClientDataImportMode* {.pure.} = enum
     ## Controls which classes of light client data are imported.
     None = "none"
       ## Import no light client data.

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -682,8 +682,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
            onLCFinalityUpdateCb: OnLightClientFinalityUpdateCallback = nil,
            onLCOptimisticUpdateCb: OnLightClientOptimisticUpdateCallback = nil,
-           serveLightClientData = false,
-           importLightClientData = ImportLightClientData.None,
+           lightClientDataServe = false,
+           lightClientDataImportMode = LightClientDataImportMode.None,
            vanityLogs = default(VanityLogs)): ChainDAGRef =
   cfg.checkForkConsistency()
 
@@ -720,8 +720,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
       vanityLogs: vanityLogs,
 
-      serveLightClientData: serveLightClientData,
-      importLightClientData: importLightClientData,
+      lightClientDataServe: lightClientDataServe,
+      lightClientDataImportMode: lightClientDataImportMode,
 
       onBlockAdded: onBlockCb,
       onHeadChanged: onHeadCb,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1706,7 +1706,7 @@ proc new*(T: type Eth2Node,
 
     for msg in proto.messages:
       when config is BeaconNodeConf:
-        if msg.isLightClientRequest and not config.serveLightClientData.get:
+        if msg.isLightClientRequest and not config.lightClientDataServe.get:
           continue
       elif config is LightClientConf:
         if not msg.isRequired:

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -19,7 +19,7 @@ import
   ../spec/datatypes/phase0
 
 from ../consensus_object_pools/block_pools_types_light_client
-  import ImportLightClientData
+  import LightClientDataImportMode
 
 # ATTENTION! This file will produce a large C file, because we are inlining
 # genesis states as C literals in the generated code (and blobs in the final
@@ -44,8 +44,8 @@ type
   Eth2NetworkConfigDefaults* = object
     ## Network specific config defaults
     lightClientEnable*: bool
-    serveLightClientData*: bool
-    importLightClientData*: ImportLightClientData
+    lightClientDataServe*: bool
+    lightClientDataImportMode*: LightClientDataImportMode
 
   Eth2NetworkMetadata* = object
     case incompatible*: bool
@@ -197,13 +197,13 @@ proc loadEth2NetworkMetadata*(path: string, eth1Network = none(Eth1Network)): Et
         Eth2NetworkConfigDefaults(
           lightClientEnable:
             false, # Only produces debug logs so far
-          serveLightClientData:
+          lightClientDataServe:
             shouldSupportLightClient,
-          importLightClientData:
+          lightClientDataImportMode:
             if shouldSupportLightClient:
-              ImportLightClientData.OnlyNew
+              LightClientDataImportMode.OnlyNew
             else:
-              ImportLightClientData.None
+              LightClientDataImportMode.None
         )
 
     Eth2NetworkMetadata(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -170,18 +170,18 @@ proc loadChainDag(
       if config.verifyFinalization: {verifyFinalization}
       else: {}
     onLightClientFinalityUpdateCb =
-      if config.serveLightClientData.get: onLightClientFinalityUpdate
+      if config.lightClientDataServe.get: onLightClientFinalityUpdate
       else: nil
     onLightClientOptimisticUpdateCb =
-      if config.serveLightClientData.get: onLightClientOptimisticUpdate
+      if config.lightClientDataServe.get: onLightClientOptimisticUpdate
       else: nil
     dag = ChainDAGRef.init(
       cfg, db, validatorMonitor, chainDagFlags, config.eraDir,
       onBlockAdded, onHeadChanged, onChainReorg,
       onLCFinalityUpdateCb = onLightClientFinalityUpdateCb,
       onLCOptimisticUpdateCb = onLightClientOptimisticUpdateCb,
-      serveLightClientData = config.serveLightClientData.get,
-      importLightClientData = config.importLightClientData.get,
+      lightClientDataServe = config.lightClientDataServe.get,
+      lightClientDataImportMode = config.lightClientDataImportMode.get,
       vanityLogs = getPandas(detectTTY(config.logStdout)))
     databaseGenesisValidatorsRoot =
       getStateField(dag.headState, genesis_validators_root)
@@ -1707,8 +1707,8 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref BrHmacDrbgContext) {.r
       config.`field` = some metadata.configDefaults.`field`
 
   applyConfigDefault(lightClientEnable)
-  applyConfigDefault(serveLightClientData)
-  applyConfigDefault(importLightClientData)
+  applyConfigDefault(lightClientDataServe)
+  applyConfigDefault(lightClientDataImportMode)
 
   let node = BeaconNode.init(
     metadata.cfg,

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -535,7 +535,7 @@ p2pProtocol BeaconSync(version = 1,
                               isLightClientRequest = true).} =
     trace "Received LC bootstrap request", peer, blockRoot
     let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
+    doAssert dag.lightClientDataServe
 
     peer.updateRequestQuota(lightClientBootstrapLookupCost)
     peer.awaitNonNegativeRequestQuota()
@@ -565,7 +565,7 @@ p2pProtocol BeaconSync(version = 1,
                               isLightClientRequest = true).} =
     trace "Received LC updates by range request", peer, startPeriod, reqCount
     let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
+    doAssert dag.lightClientDataServe
 
     let
       headPeriod = dag.head.slot.sync_committee_period
@@ -605,7 +605,7 @@ p2pProtocol BeaconSync(version = 1,
                               isLightClientRequest = true).} =
     trace "Received LC finality update request", peer
     let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
+    doAssert dag.lightClientDataServe
 
     peer.awaitNonNegativeRequestQuota()
 
@@ -632,7 +632,7 @@ p2pProtocol BeaconSync(version = 1,
                               isLightClientRequest = true).} =
     trace "Received LC optimistic update request", peer
     let dag = peer.networkState.dag
-    doAssert dag.serveLightClientData
+    doAssert dag.lightClientDataServe
 
     peer.awaitNonNegativeRequestQuota()
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -282,7 +282,7 @@ proc handleLightClientUpdates(node: BeaconNode, slot: Slot) {.async.} =
     notice "LC optimistic update sent", message = shortLog(msg)
 
 proc scheduleSendingLightClientUpdates(node: BeaconNode, slot: Slot) =
-  if not node.config.serveLightClientData.get:
+  if not node.config.lightClientDataServe.get:
     return
   if node.lightClientPool[].broadcastGossipFut != nil:
     return

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -684,8 +684,8 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
     --light-client-enable=on \
-    --serve-light-client-data=on \
-    --import-light-client-data=only-new \
+    --light-client-data-serve=on \
+    --light-client-data-import-mode=only-new \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &
 

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -160,8 +160,8 @@ proc startSingleNodeNetwork {.raises: [CatchableError, Defect].} =
     "--keymanager-port=" & $keymanagerPort,
     "--keymanager-token-file=" & tokenFilePath,
     "--light-client-enable=off",
-    "--serve-light-client-data=off",
-    "--import-light-client-data=none",
+    "--light-client-data-serve=off",
+    "--light-client-data-import-mode=none",
     "--doppelganger-detection=off"], it))
   except Exception as exc: # TODO fix confutils exceptions
     raiseAssert exc.msg

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -79,8 +79,8 @@ suite "Light client" & preset():
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
         cfg, makeTestDB(num_validators), validatorMonitor, {},
-        serveLightClientData = true,
-        importLightClientData = ImportLightClientData.OnlyNew)
+        lightClientDataServe = true,
+        lightClientDataImportMode = LightClientDataImportMode.OnlyNew)
       quarantine = newClone(Quarantine.init())
       taskpool = Taskpool.new()
     var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
@@ -185,8 +185,8 @@ suite "Light client" & preset():
       dag.headState, dag.getForkedBlock(dag.head.bid).get)
     let cpDag = ChainDAGRef.init(
       cfg, cpDb, validatorMonitor, {},
-      serveLightClientData = true,
-      importLightClientData = ImportLightClientData.Full)
+      lightClientDataServe = true,
+      lightClientDataImportMode = LightClientDataImportMode.Full)
 
     # Advance by a couple epochs
     for i in 1'u64 .. 10:

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -30,8 +30,8 @@ suite "Light client processor" & preset():
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(
       cfg, makeTestDB(numValidators), validatorMonitor, {},
-      serveLightClientData = true,
-      importLightClientData = ImportLightClientData.OnlyNew)
+      lightClientDataServe = true,
+      lightClientDataImportMode = LightClientDataImportMode.OnlyNew)
     quarantine = newClone(Quarantine.init())
     taskpool = Taskpool.new()
   var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)


### PR DESCRIPTION
For consistency with other options, use a common prefix for light client
data configuration options.

* `--serve-light-client-data` --> `--light-client-data-serve`
* `--import-light-client-data` --> `--light-client-data-import-mode`

No deprecation of the old identifiers as they were only sparingly used
and all usage can be easily updated without interferance.