### PR TITLE
use LC features on all networks

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -94,53 +94,7 @@ type DeploymentPhase* {.pure.} = enum
   Mainnet
 
 func deploymentPhase*(genesisData: string): DeploymentPhase =
-  # SSZ processing at compile time does not work well.
-  #
-  # `BeaconState` layout:
-  # ```
-  # - genesis_time: uint64
-  # - genesis_validators_root: Eth2Digest
-  # - ...
-  # ```
-  #
-  # Comparing the first 40 bytes covers those two fields,
-  # which should identify the network with high likelihood.
-  # ''.join('%02X'%b for b in open("network_name/genesis.ssz", "rb").read()[:40])
-  if genesisData.len < 40:
-    return DeploymentPhase.None
-
-  const
-    mainnets = [
-      # Mainnet
-      "5730C65F000000004B363DB94E286120D76EB905340FDD4E54BFE9F06BF33FF6CF5AD27F511BFE95",
-    ]
-    testnets = [
-      # Kiln
-      "0C572B620000000099B09FCD43E5905236C370F184056BEC6E6638CFC31A323B304FC4AA789CB4AD",
-    ]
-    devnets = [
-      # Ropsten
-      "F0DB94620000000044F1E56283CA88B35C789F7F449E52339BC1FEFE3A45913A43A6D16EDCD33CF1",
-      # Sepolia
-      "607DB06200000000D8EA171F3C94AEA21EBC42A1ED61052ACF3F9209C00E4EFBAADDAC09ED9B8078",
-      # Mainnet Shadow Fork 9
-      "0C2ECC6200000000209BA2806D11E2394A9C6682815453EDCFDBA1DCE0C25D71BCFEF6363FBD3A43",
-      # Prater
-      "60F4596000000000043DB0D9A83813551EE2F33450D23797757D430911A9320530AD8A0EABC43EFB",
-      # Goerli Shadow Fork 5
-      "7CFDD76200000000E45F26D5A29B0ED5A9F62F248B842A30DD7B7FBA0B5B104EAB271EFC04E0CF66",
-      # Mainnet Shadow Fork 10
-      "35A3DE620000000049836C2A8BEC13B221BC496FCD3774C60EF145402D9754F00DBA0BE881C3A69E",
-    ]
-
-  let data = (genesisData[0 ..< 40].toHex())
-  if data in mainnets:
-    return DeploymentPhase.Mainnet
-  if data in testnets:
-    return DeploymentPhase.Testnet
-  if data in devnets:
-    return DeploymentPhase.Devnet
-  DeploymentPhase.None
+  DeploymentPhase.Devnet
 
 const
   eth2NetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/eth2-networks"


### PR DESCRIPTION
Prepares removing functionality to restrict LC features to testnets.
Rest of functions is removed later to have a quick way of reverting.