### PR TITLE
ci: specify explicit throttle limits for Jenkins

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -23,9 +23,11 @@ pipeline {
     ))
     /* Throttle number of concurrent builds. */
     throttleJobProperty(
-      categories: ['nimbus-eth2'],
       throttleEnabled: true,
-      throttleOption: 'category'
+      throttleOption: 'category',
+      categories: ['nimbus-eth2'],
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 6
     )
     /* Abort old builds for non-main branches. */
     disableConcurrentBuilds(


### PR DESCRIPTION
Otherwise they appear to not have any effect:
https://issues.jenkins.io/browse/JENKINS-49173
https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/68

Appears to work:

![image](https://user-images.githubusercontent.com/2212681/180799872-eff2e031-3ddf-4a0b-a172-e1661943ff23.png)