### PR TITLE
Doppelganger detection bug fix

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -248,11 +248,19 @@ proc setupDoppelgangerDetection*(self: var Eth2Processor, slot: Slot) =
   # and one should gauge the likelihood of this simultaneous launch to tune
   # the epoch delay to one's perceived risk.
 
-  if self.validatorPool[].count() > 0:
-    const duplicateValidatorEpochs = 2
+  const duplicateValidatorEpochs = 2
 
-    self.doppelgangerDetection.broadcastStartEpoch =
-      slot.epoch + duplicateValidatorEpochs
+  # TODO:
+  # We should switch to a model where this value is set for each validator
+  # as it gets added to the validator pool.
+  # Currently, we set it here because otherwise if the client is started
+  # without any validators, it will remain set to FAR_FUTURE_EPOCH and
+  # any new validators added through the Keymanager API will never get
+  # activated.
+  self.doppelgangerDetection.broadcastStartEpoch =
+    slot.epoch + duplicateValidatorEpochs
+
+  if self.validatorPool[].count() > 0:
     if self.doppelgangerDetectionEnabled:
       notice "Setting up doppelganger detection",
         epoch = slot.epoch,

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -481,7 +481,6 @@ proc doppelgangerCheck*(vc: ValidatorClientRef,
       let
         vindex = validator.index.get()
         default = DoppelgangerState(status: DoppelgangerStatus.None)
-        currentEpoch = vc.currentSlot().epoch()
         state = vc.doppelgangerDetection.validators.getOrDefault(vindex,
                                                                  default)
       state.status == DoppelgangerStatus.Passed

--- a/beacon_chain/validator_client/doppelganger_service.nim
+++ b/beacon_chain/validator_client/doppelganger_service.nim
@@ -59,7 +59,7 @@ proc processActivities(service: DoppelgangerServiceRef, epoch: Epoch,
                     validator_index = vindex
             else:
               inc(value.epochsCount)
-              notice "Validator's activity was not seen",
+              debug "Validator's activity was not seen",
                      validator_index = vindex, epoch = epoch,
                      epochs_count = value.epochsCount
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1281,10 +1281,6 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
       notice "Doppelganger detection active - skipping validator duties while observing activity on the network",
         slot, epoch = slot.epoch,
         broadcastStartEpoch = doppelgangerDetection.broadcastStartEpoch
-    else:
-      debug "Doppelganger detection active - skipping validator duties while observing activity on the network",
-        slot, epoch = slot.epoch,
-        broadcastStartEpoch = doppelgangerDetection.broadcastStartEpoch
 
     return
 


### PR DESCRIPTION
When the client was started without any validators, the doppelganger
detection structures were never initialized properly. Later, when
validators were added through the Keymanager API, they interacted
with the uninitialized doppelganger detection structures and their
duties were inappropriately skipped.