### PR TITLE
format pragmas consistently in `conf.nim`

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -108,93 +108,93 @@ type
   BeaconNodeConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"
-      name: "config-file" }: Option[InputFile]
+      name: "config-file" .}: Option[InputFile]
 
     logLevel* {.
       desc: "Sets the log level for process and topics (e.g. \"DEBUG; TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none\")"
       defaultValue: "INFO"
-      name: "log-level" }: string
+      name: "log-level" .}: string
 
     logStdout* {.
       hidden
       desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
-      name: "log-format" }: StdoutLogKind
+      name: "log-format" .}: StdoutLogKind
 
     logFile* {.
       desc: "Specifies a path for the written Json log file (deprecated)"
-      name: "log-file" }: Option[OutFile]
+      name: "log-file" .}: Option[OutFile]
 
     eth2Network* {.
       desc: "The Eth2 network to join"
       defaultValueDesc: "mainnet"
-      name: "network" }: Option[string]
+      name: "network" .}: Option[string]
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
       defaultValue: config.defaultDataDir()
       defaultValueDesc: ""
       abbr: "d"
-      name: "data-dir" }: OutDir
+      name: "data-dir" .}: OutDir
 
     validatorsDirFlag* {.
       desc: "A directory containing validator keystores"
-      name: "validators-dir" }: Option[InputDir]
+      name: "validators-dir" .}: Option[InputDir]
 
     secretsDirFlag* {.
       desc: "A directory containing validator keystore passwords"
-      name: "secrets-dir" }: Option[InputDir]
+      name: "secrets-dir" .}: Option[InputDir]
 
     walletsDirFlag* {.
       desc: "A directory containing wallet files"
-      name: "wallets-dir" }: Option[InputDir]
+      name: "wallets-dir" .}: Option[InputDir]
 
     web3Urls* {.
       desc: "One or more Web3 provider URLs used for obtaining deposit contract data"
-      name: "web3-url" }: seq[string]
+      name: "web3-url" .}: seq[string]
 
     web3ForcePolling* {.
       hidden
       defaultValue: false
       desc: "Force the use of polling when determining the head block of Eth1"
-      name: "web3-force-polling" }: bool
+      name: "web3-force-polling" .}: bool
 
     nonInteractive* {.
       desc: "Do not display interative prompts. Quit on missing configuration"
-      name: "non-interactive" }: bool
+      name: "non-interactive" .}: bool
 
     netKeyFile* {.
       desc: "Source of network (secp256k1) private key file " &
             "(random|<path>)"
       defaultValue: "random",
-      name: "netkey-file" }: string
+      name: "netkey-file" .}: string
 
     netKeyInsecurePassword* {.
       desc: "Use pre-generated INSECURE password for network private key file"
       defaultValue: false,
-      name: "insecure-netkey-password" }: bool
+      name: "insecure-netkey-password" .}: bool
 
     agentString* {.
       defaultValue: "nimbus",
       desc: "Node agent string which is used as identifier in network"
-      name: "agent-string" }: string
+      name: "agent-string" .}: string
 
     subscribeAllSubnets* {.
       defaultValue: false,
       desc: "Subscribe to all subnet topics when gossiping"
-      name: "subscribe-all-subnets" }: bool
+      name: "subscribe-all-subnets" .}: bool
 
     slashingDbKind* {.
       hidden
       defaultValue: SlashingDbKind.v2
       desc: "The slashing DB flavour to use"
-      name: "slashing-db-kind" }: SlashingDbKind
+      name: "slashing-db-kind" .}: SlashingDbKind
 
     numThreads* {.
       defaultValue: 0,
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
-      name: "num-threads" }: int
+      name: "num-threads" .}: int
 
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#key-distribution
     jwtSecret* {.
@@ -203,51 +203,51 @@ type
 
     case cmd* {.
       command
-      defaultValue: BNStartUpCmd.noCommand }: BNStartUpCmd
+      defaultValue: BNStartUpCmd.noCommand .}: BNStartUpCmd
 
     of BNStartUpCmd.noCommand:
       runAsServiceFlag* {.
         windowsOnly
         defaultValue: false,
         desc: "Run as a Windows service"
-        name: "run-as-service" }: bool
+        name: "run-as-service" .}: bool
 
       bootstrapNodes* {.
         desc: "Specifies one or more bootstrap nodes to use when connecting to the network"
         abbr: "b"
-        name: "bootstrap-node" }: seq[string]
+        name: "bootstrap-node" .}: seq[string]
 
       bootstrapNodesFile* {.
         desc: "Specifies a line-delimited file of bootstrap Ethereum network addresses"
         defaultValue: ""
-        name: "bootstrap-file" }: InputFile
+        name: "bootstrap-file" .}: InputFile
 
       listenAddress* {.
         desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
         defaultValue: defaultListenAddress
         defaultValueDesc: "0.0.0.0"
-        name: "listen-address" }: ValidIpAddress
+        name: "listen-address" .}: ValidIpAddress
 
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: "9000"
-        name: "tcp-port" }: Port
+        name: "tcp-port" .}: Port
 
       udpPort* {.
         desc: "Listening UDP port for node discovery"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: "9000"
-        name: "udp-port" }: Port
+        name: "udp-port" .}: Port
 
       maxPeers* {.
         desc: "The target number of peers to connect to"
         defaultValue: 160 # 5 (fanout) * 64 (subnets) / 2 (subs) for a heathy mesh
-        name: "max-peers" }: int
+        name: "max-peers" .}: int
 
       hardMaxPeers* {.
         desc: "The maximum number of peers to connect to. Defaults to maxPeers * 1.5"
-        name: "hard-max-peers" }: Option[int]
+        name: "hard-max-peers" .}: Option[int]
 
       nat* {.
         desc: "Specify method to use for determining public address. " &
@@ -265,7 +265,7 @@ type
 
       weakSubjectivityCheckpoint* {.
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
-        name: "weak-subjectivity-checkpoint" }: Option[Checkpoint]
+        name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
 
       lightClientEnable* {.
         hidden
@@ -275,66 +275,66 @@ type
       lightClientTrustedBlockRoot* {.
         hidden
         desc: "BETA: Recent trusted finalized block root to initialize light client from."
-        name: "light-client-trusted-block-root" }: Option[Eth2Digest]
+        name: "light-client-trusted-block-root" .}: Option[Eth2Digest]
 
       finalizedCheckpointState* {.
         desc: "SSZ file specifying a recent finalized state"
-        name: "finalized-checkpoint-state" }: Option[InputFile]
+        name: "finalized-checkpoint-state" .}: Option[InputFile]
 
       finalizedCheckpointBlock* {.
         desc: "SSZ file specifying a recent finalized block"
-        name: "finalized-checkpoint-block" }: Option[InputFile]
+        name: "finalized-checkpoint-block" .}: Option[InputFile]
 
       nodeName* {.
         desc: "A name for this node that will appear in the logs. " &
               "If you set this to 'auto', a persistent automatically generated ID will be selected for each --data-dir folder"
         defaultValue: ""
-        name: "node-name" }: string
+        name: "node-name" .}: string
 
       graffiti* {.
         desc: "The graffiti value that will appear in proposed blocks. " &
               "You can use a 0x-prefixed hex encoded string to specify raw bytes"
-        name: "graffiti" }: Option[GraffitiBytes]
+        name: "graffiti" .}: Option[GraffitiBytes]
 
       verifyFinalization* {.
         hidden
         desc: "Specify whether to verify finalization occurs on schedule (debug only)"
         defaultValue: false
-        name: "verify-finalization" }: bool
+        name: "verify-finalization" .}: bool
 
       stopAtEpoch* {.
         hidden
         desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
-        name: "stop-at-epoch" }: uint64
+        name: "stop-at-epoch" .}: uint64
 
       stopAtSyncedEpoch* {.
         hidden
         desc: "The synced epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
-        name: "stop-at-synced-epoch" }: uint64
+        name: "stop-at-synced-epoch" .}: uint64
 
       metricsEnabled* {.
         desc: "Enable the metrics server"
         defaultValue: false
-        name: "metrics" }: bool
+        name: "metrics" .}: bool
 
       metricsAddress* {.
         desc: "Listening address of the metrics server"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: "127.0.0.1"
-        name: "metrics-address" }: ValidIpAddress
+        name: "metrics-address" .}: ValidIpAddress
 
       metricsPort* {.
         desc: "Listening HTTP port of the metrics server"
         defaultValue: 8008
-        name: "metrics-port" }: Port
+        name: "metrics-port" .}: Port
 
       statusBarEnabled* {.
         posixOnly
         desc: "Display a status bar at the bottom of the terminal screen"
         defaultValue: true
-        name: "status-bar" }: bool
+        name: "status-bar" .}: bool
 
       statusBarContents* {.
         posixOnly
@@ -346,130 +346,130 @@ type
                       "sync: $sync_status|" &
                       "ETH: $attached_validators_balance"
         defaultValueDesc: ""
-        name: "status-bar-contents" }: string
+        name: "status-bar-contents" .}: string
 
       rpcEnabled* {.
         hidden
         desc: "Enable the JSON-RPC server (deprecated for removal)"
         defaultValue: false
-        name: "rpc" }: bool
+        name: "rpc" .}: bool
 
       rpcPort* {.
         hidden
         desc: "HTTP port for the JSON-RPC service (deprecated for removal)"
         defaultValue: 9190
         defaultValueDesc: "9190"
-        name: "rpc-port" }: Port
+        name: "rpc-port" .}: Port
 
       rpcAddress* {.
         hidden
         desc: "Listening address of the RPC server (deprecated for removal)"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: "127.0.0.1"
-        name: "rpc-address" }: ValidIpAddress
+        name: "rpc-address" .}: ValidIpAddress
 
       restEnabled* {.
         desc: "Enable the REST server"
         defaultValue: false
-        name: "rest" }: bool
+        name: "rest" .}: bool
 
       restPort* {.
         desc: "Port for the REST server"
         defaultValue: DefaultEth2RestPort
         defaultValueDesc: "5052"
-        name: "rest-port" }: Port
+        name: "rest-port" .}: Port
 
       restAddress* {.
         desc: "Listening address of the REST server"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: "127.0.0.1"
-        name: "rest-address" }: ValidIpAddress
+        name: "rest-address" .}: ValidIpAddress
 
       restAllowedOrigin* {.
         desc: "Limit the access to the REST API to a particular hostname " &
               "(for CORS-enabled clients such as browsers)"
-        name: "rest-allow-origin" }: Option[string]
+        name: "rest-allow-origin" .}: Option[string]
 
       restCacheSize* {.
         defaultValue: 3
         desc: "The maximum number of recently accessed states that are kept in " &
               "memory. Speeds up requests obtaining information for consecutive " &
               "slots or epochs."
-        name: "rest-statecache-size" }: Natural
+        name: "rest-statecache-size" .}: Natural
 
       restCacheTtl* {.
         defaultValue: 60
         desc: "The number of seconds to keep recently accessed states in memory"
-        name: "rest-statecache-ttl" }: Natural
+        name: "rest-statecache-ttl" .}: Natural
 
       restRequestTimeout* {.
         defaultValue: 0
         defaultValueDesc: "infinite"
         desc: "The number of seconds to wait until complete REST request " &
               "will be received"
-        name: "rest-request-timeout" }: Natural
+        name: "rest-request-timeout" .}: Natural
 
       restMaxRequestBodySize* {.
         defaultValue: 16_384
         desc: "Maximum size of REST request body (kilobytes)"
-        name: "rest-max-body-size" }: Natural
+        name: "rest-max-body-size" .}: Natural
 
       restMaxRequestHeadersSize* {.
         defaultValue: 64
         desc: "Maximum size of REST request headers (kilobytes)"
-        name: "rest-max-headers-size" }: Natural
+        name: "rest-max-headers-size" .}: Natural
 
       keymanagerEnabled* {.
         desc: "Enable the REST keymanager API (BETA version)"
         defaultValue: false
-        name: "keymanager" }: bool
+        name: "keymanager" .}: bool
 
       keymanagerPort* {.
         desc: "Listening port for the REST keymanager API"
         defaultValue: DefaultEth2RestPort
         defaultValueDesc: "5052"
-        name: "keymanager-port" }: Port
+        name: "keymanager-port" .}: Port
 
       keymanagerAddress* {.
         desc: "Listening port for the REST keymanager API"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: "127.0.0.1"
-        name: "keymanager-address" }: ValidIpAddress
+        name: "keymanager-address" .}: ValidIpAddress
 
       keymanagerAllowedOrigin* {.
         desc: "Limit the access to the Keymanager API to a particular hostname " &
               "(for CORS-enabled clients such as browsers)"
-        name: "keymanager-allow-origin" }: Option[string]
+        name: "keymanager-allow-origin" .}: Option[string]
 
       keymanagerTokenFile* {.
         desc: "A file specifying the authorization token required for accessing the keymanager API"
-        name: "keymanager-token-file" }: Option[InputFile]
+        name: "keymanager-token-file" .}: Option[InputFile]
 
       lightClientDataServe* {.
         hidden
         desc: "BETA: Serve data for enabling light clients to stay in sync with the network"
-        name: "light-client-data-serve"}: Option[bool]
+        name: "light-client-data-serve" .}: Option[bool]
 
       lightClientDataImportMode* {.
         hidden
         desc: "BETA: Which classes of light client data to import. " &
               "Must be one of: none, only-new, full (slow startup), on-demand (may miss validator duties)"
-        name: "light-client-data-import-mode"}: Option[LightClientDataImportMode]
+        name: "light-client-data-import-mode" .}: Option[LightClientDataImportMode]
 
       inProcessValidators* {.
         desc: "Disable the push model (the beacon node tells a signing process with the private keys of the validators what to sign and when) and load the validators in the beacon node itself"
         defaultValue: true # the use of the nimbus_signing_process binary by default will be delayed until async I/O over stdin/stdout is developed for the child process.
-        name: "in-process-validators" }: bool
+        name: "in-process-validators" .}: bool
 
       discv5Enabled* {.
         desc: "Enable Discovery v5"
         defaultValue: true
-        name: "discv5" }: bool
+        name: "discv5" .}: bool
 
       dumpEnabled* {.
         desc: "Write SSZ dumps of blocks, attestations and states to data dir"
         defaultValue: false
-        name: "dump" }: bool
+        name: "dump" .}: bool
 
       directPeers* {.
         desc: "The list of priviledged, secure and known peers to connect and maintain the connection to, this requires a not random netkey-file. In the complete multiaddress format like: /ip4/<address>/tcp/<port>/p2p/<peerId-public-key>. Peering agreements are established out of band and must be reciprocal."
@@ -478,15 +478,14 @@ type
       doppelgangerDetection* {.
         desc: "If enabled, the beacon node prudently listens for 2 epochs for attestations from a validator with the same index (a doppelganger), before sending an attestation itself. This protects against slashing (due to double-voting) but means you will miss two attestations when restarting."
         defaultValue: true
-        name: "doppelganger-detection"
-      }: bool
+        name: "doppelganger-detection" .}: bool
 
       syncHorizon* {.
         hidden
         desc: "Number of empty slots to process before considering the client out of sync"
         defaultValue: MaxEmptySlotCount
         defaultValueDesc: "50"
-        name: "sync-horizon" }: uint64
+        name: "sync-horizon" .}: uint64
 
       # TODO nim-confutils on 32-bit platforms overflows decoding integers
       # requiring 64-bit representations and doesn't build when specifying
