### PR TITLE
avoid materializing potentially long deposits seq

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -150,10 +150,11 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 10/12 Fail: 0/12 Skip: 2/12
 ## Eth1 monitor
 ```diff
++ Deposits chain                                                                             OK
 + Rewrite HTTPS Infura URLs                                                                  OK
 + Roundtrip engine RPC and consensus ExecutionPayload representations                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Eth2 specific discovery tests
 ```diff
 + Invalid attnets field                                                                      OK
@@ -586,4 +587,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 327/332 Fail: 0/332 Skip: 5/332
+OK: 328/333 Fail: 0/333 Skip: 5/333


### PR DESCRIPTION
When fetching eth1 data and deposits for a new block proposal, the list
of deposits from previous eth1 data to the next one is fully loaded into
a `seq`. This can potentially be a very long list in active periods.
Changing this to an `iterator` saves memory by ensuring that the entire
list is no longer materialized; only the `DepositData` roots are needed.