### PR TITLE
update EL head on slot and before attesting

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -267,7 +267,7 @@ proc storeBlock*(
     self.consensusManager.dag.markBlockVerified(
       self.consensusManager.quarantine[], signedBlock.root)
 
-  asyncSpawn self.consensusManager.updateHead(wallTime.slotOrZero)
+  self.consensusManager.updateHead(wallTime.slotOrZero)
 
   let
     updateHeadTick = Moment.now()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1343,7 +1343,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
   if node.config.strictVerification:
     verifyFinalization(node, wallSlot)
 
-  node.consensusManager[].updateHead(wallSlot)
+  asyncSpawn node.consensusManager.updateHead(wallSlot)
 
   await node.handleValidatorDuties(lastSlot, wallSlot)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1343,7 +1343,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
   if node.config.strictVerification:
     verifyFinalization(node, wallSlot)
 
-  asyncSpawn node.consensusManager.updateHead(wallSlot)
+  node.consensusManager.updateHead(wallSlot)
 
   await node.handleValidatorDuties(lastSlot, wallSlot)
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1415,7 +1415,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
         await sleepAsync(afterBlockCutoff.offset)
 
     # Time passed - we might need to select a new head in that case
-    asyncSpawn node.consensusManager.updateHead(slot)
+    node.consensusManager.updateHead(slot)
     head = node.dag.head
 
   static: doAssert attestationSlotOffset == syncCommitteeMessageSlotOffset

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1415,7 +1415,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
         await sleepAsync(afterBlockCutoff.offset)
 
     # Time passed - we might need to select a new head in that case
-    node.consensusManager[].updateHead(slot)
+    asyncSpawn node.consensusManager.updateHead(slot)
     head = node.dag.head
 
   static: doAssert attestationSlotOffset == syncCommitteeMessageSlotOffset


### PR DESCRIPTION
`forkChoiceUpdated` was only triggered when selecting a new head as part
of storing a block. However, fork choice is also refreshed on slot start
and before sending attestations. Code has been streamlined to share the
same logic regardless of the context for fork choice.