### PR TITLE
accelerate EL sync with LC with `--sync-light-client`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ define CONNECT_TO_NETWORK_IN_DEV_MODE
 		--network=$(1) $(3) $(GOERLI_TESTNETS_PARAMS) \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_$(1)_$(NODE_ID) \
-		--light-client=on \
+		--sync-light-client=on \
 		--dump $(NODE_PARAMS)
 endef
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -284,16 +284,16 @@ type
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
 
-      lightClientEnable* {.
+      syncLightClient* {.
         hidden
-        desc: "BETA: Accelerate sync using light client."
+        desc: "Accelerate sync using light client"
         defaultValue: false
-        name: "light-client" .}: bool
+        name: "sync-light-client" .}: bool
 
-      lightClientTrustedBlockRoot* {.
+      trustedBlockRoot* {.
         hidden
-        desc: "BETA: Recent trusted finalized block root to initialize light client from."
-        name: "light-client-trusted-block-root" .}: Option[Eth2Digest]
+        desc: "Recent trusted finalized block root to initialize light client from"
+        name: "trusted-block-root" .}: Option[Eth2Digest]
 
       finalizedCheckpointState* {.
         desc: "SSZ file specifying a recent finalized state"

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -738,7 +738,7 @@ type BeaconHead* = object
   safeExecutionPayloadHash*, finalizedExecutionPayloadHash*: Eth2Digest
 
 proc getBeaconHead*(
-    pool: var AttestationPool, headBlock: BlockRef): BeaconHead =
+    pool: AttestationPool, headBlock: BlockRef): BeaconHead =
   let
     finalizedExecutionPayloadHash =
       pool.dag.loadExecutionBlockRoot(pool.dag.finalizedHead.blck)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -56,6 +56,7 @@ type
     # Tracking last proposal forkchoiceUpdated payload information
     # ----------------------------------------------------------------
     forkchoiceUpdatedInfo*: Opt[ForkchoiceUpdatedInformation]
+    optimisticHead: tuple[bid: BlockId, execution_block_hash: Eth2Digest]
 
 # Initialization
 # ------------------------------------------------------------------------------
@@ -117,6 +118,45 @@ from web3/engine_api_types import
 
 func `$`(h: BlockHash): string = $h.asEth2Digest
 
+func shouldSyncOptimistically*(
+    optimisticSlot, dagSlot, wallSlot: Slot): bool =
+  ## Determine whether an optimistic execution block hash should be reported
+  ## to the EL client instead of the current head as determined by fork choice.
+
+  # Check whether optimistic head is sufficiently ahead of DAG
+  const minProgress = 8 * SLOTS_PER_EPOCH  # Set arbitrarily
+  if dagSlot + minProgress > optimisticSlot:
+    return false
+
+  # Check whether optimistic head has synced sufficiently close to wall slot
+  const maxAge = 2 * SLOTS_PER_EPOCH  # Set arbitrarily
+  if optimisticSlot < max(wallSlot, maxAge.Slot) - maxAge:
+    return false
+
+  true
+
+func shouldSyncOptimistically*(self: ConsensusManager, wallSlot: Slot): bool =
+  if self.eth1Monitor == nil:
+    return false
+  if self.optimisticHead.execution_block_hash.isZero:
+    return false
+
+  shouldSyncOptimistically(
+    optimisticSlot = self.optimisticHead.bid.slot,
+    dagSlot = getStateField(self.dag.headState, slot),
+    wallSlot = wallSlot)
+
+func optimisticHead*(self: ConsensusManager): BlockId =
+  self.optimisticHead.bid
+
+func optimisticExecutionPayloadHash*(self: ConsensusManager): Eth2Digest =
+  self.optimisticHead.execution_block_hash
+
+func setOptimisticHead*(
+    self: var ConsensusManager,
+    bid: BlockId, execution_block_hash: Eth2Digest) =
+  self.optimisticHead = (bid: bid, execution_block_hash: execution_block_hash)
+
 proc runForkchoiceUpdated*(
     eth1Monitor: Eth1Monitor,
     headBlockRoot, safeBlockRoot, finalizedBlockRoot: Eth2Digest):