@@ -494,22 +493,21 @@ type
       terminalTotalDifficultyOverride* {.
         hidden
         desc: "Override pre-configured TERMINAL_TOTAL_DIFFICULTY parameter"
-        name: "terminal-total-difficulty-override"
-      }: Option[string]
+        name: "terminal-total-difficulty-override" .}: Option[string]
 
       validatorMonitorAuto* {.
         desc: "Automatically monitor locally active validators (BETA)"
         defaultValue: false
-        name: "validator-monitor-auto" }: bool
+        name: "validator-monitor-auto" .}: bool
 
       validatorMonitorPubkeys* {.
         desc: "One or more validators to monitor - works best when --subscribe-all-subnets is enabled (BETA)"
-        name: "validator-monitor-pubkey" }: seq[ValidatorPubKey]
+        name: "validator-monitor-pubkey" .}: seq[ValidatorPubKey]
 
       validatorMonitorTotals* {.
         desc: "Publish metrics to single 'totals' label for better collection performance when monitoring many validators (BETA)"
         defaultValue: false
-        name: "validator-monitor-totals" }: bool
+        name: "validator-monitor-totals" .}: bool
 
       # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#fork-choice-poisoning
       safeSlotsToImportOptimistically* {.
@@ -517,7 +515,7 @@ type
         desc: "Modify SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY"
         # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#constants
         defaultValue: 128
-        name: "safe-slots-to-import-optimistically" }: uint16
+        name: "safe-slots-to-import-optimistically" .}: uint16
 
       # Same option as appears in Lighthouse and Prysm
       # https://lighthouse-book.sigmaprime.io/suggested-fee-recipient.html
