### PR TITLE
group justified and finalized `Checkpoint`

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -158,6 +158,58 @@ ConsensusSpecPreset-mainnet
 + EF - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset: mainnet]          OK
 + EF - Phase 0 - Rewards - with_slashed_validators [Preset: mainnet]                         OK
 + EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: mainnet]                    OK
++ ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
++ ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_n OK
++ ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
++ ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
++ ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/discard_equivocations        OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/genesis                      OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
++ ForkChoice - mainnet/altair/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
++ ForkChoice - mainnet/altair/fork_choice/on_block/pyspec_tests/basic                        OK
++ ForkChoice - mainnet/altair/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
+  ForkChoice - mainnet/altair/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
++ ForkChoice - mainnet/altair/fork_choice/on_block/pyspec_tests/proposer_boost               OK
++ ForkChoice - mainnet/altair/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
++ ForkChoice - mainnet/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_gr OK
++ ForkChoice - mainnet/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boos OK
++ ForkChoice - mainnet/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_hone OK
++ ForkChoice - mainnet/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_a OK
++ ForkChoice - mainnet/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla            OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/chain_no_attestations     OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/discard_equivocations     OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/genesis                   OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/proposer_boost_correct_he OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier OK
++ ForkChoice - mainnet/bellatrix/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_atte OK
++ ForkChoice - mainnet/bellatrix/fork_choice/on_block/pyspec_tests/basic                     OK
++ ForkChoice - mainnet/bellatrix/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root  OK
+  ForkChoice - mainnet/bellatrix/fork_choice/on_block/pyspec_tests/on_block_future_block     Skip
++ ForkChoice - mainnet/bellatrix/fork_choice/on_block/pyspec_tests/proposer_boost            OK
++ ForkChoice - mainnet/bellatrix/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_ OK
+  ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/all_valid           Skip
+  ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/block_lookup_failed Skip
+  ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_early_for_merge Skip
+  ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_late_for_merge  Skip
++ ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
++ ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_n OK
++ ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
++ ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
++ ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
++ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/basic                        OK
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
+  ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               OK
++ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
@@ -379,7 +431,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 376/376 Fail: 0/376 Skip: 0/376
+OK: 421/428 Fail: 0/428 Skip: 7/428
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -961,21 +1013,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 38/38 Fail: 0/38 Skip: 0/38
-## EF - ForkChoice [Preset: mainnet]
-```diff
-+ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
-  ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        Skip
-+ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
-+ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
-+ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
-+ ForkChoice - mainnet/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
-+ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/basic                        OK
-+ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
-  ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
-+ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               OK
-+ ForkChoice - mainnet/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
-```
-OK: 9/11 Fail: 0/11 Skip: 2/11
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1224,4 +1261,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 27/27 Fail: 0/27 Skip: 0/27
 
 ---TOTAL---
-OK: 1038/1042 Fail: 0/1042 Skip: 4/1042
+OK: 1074/1083 Fail: 0/1083 Skip: 9/1083

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -166,6 +166,82 @@ ConsensusSpecPreset-minimal
 + EF - Phase 0 - Rewards - with_not_yet_activated_validators_leak [Preset: minimal]          OK
 + EF - Phase 0 - Rewards - with_slashed_validators [Preset: minimal]                         OK
 + EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: minimal]                    OK
