### PR TITLE
revise github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nimbus Eth2 (Beacon Chain)
 
-[![Github Actions CI](https://github.com/status-im/nimbus-eth2/actions/workflows/ci.yml/badge.svg)](https://github.com/status-im/nimbus-eth2/actions/workflows/ci.yml)
+[![Github Actions CI](https://github.com/status-im/nimbus-eth2/actions/workflows/ci.yml/badge.svg?branch=stable)](https://github.com/status-im/nimbus-eth2/actions/workflows/ci.yml?query=branch%3Astable)
 [![License: Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 ![Stability: experimental](https://img.shields.io/badge/stability-experimental-orange.svg)


### PR DESCRIPTION
Revise urls so that badge reflects status of the CI workflow for the stable branch and links specifically to run results for the same.

---

This is a follow-up to #4073. When I mentioned the broken badge in discord yesterday, I didn't have access to my computer so couldn't submit a PR. These changes are what I had in mind.