@@ -529,60 +527,60 @@ type
     of BNStartUpCmd.createTestnet:
       testnetDepositsFile* {.
         desc: "A LaunchPad deposits file for the genesis state validators"
-        name: "deposits-file" }: InputFile
+        name: "deposits-file" .}: InputFile
 
       totalValidators* {.
         desc: "The number of validator deposits in the newly created chain"
-        name: "total-validators" }: uint64
+        name: "total-validators" .}: uint64
 
       bootstrapAddress* {.
         desc: "The public IP address that will be advertised as a bootstrap node for the testnet"
         defaultValue: init(ValidIpAddress, "127.0.0.1")
         defaultValueDesc: "127.0.0.1"
-        name: "bootstrap-address" }: ValidIpAddress
+        name: "bootstrap-address" .}: ValidIpAddress
 
       bootstrapPort* {.
         desc: "The TCP/UDP port that will be used by the bootstrap node"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: "9000"
-        name: "bootstrap-port" }: Port
+        name: "bootstrap-port" .}: Port
 
       genesisOffset* {.
         desc: "Seconds from now to add to genesis time"
         defaultValue: 5
-        name: "genesis-offset" }: int
+        name: "genesis-offset" .}: int
 
       outputGenesis* {.
         desc: "Output file where to write the initial state snapshot"
-        name: "output-genesis" }: OutFile
+        name: "output-genesis" .}: OutFile
 
       outputBootstrapFile* {.
         desc: "Output file with list of bootstrap nodes for the network"
-        name: "output-bootstrap-file" }: OutFile
+        name: "output-bootstrap-file" .}: OutFile
 
     of BNStartUpCmd.wallets:
       case walletsCmd* {.command.}: WalletsCmd
       of WalletsCmd.create:
         nextAccount* {.
           desc: "Initial value for the 'nextaccount' property of the wallet"
-          name: "next-account" }: Option[Natural]
+          name: "next-account" .}: Option[Natural]
 
         createdWalletNameFlag* {.
           desc: "An easy-to-remember name for the wallet of your choice"
-          name: "name"}: Option[WalletName]
+          name: "name" .}: Option[WalletName]
 
         createdWalletFileFlag* {.
           desc: "Output wallet file"
-          name: "out" }: Option[OutFile]
+          name: "out" .}: Option[OutFile]
 
       of WalletsCmd.restore:
         restoredWalletNameFlag* {.
           desc: "An easy-to-remember name for the wallet of your choice"
-          name: "name"}: Option[WalletName]
+          name: "name" .}: Option[WalletName]
 
         restoredWalletFileFlag* {.
           desc: "Output wallet file"
-          name: "out" }: Option[OutFile]
+          name: "out" .}: Option[OutFile]
 
         restoredDepositsCount* {.
           desc: "Expected number of deposits to recover. If not specified, " &
@@ -599,33 +597,33 @@ type
         totalDeposits* {.
           desc: "Number of deposits to generate"
           defaultValue: 1
-          name: "count" }: int
+          name: "count" .}: int
 
         existingWalletId* {.
           desc: "An existing wallet ID. If not specified, a new wallet will be created"
-          name: "wallet" }: Option[WalletName]
+          name: "wallet" .}: Option[WalletName]
 
         outValidatorsDir* {.
           desc: "Output folder for validator keystores"
           defaultValue: "validators"
-          name: "out-validators-dir" }: string
+          name: "out-validators-dir" .}: string
 
         outSecretsDir* {.
           desc: "Output folder for randomly generated keystore passphrases"
           defaultValue: "secrets"
-          name: "out-secrets-dir" }: string
+          name: "out-secrets-dir" .}: string
 
         outDepositsFile* {.
           desc: "The name of generated deposits file"
-          name: "out-deposits-file" }: Option[OutFile]
+          name: "out-deposits-file" .}: Option[OutFile]
 
         newWalletNameFlag* {.
           desc: "An easy-to-remember name for the wallet of your choice"
-          name: "new-wallet-name" }: Option[WalletName]
+          name: "new-wallet-name" .}: Option[WalletName]
 
         newWalletFileFlag* {.
           desc: "Output wallet file"
-          name: "new-wallet-file" }: Option[OutFile]
+          name: "new-wallet-file" .}: Option[OutFile]
 
       #[
       of DepositsCmd.status:
