### PR TITLE
rename verifyFinalization internal flag to strictVerification

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -295,7 +295,7 @@ type
               "You can use a 0x-prefixed hex encoded string to specify raw bytes"
         name: "graffiti" .}: Option[GraffitiBytes]
 
-      verifyFinalization* {.
+      strictVerification* {.
         hidden
         desc: "Specify whether to verify finalization occurs on schedule (debug only)"
         defaultValue: false

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -699,7 +699,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            lcDataConfig = default(LightClientDataConfig)): ChainDAGRef =
   cfg.checkForkConsistency()
 
-  doAssert updateFlags - {verifyFinalization, enableTestFeatures} == {},
+  doAssert updateFlags - {strictVerification, enableTestFeatures} == {},
     "Other flags not supported in ChainDAG"
 
   # TODO we require that the db contains both a head and a tail block -
@@ -725,9 +725,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       genesis: BlockId(root: genesisRoot, slot: GENESIS_SLOT),
       tail: tailBlock.toBlockId(),
 
-      # The only allowed flag right now is verifyFinalization, as the others all
+      # The only allowed flag right now is strictVerification, as the others all
       # allow skipping some validation.
-      updateFlags: {verifyFinalization, enableTestFeatures} * updateFlags,
+      updateFlags: {strictVerification, enableTestFeatures} * updateFlags,
       cfg: cfg,
 
       vanityLogs: vanityLogs,
@@ -1433,7 +1433,7 @@ proc markBlockInvalid*(dag: ChainDAGRef, root: Eth2Digest) =
     # "It is outside of the scope of the specification since it's only possible
     # with a faulty EE. Such a scenario requires manual intervention."
     warn "markBlockInvalid: attempt to invalidate valid block"
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
     return
 
   if root == dag.finalizedHead.blck.root:
@@ -1444,7 +1444,7 @@ proc markBlockInvalid*(dag: ChainDAGRef, root: Eth2Digest) =
     #
     # But be slightly less aggressive, and only check finalized.
     warn "markBlockInvalid: finalized block invalidated"
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
     return
 
   debug "markBlockInvalid"

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -41,7 +41,7 @@ proc updateExistingState(
   let ok = dag.updateState(state, bsi, save, cache)
   if not ok:
     error "State failed to load unexpectedly", bsi, tail = dag.tail.slot
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
   ok
 
 template withUpdatedExistingState(
@@ -54,7 +54,7 @@ template withUpdatedExistingState(
       okBody
     do:
       error "State failed to load unexpectedly", bsi, tail = dag.tail.slot
-      doAssert verifyFinalization notin dag.updateFlags
+      doAssert strictVerification notin dag.updateFlags
       failureBody
 
 proc getExistingBlockIdAtSlot(dag: ChainDAGRef, slot: Slot): Opt[BlockSlotId] =
@@ -62,7 +62,7 @@ proc getExistingBlockIdAtSlot(dag: ChainDAGRef, slot: Slot): Opt[BlockSlotId] =
   let bsi = dag.getBlockIdAtSlot(slot)
   if bsi.isErr:
     error "Block failed to load unexpectedly", slot, tail = dag.tail.slot
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
   bsi
 
 proc existingParent(dag: ChainDAGRef, bid: BlockId): Opt[BlockId] =
@@ -70,7 +70,7 @@ proc existingParent(dag: ChainDAGRef, bid: BlockId): Opt[BlockId] =
   let parent = dag.parent(bid)
   if parent.isErr:
     error "Parent failed to load unexpectedly", bid, tail = dag.tail.slot
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
   parent
 
 proc getExistingForkedBlock(
@@ -79,7 +79,7 @@ proc getExistingForkedBlock(
   let bdata = dag.getForkedBlock(bid)
   if bdata.isErr:
     error "Block failed to load unexpectedly", bid, tail = dag.tail.slot
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
   bdata
 
 proc existingCurrentSyncCommitteeForPeriod(
@@ -91,7 +91,7 @@ proc existingCurrentSyncCommitteeForPeriod(
   if syncCommittee.isErr:
     error "Current sync committee failed to load unexpectedly",
       period, tail = dag.tail.slot
-    doAssert verifyFinalization notin dag.updateFlags
+    doAssert strictVerification notin dag.updateFlags
   syncCommittee
 
 template syncCommitteeRoot(
@@ -149,7 +149,7 @@ func handleUnexpectedLightClientError(dag: ChainDAGRef, buggedSlot: Slot) =
   ## If there is an unexpected error, adjust `tailSlot` to keep track of the
   ## section for which complete light client data is available, and to avoid
   ## failed lookups of cached light client data.
-  doAssert verifyFinalization notin dag.updateFlags
+  doAssert strictVerification notin dag.updateFlags
   if buggedSlot >= dag.lcDataStore.cache.tailSlot:
     dag.lcDataStore.cache.tailSlot = buggedSlot + 1
 

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -97,7 +97,7 @@ iterator get_attesting_indices*(
       slot =
         check_attestation_slot_target(attestation.data).valueOr:
           warn "Invalid attestation slot"
-          doAssert verifyFinalization notin dag.updateFlags
+          doAssert strictVerification notin dag.updateFlags
           break
       blck =
         dag.getBlockRef(attestation.data.beacon_block_root).valueOr:
@@ -106,19 +106,19 @@ iterator get_attesting_indices*(
       target =
         blck.atCheckpoint(attestation.data.target).valueOr:
           warn "Invalid attestation target"
-          doAssert verifyFinalization notin dag.updateFlags
+          doAssert strictVerification notin dag.updateFlags
           break
       epochRef =
         dag.getEpochRef(target.blck, target.slot.epoch, false).valueOr:
           warn "Attestation `EpochRef` not found"
-          doAssert verifyFinalization notin dag.updateFlags
+          doAssert strictVerification notin dag.updateFlags
           break
 
       committeesPerSlot = get_committee_count_per_slot(epochRef)
       committeeIndex =
         CommitteeIndex.init(attestation.data.index, committeesPerSlot).valueOr:
           warn "Unexpected committee index in block attestation"
-          doAssert verifyFinalization notin dag.updateFlags
+          doAssert strictVerification notin dag.updateFlags
           break
 
     for validator in get_attesting_indices(

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -26,7 +26,9 @@ type
     ## Also useful to avoid unnecessary work when replaying known, good blocks.
     skipStateRootValidation ##\
     ## Skip verification of block state root.
-    strictVerification
+    strictVerification ##\
+    ## Strictly assert on unexpected conditions to aid debugging.
+    ## Should not be used in production, as additional asserts are reachable.
     slotProcessed ##\
     ## Allow blocks to be applied to states with the same slot number as the
     ## block which is what happens when `process_block` is called separately

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -26,7 +26,7 @@ type
     ## Also useful to avoid unnecessary work when replaying known, good blocks.
     skipStateRootValidation ##\
     ## Skip verification of block state root.
-    verifyFinalization
+    strictVerification
     slotProcessed ##\
     ## Allow blocks to be applied to states with the same slot number as the
     ## block which is what happens when `process_block` is called separately

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -158,7 +158,7 @@ func check_attestation_subnet(
 # ----------------------------------------------------------------
 
 template checkedReject(msg: cstring): untyped =
-  if verifyFinalization in pool.dag.updateFlags:
+  if strictVerification in pool.dag.updateFlags:
     # This doesn't depend on the wall clock or the exact state of the DAG; it's
     # an internal consistency/correctness check only, and effectively never has
     # false positives. These don't, for example, arise from timeouts.
@@ -167,7 +167,7 @@ template checkedReject(msg: cstring): untyped =
 
 template checkedReject(error: ValidationError): untyped =
   doAssert error[0] == ValidationResult.Reject
-  if verifyFinalization in pool.dag.updateFlags:
+  if strictVerification in pool.dag.updateFlags:
     # This doesn't depend on the wall clock or the exact state of the DAG; it's
     # an internal consistency/correctness check only, and effectively never has
     # false positives. These don't, for example, arise from timeouts.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -180,7 +180,7 @@ proc loadChainDag(
       if shouldEnableTestFeatures: {enableTestFeatures}
       else: {}
     chainDagFlags =
-      if config.verifyFinalization: {verifyFinalization}
+      if config.strictVerification: {strictVerification}
       else: {}
     onLightClientFinalityUpdateCb =
       if config.lightClientDataServe.get: onLightClientFinalityUpdate
@@ -798,7 +798,7 @@ proc init*(T: type BeaconNode,
 
   node
 
-func verifyFinalization(node: BeaconNode, slot: Slot) =
+func strictVerification(node: BeaconNode, slot: Slot) =
   # Epoch must be >= 4 to check finalization
   const SETTLING_TIME_OFFSET = 1'u64
   let epoch = slot.epoch()
@@ -1370,8 +1370,8 @@ proc onSlotStart(
   finalization_delay.set(
     wallSlot.epoch.toGaugeValue - finalizedEpoch.toGaugeValue)
 
-  if node.config.verifyFinalization:
-    verifyFinalization(node, wallSlot)
+  if node.config.strictVerification:
+    strictVerification(node, wallSlot)
 
   node.consensusManager[].updateHead(wallSlot)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -319,7 +319,7 @@ proc weigh_justification_and_finalization(
     trace "Justified with previous epoch",
       current_epoch = current_epoch,
       checkpoint = shortLog(state.current_justified_checkpoint)
-  elif verifyFinalization in flags:
+  elif strictVerification in flags:
     warn "Low attestation participation in previous epoch",
       total_active_balance,
       previous_epoch_target_balance,
@@ -1054,10 +1054,10 @@ proc process_epoch*(
   process_justification_and_finalization(state, info.balances, flags)
 
   # state.slot hasn't been incremented yet.
-  if verifyFinalization in flags and currentEpoch >= 2:
+  if strictVerification in flags and currentEpoch >= 2:
     doAssert state.current_justified_checkpoint.epoch + 2 >= currentEpoch
 
-  if verifyFinalization in flags and currentEpoch >= 3:
+  if strictVerification in flags and currentEpoch >= 3:
     # Rule 2/3/4 finalization results in the most pessimal case. The other
     # three finalization rules finalize more quickly as long as the any of
     # the finalization rules triggered.
@@ -1111,10 +1111,10 @@ proc process_epoch*(
   process_justification_and_finalization(state, info.balances, flags)
 
   # state.slot hasn't been incremented yet.
-  if verifyFinalization in flags and currentEpoch >= 2:
+  if strictVerification in flags and currentEpoch >= 2:
     doAssert state.current_justified_checkpoint.epoch + 2 >= currentEpoch
 
-  if verifyFinalization in flags and currentEpoch >= 3:
+  if strictVerification in flags and currentEpoch >= 3:
     # Rule 2/3/4 finalization results in the most pessimal case. The other
     # three finalization rules finalize more quickly as long as the any of
     # the finalization rules triggered.


### PR DESCRIPTION
It began as `verifyFinalization`, but it's more general now. The unifying theme is that it covers stricter reactions, e.g., quitting via assertions, that would be inappropriate in a production, or even live-testnet (ropsten, sepolia, prater, etc) setting but useful for debugging. Its main user is `launch_local_testnet.sh`, but in principle, it can be used in any situation where one wants to run `nimbus_beacon_node` or related commands such that, e.g., invalid signatures or other gossip `REJECT` conditions cause it to quit via assert.

This PR deliberately changes only the internal flag name; the command-line option will be a separate PR.