### PR TITLE
support connecting to peers without bellatrix

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -126,6 +126,11 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Missing Authorization header [Preset: mainnet]                                             OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
+## Discovery fork ID
+```diff
++ Expected fork IDs                                                                          OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Diverging hardforks
 ```diff
 + Non-tail block in common                                                                   OK
@@ -587,4 +592,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 328/333 Fail: 0/333 Skip: 5/333
+OK: 329/334 Fail: 0/334 Skip: 5/334

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -127,10 +127,10 @@ func getENRForkID*(cfg: RuntimeConfig,
     next_fork_epoch: cfg.nextForkEpochAtEpoch(epoch))
 
 func getDiscoveryForkID*(cfg: RuntimeConfig,
-                   epoch: Epoch,
-                   genesis_validators_root: Eth2Digest): ENRForkID =
-  # Until 1 epoch from fork, returns pre-fork value
-  if epoch + 1 >= cfg.ALTAIR_FORK_EPOCH:
+                         epoch: Epoch,
+                         genesis_validators_root: Eth2Digest): ENRForkID =
+  # Until 1 epoch from fork, return pre-fork value.
+  if cfg.nextForkEpochAtEpoch(epoch) - epoch <= 1:
     getENRForkID(cfg, epoch, genesis_validators_root)
   else:
     let

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -294,18 +294,30 @@ suite "Discovery fork ID":
     check:  # isCompatibleForkId(ourForkId, peerForkId)
       isCompatibleForkId(phase0ForkId, phase0ForkId)
       isCompatibleForkId(phase0ForkId, phase0AltairForkId)
-      not isCompatibleForkId(phase0AltairForkId, phase0ForkId)  # fork -1 epoch
       not isCompatibleForkId(phase0ForkId, altairForkId)
-      not isCompatibleForkId(altairForkId, phase0ForkId)
       not isCompatibleForkId(phase0ForkId, altairBellatrixForkId)
-      not isCompatibleForkId(altairBellatrixForkId, phase0ForkId)
       not isCompatibleForkId(phase0ForkId, bellatrixForkId)
-      not isCompatibleForkId(bellatrixForkId, phase0ForkId)
 
+      not isCompatibleForkId(phase0AltairForkId, phase0ForkId)  # fork -1 epoch
+      isCompatibleForkId(phase0AltairForkId, phase0AltairForkId)
+      not isCompatibleForkId(phase0AltairForkId, altairForkId)
+      not isCompatibleForkId(phase0AltairForkId, altairBellatrixForkId)
+      not isCompatibleForkId(phase0AltairForkId, bellatrixForkId)
+
+      not isCompatibleForkId(altairForkId, phase0ForkId)
+      not isCompatibleForkId(altairForkId, phase0AltairForkId)
       isCompatibleForkId(altairForkId, altairForkId)
       isCompatibleForkId(altairForkId, altairBellatrixForkId)
-      not isCompatibleForkId(altairBellatrixForkId, altairForkId)  # fork -1 ep
       not isCompatibleForkId(altairForkId, bellatrixForkId)
-      not isCompatibleForkId(bellatrixForkId, altairForkId)
 
+      not isCompatibleForkId(altairBellatrixForkId, phase0ForkId)
+      not isCompatibleForkId(altairBellatrixForkId, phase0AltairForkId)
+      not isCompatibleForkId(altairBellatrixForkId, altairForkId)  # fork -1 ep
+      isCompatibleForkId(altairBellatrixForkId, altairBellatrixForkId)
+      not isCompatibleForkId(altairBellatrixForkId, bellatrixForkId)
+
+      not isCompatibleForkId(bellatrixForkId, phase0ForkId)
+      not isCompatibleForkId(bellatrixForkId, phase0AltairForkId)
+      not isCompatibleForkId(bellatrixForkId, altairForkId)
+      not isCompatibleForkId(bellatrixForkId, altairBellatrixForkId)
       isCompatibleForkId(bellatrixForkId, bellatrixForkId)


### PR DESCRIPTION
Make discovery fork ID aware of scheduled Bellatrix fork to enable
connections to peers that don't have Bellatrix scheduled yet.
Without this, has peering issues with peers on older SW version.