@@ -635,22 +633,22 @@ type
       of DepositsCmd.`import`:
         importedDepositsDir* {.
           argument
-          desc: "A directory with keystores to import" }: Option[InputDir]
+          desc: "A directory with keystores to import" .}: Option[InputDir]
 
       of DepositsCmd.exit:
         exitedValidator* {.
           name: "validator"
-          desc: "Validator index or a public key of the exited validator" }: string
+          desc: "Validator index or a public key of the exited validator" .}: string
 
         exitAtEpoch* {.
           name: "epoch"
-          desc: "The desired exit epoch" }: Option[uint64]
+          desc: "The desired exit epoch" .}: Option[uint64]
 
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
           defaultValue: defaultBeaconNode
           defaultValueDesc: "http://127.0.0.1:5052"
-          name: "rest-url" }: string
+          name: "rest-url" .}: string
 
     of BNStartUpCmd.record:
       case recordCmd* {.command.}: RecordCmd
@@ -688,7 +686,7 @@ type
         web3TestUrl* {.
           argument
           desc: "The web3 provider URL to test"
-          name: "url" }: Uri
+          name: "url" .}: Uri
 
     of BNStartUpCmd.slashingdb:
       case slashingdbCmd* {.command.}: SlashProtCmd
@@ -701,10 +699,10 @@ type
           desc: "Limit the export to specific validators " &
                 "(specified as numeric indices or public keys)"
           abbr: "v"
