### PR TITLE
Fix a VC crash observed in the local_testnet simulation

### DIFF
--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -86,6 +86,9 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
         res.add(index)
       res
 
+  if validatorIndices.len == 0:
+    return 0
+
   var duties: seq[RestAttesterDuty]
   var currentRoot: Option[Eth2Digest]
 


### PR DESCRIPTION
It's not quite clear why this condition was triggered in the local
simulation, but it seems a viable scenario after the Keymanager API
is integrated in the validator client.

The user can temporarily remove all validator keys from a running
client before adding another set of keys.