### PR TITLE
use eth_chainId instead of net_version

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1061,8 +1061,7 @@ proc detectPrimaryProviderComingOnline(m: Eth1Monitor) {.async.} =
     # Use one of the get/request-type methods from
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#underlying-protocol
     # which does nit take parameters and returns a small structure, to ensure
-    # this works with engine API endpoints. Either eth_chainId or eth_syncing
-    # works for this purpose.
+    # this works with engine API endpoints.
     let testRequest = tempProvider.web3.provider.eth_syncing()
 
     yield testRequest or sleepAsync(web3Timeouts)
@@ -1343,18 +1342,27 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
     contract = $m.depositContractAddress
 
   if isFirstRun and m.eth1Network.isSome:
-    let
-      providerNetwork = awaitWithRetries m.dataProvider.web3.provider.net_version()
-      expectedNetwork = case m.eth1Network.get
-        of mainnet: "1"
-        of ropsten: "3"
-        of rinkeby: "4"
-        of goerli:  "5"
-        of sepolia: "11155111"
-    if expectedNetwork != providerNetwork:
-      fatal "The specified web3 provider serves data for a different network",
-             expectedNetwork, providerNetwork
-      quit 1
+    try:
+      let
+        providerChain =
+          (awaitWithRetries m.dataProvider.web3.provider.eth_chainId()).uint64
+
+        # https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids
+        expectedChain = case m.eth1Network.get
+          of mainnet: 1'u64
+          of ropsten: 3'u64
+          of rinkeby: 4'u64
+          of goerli:  5'u64
+          of sepolia: 11155111'u64   # https://chainid.network/
+      if expectedChain != providerChain:
+        fatal "The specified web3 provider serves data for a different chain",
+               expectedChain, providerChain
+        quit 1
+    except CatchableError as exc:
+      # Typically because it's not synced through EIP-155, assuming this Web3
+      # endpoint has been otherwise working.
+      debug "startEth1Syncing: eth_chainId failed: ",
+        error = exc.msg
 
   var mustUsePolling = m.forcePolling or
                        web3Url.startsWith("http://") or
@@ -1526,8 +1534,6 @@ proc testWeb3Provider*(web3Url: Uri,
     web3 = mustSucceed "connect to web3 provider":
       await newWeb3(
         $web3Url, getJsonRpcRequestHeaders(jwtSecret))
-    networkVersion = mustSucceed "get network version":
-      awaitWithRetries web3.provider.net_version()
     latestBlock = mustSucceed "get latest block":
       awaitWithRetries web3.provider.eth_getBlockByNumber(blockId("latest"), false)
     syncStatus = mustSucceed "get sync status":
@@ -1543,12 +1549,18 @@ proc testWeb3Provider*(web3Url: Uri,
       awaitWithRetries web3.provider.eth_mining()
 
   echo "Client Version: ", clientVersion
-  echo "Network Version: ", networkVersion
   echo "Network Peers: ", peers
   echo "Syncing: ", syncStatus
   echo "Latest block: ", latestBlock.number.uint64
   echo "Last Known Nonce: ", web3.lastKnownNonce
   echo "Mining: ", mining
+
+  try:
+    let chainId = awaitWithRetries web3.provider.eth_chainId()
+    echo "Chain ID: ", chainId.uint64
+  except DataProviderFailure as exc:
+    # Typically because it's not synced through EIP-155.
+    echo "Web3 provider does not provide chain ID: " & exc.msg
 
   let ns = web3.contractSender(DepositContract, depositContractAddress)
   try:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1355,8 +1355,9 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
           of goerli:  5.Quantity
           of sepolia: 11155111.Quantity   # https://chainid.network/
       if expectedChain != providerChain:
-        fatal "The specified web3 provider serves data for a different chain",
-               expectedChain, providerChain
+        fatal "The specified Web3 provider serves data for a different chain",
+               expectedChain = distinctBase(expectedChain),
+               providerChain = distinctBase(providerChain)
         quit 1
     except CatchableError as exc:
       # Typically because it's not synced through EIP-155, assuming this Web3

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1345,15 +1345,15 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
     try:
       let
         providerChain =
-          (awaitWithRetries m.dataProvider.web3.provider.eth_chainId()).uint64
+          awaitWithRetries m.dataProvider.web3.provider.eth_chainId()
 
         # https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids
         expectedChain = case m.eth1Network.get
-          of mainnet: 1'u64
-          of ropsten: 3'u64
-          of rinkeby: 4'u64
-          of goerli:  5'u64
-          of sepolia: 11155111'u64   # https://chainid.network/
+          of mainnet: 1.Quantity
+          of ropsten: 3.Quantity
+          of rinkeby: 4.Quantity
+          of goerli:  5.Quantity
+          of sepolia: 11155111.Quantity   # https://chainid.network/
       if expectedChain != providerChain:
         fatal "The specified web3 provider serves data for a different chain",
                expectedChain, providerChain


### PR DESCRIPTION
`net_version` isn't one of the supported engine API methods in https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#underlying-protocol while `eth_chainId` is.

Until https://github.com/ethereum/go-ethereum/pull/25166 was merged, Geth effectively didn't support `eth_chainId` in merge networks in situations where it mattered, but with that fixed, it's now worth switching Nimbus to use it.

Tested with
- `rm ~/.ethereum/ -rv && go-ethereum/build/bin/geth --http --mainnet` and `build/nimbus_beacon_node --network=mainnet web3 test --url=http://127.0.0.1:8545`
- `rm ~/.ethereum/ -rv && go-ethereum/build/bin/geth --http --ropsten` and `build/nimbus_beacon_node --network=ropsten web3 test --url=http://127.0.0.1:8545`
- `rm ~/.ethereum/ -rv && go-ethereum/build/bin/geth --http --goerli` and `build/nimbus_beacon_node --network=prater web3 test --url=http://127.0.0.1:8545`
- `rm ~/.ethereum/ -rv && go-ethereum/build/bin/geth --http --sepolia` and `build/nimbus_beacon_node --network=sepolia web3 test --url=http://127.0.0.1:8545`