### PR TITLE
improve deposit processing performance

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -530,16 +530,14 @@ const
   DOMAIN_CONTRIBUTION_AND_PROOF* = DomainType([byte 0x09, 0x00, 0x00, 0x00])
 
 func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData2 =
-  let cookedKey = validator.pubkey.load() # Loading the pubkey is slow!
-  doAssert cookedKey.isSome,
-    "Cannot parse validator key: " & toHex(validator.pubkey)
+  let cookedKey = validator.pubkey.loadValid()  # `Validator` has valid key
   ImmutableValidatorData2(
-    pubkey: cookedKey.get(),
+    pubkey: cookedKey,
     withdrawal_credentials: validator.withdrawal_credentials)
 
 func getImmutableValidatorData*(
     deposit: DepositData): Opt[ImmutableValidatorData2] =
-  let cookedKey = deposit.pubkey.load()
+  let cookedKey = deposit.pubkey.load()  # Loading the pubkey is slow!
   if cookedKey.isNone:
     return err()
   ok ImmutableValidatorData2(

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -537,6 +537,15 @@ func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData2 =
     pubkey: cookedKey.get(),
     withdrawal_credentials: validator.withdrawal_credentials)
 
+func getImmutableValidatorData*(
+    deposit: DepositData): Opt[ImmutableValidatorData2] =
+  let cookedKey = deposit.pubkey.load()
+  if cookedKey.isNone:
+    return err()
+  ok ImmutableValidatorData2(
+    pubkey: cookedKey.get(),
+    withdrawal_credentials: deposit.withdrawal_credentials)
+
 template makeLimitedUInt*(T: untyped, limit: SomeUnsignedInt) =
   # A "tigher" type is often used for T, but for the range check to be effective
   # it must make sense..

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -535,15 +535,6 @@ func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData2 =
     pubkey: cookedKey,
     withdrawal_credentials: validator.withdrawal_credentials)
 
-func getImmutableValidatorData*(
-    deposit: DepositData): Opt[ImmutableValidatorData2] =
-  let cookedKey = deposit.pubkey.load()  # Loading the pubkey is slow!
-  if cookedKey.isNone:
-    return err()
-  ok ImmutableValidatorData2(
-    pubkey: cookedKey.get(),
-    withdrawal_credentials: deposit.withdrawal_credentials)
-
 template makeLimitedUInt*(T: untyped, limit: SomeUnsignedInt) =
   # A "tigher" type is often used for T, but for the range check to be effective
   # it must make sense..

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -214,9 +214,10 @@ proc verify_deposit_signature*(preset: RuntimeConfig,
   # Deposits come with compressed public keys; uncompressing them is expensive.
   # `blsVerify` fills an internal cache when using `ValidatorPubKey`.
   # To avoid filling this cache unnecessarily, uncompress explicitly here.
-  let validator = getImmutableValidatorData(deposit).valueOr:
+  let pubkey = deposit.pubkey.load()  # Loading the pubkey is slow!
+  if pubkey.isNone:
     return false
-  verify_deposit_signature(preset, deposit, validator.pubkey)
+  verify_deposit_signature(preset, deposit, pubkey.get)
 
 func compute_voluntary_exit_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest,

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -200,13 +200,23 @@ func get_deposit_signature*(message: DepositMessage, version: Version,
   blsSign(privkey, signing_root.data)
 
 proc verify_deposit_signature*(preset: RuntimeConfig,
-                               deposit: DepositData): bool =
+                               deposit: DepositData,
+                               pubkey: CookedPubKey): bool =
   let
     deposit_message = deposit.getDepositMessage()
     signing_root = compute_deposit_signing_root(
       preset.GENESIS_FORK_VERSION, deposit_message)
 
-  blsVerify(deposit.pubkey, signing_root.data, deposit.signature)
+  blsVerify(pubkey, signing_root.data, deposit.signature)
+
+proc verify_deposit_signature*(preset: RuntimeConfig,
+                               deposit: DepositData): bool =
+  # Deposits come with compressed public keys; uncompressing them is expensive.
+  # `blsVerify` fills an internal cache when using `ValidatorPubKey`.
+  # To avoid filling this cache unnecessarily, uncompress explicitly here.
+  let validator = getImmutableValidatorData(deposit).valueOr:
+    return false
+  verify_deposit_signature(preset, deposit, validator.pubkey)
 
 func compute_voluntary_exit_signing_root*(
     fork: Fork, genesis_validators_root: Eth2Digest,


### PR DESCRIPTION
When there are a lot of deposits, we decompress the public key into a crypto cache. To avoid having those caches grow unreasonably big, make sure to operate on the decompressed pubkey instead.