-          name: "validator" }: seq[PubKey0x]
+          name: "validator" .}: seq[PubKey0x]
         exportedInterchangeFile* {.
           desc: "EIP-3076 slashing protection interchange file to export"
-          argument }: OutFile
+          argument .}: OutFile
 
     of BNStartUpCmd.trustedNodeSync:
       trustedNodeUrl* {.
@@ -722,163 +720,163 @@ type
       backfillBlocks* {.
         desc: "Backfill blocks directly from REST server instead of fetching via API"
         defaultValue: true
-        name: "backfill"}: bool
+        name: "backfill" .}: bool
 
       reindex* {.
         desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
-        defaultValue: false}: bool
+        defaultValue: false .}: bool
 
   ValidatorClientConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"
-      name: "config-file" }: Option[InputFile]
+      name: "config-file" .}: Option[InputFile]
 
     logLevel* {.
       desc: "Sets the log level"
       defaultValue: "INFO"
-      name: "log-level" }: string
+      name: "log-level" .}: string
 
     logStdout* {.
       hidden
       desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
-      name: "log-format" }: StdoutLogKind
+      name: "log-format" .}: StdoutLogKind
 
     logFile* {.
       desc: "Specifies a path for the written Json log file (deprecated)"
-      name: "log-file" }: Option[OutFile]
+      name: "log-file" .}: Option[OutFile]
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
       defaultValue: config.defaultDataDir()
       defaultValueDesc: ""
       abbr: "d"
