### PR TITLE
distinguish between optimistic and non-optimistic sync progress

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1343,13 +1343,13 @@ func syncStatus(node: BeaconNode): string =
   let optimistic_head = node.dag.is_optimistic(node.dag.head.root)
   if node.syncManager.inProgress:
     if optimistic_head:
-      node.syncManager.syncStatus & ": opt"
+      node.syncManager.syncStatus & "/opt"
     else:
       node.syncManager.syncStatus
   elif node.backfiller.inProgress:
     "backfill: " & node.backfiller.syncStatus
   elif optimistic_head:
-    "opt synced"
+    "synced/opt"
   else:
     "synced"
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1340,11 +1340,15 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   await node.updateGossipStatus(slot + 1)
 
 func syncStatus(node: BeaconNode): string =
+  let optimistic_head = node.dag.is_optimistic(node.dag.head.root)
   if node.syncManager.inProgress:
-    node.syncManager.syncStatus
+    if optimistic_head:
+      node.syncManager.syncStatus & ": opt"
+    else:
+      node.syncManager.syncStatus
   elif node.backfiller.inProgress:
     "backfill: " & node.backfiller.syncStatus
-  elif node.dag.is_optimistic(node.dag.head.root):
+  elif optimistic_head:
     "opt synced"
   else:
     "synced"


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/3963

I'm not certain this is the best formatting, but it's arguably better to put the `opt` after rather than before the time stamp, since there's a race-condition like setup where exactly when the execution client verifies a payload can vary, and this makes the churn more readable in that case.

There's a case for doing this for "opt synced" too, but there, at least, there isn't any additional changing information to read (the estimated time).