### PR TITLE
update CI timeouts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,72 +13,60 @@ def runStages(nodeDir) {
 	sh "mkdir -p ${nodeDir}"
 	dir(nodeDir) {
 		try {
-			stage("Clone") {
-				timeout(time: 10) {
-					/* source code checkout */
-					checkout scm
-					/* we need to update the submodules before caching kicks in */
-					sh "git submodule update --init --recursive"
-				}
-			}
+			stage("Clone") { timeout(10) {
+				/* source code checkout */
+				checkout scm
+				/* we need to update the submodules before caching kicks in */
+				sh "git submodule update --init --recursive"
+			} }
 
-			stage("Preparations") {
-				timeout(time: 10) {
-					sh """#!/bin/bash
-					set -e
-					# macOS shows scary warnings if there are old libraries and object files laying around
-					make clean
-					# to allow the following parallel stages
-					make -j${env.NPROC} QUICK_AND_DIRTY_COMPILER=1 update
-					./scripts/setup_scenarios.sh
-					"""
-				}
-			}
+			stage("Preparations") { timeout(10) {
+				sh """#!/bin/bash
+				set -e
+				# macOS shows scary warnings if there are old libraries and object files laying around
+				make clean
+				# to allow the following parallel stages
+				make -j${env.NPROC} QUICK_AND_DIRTY_COMPILER=1 update
+				./scripts/setup_scenarios.sh
+				"""
+			} }
 
-			stage("Tools") {
-				timeout(time: 30) {
-					sh """#!/bin/bash
-					set -e
-					make -j${env.NPROC} LOG_LEVEL=TRACE
-					"""
-				}
-			}
+			stage("Tools") { timeout(30) {
+				sh """#!/bin/bash
+				set -e
+				make -j${env.NPROC} LOG_LEVEL=TRACE
+				"""
+			} }
 
-			stage("Test suite") {
-				timeout(time: 60) {
-					sh "make -j${env.NPROC} DISABLE_TEST_FIXTURES_SCRIPT=1 test"
-				}
-			}
+			stage("Test suite") { timeout(60) {
+				sh "make -j${env.NPROC} DISABLE_TEST_FIXTURES_SCRIPT=1 test"
+			} }
 
-			stage("REST test suite") {
-				timeout(time: 5) {
-					sh """#!/bin/bash
-					set -e
-					./tests/simulation/restapi.sh --data-dir resttest0_data --base-port \$(( 9100 + EXECUTOR_NUMBER * 100 )) \
-						--base-rest-port \$(( 7100 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \
-					\$(( 8108 + EXECUTOR_NUMBER * 100 )) --resttest-delay 30 --kill-old-processes
-					"""
-				}
-			}
+			stage("REST test suite") { timeout(5) {
+				sh """#!/bin/bash
+				set -e
+				./tests/simulation/restapi.sh --data-dir resttest0_data --base-port \$(( 9100 + EXECUTOR_NUMBER * 100 )) \
+					--base-rest-port \$(( 7100 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \
+				\$(( 8108 + EXECUTOR_NUMBER * 100 )) --resttest-delay 30 --kill-old-processes
+				"""
+			} }
 
-			stage("Testnet finalization") {
-				timeout(time: 75) {
-					// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
-					sh """#!/bin/bash
-					set -e
-					./scripts/launch_local_testnet.sh --preset minimal --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
-						--data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
-						\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 600 \
-						--kill-old-processes \
-						-- --verify-finalization --discv5:no
-					./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
-						--data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
-						\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 2400 \
-						--kill-old-processes \
-						-- --verify-finalization --discv5:no
-					"""
-				}
-			}
+			stage("Testnet finalization") { timeout(75) {
+				// EXECUTOR_NUMBER will be 0 or 1, since we have 2 executors per Jenkins node
+				sh """#!/bin/bash
+				set -e
+				./scripts/launch_local_testnet.sh --preset minimal --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
+					--data-dir local_testnet0_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
+					\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 600 \
+					--kill-old-processes \
+					-- --verify-finalization --discv5:no
+				./scripts/launch_local_testnet.sh --nodes 4 --stop-at-epoch 5 --disable-htop --enable-logtrace \
+					--data-dir local_testnet1_data --base-port \$(( 9000 + EXECUTOR_NUMBER * 100 )) --base-rest-port \
+					\$(( 7000 + EXECUTOR_NUMBER * 100 )) --base-metrics-port \$(( 8008 + EXECUTOR_NUMBER * 100 )) --timeout 2400 \
+					--kill-old-processes \
+					-- --verify-finalization --discv5:no
+				"""
+			} }
 		} catch(e) {
 			// we need to rethrow the exception here
 			throw e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,7 @@ def runStages(nodeDir) {
 parallel(
 	"Linux": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 12, unit: 'HOURS') { // includes time in build queue
+			timeout(time: 24, unit: 'HOURS') { // includes time in build queue
 				node("linux") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'nproc').trim()}"]) {
 						runStages("linux")
@@ -104,7 +104,7 @@ parallel(
 	},
 	"macOS (AMD64)": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 12, unit: 'HOURS') { // includes time in build queue
+			timeout(time: 24, unit: 'HOURS') { // includes time in build queue
 				node("macos && x86_64") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 						runStages("macos_amd64")
@@ -115,7 +115,7 @@ parallel(
 	},
 	"macOS (ARM64)": {
 		throttle(['nimbus-eth2']) {
-			timeout(time: 12, unit: 'HOURS') { // includes time in build queue
+			timeout(time: 24, unit: 'HOURS') { // includes time in build queue
 				node("macos && arm64") {
 					withEnv(["NPROC=${sh(returnStdout: true, script: 'sysctl -n hw.logicalcpu').trim()}"]) {
 						runStages("macos_arm64")


### PR DESCRIPTION
Assign a longer overall timeout that a CI job can spend in queue,
and define short timeouts for the individual stages to avoid stuck jobs.