### PR TITLE
include capella fork version in fork consistency check

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -553,6 +553,19 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + should register stability subnets on attester duties                                       OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## weak-subjectivity-checkpoint
+```diff
++ Correct values                                                                             OK
++ invalid characters in root                                                                 OK
++ longer root                                                                                OK
++ missing epoch                                                                              OK
++ missing root                                                                               OK
++ missing separator                                                                          OK
++ negative epoch                                                                             OK
++ non-number epoch                                                                           OK
++ shorter root                                                                               OK
+```
+OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 308/313 Fail: 0/313 Skip: 5/313
+OK: 317/322 Fail: 0/322 Skip: 5/322

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -960,15 +960,13 @@ func clear*(cache: var StateCache) =
   cache.sync_committees.clear
 
 func checkForkConsistency*(cfg: RuntimeConfig) =
-  # TODO add cfg.CAPELLA_FORK_VERSION once merge-testnets repo includes it and
-  # fixes SHARDING_FORK_VERSION to be a new FORK_VERSION. Until then make sure
-  # that it will never actually use the Capella fork.
   doAssert cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH
   doAssert cfg.SHARDING_FORK_EPOCH == FAR_FUTURE_EPOCH
 
   let forkVersions =
     [cfg.GENESIS_FORK_VERSION, cfg.ALTAIR_FORK_VERSION,
-     cfg.BELLATRIX_FORK_VERSION, cfg.SHARDING_FORK_VERSION]
+     cfg.BELLATRIX_FORK_VERSION, cfg.CAPELLA_FORK_VERSION,
+     cfg.SHARDING_FORK_VERSION]
   for i in 0 ..< forkVersions.len:
     for j in i+1 ..< forkVersions.len:
       doAssert distinctBase(forkVersions[i]) != distinctBase(forkVersions[j])

--- a/tests/test_conf.nim
+++ b/tests/test_conf.nim
@@ -1,3 +1,11 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [Defect].}
 {.used.}
 
 import

--- a/tests/test_conf.nim
+++ b/tests/test_conf.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import
   unittest2,
   ../beacon_chain/conf


### PR DESCRIPTION
Followup to https://github.com/status-im/nimbus-eth2/pull/3767

Tested at build time with mainnet, Prater, Ropsten, and Sepolia, and Gnosis (the last using the define flag to trigger it):
https://github.com/status-im/nimbus-eth2/blob/c48ea3cdc8b3fec12a1256bc0c95a1ba1010d727/beacon_chain/networking/network_metadata.nim#L251-L253
https://github.com/status-im/nimbus-eth2/blob/c48ea3cdc8b3fec12a1256bc0c95a1ba1010d727/beacon_chain/networking/network_metadata.nim#L300

Tested with those at runtime, plus some not included in the compile-time set in this branch or `unstable`: kiln and mainnet shadow forks 2, 6, and 7.