### PR TITLE
cleanups

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -21,7 +21,6 @@ import
   eth/common/eth_types as commonEthTypes, eth/net/nat,
   eth/p2p/discoveryv5/enr,
   json_serialization, web3/[ethtypes, confutils_defs],
-
   ./spec/[keystore, network, crypto],
   ./spec/datatypes/base,
   ./networking/network_metadata,

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -13,7 +13,6 @@
 import
   # Status libraries
   stew/[bitops2, objects],
-  chronos,
   # Beacon chain internals
   ../spec/datatypes/[phase0, altair, bellatrix],
   "."/[block_pools_types, blockchain_dag]

--- a/beacon_chain/consensus_object_pools/vanity_logs/pandas.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/pandas.nim
@@ -8,7 +8,6 @@
 {.push raises: [Defect].}
 
 import chronicles
-from ".."/".."/conf import StdoutLogKind
 
 type
   VanityLogs* = object
@@ -17,22 +16,6 @@ type
 
 # Created by http://beatscribe.com/ (beatscribe#1008 on Discord)
 # These need to be the main body of the log not to be reformatted or escaped.
-proc mono🐼()  = notice "\n" & "text-version.txt".staticRead
-proc color🐼() = notice "\n" & "color-version.ans".staticRead
-proc blink🐼() = notice "\n" & "blink-version.ans".staticRead
-
-func getPandas*(stdoutKind: StdoutLogKind): VanityLogs =
-  case stdoutKind
-  of StdoutLogKind.Auto: raiseAssert "inadmissable here"
-  of StdoutLogKind.Colors:
-    VanityLogs(
-      onMergeTransitionBlock:          color🐼,
-      onFinalizedMergeTransitionBlock: blink🐼)
-  of StdoutLogKind.NoColors:
-    VanityLogs(
-      onMergeTransitionBlock:          mono🐼,
-      onFinalizedMergeTransitionBlock: mono🐼)
-  of StdoutLogKind.Json, StdoutLogKind.None:
-    VanityLogs(
-      onMergeTransitionBlock:          (proc() = notice "🐼 Proof of Stake Activated 🐼"),
-      onFinalizedMergeTransitionBlock: (proc() = notice "🐼 Proof of Stake Finalized 🐼"))
+proc mono🐼*()  = notice "\n" & "text-version.txt".staticRead
+proc color🐼*() = notice "\n" & "color-version.ans".staticRead
+proc blink🐼*() = notice "\n" & "blink-version.ans".staticRead

--- a/beacon_chain/eth1/merkle_minimal.nim
+++ b/beacon_chain/eth1/merkle_minimal.nim
@@ -19,12 +19,10 @@ import
   ../spec/[eth2_merkleization, digest],
   ../spec/datatypes/base
 
-const depositContractLimit* = Limit(1'u64 shl DEPOSIT_CONTRACT_TREE_DEPTH)
-
 func attachMerkleProofs*(deposits: var openArray[Deposit]) =
   let depositsRoots = mapIt(deposits, hash_tree_root(it.data))
 
-  var incrementalMerkleProofs = createMerkleizer(depositContractLimit)
+  var incrementalMerkleProofs = createMerkleizer(DEPOSIT_CONTRACT_LIMIT)
 
   for i in 0 ..< depositsRoots.len:
     incrementalMerkleProofs.addChunkAndGenMerkleProof(depositsRoots[i], deposits[i].proof)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -14,6 +14,7 @@ import
   stew/[byteutils, io2],
   eth/p2p/discoveryv5/[enr, random2],
   eth/keys,
+  ./consensus_object_pools/vanity_logs/pandas,
   ./rpc/[rest_api, state_ttl_cache],
   ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/[engine_authentication, weak_subjectivity],
@@ -29,8 +30,6 @@ from
   libp2p/protocols/pubsub/gossipsub
 import
   TopicParams, validateParameters, init
-
-from "."/consensus_object_pools/vanity_logs/pandas import getPandas
 
 when defined(windows):
   import winlean
@@ -144,6 +143,22 @@ declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version",
 versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])
 
 logScope: topics = "beacnde"
