### PR TITLE
update engine API spec ref URLs from alpha.9 to beta.1

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -213,7 +213,7 @@ type
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
       name: "num-threads" .}: int
 
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
     jwtSecret* {.
       desc: "A file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens"
       name: "jwt-secret" .}: Option[string]

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1110,8 +1110,8 @@ proc detectPrimaryProviderComingOnline(m: Eth1Monitor) {.async.} =
     var tempProvider = tempProviderRes.get
 
     # Use one of the get/request-type methods from
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#underlying-protocol
-    # which does nit take parameters and returns a small structure, to ensure
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#underlying-protocol
+    # which doesn't take parameters and returns a small structure, to ensure
     # this works with engine API endpoints.
     let testRequest = tempProvider.web3.provider.eth_syncing()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1366,7 +1366,7 @@ proc onSecond(node: BeaconNode, time: Moment) =
   updateThreadMetrics()
 
   ## This procedure will be called once per minute.
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#engine_exchangetransitionconfigurationv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#engine_exchangetransitionconfigurationv1
   if time > node.nextExchangeTransitionConfTime and not node.eth1Monitor.isNil:
     node.nextExchangeTransitionConfTime = time + chronos.minutes(1)
     traceAsyncErrors node.eth1Monitor.exchangeTransitionConfiguration()

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -31,10 +31,10 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#transition-settings
   TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH* = FAR_FUTURE_EPOCH
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#request-1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-1
   FORKCHOICEUPDATED_TIMEOUT* = 8.seconds
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#request
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request
   NEWPAYLOAD_TIMEOUT* = 8.seconds
 
 type

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -25,9 +25,9 @@ proc base64urlEncode(x: auto): string =
   base64.encode(x, safe = true).replace("=", "")
 
 func getIatToken*(time: int64): JsonNode =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#jwt-claims
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#jwt-claims
   # "Required: iat (issued-at) claim. The EL SHOULD only accept iat timestamps
-  # which are within +-5 seconds from the current time."
+  # which are within +-60 seconds from the current time."
   #
   # https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6 describes iat
   # claims.
@@ -37,7 +37,7 @@ func getIatToken*(time: int64): JsonNode =
   %* {"iat": time}
 
 proc getSignedToken*(key: openArray[byte], payload: string): string =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#jwt-specifications
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#jwt-specifications
   # "The EL MUST support at least the following alg: HMAC + SHA256 (HS256)"
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
@@ -70,7 +70,7 @@ proc checkJwtSecret*(
     # hex-encoded secret as a jwt.hex file on the filesystem. This file can
     # then be used to provision the counterpart client.
     #
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
     const jwtSecretFilename = "jwt.hex"
     let jwtSecretPath = dataDir / jwtSecretFilename
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -389,7 +389,7 @@ proc getExecutionPayload(
     # Minimize window for Eth1 monitor to shut down connection
     await node.consensusManager.eth1Monitor.ensureDataProvider()
 
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/specification.md#request-2
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-2
     const GETPAYLOAD_TIMEOUT = 1.seconds
 
     let

--- a/scripts/test_merge_node.nim
+++ b/scripts/test_merge_node.nim
@@ -29,11 +29,11 @@ from ../beacon_chain/spec/presets import Eth1Address, defaultRuntimeConfig
 # TODO factor this out and have a version with the result of the JWT secret
 # slurp for testing purposes
 proc readJwtSecret(jwtSecretFile: string): Result[seq[byte], cstring] =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#key-distribution
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
   # If such a parameter is given, but the file cannot be read, or does not
-  # contain a hex-encoded key of at least 256 bits, the client should treat
-  # this as an error: either abort the startup, or show error and continue
-  # without exposing the authenticated port.
+  # contain a hex-encoded key of 256 bits, the client should treat this as an
+  # error: either abort the startup, or show error and continue without
+  # exposing the authenticated port.
   const MIN_SECRET_LEN = 32
 
   try:

--- a/scripts/test_merge_vectors.nim
+++ b/scripts/test_merge_vectors.nim
@@ -28,11 +28,11 @@ else:
 # TODO hm, actually factor this out into a callable function
 # and have a version with the result of the JWT secret slurp for testing purposes
 proc readJwtSecret(jwtSecretFile: string): Result[seq[byte], cstring] =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.9/src/engine/authentication.md#key-distribution
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
   # If such a parameter is given, but the file cannot be read, or does not
-  # contain a hex-encoded key of at least 256 bits, the client should treat
-  # this as an error: either abort the startup, or show error and continue
-  # without exposing the authenticated port.
+  # contain a hex-encoded key of 256 bits, the client should treat this as an
+  # error: either abort the startup, or show error and continue without
+  # exposing the authenticated port.
   const MIN_SECRET_LEN = 32
 
   try:


### PR DESCRIPTION
https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-beta.1 lists other changes.

In the engine API namespace:
-  "Auth spec shouldn't specify which methods are provided over it by @lightclient" properly applies only to ELs
- "Engine API: respond with error if payload attributes are invalid by @mkalinin" similarly modifies constraints on ELs, not directly CLs -- correct usage on CLs won't hit that either way
- "engine timeouts (redux) by @djrtwo" is done
- "Engine API: adjust error codes with JSON-RPC 2.0 spec by @mkalinin"  is done
- "Engine API: return error if forkchoice state is inconsistent by @mkalinin" applies to ELs -- to the extent it affects CLs, something has already gone wrong and CL just sees whatever error message, up to EL (but hopefully within spec)
- "Engine API: remove unauth port and refer to auth spec by @mkalinin" is likewise basically for ELs
- "Clarify the difference between `SYNCING` and `ACCEPTED` by @djrtwo" Nimbus treats them the same, which is fine and typical
- "Engine API: replace INVALID_TERMINAL_BLOCK with INVALID + lvh=0x00..00 by @mkalinin" done
- "Engine API: a few clarifications by @mkalinin" nothing relevant to change in Nimbus
- "Make td optional field on block by @lightclient" I see why it shows up here, but it's not really about the engine API directly
- "require JWT keys to be exactly 32 bytes by @tersec" -- constraint mostly on EL (JWT-token-consuming) side in this case. Nimbus always used 32 by default and now constrains JWT tokens it reads as well
- "Engine API: narrow down fcU skip conditions by @mkalinin" applies to ELs
- "Engine API: recommend to retry the call after timeout by @mkalinin" happens now by reinserting a timed-out block in the block processing queue
- "Increase JWT issued-at window to 60s by @dapplion" doesn't directly affect Nimbus, though it's nice. Updated some comment text.