### PR TITLE
use ZERO_HASH for default(Eth2Digest)/Eth2Digest() in func calls

### DIFF
--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -61,7 +61,7 @@ func init*(
     T: type BlockRef, root: Eth2Digest,
     blck: phase0.SomeBeaconBlock | altair.SomeBeaconBlock |
           phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock): BlockRef =
-  BlockRef.init(root, Eth2Digest(), blck.slot)
+  BlockRef.init(root, ZERO_HASH, blck.slot)
 
 func init*(
     T: type BlockRef, root: Eth2Digest,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -752,8 +752,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # Load head -> finalized, or all summaries in case the finalized block table
   # hasn't been written yet
   for blck in db.getAncestorSummaries(head.root):
-    let newRef = BlockRef.init(
-      blck.root, default(Eth2Digest), blck.summary.slot)
+    let newRef = BlockRef.init(blck.root, ZERO_HASH, blck.summary.slot)
     if headRef == nil:
       doAssert blck.root == head.root
       headRef = newRef

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -20,9 +20,6 @@ type
     summaries: Table[Eth2Digest, BeaconBlockSummary]
     slots: seq[Option[Eth2Digest]]
 
-const
-  emptyHash = Eth2Digest()
-
 proc updateSlots(cache: var DbCache, root: Eth2Digest, slot: Slot) =
   # The slots mapping stores one linear block history - we construct it by
   # starting from a given root/slot and walking the known parents as far back
@@ -40,7 +37,7 @@ proc updateSlots(cache: var DbCache, root: Eth2Digest, slot: Slot) =
       let slot = v[].slot
 
       for i in slot.int + 1..<lastSlot.int: # Avoid re-querying known gaps
-        cache.slots[i] = some(emptyHash)
+        cache.slots[i] = some(ZERO_HASH)
 
       cache.slots[slot.int] = some(root)
 
@@ -315,7 +312,7 @@ proc doTrustedNodeSync*(
       processed += 1
       var blck = await fut
       if blck.isNone():
-        dbCache.slots[slot.int] = some emptyHash
+        dbCache.slots[slot.int] = some ZERO_HASH
         return
 
       let data = blck.get()
@@ -336,7 +333,7 @@ proc doTrustedNodeSync*(
             quit 1
 
           let knownRoot = dbCache.slots[childSlot.int].get()
-          if knownRoot == emptyHash:
+          if knownRoot == ZERO_HASH:
             childSlot += 1
             continue
 

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1307,8 +1307,7 @@ proc registerSyntheticAttestation*(
     checkStatus()
   block:
     let status = db.sqlInsertAtt.exec(
-      (valID, int64 source, int64 target,
-      Eth2Digest().data))
+      (valID, int64 source, int64 target, ZERO_HASH.data))
     checkStatus()
   block:
     let status = db.sqlCommitTransaction.exec()

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   stew/io2,
   stats, os, strformat, times,
@@ -108,7 +115,7 @@ proc loadGenesis*(validators: Natural, validate: bool):
     let res = (ref ForkedHashedBeaconState)(
       kind: BeaconStateFork.Phase0,
       phase0Data: initialize_hashed_beacon_state_from_eth1(
-        cfg, Eth2Digest(), 0, deposits, flags))
+        cfg, ZERO_HASH, 0, deposits, flags))
 
     echo &"Saving to {genesisFn}..."
     SSZ.saveFile(genesisFn, res.phase0Data.data)

--- a/scripts/test_merge_vectors.nim
+++ b/scripts/test_merge_vectors.nim
@@ -22,7 +22,7 @@ suite "Merge test vectors":
         existingBlock.hash.asEth2Digest,
         existingBlock.hash.asEth2Digest,
         existingBlock.timestamp.uint64 + 12,
-        default(Eth2Digest).data,  # Random
+        ZERO_HASH.data,  # Random
         feeRecipient)
       payload =         waitFor web3Provider.getPayload(
         array[8, byte] (payloadId.payloadId.get))
