### PR TITLE
switch GitHub Actions CI images from Ubuntu 18.04 to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -25,7 +25,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-18.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/6002