### PR TITLE
cleanup magic strings

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -37,8 +37,6 @@ export
   consensus_manager
 
 type
-  RpcServer* = RpcHttpServer
-
   EventBus* = object
     blocksQueue*: AsyncEventQueue[EventBeaconBlockObject]
     headQueue*: AsyncEventQueue[HeadChangeInfoObject]

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -47,6 +47,10 @@ const
   defaultSigningNodeRequestTimeout* = 60
   defaultBeaconNode* = "http://127.0.0.1:" & $DefaultEth2RestPort
 
+  defaultListenAddressDesc* = $defaultListenAddress
+  defaultAdminListenAddressDesc* = $defaultAdminListenAddress
+  defaultBeaconNodeDesc* = $defaultBeaconNode
+
 when defined(windows):
   {.pragma: windowsOnly.}
   {.pragma: posixOnly, hidden.}
@@ -224,7 +228,7 @@ type
       listenAddress* {.
         desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
         defaultValue: defaultListenAddress
-        defaultValueDesc: "0.0.0.0"
+        defaultValueDesc: defaultListenAddressDesc
         name: "listen-address" .}: ValidIpAddress
 
       tcpPort* {.
@@ -321,7 +325,7 @@ type
       metricsAddress* {.
         desc: "Listening address of the metrics server"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: "127.0.0.1"
+        defaultValueDesc: defaultAdminListenAddressDesc
         name: "metrics-address" .}: ValidIpAddress
 
       metricsPort* {.
@@ -364,7 +368,7 @@ type
         hidden
         desc: "Listening address of the RPC server (deprecated for removal)"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: "127.0.0.1"
+        defaultValueDesc: defaultAdminListenAddressDesc
         name: "rpc-address" .}: ValidIpAddress
 
       restEnabled* {.
@@ -381,7 +385,7 @@ type
       restAddress* {.
         desc: "Listening address of the REST server"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: "127.0.0.1"
+        defaultValueDesc: defaultAdminListenAddressDesc
         name: "rest-address" .}: ValidIpAddress
 
       restAllowedOrigin* {.
@@ -432,7 +436,7 @@ type
       keymanagerAddress* {.
         desc: "Listening port for the REST keymanager API"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: "127.0.0.1"
+        defaultValueDesc: defaultAdminListenAddressDesc
         name: "keymanager-address" .}: ValidIpAddress
 
       keymanagerAllowedOrigin* {.
@@ -539,8 +543,8 @@ type
 
       bootstrapAddress* {.
         desc: "The public IP address that will be advertised as a bootstrap node for the testnet"
-        defaultValue: init(ValidIpAddress, "127.0.0.1")
-        defaultValueDesc: "127.0.0.1"
+        defaultValue: init(ValidIpAddress, defaultAdminListenAddress)
+        defaultValueDesc: defaultAdminListenAddressDesc
         name: "bootstrap-address" .}: ValidIpAddress
 
       bootstrapPort* {.
@@ -651,7 +655,7 @@ type
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
           defaultValue: defaultBeaconNode
-          defaultValueDesc: "http://127.0.0.1:5052"
+          defaultValueDesc: defaultBeaconNodeDesc
           name: "rest-url" .}: string
 
     of BNStartUpCmd.record:
@@ -712,7 +716,7 @@ type
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
         defaultValue: defaultBeaconNode
-        defaultValueDesc: "http://127.0.0.1:5052"
+        defaultValueDesc: defaultBeaconNodeDesc
         name: "trusted-node-url"
       .}: string
 
@@ -784,7 +788,7 @@ type
     keymanagerAddress* {.
       desc: "Listening port for the REST keymanager API"
       defaultValue: defaultAdminListenAddress
-      defaultValueDesc: "127.0.0.1"
+      defaultValueDesc: defaultAdminListenAddressDesc
       name: "keymanager-address" .}: ValidIpAddress
 
     keymanagerTokenFile* {.
@@ -805,7 +809,7 @@ type
     beaconNodes* {.
       desc: "URL addresses to one or more beacon node HTTP REST APIs",
       defaultValue: @[defaultBeaconNode]
-      defaultValueDesc: "http://127.0.0.1:5052"
+      defaultValueDesc: defaultBeaconNodeDesc
       name: "beacon-node" .}: seq[string]
 
   SigningNodeConf* = object
@@ -860,13 +864,13 @@ type
     bindPort* {.
       desc: "Port for the REST (BETA version) HTTP server"
       defaultValue: DefaultEth2RestPort
-      defaultValueDesc: "5052"
+      defaultValueDesc: DefaultEth2RestPortDesc
       name: "bind-port" .}: Port
 
     bindAddress* {.
       desc: "Listening address of the REST (BETA version) HTTP server"
       defaultValue: defaultAdminListenAddress
-      defaultValueDesc: "127.0.0.1"
+      defaultValueDesc: defaultAdminListenAddressDesc
       name: "bind-address" .}: ValidIpAddress
 
     tlsEnabled* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -45,7 +45,7 @@ const
   defaultListenAddress* = (static ValidIpAddress.init("0.0.0.0"))
   defaultAdminListenAddress* = (static ValidIpAddress.init("127.0.0.1"))
   defaultSigningNodeRequestTimeout* = 60
-  defaultBeaconNode* = "http://127.0.0.1:" & $DefaultEth2RestPort
+  defaultBeaconNode* = "http://127.0.0.1:" & $defaultEth2RestPort
 
   defaultListenAddressDesc* = $defaultListenAddress
   defaultAdminListenAddressDesc* = $defaultAdminListenAddress
@@ -378,7 +378,7 @@ type
 
       restPort* {.
         desc: "Port for the REST server"
-        defaultValue: DefaultEth2RestPort
+        defaultValue: defaultEth2RestPort
         defaultValueDesc: "5052"
         name: "rest-port" .}: Port
 
@@ -429,7 +429,7 @@ type
 
       keymanagerPort* {.
         desc: "Listening port for the REST keymanager API"
-        defaultValue: DefaultEth2RestPort
+        defaultValue: defaultEth2RestPort
         defaultValueDesc: "5052"
         name: "keymanager-port" .}: Port
 
@@ -781,7 +781,7 @@ type
 
     keymanagerPort* {.
       desc: "Listening port for the REST keymanager API"
-      defaultValue: DefaultEth2RestPort
+      defaultValue: defaultEth2RestPort
       defaultValueDesc: "5052"
       name: "keymanager-port" .}: Port
 
@@ -863,8 +863,8 @@ type
 
     bindPort* {.
       desc: "Port for the REST (BETA version) HTTP server"
-      defaultValue: DefaultEth2RestPort
-      defaultValueDesc: $DefaultEth2RestPortDesc
+      defaultValue: defaultEth2RestPort
+      defaultValueDesc: $defaultEth2RestPortDesc
       name: "bind-port" .}: Port
 
     bindAddress* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -864,7 +864,7 @@ type
     bindPort* {.
       desc: "Port for the REST (BETA version) HTTP server"
       defaultValue: DefaultEth2RestPort
-      defaultValueDesc: DefaultEth2RestPortDesc
+      defaultValueDesc: $DefaultEth2RestPortDesc
       name: "bind-port" .}: Port
 
     bindAddress* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -379,7 +379,7 @@ type
       restPort* {.
         desc: "Port for the REST server"
         defaultValue: defaultEth2RestPort
-        defaultValueDesc: "5052"
+        defaultValueDesc: $defaultEth2RestPortDesc
         name: "rest-port" .}: Port
 
       restAddress* {.
@@ -430,7 +430,7 @@ type
       keymanagerPort* {.
         desc: "Listening port for the REST keymanager API"
         defaultValue: defaultEth2RestPort
-        defaultValueDesc: "5052"
+        defaultValueDesc: $defaultEth2RestPortDesc
         name: "keymanager-port" .}: Port
 
       keymanagerAddress* {.
@@ -782,7 +782,7 @@ type
     keymanagerPort* {.
       desc: "Listening port for the REST keymanager API"
       defaultValue: defaultEth2RestPort
-      defaultValueDesc: "5052"
+      defaultValueDesc: $defaultEth2RestPortDesc
       name: "keymanager-port" .}: Port
 
     keymanagerAddress* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -228,19 +228,19 @@ type
       listenAddress* {.
         desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
         defaultValue: defaultListenAddress
-        defaultValueDesc: defaultListenAddressDesc
+        defaultValueDesc: $defaultListenAddressDesc
         name: "listen-address" .}: ValidIpAddress
 
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: "9000"
+        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "tcp-port" .}: Port
 
       udpPort* {.
         desc: "Listening UDP port for node discovery"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: "9000"
+        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "udp-port" .}: Port
 
       maxPeers* {.
@@ -325,7 +325,7 @@ type
       metricsAddress* {.
         desc: "Listening address of the metrics server"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: defaultAdminListenAddressDesc
+        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "metrics-address" .}: ValidIpAddress
 
       metricsPort* {.
@@ -368,7 +368,7 @@ type
         hidden
         desc: "Listening address of the RPC server (deprecated for removal)"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: defaultAdminListenAddressDesc
+        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "rpc-address" .}: ValidIpAddress
 
       restEnabled* {.
@@ -385,7 +385,7 @@ type
       restAddress* {.
         desc: "Listening address of the REST server"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: defaultAdminListenAddressDesc
+        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "rest-address" .}: ValidIpAddress
 
       restAllowedOrigin* {.
@@ -436,7 +436,7 @@ type
       keymanagerAddress* {.
         desc: "Listening port for the REST keymanager API"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: defaultAdminListenAddressDesc
+        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "keymanager-address" .}: ValidIpAddress
 
       keymanagerAllowedOrigin* {.
@@ -544,13 +544,13 @@ type
       bootstrapAddress* {.
         desc: "The public IP address that will be advertised as a bootstrap node for the testnet"
         defaultValue: init(ValidIpAddress, defaultAdminListenAddress)
-        defaultValueDesc: defaultAdminListenAddressDesc
+        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "bootstrap-address" .}: ValidIpAddress
 
       bootstrapPort* {.
         desc: "The TCP/UDP port that will be used by the bootstrap node"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: "9000"
+        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "bootstrap-port" .}: Port
 
       genesisOffset* {.
@@ -655,7 +655,7 @@ type
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
           defaultValue: defaultBeaconNode
-          defaultValueDesc: defaultBeaconNodeDesc
+          defaultValueDesc: $defaultBeaconNodeDesc
           name: "rest-url" .}: string
 
     of BNStartUpCmd.record:
@@ -716,7 +716,7 @@ type
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
         defaultValue: defaultBeaconNode
-        defaultValueDesc: defaultBeaconNodeDesc
+        defaultValueDesc: $defaultBeaconNodeDesc
         name: "trusted-node-url"
       .}: string
 
@@ -788,7 +788,7 @@ type
     keymanagerAddress* {.
       desc: "Listening port for the REST keymanager API"
       defaultValue: defaultAdminListenAddress
-      defaultValueDesc: defaultAdminListenAddressDesc
+      defaultValueDesc: $defaultAdminListenAddressDesc
       name: "keymanager-address" .}: ValidIpAddress
 
     keymanagerTokenFile* {.
@@ -809,7 +809,7 @@ type
     beaconNodes* {.
       desc: "URL addresses to one or more beacon node HTTP REST APIs",
       defaultValue: @[defaultBeaconNode]
-      defaultValueDesc: defaultBeaconNodeDesc
+      defaultValueDesc: $defaultBeaconNodeDesc
       name: "beacon-node" .}: seq[string]
 
   SigningNodeConf* = object
@@ -870,7 +870,7 @@ type
     bindAddress* {.
       desc: "Listening address of the REST (BETA version) HTTP server"
       defaultValue: defaultAdminListenAddress
-      defaultValueDesc: defaultAdminListenAddressDesc
+      defaultValueDesc: $defaultAdminListenAddressDesc
       name: "bind-address" .}: ValidIpAddress
 
     tlsEnabled* {.

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -67,19 +67,19 @@ type LightClientConf* = object
   listenAddress* {.
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
     defaultValue: defaultListenAddress
-    defaultValueDesc: defaultListenAddressDesc
+    defaultValueDesc: $defaultListenAddressDesc
     name: "listen-address" .}: ValidIpAddress
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"
     defaultValue: defaultEth2TcpPort
-    defaultValueDesc: "9000"
+    defaultValueDesc: $defaultEth2TcpPortDesc
     name: "tcp-port" .}: Port
 
   udpPort* {.
     desc: "Listening UDP port for node discovery"
     defaultValue: defaultEth2TcpPort
-    defaultValueDesc: "9000"
+    defaultValueDesc: $defaultEth2TcpPortDesc
     name: "udp-port" .}: Port
 
   maxPeers* {.

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -67,7 +67,7 @@ type LightClientConf* = object
   listenAddress* {.
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
     defaultValue: defaultListenAddress
-    defaultValueDesc: "0.0.0.0"
+    defaultValueDesc: defaultListenAddressDesc
     name: "listen-address" .}: ValidIpAddress
 
   tcpPort* {.

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -70,22 +70,24 @@ programMain:
 
     optimisticProcessor = proc(signedBlock: ForkedMsgTrustedSignedBeaconBlock):
         Future[void] {.async.} =
-      debug "New LC optimistic block",
+      notice "New LC optimistic block",
         opt = signedBlock.toBlockId(),
         wallSlot = getBeaconTime().slotOrZero
       withBlck(signedBlock):
         when stateFork >= BeaconStateFork.Bellatrix:
           if blck.message.is_execution_block:
-            await eth1Monitor.ensureDataProvider()
-
-            # engine_newPayloadV1
             template payload(): auto = blck.message.body.execution_payload
-            discard await eth1Monitor.newExecutionPayload(payload)
 
-            # engine_forkchoiceUpdatedV1
-            discard await eth1Monitor.runForkchoiceUpdated(
-              headBlockRoot = payload.block_hash,
-              finalizedBlockRoot = ZERO_HASH)
+            if eth1Monitor != nil:
+              await eth1Monitor.ensureDataProvider()
+
+              # engine_newPayloadV1
+              discard await eth1Monitor.newExecutionPayload(payload)
+
+              # engine_forkchoiceUpdatedV1
+              discard await eth1Monitor.runForkchoiceUpdated(
+                headBlockRoot = payload.block_hash,
+                finalizedBlockRoot = ZERO_HASH)
         else: discard
       return
     optSync = initLCOptimisticSync(
@@ -115,7 +117,7 @@ programMain:
       true
 
   proc onFinalizedHeader(lightClient: LightClient) =
-    notice "New LC finalized header",
+    info "New LC finalized header",
       finalized_header = shortLog(lightClient.finalizedHeader.get)
     let optimisticHeader = lightClient.optimisticHeader.valueOr:
       return
@@ -127,7 +129,7 @@ programMain:
     optSync.setFinalizedHeader(finalizedHeader)
 
   proc onOptimisticHeader(lightClient: LightClient) =
-    notice "New LC optimistic header",
+    info "New LC optimistic header",
       optimistic_header = shortLog(lightClient.optimisticHeader.get)
     let optimisticHeader = lightClient.optimisticHeader.valueOr:
       return

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -39,6 +39,7 @@ const
 
   # This is not part of the spec! But its port which uses Lighthouse
   DefaultEth2RestPort* = 5052
+  DefaultEth2RestPortDesc* = $DefaultEth2RestPort
 
   enrAttestationSubnetsField* = "attnets"
   enrSyncSubnetsField* = "syncnets"

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -36,6 +36,7 @@ const
   MAX_CHUNK_SIZE_BELLATRIX* = 10 * 1024 * 1024 # bytes
 
   defaultEth2TcpPort* = 9000
+  defaultEth2TcpPortDesc* = $defaultEth2TcpPort
 
   # This is not part of the spec! But its port which uses Lighthouse
   DefaultEth2RestPort* = 5052

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -39,8 +39,8 @@ const
   defaultEth2TcpPortDesc* = $defaultEth2TcpPort
 
   # This is not part of the spec! But its port which uses Lighthouse
-  DefaultEth2RestPort* = 5052
-  DefaultEth2RestPortDesc* = $DefaultEth2RestPort
+  defaultEth2RestPort* = 5052
+  defaultEth2RestPortDesc* = $defaultEth2RestPort
 
   enrAttestationSubnetsField* = "attnets"
   enrSyncSubnetsField* = "syncnets"


### PR DESCRIPTION
Replaces hardcoded IP address strings with constants.
Adjusts some LC log levels.
Removes no longer used `RpcServer` type.