### PR TITLE
refactor `newPayload` timeout/retry handling

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -397,7 +397,6 @@ proc processBlock(
       if res.isOk(): Result[void, BlockError].ok()
       else: Result[void, BlockError].err(res.error()))
 
-from eth/async_utils import awaitWithTimeout
 from ../spec/datatypes/bellatrix import ExecutionPayload, SignedBeaconBlock
 
 proc newExecutionPayload*(
@@ -423,24 +422,15 @@ proc newExecutionPayload*(
 
   try:
     let
-      payloadResponse =
-        awaitWithTimeout(
-            eth1Monitor.newPayload(
-              executionPayload.asEngineExecutionPayload),
-            NEWPAYLOAD_TIMEOUT):
-          info "newPayload: newPayload timed out"
-          return Opt.none PayloadExecutionStatus
-
-          # Placeholder for type system
-          PayloadStatusV1(status: PayloadExecutionStatus.syncing)
-
+      payloadResponse = await eth1Monitor.newPayload(
+        executionPayload.asEngineExecutionPayload)
       payloadStatus = payloadResponse.status
 
     debug "newPayload: succeeded",
       parentHash = executionPayload.parent_hash,
       blockHash = executionPayload.block_hash,
       blockNumber = executionPayload.block_number,
-      payloadStatus
+      payloadStatus = $payloadStatus
 
     return Opt.some payloadStatus
   except CatchableError as err:

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -34,9 +34,6 @@ const
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-1
   FORKCHOICEUPDATED_TIMEOUT* = 8.seconds
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request
-  NEWPAYLOAD_TIMEOUT* = 8.seconds
-
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -445,13 +445,8 @@ proc getExecutionPayload(
           warn "Getting execution payload from Engine API failed",
                 payload_id, err = err.msg
           empty_execution_payload
-
       executionPayloadStatus =
-        awaitWithTimeout(
-          node.consensusManager.eth1Monitor.newExecutionPayload(payload),
-          NEWPAYLOAD_TIMEOUT):
-            info "getExecutionPayload: newPayload timed out"
-            Opt.none PayloadExecutionStatus
+        await node.consensusManager.eth1Monitor.newExecutionPayload(payload)
 
     if executionPayloadStatus.isNone or executionPayloadStatus.get in [
         PayloadExecutionStatus.invalid,


### PR DESCRIPTION
This addresses:
- it should, per spec, be retrying calls such as `newPayload` when they're crucial to forward progress. `newPayload` occurs in two timing contexts, the block processing queue which doesn't constrain the timing of the rest of Nimbus, and during block proposal, where to the extent it's required, it also constrains forward progress
- it centralizes timeout handling at the same time, because all calls to `newPayload` must respect its 8 second timeout, and simplifies calling code as a result.
- if `newPayload` isn't callable, then that's not equivalent to `SYNCING`, because `SYNCING` allows optimistic import, whereas an inability to call the EL does not, so signal that separately. All `newPayload` callers already handle `CatchableError`, so use that with an informative error message.