### PR TITLE
encapsulate LC config into one type

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -71,6 +71,18 @@ type
     tailSlot*: Slot
       ## The earliest slot for which light client data is imported.
 
+  LightClientDataConfig* = object
+    serve*: bool
+      ## Whether to make local light client data available or not
+    importMode*: LightClientDataImportMode
+      ## Which classes of light client data to import
+    maxPeriods*: Option[uint64]
+      ## Maximum number of sync committee periods to retain light client data
+    onLightClientFinalityUpdate*: OnLightClientFinalityUpdateCallback
+      ## On new `LightClientFinalityUpdate` callback
+    onLightClientOptimisticUpdate*: OnLightClientOptimisticUpdateCallback
+      ## On new `LightClientOptimisticUpdate` callback
+
   LightClientDataStore* = object
     # -----------------------------------
     # Light client data

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -685,12 +685,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            eraPath = ".",
            onBlockCb: OnBlockCallback = nil, onHeadCb: OnHeadCallback = nil,
            onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
-           onLCFinalityUpdateCb: OnLightClientFinalityUpdateCallback = nil,
-           onLCOptimisticUpdateCb: OnLightClientOptimisticUpdateCallback = nil,
-           lightClientDataServe = false,
-           lightClientDataImportMode = LightClientDataImportMode.None,
-           lightClientDataMaxPeriods = none(uint64),
-           vanityLogs = default(VanityLogs)): ChainDAGRef =
+           vanityLogs = default(VanityLogs),
+           lcDataConfig = default(LightClientDataConfig)): ChainDAGRef =
   cfg.checkForkConsistency()
 
   doAssert updateFlags - {verifyFinalization, enableTestFeatures} == {},
@@ -726,12 +722,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
       vanityLogs: vanityLogs,
 
-      lcDataStore: initLightClientDataStore(
-        serve = lightClientDataServe,
-        importMode = lightClientDataImportMode,
-        maxPeriods = lightClientDataMaxPeriods.get(cfg.defaultLCDataMaxPeriods),
-        onLCFinalityUpdateCb = onLCFinalityUpdateCb,
-        onLCOptimisticUpdateCb = onLCOptimisticUpdateCb),
+      lcDataStore: initLightClientDataStore(lcDataConfig, cfg),
 
       onBlockAdded: onBlockCb,
       onHeadChanged: onHeadCb,

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -123,18 +123,15 @@ proc syncCommitteeRootForPeriod(
       else: raiseAssert "Unreachable"
   do: err()
 
-func initLightClientDataStore*(
-    serve: bool, importMode: LightClientDataImportMode, maxPeriods: uint64,
-    onLCFinalityUpdateCb: OnLightClientFinalityUpdateCallback = nil,
-    onLCOptimisticUpdateCb: OnLightClientOptimisticUpdateCallback = nil
-): LightClientDataStore =
+proc initLightClientDataStore*(
+    config: LightClientDataConfig, cfg: RuntimeConfig): LightClientDataStore =
   ## Initialize light client data store.
   LightClientDataStore(
-    serve: serve,
-    importMode: importMode,
-    maxPeriods: maxPeriods,
-    onLightClientFinalityUpdate: onLCFinalityUpdateCb,
-    onLightClientOptimisticUpdate: onLCOptimisticUpdateCb)
+    serve: config.serve,
+    importMode: config.importMode,
+    maxPeriods: config.maxPeriods.get(cfg.defaultLightClientDataMaxPeriods),
+    onLightClientFinalityUpdate: config.onLightClientFinalityUpdate,
+    onLightClientOptimisticUpdate: config.onLightClientOptimisticUpdate)
 
 func targetLightClientTailSlot(dag: ChainDAGRef): Slot =
   ## Earliest slot for which light client data is retained.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -175,14 +175,14 @@ proc loadChainDag(
       else: nil
     dag = ChainDAGRef.init(
       cfg, db, validatorMonitor, extraFlags + chainDagFlags, config.eraDir,
-      onLCFinalityUpdateCb = onLightClientFinalityUpdateCb,
-      onLCOptimisticUpdateCb = onLightClientOptimisticUpdateCb,
-      lightClientDataServe = config.lightClientDataServe.get,
-      lightClientDataImportMode = config.lightClientDataImportMode.get,
-      lightClientDataMaxPeriods = config.lightClientDataMaxPeriods,
-      vanityLogs = getPandas(detectTTY(config.logStdout)))
+      vanityLogs = getPandas(detectTTY(config.logStdout)),
+      lcDataConfig = LightClientDataConfig(
+        serve: config.lightClientDataServe.get,
+        importMode: config.lightClientDataImportMode.get,
+        maxPeriods: config.lightClientDataMaxPeriods,
+        onLightClientFinalityUpdate: onLightClientFinalityUpdateCb,
+        onLightClientOptimisticUpdate: onLightClientOptimisticUpdateCb))
 
-  let
     databaseGenesisValidatorsRoot =
       getStateField(dag.headState, genesis_validators_root)
 

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -484,7 +484,7 @@ template name*(cfg: RuntimeConfig): string =
 func MIN_EPOCHS_FOR_BLOCK_REQUESTS*(cfg: RuntimeConfig): uint64 =
   cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY + cfg.CHURN_LIMIT_QUOTIENT div 2
 
-func defaultLCDataMaxPeriods*(cfg: RuntimeConfig): uint64 =
+func defaultLightClientDataMaxPeriods*(cfg: RuntimeConfig): uint64 =
   const epochsPerPeriod = EPOCHS_PER_SYNC_COMMITTEE_PERIOD
   let maxEpochs = cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS
   (maxEpochs + epochsPerPeriod - 1) div epochsPerPeriod

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -79,8 +79,9 @@ suite "Light client" & preset():
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
         cfg, makeTestDB(num_validators), validatorMonitor, {},
-        lightClientDataServe = true,
-        lightClientDataImportMode = LightClientDataImportMode.OnlyNew)
+        lcDataConfig = LightClientDataConfig(
+          serve: true,
+          importMode: LightClientDataImportMode.OnlyNew))
       quarantine = newClone(Quarantine.init())
       taskpool = Taskpool.new()
     var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
@@ -185,8 +186,9 @@ suite "Light client" & preset():
       dag.headState, dag.getForkedBlock(dag.head.bid).get)
     let cpDag = ChainDAGRef.init(
       cfg, cpDb, validatorMonitor, {},
-      lightClientDataServe = true,
-      lightClientDataImportMode = LightClientDataImportMode.Full)
+      lcDataConfig = LightClientDataConfig(
+        serve: true,
+        importMode: LightClientDataImportMode.Full))
 
     # Advance by a couple epochs
     for i in 1'u64 .. 10:

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -30,8 +30,9 @@ suite "Light client processor" & preset():
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(
       cfg, makeTestDB(numValidators), validatorMonitor, {},
-      lightClientDataServe = true,
-      lightClientDataImportMode = LightClientDataImportMode.OnlyNew)
+      lcDataConfig = LightClientDataConfig(
+        serve: true,
+        importMode: LightClientDataImportMode.OnlyNew))
     quarantine = newClone(Quarantine.init())
     taskpool = Taskpool.new()
   var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)


### PR DESCRIPTION
Separate LC initialization options from the main ChainDAGRef options to
allow ChainDAGRef to treat them as opaque and reduce risk for conflicts
when extending those options in the future.