@@ -31,7 +31,7 @@ suite "Merge test vectors":
         payload.blockHash.asEth2Digest,
         payload.blockHash.asEth2Digest,
         existingBlock.timestamp.uint64 + 24,
-        default(Eth2Digest).data,  # Random
+        ZERO_HASH.data,  # Random
         feeRecipient)
 
       payload2 =         waitFor web3Provider.getPayload(
@@ -41,7 +41,7 @@ suite "Merge test vectors":
         payload2.blockHash.asEth2Digest,
         payload2.blockHash.asEth2Digest,
         existingBlock.timestamp.uint64 + 36,
-        default(Eth2Digest).data,  # Random
+        ZERO_HASH.data,  # Random
         feeRecipient)
 
     check:

--- a/scripts/test_mev_boost.nim
+++ b/scripts/test_mev_boost.nim
@@ -40,7 +40,7 @@ suite "MEV tests":
         existingBlock.hash.asEth2Digest,
         existingBlock.hash.asEth2Digest,
         existingBlock.timestamp.uint64 + 12,
-        default(Eth2Digest).data,  # Random
+        ZERO_HASH.data,  # Random
         feeRecipient)
       blindedHeader = waitFor restClient.getHeader(
         1.Slot, existingBlock.hash.asEth2Digest, pubKey)

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -70,7 +70,7 @@ func apply(ctx: var ForkChoiceBackend, id: int, op: Operation) =
       op.finalized_checkpoint,
       op.justified_state_balances,
       # Don't use proposer boosting
-      default(Eth2Digest)
+      ZERO_HASH
     )
     if op.kind == FindHead:
       doAssert r.isOk(), &"find_head (op #{id}) returned an error: {r.error}"

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -52,11 +52,7 @@ const TestDbName = "test_slashprot"
 suite "Slashing Protection DB" & preset():
   test "Empty database" & preset():
     sqlite3db_delete(TestDir, TestDbName)
-    let db = SlashingProtectionDB.init(
-               default(Eth2Digest),
-               TestDir,
-               TestDbName
-             )
+    let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
     defer:
       db.close()
       sqlite3db_delete(TestDir, TestDbName)
@@ -82,11 +78,7 @@ suite "Slashing Protection DB" & preset():
 
   test "SP for block proposal - linear append":
     sqlite3db_delete(TestDir, TestDbName)
-    let db = SlashingProtectionDB.init(
-               default(Eth2Digest),
-               TestDir,
-               TestDbName
-             )
+    let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
     defer:
       db.close()
       sqlite3db_delete(TestDir, TestDbName)
@@ -172,11 +164,7 @@ suite "Slashing Protection DB" & preset():
 
   test "SP for block proposal - backtracking append":
     sqlite3db_delete(TestDir, TestDbName)
-    let db = SlashingProtectionDB.init(
-               default(Eth2Digest),
-               TestDir,
-               TestDbName
-             )
+    let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
     defer:
       db.close()
       sqlite3db_delete(TestDir, TestDbName)
@@ -306,11 +294,7 @@ suite "Slashing Protection DB" & preset():
 
   test "SP for same epoch attestation target - linear append":
     sqlite3db_delete(TestDir, TestDbName)
-    let db = SlashingProtectionDB.init(
-               default(Eth2Digest),
-               TestDir,
-               TestDbName
-             )
+    let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
     defer:
       db.close()
       sqlite3db_delete(TestDir, TestDbName)
@@ -392,11 +376,7 @@ suite "Slashing Protection DB" & preset():
   test "SP for surrounded attestations":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -427,11 +407,7 @@ suite "Slashing Protection DB" & preset():
 
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -476,11 +452,7 @@ suite "Slashing Protection DB" & preset():
   test "SP for surrounding attestations":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -505,11 +477,7 @@ suite "Slashing Protection DB" & preset():
 
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -544,11 +512,7 @@ suite "Slashing Protection DB" & preset():
   test "Attestation ordering #1698":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -596,11 +560,7 @@ suite "Slashing Protection DB" & preset():
   test "Test valid attestation #1699":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -630,11 +590,7 @@ suite "Slashing Protection DB" & preset():
   test "Pruning blocks works":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -672,11 +628,7 @@ suite "Slashing Protection DB" & preset():
   test "Don't prune the very last block even by mistake":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -715,11 +667,7 @@ suite "Slashing Protection DB" & preset():
   test "Pruning attestations works":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)
