### PR TITLE
cleanup `getPersistentNetKeys` for better reuse

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2034,129 +2034,90 @@ proc initAddress(T: type MultiAddress, str: string): T =
 template tcpEndPoint(address, port): auto =
   MultiAddress.init(address, tcpProtocol, port)
 
-proc optimisticgetRandomNetKeys*(rng: var HmacDrbgContext): NetKeyPair =
-  let res = PrivateKey.random(Secp256k1, rng)
-  if res.isErr():
-    fatal "Could not generate random network key file"
-    quit QuitFailure
-
-  let
-    privKey = res.get()
-    pubKey = privKey.getPublicKey().expect("working public key from random")
+func initNetKeys(privKey: PrivateKey): NetKeyPair =
+  let pubKey = privKey.getPublicKey().expect("working public key from random")
   NetKeyPair(seckey: privKey, pubkey: pubKey)
 
-proc getPersistentNetKeys*(rng: var HmacDrbgContext,
-                           config: BeaconNodeConf): NetKeyPair =
-  case config.cmd
-  of BNStartUpCmd.noCommand, BNStartUpCmd.record:
-    if config.netKeyFile == "random":
-      let res = PrivateKey.random(Secp256k1, rng)
-      if res.isErr():
-        fatal "Could not generate random network key file"
-        quit QuitFailure
-      let
-        privKey = res.get()
-        pubKey = privKey.getPublicKey().expect("working public key from random")
-        pres = PeerId.init(pubKey)
-      if pres.isErr():
+proc getRandomNetKeys*(rng: var HmacDrbgContext): NetKeyPair =
+  let privKey = PrivateKey.random(Secp256k1, rng).valueOr:
+    fatal "Could not generate random network key file"
+    quit QuitFailure
+  initNetKeys(privKey)
+
+proc getPersistentNetKeys(
+    rng: var HmacDrbgContext,
+    dataDir, netKeyFile: string,
+    netKeyInsecurePassword: bool,
+    allowLoadExisting: bool): NetKeyPair =
+  if netKeyFile == "random":
+    let
+      keys = rng.getRandomNetKeys()
+      pres = PeerId.init(keys.pubkey).valueOr:
         fatal "Could not obtain PeerId from network key"
         quit QuitFailure
-      info "Generating new networking key", network_public_key = pubKey,
-                                            network_peer_id = $pres.get()
-      NetKeyPair(seckey: privKey, pubkey: pubKey)
-    else:
-      let keyPath =
-        if isAbsolute(config.netKeyFile):
-          config.netKeyFile
+    info "Generating new networking key",
+      network_public_key = keys.pubkey, network_peer_id = $pres
+    keys
+  else:
+    let
+      # Insecure password used only for automated testing.
+      insecurePassword =
+        if netKeyInsecurePassword:
+          some(NetworkInsecureKeyPassword)
         else:
-          config.dataDir / config.netKeyFile
+          none[string]()
 
-      if fileAccessible(keyPath, {AccessFlags.Find}):
-        info "Network key storage is present, unlocking", key_path = keyPath
+      keyPath =
+        if isAbsolute(netKeyFile):
+          netKeyFile
+        else:
+          dataDir / netKeyFile
+    logScope: key_path = keyPath
 
-        # Insecure password used only for automated testing.
-        let insecurePassword =
-          if config.netKeyInsecurePassword:
-            some(NetworkInsecureKeyPassword)
-          else:
-            none[string]()
+    if fileAccessible(keyPath, {AccessFlags.Find}) and allowLoadExisting:
+      info "Network key storage is present, unlocking"
 
-        let res = loadNetKeystore(keyPath, insecurePassword)
-        if res.isNone():
+      let
+        privKey = loadNetKeystore(keyPath, insecurePassword).valueOr:
           fatal "Could not load network key file"
           quit QuitFailure
-        let
-          privKey = res.get()
-          pubKey = privKey.getPublicKey().expect("working public key from file")
-        info "Network key storage was successfully unlocked",
-             key_path = keyPath, network_public_key = pubKey
-        NetKeyPair(seckey: privKey, pubkey: pubKey)
-      else:
+        keys = initNetKeys(privKey)
+      info "Network key storage was successfully unlocked",
+        network_public_key = keys.pubkey
+      keys
+    else:
+      if allowLoadExisting:
         info "Network key storage is missing, creating a new one",
-             key_path = keyPath
-        let rres = PrivateKey.random(Secp256k1, rng)
-        if rres.isErr():
-          fatal "Could not generate random network key file"
-          quit QuitFailure
+            key_path = keyPath
+      let
+        keys = rng.getRandomNetKeys()
+        sres = saveNetKeystore(rng, keyPath, keys.seckey, insecurePassword)
+      if sres.isErr():
+        fatal "Could not create network key file"
+        quit QuitFailure
 
