### PR TITLE
denote merge readiness in default graffiti

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -871,7 +871,7 @@ func init*(
 
 func defaultGraffitiBytes*(): GraffitiBytes =
   const graffitiBytes =
-    toBytes("Nimbus/" & fullVersionStr)
+    toBytes("Nimbus/" & shortVersionStr & "/🐼")  # PR #2875
   static: doAssert graffitiBytes.len <= MAX_GRAFFITI_SIZE
   distinctBase(result)[0 ..< graffitiBytes.len] = graffitiBytes
 

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -20,7 +20,7 @@ const
   versionMinor* = 8
   versionBuild* = 2
 
-  versionBlob* = "stateofus" # Single word - ends up in the default graffiti
+  versionBlob* = "stateofus" # Single word
 
   gitRevision* = strip(staticExec("git rev-parse --short HEAD"))[0..5]
 
@@ -29,7 +29,8 @@ const
   versionAsStr* =
     $versionMajor & "." & $versionMinor & "." & $versionBuild
 
-  fullVersionStr* = "v" & versionAsStr & "-" & gitRevision & "-" & versionBlob
+  shortVersionStr* = "v" & versionAsStr & "-" & gitRevision
+  fullVersionStr* = shortVersionStr & "-" & versionBlob
 
 func shortNimBanner*(): string =
   const gitPrefix = "git hash: "


### PR DESCRIPTION
Replace `-$versionBlob` in default graffiti with `/🐼` to indicate merge readiness according to social consensus.

Our current default graffiti format currently uses 32 bytes, which is right at the capacity of what is possible. If we ever have a .10 patch in Oct/Nov/Dec, we would be surprised by an overflow.
```
Nimbus/v##.##.#-######-stateofus
```