@@ -790,11 +738,7 @@ suite "Slashing Protection DB" & preset():
   test "Don't prune the very last attestation(s) even by mistake":
     block:
       sqlite3db_delete(TestDir, TestDbName)
-      let db = SlashingProtectionDB.init(
-                default(Eth2Digest),
-                TestDir,
-                TestDbName
-              )
+      let db = SlashingProtectionDB.init(ZERO_HASH, TestDir, TestDbName)
       defer:
         db.close()
         sqlite3db_delete(TestDir, TestDbName)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -167,7 +167,7 @@ suite "Attestation pool processing" & preset():
 
     let
       # Someone votes for a different root
-      att3 = makeAttestation(state[], Eth2Digest(), bc1[2], cache)
+      att3 = makeAttestation(state[], ZERO_HASH, bc1[2], cache)
     pool[].addAttestation(
       att3, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 
@@ -182,7 +182,7 @@ suite "Attestation pool processing" & preset():
 
     let
       # Someone votes for a different root
-      att4 = makeAttestation(state[], Eth2Digest(), bc1[2], cache)
+      att4 = makeAttestation(state[], ZERO_HASH, bc1[2], cache)
     pool[].addAttestation(
       att4, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -88,8 +88,8 @@ suite "Beacon chain DB" & preset():
     var
       db = BeaconChainDB.new("", inMemory = true)
     check:
-      db.getPhase0StateRef(Eth2Digest()).isNil
-      db.getBlock(Eth2Digest(), phase0.TrustedSignedBeaconBlock).isNone
+      db.getPhase0StateRef(ZERO_HASH).isNil
+      db.getBlock(ZERO_HASH, phase0.TrustedSignedBeaconBlock).isNone
 
   test "sanity check phase 0 blocks" & preset():
     let db = BeaconChainDB.new("", inMemory = true)
@@ -496,12 +496,12 @@ suite "FinalizedBlocks" & preset():
       s.low.isNone
       s.high.isNone
 
-    s.insert(Slot 0, Eth2Digest())
+    s.insert(Slot 0, ZERO_HASH)
     check:
       s.low.get() == Slot 0
       s.high.get() == Slot 0
 
-    s.insert(Slot 5, Eth2Digest())
+    s.insert(Slot 5, ZERO_HASH)
     check:
       s.low.get() == Slot 0
       s.high.get() == Slot 5

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -23,7 +23,7 @@ func makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
 suite "Block quarantine":
   test "Unviable smoke test":
     let
-      b0 = makeBlock(Slot 0, Eth2Digest())
+      b0 = makeBlock(Slot 0, ZERO_HASH)
       b1 = makeBlock(Slot 1, b0.root)
       b2 = makeBlock(Slot 2, b1.root)
       b3 = makeBlock(Slot 3, b2.root)

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -292,7 +292,7 @@ suite "Block pool altair processing" & preset():
 
   test "Invalid signatures" & preset():
     let badSignature = get_slot_signature(
-      Fork(), Eth2Digest(), 42.Slot,
+      Fork(), ZERO_HASH, 42.Slot,
       MockPrivKeys[ValidatorIndex(0)]).toValidatorSig()
 
     check:
@@ -605,9 +605,7 @@ suite "Old database versions" & preset():
   setup:
     let
       genState = newClone(initialize_hashed_beacon_state_from_eth1(
-        defaultRuntimeConfig,
-        Eth2Digest(),
-        0,
+        defaultRuntimeConfig, ZERO_HASH, 0,
         makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation}))
       genBlock = get_initial_beacon_block(genState[])
@@ -721,9 +719,7 @@ suite "Backfill":
       genState = (ref ForkedHashedBeaconState)(
         kind: BeaconStateFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig,
-          Eth2Digest(),
-          0,
+          defaultRuntimeConfig, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
           {skipBlsValidation}))
       tailState = assignClone(genState[])

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -23,8 +23,7 @@ suite "Beacon state" & preset():
 
   test "Smoke test initialize_beacon_state_from_eth1" & preset():
     let state = newClone(initialize_beacon_state_from_eth1(
-      cfg, Eth2Digest(), 0,
-      makeInitialDeposits(SLOTS_PER_EPOCH, {}), {}))
+      cfg, ZERO_HASH, 0, makeInitialDeposits(SLOTS_PER_EPOCH, {}), {}))
     check: state.validators.lenu64 == SLOTS_PER_EPOCH
 
   test "process_slots":