+
+func getPandas(stdoutKind: StdoutLogKind): VanityLogs =
+  case stdoutKind
+  of StdoutLogKind.Auto: raiseAssert "inadmissable here"
+  of StdoutLogKind.Colors:
+    VanityLogs(
+      onMergeTransitionBlock:          color🐼,
+      onFinalizedMergeTransitionBlock: blink🐼)
+  of StdoutLogKind.NoColors:
+    VanityLogs(
+      onMergeTransitionBlock:          mono🐼,
+      onFinalizedMergeTransitionBlock: mono🐼)
+  of StdoutLogKind.Json, StdoutLogKind.None:
+    VanityLogs(
+      onMergeTransitionBlock:          (proc() = notice "🐼 Proof of Stake Activated 🐼"),
+      onFinalizedMergeTransitionBlock: (proc() = notice "🐼 Proof of Stake Finalized 🐼"))
 
 proc loadChainDag(
     config: BeaconNodeConf,

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -28,21 +28,32 @@ import
   chronicles,
   nimcrypto/[sha2, hash],
   stew/[byteutils, endians2, objects],
-  json_serialization,
-  blscurve
+  json_serialization
 
 export
   # Exports from sha2 / hash are explicit to avoid exporting upper-case `$` and
   # constant-time `==`
-  sha2.update, hash.fromHex, json_serialization
+  hash.fromHex, json_serialization
 
 type
   Eth2Digest* = MDigest[32 * 8] ## `hash32` from spec
 
-when BLS_BACKEND == BLST:
+const PREFER_BLST_SHA256* {.booldefine.} = true
+
+when PREFER_BLST_SHA256:
+  import blscurve
+  when BLS_BACKEND == BLST:
+    const USE_BLST_SHA256 = true
+  else:
+    const USE_BLST_SHA256 = false
+else:
+  const USE_BLST_SHA256 = false
+
+when USE_BLST_SHA256:
   export blscurve.update
   type Eth2DigestCtx* = BLST_SHA256_CTX
 else:
+  export sha2.update
   type Eth2DigestCtx* = sha2.sha256
 
 func `$`*(x: Eth2Digest): string =
@@ -60,13 +71,13 @@ chronicles.formatIt Eth2Digest:
 func eth2digest*(v: openArray[byte]): Eth2Digest {.noinit.} =
   ## Apply the Eth2 Hash function
   ## Do NOT use for secret data.
-  when BLS_BACKEND == BLST:
+  when USE_BLST_SHA256:
     # BLST has a fast assembly optimized SHA256
     result.data.bls_sha256_digest(v)
   else:
     # We use the init-update-finish interface to avoid
     # the expensive burning/clearing memory (20~30% perf)
-    let ctx: Eth2DigestCtx
+    var ctx {.noinit.}: Eth2DigestCtx
     ctx.init()
     ctx.update(v)
     ctx.finish()
@@ -83,9 +94,9 @@ template withEth2Hash*(body: untyped): Eth2Digest =
       body
       finish(h)
   else:
-    when BLS_BACKEND == BLST:
+    when USE_BLST_SHA256:
       block:
-        var h  {.inject, noinit.}: Eth2DigestCtx
+        var h {.inject, noinit.}: Eth2DigestCtx
         init(h)
         body
         var res {.noinit.}: Eth2Digest
@@ -93,7 +104,7 @@ template withEth2Hash*(body: untyped): Eth2Digest =
         res
     else:
       block:
-        let h  {.inject, noinit.}: Eth2DigestCtx
+        var h {.inject, noinit.}: Eth2DigestCtx
         init(h)
         body
         finish(h)

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -121,7 +121,7 @@ type
     slot*: Slot
     beacon_block_root*: Eth2Digest
     subcommittee_index*: uint64
-    aggregation_bits*: SyncCommitteeAggregationBits ##\
+    aggregation_bits*: SyncCommitteeAggregationBits
     signature*: ValidatorSig
 
   RestContributionAndProof* = object

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -24,7 +24,8 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
   try:
     let randaoReveal =
       block:
-        let res = await validator.genRandaoReveal(fork, genesisRoot, slot)
+        let res = await validator.getEpochSignature(
+          fork, genesisRoot, slot.epoch)
         if res.isErr():
           error "Unable to generate randao reveal usint remote signer",
                 validator = shortLog(validator), error_msg = res.error()
@@ -44,7 +45,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
         return
 
     let blockRoot = withBlck(beaconBlock): hash_tree_root(blck)
-    # TODO: signing_root is recomputed in signBlockProposal just after
+    # TODO: signing_root is recomputed in getBlockSignature just after
     let signing_root = compute_block_signing_root(fork, genesisRoot, slot,
                                                   blockRoot)
     let notSlashable = vc.attachedValidators
@@ -55,7 +56,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
     if notSlashable.isOk():
       let signature =
         block:
-          let res = await validator.signBlockProposal(fork, genesisRoot,
+          let res = await validator.getBlockSignature(fork, genesisRoot,
                                                       slot, blockRoot,
                                                       beaconBlock)
           if res.isErr():

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -17,8 +17,8 @@ chronicles.formatIt(DutiesServiceLoop):
 
 proc checkDuty(duty: RestAttesterDuty): bool =
   (duty.committee_length <= MAX_VALIDATORS_PER_COMMITTEE) and
-  (uint64(duty.committee_index) <= MAX_COMMITTEES_PER_SLOT) and
-  (uint64(duty.validator_committee_index) <= duty.committee_length) and
+  (uint64(duty.committee_index) < MAX_COMMITTEES_PER_SLOT) and
+  (uint64(duty.validator_committee_index) < duty.committee_length) and
   (uint64(duty.validator_index) <= VALIDATOR_REGISTRY_LIMIT)
 
 proc checkSyncDuty(duty: RestSyncCommitteeDuty): bool =
@@ -159,7 +159,8 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
     for item in addOrReplaceItems:
       let validator = vc.attachedValidators.getValidator(item.duty.pubkey)
       let fork = vc.forkAtEpoch(item.duty.slot.epoch)
-      let future = validator.getSlotSig(fork, genesisRoot, item.duty.slot)
+      let future = validator.getSlotSignature(
+        fork, genesisRoot, item.duty.slot)
       pending.add(future)
       validators.add(validator)
 

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -56,7 +56,6 @@ type
   SignResponse* = Web3SignerDataResponse
 
   SignatureResult* = Result[ValidatorSig, string]
-  AttestationResult* = Result[Attestation, string]
   SyncCommitteeMessageResult* = Result[SyncCommitteeMessage, string]
 
   ValidatorPool* = object
@@ -189,173 +188,74 @@ proc signWithSingleKey(v: AttachedValidator,
     return SignatureResult.ok res.get.toValidatorSig
 
 proc signData(v: AttachedValidator,
-              request: Web3SignerRequest): Future[SignatureResult]
-             {.async.} =
-  return
-    case v.kind
-    of ValidatorKind.Local:
-      SignatureResult.err "Invalid validator kind"
-    of ValidatorKind.Remote:
-      if v.clients.len == 1:
-        await v.signWithSingleKey(request)
-      else:
-        await v.signWithDistributedKey(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              blck: ForkedBeaconBlock): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, blck.Web3SignerForkedBeaconBlock)
-  debug "Signing block proposal using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              adata: AttestationData): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, adata)
-  debug "Signing block proposal using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              epoch: Epoch): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, epoch)
-  debug "Generating randao reveal signature using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              proof: AggregateAndProof): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, proof)
-  debug "Signing aggregate and proof using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              slot: Slot): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, slot)
-  debug "Signing aggregate slot using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              slot: Slot,
-                              blockRoot: Eth2Digest): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(fork, genesis_validators_root, blockRoot,
-                                       slot)
-  debug "Signing sync committee message using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              slot: Slot,
-                              subcommittee: SyncSubcommitteeIndex): Future[SignatureResult]
-                             {.async.} =
-  let request = Web3SignerRequest.init(
-    fork, genesis_validators_root,
-    SyncAggregatorSelectionData(slot: slot, subcommittee_index: uint64 subcommittee)
-  )
-  debug "Signing sync aggregator selection data using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
-
-proc signWithRemoteValidator*(v: AttachedValidator, fork: Fork,
-                              genesis_validators_root: Eth2Digest,
-                              contribution: ContributionAndProof
-                             ): Future[SignatureResult] {.async.} =
-  let request = Web3SignerRequest.init(
-    fork, genesis_validators_root, contribution
-  )
-  debug "Signing sync contribution and proof message using remote signer",
-        validator = shortLog(v)
-  return await v.signData(request)
+              request: Web3SignerRequest): Future[SignatureResult] =
+  doAssert v.kind == ValidatorKind.Remote
+  debug "Signing request with remote signer",
+    validator = shortLog(v), kind = request.kind
+  if v.clients.len == 1:
+    v.signWithSingleKey(request)
+  else:
+    v.signWithDistributedKey(request)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#signature
-proc signBlockProposal*(v: AttachedValidator, fork: Fork,
+proc getBlockSignature*(v: AttachedValidator, fork: Fork,
                         genesis_validators_root: Eth2Digest, slot: Slot,
-                        blockRoot: Eth2Digest, blck: ForkedBeaconBlock
+                        block_root: Eth2Digest, blck: ForkedBeaconBlock
                        ): Future[SignatureResult] {.async.} =
   return
     case v.kind
     of ValidatorKind.Local:
       SignatureResult.ok(
-        get_block_signature(fork, genesis_validators_root, slot, blockRoot,
-                            v.data.privateKey).toValidatorSig()
-      )
+        get_block_signature(
+          fork, genesis_validators_root, slot, block_root,
+          v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              blck)
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root, blck.Web3SignerForkedBeaconBlock)
+      await v.signData(request)
 
