### PR TITLE
re-generate test report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 nimcache/
 
 # Executables shall be put in an ignored build/ directory
@@ -39,6 +46,8 @@ build/
 /local_testnet_data*/
 /local_testnet*_data*/
 
+test_keymanager_api
+
 # Prometheus db
 /data
 # Grafana dashboards
@@ -52,7 +61,7 @@ build/
 /.update.timestamp
 resttest0_data
 
-# OSX
+# macOS
 .DS_Store
 **/.DS_Store
 

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -117,14 +117,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
-## DeleteKeys requests [Validator Client] [Preset: mainnet]
-```diff
-+ Deleting not existing key [Validator Client] [Preset: mainnet]                             OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## DeleteRemoteKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Deleting existing local key and remote key [Beacon Node] [Preset: mainnet]                 OK
@@ -132,15 +124,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Invalid Authorization Header [Beacon Node] [Preset: mainnet]                               OK
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
-```
-OK: 5/5 Fail: 0/5 Skip: 0/5
-## DeleteRemoteKeys requests [Validator Client] [Preset: mainnet]
-```diff
-+ Deleting existing local key and remote key [Validator Client] [Preset: mainnet]            OK
-+ Deleting not existing key [Validator Client] [Preset: mainnet]                             OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Diverging hardforks
@@ -195,17 +178,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Obtaining the fee recpient of a missing validator returns 404 [Beacon Node] [Preset: mainn OK
 + Obtaining the fee recpient of an unconfigured validator returns the suggested default [Bea OK
 + Setting the fee recipient on a missing validator creates a record for it [Beacon Node] [Pr OK
-```
-OK: 7/7 Fail: 0/7 Skip: 0/7
-## Fee recipient management [Validator Client] [Preset: mainnet]
-```diff
-+ Configuring the fee recpient [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
-+ Obtaining the fee recpient of a missing validator returns 404 [Validator Client] [Preset:  OK
-+ Obtaining the fee recpient of an unconfigured validator returns the suggested default [Val OK
-+ Setting the fee recipient on a missing validator creates a record for it [Validator Client OK
 ```
 OK: 7/7 Fail: 0/7 Skip: 0/7
 ## FinalizedBlocks [Preset: mainnet]
@@ -271,28 +243,12 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
-## ImportKeystores requests [Validator Client] [Preset: mainnet]
-```diff
-+ ImportKeystores/ListKeystores/DeleteKeystores [Validator Client] [Preset: mainnet]         OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## ImportRemoteKeys/ListRemoteKeys/DeleteRemoteKeys [Beacon Node] [Preset: mainnet]
 ```diff
 + Importing list of remote keys [Beacon Node] [Preset: mainnet]                              OK
 + Invalid Authorization Header [Beacon Node] [Preset: mainnet]                               OK
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
-## ImportRemoteKeys/ListRemoteKeys/DeleteRemoteKeys [Validator Client] [Preset: mainnet]
-```diff
-+ Importing list of remote keys [Validator Client] [Preset: mainnet]                         OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Interop
@@ -357,28 +313,12 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
-## ListKeys requests [Validator Client] [Preset: mainnet]
-```diff
-+ Correct token provided [Validator Client] [Preset: mainnet]                                OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## ListRemoteKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Correct token provided [Beacon Node] [Preset: mainnet]                                     OK
 + Invalid Authorization Header [Beacon Node] [Preset: mainnet]                               OK
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
-## ListRemoteKeys requests [Validator Client] [Preset: mainnet]
-```diff
-+ Correct token provided [Validator Client] [Preset: mainnet]                                OK
-+ Invalid Authorization Header [Validator Client] [Preset: mainnet]                          OK
-+ Invalid Authorization Token [Validator Client] [Preset: mainnet]                           OK
-+ Missing Authorization header [Validator Client] [Preset: mainnet]                          OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Message signatures
@@ -422,11 +362,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Serialization/deserialization [Beacon Node] [Preset: mainnet]
-```diff
-+ Deserialization test vectors                                                               OK
-```
-OK: 1/1 Fail: 0/1 Skip: 0/1
-## Serialization/deserialization [Validator Client] [Preset: mainnet]
 ```diff
 + Deserialization test vectors                                                               OK
 ```
@@ -655,4 +590,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 364/369 Fail: 0/369 Skip: 5/369
+OK: 331/336 Fail: 0/336 Skip: 5/336


### PR DESCRIPTION
A couple tests have been removed recently; re-ran `make -j test` to sync
the test report.