-      name: "data-dir" }: OutDir
+      name: "data-dir" .}: OutDir
 
     nonInteractive* {.
       desc: "Do not display interative prompts. Quit on missing configuration"
-      name: "non-interactive" }: bool
+      name: "non-interactive" .}: bool
 
     validatorsDirFlag* {.
       desc: "A directory containing validator keystores"
-      name: "validators-dir" }: Option[InputDir]
+      name: "validators-dir" .}: Option[InputDir]
 
     secretsDirFlag* {.
       desc: "A directory containing validator keystore passwords"
-      name: "secrets-dir" }: Option[InputDir]
+      name: "secrets-dir" .}: Option[InputDir]
 
     keymanagerEnabled* {.
       desc: "Enable the REST keymanager API (BETA version)"
       defaultValue: false
-      name: "keymanager" }: bool
+      name: "keymanager" .}: bool
 
     keymanagerPort* {.
       desc: "Listening port for the REST keymanager API"
       defaultValue: DefaultEth2RestPort
       defaultValueDesc: "5052"
-      name: "keymanager-port" }: Port
+      name: "keymanager-port" .}: Port
 
     keymanagerAddress* {.
       desc: "Listening port for the REST keymanager API"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: "127.0.0.1"
-      name: "keymanager-address" }: ValidIpAddress
+      name: "keymanager-address" .}: ValidIpAddress
 
     keymanagerTokenFile* {.
       desc: "A file specifying the authorizition token required for accessing the keymanager API"
-      name: "keymanager-token-file" }: Option[InputFile]
+      name: "keymanager-token-file" .}: Option[InputFile]
 
     graffiti* {.
       desc: "The graffiti value that will appear in proposed blocks. " &
             "You can use a 0x-prefixed hex encoded string to specify " &
             "raw bytes"
-      name: "graffiti" }: Option[GraffitiBytes]
+      name: "graffiti" .}: Option[GraffitiBytes]
 
     stopAtEpoch* {.
       desc: "A positive epoch selects the epoch at which to stop"
       defaultValue: 0
-      name: "stop-at-epoch" }: uint64
+      name: "stop-at-epoch" .}: uint64
 
     beaconNodes* {.
       desc: "URL addresses to one or more beacon node HTTP REST APIs",
       defaultValue: @[defaultBeaconNode]
       defaultValueDesc: "http://127.0.0.1:5052"
-      name: "beacon-node" }: seq[string]
+      name: "beacon-node" .}: seq[string]
 
   SigningNodeConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"
