### PR TITLE
allow accessing withState forky state via `forkyState`

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -487,10 +487,10 @@ proc getState(
     state = (ref ForkedHashedBeaconState)(kind: fork)[]
 
   withState(state):
-    if not db.getState(state_root, state.data, rollback):
+    if not db.getState(state_root, forkyState.data, rollback):
       return false
 
-    state.root = state_root
+    forkyState.root = state_root
 
   true
 
@@ -608,7 +608,7 @@ proc currentSyncCommitteeForPeriod*(
   dag.withUpdatedState(tmpState, bsi) do:
     withState(state):
       when stateFork >= BeaconStateFork.Altair:
-        ok state.data.current_sync_committee
+        ok forkyState.data.current_sync_committee
       else: err()
   do: err()
 
@@ -638,26 +638,26 @@ proc updateBeaconMetrics(
 
   withState(state):
     beacon_pending_deposits.set(
-      (state.data.eth1_data.deposit_count -
-        state.data.eth1_deposit_index).toGaugeValue)
+      (forkyState.data.eth1_data.deposit_count -
+        forkyState.data.eth1_deposit_index).toGaugeValue)
     beacon_processed_deposits_total.set(
-      state.data.eth1_deposit_index.toGaugeValue)
+      forkyState.data.eth1_deposit_index.toGaugeValue)
 
     beacon_current_justified_epoch.set(
-      state.data.current_justified_checkpoint.epoch.toGaugeValue)
+      forkyState.data.current_justified_checkpoint.epoch.toGaugeValue)
     beacon_current_justified_root.set(
-      state.data.current_justified_checkpoint.root.toGaugeValue)
+      forkyState.data.current_justified_checkpoint.root.toGaugeValue)
     beacon_previous_justified_epoch.set(
-      state.data.previous_justified_checkpoint.epoch.toGaugeValue)
+      forkyState.data.previous_justified_checkpoint.epoch.toGaugeValue)
     beacon_previous_justified_root.set(
-      state.data.previous_justified_checkpoint.root.toGaugeValue)
+      forkyState.data.previous_justified_checkpoint.root.toGaugeValue)
     beacon_finalized_epoch.set(
-      state.data.finalized_checkpoint.epoch.toGaugeValue)
+      forkyState.data.finalized_checkpoint.epoch.toGaugeValue)
     beacon_finalized_root.set(
-      state.data.finalized_checkpoint.root.toGaugeValue)
+      forkyState.data.finalized_checkpoint.root.toGaugeValue)
 
     let active_validators = count_active_validators(
-      state.data, state.data.slot.epoch, cache).toGaugeValue
+      forkyState.data, forkyState.data.slot.epoch, cache).toGaugeValue
     beacon_active_validators.set(active_validators)
     beacon_current_active_validators.set(active_validators)
 

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -203,9 +203,9 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
         let
           proposer = getForkedBlockField(blck[], proposer_index)
           key = withState(state[]):
-            if proposer >= state.data.validators.lenu64:
+            if proposer >= forkyState.data.validators.lenu64:
               return err("Invalid proposer in block")
-            state.data.validators.item(proposer).pubkey
+            forkyState.data.validators.item(proposer).pubkey
           cooked = key.load()
           sig = blck[].signature.load()
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -359,7 +359,7 @@ func get_initial_beacon_block*(state: bellatrix.HashedBeaconState):
 func get_initial_beacon_block*(state: ForkedHashedBeaconState):
     ForkedTrustedSignedBeaconBlock =
   withState(state):
-    ForkedTrustedSignedBeaconBlock.init(get_initial_beacon_block(state))
+    ForkedTrustedSignedBeaconBlock.init(get_initial_beacon_block(forkyState))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_block_root_at_slot
 func get_block_root_at_slot*(state: ForkyBeaconState, slot: Slot): Eth2Digest =
@@ -377,7 +377,7 @@ func get_block_root_at_slot*(
     state: ForkedHashedBeaconState, slot: Slot): Eth2Digest =
   ## Return the block root at a recent ``slot``.
   withState(state):
-    get_block_root_at_slot(state.data, slot)
+    get_block_root_at_slot(forkyState.data, slot)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_block_root
 func get_block_root*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