-        let
-          privKey = rres.get()
-          pubKey = privKey.getPublicKey().expect("working public key from random")
+      info "New network key storage was created",
+        network_public_key = keys.pubkey
+      keys
 
-        # Insecure password used only for automated testing.
-        let insecurePassword =
-          if config.netKeyInsecurePassword:
-            some(NetworkInsecureKeyPassword)
-          else:
-            none[string]()
-
-        let sres = saveNetKeystore(rng, keyPath, privKey, insecurePassword)
-        if sres.isErr():
-          fatal "Could not create network key file", key_path = keyPath
-          quit QuitFailure
-
-        info "New network key storage was created", key_path = keyPath,
-             network_public_key = pubKey
-        NetKeyPair(seckey: privKey, pubkey: pubKey)
+proc getPersistentNetKeys*(
+    rng: var HmacDrbgContext, config: BeaconNodeConf): NetKeyPair =
+  case config.cmd
+  of BNStartUpCmd.noCommand, BNStartUpCmd.record:
+    rng.getPersistentNetKeys(
+      string(config.dataDir), config.netKeyFile, config.netKeyInsecurePassword,
+      allowLoadExisting = true)
 
   of BNStartUpCmd.createTestnet:
     if config.netKeyFile == "random":
       fatal "Could not create testnet using `random` network key"
       quit QuitFailure
 
-    let keyPath =
-      if isAbsolute(config.netKeyFile):
-        config.netKeyFile
-      else:
-        config.dataDir / config.netKeyFile
-
-    let rres = PrivateKey.random(Secp256k1, rng)
-    if rres.isErr():
-      fatal "Could not generate random network key file"
-      quit QuitFailure
-
-    let
-      privKey = rres.get()
-      pubKey = privKey.getPublicKey().expect("working public key from random")
-
-    # Insecure password used only for automated testing.
-    let insecurePassword =
-      if config.netKeyInsecurePassword:
-        some(NetworkInsecureKeyPassword)
-      else:
-        none[string]()
-
-    let sres = saveNetKeystore(rng, keyPath, privKey, insecurePassword)
-    if sres.isErr():
-      fatal "Could not create network key file", key_path = keyPath
-      quit QuitFailure
-
-    info "New network key storage was created", key_path = keyPath,
-         network_public_key = pubKey
-
-    NetKeyPair(seckey: privKey, pubkey: pubKey)
+    rng.getPersistentNetKeys(
+      string(config.dataDir), config.netKeyFile, config.netKeyInsecurePassword,
+      allowLoadExisting = false)
   else:
-    optimisticgetRandomNetKeys(rng)
+    rng.getRandomNetKeys()
 
 func gossipId(
     data: openArray[byte], altairPrefix, topic: string): seq[byte] =

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -74,7 +74,7 @@ programMain:
     genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
 
     rng = keys.newRng()
-    netKeys = optimisticgetRandomNetKeys(rng[])
+    netKeys = getRandomNetKeys(rng[])
     network = createEth2Node(
       rng, config, netKeys, cfg,
       forkDigests, getBeaconTime, genesis_validators_root)

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -639,7 +639,7 @@ proc mapErrTo*[T, E](r: Result[T, E], v: static KeystoreGenerationErrorKind):
     KeystoreGenerationError(kind: v, error: $e))
 
 proc loadNetKeystore*(keystorePath: string,
-                      insecurePwd: Option[string]): Option[lcrypto.PrivateKey] =
+                      insecurePwd: Option[string]): Opt[lcrypto.PrivateKey] =
 
   if not(checkSensitiveFilePermissions(keystorePath)):
     error "Network keystorage file has insecure permissions",
@@ -662,7 +662,7 @@ proc loadNetKeystore*(keystorePath: string,
     let decrypted = decryptNetKeystore(keyStore,
                                        KeystorePass.init(insecurePwd.get()))
     if decrypted.isOk:
-      return some(decrypted.get())
+      return ok(decrypted.get())
     else:
       error "Network keystore decryption failed", key_store = keystorePath
       return
@@ -676,7 +676,7 @@ proc loadNetKeystore*(keystorePath: string,
         decrypted
     )
     if res.isOk():
-      some(res.get())
+      ok(res.get())
     else:
       return
 


### PR DESCRIPTION
Allow using `getPersistentNetKeys` without passing a `config`, and reuse
local helpers in its implementation.