### PR TITLE
state/forkyState cleanup; spec URL updates; rm unused imports

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -538,11 +538,11 @@ type
         defaultValue: false
         name: "validator-monitor-totals" .}: bool
 
-      # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#fork-choice-poisoning
+      # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/sync/optimistic.md#fork-choice-poisoning
       safeSlotsToImportOptimistically* {.
         hidden
         desc: "Modify SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY"
-        # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#constants
+        # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/sync/optimistic.md#constants
         defaultValue: 128
         name: "safe-slots-to-import-optimistically" .}: uint16
 

--- a/beacon_chain/consensus_object_pools/README.md
+++ b/beacon_chain/consensus_object_pools/README.md
@@ -7,9 +7,9 @@ to specs:
 - blocks: https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#beacon_block
 - aggregate attestations: https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
 - unaggregated attestation: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
-- voluntary exits: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#voluntary_exit
-- Attester slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#attester_slashing
-- Proposer slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#proposer_slashing
+- voluntary exits: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#voluntary_exit
+- Attester slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#attester_slashing
+- Proposer slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#proposer_slashing
 
 After "gossip validation" the consensus objects can be rebroadcasted as they are optimistically good, however for internal processing further verification is needed.
 For blocks, this means verifying state transition and all contained cryptographic signatures (instead of just the proposer signature).

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1954,21 +1954,22 @@ proc preInit*(
   let genesisBlockRoot = withState(genesisState):
     if forkyState.root != getStateRoot(tailState):
       # Different tail and genesis
-      if state.data.slot >= getStateField(tailState, slot):
+      if forkyState.data.slot >= getStateField(tailState, slot):
         fatal "Tail state must be newer or the same as genesis state"
         quit 1
 
       let tail_genesis_validators_root =
         getStateField(tailState, genesis_validators_root)
-      if state.data.genesis_validators_root != tail_genesis_validators_root:
+      if  forkyState.data.genesis_validators_root !=
+          tail_genesis_validators_root:
         fatal "Tail state doesn't match genesis validators root, it is likely from a different network!",
-          genesis_validators_root = shortLog(state.data.genesis_validators_root),
+          genesis_validators_root = shortLog(forkyState.data.genesis_validators_root),
           tail_genesis_validators_root = shortLog(tail_genesis_validators_root)
         quit 1
 
-      let blck = get_initial_beacon_block(state)
+      let blck = get_initial_beacon_block(forkyState)
       db.putBlock(blck)
-      db.putState(state)
+      db.putState(forkyState)
 
       db.putGenesisBlock(blck.root)
 
@@ -1984,14 +1985,14 @@ proc preInit*(
       # BlockSlot->state_root map, so the only way the init code can find the
       # state is through the state root in the block - this could be relaxed
       # down the line
-      if blck.message.state_root != state.root:
+      if blck.message.state_root != forkyState.root:
         fatal "State must match the given block",
             tailBlck = shortLog(blck)
 
         quit 1
 
       db.putBlock(blck)
-      db.putState(state)
+      db.putState(forkyState)
 
       db.putTailBlock(blck.root)
       db.putHeadBlock(blck.root)
@@ -2001,8 +2002,8 @@ proc preInit*(
         genesisStateRoot = shortLog(getStateRoot(genesisState)),
         tailBlockRoot = shortLog(blck.root),
         tailStateRoot = shortLog(state.root),
-        fork = state.data.fork,
-        validators = state.data.validators.len()
+        fork = forkyState.data.fork,
+        validators = forkyState.data.validators.len()
 
 proc getProposer*(
     dag: ChainDAGRef, head: BlockRef, slot: Slot): Option[ValidatorIndex] =

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -12,7 +12,7 @@ else:
 
 import
   # Standard library
-  std/[options, tables],
+  std/tables,
   # Status
   stew/results,
   chronicles,

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -12,7 +12,7 @@ else:
 
 import
   # Standard library
-  std/[options, tables, typetraits],
+  std/[tables, typetraits],
   # Status libraries
   chronicles,
   stew/results,

--- a/beacon_chain/gossip_processing/README.md
+++ b/beacon_chain/gossip_processing/README.md
@@ -12,9 +12,9 @@ Gossip validation is different from consensus verification in particular for blo
 - Blocks: https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#beacon_block
 - Attestations (aggregated): https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
 - Attestations (unaggregated): https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#attestation-subnets
-- Voluntary exits: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#voluntary_exit
-- Proposer slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#proposer_slashing
-- Attester slashing: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#attester_slashing
+- Voluntary exits: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#voluntary_exit
+- Proposer slashings: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#proposer_slashing
+- Attester slashing: https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#attester_slashing
 
 There are multiple consumers of validated consensus objects:
 - a `ValidationResult.Accept` output triggers rebroadcasting in libp2p

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -165,7 +165,7 @@ func get_proposer_reward(state: ForkyBeaconState, whistleblower_reward: Gwei): G
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#slash_validator
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#modified-slash_validator
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#modified-slash_validator
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/bellatrix/beacon-chain.md#modified-slash_validator
 proc slash_validator*(
     cfg: RuntimeConfig, state: var ForkyBeaconState,
     slashed_index: ValidatorIndex, cache: var StateCache):

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -85,7 +85,7 @@ const
   ZERO_HASH* = Eth2Digest()
   MAX_GRAFFITI_SIZE* = 32
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.2/specs/phase0/p2p-interface.md#configuration
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/p2p-interface.md#configuration
   MAXIMUM_GOSSIP_CLOCK_DISPARITY* = 500.millis
 
   SLOTS_PER_ETH1_VOTING_PERIOD* =
@@ -94,7 +94,7 @@ const
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
   BASE_REWARDS_PER_EPOCH* = 4
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#misc
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#misc
   ATTESTATION_SUBNET_COUNT* = 64
 
   DEPOSIT_CONTRACT_LIMIT* = Limit(1'u64 shl DEPOSIT_CONTRACT_TREE_DEPTH)

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -70,7 +70,7 @@ func compute_epoch_signing_root*(
   let domain = get_domain(fork, DOMAIN_RANDAO, epoch, genesis_validators_root)
   compute_signing_root(epoch, domain)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#randao-reveal
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#randao-reveal
 func get_epoch_signature*(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
     privkey: ValidatorPrivKey): CookedSig =

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -368,7 +368,7 @@ proc check_voluntary_exit*(
     signed_voluntary_exit: SomeSignedVoluntaryExit;
     flags: UpdateFlags): Result[ValidatorIndex, cstring] =
   withState(state):
-    check_voluntary_exit(cfg, state.data, signed_voluntary_exit, flags)
+    check_voluntary_exit(cfg, forkyState.data, signed_voluntary_exit, flags)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#voluntary-exits
 proc process_voluntary_exit*(

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -36,7 +36,7 @@ import
 # - https://notes.ethereum.org/@djrtwo/Bkn3zpwxB#Validator-responsibilities
 #
 # Phase 0 spec - Honest Validator - how to avoid slashing
-# - https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#how-to-avoid-slashing
+# - https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#how-to-avoid-slashing
 #
 # In-depth reading on slashing conditions
 #

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/[options, tables],
+  std/tables,
   metrics, chronicles,
   ../spec/[beaconstate, forks, helpers],
   ../beacon_clock

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -274,7 +274,7 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
             fork, genesis_validators_root, web3SignerBlock)
         await v.signData(request)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#aggregate-signature
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#aggregate-signature
 proc getAttestationSignature*(v: AttachedValidator, fork: Fork,
                               genesis_validators_root: Eth2Digest,
                               data: AttestationData
@@ -391,7 +391,7 @@ proc getEpochSignature*(v: AttachedValidator, fork: Fork,
         fork, genesis_validators_root, epoch)
       await v.signData(request)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#aggregation-selection
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#aggregation-selection
 proc getSlotSignature*(v: AttachedValidator, fork: Fork,
                        genesis_validators_root: Eth2Digest, slot: Slot
                       ): Future[SignatureResult] {.async.} =

--- a/research/state_sim.nim
+++ b/research/state_sim.nim
@@ -110,10 +110,10 @@ cli do(slots = SLOTS_PER_EPOCH * 5,
           slot = forkyState.data.slot
           epoch = slot.epoch
           committees_per_slot =
-            get_committee_count_per_slot(state.data, epoch, cache)
+            get_committee_count_per_slot(forkyState.data, epoch, cache)
         for committee_index in get_committee_indices(committees_per_slot):
           let committee = get_beacon_committee(
-            state.data, slot, committee_index, cache)
+            forkyState.data, slot, committee_index, cache)
           var
             attestation = Attestation(
               aggregation_bits: CommitteeValidatorsBits.init(committee.len),

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -169,7 +169,7 @@ func makeAttestationData*(
     "Computed epoch was " & $slot.epoch &
     "  while the state current_epoch was " & $current_epoch
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#attestation-data
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#attestation-data
   AttestationData(
     slot: slot,
     index: committee_index.uint64,


### PR DESCRIPTION
Cleanups:
- continue `withState` `forkyState` transition
- some spec URL updates, for those which for various reasons didn't get caught by automated search/replace
- remove some unused `std/options` imports