### PR TITLE
fix tesnet port conflicts on Jenkins CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ NODE_ID := 0
 BASE_PORT := 9000
 BASE_REST_PORT := 5052
 BASE_METRICS_PORT := 8008
-EXECUTOR_NUMBER := 0
+# WARNING: Use lazy assignment to allow CI to override.
+EXECUTOR_NUMBER ?= 0
 
 ROPSTEN_WEB3_URL := "--web3-url=wss://ropsten.infura.io/ws/v3/809a18497dd74102b5f37d25aae3c85a"
 SEPOLIA_WEB3_URL := "--web3-url=https://rpc.sepolia.dev --web3-url=https://www.sepoliarpc.space"

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -581,14 +581,14 @@ cleanup() {
 
   for proc in "${PROCS_TO_KILL[@]}"
   do
-    pkill -f -P $$ "${proc}" &>/dev/null || true
+    pkill -f -P $$ "${proc}" || true
   done
 
   sleep 2
 
   for proc in "${PROCS_TO_KILL[@]}"
   do
-    pkill -f -9 -P $$ "${proc}" &>/dev/null || true
+    pkill -f -9 -P $$ "${proc}" || true
   done
 
   # Delete all binaries we just built, because these are unusable outside this


### PR DESCRIPTION
A fix for a bug triggered by recent `Jenkinsfile` refactoring done in:

* https://github.com/status-im/nimbus-eth2/pull/3827

Which due to a big in Jenkins Throttling plugin caused jobs to start running in parallel on the same host despite global configuration that is supposed to block this:

* https://issues.jenkins.io/browse/JENKINS-49173
* https://github.com/jenkinsci/throttle-concurrent-builds-plugin/pull/68

An attempt to fix this was made in this PR:

* https://github.com/status-im/nimbus-eth2/pull/3913

But it was ineffective due to bugs in the Throttle plugin.

As a result semi-random testnet launches would fail with errors like this:
```
./scripts/launch_local_testnet.sh: line 1026: 58977 Killed: 9   ${BEACON_NODE_COMMAND} ...
```
The culprit was the old process cleanup in `scripts/launch_local_testnet.sh`:
```
+ make local-testnet-mainnet
Found old process listening on port 7001, with PID 58977. Killing it.
Found old process listening on port 7002, with PID 59024. Killing it.
Found old process listening on port 7003, with PID 59027. Killing it.
Found old process listening on port 7004, with PID 59030. Killing it.
```
Which was triggered due to use of immediate assignment for `EXECUTOR_NUMBER`:
```
EXECUTOR_NUMBER := 0
```
Which cause the `EXECUTOR_NUMBER` value set by Jenkins to be ignored.

For more details see:
https://www.gnu.org/software/make/manual/html_node/Flavors.html#Flavors