### PR TITLE
Fix a potential segfault and various potential stalls

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -610,7 +610,7 @@ proc init*(T: type BeaconNode,
       config.validatorMonitorAuto, config.validatorMonitorTotals))
 
   for key in config.validatorMonitorPubkeys:
-    validatorMonitor[].addMonitor(key, none(ValidatorIndex))
+    validatorMonitor[].addMonitor(key, Opt.none(ValidatorIndex))
 
   let
     networkGenesisValidatorsRoot: Option[Eth2Digest] =
@@ -672,7 +672,7 @@ proc init*(T: type BeaconNode,
   info "Loading slashing protection database (v2)",
     path = config.validatorsDir()
 
-  proc getValidatorIdx(pubkey: ValidatorPubKey): Option[ValidatorIndex] =
+  proc getValidatorIdx(pubkey: ValidatorPubKey): Opt[ValidatorIndex] =
     withState(dag.headState):
       findValidator(state().data.validators.asSeq(), pubkey)
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -266,8 +266,8 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
     vc.syncCommitteeService = await SyncCommitteeServiceRef.init(vc)
     vc.keymanagerServer = keymanagerInitResult.server
     if vc.keymanagerServer != nil:
-      func getValidatorIdx(pubkey: ValidatorPubKey): Option[ValidatorIndex] =
-        none ValidatorIndex
+      func getValidatorIdx(pubkey: ValidatorPubKey): Opt[ValidatorIndex] =
+        Opt.none ValidatorIndex
 
       vc.keymanagerHost = newClone KeymanagerHost.init(
         validatorPool,

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -69,3 +69,17 @@ const
   # https://github.com/ethereum/builder-specs/blob/v0.2.0/specs/validator.md#constants
   EPOCHS_PER_VALIDATOR_REGISTRATION_SUBMISSION* = 1
   BUILDER_PROPOSAL_DELAY_TOLERANCE* = 1.seconds
+
+func shortLog*(v: BlindedBeaconBlock): auto =
+  (
+    slot: shortLog(v.slot),
+    proposer_index: v.proposer_index,
+    parent_root: shortLog(v.parent_root),
+    state_root: shortLog(v.state_root),
+  )
+
+func shortLog*(v: SignedBlindedBeaconBlock): auto =
+  (
+    blck: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -416,7 +416,7 @@ proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
   let slot = vc.currentSlot()
   case keystore.kind
   of KeystoreKind.Local:
-    vc.attachedValidators[].addLocalValidator(keystore, none[ValidatorIndex](),
+    vc.attachedValidators[].addLocalValidator(keystore, Opt.none ValidatorIndex,
                                               slot)
   of KeystoreKind.Remote:
     let
@@ -442,7 +442,7 @@ proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
           res
     if len(clients) > 0:
       vc.attachedValidators[].addRemoteValidator(keystore, clients,
-                                                 none[ValidatorIndex](), slot)
+                                                 Opt.none ValidatorIndex, slot)
     else:
       warn "Unable to initialize remote validator",
            validator = $keystore.pubkey

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -85,7 +85,7 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
       debug "Local validator updated with index",
             pubkey = item.validator.pubkey, index = item.index
       vc.attachedValidators[].updateValidator(item.validator.pubkey,
-                                            item.index)
+                                              item.index)
       # Adding validator for doppelganger detection.
       vc.addDoppelganger(
         vc.attachedValidators[].getValidator(item.validator.pubkey))

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -68,7 +68,7 @@ type
   ImportResult*[T] = Result[T, AddValidatorFailure]
 
   ValidatorPubKeyToIdxFn* =
-    proc (pubkey: ValidatorPubKey): Option[ValidatorIndex]
+    proc (pubkey: ValidatorPubKey): Opt[ValidatorIndex]
          {.raises: [Defect], gcsafe.}
 
   KeymanagerHost* = object
@@ -109,11 +109,11 @@ func init*(T: type KeymanagerHost,
     getBeaconTimeFn: getBeaconTimeFn)
 
 proc getValidatorIdx*(host: KeymanagerHost,
-                      pubkey: ValidatorPubKey): Option[ValidatorIndex] =
+                      pubkey: ValidatorPubKey): Opt[ValidatorIndex] =
   if host.getValidatorIdxFn != nil:
     host.getValidatorIdxFn(pubkey)
   else:
-    none ValidatorIndex
+    Opt.none ValidatorIndex
 
 proc addLocalValidator*(host: KeymanagerHost, keystore: KeystoreData) =
   let

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -188,7 +188,7 @@ type
   MonitoredValidator = object
     id: string # A short id is used above all for metrics
     pubkey: ValidatorPubKey
-    index: Option[ValidatorIndex]
+    index: Opt[ValidatorIndex]
     summaries: array[2, EpochSummary] # We monitor the current and previous epochs
 
   ValidatorMonitor* = object
@@ -222,7 +222,7 @@ proc update_if_lt[T](current: var Option[T], val: T) =
 
 proc addMonitor*(
     self: var ValidatorMonitor, pubkey: ValidatorPubKey,
-    index: Option[ValidatorIndex]) =
+    index: Opt[ValidatorIndex]) =
   if pubkey in self.monitors:
     return
 
