### PR TITLE
only process deposits if merkleizer available

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1469,7 +1469,7 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
         m.terminalBlockHash = some terminalBlockCandidate.hash
         m.terminalBlockNumber = some terminalBlockCandidate.number
 
-    if shouldProcessDeposits:
+    if shouldProcessDeposits and scratchMerkleizer != nil:
       if m.latestEth1BlockNumber <= m.cfg.ETH1_FOLLOW_DISTANCE:
         continue
 


### PR DESCRIPTION
`m.depositsChain.blocks.len` may change during `startEth1Syncing`. If
that happened, an additional check now ensures that `scratchMerkleizer`
was initialized before attempting to use it.