### PR TITLE
re-enable `LightClientUpdate` tests

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -117,7 +117,7 @@ suite "EF - Altair - SSZ consensus objects " & preset():
           of "LightClientBootstrap":
             checkSSZ(LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            discard # Modified - checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
             checkSSZ(LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -120,7 +120,7 @@ suite "EF - Bellatrix - SSZ consensus objects " & preset():
           of "LightClientBootstrap":
             checkSSZ(LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            discard # Modified - checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
             checkSSZ(LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":


### PR DESCRIPTION
Now that the 1.2.0-rc.2 spec contains the same `LightClientUpdate`
definition that Nimbus was already using before, the corresponding
SSZ test vectors can be re-enabled.