### PR TITLE
reduce received invalid sync block logging to notice; decimal TTD logs

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -528,27 +528,27 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[void] {.async.} =
       if p.terminalBlockHash.isSome:
         p.terminalBlockHash.get
       else:
-        # TODO can't use static(default(...)) in this context
-        default(BlockHash),
+        # https://github.com/nim-lang/Nim/issues/19802
+        (static(default(BlockHash))),
     terminalBlockNumber:
       if p.terminalBlockNumber.isSome:
         p.terminalBlockNumber.get
       else:
-        # TODO can't use static(default(...)) in this context
-        default(Quantity))
+        # https://github.com/nim-lang/Nim/issues/19802
+        (static(default(Quantity))))
   let ecTransitionConfiguration =
     await p.dataProvider.web3.provider.engine_exchangeTransitionConfigurationV1(
       ccTransitionConfiguration)
   if ccTransitionConfiguration != ecTransitionConfiguration:
     warn "exchangeTransitionConfiguration: Configuration mismatch detected",
       consensusTerminalTotalDifficulty =
-        ccTransitionConfiguration.terminalTotalDifficulty,
+        $ccTransitionConfiguration.terminalTotalDifficulty,
       consensusTerminalBlockHash =
         ccTransitionConfiguration.terminalBlockHash,
       consensusTerminalBlockNumber =
         ccTransitionConfiguration.terminalBlockNumber.uint64,
       executionTerminalTotalDifficulty =
-        ecTransitionConfiguration.terminalTotalDifficulty,
+        $ecTransitionConfiguration.terminalTotalDifficulty,
       executionTerminalBlockHash =
         ecTransitionConfiguration.terminalBlockHash,
       executionTerminalBlockNumber =

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -109,7 +109,7 @@ proc fetchAncestorBlocksFromNetwork(rman: RequestManager,
             of BlockError.Invalid:
               # We stop processing blocks because peer is either sending us
               # junk or working a different fork
-              warn "Received invalid block",
+              notice "Received invalid block",
                 peer = peer, blocks = shortLog(items),
                 peer_score = peer.getScore()
               peer.updateScore(PeerScoreBadBlocks)

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -641,9 +641,9 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
           hasInvalidBlock = true
 
           let req = item.request
-          warn "Received invalid sequence of blocks", request = req,
-                blocks_count = len(item.data),
-                blocks_map = getShortMap(req, item.data)
+          notice "Received invalid sequence of blocks", request = req,
+                  blocks_count = len(item.data),
+                  blocks_map = getShortMap(req, item.data)
           req.item.updateScore(PeerScoreBadBlocks)
           break
 


### PR DESCRIPTION
- reduce received invalid sync block logging to notice from warnings; they're not user-actionable nor are they, in themselves, catastrophic, and while they do indicate a potential attack, they're not comparable in severity to typical `warn`s
- Eth1 monitor TTD logging was logging raw `UInt256` representations, not their human-readable decimal representations