### PR TITLE
revert `requireAllFields` regression

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2179,7 +2179,7 @@ proc decodeBody*[T](t: typedesc[T],
   let data =
     try:
       RestJson.decode(body.data, T,
-                      requireAllFields = true,
+                      requireAllFields = false,
                       allowUnknownFields = true)
     except SerializationError as exc:
       debug "Failed to deserialize REST JSON data",
@@ -2233,7 +2233,7 @@ proc decodeBytes*[T: DecodeTypes](t: typedesc[T], value: openArray[byte],
   of "application/json":
     try:
       ok RestJson.decode(value, T,
-                         requireAllFields = true,
+                         requireAllFields = false,
                          allowUnknownFields = true)
     except SerializationError as exc:
       debug "Failed to deserialize REST JSON data",


### PR DESCRIPTION
#3864 introduced a regression by turning on `requireAllFields` globally
for JSON parsing. Certain endpoints such as `RestSyncInfo` have optional
fields that do not parse correctly without additional changes. This is
reverted for now to restore previous behaviour and unblock CI testing.