@@ -387,7 +387,7 @@ func get_block_root*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
 func get_block_root*(state: ForkedHashedBeaconState, epoch: Epoch): Eth2Digest =
   ## Return the block root at the start of a recent ``epoch``.
   withState(state):
-    get_block_root(state.data, epoch)
+    get_block_root(forkyState.data, epoch)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_total_balance
 template get_total_balance(
@@ -485,7 +485,7 @@ func get_attesting_indices*(state: ForkedHashedBeaconState;
 
   var idxBuf: seq[ValidatorIndex]
   withState(state):
-    for vidx in state.data.get_attesting_indices(data, bits, cache):
+    for vidx in forkyState.data.get_attesting_indices(data, bits, cache):
       idxBuf.add vidx
   idxBuf
 

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -312,14 +312,17 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
+    template forkyState: untyped {.inject, used.} = x.bellatrixData
     template state: untyped {.inject, used.} = x.bellatrixData
     body
   of BeaconStateFork.Altair:
     const stateFork {.inject, used.} = BeaconStateFork.Altair
+    template forkyState: untyped {.inject, used.} = x.altairData
     template state: untyped {.inject, used.} = x.altairData
     body
   of BeaconStateFork.Phase0:
     const stateFork {.inject, used.} = BeaconStateFork.Phase0
+    template forkyState: untyped {.inject, used.} = x.phase0Data
     template state: untyped {.inject, used.} = x.phase0Data
     body
 
@@ -373,10 +376,10 @@ template getStateField*(x: ForkedHashedBeaconState, y: untyped): untyped =
   of BeaconStateFork.Phase0:    unsafeAddr x.phase0Data.data.y)[]
 
 func getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
-  withState(x): state.root
+  withState(x): forkyState.root
 
 func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
-  withState(x): state.root = root
+  withState(x): forkyState.root = root
 
 func stateForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconStateFork =
   ## Return the current fork for the given epoch.
@@ -615,8 +618,8 @@ func readSszForkedHashedBeaconState*(cfg: RuntimeConfig, data: openArray[byte]):
     kind: cfg.stateForkAtEpoch(header.slot.epoch()))
 
   withState(result):
-    readSszBytes(data, state.data)
-    state.root = hash_tree_root(state.data)
+    readSszBytes(data, forkyState.data)
+    forkyState.root = hash_tree_root(forkyState.data)
 
 type
   ForkedBeaconBlockHeader = object

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -92,7 +92,7 @@ func get_active_validator_indices_len*(state: ForkyBeaconState, epoch: Epoch):
 func get_active_validator_indices_len*(
     state: ForkedHashedBeaconState; epoch: Epoch): uint64 =
   withState(state):
-    get_active_validator_indices_len(state.data, epoch)
+    get_active_validator_indices_len(forkyState.data, epoch)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: ForkyBeaconState): Epoch =
@@ -102,7 +102,7 @@ func get_current_epoch*(state: ForkyBeaconState): Epoch =
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_current_epoch
 func get_current_epoch*(state: ForkedHashedBeaconState): Epoch =
   ## Return the current epoch.
