### PR TITLE
don't use empty execution payload when newPayload rejects it

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -398,10 +398,10 @@ from ../spec/datatypes/bellatrix import ExecutionPayload, SignedBeaconBlock
 
 proc newExecutionPayload*(
     eth1Monitor: Eth1Monitor, executionPayload: bellatrix.ExecutionPayload):
-    Future[PayloadExecutionStatus] {.async.} =
+    Future[Opt[PayloadExecutionStatus]] {.async.} =
   if eth1Monitor.isNil:
     warn "newPayload: attempting to process execution payload without Eth1Monitor. Ensure --web3-url setting is correct and JWT is configured."
-    return PayloadExecutionStatus.syncing
+    return Opt.none PayloadExecutionStatus
 
   debug "newPayload: inserting block into execution engine",
     parentHash = executionPayload.parent_hash,
@@ -425,7 +425,11 @@ proc newExecutionPayload*(
               executionPayload.asEngineExecutionPayload),
             NEWPAYLOAD_TIMEOUT):
           info "newPayload: newPayload timed out"
+          return Opt.none PayloadExecutionStatus
+
+          # Placeholder for type system
           PayloadStatusV1(status: PayloadExecutionStatus.syncing)
+
       payloadStatus = payloadResponse.status
 
     debug "newPayload: succeeded",
@@ -434,10 +438,10 @@ proc newExecutionPayload*(
       blockNumber = executionPayload.block_number,
       payloadStatus
 
-    return payloadStatus
+    return Opt.some payloadStatus
   except CatchableError as err:
     error "newPayload failed", msg = err.msg
-    return PayloadExecutionStatus.syncing
+    return Opt.none PayloadExecutionStatus
 
 from ../consensus_object_pools/blockchain_dag import
   getBlockRef, loadExecutionBlockRoot, markBlockInvalid
@@ -510,8 +514,17 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
                    doAssert false
                    default(bellatrix.ExecutionPayload) # satisfy Nim
 
-             await newExecutionPayload(
+             let executionPayloadStatus = await newExecutionPayload(
                self.consensusManager.eth1Monitor, executionPayload)
+
+             if executionPayloadStatus.isNone:
+               # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/sync/optimistic.md#execution-engine-errors
+               if not blck.resfut.isNil:
+                 blck.resfut.complete(
+                   Result[void, BlockError].err(BlockError.MissingParent))
+               continue
+
+             executionPayloadStatus.get
            except CatchableError as err:
              error "runQueueProcessingLoop: newPayload failed",
                err = err.msg

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -398,9 +398,9 @@ proc getExecutionPayload(
           node.consensusManager.eth1Monitor.newExecutionPayload(payload),
           NEWPAYLOAD_TIMEOUT):
             info "getExecutionPayload: newPayload timed out"
-            PayloadExecutionStatus.syncing
+            Opt.none PayloadExecutionStatus
 
-    if executionPayloadStatus in [
+    if executionPayloadStatus.isNone or executionPayloadStatus.get in [
         PayloadExecutionStatus.invalid,
         PayloadExecutionStatus.invalid_block_hash]:
       info "getExecutionPayload: newExecutionPayload invalid",


### PR DESCRIPTION
This still allows the empty payload fallback, but catches the specific `newPayload`-returns-`INVALID` scenario that has been occurring. Even with that fixed in general, it's useful to have this guardrail function.

Furthermore, https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md#execution-engine-errors effectively specifies that only blocks for which the execution engine returns either `SYNCING` or `ACCEPTED` may be optimistically imported.