### PR TITLE
remove web3 url prompt in launcher script

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -474,6 +474,12 @@ proc init*(T: type BeaconNode,
     else:
       none(DepositContractSnapshot)
 
+  if config.web3Urls.len() == 0:
+    if BELLATRIX_FORK_EPOCH == FAR_FUTURE_EPOCH:
+      notice "Running without execution client - validator features partially disabled (see https://nimbus.guide/eth1.html)"
+    else:
+      notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
+
   var eth1Monitor: Eth1Monitor
   if not ChainDAGRef.isInitialized(db).isOk():
     var

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -475,7 +475,7 @@ proc init*(T: type BeaconNode,
       none(DepositContractSnapshot)
 
   if config.web3Urls.len() == 0:
-    if BELLATRIX_FORK_EPOCH == FAR_FUTURE_EPOCH:
+    if cfg.BELLATRIX_FORK_EPOCH == FAR_FUTURE_EPOCH:
       notice "Running without execution client - validator features partially disabled (see https://nimbus.guide/eth1.html)"
     else:
       notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"

--- a/docs/the_nimbus_book/src/eth1.md
+++ b/docs/the_nimbus_book/src/eth1.md
@@ -4,7 +4,13 @@ In order to be able to produce blocks and process incoming validator deposits, y
 
 Nimbus has been tested all major execution clients - see the [execution client comparison](https://ethereum.org/en/developers/docs/nodes-and-clients/#execution-clients) for more information.
 
-By default, Nimbus uses WebSockets to communicate with the execution client, connecting to ws://localhost:8546. You can provide a different URL with the `--web3-url` parameter.
+The `--web3-url` option informs the beacon node how to connect to the execution client - both `http://` and `ws://` URL:s are supported.
+
+Assuming the execution client is running on the same computer as the beacon node:
+
+```sh
+./run-mainnet-beacon-node.sh --web3-url=ws://127.0.0.1:8546
+```
 
 > ⚠️ You need to run your own execution client after [the merge](./merge.md) - relying on third-party services such as Infura, Alchemy and Pocket will not be possible.
 
@@ -54,7 +60,6 @@ INFO [05-29|01:16:10] Imported new chain segment               blocks=1 txs=0   
 INFO [05-29|01:16:10] Imported new chain segment               blocks=1 txs=1   mgas=0.021  elapsed=7.382ms   mgasps=2.845   number=3785447 hash=39986c…dd2a01
 INFO [05-29|01:16:14] Imported new chain segment               blocks=1 txs=11  mgas=1.135  elapsed=22.281ms  mgasps=50.943  number=3785444 hash=277bb9…623d8c
 ```
-
 
 Geth accepts connections from the loopback interface (`127.0.0.1`), with default WebSocket port `8546`. This means that your default Web3 provider URL should be: `ws://127.0.0.1:8546`
 

--- a/run-mainnet-beacon-node.sh
+++ b/run-mainnet-beacon-node.sh
@@ -9,5 +9,5 @@
 
 cd "$(dirname $0)"
 # Allow the binary to receive signals directly.
-exec scripts/run-beacon-node.sh nimbus_beacon_node mainnet $@
+exec scripts/run-beacon-node.sh nimbus_beacon_node mainnet "$@"
 

--- a/run-prater-beacon-node.sh
+++ b/run-prater-beacon-node.sh
@@ -9,5 +9,5 @@
 
 cd "$(dirname $0)"
 # Allow the binary to receive signals directly.
-exec scripts/run-beacon-node.sh nimbus_beacon_node prater $@
+exec scripts/run-beacon-node.sh nimbus_beacon_node prater "$@"
 

--- a/run-ropsten-beacon-node.sh
+++ b/run-ropsten-beacon-node.sh
@@ -9,4 +9,4 @@
 
 cd "$(dirname $0)"
 # Allow the binary to receive signals directly.
-exec scripts/run-beacon-node.sh nimbus_beacon_node ropsten $@
+exec scripts/run-beacon-node.sh nimbus_beacon_node ropsten "$@"

--- a/run-sepolia-beacon-node.sh
+++ b/run-sepolia-beacon-node.sh
@@ -9,4 +9,4 @@
 
 cd "$(dirname $0)"
 # Allow the binary to receive signals directly.
-exec scripts/run-beacon-node.sh nimbus_beacon_node sepolia $@
+exec scripts/run-beacon-node.sh nimbus_beacon_node sepolia "$@"

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -58,36 +58,6 @@ MISSING_BINARY_HELP
   exit 1
 fi
 
-WEB3_URL_OPT_PRESENT=0
-for op in "$@"; do
-  if [[ "${op}" =~ ^--web3-url=.*$ ]]; then
-    WEB3_URL_OPT_PRESENT=1
-    break
-  fi
-done
-
-if [[ "${WEB3_URL}" == "" && "${WEB3_URL_OPT_PRESENT}" == "0" ]]; then
-  cat <<WEB3_HELP
-
-To monitor the Eth1 validator deposit contract, you'll need to pair
-the Nimbus beacon node with a Web3 provider capable of serving Eth1
-event logs. This could be a locally running Eth1 client such as Geth
-or a cloud service such as Infura. For more information please see
-our setup guides:
-
-https://nimbus.guide/eth1.html
-
-WEB3_HELP
-
-  echo -n "Please enter a Web3 provider URL: "
-  read WEB3_URL
-fi
-
-EXTRA_ARGS=""
-if [[ "${WEB3_URL}" != "" ]]; then
-  EXTRA_ARGS="--web3-url=${WEB3_URL}"
-fi
-
 # Allow the binary to receive signals directly.
 exec ${WINPTY} build/${NBC_BINARY} \
   --network=${NETWORK} \
@@ -98,4 +68,4 @@ exec ${WINPTY} build/${NBC_BINARY} \
   --rest-port=$(( ${BASE_REST_PORT} + ${NODE_ID} )) \
   --metrics \
   ${EXTRA_ARGS} \
-  $@
+  "$@"


### PR DESCRIPTION
The interactive prompt for web3 has outlived its utility as we now load
url:s from command line params and config files, preventing the prompt
from correctly detecting when it's needed.

Also, after the merge, a JWT secret will (likely) be needed.

* log notice when web3 url is missing
* fix docs to not mention default that doesn't exist
* fix scripts to properly quote arguments