### PR TITLE
consider blocks with deposits in eth1 data vote

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1168,6 +1168,7 @@ proc syncBlockRange(m: Eth1Monitor,
 
     for i in 0 ..< blocksWithDeposits.len:
       let blk = blocksWithDeposits[i]
+      awaitWithRetries m.dataProvider.fetchTimestamp(blk)
 
       for deposit in blk.deposits:
         merkleizer[].addChunk hash_tree_root(deposit).data


### PR DESCRIPTION
When importing blocks with deposits from the EL, the timestamp is never
initialized for them. Therefore, only blocks without deposits (for which
the timestamp is obtained) are considered for `is_candidate_block`.
This is fixed by also importing timestamps for blocks with deposits.