### PR TITLE
log NimVersion

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -145,6 +145,9 @@ declareGauge next_action_wait,
 declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version", "commit"], name = "version"
 versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])
 
+declareGauge nimVersionGauge, "Nim version info", ["nim_version"], name = "Nim_version"
+nimVersionGauge.set(1, labelValues=[NimVersion])
+
 logScope: topics = "beacnde"
 
 func getPandas(stdoutKind: StdoutLogKind): VanityLogs =
@@ -1658,6 +1661,7 @@ proc start*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
 
   notice "Starting beacon node",
     version = fullVersionStr,
+    nimVersion = NimVersion,
     enr = node.network.announcedENR.toURI,
     peerId = $node.network.switch.peerInfo.peerId,
     timeSinceFinalization =


### PR DESCRIPTION
After this PR:

```
NOT 2022-08-03 19:22:16.939+02:00 Starting beacon node                       topics="beacnde" version=v22.7.0-52b32c-stateofus nimVersion=1.2.16 enr=(...)
```

IMO, the commit hash for Nim is not needed if we stick to the released stable versions of the compiler. (e.g. 1.2.16 or 1.6.8)