### PR TITLE
increase blinded block submission timeout from 1s to 4s

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -49,7 +49,7 @@ const
   delayBuckets = [-Inf, -4.0, -2.0, -1.0, -0.5, -0.1, -0.05,
                   0.05, 0.1, 0.5, 1.0, 2.0, 4.0, 8.0, Inf]
 
-  BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE = 1.seconds
+  BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE = 4.seconds
   BUILDER_STATUS_DELAY_TOLERANCE = 3.seconds
   BUILDER_VALIDATOR_REGISTRATION_DELAY_TOLERANCE = 3.seconds
 


### PR DESCRIPTION
At this point, why not -- one can't fallback to a local EL anymore.