++ ForkChoice - minimal/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
++ ForkChoice - minimal/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
++ ForkChoice - minimal/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/discard_equivocations        OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/filtered_block_tree          OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/genesis                      OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
++ ForkChoice - minimal/altair/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/basic                        OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justif OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_ju OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/new_justified_is_later_than_ OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_before_finalized    OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_checkpoints         OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot OK
+  ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots_ OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/on_block_update_justified_ch OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/proposer_boost               OK
++ ForkChoice - minimal/altair/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
++ ForkChoice - minimal/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_hone OK
++ ForkChoice - minimal/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_a OK
++ ForkChoice - minimal/bellatrix/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla            OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/chain_no_attestations     OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/discard_equivocations     OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/filtered_block_tree       OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/genesis                   OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/proposer_boost_correct_he OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier OK
++ ForkChoice - minimal/bellatrix/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_atte OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/basic                     OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_jus OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/new_justified_is_later_th OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root  OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_before_finalized OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_checkpoints      OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_s OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_s OK
+  ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_future_block     Skip
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slo OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/on_block_update_justified OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/proposer_boost            OK
++ ForkChoice - minimal/bellatrix/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_ OK
+  ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/all_valid           Skip
+  ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/block_lookup_failed Skip
+  ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_early_for_merge Skip
+  ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_late_for_merge  Skip
++ ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
++ ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
++ ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/filtered_block_tree          OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/genesis                      OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we OK
++ ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/basic                        OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justif OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_ju OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_justified_is_later_than_ OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_before_finalized    OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_checkpoints         OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot OK
+  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots_ OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_update_justified_ch OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               OK
++ ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo OK
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
@@ -405,7 +481,7 @@ ConsensusSpecPreset-minimal
 + fork_random_misc_balances                                                                  OK
 + next_sync_committee_merkle_proof                                                           OK
 ```
-OK: 402/402 Fail: 0/402 Skip: 0/402
+OK: 471/478 Fail: 0/478 Skip: 7/478
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1017,31 +1093,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 38/38 Fail: 0/38 Skip: 0/38
-## EF - ForkChoice [Preset: minimal]
-```diff
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/chain_no_attestations        Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/discard_equivocations        Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/filtered_block_tree          Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/genesis                      Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head  Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_we Skip
-  ForkChoice - minimal/phase0/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attesta Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/basic                        Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justif Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_ju Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/new_justified_is_later_than_ Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root     Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_before_finalized    Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_checkpoints         Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slot Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_future_block        Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots_ Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/on_block_update_justified_ch Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost               Skip
-  ForkChoice - minimal/phase0/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slo Skip
-```
-OK: 0/21 Fail: 0/21 Skip: 21/21
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1301,4 +1352,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 30/30 Fail: 0/30 Skip: 0/30
 
 ---TOTAL---
-OK: 1088/1111 Fail: 0/1111 Skip: 23/1111
+OK: 1157/1166 Fail: 0/1166 Skip: 9/1166

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -178,4 +178,4 @@ type
     next_sync_committee*: SyncCommittee
 
     # Execution
-    latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Merge]
+    latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Bellatrix]

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -35,7 +35,7 @@ type
     executionBlockRoot*: Option[Eth2Digest]
 
     parent*: BlockRef ##\
-    ## Not nil, except for the finalized head
+      ## Not nil, except for the finalized head
 
   BlockSlot* = object
     ## Unique identifier for a particular fork and time in the block chain -
@@ -55,8 +55,7 @@ func init*(
     executionPayloadRoot: Option[Eth2Digest], slot: Slot): BlockRef =
   BlockRef(
     bid: BlockId(root: root, slot: slot),
-    executionBlockRoot: executionPayloadRoot,
-  )
+    executionBlockRoot: executionPayloadRoot)
 
 func init*(
     T: type BlockRef, root: Eth2Digest,
@@ -177,6 +176,15 @@ func atSlotEpoch*(blck: BlockRef, epoch: Epoch): BlockSlot =
       BlockSlot()
     else:
       tmp.blck.atSlot(start)
+
+func atCheckpoint*(blck: BlockRef, checkpoint: Checkpoint): Opt[BlockSlot] =
+  ## Rewind from `blck` to the given `checkpoint` iff it is an ancestor
+  let target = blck.atSlot(checkpoint.epoch.start_slot)
+  if target.blck == nil:
+    return err()
+  if target.blck.root != checkpoint.root:
+    return err()
+  ok target
 
 func toBlockSlotId*(bs: BlockSlot): Opt[BlockSlotId] =
   if isNil(bs.blck):

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -154,7 +154,7 @@ type
       ## backfilling reaches this point - empty when not backfilling.
 
     heads*: seq[BlockRef]
-    ## Candidate heads of candidate chains
+      ## Candidate heads of candidate chains
 
     finalizedHead*: BlockSlot
       ## The latest block that was finalized according to the block in head
@@ -243,10 +243,12 @@ type
   EpochRef* = ref object
     dag*: ChainDAGRef
     key*: EpochKey
-    current_justified_checkpoint*: Checkpoint
-    finalized_checkpoint*: Checkpoint
+
     eth1_data*: Eth1Data
     eth1_deposit_index*: uint64
+
+    checkpoints*: FinalityCheckpoints
+
     beacon_proposers*: array[SLOTS_PER_EPOCH, Option[ValidatorIndex]]
     proposer_dependent_root*: Eth2Digest
 
@@ -270,17 +272,20 @@ type
   OnPhase0BlockAdded* = proc(
     blckRef: BlockRef,
     blck: phase0.TrustedSignedBeaconBlock,
-    epochRef: EpochRef) {.gcsafe, raises: [Defect].}
+    epochRef: EpochRef,
+    unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 
   OnAltairBlockAdded* = proc(
     blckRef: BlockRef,
     blck: altair.TrustedSignedBeaconBlock,
-    epochRef: EpochRef) {.gcsafe, raises: [Defect].}
+    epochRef: EpochRef,
+    unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 
   OnBellatrixBlockAdded* = proc(
     blckRef: BlockRef,
     blck: bellatrix.TrustedSignedBeaconBlock,
-    epochRef: EpochRef) {.gcsafe, raises: [Defect].}
+    epochRef: EpochRef,
+    unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 
   HeadChangeInfoObject* = object
     slot*: Slot

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -19,6 +19,8 @@ import
 export
   base, extras, block_pools_types, results
 
+logScope: topics = "spec_cache"
+
 # Spec functions implemented based on cached values instead of the full state
 func count_active_validators*(epochInfo: EpochRef): uint64 =
   epochInfo.shuffled_active_validator_indices.lenu64
@@ -41,8 +43,8 @@ iterator get_beacon_committee*(
     epochRef: EpochRef, slot: Slot, committee_index: CommitteeIndex):
     (int, ValidatorIndex) =
   ## Return the beacon committee at ``slot`` for ``index``.
-  let
-    committees_per_slot = get_committee_count_per_slot(epochRef)
+  doAssert slot.epoch == epochRef.epoch
+  let committees_per_slot = get_committee_count_per_slot(epochRef)
   for index_in_committee, idx in compute_committee(
     epochRef.shuffled_active_validator_indices,
     (slot mod SLOTS_PER_EPOCH) * committees_per_slot + committee_index.asUInt64,
@@ -54,8 +56,8 @@ func get_beacon_committee*(
     epochRef: EpochRef, slot: Slot, committee_index: CommitteeIndex):
     seq[ValidatorIndex] =
   ## Return the beacon committee at ``slot`` for ``index``.
-  let
-    committees_per_slot = get_committee_count_per_slot(epochRef)
+  doAssert slot.epoch == epochRef.epoch
+  let committees_per_slot = get_committee_count_per_slot(epochRef)
   compute_committee(
     epochRef.shuffled_active_validator_indices,
     (slot mod SLOTS_PER_EPOCH) * committees_per_slot + committee_index.asUInt64,
@@ -66,9 +68,8 @@ func get_beacon_committee*(
 func get_beacon_committee_len*(
     epochRef: EpochRef, slot: Slot, committee_index: CommitteeIndex): uint64 =
   ## Return the number of members in the beacon committee at ``slot`` for ``index``.
-  let
-    committees_per_slot = get_committee_count_per_slot(epochRef)
-
+  doAssert slot.epoch == epochRef.epoch
+  let committees_per_slot = get_committee_count_per_slot(epochRef)
   compute_committee_len(
     count_active_validators(epochRef),
     (slot mod SLOTS_PER_EPOCH) * committees_per_slot + committee_index.asUInt64,
@@ -88,6 +89,41 @@ iterator get_attesting_indices*(epochRef: EpochRef,
         epochRef, slot, committee_index):
       if bits[index_in_committee]:
         yield validator_index
+
+iterator get_attesting_indices*(
+    dag: ChainDAGRef, attestation: TrustedAttestation): ValidatorIndex =
+  block: # `return` is not allowed in an inline iterator
+    let
+      slot =
+        check_attestation_slot_target(attestation.data).valueOr:
+          warn "Invalid attestation slot"
+          doAssert verifyFinalization notin dag.updateFlags
+          break
+      blck =
+        dag.getBlockRef(attestation.data.beacon_block_root).valueOr:
+          # Attestation block unknown
+          break
+      target =
+        blck.atCheckpoint(attestation.data.target).valueOr:
+          warn "Invalid attestation target"
+          doAssert verifyFinalization notin dag.updateFlags
+          break
+      epochRef =
+        dag.getEpochRef(target.blck, target.slot.epoch, false).valueOr:
+          warn "Attestation `EpochRef` not found"
+          doAssert verifyFinalization notin dag.updateFlags
+          break
+
+      committeesPerSlot = get_committee_count_per_slot(epochRef)
+      committeeIndex =
+        CommitteeIndex.init(attestation.data.index, committeesPerSlot).valueOr:
+          warn "Unexpected committee index in block attestation"
+          doAssert verifyFinalization notin dag.updateFlags
+          break
+
+    for validator in get_attesting_indices(
+        epochRef, slot, committeeIndex, attestation.aggregation_bits):
+      yield validator
 
 func get_attesting_indices_one*(epochRef: EpochRef,
                                 slot: Slot,
@@ -163,12 +199,10 @@ func makeAttestationData*(
     slot: slot,
     index: committee_index.asUInt64,
     beacon_block_root: bs.blck.root,
-    source: epochRef.current_justified_checkpoint,
+    source: epochRef.checkpoints.justified,
     target: Checkpoint(
       epoch: current_epoch,
-      root: epoch_boundary_block.blck.root
-    )
-  )
+      root: epoch_boundary_block.blck.root))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#validator-assignments
 iterator get_committee_assignments*(

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -12,10 +12,10 @@ import
   std/[options, tables],
   # Status
   stew/results,
-
   chronicles,
   # Internal
   ../spec/datatypes/base
+
 # https://github.com/ethereum/consensus-specs/blob/v0.11.1/specs/phase0/fork-choice.md
 # This is a port of https://github.com/sigp/lighthouse/pull/804
 # which is a port of "Proto-Array": https://github.com/protolambda/lmd-ghost
@@ -70,11 +70,9 @@ type
       indicesLen*: int
     of fcInvalidBestNode:
       startRoot*: Eth2Digest
-      fkChoiceJustifiedCheckpoint*: Checkpoint
-      fkChoiceFinalizedCheckpoint*: Checkpoint
+      fkChoiceCheckpoints*: FinalityCheckpoints
       headRoot*: Eth2Digest
-      headJustifiedCheckpoint*: Checkpoint
-      headFinalizedCheckpoint*: Checkpoint
+      headCheckpoints*: FinalityCheckpoints
     of fcUnknownParent:
       childRoot*: Eth2Digest
       parentRoot*: Eth2Digest
@@ -90,18 +88,17 @@ type
     ## to get the physical index
 
   ProtoArray* = object
-    justifiedCheckpoint*: Checkpoint
-    finalizedCheckpoint*: Checkpoint
+    checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]
+    currentEpochTips*: Table[Index, FinalityCheckpoints]
     previousProposerBoostRoot*: Eth2Digest
     previousProposerBoostScore*: int64
 
   ProtoNode* = object
     root*: Eth2Digest
     parent*: Option[Index]
-    justifiedCheckpoint*: Checkpoint
-    finalizedCheckpoint*: Checkpoint
+    checkpoints*: FinalityCheckpoints
     weight*: int64
     bestChild*: Option[Index]
     bestDescendant*: Option[Index]
@@ -144,8 +141,8 @@ type
 
 func shortLog*(vote: VoteTracker): auto =
   (
-    current_root: vote.current_root,
-    next_root: vote.next_root,
+    current_root: shortLog(vote.current_root),
+    next_root: shortLog(vote.next_root),
     next_epoch: vote.next_epoch
   )
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -83,25 +83,18 @@ func nodeLeadsToViableHead(self: ProtoArray, node: ProtoNode): FcResult[bool]
 # ProtoArray routines
 # ----------------------------------------------------------------------
 
-func init*(T: type ProtoArray,
-           justifiedCheckpoint: Checkpoint,
-           finalizedCheckpoint: Checkpoint): T =
+func init*(T: type ProtoArray, checkpoints: FinalityCheckpoints): T =
   let node = ProtoNode(
-    root: finalizedCheckpoint.root,
+    root: checkpoints.finalized.root,
     parent: none(int),
-    justifiedCheckpoint: justifiedCheckpoint,
-    finalizedCheckpoint: finalizedCheckpoint,
+    checkpoints: checkpoints,
     weight: 0,
     bestChild: none(int),
-    bestDescendant: none(int)
-  )
+    bestDescendant: none(int))
 
-  T(
-    justifiedCheckpoint: justifiedCheckpoint,
-    finalizedCheckpoint: finalizedCheckpoint,
+  T(checkpoints: checkpoints,
     nodes: ProtoNodes(buf: @[node], offset: 0),
-    indices: {node.root: 0}.toTable()
-  )
+    indices: {node.root: 0}.toTable())
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/fork-choice.md#configuration
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/fork-choice.md#get_latest_attesting_balance
@@ -127,8 +120,7 @@ func calculateProposerBoost(validatorBalances: openArray[Gwei]): int64 =
 
 func applyScoreChanges*(self: var ProtoArray,
                         deltas: var openArray[Delta],
-                        justifiedCheckpoint: Checkpoint,
-                        finalizedCheckpoint: Checkpoint,
+                        checkpoints: FinalityCheckpoints,
                         newBalances: openArray[Gwei],
                         proposerBoostRoot: Eth2Digest): FcResult[void] =
   ## Iterate backwards through the array, touching all nodes and their parents
@@ -152,8 +144,7 @@ func applyScoreChanges*(self: var ProtoArray,
       deltasLen: deltas.len,
       indicesLen: self.indices.len)
 
-  self.justifiedCheckpoint = justifiedCheckpoint
-  self.finalizedCheckpoint = finalizedCheckpoint
+  self.checkpoints = checkpoints
 
   ## Alias
   # This cannot raise the IndexError exception, how to tell compiler?
@@ -261,8 +252,8 @@ func applyScoreChanges*(self: var ProtoArray,
 func onBlock*(self: var ProtoArray,
               root: Eth2Digest,
               parent: Eth2Digest,
-              justifiedCheckpoint: Checkpoint,
-              finalizedCheckpoint: Checkpoint): FcResult[void] =
+              checkpoints: FinalityCheckpoints,
+              unrealized = none(FinalityCheckpoints)): FcResult[void] =
   ## Register a block with the fork choice
   ## A block `hasParentInForkChoice` may be false
   ## on fork choice initialization:
@@ -289,19 +280,36 @@ func onBlock*(self: var ProtoArray,
   let node = ProtoNode(
     root: root,
     parent: some(parentIdx),
-    justifiedCheckpoint: justifiedCheckpoint,
-    finalizedCheckpoint: finalizedCheckpoint,
+    checkpoints: checkpoints,
     weight: 0,
     bestChild: none(int),
-    bestDescendant: none(int)
-  )
+    bestDescendant: none(int))
 
   self.indices[node.root] = nodeLogicalIdx
   self.nodes.add node
 
+  if unrealized.isSome:
+    self.currentEpochTips.del parentIdx
+    self.currentEpochTips[nodeLogicalIdx] = unrealized.get
+
   ? self.maybeUpdateBestChildAndDescendant(parentIdx, nodeLogicalIdx)
 
   ok()
+
+iterator realizePendingCheckpoints*(self: var ProtoArray): FinalityCheckpoints =
+  # Pull-up chain tips from previous epoch
+  for idx, unrealized in self.currentEpochTips.pairs():
+    let physicalIdx = idx - self.nodes.offset
+    trace "Pulling up chain tip",
+      blck = self.nodes.buf[physicalIdx].root,
+      checkpoints = self.nodes.buf[physicalIdx].checkpoints,
+      unrealized
+    self.nodes.buf[physicalIdx].checkpoints = unrealized
+
+    yield unrealized
+
+  # Reset tip tracking for new epoch
+  self.currentEpochTips.clear()
 
 func findHead*(self: var ProtoArray,
                head: var Eth2Digest,
@@ -338,11 +346,9 @@ func findHead*(self: var ProtoArray,
     return err ForkChoiceError(
       kind: fcInvalidBestNode,
       startRoot: justifiedRoot,
-      fkChoiceJustifiedCheckpoint: self.justifiedCheckpoint,
-      fkChoiceFinalizedCheckpoint: self.finalizedCheckpoint,
+      fkChoiceCheckpoints: self.checkpoints,
       headRoot: justifiedNode.get().root,
-      headJustifiedCheckpoint: justifiedNode.get().justifiedCheckpoint,
-      headFinalizedCheckpoint: justifiedNode.get().finalizedCheckpoint)
+      headCheckpoints: justifiedNode.get().checkpoints)
 
   head = bestNode.get().root
   ok()
@@ -379,6 +385,7 @@ func prune*(self: var ProtoArray, finalizedRoot: Eth2Digest): FcResult[void] =
 
   let finalPhysicalIdx = finalizedIdx - self.nodes.offset
   for nodeIdx in 0 ..< finalPhysicalIdx:
+    self.currentEpochTips.del nodeIdx
     self.indices.del(self.nodes.buf[nodeIdx].root)
 
   # Drop all nodes prior to finalization.
@@ -511,11 +518,11 @@ func nodeIsViableForHead(self: ProtoArray, node: ProtoNode): bool =
   ## Any node that has a different finalized or justified epoch
   ## should not be viable for the head.
   (
-    (node.justifiedCheckpoint == self.justifiedCheckpoint) or
-    (self.justifiedCheckpoint.epoch == Epoch(0))
+    (node.checkpoints.justified == self.checkpoints.justified) or
+    (self.checkpoints.justified.epoch == GENESIS_EPOCH)
   ) and (
-    (node.finalizedCheckpoint == self.finalizedCheckpoint) or
-    (self.finalizedCheckpoint.epoch == Epoch(0))
+    (node.checkpoints.finalized == self.checkpoints.finalized) or
+    (self.checkpoints.finalized.epoch == GENESIS_EPOCH)
   )
 
 # Sanity checks

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -126,17 +126,8 @@ func check_beacon_and_target_block(
   # compute_start_slot_at_epoch(attestation.data.target.epoch)) ==
   # attestation.data.target.root
   # the sanity of target.epoch has been checked by check_attestation_slot_target
-  let
-    target = blck.atSlot(data.target.epoch.start_slot())
-
-  if isNil(target.blck):
-    # Shouldn't happen - we've checked that the target epoch is within range
-    # already
-    return errReject("Attestation target block not found")
-
-  if not (target.blck.root == data.target.root):
-    return errReject(
-      "Attestation target block not the correct ancestor of LMD vote block")
+  let target = blck.atCheckpoint(data.target).valueOr:
+    return errReject("Attestation target is not ancestor of LMD vote block")
 
   ok(target)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -312,7 +312,7 @@ proc initFullNode(
     lightClientPool = newClone(
       LightClientPool())
     exitPool = newClone(
-      ExitPool.init(dag, onVoluntaryExitAdded))
+      ExitPool.init(dag, attestationPool, onVoluntaryExitAdded))
     consensusManager = ConsensusManager.new(
       dag, attestationPool, quarantine, node.eth1Monitor)
     blockProcessor = BlockProcessor.new(

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -60,7 +60,7 @@ proc getSyncedHead*(node: BeaconNode, slot: Slot): Result[BlockRef, cstring] =
   ok(head)
 
 proc getSyncedHead*(node: BeaconNode,
-                     epoch: Epoch): Result[BlockRef, cstring] =
+                    epoch: Epoch): Result[BlockRef, cstring] =
   if epoch > MaxEpoch:
     return err("Requesting epoch for which slot would overflow")
   node.getSyncedHead(epoch.start_slot())

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -370,8 +370,8 @@ func get_block_root_at_slot*(state: ForkyBeaconState, slot: Slot): Eth2Digest =
   doAssert slot < state.slot
   state.block_roots[slot mod SLOTS_PER_HISTORICAL_ROOT]
 
-func get_block_root_at_slot*(state: ForkedHashedBeaconState,
-                             slot: Slot): Eth2Digest =
+func get_block_root_at_slot*(
+    state: ForkedHashedBeaconState, slot: Slot): Eth2Digest =
   ## Return the block root at a recent ``slot``.
   withState(state):
     get_block_root_at_slot(state.data, slot)
@@ -381,12 +381,17 @@ func get_block_root*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
   ## Return the block root at the start of a recent ``epoch``.
   get_block_root_at_slot(state, epoch.start_slot())
 
+func get_block_root*(state: ForkedHashedBeaconState, epoch: Epoch): Eth2Digest =
+  ## Return the block root at the start of a recent ``epoch``.
+  withState(state):
+    get_block_root(state.data, epoch)
+
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#get_total_balance
 template get_total_balance(
     state: ForkyBeaconState, validator_indices: untyped): Gwei =
   ## Return the combined effective balance of the ``indices``.
   ## ``EFFECTIVE_BALANCE_INCREMENT`` Gwei minimum to avoid divisions by zero.
-  ## Math safe up to ~10B ETH, afterwhich this overflows uint64.
+  ## Math safe up to ~10B ETH, after which this overflows uint64.
   var res = 0.Gwei
   for validator_index in validator_indices:
     res += state.validators[validator_index].effective_balance
@@ -399,8 +404,8 @@ func is_eligible_for_activation_queue*(validator: Validator): bool =
     validator.effective_balance == MAX_EFFECTIVE_BALANCE
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#is_eligible_for_activation
-func is_eligible_for_activation*(state: ForkyBeaconState, validator: Validator):
-    bool =
+func is_eligible_for_activation*(
+    state: ForkyBeaconState, validator: Validator): bool =
   ## Check if ``validator`` is eligible for activation.
 
   # Placement in queue is finalized
@@ -709,7 +714,7 @@ proc process_attestation*(
     pa[].inclusion_delay = state.slot - attestation.data.slot
     pa[].proposer_index = proposer_index.get().uint64
 
-  # Altair and Merge
+  # Altair and Bellatrix
   template updateParticipationFlags(epoch_participation: untyped) =
     let proposer_reward = get_proposer_reward(
       state, attestation, base_reward_per_increment, cache, epoch_participation)

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -265,7 +265,7 @@ type
     sync_aggregate*: SyncAggregate # TODO TrustedSyncAggregate after batching
 
     # Execution
-    execution_payload*: ExecutionPayload  # [New in Merge]
+    execution_payload*: ExecutionPayload  # [New in Bellatrix]
 
   TrustedBeaconBlockBody* = object
     ## A full verified block
@@ -285,7 +285,7 @@ type
     sync_aggregate*: TrustedSyncAggregate
 
     # Execution
-    execution_payload*: ExecutionPayload  # [New in Merge]
+    execution_payload*: ExecutionPayload  # [New in Bellatrix]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#signedbeaconblock
   SignedBeaconBlock* = object

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -72,6 +72,33 @@ type
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#get_total_balance
+  TotalBalances* = object
+    # The total effective balance of all active validators during the _current_
+    # epoch.
+    current_epoch_raw*: Gwei
+    # The total effective balance of all active validators during the _previous_
+    # epoch.
+    previous_epoch_raw*: Gwei
+    # The total effective balance of all validators who attested during the
+    # _current_ epoch.
+    current_epoch_attesters_raw*: Gwei
+    # The total effective balance of all validators who attested during the
+    # _current_ epoch and agreed with the state about the beacon block at the
+    # first slot of the _current_ epoch.
+    current_epoch_target_attesters_raw*: Gwei
+    # The total effective balance of all validators who attested during the
+    # _previous_ epoch.
+    previous_epoch_attesters_raw*: Gwei
+    # The total effective balance of all validators who attested during the
+    # _previous_ epoch and agreed with the state about the beacon block at the
+    # first slot of the _previous_ epoch.
+    previous_epoch_target_attesters_raw*: Gwei
+    # The total effective balance of all validators who attested during the
+    # _previous_ epoch and agreed with the state about the beacon block at the
+    # time of attestation.
+    previous_epoch_head_attesters_raw*: Gwei
+
   # TODO Careful, not nil analysis is broken / incomplete and the semantics will
   #      likely change in future versions of the language:
   #      https://github.com/nim-lang/RFCs/issues/250

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -88,6 +88,12 @@ func get_current_epoch*(state: ForkedHashedBeaconState): Epoch =
   ## Return the current epoch.
   withState(state): get_current_epoch(state.data)
 
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#get_previous_epoch
+func get_previous_epoch*(
+    state: ForkyBeaconState | ForkedHashedBeaconState): Epoch =
+  ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
+  get_previous_epoch(get_current_epoch(state))
+
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
   ## Returns the randao mix at a recent ``epoch``.

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -184,16 +184,6 @@ iterator get_committee_indices*(committee_count_per_slot: uint64): CommitteeInde
     let committee_index = CommitteeIndex.init(idx).expect("value clamped")
     yield committee_index
 
-func get_previous_epoch*(state: ForkyBeaconState): Epoch =
-  ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
-  # Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
-  get_previous_epoch(get_current_epoch(state))
-
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#get_previous_epoch
-func get_previous_epoch*(state: ForkedHashedBeaconState): Epoch =
-  ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
-  get_previous_epoch(get_current_epoch(state))
-
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#compute_committee
 func compute_committee_slice*(
     active_validators, index, count: uint64): Slice[int] =

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -27,7 +27,7 @@ export
 when defined(windows):
   import stew/[windows/acl]
 
-{.localPassc: "-fno-lto".} # no LTO for crypto
+{.localPassC: "-fno-lto".} # no LTO for crypto
 
 const
   KeystoreFileName* = "keystore.json"

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1102,7 +1102,7 @@ proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):
     else:
       await proposeBlock(node, validator, proposer.get(), head, slot)
 
-proc makeAggregateAndProof*(
+proc makeAggregateAndProof(
     pool: var AttestationPool, epochRef: EpochRef, slot: Slot,
     committee_index: CommitteeIndex,
     validator_index: ValidatorIndex,

--- a/config.nims
+++ b/config.nims
@@ -175,7 +175,7 @@ switch("warning", "LockLevel:off")
 # ############################################################
 
 # This applies per-file compiler flags to C files
-# which do not support {.localPassc: "-fno-lto".}
+# which do not support {.localPassC: "-fno-lto".}
 # Unfortunately this is filename based instead of path-based
 # Assumes GCC
 
@@ -203,4 +203,3 @@ put("ecp_BLS12381.always", "-fno-lto")
 # sqlite3.c: In function ‘sqlite3SelectNew’:
 # vendor/nim-sqlite3-abi/sqlite3.c:124500: warning: function may return address of local variable [-Wreturn-local-addr]
 put("sqlite3.always", "-fno-lto") # -Wno-return-local-addr
-

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -308,10 +308,11 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         newBlock = getNewBlock[phase0.SignedBeaconBlock](state, slot, cache)
         added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-            epochRef: EpochRef):
+            epochRef: EpochRef, unrealized: FinalityCheckpoints):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+            epochRef, blckRef, unrealized, signedBlock.message,
+            blckRef.slot.start_beacon_time)
 
       dag.updateHead(added[], quarantine[])
       if dag.needStateCachesAndForkChoicePruning():
@@ -329,10 +330,11 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         newBlock = getNewBlock[altair.SignedBeaconBlock](state, slot, cache)
         added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: altair.TrustedSignedBeaconBlock,
-            epochRef: EpochRef):
+            epochRef: EpochRef, unrealized: FinalityCheckpoints):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+            epochRef, blckRef, unrealized, signedBlock.message,
+            blckRef.slot.start_beacon_time)
 
       dag.updateHead(added[], quarantine[])
       if dag.needStateCachesAndForkChoicePruning():
@@ -350,10 +352,11 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         newBlock = getNewBlock[bellatrix.SignedBeaconBlock](state, slot, cache)
         added = dag.addHeadBlock(verifier, newBlock) do (
             blckRef: BlockRef, signedBlock: bellatrix.TrustedSignedBeaconBlock,
-            epochRef: EpochRef):
+            epochRef: EpochRef, unrealized: FinalityCheckpoints):
           # Callback add to fork choice if valid
           attPool.addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+            epochRef, blckRef, unrealized, signedBlock.message,
+            blckRef.slot.start_beacon_time)
 
       dag.updateHead(added[], quarantine[])
       if dag.needStateCachesAndForkChoicePruning():

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -10,7 +10,7 @@ import
   std/[os, strutils, typetraits],
   # Internals
   ../../beacon_chain/spec/[
-    eth2_merkleization, eth2_ssz_serialization],
+    eth2_merkleization, eth2_ssz_serialization, forks],
   # Status libs,
   snappy,
   stew/byteutils
@@ -22,11 +22,35 @@ export
 # ---------------------------------------------
 
 # #######################
+# Path parsing
+
+func forkForPathComponent*(forkPath: string): Opt[BeaconStateFork] =
+  for fork in BeaconStateFork:
+    if ($fork).toLowerAscii() == forkPath:
+      return ok fork
+  err()
+
+# #######################
 # JSON deserialization
 
 func readValue*(r: var JsonReader, a: var seq[byte]) =
   ## Custom deserializer for seq[byte]
   a = hexToSeqByte(r.readValue(string))
+
+# #######################
+# Mock RuntimeConfig
+
+func genesisTestRuntimeConfig*(stateFork: BeaconStateFork): RuntimeConfig =
+  var res = defaultRuntimeConfig
+  case stateFork
+  of BeaconStateFork.Bellatrix:
+    res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+    res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+  of BeaconStateFork.Altair:
+    res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+  of BeaconStateFork.Phase0:
+    discard
+  res
 
 # #######################
 # Test helpers

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -9,26 +9,26 @@
 
 import
   # Standard library
-  std/[json, os, strutils, tables],
+  std/[json, os, sequtils, strutils, tables],
   # Status libraries
   stew/[results, endians2], chronicles,
   eth/keys, taskpools,
   # Internals
-  ../../beacon_chain/spec/[helpers, forks],
+  ../../beacon_chain/spec/[helpers, forks, state_transition_block],
   ../../beacon_chain/spec/datatypes/[
     base,
     phase0, altair, bellatrix],
   ../../beacon_chain/fork_choice/[fork_choice, fork_choice_types],
   ../../beacon_chain/[beacon_chain_db, beacon_clock],
   ../../beacon_chain/consensus_object_pools/[
-    blockchain_dag, block_clearance, spec_cache],
+    blockchain_dag, block_clearance, block_quarantine, spec_cache],
   # Third-party
   yaml,
   # Test
   ../testutil,
   ./fixtures_utils
 
-# Test format described at https://github.com/ethereum/consensus-specs/tree/v1.1.6/tests/formats/fork_choice
+# Test format described at https://github.com/ethereum/consensus-specs/tree/v1.2.0-rc.1/tests/formats/fork_choice
 # Note that our implementation has been optimized with "ProtoArray"
 # instead of following the spec (in particular the "store").
 
@@ -38,31 +38,30 @@ type
     opOnAttestation
     opOnBlock
     opOnMergeBlock
+    opOnAttesterSlashing
     opChecks
 
   Operation = object
     valid: bool
     # variant specific fields
-    case kind*: OpKind
+    case kind: OpKind
     of opOnTick:
       tick: int
     of opOnAttestation:
       att: Attestation
     of opOnBlock:
-      blk: ForkedSignedBeaconBlock
+      blck: ForkedSignedBeaconBlock
     of opOnMergeBlock:
       powBlock: PowBlock
+    of opOnAttesterSlashing:
+      attesterSlashing: AttesterSlashing
     of opChecks:
       checks: JsonNode
 
 proc initialLoad(
-       path: string, db: BeaconChainDB,
-       StateType, BlockType: typedesc): tuple[
-       dag: ChainDAGRef, fkChoice: ref ForkChoice
-    ] =
-
-   # TODO: support more than phase 0 genesis
-
+    path: string, db: BeaconChainDB,
+    StateType, BlockType: typedesc
+): tuple[dag: ChainDAGRef, fkChoice: ref ForkChoice] =
   let state = newClone(parseTest(
     path/"anchor_state.ssz_snappy",
     SSZ, StateType
@@ -71,32 +70,54 @@ proc initialLoad(
   # TODO stack usage. newClone and assignClone do not seem to
   # prevent temporaries created by case objects
   let forkedState = new ForkedHashedBeaconState
-  forkedState.kind = BeaconStateFork.Phase0
-  forkedState.phase0Data.data = state[]
-  forkedState.phase0Data.root = hash_tree_root(state[])
+  when StateType is bellatrix.BeaconState:
+    forkedState.kind = BeaconStateFork.Bellatrix
+    forkedState.bellatrixData.data = state[]
+    forkedState.bellatrixData.root = hash_tree_root(state[])
+  elif StateType is altair.BeaconState:
+    forkedState.kind = BeaconStateFork.Altair
+    forkedState.altairData.data = state[]
+    forkedState.altairData.root = hash_tree_root(state[])
+  elif StateType is phase0.BeaconState:
+    forkedState.kind = BeaconStateFork.Phase0
+    forkedState.phase0Data.data = state[]
+    forkedState.phase0Data.root = hash_tree_root(state[])
+  else: {.error: "Unknown state fork: " & name(StateType).}
 
-  let blk = parseTest(
+  let blck = parseTest(
     path/"anchor_block.ssz_snappy",
     SSZ, BlockType
   )
 
-
-  let signedBlock = ForkedSignedBeaconBlock.init(phase0.SignedBeaconBlock(
-        message: blk,
-        # signature: - unused as it's trusted
-        root: hash_tree_root(blk)
-      ))
+  when BlockType is bellatrix.BeaconBlock:
+    let signedBlock = ForkedSignedBeaconBlock.init(bellatrix.SignedBeaconBlock(
+      message: blck,
+      # signature: - unused as it's trusted
+      root: hash_tree_root(blck)
+    ))
+  elif BlockType is altair.BeaconBlock:
+    let signedBlock = ForkedSignedBeaconBlock.init(altair.SignedBeaconBlock(
+      message: blck,
+      # signature: - unused as it's trusted
+      root: hash_tree_root(blck)
+    ))
+  elif BlockType is phase0.BeaconBlock:
+    let signedBlock = ForkedSignedBeaconBlock.init(phase0.SignedBeaconBlock(
+      message: blck,
+      # signature: - unused as it's trusted
+      root: hash_tree_root(blck)
+    ))
+  else: {.error: "Unknown block fork: " & name(BlockType).}
 
   ChainDAGRef.preInit(
     db,
     forkedState[], forkedState[],
-    asTrusted(signedBlock)
-  )
+    asTrusted(signedBlock))
 
   let
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(
-      defaultRuntimeConfig, db, validatorMonitor, {})
+      forkedState[].kind.genesisTestRuntimeConfig, db, validatorMonitor, {})
     fkChoice = newClone(ForkChoice.init(
       dag.getFinalizedEpochRef(),
       dag.finalizedHead.blck,
@@ -104,38 +125,15 @@ proc initialLoad(
 
   (dag, fkChoice)
 
-proc loadOps(path: string, fork: BeaconBlockFork): seq[Operation] =
+proc loadOps(path: string, fork: BeaconStateFork): seq[Operation] =
   let stepsYAML = readFile(path/"steps.yaml")
   let steps = yaml.loadToJson(stepsYAML)
 
   result = @[]
   for step in steps[0]:
     if step.hasKey"tick":
-      result.add Operation(kind: opOnTick, tick: step["tick"].getInt())
-    elif step.hasKey"block":
-      let filename = step["block"].getStr()
-      case fork
-      of BeaconBlockFork.Phase0:
-        let blk = parseTest(
-          path/filename & ".ssz_snappy",
-          SSZ, phase0.SignedBeaconBlock
-        )
-        result.add Operation(kind: opOnBlock,
-          blk: ForkedSignedBeaconBlock.init(blk))
-      of BeaconBlockFork.Altair:
-        let blk = parseTest(
-          path/filename & ".ssz_snappy",
-          SSZ, altair.SignedBeaconBlock
-        )
-        result.add Operation(kind: opOnBlock,
-          blk: ForkedSignedBeaconBlock.init(blk))
-      of BeaconBlockFork.Bellatrix:
-        let blk = parseTest(
-          path/filename & ".ssz_snappy",
-          SSZ, bellatrix.SignedBeaconBlock
-        )
-        result.add Operation(kind: opOnBlock,
-          blk: ForkedSignedBeaconBlock.init(blk))
+      result.add Operation(kind: opOnTick,
+        tick: step["tick"].getInt())
     elif step.hasKey"attestation":
       let filename = step["attestation"].getStr()
       let att = parseTest(
@@ -144,11 +142,43 @@ proc loadOps(path: string, fork: BeaconBlockFork): seq[Operation] =
       )
       result.add Operation(kind: opOnAttestation,
         att: att)
+    elif step.hasKey"block":
+      let filename = step["block"].getStr()
+      case fork
+      of BeaconStateFork.Phase0:
+        let blck = parseTest(
+          path/filename & ".ssz_snappy",
+          SSZ, phase0.SignedBeaconBlock
+        )
+        result.add Operation(kind: opOnBlock,
+          blck: ForkedSignedBeaconBlock.init(blck))
+      of BeaconStateFork.Altair:
+        let blck = parseTest(
+          path/filename & ".ssz_snappy",
+          SSZ, altair.SignedBeaconBlock
+        )
+        result.add Operation(kind: opOnBlock,
+          blck: ForkedSignedBeaconBlock.init(blck))
+      of BeaconStateFork.Bellatrix:
+        let blck = parseTest(
+          path/filename & ".ssz_snappy",
+          SSZ, bellatrix.SignedBeaconBlock
+        )
+        result.add Operation(kind: opOnBlock,
+          blck: ForkedSignedBeaconBlock.init(blck))
+    elif step.hasKey"attester_slashing":
+      let filename = step["attester_slashing"].getStr()
+      let attesterSlashing = parseTest(
+        path/filename & ".ssz_snappy",
+        SSZ, AttesterSlashing
+      )
+      result.add Operation(kind: opOnAttesterSlashing,
+        attesterSlashing: attesterSlashing)
     elif step.hasKey"checks":
       result.add Operation(kind: opChecks,
         checks: step["checks"])
     else:
-      doAssert false, "Unreachable: " & $step
+      doAssert false, "Unknown test step: " & $step
 
     if step.hasKey"valid":
       doAssert step.len == 2
@@ -182,38 +212,24 @@ proc stepOnBlock(
     type TrustedBlock = bellatrix.TrustedSignedBeaconBlock
 
   let blockAdded = dag.addHeadBlock(verifier, signedBlock) do (
-      blckRef: BlockRef, signedBlock: TrustedBlock, epochRef: EpochRef
-    ):
+      blckRef: BlockRef, signedBlock: TrustedBlock,
+      epochRef: EpochRef, unrealized: FinalityCheckpoints):
 
     # 3. Update fork choice if valid
     let status = fkChoice[].process_block(
-      dag,
-      epochRef,
-      blckRef,
-      signedBlock.message,
-      time
-    )
+      dag, epochRef, blckRef, unrealized, signedBlock.message, time)
     doAssert status.isOk()
 
+    # 4. Update DAG with new head
+    var quarantine = Quarantine.init()
+    let newHead = fkChoice[].get_head(dag, time).get()
+    dag.updateHead(dag.getBlockRef(newHead).get(), quarantine)
+    if dag.needStateCachesAndForkChoicePruning():
+      dag.pruneStateCachesDAG()
+      let pruneRes = fkChoice[].prune()
+      doAssert pruneRes.isOk()
+
   blockAdded
-
-proc stepOnAttestation(
-       dag: ChainDAGRef,
-       fkChoice: ref ForkChoice,
-       att: Attestation,
-       time: BeaconTime): FcResult[void] =
-  let epochRef =
-    dag.getEpochRef(
-      dag.head, time.slotOrZero().epoch(), false).expect("no pruning in test")
-  let attesters = epochRef.get_attesting_indices(
-    att.data.slot, CommitteeIndex(att.data.index), att.aggregation_bits)
-  let status = fkChoice[].on_attestation(
-    dag,
-    att.data.slot, att.data.beacon_block_root, attesters,
-    time
-  )
-
-  status
 
 proc stepChecks(
        checks: JsonNode,
@@ -260,34 +276,20 @@ proc stepChecks(
     else:
       doAssert false, "Unsupported check '" & $check & "'"
 
-proc runTest(path: string, fork: BeaconBlockFork) =
+proc doRunTest(path: string, fork: BeaconStateFork) =
   let db = BeaconChainDB.new("", inMemory = true)
   defer:
     db.close()
 
-  let stores = case fork
-    of BeaconBlockFork.Phase0:
-      initialLoad(
-        path, db,
-        phase0.BeaconState, phase0.BeaconBlock
-      )
-    else:
-      doAssert false, "Unsupported fork: " & $fork
-      (ChainDAGRef(), (ref ForkChoice)())
-    # of BeaconBlockFork.Altair:
-    #   initialLoad(
-    #     path, db,
-    #     # The tests always use phase 0 block for anchor - https://github.com/ethereum/consensus-specs/pull/2323
-    #     # TODO: support altair genesis state
-    #     altair.BeaconState, phase0.BeaconBlock
-    #   )
-    # of BeaconBlockFork.Merge:
-    #   initialLoad(
-    #     path, db,
-    #     # The tests always use phase 0 block for anchor - https://github.com/ethereum/consensus-specs/pull/2323
-    #     # TODO: support merge genesis state
-    #     bellatrix.BeaconState, phase0.BeaconBlock
-    #   )
+  let stores =
+    case fork
+    of BeaconStateFork.Bellatrix:
+      initialLoad(path, db, bellatrix.BeaconState, bellatrix.BeaconBlock)
+    of BeaconStateFork.Altair:
+      initialLoad(path, db, altair.BeaconState, altair.BeaconBlock)
+    of BeaconStateFork.Phase0:
+      initialLoad(path, db, phase0.BeaconState, phase0.BeaconBlock)
+
   var
     taskpool = Taskpool.new()
     verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
@@ -302,53 +304,68 @@ proc runTest(path: string, fork: BeaconBlockFork) =
     case step.kind
     of opOnTick:
       time = BeaconTime(ns_since_genesis: step.tick.seconds.nanoseconds)
-      doAssert stores.fkChoice.checkpoints.on_tick(time).isOk
+      let status = stores.fkChoice[].update_time(stores.dag, time)
+      doAssert status.isOk == step.valid
+    of opOnAttestation:
+      let status = stores.fkChoice[].on_attestation(
+        stores.dag, step.att.data.slot, step.att.data.beacon_block_root,
+        toSeq(stores.dag.get_attesting_indices(step.att.asTrusted)), time)
+      doAssert status.isOk == step.valid
     of opOnBlock:
-      withBlck(step.blk):
+      withBlck(step.blck):
         let status = stepOnBlock(
           stores.dag, stores.fkChoice,
-          verifier,
-          state[], stateCache,
-          blck,
-          time)
+          verifier, state[], stateCache,
+          blck, time)
         doAssert status.isOk == step.valid
-    of opOnAttestation:
-      let status = stepOnAttestation(
-        stores.dag, stores.fkChoice,
-        step.att, time)
-      doAssert status.isOk == step.valid
+    of opOnAttesterSlashing:
+      let indices =
+        check_attester_slashing(state[], step.attesterSlashing, flags = {})
+      if indices.isOk:
+        for idx in indices.get:
+          stores.fkChoice[].process_equivocation(idx)
+      doAssert indices.isOk == step.valid
     of opChecks:
       stepChecks(step.checks, stores.dag, stores.fkChoice, time)
     else:
       doAssert false, "Unsupported"
 
-suite "EF - ForkChoice" & preset():
+proc runTest(path: string, fork: BeaconStateFork) =
   const SKIP = [
     # protoArray can handle blocks in the future gracefully
     # spec: https://github.com/ethereum/consensus-specs/blame/v1.1.3/specs/phase0/fork-choice.md#L349
     # test: tests/fork_choice/scenarios/no_votes.nim
     #       "Ensure the head is still 4 whilst the justified epoch is 0."
     "on_block_future_block",
-    "discard_equivocations" # TODO
+
+    # TODO on_merge_block
+    "too_early_for_merge",
+    "too_late_for_merge",
+    "block_lookup_failed",
+    "all_valid",
   ]
 
-  for fork in [BeaconBlockFork.Phase0]: # TODO: init ChainDAG from Merge/Altair
-    let forkStr = toLowerAscii($fork)
-    for testKind in ["get_head", "on_block"]:
-      let basePath = SszTestsDir/const_preset/forkStr/"fork_choice"/testKind/"pyspec_tests"
+  test "ForkChoice - " & path.relativePath(SszTestsDir):
+    when defined(windows):
+      # Some test files have very long paths
+      skip()
+    else:
+      if os.splitPath(path).tail in SKIP:
+        skip()
+      else:
+        doRunTest(path, fork)
+
+suite "EF - ForkChoice" & preset():
+  const presetPath = SszTestsDir/const_preset
+  for kind, path in walkDir(presetPath, relative = true, checkDir = true):
+    let testsPath = presetPath/path/"fork_choice"
+    if kind != pcDir or not dirExists(testsPath):
+      continue
+    let fork = forkForPathComponent(path).valueOr:
+      raiseAssert "Unknown test fork: " & testsPath
+    for kind, path in walkDir(testsPath, relative = true, checkDir = true):
+      let basePath = testsPath/path/"pyspec_tests"
+      if kind != pcDir:
+        continue
       for kind, path in walkDir(basePath, relative = true, checkDir = true):
-        test "ForkChoice - " & const_preset/forkStr/"fork_choice"/testKind/"pyspec_tests"/path:
-          if const_preset == "minimal":
-            # TODO: Minimal tests have long paths issues on Windows
-            # and some are testing implementation details:
-            # - assertion that input block is not in the future
-            # - block slot is later than finalized slot
-            # - ...
-            # that ProtoArray handles gracefully
-            skip()
-          elif path in SKIP:
-            skip()
-          else:
-            runTest(basePath/path, fork)
-
-
+        runTest(basePath/path, fork)

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -19,9 +19,9 @@ export results, base, fork_choice, fork_choice_types, tables, options
 func fakeHash*(index: SomeInteger): Eth2Digest =
   ## Create fake hashes
   ## Those are just the value serialized in big-endian
-  ## We add 16x16 to avoid having a zero hash are those are special cased
+  ## We add 16x16 to avoid having a zero hash as those are special cased
   ## We store them in the first 8 bytes
-  ## as those are the one used in hash tables Table[Eth2Digest, T]
+  ## as those are the ones used in hash tables Table[Eth2Digest, T]
   result.data[0 ..< 8] = (16*16+index).uint64.toBytesBE()
 
 # The fork choice tests are quite complex.
@@ -41,15 +41,13 @@ type
     # variant specific fields
     case kind*: OpKind
     of FindHead, InvalidFindHead:
-      justified_checkpoint*: Checkpoint
-      finalized_checkpoint*: Checkpoint
+      checkpoints*: FinalityCheckpoints
       justified_state_balances*: seq[Gwei]
       expected_head*: Eth2Digest
     of ProcessBlock:
       root*: Eth2Digest
       parent_root*: Eth2Digest
-      blk_justified_checkpoint*: Checkpoint
-      blk_finalized_checkpoint*: Checkpoint
+      blk_checkpoints*: FinalityCheckpoints
     of ProcessAttestation:
       validator_index*: ValidatorIndex
       block_root*: Eth2Digest
@@ -66,34 +64,29 @@ func apply(ctx: var ForkChoiceBackend, id: int, op: Operation) =
   case op.kind
   of FindHead, InvalidFindHead:
     let r = ctx.find_head(
-      op.justified_checkpoint,
-      op.finalized_checkpoint,
+      op.checkpoints,
       op.justified_state_balances,
       # Don't use proposer boosting
-      ZERO_HASH
-    )
+      ZERO_HASH)
     if op.kind == FindHead:
       doAssert r.isOk(), &"find_head (op #{id}) returned an error: {r.error}"
-      doAssert r.get() == op.expected_head, &"find_head (op #{id}) returned an incorrect result: {r.get()} (expected: {op.expected_head}, from justified checkpoint: {op.justified_checkpoint}, finalized checkpoint: {op.finalized_checkpoint})"
-      debugEcho &"    Found expected head: 0x{op.expected_head} from justified checkpoint {op.justified_checkpoint}, finalized checkpoint {op.finalized_checkpoint}"
+      doAssert r.get() == op.expected_head, &"find_head (op #{id}) returned an incorrect result: {r.get()} (expected: {op.expected_head}, from justified checkpoint: {op.checkpoints.justified}, finalized checkpoint: {op.checkpoints.finalized})"
+      debugEcho &"    Found expected head: 0x{op.expected_head} from justified checkpoint {op.checkpoints.justified}, finalized checkpoint {op.checkpoints.justified}"
     else:
-      doAssert r.isErr(), &"invalid_find_head (op #{id}) was unexpectedly successful, head {op.expected_head} from justified checkpoint {op.justified_checkpoint}, finalized checkpoint {op.finalized_checkpoint}"
-      debugEcho &"    Detected an expected invalid head from justified checkpoint {op.justified_checkpoint}, finalized checkpoint {op.finalized_checkpoint}"
+      doAssert r.isErr(), &"invalid_find_head (op #{id}) was unexpectedly successful, head {op.expected_head} from justified checkpoint {op.checkpoints.justified}, finalized checkpoint {op.checkpoints.finalized}"
+      debugEcho &"    Detected an expected invalid head from justified checkpoint {op.checkpoints.justified}, finalized checkpoint {op.checkpoints.finalized}"
   of ProcessBlock:
     let r = ctx.process_block(
       block_root = op.root,
       parent_root = op.parent_root,
-      justified_checkpoint = op.blk_justified_checkpoint,
-      finalized_checkpoint = op.blk_finalized_checkpoint
-    )
+      checkpoints = op.blk_checkpoints)
     doAssert r.isOk(), &"process_block (op #{id}) returned an error: {r.error}"
-    debugEcho "    Processed block      0x", op.root, " with parent 0x", op.parent_root, " and justified checkpoint ", op.blk_justified_checkpoint
+    debugEcho "    Processed block      0x", op.root, " with parent 0x", op.parent_root, " and justified checkpoint ", op.blk_checkpoints.justified
   of ProcessAttestation:
     ctx.process_attestation(
       validator_index = op.validator_index,
       block_root = op.block_root,
-      target_epoch = op.target_epoch
-    )
+      target_epoch = op.target_epoch)
     debugEcho "    Processed att target 0x", op.block_root, " from validator ", op.validator_index, " for epoch ", op.target_epoch
   of Prune:
     let r = ctx.prune(op.finalized_root)

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [Defect].}
+
 # import ../interpreter # included to be able to use "suite"
 
 func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
@@ -13,20 +15,20 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   # Initialize the fork choice context
   result.fork_choice = ForkChoiceBackend.init(
-    justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # ----------------------------------
 
   # Head should be genesis
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: GenesisRoot
-  )
+    expected_head: GenesisRoot)
 
   # Build the following tree.
   #
@@ -47,37 +49,41 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
     kind: ProcessBlock,
     root: fakeHash(1),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(3),
     parent_root: fakeHash(1),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(5),
     parent_root: fakeHash(3),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(7),
     parent_root: fakeHash(5),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(9),
     parent_root: fakeHash(7),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
 
   # Build the following tree.
   #
@@ -98,37 +104,41 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
     kind: ProcessBlock,
     root: fakeHash(2),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(4),
     parent_root: fakeHash(2),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(6),
     parent_root: fakeHash(4),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(8),
     parent_root: fakeHash(6),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(2), epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(2), epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(10),
     parent_root: fakeHash(8),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))))
 
   # Ensure that if we start at 0 we find 10 (just: 0, fin: 0).
   #
@@ -145,28 +155,28 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #         9  10 <-- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Same with justified_epoch 2
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Justified epoch 3 is invalid
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(3)), # <--- Wrong epoch
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(3)), # < Wrong epoch
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
+    justified_state_balances: balances)
 
   # Add a vote to 1.
   #
@@ -185,8 +195,7 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(0),
     block_root: fakeHash(1),
-    target_epoch: Epoch(0)
-  )
+    target_epoch: Epoch(0))
 
   # Ensure that if we start at 0 we find 9 (just: 0, fin: 0).
   #
@@ -203,28 +212,28 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   # head -> 9  10
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Same with justified_epoch 2
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Justified epoch 3 is invalid
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(3)), # <--- Wrong epoch
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(3)), # < Wrong epoch
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
+    justified_state_balances: balances)
 
   # Add a vote to 2.
   #
@@ -243,8 +252,7 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(2),
-    target_epoch: Epoch(0)
-  )
+    target_epoch: Epoch(0))
 
   # Ensure that if we start at 0 we find 10 again (just: 0, fin: 0).
   #
@@ -261,28 +269,28 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #         9  10 <-- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Same with justified_epoch 2
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Justified epoch 3 is invalid
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(3)), # <--- Wrong epoch
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(3)), # < Wrong epoch
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
+    justified_state_balances: balances)
 
   # Ensure that if we start at 1 (instead of 0) we find 9 (just: 0, fin: 0).
   #
@@ -299,28 +307,29 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   # head -> 9  10
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(1), epoch: Epoch(0)), # <- in production the root/epoch mismatch isn't used.
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      # Justified: In production the root/epoch mismatch isn't used.
+      justified: Checkpoint(root: fakeHash(1), epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Same with justified_epoch 2
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Justified epoch 3 is invalid
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(3)), # <--- Wrong epoch
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(3)), # < Wrong epoch
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
+    justified_state_balances: balances)
 
   # Ensure that if we start at 2 (instead of 0) we find 10 (just: 0, fin: 0).
   #
@@ -337,28 +346,29 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #         9  10 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(2), epoch: Epoch(0)), # In production this can't happen
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      # Justified: In production this can't happen
+      justified: Checkpoint(root: fakeHash(2), epoch: Epoch(0)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Same with justified_epoch 2
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Justified epoch 3 is invalid
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(4), epoch: Epoch(3)), # <--- Wrong epoch
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(4), epoch: Epoch(3)), # < Wrong epoch
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(0))),
+    justified_state_balances: balances)
 
 proc test_ffg02() =
   test "fork_choice - testing finality #02":

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [Defect].}
+
 # import ../interpreter # included to be able to use "suite"
 
 func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
@@ -14,20 +16,20 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   # Initialize the fork choice context
   # We start with epoch 0 fully finalized to avoid epoch 0 special cases.
   result.fork_choice = ForkChoiceBackend.init(
-    justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # ----------------------------------
 
   # Head should be genesis
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: GenesisRoot
-  )
+    expected_head: GenesisRoot)
 
   # Add block 2
   #
@@ -38,9 +40,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(2),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head should be 2
   #
@@ -49,11 +51,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #       2 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add block 1 as a fork
   #
@@ -64,9 +66,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(1),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head is still 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
   #
@@ -75,11 +77,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   # head-> 2  1
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add block 3
   #
@@ -92,9 +94,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(3),
     parent_root: fakeHash(1),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head is still 2
   #
@@ -105,11 +107,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #           3
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add block 4
   #
@@ -122,9 +124,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(4),
     parent_root: fakeHash(2),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Check that head is 4
   #
@@ -135,11 +137,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   # head-> 4  3
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(4)
-  )
+    expected_head: fakeHash(4))
 
   # Add block 5 with justified epoch of 2
   #
@@ -154,9 +156,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(5),
     parent_root: fakeHash(4),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Ensure the head is still 4 whilst the justified epoch is 0.
   #
@@ -169,11 +171,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #        5
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(4)
-  )
+    expected_head: fakeHash(4))
 
   # Ensure that there is an error when starting from a block with the wrong justified epoch
   #      0
@@ -185,10 +187,10 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #    5 <- starting from 5 with justified epoch 0 should error.
   result.ops.add Operation(
     kind: InvalidFindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    justified_state_balances: balances
-  )
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
+    justified_state_balances: balances)
 
   # Set the justified epoch to 2 and the start block to 5 and ensure 5 is the head.
   #      0
@@ -200,11 +202,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #    5 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(5)
-  )
+    expected_head: fakeHash(5))
 
   # Add block 6
   #
@@ -221,9 +223,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
     kind: ProcessBlock,
     root: fakeHash(6),
     parent_root: fakeHash(5),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Ensure 6 is the head
   #      0
@@ -237,11 +239,11 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #    6 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(6)
-  )
+    expected_head: fakeHash(6))
 
 proc test_no_votes() =
   test "fork_choice - testing no votes":

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [Defect].}
+
 # import ../interpreter # included to be able to use "suite"
 
 func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
@@ -14,20 +16,20 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # Initialize the fork choice context
   # We start with epoch 0 fully finalized to avoid epoch 0 special cases.
   result.fork_choice = ForkChoiceBackend.init(
-    justifiedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalizedCheckpoint = Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # ----------------------------------
 
   # Head should be genesis
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: GenesisRoot
-  )
+    expected_head: GenesisRoot)
 
   # Add block 2
   #
@@ -38,9 +40,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(2),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head should be 2
   #
@@ -49,11 +51,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #       2 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add block 1 as a fork
   #
@@ -64,9 +66,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(1),
     parent_root: GenesisRoot,
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head is still 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
   #
@@ -75,11 +77,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head-> 2  1
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add a vote to block 1
   #
@@ -90,8 +92,7 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(0),
     block_root: fakeHash(1),
-    target_epoch: Epoch(2)
-  )
+    target_epoch: Epoch(2))
 
   # Head is now 1 as 1 has an extra vote
   #
@@ -100,11 +101,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #        2  1 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(1)
-  )
+    expected_head: fakeHash(1))
 
   # Add a vote to block 2
   #
@@ -115,8 +116,7 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(2),
-    target_epoch: Epoch(2)
-  )
+    target_epoch: Epoch(2))
 
   # Head is back to 2 due to tiebreaker as fakeHash(2) (0xD8...) > fakeHash(1) (0x7C...)
   #
@@ -125,11 +125,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head-> 2  1
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Add block 3 as on chain 1
   #
@@ -142,9 +142,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(3),
     parent_root: fakeHash(1),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head is still 2
   #
@@ -153,8 +153,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head-> 2  1
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
     expected_head: fakeHash(2)
   )
@@ -170,8 +171,7 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(0),
     block_root: fakeHash(3),
-    target_epoch: Epoch(3)
-  )
+    target_epoch: Epoch(3))
 
   # Head is still 2
   #
@@ -180,11 +180,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head-> 2  1
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(2)
-  )
+    expected_head: fakeHash(2))
 
   # Move validator #1 vote from 2 to 1 (this is an equivocation, but fork choice doesn't
   # care)
@@ -198,8 +198,7 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(1),
-    target_epoch: Epoch(3)
-  )
+    target_epoch: Epoch(3))
 
   # Head is now 3
   #
@@ -210,11 +209,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #           3 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(3)
-  )
+    expected_head: fakeHash(3))
 
   # Add block 4 on chain 1-3
   #
@@ -229,9 +228,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(4),
     parent_root: fakeHash(3),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Head is now 4
   #
@@ -244,11 +243,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #           4 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(4)
-  )
+    expected_head: fakeHash(4))
 
   # Add block 5, which has a justified epoch of 2.
   #
@@ -265,9 +264,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(5),
     parent_root: fakeHash(4),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))))
 
   # Ensure that 5 is filtered out and the head stays at 4.
   #
@@ -282,11 +281,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #          5
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(4)
-  )
+    expected_head: fakeHash(4))
 
   # Add block 6, which has a justified epoch of 0.
   #
@@ -303,9 +302,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(6),
     parent_root: fakeHash(4),
-    blk_justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Move both votes to 5.
   #
@@ -322,14 +321,13 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(0),
     block_root: fakeHash(5),
-    target_epoch: Epoch(4)
-  )
+    target_epoch: Epoch(4))
+
   result.ops.add Operation(
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(5),
-    target_epoch: Epoch(4)
-  )
+    target_epoch: Epoch(4))
 
   # Add blocks 7, 8 and 9. Adding these blocks helps test the `best_descendant`
   # functionality.
@@ -353,25 +351,26 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(7),
     parent_root: fakeHash(5),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
+
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(8),
     parent_root: fakeHash(7),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))))
 
   # Finalizes 5
   result.ops.add Operation(
     kind: ProcessBlock,
     root: fakeHash(9),
     parent_root: fakeHash(8),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))))
 
   # Ensure that 6 is the head, even though 5 has all the votes. This is testing to ensure
   # that 5 is filtered out due to a differing justified epoch.
@@ -393,11 +392,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #         9
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
-    finalized_checkpoint: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
+      finalized: Checkpoint(root: GenesisRoot, epoch: Epoch(1))),
     justified_state_balances: balances,
-    expected_head: fakeHash(6)
-  )
+    expected_head: fakeHash(6))
 
   # Change fork-choice justified epoch to 1, and the start block to 5 and ensure that 9 is
   # the head.
@@ -421,11 +420,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head-> 9
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Update votes to block 9
   #          0
@@ -447,23 +446,22 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(0),
     block_root: fakeHash(9),
-    target_epoch: Epoch(5)
-  )
+    target_epoch: Epoch(5))
+
   result.ops.add Operation(
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(1),
     block_root: fakeHash(9),
-    target_epoch: Epoch(5)
-  )
+    target_epoch: Epoch(5))
 
   # Head should still be 9
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Add block 10 (also finalizes 5)
   #          0
@@ -485,18 +483,18 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(10),
     parent_root: fakeHash(8),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))))
 
   # Head should still be 9
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Introduce 2 new validators
   balances = @[Gwei(1), Gwei(1), Gwei(1), Gwei(1)]
@@ -521,14 +519,13 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(2),
     block_root: fakeHash(10),
-    target_epoch: Epoch(5)
-  )
+    target_epoch: Epoch(5))
+
   result.ops.add Operation(
     kind: ProcessAttestation,
     validator_index: ValidatorIndex(3),
     block_root: fakeHash(10),
-    target_epoch: Epoch(5)
-  )
+    target_epoch: Epoch(5))
 
   # Check that the head is now 10.
   #
@@ -549,11 +546,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #        9  10 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Set the last 2 validators balances to 0
   balances = @[Gwei(1), Gwei(1), Gwei(0), Gwei(0)]
@@ -566,11 +563,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head -> 9  10
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Set the last 2 validators balances back to 1
   balances = @[Gwei(1), Gwei(1), Gwei(1), Gwei(1)]
@@ -583,11 +580,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #         9  10 <- head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(10)
-  )
+    expected_head: fakeHash(10))
 
   # Remove the validators
   balances = @[Gwei(1), Gwei(1)]
@@ -600,11 +597,11 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # head -> 9  10
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Ensure that pruning does prune.
   #
@@ -630,17 +627,16 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   result.ops.add Operation(
     kind: Prune,
     finalized_root: fakeHash(5),
-    expected_len: 6
-  )
+    expected_len: 6)
 
   # Prune shouldn't have changed the head
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(9)
-  )
+    expected_head: fakeHash(9))
 
   # Add block 11
   #
@@ -657,18 +653,18 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
     kind: ProcessBlock,
     root: fakeHash(11),
     parent_root: fakeHash(9),
-    blk_justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    blk_finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2))
-  )
+    blk_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))))
 
   # Head is now 11
   result.ops.add Operation(
     kind: FindHead,
-    justified_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
-    finalized_checkpoint: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+    checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     justified_state_balances: balances,
-    expected_head: fakeHash(11)
-  )
+    expected_head: fakeHash(11))
 
 proc test_votes() =
   test "fork_choice - testing with votes":

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -409,10 +409,11 @@ suite "Attestation pool processing" & preset():
       b1 = addTestBlock(state[], cache).phase0Data
       b1Add = dag.addHeadBlock(verifier, b1) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     let head = pool[].selectOptimisticHead(b1Add[].slot.start_beacon_time).get()
     check:
@@ -422,10 +423,11 @@ suite "Attestation pool processing" & preset():
       b2 = addTestBlock(state[], cache).phase0Data
       b2Add = dag.addHeadBlock(verifier, b2) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     let head2 = pool[].selectOptimisticHead(b2Add[].slot.start_beacon_time).get()
 
@@ -438,10 +440,11 @@ suite "Attestation pool processing" & preset():
       b10 = makeTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     let head = pool[].selectOptimisticHead(b10Add[].slot.start_beacon_time).get()
 
@@ -456,10 +459,10 @@ suite "Attestation pool processing" & preset():
       ).phase0Data
       b11Add = dag.addHeadBlock(verifier, b11) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message,
+          epochRef, blckRef, unrealized, signedBlock.message,
           blckRef.slot.start_beacon_time + SECONDS_PER_SLOT.int64.seconds)
 
       bc1 = get_beacon_committee(
@@ -507,10 +510,11 @@ suite "Attestation pool processing" & preset():
       b10 = makeTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
-        pool[].addForkChoice(epochRef, blckRef, signedBlock.message,
-        blckRef.slot.start_beacon_time)
+        pool[].addForkChoice(
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     let head = pool[].selectOptimisticHead(b10Add[].slot.start_beacon_time).get()
 
@@ -522,10 +526,11 @@ suite "Attestation pool processing" & preset():
     let b10_clone = b10 # Assumes deep copy
     let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     doAssert: b10Add_clone.error == BlockError.Duplicate
 
@@ -538,10 +543,11 @@ suite "Attestation pool processing" & preset():
       b10 = addTestBlock(state[], cache).phase0Data
       b10Add = dag.addHeadBlock(verifier, b10) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     let head = pool[].selectOptimisticHead(b10Add[].slot.start_beacon_time).get()
 
@@ -564,10 +570,11 @@ suite "Attestation pool processing" & preset():
 
         let blockRef = dag.addHeadBlock(verifier, new_block) do (
             blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-            epochRef: EpochRef):
+            epochRef: EpochRef, unrealized: FinalityCheckpoints):
           # Callback add to fork choice if valid
           pool[].addForkChoice(
-            epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+            epochRef, blckRef, unrealized, signedBlock.message,
+            blckRef.slot.start_beacon_time)
 
         let head = pool[].selectOptimisticHead(blockRef[].slot.start_beacon_time).get()
         doAssert: head == blockRef[]
@@ -606,9 +613,10 @@ suite "Attestation pool processing" & preset():
     # Add back the old block to ensure we have a duplicate error
     let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
     doAssert: b10Add_clone.error == BlockError.Duplicate

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -78,10 +78,11 @@ suite "Gossip validation " & preset():
         dag.headState, cache, int(SLOTS_PER_EPOCH * 5), false):
       let added = dag.addHeadBlock(verifier, blck.phase0Data) do (
           blckRef: BlockRef, signedBlock: phase0.TrustedSignedBeaconBlock,
-          epochRef: EpochRef):
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
         # Callback add to fork choice if valid
         pool[].addForkChoice(
-          epochRef, blckRef, signedBlock.message, blckRef.slot.start_beacon_time)
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time)
 
       check: added.isOk()
       dag.updateHead(added[], quarantine[])


### PR DESCRIPTION
The justified and finalized `Checkpoint` are frequently passed around
together. This introduces a new `FinalityCheckpoint` data structure that
combines them into one.

Due to the large usage of this structure in fork choice, also took this
opportunity to update fork choice tests to the latest v1.2.0-rc.1 spec.
Many additional tests enabled, some need more work, e.g. EL mock blocks.
Also implemented `discard_equivocations` which was skipped in #3661,
and improved code reuse across fork choice logic while at it.