-      name: "config-file" }: Option[InputFile]
+      name: "config-file" .}: Option[InputFile]
 
     logLevel* {.
       desc: "Sets the log level"
       defaultValue: "INFO"
-      name: "log-level" }: string
+      name: "log-level" .}: string
 
     logStdout* {.
       desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
-      name: "log-stdout" }: StdoutLogKind
+      name: "log-stdout" .}: StdoutLogKind
 
     logFile* {.
       desc: "Specifies a path for the written Json log file"
-      name: "log-file" }: Option[OutFile]
+      name: "log-file" .}: Option[OutFile]
 
     nonInteractive* {.
       desc: "Do not display interative prompts. Quit on missing configuration"
-      name: "non-interactive" }: bool
+      name: "non-interactive" .}: bool
 
     dataDir* {.
       desc: "The directory where nimbus will store validator's keys"
       defaultValue: config.defaultDataDir()
       defaultValueDesc: ""
       abbr: "d"
-      name: "data-dir" }: OutDir
+      name: "data-dir" .}: OutDir
 
     validatorsDirFlag* {.
       desc: "A directory containing validator keystores"
-      name: "validators-dir" }: Option[InputDir]
+      name: "validators-dir" .}: Option[InputDir]
 
     secretsDirFlag* {.
       desc: "A directory containing validator keystore passwords"
-      name: "secrets-dir" }: Option[InputDir]
+      name: "secrets-dir" .}: Option[InputDir]
 
     serverIdent* {.
       desc: "Server identifier which will be used in HTTP Host header"
-      name: "server-ident" }: Option[string]
+      name: "server-ident" .}: Option[string]
 
     requestTimeout* {.
       desc: "Request timeout, maximum time that node will wait for remote " &
             "client request (in seconds)"
       defaultValue: defaultSigningNodeRequestTimeout
-      name: "request-timeout" }: int
+      name: "request-timeout" .}: int
 
     bindPort* {.
       desc: "Port for the REST (BETA version) HTTP server"
       defaultValue: DefaultEth2RestPort
       defaultValueDesc: "5052"
-      name: "bind-port" }: Port
+      name: "bind-port" .}: Port
 
     bindAddress* {.
       desc: "Listening address of the REST (BETA version) HTTP server"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: "127.0.0.1"
-      name: "bind-address" }: ValidIpAddress
+      name: "bind-address" .}: ValidIpAddress
 
     tlsEnabled* {.
       desc: "Use secure TLS communication for REST (BETA version) server"
       defaultValue: false
-      name: "tls" }: bool
+      name: "tls" .}: bool
 
     tlsCertificate* {.
       desc: "Path to SSL certificate file"
-      name: "tls-cert" }: Option[InputFile]
+      name: "tls-cert" .}: Option[InputFile]
 
     tlsPrivateKey* {.
       desc: "Path to SSL ceritificate's private key"
-      name: "tls-key" }: Option[InputFile]
+      name: "tls-key" .}: Option[InputFile]
 
   AnyConf* = BeaconNodeConf | ValidatorClientConf | SigningNodeConf
 

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -20,68 +20,68 @@ type LightClientConf* = object
   # Config
   configFile* {.
     desc: "Loads the configuration from a TOML file"
-    name: "config-file" }: Option[InputFile]
+    name: "config-file" .}: Option[InputFile]
 
   # Logging
   logLevel* {.
     desc: "Sets the log level"
     defaultValue: "INFO"
-    name: "log-level" }: string
+    name: "log-level" .}: string
 
   logStdout* {.
     hidden
     desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
     defaultValueDesc: "auto"
     defaultValue: StdoutLogKind.Auto
-    name: "log-format" }: StdoutLogKind
+    name: "log-format" .}: StdoutLogKind
 
   logFile* {.
     desc: "Specifies a path for the written Json log file (deprecated)"
-    name: "log-file" }: Option[OutFile]
+    name: "log-file" .}: Option[OutFile]
 
   # Network
   eth2Network* {.
     desc: "The Eth2 network to join"
     defaultValueDesc: "mainnet"
-    name: "network" }: Option[string]
+    name: "network" .}: Option[string]
 
   # Libp2p
   bootstrapNodes* {.
     desc: "Specifies one or more bootstrap nodes to use when connecting to the network"
     abbr: "b"
-    name: "bootstrap-node" }: seq[string]
+    name: "bootstrap-node" .}: seq[string]
 
   bootstrapNodesFile* {.
     desc: "Specifies a line-delimited file of bootstrap Ethereum network addresses"
     defaultValue: ""
-    name: "bootstrap-file" }: InputFile
+    name: "bootstrap-file" .}: InputFile
 
   listenAddress* {.
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
     defaultValue: defaultListenAddress
     defaultValueDesc: "0.0.0.0"
-    name: "listen-address" }: ValidIpAddress
+    name: "listen-address" .}: ValidIpAddress
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"
     defaultValue: defaultEth2TcpPort
     defaultValueDesc: "9000"
