### PR TITLE
avoid rechecking bellatrix+ block signatures in state transition

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -421,7 +421,10 @@ type
     ## The block state transition has NOT been verified
     randao_reveal*: TrustedSig
     eth1_data*: Eth1Data
+      ## Eth1 data vote
+
     graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
@@ -445,7 +448,10 @@ type
     ## A full verified block
     randao_reveal*: TrustedSig
     eth1_data*: Eth1Data
+      ## Eth1 data vote
+
     graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -145,11 +145,11 @@ type
     finalized_checkpoint*: Checkpoint
 
     # Inactivity
-    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]  # [New in Altair]
 
-    # Sync
-    current_sync_committee*: SyncCommittee
-    next_sync_committee*: SyncCommittee
+    # Light client sync committees
+    current_sync_committee*: SyncCommittee     # [New in Altair]
+    next_sync_committee*: SyncCommittee        # [New in Altair]
 
     # Execution
     latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Bellatrix]
@@ -186,6 +186,7 @@ type
   SigVerifiedBeaconBlock* = object
     ## A BeaconBlock that contains verified signatures
     ## but that has not been verified for state transition
+
     slot*: Slot
     proposer_index*: uint64 # `ValidatorIndex` after validation
 
@@ -235,6 +236,8 @@ type
     attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    # [New in Altair]
     sync_aggregate*: SyncAggregate
 
     # Execution
@@ -248,11 +251,13 @@ type
     ## - ProposerSlashing (SignedBeaconBlockHeader)
     ## - AttesterSlashing (IndexedAttestation)
     ## - SignedVoluntaryExits
+    ## - SyncAggregate
     ##
+    ## However:
     ## - ETH1Data (Deposits) can contain invalid BLS signatures
     ##
     ## The block state transition has NOT been verified
-    randao_reveal*: ValidatorSig
+    randao_reveal*: TrustedSig
     eth1_data*: Eth1Data
       ## Eth1 data vote
 
@@ -260,12 +265,14 @@ type
       ## Arbitrary data
 
     # Operations
-    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
-    attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
+    proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
-    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
-    sync_aggregate*: SyncAggregate # TODO TrustedSyncAggregate after batching
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    # [New in Altair]
+    sync_aggregate*: TrustedSyncAggregate
 
     # Execution
     execution_payload*: ExecutionPayload  # [New in Bellatrix]
@@ -285,6 +292,8 @@ type
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    # [New in Altair]
     sync_aggregate*: TrustedSyncAggregate
 
     # Execution
@@ -351,9 +360,6 @@ type
 
   BoolReturnSuccessRPC = object
     success*: bool
-
-func encodeQuantityHex*(x: auto): string =
-  "0x" & x.toHex
 
 func fromHex*(T: typedesc[BloomLogs], s: string): T {.
      raises: [Defect, ValueError].} =

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -385,31 +385,32 @@ proc collectSignatureSets*(
         "collectSignatureSets: cannot load voluntary exit signature"))
 
   block:
-    # 7. SyncAggregate
-    # ----------------------------------------------------
-    withState(state):
-      when stateFork >= BeaconStateFork.Altair and
-          (signed_block is altair.SignedBeaconBlock or
-            signed_block is bellatrix.SignedBeaconBlock):
-        if signed_block.message.body.sync_aggregate.sync_committee_bits.countOnes() == 0:
-          if signed_block.message.body.sync_aggregate.sync_committee_signature != ValidatorSig.infinity():
-            return err("collectSignatureSets: empty sync aggregates need signature of point at infinity")
-        else:
-          let
-            current_sync_committee =
-              state.data.get_sync_committee_cache(cache).current_sync_committee
-            previous_slot = max(state.data.slot, Slot(1)) - 1
-            beacon_block_root = get_block_root_at_slot(state.data, previous_slot)
-            pubkey = ? aggregateAttesters(
-              current_sync_committee,
-              signed_block.message.body.sync_aggregate.sync_committee_bits,
-              validatorKeys)
+    when signed_block is phase0.SignedBeaconBlock:
+      discard
+    else:
+      # 7. SyncAggregate
+      # ----------------------------------------------------
+      withState(state):
+        when stateFork >= BeaconStateFork.Altair:
+          if signed_block.message.body.sync_aggregate.sync_committee_bits.countOnes() == 0:
+            if signed_block.message.body.sync_aggregate.sync_committee_signature != ValidatorSig.infinity():
+              return err("collectSignatureSets: empty sync aggregates need signature of point at infinity")
+          else:
+            let
+              current_sync_committee =
+                state.data.get_sync_committee_cache(cache).current_sync_committee
+              previous_slot = max(state.data.slot, Slot(1)) - 1
+              beacon_block_root = get_block_root_at_slot(state.data, previous_slot)
+              pubkey = ? aggregateAttesters(
+                current_sync_committee,
+                signed_block.message.body.sync_aggregate.sync_committee_bits,
+                validatorKeys)
 
-          sigs.add sync_committee_message_signature_set(
-            fork, genesis_validators_root, previous_slot, beacon_block_root,
-            pubkey,
-            signed_block.message.body.sync_aggregate.sync_committee_signature.loadOrExit(
-              "collectSignatureSets: cannot load signature"))
+            sigs.add sync_committee_message_signature_set(
+              fork, genesis_validators_root, previous_slot, beacon_block_root,
+              pubkey,
+              signed_block.message.body.sync_aggregate.sync_committee_signature.loadOrExit(
+                "collectSignatureSets: cannot load signature"))
 
   ok()
 


### PR DESCRIPTION
Like the other forks, these are already batch-verified - this also avoids polluting the last-resort global key cache