@@ -157,6 +197,12 @@ proc runForkchoiceUpdated*(
     error "runForkchoiceUpdated: forkchoiceUpdated failed",
       err = err.msg
     return PayloadExecutionStatus.syncing
+
+proc runForkchoiceUpdatedDiscardResult*(
+    eth1Monitor: Eth1Monitor,
+    headBlockRoot, safeBlockRoot, finalizedBlockRoot: Eth2Digest) {.async.} =
+  discard await eth1Monitor.runForkchoiceUpdated(
+    headBlockRoot, safeBlockRoot, finalizedBlockRoot)
 
 proc updateExecutionClientHead(self: ref ConsensusManager, newHead: BeaconHead)
     {.async.} =

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -125,7 +125,7 @@ func shouldSyncOptimistically*(
 
   # Check whether optimistic head is sufficiently ahead of DAG
   const minProgress = 8 * SLOTS_PER_EPOCH  # Set arbitrarily
-  if dagSlot + minProgress > optimisticSlot:
+  if optimisticSlot < dagSlot or optimisticSlot - dagSlot < minProgress:
     return false
 
   # Check whether optimistic head has synced sufficiently close to wall slot

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -414,7 +414,7 @@ proc get_head*(self: var ForkChoice,
     self.checkpoints.proposer_boost_root)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/fork_choice/safe-block.md#get_safe_beacon_block_root
-func get_safe_beacon_block_root*(self: var ForkChoice): Eth2Digest =
+func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
   # Use most recent justified block as a stopgap
   self.checkpoints.justified.checkpoint.root
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -81,7 +81,7 @@ programMain:
           if blck.message.is_execution_block:
             template payload(): auto = blck.message.body.execution_payload
 
-            if eth1Monitor != nil:
+            if eth1Monitor != nil and not payload.block_hash.isZero:
               await eth1Monitor.ensureDataProvider()
 
               # engine_newPayloadV1
@@ -93,7 +93,6 @@ programMain:
                 safeBlockRoot = payload.block_hash,  # stub value
                 finalizedBlockRoot = ZERO_HASH)
         else: discard
-      return
     optimisticProcessor = initOptimisticProcessor(
       getBeaconTime, optimisticHandler)
 
@@ -139,7 +138,8 @@ programMain:
   lightClient.trustedBlockRoot = some config.trustedBlockRoot
 
   # Full blocks gossip is required to portably drive an EL client:
-  # - EL clients may not sync when only driven with `forkChoiceUpdated`
+  # - EL clients may not sync when only driven with `forkChoiceUpdated`,
+  #   e.g., Geth: "Forkchoice requested unknown head"
   # - `newPayload` requires the full `ExecutionPayload` (most of block content)
   # - `ExecutionPayload` block root is not available in `BeaconBlockHeader`,
   #   so won't be exchanged via light client gossip

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -35,6 +35,8 @@ The following options are available:
      --secrets-dir             A directory containing validator keystore passwords.
      --wallets-dir             A directory containing wallet files.
      --web3-url                One or more execution layer Web3 provider URLs.
+     --require-engine-api-in-bellatrix  Require Nimbus to be configured with an Engine API end-point after the Bellatrix
+                               fork epoch [=true].
      --non-interactive         Do not display interative prompts. Quit on missing configuration.
      --netkey-file             Source of network (secp256k1) private key file (random|<path>) [=random].
      --insecure-netkey-password  Use pre-generated INSECURE password for network private key file [=false].

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -986,7 +986,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --keymanager-token-file="${DATA_DIR}/keymanager-token" \
     --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
-    --light-client=on \
+    --sync-light-client=on \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &
 


### PR DESCRIPTION
When the BN-embedded LC makes sync progress, pass the corresponding
execution block hash to the EL via `engine_forkchoiceUpdatedV1`.
This allows the EL to sync to wall slot while the chain DAG is behind.
Renamed `--light-client` to `--sync-light-client` for clarity, and
`--light-client-trusted-block-root` to `--trusted-block-root` for
consistency with `nimbus_light_client`.

Note that this does not work well in practice at this time:
- Geth sticks to the optimistic sync:
  "Ignoring payload while snap syncing" (when passing the LC head)
  "Forkchoice requested unknown head" (when updating to LC head)
- Nethermind syncs to LC head but does not report ancestors as VALID,
  so the main forward sync is still stuck in optimistic mode:
  "Pre-pivot block, ignored and returned Syncing"

To aid EL client teams in fixing those issues, having this available
as a hidden option is still useful.