### PR TITLE
Use .tar.gz consistently in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ def runStages(nodeDir) {
 			// archive testnet logs
 			sh """#!/bin/bash
 			for D in local_testnet0_data local_testnet1_data resttest0_data; do
-				[[ -d "\$D" ]] && tar czf "\${D}-\${NODE_NAME}.tar.gz" "\${D}"/*.txt || true
+				[[ -d "\$D" ]] && tar cjf "\${D}-\${NODE_NAME}.tar.bz2" "\${D}"/*.txt || true
 			done
 			"""
 			try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,11 +74,11 @@ def runStages(nodeDir) {
 			// archive testnet logs
 			sh """#!/bin/bash
 			for D in local_testnet0_data local_testnet1_data resttest0_data; do
-				[[ -d "\$D" ]] && tar cjf "\${D}-\${NODE_NAME}.tar.bz2" "\${D}"/*.txt || true
+				[[ -d "\$D" ]] && tar czf "\${D}-\${NODE_NAME}.tar.gz" "\${D}"/*.txt || true
 			done
 			"""
 			try {
-				archiveArtifacts("*.tar.bz2")
+				archiveArtifacts("*.tar.gz")
 			} catch(e) {
 				println("Couldn't archive artefacts.")
 				println(e.toString());


### PR DESCRIPTION
Currently, Jenkins artifacts aren't being created at all because of a mismatch between different stages.