-proc signAttestation*(v: AttachedValidator,
-                      data: AttestationData,
-                      fork: Fork, genesis_validators_root: Eth2Digest
-                     ): Future[SignatureResult] {.async.} =
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#aggregate-signature
+proc getAttestationSignature*(v: AttachedValidator, fork: Fork,
+                              genesis_validators_root: Eth2Digest,
+                              data: AttestationData
+                             ): Future[SignatureResult] {.async.} =
   return
     case v.kind
     of ValidatorKind.Local:
       SignatureResult.ok(
-        get_attestation_signature(fork, genesis_validators_root, data,
-                                  v.data.privateKey).toValidatorSig()
-      )
+        get_attestation_signature(
+          fork, genesis_validators_root, data,
+          v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root, data)
+      let request = Web3SignerRequest.init(fork, genesis_validators_root, data)
+      await v.signData(request)
 
-proc produceAndSignAttestation*(validator: AttachedValidator,
-                                attestationData: AttestationData,
-                                committeeLen: int, indexInCommittee: Natural,
-                                fork: Fork,
-                                genesis_validators_root: Eth2Digest):
-                                Future[AttestationResult] {.async.} =
-  let validatorSignature =
-    block:
-      let res = await validator.signAttestation(attestationData, fork,
-                                                genesis_validators_root)
-      if res.isErr():
-        return AttestationResult.err(res.error())
-      res.get()
-
-  var aggregationBits = CommitteeValidatorsBits.init(committeeLen)
-  aggregationBits.setBit indexInCommittee
-
-  return AttestationResult.ok(
-    Attestation(data: attestationData, signature: validatorSignature,
-                aggregation_bits: aggregationBits)
-  )
-
-proc signAggregateAndProof*(v: AttachedValidator,
-                            aggregate_and_proof: AggregateAndProof,
-                            fork: Fork, genesis_validators_root: Eth2Digest):
-                            Future[SignatureResult] {.async.} =
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#broadcast-aggregate
+proc getAggregateAndProofSignature*(v: AttachedValidator,
+                                    fork: Fork,
+                                    genesis_validators_root: Eth2Digest,
+                                    aggregate_and_proof: AggregateAndProof
+                                   ): Future[SignatureResult] {.async.} =
   return
     case v.kind
     of ValidatorKind.Local:
       SignatureResult.ok(
-        get_aggregate_and_proof_signature(fork, genesis_validators_root,
-                                          aggregate_and_proof,
-                                          v.data.privateKey).toValidatorSig()
+        get_aggregate_and_proof_signature(
+          fork, genesis_validators_root, aggregate_and_proof,
+          v.data.privateKey).toValidatorSig()
       )
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              aggregate_and_proof)
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root, aggregate_and_proof)
+      await v.signData(request)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/validator.md#prepare-sync-committee-message
-proc signSyncCommitteeMessage*(v: AttachedValidator,
-                               fork: Fork,
-                               genesis_validators_root: Eth2Digest,
-                               slot: Slot,
-                               beacon_block_root: Eth2Digest
-                              ): Future[SyncCommitteeMessageResult] {.async.} =
+proc getSyncCommitteeMessage*(v: AttachedValidator,
+                              fork: Fork,
+                              genesis_validators_root: Eth2Digest,
+                              slot: Slot,
+                              beacon_block_root: Eth2Digest
+                             ): Future[SyncCommitteeMessageResult] {.async.} =
   let signature =
     case v.kind
     of ValidatorKind.Local:
@@ -363,8 +263,9 @@ proc signSyncCommitteeMessage*(v: AttachedValidator,
         fork, genesis_validators_root, slot, beacon_block_root,
         v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              slot, beacon_block_root)
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root, beacon_block_root, slot)
+      await v.signData(request)
 
   if signature.isErr:
     return SyncCommitteeMessageResult.err("Failed to obtain signature")
@@ -380,8 +281,7 @@ proc signSyncCommitteeMessage*(v: AttachedValidator,
     )
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/validator.md#aggregation-selection
-proc getSyncCommitteeSelectionProof*(v: AttachedValidator,
-                                     fork: Fork,
+proc getSyncCommitteeSelectionProof*(v: AttachedValidator, fork: Fork,
                                      genesis_validators_root: Eth2Digest,
                                      slot: Slot,
                                      subcommittee_index: SyncSubcommitteeIndex
@@ -393,59 +293,60 @@ proc getSyncCommitteeSelectionProof*(v: AttachedValidator,
         fork, genesis_validators_root, slot, subcommittee_index,
         v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              slot, subcommittee_index)
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root,
+        SyncAggregatorSelectionData(
+          slot: slot, subcommittee_index: uint64 subcommittee_index)
+      )
+      await v.signData(request)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/validator.md#signature
-proc sign*(v: AttachedValidator, msg: ref SignedContributionAndProof,
-           fork: Fork, genesis_validators_root: Eth2Digest
-          ): Future[SignatureResult] {.async.} =
-  let signature =
-    case v.kind
-    of ValidatorKind.Local:
-      SignatureResult.ok(get_contribution_and_proof_signature(
-        fork, genesis_validators_root, msg.message, v.data.privateKey).toValidatorSig())
-    of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              msg.message)
-
-  if signature.isOk:
-    msg.signature = signature.get()
-
-  return signature
-
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#randao-reveal
-func genRandaoReveal*(k: ValidatorPrivKey, fork: Fork,
-                      genesis_validators_root: Eth2Digest,
-                      slot: Slot): CookedSig =
-  get_epoch_signature(fork, genesis_validators_root, slot.epoch, k)
-
-proc genRandaoReveal*(v: AttachedValidator, fork: Fork,
-                      genesis_validators_root: Eth2Digest, slot: Slot):
-                      Future[SignatureResult] {.async.} =
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/validator.md#broadcast-sync-committee-contribution
+proc getContributionAndProofSignature*(v: AttachedValidator, fork: Fork,
+                                       genesis_validators_root: Eth2Digest,
+                                       contribution_and_proof: ContributionAndProof
+                                      ): Future[SignatureResult] {.async.} =
   return
     case v.kind
     of ValidatorKind.Local:
-      SignatureResult.ok(genRandaoReveal(v.data.privateKey, fork,
-                                         genesis_validators_root,
-                                         slot).toValidatorSig())
+      SignatureResult.ok(get_contribution_and_proof_signature(
+        fork, genesis_validators_root, contribution_and_proof,
+        v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root,
-                                              slot.epoch())
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root, contribution_and_proof)
+      await v.signData(request)
 
-proc getSlotSig*(v: AttachedValidator, fork: Fork,
-                 genesis_validators_root: Eth2Digest, slot: Slot
-                ): Future[SignatureResult] {.async.} =
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#randao-reveal
+proc getEpochSignature*(v: AttachedValidator, fork: Fork,
+                        genesis_validators_root: Eth2Digest, epoch: Epoch
+                       ): Future[SignatureResult] {.async.} =
+  return
+    case v.kind
+    of ValidatorKind.Local:
+      SignatureResult.ok(get_epoch_signature(
+        fork, genesis_validators_root, epoch,
+        v.data.privateKey).toValidatorSig())
+    of ValidatorKind.Remote:
+      let request = Web3SignerRequest.init(
+        fork, genesis_validators_root, epoch)
+      await v.signData(request)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#aggregation-selection
+proc getSlotSignature*(v: AttachedValidator, fork: Fork,
+                       genesis_validators_root: Eth2Digest, slot: Slot
+                      ): Future[SignatureResult] {.async.} =
   if v.slotSignature.isSome and v.slotSignature.get.slot == slot:
     return SignatureResult.ok(v.slotSignature.get.signature)
 
   let signature =
     case v.kind
     of ValidatorKind.Local:
