### PR TITLE
do not prune LC data by default

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -18,7 +18,7 @@ import
   ../beacon_chain_db_light_client,
   "."/[block_pools_types, blockchain_dag]
 
-logScope: topics = "chaindag"
+logScope: topics = "chaindag_lc"
 
 type
   HashedBeaconStateWithSyncCommittee =
@@ -128,11 +128,19 @@ proc initLightClientDataStore*(
     cfg: RuntimeConfig,
     db: LightClientDataDB): LightClientDataStore =
   ## Initialize light client data store.
+  let
+    defaultMaxPeriods = cfg.defaultLightClientDataMaxPeriods
+    maxPeriods = config.maxPeriods.get(distinctBase(SyncCommitteePeriod.high))
+  if maxPeriods < defaultMaxPeriods:
+    warn "Retaining fewer periods than recommended",
+      lightClientDataMaxPeriods = config.maxPeriods,
+      specRecommendation = defaultMaxPeriods
+
   LightClientDataStore(
     db: db,
     serve: config.serve,
     importMode: config.importMode,
-    maxPeriods: config.maxPeriods.get(cfg.defaultLightClientDataMaxPeriods),
+    maxPeriods: maxPeriods,
     onLightClientFinalityUpdate: config.onLightClientFinalityUpdate,
     onLightClientOptimisticUpdate: config.onLightClientOptimisticUpdate)
 

--- a/docs/the_nimbus_book/src/light-client-data.md
+++ b/docs/the_nimbus_book/src/light-client-data.md
@@ -13,7 +13,7 @@ The following [configuration options](./options.md) adjust the import and servin
 |------------------------------------------------|-------------|
 | <nobr>`--light-client-data-serve`</nobr>       | <ul><li>`false`: Disable light client data serving</li><li>`true` (default): Provide imported light client data to others</li></ul> |
 | <nobr>`--light-client-data-import-mode`</nobr> | <ul><li>`none`: Do not import new light client data</li><li>`only-new` (default): Incrementally import new light client data</li><li>`full`: Import historic light client data (slow startup)</li><li>`on-demand`: Like `full`, but import on demand instead of on start</li></ul> |
-| <nobr>`--light-client-data-max-periods`</nobr> | <ul><li>Controls the maximum number of sync committee periods to retain light client data</li><li>When unspecified (default), light client data is retained based on [`MIN_EPOCHS_FOR_BLOCK_REQUESTS`](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#configuration) (129 sync committee periods, ~5 months on Ethereum mainnet)</li></ul> |
+| <nobr>`--light-client-data-max-periods`</nobr> | <ul><li>Controls the maximum number of sync committee periods to retain light client data</li><li>When unspecified (default), light client data is never pruned</li></ul> |
 
 !!! warning
     Setting `--light-client-data-import-mode` to `full` or `on-demand` imports historic light client data which is computationally expensive. While importing historic light client data, validator duties may be missed.


### PR DESCRIPTION
Aligns the default retention policy for LC data with the one for blocks.
Minimum spec requirement for both blocks and LC data is ~5 months.
Additional use cases are better supported by retaining data for longer.