### PR TITLE
libp2p: disable self triggering

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2307,7 +2307,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
     pubsub = GossipSub.init(
       switch = switch,
       msgIdProvider = msgIdProvider,
-      triggerSelf = true,
+      # We process messages in the validator, so we don't need data callbacks
+      triggerSelf = false,
       sign = false,
       verifySignature = false,
       anonymize = true,


### PR DESCRIPTION
All message processing is done in the validation callbacks, so there's
no need to trigger data handlers for messages we publish - the
self-publish is async, and therefore has an associated cost