-      SignatureResult.ok(get_slot_signature(fork, genesis_validators_root, slot,
-                         v.data.privateKey).toValidatorSig())
+      SignatureResult.ok(get_slot_signature(
+        fork, genesis_validators_root, slot,
+        v.data.privateKey).toValidatorSig())
     of ValidatorKind.Remote:
-      await signWithRemoteValidator(v, fork, genesis_validators_root, slot)
+      let request = Web3SignerRequest.init(fork, genesis_validators_root, slot)
+      await v.signData(request)
 
   if signature.isErr:
     return signature

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -86,7 +86,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
     eth1Chain = Eth1Chain.init(cfg, db)
-    merkleizer = depositContractSnapshot.createMerkleizer
+    merkleizer = DepositsMerkleizer.init(depositContractSnapshot.depositContractState)
     taskpool = Taskpool.new()
     verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
     quarantine = newClone(Quarantine.init())
@@ -113,8 +113,11 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
       attestationHead = dag.head.atSlot(slot)
 
     dag.withUpdatedState(tmpState[], attestationHead.toBlockSlotId.expect("not nil")) do:
-      let committees_per_slot =
-        get_committee_count_per_slot(state, slot.epoch, cache)
+      let
+        fork = getStateField(state, fork)
+        genesis_validators_root = getStateField(state, genesis_validators_root)
+        committees_per_slot =
+          get_committee_count_per_slot(state, slot.epoch, cache)
 
       for committee_index in get_committee_indices(committees_per_slot):
         let committee = get_beacon_committee(
@@ -126,18 +129,15 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
               data = makeAttestationData(
                 state, slot, committee_index, bid.root)
               sig =
-                get_attestation_signature(getStateField(state, fork),
-                  getStateField(state, genesis_validators_root),
-                  data, MockPrivKeys[validator_index])
-            var aggregation_bits = CommitteeValidatorsBits.init(committee.len)
-            aggregation_bits.setBit index_in_committee
+                get_attestation_signature(
+                  fork, genesis_validators_root, data,
+                  MockPrivKeys[validator_index])
+              attestation = Attestation.init(
+                [uint64 index_in_committee], committee.len, data,
+                sig.toValidatorSig()).expect("valid data")
 
             attPool.addAttestation(
-              Attestation(
-                data: data,
-                aggregation_bits: aggregation_bits,
-                signature: sig.toValidatorSig()
-              ), [validator_index], sig, data.slot.start_beacon_time)
+              attestation, [validator_index], sig, data.slot.start_beacon_time)
     do:
       raiseAssert "withUpdatedState failed"
 
@@ -267,10 +267,10 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         cfg,
         hashedState[],
         proposerIdx,
-        privKey.genRandaoReveal(
+        get_epoch_signature(
           getStateField(state, fork),
           getStateField(state, genesis_validators_root),
-          slot).toValidatorSig(),
+          slot.epoch, privKey).toValidatorSig(),
         eth1ProposalData.vote,
         default(GraffitiBytes),
         attPool.getAttestationsForBlock(state, cache),

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -12,8 +12,7 @@ import
   ../beacon_chain/beacon_chain_db,
   ../beacon_chain/spec/datatypes/[phase0, altair],
   ../beacon_chain/spec/[beaconstate, forks, helpers],
