### PR TITLE
use JWT when and only when the user specifies a JWT secret explicitly

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -435,7 +435,9 @@ proc init*(T: type BeaconNode,
     quit 1
 
   let optJwtSecret =
-    if cfg.BELLATRIX_FORK_EPOCH != FAR_FUTURE_EPOCH:
+    # Some Web3 endpoints aren't compatible with JWT, but if explicitly chosen,
+    # use it regardless.
+    if config.jwtSecret.isSome:
       let jwtSecret = rng[].checkJwtSecret(
         string(config.dataDir), config.jwtSecret)
       if jwtSecret.isErr:


### PR DESCRIPTION
This has some advantages:

- It allows people to configure and test with JWT without being on a merge testnet.

- When Prater and mainnet do each get a non-`FAR_FUTURE_EPOCH` `BELLATRIX_FORK_EPOCH` but before the merge actually happens, it won't break all those setups using those incompatible Web3 providers; rather, it'll be user choice/action determining this.

- it de-emphasizes the less useful case of using its CL-autogenerated JWT secret, because generally one's would launch the EL first, and it will generate a secret. For an EL, this is a reasonable approach. For a CL, it seldom makes sense to any default generated JWT secret.

Because of the last point, even in the testnets, there will be virtually no breakage from changing the edge case-semantics of this option.