### PR TITLE
ci: drop Jenkins timeouts for testnet launches

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -75,15 +75,15 @@ pipeline {
     stage('Finalizations') {
       stages {  /* parallel builds of minimal / mainnet not yet supported */
         stage('minimal') {
-          steps { script { timeout(15) {
+          steps { script {
             launchLocalTestnet('minimal')
-          } } }
+          } }
         }
 
         stage('mainnet') {
-          steps { script { timeout(45) {
+          steps { script {
             launchLocalTestnet('mainnet')
-          } } }
+          } }
         }
       }
     }


### PR DESCRIPTION
We've been seeing finalizations failing due to process being killed:
```
10:17:40  Waiting for Altair finalization
10:20:05  ./scripts/launch_local_testnet.sh: line 1025: 42617 Killed                  ${BEACON_NODE_COMMAND} --config-file="${CLI_CONF_FILE}" --tcp-port=$(( BASE_PORT + NUM_NODE )) --udp-port=$(( BASE_PORT + NUM_NODE )) --max-peers=$(( NUM_NODES + LC_NODES - 1 )) --data-dir="${CONTAINER_NODE_DATA_DIR}" ${BOOTSTRAP_ARG} ${WEB3_ARG} ${STOP_AT_EPOCH_FLAG} --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" --light-client-enable=on --light-client-data-serve=on --light-client-data-import-mode=only-new ${EXTRA_ARGS} &> "${DATA_DIR}/log${NUM_NODE}.txt"
```
This will test if the issue is actually per-stage timeout.