### PR TITLE
cache shuffling separately from other EpochRef data (fixes #2677)

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -88,6 +88,13 @@ proc addResolvedHeadBlock(
   # Update light client data
   dag.processNewBlockForLightClient(state, trustedBlock, parent.bid)
 
+  # Pre-heat the shuffling cache with the shuffling caused by this block - this
+  # is useful for attestation duty lookahead, REST API queries and attestation
+  # validation of untaken forks (in case of instability / multiple heads)
+  if dag.findShufflingRef(blockRef.bid, blockRef.slot.epoch + 1).isNone:
+    dag.putShufflingRef(
+      ShufflingRef.init(state, cache, blockRef.slot.epoch + 1))
+
   if not blockVerified:
     dag.optimisticRoots.incl blockRoot
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -189,6 +189,8 @@ type
 
     cfg*: RuntimeConfig
 
+    shufflingRefs*: array[16, ShufflingRef]
+
     epochRefs*: array[32, EpochRef]
       ## Cached information about a particular epoch ending with the given
       ## block - we limit the number of held EpochRefs to put a cap on
@@ -243,8 +245,18 @@ type
     epoch*: Epoch
     bid*: BlockId
 
+  ShufflingRef* = ref object
+    ## Attestation committee shuffling that determines when validators have
+    ## duties - determined with one epoch of look-ahead - the dependent root is
+    ## the block root that is the last to affect the shuffling outcome.
+    epoch*: Epoch
+    attester_dependent_root*: Eth2Digest
+      ## Root of the block that determined the shuffling - this is the last
+      ## block that was applied in (epoch - 2).
+
+    shuffled_active_validator_indices*: seq[ValidatorIndex]
+
   EpochRef* = ref object
-    dag*: ChainDAGRef
     key*: EpochKey
 
     eth1_data*: Eth1Data
@@ -255,8 +267,7 @@ type
     beacon_proposers*: array[SLOTS_PER_EPOCH, Option[ValidatorIndex]]
     proposer_dependent_root*: Eth2Digest
 
-    shuffled_active_validator_indices*: seq[ValidatorIndex]
-    attester_dependent_root*: Eth2Digest
+    shufflingRef*: ShufflingRef
 
     # balances, as used in fork choice
     effective_balances_bytes*: seq[byte]

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -339,7 +339,7 @@ proc scheduleAggregateChecks*(
       batchCrypto: ref BatchCrypto,
       fork: Fork, genesis_validators_root: Eth2Digest,
       signedAggregateAndProof: SignedAggregateAndProof,
-      epochRef: EpochRef,
+      dag: ChainDAGRef,
       attesting_indices: openArray[ValidatorIndex]
      ): Result[tuple[
         aggregatorFut, slotFut, aggregateFut: Future[BatchResult],
@@ -364,13 +364,13 @@ proc scheduleAggregateChecks*(
   # Do the eager steps first to avoid polluting batches with needlessly
   let
     aggregatorKey =
-      epochRef.validatorKey(aggregate_and_proof.aggregator_index).orReturnErr(
+      dag.validatorKey(aggregate_and_proof.aggregator_index).orReturnErr(
         "SignedAggregateAndProof: invalid aggregator index")
     aggregatorSig = signedAggregateAndProof.signature.load().orReturnErr(
       "aggregateAndProof: invalid proof signature")
     slotSig = aggregate_and_proof.selection_proof.load().orReturnErr(
       "aggregateAndProof: invalid selection signature")
-    aggregateKey = ? aggregateAll(epochRef.dag, attesting_indices)
+    aggregateKey = ? aggregateAll(dag, attesting_indices)
     aggregateSig = aggregate.signature.load().orReturnErr(
       "aggregateAndProof: invalid aggregate signature")
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -142,11 +142,11 @@ func check_aggregation_count(
   ok()
 
 func check_attestation_subnet(
-    epochRef: EpochRef, slot: Slot, committee_index: CommitteeIndex,
+    shufflingRef: ShufflingRef, slot: Slot, committee_index: CommitteeIndex,
     subnet_id: SubnetId): Result[void, ValidationError] =
   let
     expectedSubnet = compute_subnet_for_attestation(
-      get_committee_count_per_slot(epochRef), slot, committee_index)
+      get_committee_count_per_slot(shufflingRef), slot, committee_index)
 
   if expectedSubnet != subnet_id:
     return errReject("Attestation not on the correct subnet")
@@ -447,18 +447,17 @@ proc validateAttestation*(
   # compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) ==
   # store.finalized_checkpoint.root
   let
-    epochRef = block:
-      let tmp = pool.dag.getEpochRef(target.blck, target.slot.epoch, false)
-      if isErr(tmp): # shouldn't happen since we verified target
-        warn "No EpochRef for attestation",
+    shufflingRef =
+      pool.dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+        # Target is verified - shouldn't happen
+        warn "No shuffling for attestation - report bug",
           attestation = shortLog(attestation), target = shortLog(target)
-        return errIgnore("Attestation:  no EpochRef")
-      tmp.get()
+        return errIgnore("Attestation: no shuffling")
 
   # [REJECT] The committee index is within the expected range -- i.e.
   # data.index < get_committee_count_per_slot(state, data.target.epoch).
   let committee_index = block:
-    let idx = epochRef.get_committee_index(attestation.data.index)
+    let idx = shufflingRef.get_committee_index(attestation.data.index)
     if idx.isErr():
       return checkedReject("Attestation: committee index not within expected range")
     idx.get()
@@ -471,7 +470,7 @@ proc validateAttestation*(
   # committee information for the signature check.
   block:
     let v = check_attestation_subnet(
-      epochRef, attestation.data.slot, committee_index, subnet_id) # [REJECT]
+      shufflingRef, attestation.data.slot, committee_index, subnet_id) # [REJECT]
     if v.isErr():
       return err(v.error)
 
@@ -483,7 +482,7 @@ proc validateAttestation*(
   # epoch matches its target and attestation.data.target.root is an ancestor of
   # attestation.data.beacon_block_root.
   if not (attestation.aggregation_bits.lenu64 == get_beacon_committee_len(
-      epochRef, attestation.data.slot, committee_index)):
+      shufflingRef, attestation.data.slot, committee_index)):
     return checkedReject(
       "Attestation: number of aggregation bits and committee size mismatch")
 
@@ -492,7 +491,7 @@ proc validateAttestation*(
     genesis_validators_root =
       getStateField(pool.dag.headState, genesis_validators_root)
     attesting_index = get_attesting_indices_one(
-      epochRef, slot, committee_index, attestation.aggregation_bits)
+      shufflingRef, slot, committee_index, attestation.aggregation_bits)
 
   # The number of aggregation bits matches the committee size, which ensures
   # this condition holds.
@@ -509,7 +508,7 @@ proc validateAttestation*(
         attestation.data.target.epoch:
     return errIgnore("Attestation: Validator has already voted in epoch")
 
-  let pubkey = epochRef.validatorKey(validator_index)
+  let pubkey = pool.dag.validatorKey(validator_index)
   if pubkey.isNone():
     # can't happen, in theory, because we checked the aggregator index above
     return errIgnore("Attestation: cannot find validator pubkey")
@@ -635,18 +634,17 @@ proc validateAggregate*(
     return errIgnore("Aggregate already covered")
 
   let
-    epochRef = block:
-      let tmp = pool.dag.getEpochRef(target.blck, target.slot.epoch, false)
-      if tmp.isErr: # shouldn't happen since we verified target
-        warn "No EpochRef for attestation - report bug",
+    shufflingRef =
+      pool.dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+        # Target is verified - shouldn't happen
+        warn "No shuffling for attestation - report bug",
           aggregate = shortLog(aggregate), target = shortLog(target)
-        return errIgnore("Aggregate: no EpochRef")
-      tmp.get()
+        return errIgnore("Aggregate: no shuffling")
 
   # [REJECT] The committee index is within the expected range -- i.e.
   # data.index < get_committee_count_per_slot(state, data.target.epoch).
   let committee_index = block:
-    let idx = epochRef.get_committee_index(aggregate.data.index)
+    let idx = shufflingRef.get_committee_index(aggregate.data.index)
     if idx.isErr():
       return checkedReject("Attestation: committee index not within expected range")
     idx.get()
@@ -655,7 +653,7 @@ proc validateAggregate*(
   # aggregator for the slot -- i.e. is_aggregator(state, aggregate.data.slot,
   # aggregate.data.index, aggregate_and_proof.selection_proof) returns True.
   if not is_aggregator(
-      epochRef, slot, committee_index, aggregate_and_proof.selection_proof):
+      shufflingRef, slot, committee_index, aggregate_and_proof.selection_proof):
     return checkedReject("Aggregate: incorrect aggregator")
 
   # [REJECT] The aggregator's validator index is within the committee -- i.e.
@@ -667,7 +665,7 @@ proc validateAggregate*(
       return checkedReject("Aggregate: invalid aggregator index")
 
   if aggregator_index notin
-      get_beacon_committee(epochRef, slot, committee_index):
+      get_beacon_committee(shufflingRef, slot, committee_index):
     return checkedReject("Aggregate: aggregator's validator index not in committee")
 
   # 1. [REJECT] The aggregate_and_proof.selection_proof is a valid signature of the
@@ -682,14 +680,14 @@ proc validateAggregate*(
     genesis_validators_root =
       getStateField(pool.dag.headState, genesis_validators_root)
     attesting_indices = get_attesting_indices(
-      epochRef, slot, committee_index, aggregate.aggregation_bits)
+      shufflingRef, slot, committee_index, aggregate.aggregation_bits)
 
   let
     sig = if checkSignature:
       let deferredCrypto = batchCrypto
                     .scheduleAggregateChecks(
                       fork, genesis_validators_root,
-                      signedAggregateAndProof, epochRef, attesting_indices
+                      signedAggregateAndProof, pool.dag, attesting_indices
                     )
       if deferredCrypto.isErr():
         return checkedReject(deferredCrypto.error)

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -225,7 +225,7 @@ func updateActions*(
   let
     epoch = epochRef.epoch
 
-  tracker.attesterDepRoot = epochRef.attester_dependent_root
+  tracker.attesterDepRoot = epochRef.shufflingRef.attester_dependent_root
   tracker.lastCalculatedEpoch = epoch
 
   let validatorIndices = toHashSet(toSeq(tracker.knownValidators.keys()))
@@ -243,7 +243,7 @@ func updateActions*(
   static: doAssert SLOTS_PER_EPOCH <= 32
 
   for (committeeIndex, subnet_id, slot) in
-      get_committee_assignments(epochRef, validatorIndices):
+      get_committee_assignments(epochRef.shufflingRef, validatorIndices):
 
     doAssert epoch(slot) == epoch
 

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -209,19 +209,19 @@ proc routeAttestation*(
       return err(
         "Attempt to send attestation for unknown target")
 
-    epochRef = router[].dag.getEpochRef(
+    shufflingRef = router[].dag.getShufflingRef(
         target, attestation.data.target.epoch, false).valueOr:
       warn "Cannot construct EpochRef for attestation, skipping send - report bug",
         target = shortLog(target),
         attestation = shortLog(attestation)
       return
     committee_index =
-      epochRef.get_committee_index(attestation.data.index).valueOr:
+      shufflingRef.get_committee_index(attestation.data.index).valueOr:
         notice "Invalid committee index in attestation",
           attestation = shortLog(attestation)
         return err("Invalid committee index in attestation")
     subnet_id = compute_subnet_for_attestation(
-      get_committee_count_per_slot(epochRef), attestation.data.slot,
+      get_committee_count_per_slot(shufflingRef), attestation.data.slot,
       committee_index)
 
   return await router.routeAttestation(


### PR DESCRIPTION
In order to avoid full replays when validating attestations hailing from
untaken forks, it's better to keep shufflings separate from `EpochRef`
and perform a lookahead on the shuffling when processing the block that
determines them.

This also helps performance in the case where REST clients are trying to
perform lookahead on attestation duties and decreases memory usage by
sharing shufflings between EpochRef instances of the same dependent
root.