-  withState(state): get_current_epoch(state.data)
+  withState(state): get_current_epoch(forkyState.data)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_previous_epoch
 func get_previous_epoch*(

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -154,7 +154,7 @@ func get_shuffled_active_validator_indices*(
     cache: var StateCache, state: ForkedHashedBeaconState, epoch: Epoch):
     seq[ValidatorIndex] =
   withState(state):
-    cache.get_shuffled_active_validator_indices(state.data, epoch)
+    cache.get_shuffled_active_validator_indices(forkyState.data, epoch)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_active_validator_indices
 func count_active_validators*(state: ForkyBeaconState,
@@ -180,7 +180,7 @@ func get_committee_count_per_slot*(state: ForkedHashedBeaconState,
                                    epoch: Epoch,
                                    cache: var StateCache): uint64 =
   withState(state):
-    get_committee_count_per_slot(state.data, epoch, cache)
+    get_committee_count_per_slot(forkyState.data, epoch, cache)
 
 iterator get_committee_indices*(committee_count_per_slot: uint64): CommitteeIndex =
   for idx in 0'u64..<min(committee_count_per_slot, MAX_COMMITTEES_PER_SLOT):
@@ -271,7 +271,7 @@ func get_beacon_committee*(
   # wrapper approach (e.g., toSeq). This is a perf tradeoff for test
   # correctness/consistency.
   withState(state):
-    get_beacon_committee(state.data, slot, index, cache)
+    get_beacon_committee(forkyState.data, slot, index, cache)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee_len*(
@@ -294,7 +294,7 @@ func get_beacon_committee_len*(
     cache: var StateCache): uint64 =
   # This one is used by tests
   withState(state):
-    get_beacon_committee_len(state.data, slot, index, cache)
+    get_beacon_committee_len(forkyState.data, slot, index, cache)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#compute_shuffled_index
 func compute_shuffled_index*(
@@ -405,7 +405,7 @@ func get_beacon_proposer_index*(state: ForkedHashedBeaconState,
                                 cache: var StateCache, slot: Slot):
                                 Option[ValidatorIndex] =
   withState(state):
-    get_beacon_proposer_index(state.data, cache, slot)
+    get_beacon_proposer_index(forkyState.data, cache, slot)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#aggregation-selection
 func is_aggregator*(committee_len: uint64, slot_signature: ValidatorSig): bool =

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -215,7 +215,8 @@ func makeAttestationData*(
   ## `state` is the state corresponding to the `beacon_block_root` advanced to
   ## the slot we're attesting to.
   withState(state):
-    makeAttestationData(state.data, slot, committee_index, beacon_block_root)
+    makeAttestationData(
+      forkyState.data, slot, committee_index, beacon_block_root)
 
 func makeAttestation*(
     state: ForkedHashedBeaconState, beacon_block_root: Eth2Digest,
@@ -310,10 +311,10 @@ proc makeSyncAggregate(
     syncCommittee =
       withState(state):
         when stateFork >= BeaconStateFork.Altair:
-          if (state.data.slot + 1).is_sync_committee_period():
-            state.data.next_sync_committee
+          if (forkyState.data.slot + 1).is_sync_committee_period():
+            forkyState.data.next_sync_committee
           else:
-            state.data.current_sync_committee
+            forkyState.data.current_sync_committee
         else:
           return SyncAggregate.init()
     fork =
@@ -427,7 +428,7 @@ iterator makeTestBlocks*(
     state = assignClone(state)
   for _ in 0..<blocks:
     let
-      parent_root = withState(state[]): state.latest_block_root
+      parent_root = withState(state[]): forkyState.latest_block_root
       attestations =
         if attested:
           makeFullAttestations(


### PR DESCRIPTION
```nim
proc state*(server: HttpServerRef): HttpServerState {.raises: [Defect].} =
  ## Returns current HTTP server's state.
  if server.lifetime.finished():
  ...
```
in Chronos httpserver.nim and
```nim
template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
  case x.kind
  of BeaconStateFork.Bellatrix:                                       
    const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
    template state: untyped {.inject, used.} = x.bellatrixData
    body
```
in nimbus-eth2 `spec/forks.nim` regularly conflict, e.g., https://github.com/status-im/nimbus-eth2/pull/4019

Nim sees `state` in attempts to access the `state` template within a `withState` block and uses the Chronos procedure instead. There are easier ways around this sometimes, but fewer when it's a genuine field access.

A pure reproduction of this phenomenon is
```nim
# Can be in library, or other code not directly controlled
proc state(x: int) = discard

type A = object
  data: string

template withState(x: A, body: untyped): untyped =
  # `state` here sort of can be changed, but still costly
  template state: untyped {.inject.} = x
  body

withState(A()):
  echo(state.data)
```
Which will result in a compile-time error:
```
repro.nim(12, 10) template/generic instantiation of `withState` from here
repro.nim(13, 15) Error: undeclared field: 'data'
```

There are various workarounds, e.g., when `data` is a function, but when it's a field like this, there are fewer. So instead of continuing to gamble each `withState` usage that one will have to spend some time working around this, just rename the `withState` variable. `forkyState` is a bit clearer too, as often currently people name both the outer (forked) and inner (forky) state `state`, shadowing one with the other.

This PR doesn't complete the conversion, because there are some large PRs outstanding, and it's better to let them land, and gradually do this, while unblocking progress in the PR inspiring this which involves adding a bunch of `withState` blocks in different places exposed to Chronos's `state` function.