-  ../beacon_chain/consensus_object_pools/[blockchain_dag, block_pools_types],
-  ../beacon_chain/eth1/eth1_monitor
+  ../beacon_chain/consensus_object_pools/[blockchain_dag, block_pools_types]
 
 template withTimer*(stats: var RunningStat, body: untyped) =
   # TODO unify timing somehow

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -144,9 +144,9 @@ cli do(validatorsDir: string, secretsDir: string,
         blockAggregates = aggregates.filterIt(
           it.data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= slot and
           slot <= it.data.slot + SLOTS_PER_EPOCH)
-        randao_reveal =
-            validators[proposer].genRandaoReveal(
-              fork, genesis_validators_root, slot).toValidatorSig()
+        randao_reveal = get_epoch_signature(
+          fork, genesis_validators_root, slot.epoch,
+          validators[proposer]).toValidatorSig()
         message = makeBeaconBlock(
           cfg,
           state[],

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -222,7 +222,7 @@ suite "Gossip validation - Extra": # Not based on preset config
                                   privateKey: MockPrivKeys[index])
       validator = AttachedValidator(pubkey: pubkey,
         kind: ValidatorKind.Local, data: keystoreData, index: some(index))
-      resMsg = waitFor signSyncCommitteeMessage(
+      resMsg = waitFor getSyncCommitteeMessage(
         validator, state[].data.fork, state[].data.genesis_validators_root, slot,
         state[].root)
       msg = resMsg.get()
@@ -249,9 +249,11 @@ suite "Gossip validation - Extra": # Not based on preset config
           contribution.message.contribution)
         syncCommitteeMsgPool[].addContribution(
           contribution[], contribution.message.contribution.signature.load.get)
-        let signRes = waitFor validator.sign(
-          contribution, state[].data.fork, state[].data.genesis_validators_root)
+        let signRes = waitFor validator.getContributionAndProofSignature(
+          state[].data.fork, state[].data.genesis_validators_root,
+          contribution[].message)
         doAssert(signRes.isOk())
+        contribution[].signature = signRes.get()
         contribution
       aggregate = syncCommitteeMsgPool[].produceSyncAggregate(state[].root)
 

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -122,3 +122,11 @@ suite "Beacon state" & preset():
       state[].phase0Data.dependent_root(Epoch(1)) ==
         state[].phase0Data.data.get_block_root_at_slot(Epoch(1).start_slot - 1)
       state[].phase0Data.dependent_root(Epoch(0)) == genBlock.root
+
+  test "merklizer state roundtrip":
+    let
+      dcs = DepositContractState()
+      merkleizer = DepositsMerkleizer.init(dcs)
+
+    check:
+      dcs == merkleizer.toDepositContractState()

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -11,7 +11,6 @@ import
   eth/keys,
   stew/endians2,
   ../beacon_chain/consensus_object_pools/sync_committee_msg_pool,
-  ../beacon_chain/validators/validator_pool,
   ../beacon_chain/spec/datatypes/bellatrix,
   ../beacon_chain/spec/[
     beaconstate, helpers, keystore, signatures, state_transition, validator]
@@ -99,10 +98,10 @@ proc addTestBlock*(
     privKey = MockPrivKeys[proposer_index.get]
     randao_reveal =
       if skipBlsValidation notin flags:
-        privKey.genRandaoReveal(
+        get_epoch_signature(
           getStateField(state, fork),
           getStateField(state, genesis_validators_root),
-          getStateField(state, slot)).toValidatorSig()
+          getStateField(state, slot).epoch, privKey).toValidatorSig()
       else:
         ValidatorSig()
 
@@ -228,13 +227,13 @@ func makeAttestation*(
   # monotonic enumerable index, is wasteful and slow. Most test callers
   # want ValidatorIndex, so that's supported too.
   let
-    sac_index = committee.find(validator_index)
+    index_in_committee = committee.find(validator_index)
     data = makeAttestationData(state, slot, committee_index, beacon_block_root)
 
-  doAssert sac_index != -1, "find_beacon_committee should guarantee this"
+  doAssert index_in_committee != -1, "find_beacon_committee should guarantee this"
 
   var aggregation_bits = CommitteeValidatorsBits.init(committee.len)
-  aggregation_bits.setBit sac_index
+  aggregation_bits.setBit index_in_committee
 
   let sig = if skipBlsValidation in flags:
     ValidatorSig()


### PR DESCRIPTION
* avoid circular panda imports
* move deposit merkleization helpers to spec/
* normalize validator signature helpers to spec names / params
* remove redundant functions for remote signing