### PR TITLE
fix obtaining deposits after connection loss

### DIFF
--- a/beacon_chain/beacon_chain_db_light_client.nim
+++ b/beacon_chain/beacon_chain_db_light_client.nim
@@ -20,8 +20,7 @@ import
   eth/db/kvstore_sqlite3,
   # Beacon chain internals
   spec/datatypes/altair,
-  spec/[eth2_ssz_serialization, helpers],
-  ./filepath
+  spec/[eth2_ssz_serialization, helpers]
 
 logScope: topics = "lcdata"
 

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -651,7 +651,7 @@ when hasDepositRootChecks:
   const
     contractCallTimeout = 60.seconds
 
-  func fetchDepositContractData(p: Web3DataProviderRef, blk: Eth1Block):
+  proc fetchDepositContractData(p: Web3DataProviderRef, blk: Eth1Block):
                                 Future[DepositContractDataStatus] {.async.} =
     let
       depositRoot = p.ns.get_deposit_root.call(blockNumber = blk.number)
@@ -674,8 +674,8 @@ when hasDepositRootChecks:
       result = DepositRootUnavailable
 
     try:
-      let fetchedCount = bytes_to_uint64(array[8, byte](
-        awaitOrRaiseOnTimeout(rawCount, contractCallTimeout)))
+      let fetchedCount = bytes_to_uint64(
+        awaitOrRaiseOnTimeout(rawCount, contractCallTimeout).toArray)
       if blk.voteData.deposit_count == 0:
         blk.voteData.deposit_count = fetchedCount
       elif blk.voteData.deposit_count != fetchedCount:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1175,12 +1175,6 @@ proc syncBlockRange(m: Eth1Monitor,
     for i in 0 ..< blocksWithDeposits.len:
       let blk = blocksWithDeposits[i]
 
-      for deposit in blk.deposits:
-        m.headMerkleizer.addChunk hash_tree_root(deposit).data
-
-      blk.voteData.deposit_count = m.headMerkleizer.getChunkCount
-      blk.voteData.deposit_root = m.headMerkleizer.getDepositsRoot
-
       if blk.number > fullSyncFromBlock:
         let lastBlock = m.depositsChain.blocks.peekLast
         for n in max(lastBlock.number + 1, fullSyncFromBlock) ..< blk.number:
@@ -1191,6 +1185,11 @@ proc syncBlockRange(m: Eth1Monitor,
           m.depositsChain.addBlock(
             lastBlock.makeSuccessorWithoutDeposits(blockWithoutDeposits))
           eth1_synced_head.set blockWithoutDeposits.number.toGaugeValue
+
+      for deposit in blk.deposits:
+        m.headMerkleizer.addChunk hash_tree_root(deposit).data
+      blk.voteData.deposit_count = m.headMerkleizer.getChunkCount
+      blk.voteData.deposit_root = m.headMerkleizer.getDepositsRoot
 
       m.depositsChain.addBlock blk
       eth1_synced_head.set blk.number.toGaugeValue


### PR DESCRIPTION
When an error occurs during Eth1 deposits import, the already imported
blocks are kept while the connection to the EL is re-established.
However, the corresponding merkleizer is not persisted, leading to any
future deposits no longer being properly imported. This is quite common
when syncing a fresh Nimbus instance against an already-synced Geth EL.
Fixed by persisting the head merkleizer together with the blocks.