### PR TITLE
fix CI archive step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ def runStages(nodeDir) {
 			// archive testnet logs
 			sh """#!/bin/bash
 			for D in local_testnet0_data local_testnet1_data resttest0_data; do
-				[[ -d "\$D" ]] && tar czf "\${D}-\${NODE_NAME}.tar.gz "\${D}"/*.txt || true
+				[[ -d "\$D" ]] && tar czf "\${D}-\${NODE_NAME}.tar.gz" "\${D}"/*.txt || true
 			done
 			"""
 			try {


### PR DESCRIPTION
c20309ba394abb7ee57ad9a16efa02ff3edbb3b5 accidentally deleted a `"`.
This is now re-added to avoid errors during artifact CI archiving step.