@@ -249,7 +249,7 @@ proc addAutoMonitor*(
 
   # automatic monitors must be registered with index - we don't look for them in
   # the state
-  self.addMonitor(pubkey, some(index))
+  self.addMonitor(pubkey, Opt.some(index))
 
   info "Started monitoring validator",
     validator = shortLog(pubkey), pubkey, index
@@ -307,7 +307,6 @@ proc updateEpoch(self: var ValidatorMonitor, epoch: Epoch) =
         metric.observe(
           monitor.summaries[summaryIdx].name.get.toGaugeValue(),
           [if self.totals: total else: monitor.id])
-
 
   setAll(
     validator_monitor_prev_epoch_attestations_total,
@@ -542,7 +541,7 @@ proc registerState*(self: var ValidatorMonitor, state: ForkyBeaconState) =
   # Update indices for the validators we're monitoring
   for v in self.knownValidators..<state.validators.len:
     self.monitors.withValue(state.validators[v].pubkey, monitor):
-      monitor[][].index = some(ValidatorIndex(v))
+      monitor[][].index = Opt.some(ValidatorIndex(v))
       self.indices[uint64(v)] = monitor[]
 
       info "Started monitoring validator",

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -32,12 +32,12 @@ template findIt*(s: openArray, predicate: untyped): int =
   res
 
 proc findValidator(validators: seq[Validator], pubKey: ValidatorPubKey):
-    Option[ValidatorIndex] =
+    Opt[ValidatorIndex] =
   let idx = validators.findIt(it.pubkey == pubKey)
   if idx == -1:
-    none(ValidatorIndex)
+    Opt.none ValidatorIndex
   else:
-    some(idx.ValidatorIndex)
+    Opt.some idx.ValidatorIndex
 
 cli do(validatorsDir: string, secretsDir: string,
        startState: string, network: string):

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -966,6 +966,12 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     WEB3_ARG="--web3-url=http://127.0.0.1:${EL_RPC_PORTS[${NUM_NODE}]}"
   fi
 
+  # We enabled the keymanager on half of the nodes
+  KEYMANAGER_FLAG=""
+  if [ $((NUM_NODE % 2)) -eq 0 ]; then
+    KEYMANAGER_FLAG="--keymanager"
+  fi
+
   # TODO re-add --jwt-secret
   ${BEACON_NODE_COMMAND} \
     --config-file="${CLI_CONF_FILE}" \
@@ -976,9 +982,9 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     ${BOOTSTRAP_ARG} \
     ${WEB3_ARG} \
     ${STOP_AT_EPOCH_FLAG} \
-    --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
-    --keymanager \
+    ${KEYMANAGER_FLAG} \
     --keymanager-token-file="${DATA_DIR}/keymanager-token" \
+    --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
     --light-client=on \
     ${EXTRA_ARGS} \
@@ -1012,7 +1018,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
         --log-level="${LOG_LEVEL}" \
         ${STOP_AT_EPOCH_FLAG} \
         --data-dir="${VALIDATOR_DATA_DIR}" \
-        --keymanager \
+        ${KEYMANAGER_FLAG} \
         --keymanager-port=$((BASE_VC_KEYMANAGER_PORT + NUM_NODE)) \
         --keymanager-token-file="${DATA_DIR}/keymanager-token" \
         --beacon-node="http://127.0.0.1:$((BASE_REST_PORT + NUM_NODE))" \

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -222,7 +222,7 @@ suite "Gossip validation - Extra": # Not based on preset config
       keystoreData = KeystoreData(kind: KeystoreKind.Local,
                                   privateKey: MockPrivKeys[index])
       validator = AttachedValidator(pubkey: pubkey,
-        kind: ValidatorKind.Local, data: keystoreData, index: some(index))
+        kind: ValidatorKind.Local, data: keystoreData, index: Opt.some index)
       resMsg = waitFor getSyncCommitteeMessage(
         validator, state[].data.fork, state[].data.genesis_validators_root, slot,
         state[].root)


### PR DESCRIPTION
* Fixes a segfault during block production when the Keymanager API
  is disabled. The Keymanager is now disabled on half of the local
  testnet nodes to catch such problems in the future.

* Fixes multiple potential stalls from REST requests being done
  without a timeout. From practice, we know that such requests
  can hang forever if not cancelled with a timeout. At best,
  this would be a resource leak, at worst, it may lead to a
  full stall of the client and missed validator duties.

* Changes some Options usages to Opt (for easier use of valueOr)