### PR TITLE
fork choice cleanups

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -14,7 +14,8 @@ import
   stew/results,
   chronicles,
   # Internal
-  ../spec/datatypes/base
+  ../spec/datatypes/base,
+  ../spec/helpers
 
 # https://github.com/ethereum/consensus-specs/blob/v0.11.1/specs/phase0/fork-choice.md
 # This is a port of https://github.com/sigp/lighthouse/pull/804

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -15,6 +15,7 @@ import
   stew/results,
   # Internal
   ../spec/datatypes/base,
+  ../spec/helpers,
   # Fork choice
   ./fork_choice_types
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -246,10 +246,6 @@ type
     epoch*: Epoch
     root*: Eth2Digest
 
-  FinalityCheckpoints* = object
-    justified*: Checkpoint
-    finalized*: Checkpoint
-
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#AttestationData
   AttestationData* = object
     slot*: Slot
@@ -752,12 +748,6 @@ func shortLog*(v: Checkpoint): auto =
   # epoch:root when logging epoch, root:slot when logging slot!
   $shortLog(v.epoch) & ":" & shortLog(v.root)
 
-func shortLog*(v: FinalityCheckpoints): auto =
-  (
-    justified: shortLog(v.justified),
-    finalized: shortLog(v.finalized)
-  )
-
 func shortLog*(v: AttestationData): auto =
   (
     slot: shortLog(v.slot),
@@ -829,7 +819,6 @@ func shortLog*(v: SomeSignedVoluntaryExit): auto =
 chronicles.formatIt AttestationData: it.shortLog
 chronicles.formatIt Attestation: it.shortLog
 chronicles.formatIt Checkpoint: it.shortLog
-chronicles.formatIt FinalityCheckpoints: it.shortLog
 
 const
   # http://facweb.cs.depaul.edu/sjost/it212/documents/ascii-pr.htm

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -18,6 +18,7 @@ import
   std/[algorithm, math, sets, tables],
   # Status libraries
   stew/[bitops2, byteutils, endians2, objects],
+  chronicles,
   # Internal
   ./datatypes/[phase0, altair, bellatrix],
   "."/[eth2_merkleization, forks, ssz_codec]
@@ -26,6 +27,18 @@ import
 # fails to compile if the export is not done here also
 export
   forks, eth2_merkleization, ssz_codec
+
+type FinalityCheckpoints* = object
+  justified*: Checkpoint
+  finalized*: Checkpoint
+
+func shortLog*(v: FinalityCheckpoints): auto =
+  (
+    justified: shortLog(v.justified),
+    finalized: shortLog(v.finalized)
+  )
+
+chronicles.formatIt FinalityCheckpoints: it.shortLog
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#integer_squareroot
 func integer_squareroot*(n: SomeInteger): SomeInteger =

--- a/tests/fork_choice/interpreter.nim
+++ b/tests/fork_choice/interpreter.nim
@@ -12,9 +12,10 @@ import
   stew/[results, endians2],
   # Internals
   ../../beacon_chain/spec/datatypes/base,
+  ../../beacon_chain/spec/helpers,
   ../../beacon_chain/fork_choice/[fork_choice, fork_choice_types]
 
-export results, base, fork_choice, fork_choice_types, tables, options
+export results, base, helpers, fork_choice, fork_choice_types, tables, options
 
 func fakeHash*(index: SomeInteger): Eth2Digest =
   ## Create fake hashes


### PR DESCRIPTION
Removes a few extra-ambitious templates to make `self` updates explicit,
and moves the `FinalityCheckpoints` type from `base` to `helpers` as it
is an additional Nimbus specific type not defined by spec.