-    name: "tcp-port" }: Port
+    name: "tcp-port" .}: Port
 
   udpPort* {.
     desc: "Listening UDP port for node discovery"
     defaultValue: defaultEth2TcpPort
     defaultValueDesc: "9000"
-    name: "udp-port" }: Port
+    name: "udp-port" .}: Port
 
   maxPeers* {.
     desc: "The target number of peers to connect to"
     defaultValue: 160 # 5 (fanout) * 64 (subnets) / 2 (subs) for a heathy mesh
-    name: "max-peers" }: int
+    name: "max-peers" .}: int
 
   hardMaxPeers* {.
     desc: "The maximum number of peers to connect to. Defaults to maxPeers * 1.5"
-    name: "hard-max-peers" }: Option[int]
+    name: "hard-max-peers" .}: Option[int]
 
   nat* {.
     desc: "Specify method to use for determining public address. " &
@@ -100,12 +100,12 @@ type LightClientConf* = object
   agentString* {.
     defaultValue: "nimbus",
     desc: "Node agent string which is used as identifier in network"
-    name: "agent-string" }: string
+    name: "agent-string" .}: string
 
   discv5Enabled* {.
     desc: "Enable Discovery v5"
     defaultValue: true
-    name: "discv5" }: bool
+    name: "discv5" .}: bool
 
   directPeers* {.
     desc: "The list of priviledged, secure and known peers to connect and maintain the connection to, this requires a not random netkey-file. In the complete multiaddress format like: /ip4/<address>/tcp/<port>/p2p/<peerId-public-key>. Peering agreements are established out of band and must be reciprocal."
@@ -114,11 +114,11 @@ type LightClientConf* = object
   # Light client
   trustedBlockRoot* {.
     desc: "Recent trusted finalized block root to initialize light client from"
-    name: "trusted-block-root" }: Eth2Digest
+    name: "trusted-block-root" .}: Eth2Digest
 
   # Testing
   stopAtEpoch* {.
     hidden
     desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
     defaultValue: 0
-    name: "stop-at-epoch" }: uint64
+    name: "stop-at-epoch" .}: uint64


### PR DESCRIPTION
Aligns code style in `conf.nim`. Some pragmas lacked trailing `.`