### PR TITLE
import EL deposits even when EL is stuck

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1314,6 +1314,9 @@ proc syncBlockRange(m: Eth1Monitor,
 func init(T: type FullBlockId, blk: Eth1BlockHeader|BlockObject): T =
   FullBlockId(number: Eth1BlockNumber blk.number, hash: blk.hash)
 
+func isNewLastBlock(m: Eth1Monitor, blk: Eth1BlockHeader|BlockObject): bool =
+  blk.number.uint64 > m.latestEth1BlockNumber
+
 proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
   if m.state == Started:
     return
@@ -1401,7 +1404,7 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
     proc newBlockHeadersHandler(blk: Eth1BlockHeader)
                                {.raises: [Defect], gcsafe.} =
       try:
-        if blk.number.uint64 > m.latestEth1BlockNumber:
+        if m.isNewLastBlock(blk):
           eth1_latest_head.set blk.number.toGaugeValue
           m.latestEth1Block = some FullBlockId.init(blk)
           m.eth1Progress.fire()
@@ -1462,8 +1465,8 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
       let blk = awaitWithRetries(
         m.dataProvider.web3.provider.eth_getBlockByNumber(blockId("latest"), false))
 
-      # Same check as when handling events, minus `m.eth1Progress` round trip
-      if blk.number.uint64 > m.latestEth1BlockNumber:
+      # Same as when handling events, minus `m.eth1Progress` round trip
+      if m.isNewLastBlock(blk):
         eth1_latest_head.set blk.number.toGaugeValue
         m.latestEth1Block = some FullBlockId.init(blk)
       elif mustUsePolling:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1429,6 +1429,7 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
 
     debug "Starting Eth1 syncing", `from` = shortLog(m.depositsChain.blocks[0])
 
+  var didPollOnce = false
   while true:
     if bnStatus == BeaconNodeStatus.Stopping:
       when hasGenesisDetection:
@@ -1446,7 +1447,9 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
       m.startIdx = 0
       return
 
-    let nextBlock = if mustUsePolling or m.latestEth1Block.isNone:
+    let nextBlock = if mustUsePolling or not didPollOnce:
+      didPollOnce = true
+
       let blk = awaitWithRetries(
         m.dataProvider.web3.provider.eth_getBlockByNumber(blockId("latest"), false))
 

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1451,10 +1451,11 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
       let blk = awaitWithRetries(
         m.dataProvider.web3.provider.eth_getBlockByNumber(blockId("latest"), false))
 
+      # Same check as when handling events, minus `m.eth1Progress` round trip
       if blk.number.uint64 > m.latestEth1BlockNumber:
         eth1_latest_head.set blk.number.toGaugeValue
         m.latestEth1Block = some FullBlockId.init(blk)
-      elif didPollOnce:
+      elif mustUsePolling or didPollOnce:
         await sleepAsync(m.cfg.SECONDS_PER_ETH1_BLOCK.int.seconds)
         continue
       else:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1455,11 +1455,11 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
       if blk.number.uint64 > m.latestEth1BlockNumber:
         eth1_latest_head.set blk.number.toGaugeValue
         m.latestEth1Block = some FullBlockId.init(blk)
-      elif mustUsePolling or didPollOnce:
+      elif mustUsePolling:
         await sleepAsync(m.cfg.SECONDS_PER_ETH1_BLOCK.int.seconds)
         continue
       else:
-        discard
+        doAssert not didPollOnce
 
       didPollOnce = true
       blk

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1446,7 +1446,7 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
       m.startIdx = 0
       return
 
-    let nextBlock = if mustUsePolling:
+    let nextBlock = if mustUsePolling or m.latestEth1Block.isNone:
       let blk = awaitWithRetries(
         m.dataProvider.web3.provider.eth_getBlockByNumber(blockId("latest"), false))
 
@@ -1465,12 +1465,7 @@ proc startEth1Syncing(m: Eth1Monitor, delayBeforeStart: Duration) {.async.} =
 
       m.eth1Progress.clear()
 
-      if m.latestEth1Block.isNone:
-        # It should not be possible for `latestEth1Block` to be none here.
-        # Firing the `eth1Progress` event is always done after assinging
-        # a value for it.
-        continue
-
+      doAssert m.latestEth1Block.isSome
       awaitWithRetries m.dataProvider.getBlockByHash(m.latestEth1Block.get.hash)
 
     if m.currentEpoch >= m.cfg.BELLATRIX_FORK_EPOCH and m.terminalBlockHash.isNone:


### PR DESCRIPTION
The `eth1_monitor` only starts importing deposits once the EL reports a
new head block. However, the EL may be stuck at a block, e.g., the TTD.
By polling the latest EL block once after subscribing to new EL block
events it is ensured that deposits are still imported in this situation.