@@ -32,7 +31,7 @@ suite "Beacon state" & preset():
       state = (ref ForkedHashedBeaconState)(
         kind: BeaconStateFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, Eth2Digest(), 0,
+          defaultRuntimeConfig, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       cache: StateCache
       info: ForkedEpochInfo
@@ -46,7 +45,7 @@ suite "Beacon state" & preset():
       state = (ref ForkedHashedBeaconState)(
         kind: BeaconStateFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, Eth2Digest(), 0,
+          defaultRuntimeConfig, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       genBlock = get_initial_beacon_block(state[])
       cache: StateCache
@@ -72,7 +71,7 @@ suite "Beacon state" & preset():
       state = (ref ForkedHashedBeaconState)(
         kind: BeaconStateFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, Eth2Digest(), 0,
+          defaultRuntimeConfig, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       cache: StateCache
       info: ForkedEpochInfo
@@ -97,7 +96,7 @@ suite "Beacon state" & preset():
       state = (ref ForkedHashedBeaconState)(
         kind: BeaconStateFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, Eth2Digest(), 0,
+          defaultRuntimeConfig, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       genBlock = get_initial_beacon_block(state[])
       cache: StateCache

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -28,7 +28,7 @@ proc makeTestDB*(validators: Natural): BeaconChainDB =
       kind: BeaconStateFork.Phase0,
       phase0Data: initialize_hashed_beacon_state_from_eth1(
         defaultRuntimeConfig,
-        Eth2Digest(),
+        ZERO_HASH,
         0,
         makeInitialDeposits(validators.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation}))


### PR DESCRIPTION
This is handled differently in each context in which one might use `default(Eth2Digest)` or `Eth2Digest()`, but `f(default(Eth2Digest))` specifically generates a new temporary and zeros it each time. For example, this doesn't necesarily hold true in assignment statements, where it manages to optimize it in C codegen to just `NimZeroMem()`ing the variable in question. This replaces those `default(Eth2Digest)` and `Eth2Digest()` parameters of various function calls with the already-extant `ZERO_HASH` constant, saving a `NimZeroMem()` on 32 bytes each time.

For example, when using `default(Eth2Digest)` directly as a parameter of a function call `f` (here mangled as `f__WSRF65DEgqvsRVPSXaUv9cg`), Nim generates something like (will vary slightly):
```c
        nimZeroMem((void*)(&T11_), sizeof(tyObject_MDigest__law9ct65KplMYBvtmjCQxbw));
        f__WSRF65DEgqvsRVPSXaUv9cg((&T11_), ((NimStringDesc*) &TM__GRc4yQKLQNq4Xaa3826uug_5));
```
while referring to an existing constant `TM__GRc4yQKLQNq4Xaa3826uug_6` become just
```c
f__WSRF65DEgqvsRVPSXaUv9cg((&TM__GRc4yQKLQNq4Xaa3826uug_6), ((NimStringDesc*) &TM__GRc4yQKLQNq4Xaa3826uug_7));
```

where
```c
static NIM_CONST tyObject_MDigest__law9ct65KplMYBvtmjCQxbw TM__GRc4yQKLQNq4Xaa3826uug_6 = {{
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0),
        ((NU8) 0)
    }
}
;
```