### PR TITLE
don't use JWT in CI if one hasn't set up a JWT secret

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -865,6 +865,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     WEB3_ARG="--web3-url=http://127.0.0.1:${EL_RPC_PORTS[${NUM_NODE}]}"
   fi
 
+  # TODO re-add --jwt-secret
   ${BEACON_NODE_COMMAND} \
     --config-file="${CLI_CONF_FILE}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE )) \
@@ -879,7 +880,6 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --light-client-enable=on \
     --light-client-data-serve=on \
     --light-client-data-import-mode=only-new \
-    --jwt-secret=/tmp/jwtsecret \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &
 


### PR DESCRIPTION
Not meant as a real fix, but following up on https://github.com/status-im/nimbus-eth2/commit/a48d741022f6b0da1bb679e0ede4e38c019242cf and https://github.com/status-im/nimbus-eth2/commit/73227508db6f8ece8657f33c76d2762691ac172e in an expedient way.

Currently, local testnets in CI are failing on
```
{"lvl":"FAT","ts":"2022-06-28 22:27:40.767+00:00","msg":"Specified a JWT secret file which couldn't be loaded","topics":"beacnde","err":"couldn't open specified JWT secret file"}
```
because they specify `--jwt-secret=/tmp/jwtsecret` but don't appear to have actually created this file. It's straightforward to create it, but also kind of useless if Geth or another EL isn't running as well, as might not be the case.

Setting up JWT properly is outside the scope of this PR.