### PR TITLE
clean up more properly after fcU-`INVALID`

### DIFF
--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -556,6 +556,8 @@ func nodeIsViableForHead(self: ProtoArray, node: ProtoNode): bool =
   ) and (
     (node.checkpoints.finalized == self.checkpoints.finalized) or
     (self.checkpoints.finalized.epoch == GENESIS_EPOCH)
+  ) and (
+    not node.invalid
   )
 
 # Diagnostics

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -341,7 +341,7 @@ proc storeBlock*(
         asyncSpawn self.consensusManager.runProposalForkchoiceUpdated()
       else:
         asyncSpawn self.consensusManager.updateHeadWithExecution(newHead.get)
-	# TODO if invalid, mark newHead.root as invalid
+        # TODO if invalid, mark newHead.root as invalid
   else:
     warn "Head selection failed, using previous head",
       head = shortLog(self.consensusManager.dag.head), wallSlot


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/3954

Ends up conflicting too much with https://github.com/status-im/nimbus-eth2/pull/4055 so will pause and continue/rebase after that's merged.

Basic approach is visible, though -- what remains is (a) some tests and (b) the plumbing around time functionality to enable proper forkchoice re-updating after an `INVALID`.