### PR TITLE
Feature/capella

### DIFF
--- a/.projectile
+++ b/.projectile
@@ -1,0 +1,2 @@
+- ConsensusSpecPreset-mainnet.md
+- ConsensusSpecPreset-minimal.md

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -743,7 +743,7 @@ proc putState*(
   db.statesNoVal[type(value).toFork()].putSnappySSZ(
     key.data, toBeaconStateNoImmutableValidators(value))
 
-proc putState*(db: BeaconChainDB, key: Eth2Digest, value: bellatrix.BeaconState) =
+proc putState*(db: BeaconChainDB, key: Eth2Digest, value: bellatrix.BeaconState | capella.BeaconState) =
   db.updateImmutableValidators(value.validators.asSeq())
   db.statesNoVal[type(value).toFork()].putSZSSZ(
     key.data, toBeaconStateNoImmutableValidators(value))
@@ -1033,7 +1033,6 @@ proc getStateOnlyMutableValidators(
 
 proc getStateOnlyMutableValidators(
     immutableValidators: openArray[ImmutableValidatorData2],
-    # TODO: @tavurth check
     store: KvStoreRef, key: openArray[byte], output: var bellatrix.BeaconState,
     rollback: RollbackProc): bool =
   ## Load state into `output` - BeaconState is large so we want to avoid

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -719,6 +719,10 @@ template toBeaconStateNoImmutableValidators(state: bellatrix.BeaconState):
     BellatrixBeaconStateNoImmutableValidators =
   isomorphicCast[BellatrixBeaconStateNoImmutableValidators](state)
 
+template toBeaconStateNoImmutableValidators(state: capella.BeaconState):
+    CapellaBeaconStateNoImmutableValidators =
+  isomorphicCast[CapellaBeaconStateNoImmutableValidators](state)
+
 proc putState*(
     db: BeaconChainDB, key: Eth2Digest,
     value: phase0.BeaconState | altair.BeaconState) =
@@ -893,6 +897,8 @@ proc getBlockSSZ*(
     getBlockSSZ(db, key, data, altair.TrustedSignedBeaconBlock)
   of BeaconBlockFork.Bellatrix:
     getBlockSSZ(db, key, data, bellatrix.TrustedSignedBeaconBlock)
+  of BeaconBlockFork.Capella:
+    getBlockSSZ(db, key, data, capella.TrustedSignedBeaconBlock)
 
 proc getBlockSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
@@ -936,6 +942,8 @@ proc getBlockSZ*(
     getBlockSZ(db, key, data, altair.TrustedSignedBeaconBlock)
   of BeaconBlockFork.Bellatrix:
     getBlockSZ(db, key, data, bellatrix.TrustedSignedBeaconBlock)
+  of BeaconBlockFork.Capella:
+    getBlockSZ(db, key, data, capella.TrustedSignedBeaconBlock)
 
 proc getStateOnlyMutableValidators(
     immutableValidators: openArray[ImmutableValidatorData2],
@@ -1168,6 +1176,7 @@ proc containsState*(db: BeaconChainDBV0, key: Eth2Digest): bool =
     db.backend.contains(subkey(phase0.BeaconState, key)).expectDb()
 
 proc containsState*(db: BeaconChainDB, key: Eth2Digest, legacy: bool = true): bool =
+  db.statesNoVal[BeaconStateFork.Capella].contains(key.data).expectDb or
   db.statesNoVal[BeaconStateFork.Bellatrix].contains(key.data).expectDb or
   db.statesNoVal[BeaconStateFork.Altair].contains(key.data).expectDb or
   db.statesNoVal[BeaconStateFork.Phase0].contains(key.data).expectDb or

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -889,6 +889,16 @@ proc getBlockSSZ*(
 
 proc getBlockSSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
+    T: type capella.TrustedSignedBeaconBlock): bool =
+  let dataPtr = addr data # Short-lived
+  var success = true
+  func decode(data: openArray[byte]) =
+    try: dataPtr[] = decodeFramed(data)
+    except CatchableError: success = false
+  db.blocks[T.toFork].get(key.data, decode).expectDb() and success
+
+proc getBlockSSZ*(
+    db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
     fork: BeaconBlockFork): bool =
   case fork
   of BeaconBlockFork.Phase0:
@@ -926,6 +936,15 @@ proc getBlockSZ*(
 proc getBlockSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
     T: type bellatrix.TrustedSignedBeaconBlock): bool =
+  let dataPtr = addr data # Short-lived
+  var success = true
+  func decode(data: openArray[byte]) =
+    assign(dataPtr[], data)
+  db.blocks[T.toFork].get(key.data, decode).expectDb() and success
+
+proc getBlockSZ*(
+    db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
+    T: type capella.TrustedSignedBeaconBlock): bool =
   let dataPtr = addr data # Short-lived
   var success = true
   func decode(data: openArray[byte]) =

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -17,7 +17,7 @@ import
   eth/db/[kvstore, kvstore_sqlite3],
   ./networking/network_metadata, ./beacon_chain_db_immutable,
   ./spec/[eth2_ssz_serialization, eth2_merkleization, forks, state_transition],
-  ./spec/datatypes/[phase0, altair, bellatrix],
+  ./spec/datatypes/[phase0, altair, bellatrix, capella],
   "."/[beacon_chain_db_light_client, filepath]
 
 export

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -471,8 +471,7 @@ proc new*(T: type BeaconChainDB,
     lcData = db.initLightClientDataDB(LightClientDataDBNames(
       altairCurrentBranches: "lc_altair_current_branches",
       altairBestUpdates: "lc_altair_best_updates",
-      sealedPeriods: "lc_sealed_periods")
-    ).expectDb()
+      sealedPeriods: "lc_sealed_periods")).expectDb()
 
   # Versions prior to 1.4.0 (altair) stored validators in `immutable_validators`
   # which stores validator keys in compressed format - this is

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -11,7 +11,7 @@ else:
   {.push raises: [].}
 
 import
-  ./spec/datatypes/[base, altair, bellatrix],
+  ./spec/datatypes/[base, altair, bellatrix, capella],
   ./spec/[eth2_ssz_serialization, eth2_merkleization]
 
 type
@@ -181,4 +181,68 @@ type
     next_sync_committee*: SyncCommittee
 
     # Execution
-    latest_execution_payload_header*: ExecutionPayloadHeader  # [New in Bellatrix]
+    latest_execution_payload_header*: bellatrix.ExecutionPayloadHeader  # [New in Bellatrix]
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#beaconstate
+  # Memory-representation-equivalent to a Capella BeaconState for in-place SSZ
+  # reading and writing
+  CapellaBeaconStateNoImmutableValidators* = object
+    # Versioning
+    genesis_time*: uint64
+    genesis_validators_root*: Eth2Digest
+    slot*: Slot
+    fork*: Fork
+
+    # History
+    latest_block_header*: BeaconBlockHeader ##\
+    ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
+    ## Needed to process attestations, older to newer
+
+    state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*:
+      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_deposit_index*: uint64
+
+    # Registry
+    validators*: HashList[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Randomness
+    randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
+
+    # Slashings
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
+    ## Per-epoch sums of slashed effective balances
+
+    # Participation
+    previous_epoch_participation*: EpochParticipationFlags
+    current_epoch_participation*: EpochParticipationFlags
+
+    # Finality
+    justification_bits*: JustificationBits
+
+    previous_justified_checkpoint*: Checkpoint ##\
+    ## Previous epoch snapshot
+
+    current_justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
+    # Inactivity
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Sync
+    current_sync_committee*: SyncCommittee
+    next_sync_committee*: SyncCommittee
+
+    # Execution
+    latest_execution_payload_header*: capella.ExecutionPayloadHeader
+
+    # Withdrawals
+    withdrawal_queue*: List[Withdrawal, Limit capella.WITHDRAWALS_QUEUE_LIMIT]  # [New in Capella]
+    next_withdrawal_index*: WithdrawalIndex  # [New in Capella]

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -194,47 +194,40 @@ type
     fork*: Fork
 
     # History
-    latest_block_header*: BeaconBlockHeader ##\
-    ## `latest_block_header.state_root == ZERO_HASH` temporarily
-
-    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] ##\
-    ## Needed to process attestations, older to newer
+    latest_block_header*: BeaconBlockHeader
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
 
     state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
     historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
 
     # Eth1
     eth1_data*: Eth1Data
-    eth1_data_votes*:
-      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_data_votes*: List[Eth1Data, Limit EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
     eth1_deposit_index*: uint64
 
     # Registry
-    validators*: HashList[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
 
     # Slashings
-    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, uint64] ##\
-    ## Per-epoch sums of slashed effective balances
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]  # Per-epoch sums of slashed effective balances
 
     # Participation
     previous_epoch_participation*: EpochParticipationFlags
     current_epoch_participation*: EpochParticipationFlags
 
     # Finality
-    justification_bits*: JustificationBits
-
-    previous_justified_checkpoint*: Checkpoint ##\
-    ## Previous epoch snapshot
-
+    justification_bits*: JustificationBits # Bit set for every recent justified epoch
+    previous_justified_checkpoint*: Checkpoint
     current_justified_checkpoint*: Checkpoint
     finalized_checkpoint*: Checkpoint
 
     # Inactivity
-    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    inactivity_scores*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Sync
     current_sync_committee*: SyncCommittee

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -167,7 +167,7 @@ type
     # Finality
     justification_bits*: JustificationBits
 
-    previous_justified_checkpoint*: Checkpoint ##\
+    previous_justified_checkpoint*: Checkpoint
     ## Previous epoch snapshot
 
     current_justified_checkpoint*: Checkpoint
@@ -239,3 +239,8 @@ type
     # Withdrawals
     withdrawal_queue*: List[Withdrawal, Limit capella.WITHDRAWALS_QUEUE_LIMIT]  # [New in Capella]
     next_withdrawal_index*: WithdrawalIndex  # [New in Capella]
+
+    # TODO: @tavurth We should probably use ValidatorIndex here
+    #       but I see that in Altair we have a workaround
+    #       by simply putting uint64, which seems to be against the spec
+    next_partial_withdrawal_validator_index*: uint64  # [New in Capella]

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -203,7 +203,7 @@ type
 
     # Eth1
     eth1_data*: Eth1Data
-    eth1_data_votes*: List[Eth1Data, Limit EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+    eth1_data_votes*: HashList[Eth1Data, Limit EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
     eth1_deposit_index*: uint64
 
     # Registry
@@ -227,7 +227,7 @@ type
     finalized_checkpoint*: Checkpoint
 
     # Inactivity
-    inactivity_scores*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Sync
     current_sync_committee*: SyncCommittee

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -25,7 +25,7 @@ import
   ../fork_choice/fork_choice,
   ../beacon_clock
 
-export tables, results, phase0, altair, bellatrix, blockchain_dag, fork_choice
+export tables, results, phase0, altair, bellatrix, capella, blockchain_dag, fork_choice
 
 const
   ATTESTATION_LOOKBACK* =

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -481,7 +481,7 @@ func init(T: type AttestationCache, state: phase0.HashedBeaconState): T =
 
 func init(
     T: type AttestationCache,
-    state: altair.HashedBeaconState | bellatrix.HashedBeaconState,
+    state: altair.HashedBeaconState | bellatrix.HashedBeaconState | capella.HashedBeaconState,
     cache: var StateCache): T =
   # Load attestations that are scheduled for being given rewards for
   let
@@ -554,7 +554,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
     attCache =
       when state is phase0.HashedBeaconState:
         AttestationCache.init(state)
-      elif state is altair.HashedBeaconState or state is bellatrix.HashedBeaconState:
+      elif state is altair.HashedBeaconState or state is bellatrix.HashedBeaconState or state is capella.HashedBeaconState:
         AttestationCache.init(state, cache)
       else:
         static: doAssert false
@@ -609,7 +609,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
   var
     prevEpoch = state.data.get_previous_epoch()
     prevEpochSpace =
-      when state is altair.HashedBeaconState or state is bellatrix.HashedBeaconState:
+      when state is altair.HashedBeaconState or state is bellatrix.HashedBeaconState or state is capella.HashedBeaconState:
         MAX_ATTESTATIONS
       elif state is phase0.HashedBeaconState:
         state.data.previous_epoch_attestations.maxLen -

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -20,7 +20,7 @@ import
   ../spec/[
     beaconstate, eth2_merkleization, forks, helpers,
     state_transition_epoch, validator],
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   "."/[spec_cache, blockchain_dag, block_quarantine],
   ../fork_choice/fork_choice,
   ../beacon_clock

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -36,7 +36,7 @@ proc addResolvedHeadBlock(
        trustedBlock: ForkyTrustedSignedBeaconBlock,
        blockVerified: bool,
        parent: BlockRef, cache: var StateCache,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded,
+       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded | OnCapellaBlockAdded,
        stateDataDur, sigVerifyDur, stateVerifyDur: Duration
      ): BlockRef =
   doAssert state.matches_block_slot(
@@ -162,7 +162,7 @@ proc addHeadBlock*(
     signedBlock: ForkySignedBeaconBlock,
     blockVerified: bool,
     onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded
+                  OnBellatrixBlockAdded | OnCapellaBlockAdded
     ): Result[BlockRef, BlockError] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.
@@ -292,7 +292,7 @@ proc addHeadBlock*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock,
     onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded
+                  OnBellatrixBlockAdded | OnCapellaBlockAdded
     ): Result[BlockRef, BlockError] =
   addHeadBlock(
     dag, verifier, signedBlock, blockVerified = true, onBlockAdded)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -67,7 +67,8 @@ func init*(
 
 func init*(
     T: type BlockRef, root: Eth2Digest,
-    blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock): BlockRef =
+    blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock |
+          capella.SomeBeaconBlock | capella.TrustedBeaconBlock): BlockRef =
   BlockRef.init(
     root, some Eth2Digest(blck.body.execution_payload.block_hash), blck.slot)
 

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -12,7 +12,7 @@ else:
 
 import
   chronicles,
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/forks
 
 export chronicles, forks

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -298,6 +298,12 @@ type
     epochRef: EpochRef,
     unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 
+  OnCapellaBlockAdded* = proc(
+    blckRef: BlockRef,
+    blck: capella.TrustedSignedBeaconBlock,
+    epochRef: EpochRef,
+    unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
+
   HeadChangeInfoObject* = object
     slot*: Slot
     block_root* {.serializedFieldName: "block".}: Eth2Digest

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -17,7 +17,7 @@ import
   chronicles,
   # Internals
   ../spec/[signatures_batch, forks, helpers],
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ".."/[beacon_chain_db, era_db],
   ../validators/validator_monitor,
   ./block_dag, block_pools_types_light_client

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -16,7 +16,7 @@ import
   metrics, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
     state_transition, validator],
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ".."/[beacon_chain_db, era_db],
   "."/[block_pools_types, block_quarantine]
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -765,6 +765,12 @@ proc applyBlock(
     state_transition(
       dag.cfg, state, data, cache, info,
       dag.updateFlags + {slotProcessed}, noRollback)
+  of BeaconBlockFork.Capella:
+    let data = getBlock(dag, bid, capella.TrustedSignedBeaconBlock).valueOr:
+      return err("Block load failed")
+    state_transition(
+      dag.cfg, state, data, cache, info,
+      dag.updateFlags + {slotProcessed}, noRollback)
 
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
@@ -897,6 +903,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of BeaconStateFork.Phase0: genesisFork(cfg)
       of BeaconStateFork.Altair: altairFork(cfg)
       of BeaconStateFork.Bellatrix: bellatrixFork(cfg)
+      of BeaconStateFork.Capella:   capellaFork(cfg)
     stateFork = getStateField(dag.headState, fork)
 
   if stateFork != configFork:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -14,7 +14,7 @@ import
   # Status libraries
   stew/[bitops2, objects],
   # Beacon chain internals
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain_db_light_client,
   "."/[block_pools_types, blockchain_dag]
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -22,10 +22,12 @@ logScope: topics = "chaindag_lc"
 
 type
   HashedBeaconStateWithSyncCommittee =
+    capella.HashedBeaconState |
     bellatrix.HashedBeaconState |
     altair.HashedBeaconState
 
   TrustedSignedBeaconBlockWithSyncAggregate =
+    capella.TrustedSignedBeaconBlock |
     bellatrix.TrustedSignedBeaconBlock |
     altair.TrustedSignedBeaconBlock
 
@@ -709,7 +711,10 @@ proc processNewBlockForLightClient*(
   if signedBlock.message.slot < dag.lcDataStore.cache.tailSlot:
     return
 
-  when signedBlock is bellatrix.TrustedSignedBeaconBlock:
+  when signedBlock is capella.TrustedSignedBeaconBlock:
+    dag.cacheLightClientData(state.capellaData, signedBlock.toBlockId())
+    dag.createLightClientUpdates(state.capellaData, signedBlock, parentBid)
+  elif signedBlock is bellatrix.TrustedSignedBeaconBlock:
     dag.cacheLightClientData(state.bellatrixData, signedBlock.toBlockId())
     dag.createLightClientUpdates(state.bellatrixData, signedBlock, parentBid)
   elif signedBlock is altair.TrustedSignedBeaconBlock:

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -13,6 +13,7 @@ else:
 import
   chronicles, chronos,
   ../spec/datatypes/base,
+  ../spec/datatypes/[bellatrix, capella],
   ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
   ../eth1/eth1_monitor
 
@@ -319,7 +320,7 @@ proc runProposalForkchoiceUpdated*(self: ref ConsensusManager) {.async.} =
         return
 
       self.forkchoiceUpdatedInfo = Opt.some ForkchoiceUpdatedInformation(
-        payloadId: bellatrix.PayloadID(fcResult.payloadId.get),
+        payloadId: base.PayloadID(fcResult.payloadId.get),
         headBlockRoot: headBlockRoot,
         safeBlockRoot: beaconHead.safeExecutionPayloadHash,
         finalizedBlockRoot: beaconHead.finalizedExecutionPayloadHash,

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -320,7 +320,7 @@ proc runProposalForkchoiceUpdated*(self: ref ConsensusManager) {.async.} =
         return
 
       self.forkchoiceUpdatedInfo = Opt.some ForkchoiceUpdatedInformation(
-        payloadId: base.PayloadID(fcResult.payloadId.get),
+        payloadId: bellatrix.PayloadID(fcResult.payloadId.get),
         headBlockRoot: headBlockRoot,
         safeBlockRoot: beaconHead.safeExecutionPayloadHash,
         finalizedBlockRoot: beaconHead.finalizedExecutionPayloadHash,

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -8,7 +8,7 @@ import
   std/os,
   stew/results, snappy, taskpools,
   ../ncli/e2store, eth/keys,
-  ./spec/datatypes/[altair, bellatrix, phase0],
+  ./spec/datatypes/[altair, bellatrix, phase0, capella],
   ./spec/[beaconstate, forks, signatures_batch],
   ./consensus_object_pools/block_dag # TODO move to somewhere else to avoid circular deps
 
@@ -361,7 +361,7 @@ iterator getBlockIds*(
     # `case` ensures we're on a fork for which the `PartialBeaconState`
     # definition is consistent
     case db.cfg.stateForkAtEpoch(slot.epoch)
-    of BeaconStateFork.Phase0, BeaconStateFork.Altair, BeaconStateFork.Bellatrix:
+    of BeaconStateFork.Phase0, BeaconStateFork.Altair, BeaconStateFork.Bellatrix, BeaconStateFork.Capella:
       let stateSlot = (slot.era() + 1).start_slot()
       if not getPartialState(db, historical_roots, stateSlot, state[]):
         state = nil # No `return` in iterators

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -573,6 +573,7 @@ proc forkchoiceUpdated*(p: Eth1Monitor,
       finalizedBlockHash: finalizedBlock.asBlockHash),
     none(engine_api.PayloadAttributesV1))
 
+
 proc forkchoiceUpdated*(p: Eth1Monitor,
                         headBlock, safeBlock, finalizedBlock: Eth2Digest,
                         timestamp: uint64,

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -318,7 +318,6 @@ func asEth2Digest*(x: BlockHash): Eth2Digest =
 template asBlockHash*(x: Eth2Digest): BlockHash =
   BlockHash(x.data)
 
-# NOTE: First param here added to distinguish between forks
 func asConsensusExecutionPayload*(payload_id: bellatrix.PayloadID, rpcExecutionPayload: ExecutionPayloadV1):
     bellatrix.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): bellatrix.Transaction =
@@ -344,8 +343,6 @@ func asConsensusExecutionPayload*(payload_id: bellatrix.PayloadID, rpcExecutionP
     transactions: List[bellatrix.Transaction, bellatrix.MAX_TRANSACTIONS_PER_PAYLOAD].init(
       mapIt(rpcExecutionPayload.transactions, it.getTransaction)))
 
-# NOTE: First param here added to distinguish between forks
-# TODO: @tavurth is there a nicer way to write this?
 func asConsensusExecutionPayload*(payload_id: capella.PayloadID, rpcExecutionPayload: ExecutionPayloadV1):
     capella.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): capella.Transaction =
@@ -533,7 +530,7 @@ proc getPayload*(p: Eth1Monitor,
     epr.complete(default(engine_api.ExecutionPayloadV1))
     return epr
 
-  p.dataProvider.web3.provider.engine_getPayloadV1(FixedBytes[8] payloadId)
+  p.dataProvider.web3.provider.engine_getPayloadV1(FixedBytes[8] payloadId.buf)
 
 proc getPayload*(p: Eth1Monitor,
                  payloadId: capella.PayloadID): Future[engine_api.ExecutionPayloadV1] =
@@ -544,7 +541,7 @@ proc getPayload*(p: Eth1Monitor,
     epr.complete(default(engine_api.ExecutionPayloadV1))
     return epr
 
-  p.dataProvider.web3.provider.engine_getPayloadV1(FixedBytes[8] payloadId)
+  p.dataProvider.web3.provider.engine_getPayloadV1(FixedBytes[8] payloadId.buf)
 
 proc newPayload*(p: Eth1Monitor, payload: engine_api.ExecutionPayloadV1):
     Future[PayloadStatusV1] =

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -330,7 +330,7 @@ macro asConsensusExecutionPayload*(kind: untyped, rpcExecutionPayload: Execution
     `kind`.ExecutionPayload(
       parent_hash: rpcExecutionPayload.parentHash.asEth2Digest,
       feeRecipient:
-      `kind`.ExecutionAddress(data: rpcExecutionPayload.feeRecipient.distinctBase),
+      ExecutionAddress(data: rpcExecutionPayload.feeRecipient.distinctBase),
       state_root: rpcExecutionPayload.stateRoot.asEth2Digest,
       receipts_root: rpcExecutionPayload.receiptsRoot.asEth2Digest,
       logs_bloom: `kind`.BloomLogs(data: rpcExecutionPayload.logsBloom.distinctBase),
@@ -348,32 +348,9 @@ macro asConsensusExecutionPayload*(kind: untyped, rpcExecutionPayload: Execution
         mapIt(rpcExecutionPayload.transactions, it.getTransaction)))
 
 
-func asEngineExecutionPayload*(executionPayload: bellatrix.ExecutionPayload):
+func asEngineExecutionPayload*(executionPayload: bellatrix.ExecutionPayload | capella.ExecutionPayload):
     ExecutionPayloadV1 =
-  template getTypedTransaction(tt: bellatrix.Transaction): TypedTransaction =
-    TypedTransaction(tt.distinctBase)
-
-  engine_api.ExecutionPayloadV1(
-    parentHash: executionPayload.parent_hash.asBlockHash,
-    feeRecipient: Address(executionPayload.fee_recipient.data),
-    stateRoot: executionPayload.state_root.asBlockHash,
-    receiptsRoot: executionPayload.receipts_root.asBlockHash,
-    logsBloom:
-      FixedBytes[BYTES_PER_LOGS_BLOOM](executionPayload.logs_bloom.data),
-    prevRandao: executionPayload.prev_randao.asBlockHash,
-    blockNumber: Quantity(executionPayload.block_number),
-    gasLimit: Quantity(executionPayload.gas_limit),
-    gasUsed: Quantity(executionPayload.gas_used),
-    timestamp: Quantity(executionPayload.timestamp),
-    extraData:
-      DynamicBytes[0, MAX_EXTRA_DATA_BYTES](executionPayload.extra_data),
-    baseFeePerGas: executionPayload.base_fee_per_gas,
-    blockHash: executionPayload.block_hash.asBlockHash,
-    transactions: mapIt(executionPayload.transactions, it.getTypedTransaction))
-
-func asEngineExecutionPayload*(executionPayload: capella.ExecutionPayload):
-    ExecutionPayloadV1 =
-  template getTypedTransaction(tt: capella.Transaction): TypedTransaction =
+  template getTypedTransaction(tt: Transaction): TypedTransaction =
     TypedTransaction(tt.distinctBase)
 
   engine_api.ExecutionPayloadV1(
@@ -540,7 +517,6 @@ proc forkchoiceUpdated*(p: Eth1Monitor,
       safeBlockHash: safeBlock.asBlockHash,
       finalizedBlockHash: finalizedBlock.asBlockHash),
     none(engine_api.PayloadAttributesV1))
-
 
 proc forkchoiceUpdated*(p: Eth1Monitor,
                         headBlock, safeBlock, finalizedBlock: Eth2Digest,

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -478,7 +478,8 @@ proc getBlockByNumber*(p: Web3DataProviderRef,
   except ValueError as exc: raiseAssert exc.msg # Never fails
   p.web3.provider.eth_getBlockByNumber(hexNumber, false)
 
-proc getPayload*(p: Eth1Monitor, payloadId: base.PayloadID): Future[engine_api.ExecutionPayloadV1] =
+proc getPayload*(p: Eth1Monitor, payloadId: bellatrix.PayloadID):
+    Future[engine_api.ExecutionPayloadV1] =
   # Eth1 monitor can recycle connections without (external) warning; at least,
   # don't crash.
   if p.isNil or p.dataProvider.isNil:

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -319,7 +319,7 @@ template asBlockHash*(x: Eth2Digest): BlockHash =
   BlockHash(x.data)
 
 # NOTE: First param here added to distinguish between forks
-func asConsensusExecutionPayload*(_: Option[bellatrix.PayloadID], rpcExecutionPayload: ExecutionPayloadV1):
+func asConsensusExecutionPayload*(payload_id: bellatrix.PayloadID, rpcExecutionPayload: ExecutionPayloadV1):
     bellatrix.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): bellatrix.Transaction =
     bellatrix.Transaction.init(tt.distinctBase)
@@ -346,7 +346,7 @@ func asConsensusExecutionPayload*(_: Option[bellatrix.PayloadID], rpcExecutionPa
 
 # NOTE: First param here added to distinguish between forks
 # TODO: @tavurth is there a nicer way to write this?
-func asConsensusExecutionPayload*(_: Option[capella.PayloadID], rpcExecutionPayload: ExecutionPayloadV1):
+func asConsensusExecutionPayload*(payload_id: capella.PayloadID, rpcExecutionPayload: ExecutionPayloadV1):
     capella.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): capella.Transaction =
     capella.Transaction.init(tt.distinctBase)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -17,7 +17,7 @@ import
   stew/[objects, results], chronicles,
   # Internal
   ../spec/[beaconstate, helpers, state_transition_block],
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   # Fork choice
   ./fork_choice_types, ./proto_array,
   ../consensus_object_pools/[spec_cache, blockchain_dag]

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -422,8 +422,8 @@ proc processBlock(
       else: Result[void, BlockError].err(res.error()))
 
 from eth/async_utils import awaitWithTimeout
-from ../spec/datatypes/bellatrix import ExecutionPayload, SignedBeaconBlock
-from ../spec/datatypes/capella import ExecutionPayload, SignedBeaconBlock
+from ../spec/datatypes/capella import ExecutionPayload
+from ../spec/datatypes/bellatrix import ExecutionPayload
 
 proc newExecutionPayload*(
     eth1Monitor: Eth1Monitor, executionPayload: capella.ExecutionPayload):
@@ -591,9 +591,10 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
 
              let executionPayload =
                withBlck(blck.blck):
-                 when stateFork >= BeaconStateFork.Bellatrix:
+                 if stateFork >= BeaconStateFork.Bellatrix:
                    blck.message.body.execution_payload
                  else:
+                   # Unreachable
                    doAssert false
                    default(bellatrix.ExecutionPayload) # satisfy Nim
 

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -564,8 +564,11 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
 
     let
       blck = await self[].blockQueue.popFirst()
+
       hasExecutionPayload =
-        withBlck(blck.blck): blck.message.is_execution_block
+        withBlck(blck.blck):
+          blck.message.is_execution_block
+
       executionPayloadStatus =
        if hasExecutionPayload:
          # Eth1 syncing is asynchronous from this
@@ -591,7 +594,7 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
 
              let executionPayload =
                withBlck(blck.blck):
-                 if stateFork >= BeaconStateFork.Bellatrix:
+                 when stateFork >= BeaconStateFork.Bellatrix:
                    blck.message.body.execution_payload
                  else:
                    # Unreachable

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -15,7 +15,7 @@ import
   chronicles, chronos, metrics,
   stew/results,
   # Internals
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/[
     beaconstate, state_transition_block, forks, helpers, network, signatures],
   ../consensus_object_pools/[

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -29,7 +29,7 @@ import
   eth/[keys, async_utils], eth/p2p/p2p_protocol_dsl,
   eth/net/nat, eth/p2p/discoveryv5/[enr, node, random2],
   ".."/[version, conf, beacon_clock, conf_light_client],
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/[eth2_ssz_serialization, network, helpers, forks],
   ../validators/keystore_management,
   "."/[eth2_discovery, libp2p_json_serialization, peer_pool, peer_scores]

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2542,6 +2542,11 @@ proc broadcastBeaconBlock*(
   node.broadcast(topic, blck)
 
 proc broadcastBeaconBlock*(
+    node: Eth2Node, blck: capella.SignedBeaconBlock): Future[SendResult] =
+  let topic = getBeaconBlocksTopic(node.forkDigests.capella)
+  node.broadcast(topic, blck)
+
+proc broadcastBeaconBlock*(
     node: Eth2Node, forked: ForkedSignedBeaconBlock): Future[SendResult] =
   withBlck(forked): node.broadcastBeaconBlock(blck)
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -897,6 +897,8 @@ func upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState):
 func upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     ref bellatrix.BeaconState =
   let epoch = get_current_epoch(pre)
+  let executionHeader = bellatrix.ExecutionPayloadHeader()
+
   (ref bellatrix.BeaconState)(
     # Versioning
     genesis_time: pre.genesis_time,
@@ -947,7 +949,7 @@ func upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     next_sync_committee: pre.next_sync_committee,
 
     # Execution-layer
-    latest_execution_payload_header: bellatrix.ExecutionPayloadHeader()
+    latest_execution_payload_header: executionHeader
   )
 
 template isValidInState*(idx: ValidatorIndex, state: ForkyBeaconState): bool =

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -901,8 +901,7 @@ proc upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
   let epoch = get_current_epoch(pre)
 
   # TODO: @tavurth why does this not work when calling the type directly?
-  type
-    HeaderType = bellatrix.ExecutionPayloadHeader
+  type HeaderType = bellatrix.ExecutionPayloadHeader
 
   let executionHeader = HeaderType()
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -756,7 +756,7 @@ proc process_attestation*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#get_next_sync_committee_indices
-func get_next_sync_committee_keys(state: altair.BeaconState | bellatrix.BeaconState):
+func get_next_sync_committee_keys(state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState):
     array[SYNC_COMMITTEE_SIZE, ValidatorPubKey] =
   ## Return the sequence of sync committee indices, with possible duplicates,
   ## for the next sync committee.
@@ -792,7 +792,7 @@ func get_next_sync_committee_keys(state: altair.BeaconState | bellatrix.BeaconSt
   res
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#get_next_sync_committee
-func get_next_sync_committee*(state: altair.BeaconState | bellatrix.BeaconState):
+func get_next_sync_committee*(state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState):
     SyncCommittee =
   ## Return the *next* sync committee for a given ``state``.
   var res: SyncCommittee

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -160,8 +160,12 @@ func get_whistleblower_reward*(validator_effective_balance: Gwei): Gwei =
 func get_proposer_reward(state: ForkyBeaconState, whistleblower_reward: Gwei): Gwei =
   when state is phase0.BeaconState:
     whistleblower_reward div PROPOSER_REWARD_QUOTIENT
-  elif state is ForkyUpgradedBeaconState:
-    whistleblower_reward * PROPOSER_WEIGHT div WEIGHT_DENOMINATOR
+  elif state in [
+    altair.BeaconState,
+    bellatrix.BeaconState,
+    capella.BeaconState,
+  ]:
+   whistleblower_reward * PROPOSER_WEIGHT div WEIGHT_DENOMINATOR
   else:
     {.fatal: "invalid BeaconState type".}
 
@@ -370,7 +374,6 @@ func get_initial_beacon_block*(state: capella.HashedBeaconState):
   capella.TrustedSignedBeaconBlock(
     message: message, root: hash_tree_root(message))
 
-
 func get_initial_beacon_block*(state: ForkedHashedBeaconState):
     ForkedTrustedSignedBeaconBlock =
   withState(state):
@@ -577,7 +580,7 @@ func check_attestation_index*(
     Result[CommitteeIndex, cstring] =
   check_attestation_index(data.index, committees_per_slot)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/beacon-chain.md#get_attestation_participation_flag_indices
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#get_attestation_participation_flag_indices
 func get_attestation_participation_flag_indices(state: ForkyUpgradedBeaconState,
                                                 data: AttestationData,
                                                 inclusion_delay: uint64): seq[int] =
@@ -896,7 +899,7 @@ func upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState):
   post
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/fork.md#upgrading-the-state
-proc upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
+func upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     ref bellatrix.BeaconState =
   let epoch = get_current_epoch(pre)
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -899,7 +899,12 @@ func upgrade_to_altair*(cfg: RuntimeConfig, pre: phase0.BeaconState):
 proc upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     ref bellatrix.BeaconState =
   let epoch = get_current_epoch(pre)
-  let executionHeader = bellatrix.ExecutionPayloadHeader()
+
+  # TODO: @tavurth why does this not work when calling the type directly?
+  type
+    HeaderType = bellatrix.ExecutionPayloadHeader
+
+  let executionHeader = HeaderType()
 
   (ref bellatrix.BeaconState)(
     # Versioning
@@ -953,6 +958,7 @@ proc upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     # Execution-layer
     latest_execution_payload_header: executionHeader
   )
+
 
 template isValidInState*(idx: ValidatorIndex, state: ForkyBeaconState): bool =
   idx.uint64 < state.validators.lenu64

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -950,64 +950,6 @@ func upgrade_to_bellatrix*(cfg: RuntimeConfig, pre: altair.BeaconState):
     latest_execution_payload_header: bellatrix.ExecutionPayloadHeader()
   )
 
-# TODO: @tavurth Check this is correct
-# https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/fork.md#upgrading-the-state
-func upgrade_to_capella*(cfg: RuntimeConfig, pre: bellatrix.BeaconState):
-    ref capella.BeaconState =
-  let epoch = get_current_epoch(pre)
-  (ref capella.BeaconState)(
-    # Versioning
-    genesis_time: pre.genesis_time,
-    genesis_validators_root: pre.genesis_validators_root,
-    slot: pre.slot,
-    fork: Fork(
-        previous_version: pre.fork.current_version,
-        current_version: cfg.CAPELLA_FORK_VERSION,
-        epoch: epoch,
-    ),
-
-    # History
-    latest_block_header: pre.latest_block_header,
-    block_roots: pre.block_roots,
-    state_roots: pre.state_roots,
-    historical_roots: pre.historical_roots,
-
-    # Eth1
-    eth1_data: pre.eth1_data,
-    eth1_data_votes: pre.eth1_data_votes,
-    eth1_deposit_index: pre.eth1_deposit_index,
-
-    # Registry
-    validators: pre.validators,
-    balances: pre.balances,
-
-    # Randomness
-    randao_mixes: pre.randao_mixes,
-
-    # Slashings
-    slashings: pre.slashings,
-
-    # Participation
-    previous_epoch_participation: pre.previous_epoch_participation,
-    current_epoch_participation: pre.current_epoch_participation,
-
-    # Finality
-    justification_bits: pre.justification_bits,
-    previous_justified_checkpoint: pre.previous_justified_checkpoint,
-    current_justified_checkpoint: pre.current_justified_checkpoint,
-    finalized_checkpoint: pre.finalized_checkpoint,
-
-    # Inactivity
-    inactivity_scores: pre.inactivity_scores,
-
-    # Sync
-    current_sync_committee: pre.current_sync_committee,
-    next_sync_committee: pre.next_sync_committee,
-
-    # Execution-layer
-    latest_execution_payload_header: capella.ExecutionPayloadHeader()
-  )
-
 template isValidInState*(idx: ValidatorIndex, state: ForkyBeaconState): bool =
   idx.uint64 < state.validators.lenu64
 

--- a/beacon_chain/spec/datatypes/Readme.org
+++ b/beacon_chain/spec/datatypes/Readme.org
@@ -1,0 +1,31 @@
+#+title: Readme
+
+** Specs and how they extend
+
+These specs are extended from the base state.
+
+When we find a specsheet such as [[https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#beaconstate][the Capella spec]] we only need to implement the changes from the base state.
+
+It's nice to keep a link to the relevant part of the docs in your code for later reference.
+
+#+begin_src nim
+# https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayloadheader
+type ExecutionPayloadHeader* = object
+    # Execution block header fields
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32
+    block_number: uint64
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    # Extra payload fields
+    block_hash: Hash32  # Hash of execution block
+    transactions_root: Root
+    withdrawals_root: Root  # [New in Capella]
+#+end_src

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -511,9 +511,6 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
-  # NOTE: for nicer errors
-  SomeAltairBeaconBlock* =
-    SomeBeaconBlock
 
   SomeSyncAggregate* = SyncAggregate | TrustedSyncAggregate
 
@@ -610,7 +607,7 @@ template len*(epochFlags: EpochParticipationFlags): int =
 template data*(epochFlags: EpochParticipationFlags): untyped =
   asHashList(epochFlags).data
 
-func shortLog*(v: SomeAltairBeaconBlock): auto =
+func shortLog*(v: SomeBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -511,6 +511,9 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
+  # NOTE: for nicer errors
+  SomeAltairBeaconBlock* =
+    SomeBeaconBlock
 
   SomeSyncAggregate* = SyncAggregate | TrustedSyncAggregate
 
@@ -607,7 +610,7 @@ template len*(epochFlags: EpochParticipationFlags): int =
 template data*(epochFlags: EpochParticipationFlags): untyped =
   asHashList(epochFlags).data
 
-func shortLog*(v: SomeBeaconBlock): auto =
+func shortLog*(v: SomeAltairBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -102,6 +102,9 @@ type
     beacon_block_root*: Eth2Digest
       ## Block root for this signature
 
+    # TODO: This should probably be `ValidatiorIndex`
+    #       as the spec calls for 32 bit.
+    #       This should be reviewed as it could be a bug
     validator_index*: uint64 # `ValidatorIndex` after validation
       ## Index of the validator that produced this signature
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -139,6 +139,9 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#custom-types
   Eth2Domain* = array[32, byte]
 
+  # Used in capella and bellatrix
+  PayloadID* = array[8, byte]
+
   ValidatorIndex* = distinct uint32
     ## Each validator has an index that is used in lieu of the public key to
     ## identify the validator. The index is assigned according to the order of

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -926,6 +926,9 @@ template isomorphicCast*[T, U](x: U): T =
   # Each of these pairs of types has ABI-compatible memory representations.
   static: doAssert (T is ref) == (U is ref)
   when T is ref:
+    # NOTE: Uncomment for debugging type size mismatch
+    # echo alignLeft($T.typeof & ":", 50), T.sizeof
+    # echo alignLeft($U.typeof & ":", 50), U.sizeof, "\n", repeat("-", 20)
     type
       TT = typeof default(typeof T)[]
       UU = typeof default(typeof U)[]

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -916,6 +916,16 @@ func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
     # is still better to keep field names parallel.
     result.add((name.replace("blob", "data"), sizeof(value), n))
 
+macro moduleOf*(sym: typed{sym}): untyped =
+  ## Should return the string name of the type owner (file)
+  ## TODO: @tavurth find a way to fix this with imports for fork
+  var owner = sym.owner
+  while owner != nil:
+    if owner.symKind == nskModule:
+      break
+    owner = owner.owner
+  newLit($owner)
+
 ## At the GC-level, the GC is type-agnostic; it's all type-erased so
 ## casting between seq[Attestation] and seq[TrustedAttestation] will
 ## not disrupt GC operations.
@@ -941,6 +951,7 @@ template isomorphicCast*[T, U](x: U): T =
       doAssert sizeof(T) == sizeof(U)
       doAssert getSizeofSig(T()) == getSizeofSig(U())
     cast[ptr T](unsafeAddr x)[]
+
 
 func prune*(cache: var StateCache, epoch: Epoch) =
   # Prune all cache information that is no longer relevant in order to process

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -139,9 +139,6 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#custom-types
   Eth2Domain* = array[32, byte]
 
-  # Used in capella and bellatrix
-  PayloadID* = array[8, byte]
-
   ValidatorIndex* = distinct uint32
     ## Each validator has an index that is used in lieu of the public key to
     ## identify the validator. The index is assigned according to the order of

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -47,9 +47,6 @@ type
   BloomLogs* = object
     data*: array[BYTES_PER_LOGS_BLOOM, byte]
 
-  PayloadID* = object
-    buf*: array[8, byte]
-
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#executionpayload
   ExecutionPayload* = object
     parent_hash*: Eth2Digest

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -341,6 +341,9 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
+  # NOTE: for nicer errors
+  SomeBellatrixBeaconBlock =
+    SomeBeaconBlock
 
   BlockParams = object
     parentHash*: string
@@ -375,7 +378,7 @@ proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
     raiseUnexpectedValue(reader,
                          "ExecutionAddress value should be a valid hex string")
 
-func shortLog*(v: SomeBeaconBlock): auto =
+func shortLog*(v: SomeBellatrixBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -47,6 +47,8 @@ type
   BloomLogs* = object
     data*: array[BYTES_PER_LOGS_BLOOM, byte]
 
+  PayloadID* = array[8, byte]
+
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#executionpayload
   ExecutionPayload* = object
     parent_hash*: Eth2Digest
@@ -339,9 +341,6 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
-  # NOTE: for nicer errors
-  SomeBellatrixBeaconBlock =
-    SomeBeaconBlock
 
   BlockParams = object
     parentHash*: string
@@ -376,7 +375,7 @@ proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
     raiseUnexpectedValue(reader,
                          "ExecutionAddress value should be a valid hex string")
 
-func shortLog*(v: SomeBellatrixBeaconBlock): auto =
+func shortLog*(v: SomeBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -47,7 +47,8 @@ type
   BloomLogs* = object
     data*: array[BYTES_PER_LOGS_BLOOM, byte]
 
-  PayloadID* = array[8, byte]
+  PayloadID* = object
+    buf*: array[8, byte]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#executionpayload
   ExecutionPayload* = object

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -195,6 +195,8 @@ type
   # NOTE: Duplicates from bellatrix
   #
 
+  PayloadID* = array[8, byte]
+
   MsgTrustedSignedBeaconBlock* = object
     message*: TrustedBeaconBlock
     signature*: ValidatorSig

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -57,7 +57,10 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#blstoexecutionchange
   BLSToExecutionChange* = object
-    validator_index*: ValidatorIndex
+    # TODO: We should probably use ValidatorIndex here
+    #       but I see that in Altair we have a workaround
+    #       by simply putting uint64, which seems to be against the spec
+    validator_index*: uint64
     from_bls_pubkey*: ValidatorPubKey
     to_execution_address*: ExecutionAddress
 

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -36,21 +36,6 @@ const
   DOMAIN_BLS_TO_EXECUTION_CHANGE* = DomainType([byte 0x0A, 0x00, 0x00, 0x00])
 
 type
-
-  #
-  # NOTE: Duplicates from Altair
-  #
-  # TODO: @tavurth Check if fixes current compliation issue
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/beacon-chain.md#custom-types
-  # ParticipationFlags* = uint8
-
-  # EpochParticipationFlags* =
-  #   distinct HashList[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
-
-  #
-  # NOTE: End Altair
-  #
-
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]
 
@@ -149,7 +134,7 @@ type
     eth1_deposit_index*: uint64
 
     # Registry
-    validators*: List[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
+    validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
     balances*: List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -228,9 +228,6 @@ type
   # NOTE: Duplicates from bellatrix
   #
 
-  PayloadID* = object
-    buf*: array[8, byte]
-
   MsgTrustedSignedBeaconBlock* = object
     message*: TrustedBeaconBlock
     signature*: ValidatorSig

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -39,8 +39,6 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]
 
-  Hash32 = array[32, byte]
-
   ExecutionAddress* = object
     data*: array[20, byte]  # TODO there's a network_metadata type, but the import hierarchy's inconvenient
 
@@ -87,14 +85,14 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Hash32  # Hash of execution block
+    block_hash*: Eth2Digest  # Hash of execution block
     transactions*: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals*: List[Withdrawal, Limit MAX_WITHDRAWALS_PER_PAYLOAD]  # [New in Capella]
 
   # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#executionpayloadheader
   ExecutionPayloadHeader* = object
     # Execution block header fields
-    parent_hash*: Hash32
+    parent_hash*: Eth2Digest
     fee_recipient*: ExecutionAddress
     state_root*: Eth2Digest
     receipts_root*: Eth2Digest
@@ -108,7 +106,7 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Hash32  # Hash of execution block
+    block_hash*: Eth2Digest  # Hash of execution block
     transactions_root*: Eth2Digest
     withdrawals_root*: Eth2Digest  # [New in Capella]
 

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -20,7 +20,7 @@ import
   chronicles,
   ssz_serialization/types as sszTypes,
   ../digest,
-  "."/[base, phase0, altair]
+  "."/[base, phase0, altair, bellatrix]
 
 export base
 

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -165,7 +165,7 @@ type
     withdrawal_queue*: List[Withdrawal, Limit WITHDRAWALS_QUEUE_LIMIT]  # [New in Capella]
     next_withdrawal_index*: WithdrawalIndex  # [New in Capella]
 
-    # TODO: We should probably use ValidatorIndex here
+    # TODO: @tavurth We should probably use ValidatorIndex here
     #       but I see that in Altair we have a workaround
     #       by simply putting uint64, which seems to be against the spec
     next_partial_withdrawal_validator_index*: uint64  # [New in Capella]
@@ -370,3 +370,6 @@ type
 
     # Execution
     execution_payload*: ExecutionPayload
+
+  ExecutePayload* = proc(
+    execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -191,6 +191,39 @@ type
     # Capella operations
     bls_to_execution_changes*: List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]  # [New in Capella]
 
+  SigVerifiedBeaconBlockBody* = object
+    ## A BeaconBlock body with signatures verified
+    ## including:
+    ## - Randao reveal
+    ## - Attestations
+    ## - ProposerSlashing (SignedBeaconBlockHeader)
+    ## - AttesterSlashing (IndexedAttestation)
+    ## - SignedVoluntaryExits
+    ##
+    ## - ETH1Data (Deposits) can contain invalid BLS signatures
+    ##
+    ## The block state transition has NOT been verified
+    randao_reveal*: ValidatorSig
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
+
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
+
+    # Operations
+    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+    sync_aggregate*: SyncAggregate # TODO TrustedSyncAggregate after batching
+
+    # Execution
+    execution_payload*: ExecutionPayload
+
+    # Capella operations
+    bls_to_execution_changes*: List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]  # [New in Capella]
+
   #
   # NOTE: Duplicates from bellatrix
   #
@@ -261,7 +294,6 @@ type
     ## validators that will have a chance to vote on it through attestations.
     ## Each block collects attestations, or votes, on past blocks, thus a chain
     ## is formed.
-
     slot*: Slot
     proposer_index*: uint64 # `ValidatorIndex` after validation
 
@@ -309,36 +341,6 @@ type
     parent_root*: Eth2Digest
     state_root*: Eth2Digest
     body*: TrustedBeaconBlockBody
-
-  SigVerifiedBeaconBlockBody* = object
-    ## A BeaconBlock body with signatures verified
-    ## including:
-    ## - Randao reveal
-    ## - Attestations
-    ## - ProposerSlashing (SignedBeaconBlockHeader)
-    ## - AttesterSlashing (IndexedAttestation)
-    ## - SignedVoluntaryExits
-    ##
-    ## - ETH1Data (Deposits) can contain invalid BLS signatures
-    ##
-    ## The block state transition has NOT been verified
-    randao_reveal*: ValidatorSig
-    eth1_data*: Eth1Data
-      ## Eth1 data vote
-
-    graffiti*: GraffitiBytes
-      ## Arbitrary data
-
-    # Operations
-    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
-    attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
-    deposits*: List[Deposit, Limit MAX_DEPOSITS]
-    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
-    sync_aggregate*: SyncAggregate # TODO TrustedSyncAggregate after batching
-
-    # Execution
-    execution_payload*: ExecutionPayload
 
   TrustedBeaconBlockBody* = object
     ## A full verified block

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -17,6 +17,7 @@
 
 import
   json_serialization,
+  chronicles,
   ssz_serialization/types as sszTypes,
   ../digest,
   "."/[base, phase0, altair]
@@ -35,6 +36,21 @@ const
   DOMAIN_BLS_TO_EXECUTION_CHANGE* = DomainType([byte 0x0A, 0x00, 0x00, 0x00])
 
 type
+
+  #
+  # NOTE: Duplicates from Altair
+  #
+  # TODO: @tavurth Check if fixes current compliation issue
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/beacon-chain.md#custom-types
+  # ParticipationFlags* = uint8
+
+  # EpochParticipationFlags* =
+  #   distinct HashList[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+
+  #
+  # NOTE: End Altair
+  #
+
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]
 
@@ -143,8 +159,8 @@ type
     slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]  # Per-epoch sums of slashed effective balances
 
     # Participation
-    previous_epoch_participation*: List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
-    current_epoch_participation*: List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+    previous_epoch_participation*: EpochParticipationFlags
+    current_epoch_participation*: EpochParticipationFlags
 
     # Finality
     justification_bits*: JustificationBits # Bit set for every recent justified epoch
@@ -165,7 +181,11 @@ type
     # Withdrawals
     withdrawal_queue*: List[Withdrawal, Limit WITHDRAWALS_QUEUE_LIMIT]  # [New in Capella]
     next_withdrawal_index*: WithdrawalIndex  # [New in Capella]
-    next_partial_withdrawal_validator_index*: ValidatorIndex  # [New in Capella]
+
+    # TODO: We should probably use ValidatorIndex here
+    #       but I see that in Altair we have a workaround
+    #       by simply putting uint64, which seems to be against the spec
+    next_partial_withdrawal_validator_index*: uint64  # [New in Capella]
 
   # https://github.com/ethereum/consensus-specs/blob/dev/specs/capella/beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
@@ -186,6 +206,7 @@ type
 
     # Capella operations
     bls_to_execution_changes*: List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]  # [New in Capella]
+
 
   #
   # NOTE: Duplicates from bellatrix
@@ -366,4 +387,3 @@ type
 
     # Execution
     execution_payload*: ExecutionPayload
-

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -129,7 +129,7 @@ type
 
     # Eth1
     eth1_data*: Eth1Data
-    eth1_data_votes*: List[Eth1Data, Limit EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+    eth1_data_votes*: HashList[Eth1Data, Limit EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
     eth1_deposit_index*: uint64
 
     # Registry
@@ -153,7 +153,7 @@ type
     finalized_checkpoint*: Checkpoint
 
     # Inactivity
-    inactivity_scores*: List[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Sync
     current_sync_committee*: SyncCommittee
@@ -206,20 +206,6 @@ type
     signature*: TrustedSig
 
     root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
-
-  SomeSignedBeaconBlock* =
-    SignedBeaconBlock |
-    SigVerifiedSignedBeaconBlock |
-    MsgTrustedSignedBeaconBlock |
-    TrustedSignedBeaconBlock
-  SomeBeaconBlock* =
-    BeaconBlock |
-    SigVerifiedBeaconBlock |
-    TrustedBeaconBlock
-  SomeBeaconBlockBody* =
-    BeaconBlockBody |
-    SigVerifiedBeaconBlockBody |
-    TrustedBeaconBlockBody
 
   BlockParams = object
     parentHash*: string
@@ -376,6 +362,20 @@ type
 
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
+
+  SomeSignedBeaconBlock* =
+    SignedBeaconBlock |
+    SigVerifiedSignedBeaconBlock |
+    MsgTrustedSignedBeaconBlock |
+    TrustedSignedBeaconBlock
+  SomeBeaconBlock* =
+    BeaconBlock |
+    SigVerifiedBeaconBlock |
+    TrustedBeaconBlock
+  SomeBeaconBlockBody* =
+    BeaconBlockBody |
+    SigVerifiedBeaconBlockBody |
+    TrustedBeaconBlockBody
 
 func encodeQuantityHex*(x: auto): string =
   "0x" & x.toHex

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -376,6 +376,9 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
+  # NOTE: for nicer errors
+  SomeCapellaBeaconBlock =
+    SomeBeaconBlock
 
 func encodeQuantityHex*(x: auto): string =
   "0x" & x.toHex
@@ -400,7 +403,7 @@ proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
     raiseUnexpectedValue(reader,
                          "ExecutionAddress value should be a valid hex string")
 
-func shortLog*(v: SomeBeaconBlock): auto =
+func shortLog*(v: SomeCapellaBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -372,9 +372,6 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
-  # NOTE: for nicer errors
-  SomeCapellaBeaconBlock =
-    SomeBeaconBlock
 
 func encodeQuantityHex*(x: auto): string =
   "0x" & x.toHex
@@ -399,7 +396,7 @@ proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
     raiseUnexpectedValue(reader,
                          "ExecutionAddress value should be a valid hex string")
 
-func shortLog*(v: SomeCapellaBeaconBlock): auto =
+func shortLog*(v: SomeBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -133,7 +133,7 @@ type
 
     # Registry
     validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
-    balances*: List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
     randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -37,25 +37,19 @@ const
   DOMAIN_BLS_TO_EXECUTION_CHANGE* = DomainType([byte 0x0A, 0x00, 0x00, 0x00])
 
 type
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#custom-types
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/bellatrix/beacon-chain.md#custom-types
   Transaction* = List[byte, Limit MAX_BYTES_PER_TRANSACTION]
 
-  ExecutionAddress* = object
-    data*: array[20, byte]  # TODO there's a network_metadata type, but the import hierarchy's inconvenient
-
-  BloomLogs* = object
-    data*: array[BYTES_PER_LOGS_BLOOM, byte]
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#custom-types
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/capella/beacon-chain.md#custom-types
   WithdrawalIndex* = uint64
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#withdrawal
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/capella/beacon-chain.md#withdrawal
   Withdrawal* = object
     index*: WithdrawalIndex
     address*: ExecutionAddress
     amount*: Gwei
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#blstoexecutionchange
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/capella/beacon-chain.md#blstoexecutionchange
   BLSToExecutionChange* = object
     # TODO: We should probably use ValidatorIndex here
     #       but I see that in Altair we have a workaround
@@ -64,7 +58,7 @@ type
     from_bls_pubkey*: ValidatorPubKey
     to_execution_address*: ExecutionAddress
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#signedblstoexecutionchange
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/capella/beacon-chain.md#signedblstoexecutionchange
   SignedBLSToExecutionChange* = object
     message*: BLSToExecutionChange
     signature*: ValidatorSig

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -195,7 +195,8 @@ type
   # NOTE: Duplicates from bellatrix
   #
 
-  PayloadID* = array[8, byte]
+  PayloadID* = object
+    buf*: array[8, byte]
 
   MsgTrustedSignedBeaconBlock* = object
     message*: TrustedBeaconBlock

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,21 +1,24 @@
 
 # Table of Contents
 
-1.  [Bellatrix -> Capella (August 2022)](#org2a85870)
-    1.  [Setup and overview](#orgf9e47e1)
-    2.  [Spec files (capella.nim)](#orgdda82c9)
-    3.  [Fork file (forks.nim)](#orgfc15b47)
-    4.  [Review](#orgb1b3fe5)
-    5.  [Typing](#org68aef37)
-    6.  [Duplication](#org51d7350)
-    7.  [Rebase on `unstable`](#orgab74078)
-    8.  [Tracking compiler errors](#org8649fd6)
-    9.  [Ran into a serialization problem with the spec](#orgf7ef505)
-    10. [Large amount of typing errors](#orgf4ea86d)
+1.  [Bellatrix -> Capella (August 2022)](#orgb039cd2)
+    1.  [Setup and overview](#orga767886)
+    2.  [Spec files (capella.nim)](#org95a3d09)
+    3.  [Fork file (forks.nim)](#org220d1ea)
+    4.  [Review](#org9cd960e)
+    5.  [Typing](#orgf875bea)
+    6.  [Duplication](#org2b4c2ef)
+        1.  [Duplication should be preferred](#orgb5128a6)
+    7.  [Rebase on `unstable`](#org49f3e55)
+    8.  [Tracking compiler errors](#org2f23fbc)
+    9.  [Ran into a serialization problem with the spec](#orgf95b688)
+    10. [Large amount of typing errors](#org42725ab)
+    11. [Polymorphic errors](#org061c0ab)
+    12. [Ambiguous calls](#orgd80f4b0)
 
 
 
-<a id="org2a85870"></a>
+<a id="orgb039cd2"></a>
 
 # Bellatrix -> Capella (August 2022)
 
@@ -34,7 +37,7 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 &#x2014;
 
 
-<a id="orgf9e47e1"></a>
+<a id="orga767886"></a>
 
 ## Setup and overview
 
@@ -42,7 +45,7 @@ Started working on adding the relevant part of the spec files to the capella.nim
 More cleaning up of the spec files
 
 
-<a id="orgdda82c9"></a>
+<a id="org95a3d09"></a>
 
 ## Spec files (capella.nim)
 
@@ -52,7 +55,7 @@ Functions at the bottom of the page were required for later compilation steps
 Better to copy them and try to remove later if possible
 
 
-<a id="orgfc15b47"></a>
+<a id="org220d1ea"></a>
 
 ## Fork file (forks.nim)
 
@@ -60,7 +63,7 @@ Find and duplicate all bellatrix (previous entry) functions and type names
 Better to search next and modify in this case, there are many hidden ones
 
 
-<a id="orgb1b3fe5"></a>
+<a id="org9cd960e"></a>
 
 ## Review
 
@@ -69,7 +72,7 @@ specversion had inconsistencies with the previous spec
 marked with TODO and left for the end
 
 
-<a id="org68aef37"></a>
+<a id="orgf875bea"></a>
 
 ## Typing
 
@@ -79,7 +82,7 @@ these parts later when assured I could remove them (I could not),
 More helpers work and slowly tracking the compiler errors
 
 
-<a id="org51d7350"></a>
+<a id="org2b4c2ef"></a>
 
 ## Duplication
 
@@ -89,15 +92,21 @@ quick-search and replace (in selected region) was very
 helpful here.
 
 Tried to generalise some functionality but was unable to
-easily because of typing errors. \\\*Duplication should be
-preferred here because it prevents errors with previous forks.
+easily because of typing errors.
+
+
+<a id="orgb5128a6"></a>
+
+### Duplication should be preferred
+
+As it prevents errors with previous forks.
 
 Compiler errors tracked me to more duplicates, however these
 errors are not always helpful at telling you where the issue
 is as the compiler complains a lot about non-matching types.
 
 
-<a id="orgab74078"></a>
+<a id="org49f3e55"></a>
 
 ## Rebase on `unstable`
 
@@ -107,7 +116,7 @@ Understand the scope is much more spread
 Search and replace prev + new fork everywhere
 
 
-<a id="org8649fd6"></a>
+<a id="org2f23fbc"></a>
 
 ## Tracking compiler errors
 
@@ -124,7 +133,7 @@ these steps above will likely save you many compiler errors
 be sure to TODO tag the ones which differ from spec to spec
 
 
-<a id="orgf7ef505"></a>
+<a id="orgf95b688"></a>
 
 ## Ran into a serialization problem with the spec
 
@@ -134,7 +143,7 @@ There was a better implementation below which
 takes the version (in REST) from the JSON body
 
 
-<a id="orgf4ea86d"></a>
+<a id="org42725ab"></a>
 
 ## Large amount of typing errors
 
@@ -149,4 +158,26 @@ More typing problems, this time with `shortLog` who&rsquo;s asking
 for a BeaconBlock and getting one, but does not seem happy.
 Found some more missed areas from the first code sweep and fixed
 them up.
+
+
+<a id="org061c0ab"></a>
+
+## Polymorphic errors
+
+Sometimes we don&rsquo;t import the spec files directly, but rather export
+them from some other file.
+
+Search `export {previous_fork_name}` and be sure that all of them are
+updated with your new fork name.
+
+
+<a id="orgd80f4b0"></a>
+
+## Ambiguous calls
+
+I found that some places the spec has new features from the bellatrix
+upgrade which need to be modified or in some way made non-ambiguous.
+
+So far in the slow process of migration type ambiguity has been the single
+largest slowdown to progress.
 

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,0 +1,152 @@
+
+# Table of Contents
+
+1.  [Bellatrix -> Capella (August 2022)](#org2a85870)
+    1.  [Setup and overview](#orgf9e47e1)
+    2.  [Spec files (capella.nim)](#orgdda82c9)
+    3.  [Fork file (forks.nim)](#orgfc15b47)
+    4.  [Review](#orgb1b3fe5)
+    5.  [Typing](#org68aef37)
+    6.  [Duplication](#org51d7350)
+    7.  [Rebase on `unstable`](#orgab74078)
+    8.  [Tracking compiler errors](#org8649fd6)
+    9.  [Ran into a serialization problem with the spec](#orgf7ef505)
+    10. [Large amount of typing errors](#orgf4ea86d)
+
+
+
+<a id="org2a85870"></a>
+
+# Bellatrix -> Capella (August 2022)
+
+In this guide I mostly lay out the problems I ran into
+while making the forward migration.
+
+In general I would suggest getting the spec/datatypes/\\\* files
+done first and them performing a search-and replace sweep on the
+whole project.
+
+Look for all complex matches and then prepare macros for different
+files to sweep.
+
+Stop at unviable areas, tag with TODO and get it to compile first.
+
+&#x2014;
+
+
+<a id="orgf9e47e1"></a>
+
+## Setup and overview
+
+Started working on adding the relevant part of the spec files to the capella.nim I added
+More cleaning up of the spec files
+
+
+<a id="orgdda82c9"></a>
+
+## Spec files (capella.nim)
+
+Here it was useful to copy from previous spec files rather than the spec itself
+mostly because the spec file types can differ slightly
+Functions at the bottom of the page were required for later compilation steps
+Better to copy them and try to remove later if possible
+
+
+<a id="orgfc15b47"></a>
+
+## Fork file (forks.nim)
+
+Find and duplicate all bellatrix (previous entry) functions and type names
+Better to search next and modify in this case, there are many hidden ones
+
+
+<a id="orgb1b3fe5"></a>
+
+## Review
+
+Found a few places that should be checked later because the previous
+specversion had inconsistencies with the previous spec
+marked with TODO and left for the end
+
+
+<a id="org68aef37"></a>
+
+## Typing
+
+Started working on moving some types into helper and rest<sub>types</sub>
+Sorted code in datatypes/capella.nim, and Added TODO to cleanup
+these parts later when assured I could remove them (I could not),
+More helpers work and slowly tracking the compiler errors
+
+
+<a id="org51d7350"></a>
+
+## Duplication
+
+Duplication starts with finding functions that match your
+previous fork name and duplicating them. I found that
+quick-search and replace (in selected region) was very
+helpful here.
+
+Tried to generalise some functionality but was unable to
+easily because of typing errors. \\\*Duplication should be
+preferred here because it prevents errors with previous forks.
+
+Compiler errors tracked me to more duplicates, however these
+errors are not always helpful at telling you where the issue
+is as the compiler complains a lot about non-matching types.
+
+
+<a id="orgab74078"></a>
+
+## Rebase on `unstable`
+
+which was thankfully easy and required a few easy refactor
+
+Understand the scope is much more spread
+Search and replace prev + new fork everywhere
+
+
+<a id="org8649fd6"></a>
+
+## Tracking compiler errors
+
+In general these are helpful at this stage and tell you where
+to start looking. However,
+
+at this stage it would be more helpful to
+start combing through files. I suggest:
+
+-   prepare a list of files containing `complex(prev_fork)` declarations
+-   comb those files using a macro for cases one by one
+
+these steps above will likely save you many compiler errors
+be sure to TODO tag the ones which differ from spec to spec
+
+
+<a id="orgf7ef505"></a>
+
+## Ran into a serialization problem with the spec
+
+seemed likely there was no spec version present,
+but the code was a bit out of date in one part.
+There was a better implementation below which
+takes the version (in REST) from the JSON body
+
+
+<a id="orgf4ea86d"></a>
+
+## Large amount of typing errors
+
+This was likely because I culled out some
+important functions from `capella.nim` too early.
+
+At this point I also ran into `sizeof(U) or sizeof(T)` problems
+which was caused because the spec is duplicated in a few places
+and also made immutable. All areas must be updated correctly.
+
+More typing problems, this time with `shortLog` who&rsquo;s asking
+for a BeaconBlock and getting one, but does not seem happy.
+Found some more missed areas from the first code sweep and fixed
+them up.
+

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,26 +1,26 @@
 
 # Table of Contents
 
-1.  [Bellatrix -> Capella (August 2022)](#org11abd63)
-    1.  [Getting stuck](#orgb751fa6)
-    2.  [Setup and overview](#org9d62310)
-    3.  [Spec files (capella.nim)](#org41b7d98)
-    4.  [Fork file (forks.nim)](#org73fa67a)
-    5.  [Review](#org20cf005)
-    6.  [Typing](#org6b1d016)
-    7.  [Duplication](#orgc3d7a1d)
-        1.  [Duplication should be preferred](#orgb9e257d)
-    8.  [Rebase on `unstable`](#org613acb7)
-    9.  [Tracking compiler errors](#orgf87b634)
-    10. [Ran into a serialization problem with the spec](#orgb77b6d5)
-    11. [Large amount of typing errors](#org9108b4c)
-    12. [Polymorphic errors](#org4b62395)
-    13. [Ambiguous calls](#org53b0c3a)
-    14. [sizeof(U) !== sizeof(T)](#org6973085)
+1.  [Bellatrix -> Capella (August 2022)](#org5a7261e)
+    1.  [Getting stuck](#org835ddfe)
+    2.  [Setup and overview](#orgbaf02eb)
+    3.  [Spec files (capella.nim)](#org843501a)
+    4.  [Fork file (forks.nim)](#org39f67a2)
+    5.  [Review](#org6603b1e)
+    6.  [Typing](#org50b8842)
+    7.  [Duplication](#org7846de1)
+        1.  [Duplication should be preferred](#org055837f)
+    8.  [Rebase on `unstable`](#org1d98c5f)
+    9.  [Tracking compiler errors](#orge9b96e9)
+    10. [Ran into a serialization problem with the spec](#orgc07342f)
+    11. [Large amount of typing errors](#org2334a4b)
+    12. [Polymorphic errors](#orgedb1c82)
+    13. [Ambiguous calls](#org2df0fac)
+    14. [sizeof(U) !== sizeof(T)](#org883415d)
 
 
 
-<a id="org11abd63"></a>
+<a id="org5a7261e"></a>
 
 # Bellatrix -> Capella (August 2022)
 
@@ -39,7 +39,7 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 &#x2014;
 
 
-<a id="orgb751fa6"></a>
+<a id="org835ddfe"></a>
 
 ## Getting stuck
 
@@ -49,7 +49,7 @@ Try to compile a different part of the project using the command:
 `./env.sh nim c beacon_chain/foo.nim`
 
 
-<a id="org9d62310"></a>
+<a id="orgbaf02eb"></a>
 
 ## Setup and overview
 
@@ -57,7 +57,7 @@ Started working on adding the relevant part of the spec files to the capella.nim
 More cleaning up of the spec files
 
 
-<a id="org41b7d98"></a>
+<a id="org843501a"></a>
 
 ## Spec files (capella.nim)
 
@@ -67,7 +67,7 @@ Functions at the bottom of the page were required for later compilation steps
 Better to copy them and try to remove later if possible
 
 
-<a id="org73fa67a"></a>
+<a id="org39f67a2"></a>
 
 ## Fork file (forks.nim)
 
@@ -75,7 +75,7 @@ Find and duplicate all bellatrix (previous entry) functions and type names
 Better to search next and modify in this case, there are many hidden ones
 
 
-<a id="org20cf005"></a>
+<a id="org6603b1e"></a>
 
 ## Review
 
@@ -84,7 +84,7 @@ specversion had inconsistencies with the previous spec
 marked with TODO and left for the end
 
 
-<a id="org6b1d016"></a>
+<a id="org50b8842"></a>
 
 ## Typing
 
@@ -94,7 +94,7 @@ these parts later when assured I could remove them (I could not),
 More helpers work and slowly tracking the compiler errors
 
 
-<a id="orgc3d7a1d"></a>
+<a id="org7846de1"></a>
 
 ## Duplication
 
@@ -107,7 +107,7 @@ Tried to generalise some functionality but was unable to
 easily because of typing errors.
 
 
-<a id="orgb9e257d"></a>
+<a id="org055837f"></a>
 
 ### Duplication should be preferred
 
@@ -118,7 +118,7 @@ errors are not always helpful at telling you where the issue
 is as the compiler complains a lot about non-matching types.
 
 
-<a id="org613acb7"></a>
+<a id="org1d98c5f"></a>
 
 ## Rebase on `unstable`
 
@@ -128,7 +128,7 @@ Understand the scope is much more spread
 Search and replace prev + new fork everywhere
 
 
-<a id="orgf87b634"></a>
+<a id="orge9b96e9"></a>
 
 ## Tracking compiler errors
 
@@ -145,7 +145,7 @@ these steps above will likely save you many compiler errors
 be sure to TODO tag the ones which differ from spec to spec
 
 
-<a id="orgb77b6d5"></a>
+<a id="orgc07342f"></a>
 
 ## Ran into a serialization problem with the spec
 
@@ -155,7 +155,7 @@ There was a better implementation below which
 takes the version (in REST) from the JSON body
 
 
-<a id="org9108b4c"></a>
+<a id="org2334a4b"></a>
 
 ## Large amount of typing errors
 
@@ -172,7 +172,7 @@ Found some more missed areas from the first code sweep and fixed
 them up.
 
 
-<a id="org4b62395"></a>
+<a id="orgedb1c82"></a>
 
 ## Polymorphic errors
 
@@ -183,7 +183,7 @@ Search `export {previous_fork_name}` and be sure that all of them are
 updated with your new fork name.
 
 
-<a id="org53b0c3a"></a>
+<a id="org2df0fac"></a>
 
 ## Ambiguous calls
 
@@ -194,7 +194,7 @@ So far in the slow process of migration type ambiguity has been the single
 largest slowdown to progress.
 
 
-<a id="org6973085"></a>
+<a id="org883415d"></a>
 
 ## sizeof(U) !== sizeof(T)
 

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,25 +1,25 @@
 
 # Table of Contents
 
-1.  [Bellatrix -> Capella (August 2022)](#org32b378a)
-    1.  [Setup and overview](#orgd0d532f)
-    2.  [Spec files (capella.nim)](#org0308a33)
-    3.  [Fork file (forks.nim)](#org9d5a8d9)
-    4.  [Review](#org50832d4)
-    5.  [Typing](#org96d43f4)
-    6.  [Duplication](#org6b5a16c)
-        1.  [Duplication should be preferred](#org2b30f71)
-    7.  [Rebase on `unstable`](#org3b5cbc9)
-    8.  [Tracking compiler errors](#org870ee63)
-    9.  [Ran into a serialization problem with the spec](#orgab005bf)
-    10. [Large amount of typing errors](#org64ea657)
-    11. [Polymorphic errors](#org8b97db0)
-    12. [Ambiguous calls](#org1b622ca)
-    13. [sizeof(U) !== sizeof(T)](#org87b79a5)
+1.  [Bellatrix -> Capella (August 2022)](#orga9cb28e)
+    1.  [Setup and overview](#orgb55d43d)
+    2.  [Spec files (capella.nim)](#org841fa8d)
+    3.  [Fork file (forks.nim)](#org93c364b)
+    4.  [Review](#org8a8b0a8)
+    5.  [Typing](#org14b11a6)
+    6.  [Duplication](#org6c47389)
+        1.  [Duplication should be preferred](#org0e7075d)
+    7.  [Rebase on `unstable`](#orgda99c04)
+    8.  [Tracking compiler errors](#org78596b2)
+    9.  [Ran into a serialization problem with the spec](#orge2e15b4)
+    10. [Large amount of typing errors](#orge24f293)
+    11. [Polymorphic errors](#org625eca5)
+    12. [Ambiguous calls](#orgf36c394)
+    13. [sizeof(U) !== sizeof(T)](#orgbad8329)
 
 
 
-<a id="org32b378a"></a>
+<a id="orga9cb28e"></a>
 
 # Bellatrix -> Capella (August 2022)
 
@@ -38,7 +38,7 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 &#x2014;
 
 
-<a id="orgd0d532f"></a>
+<a id="orgb55d43d"></a>
 
 ## Setup and overview
 
@@ -46,7 +46,7 @@ Started working on adding the relevant part of the spec files to the capella.nim
 More cleaning up of the spec files
 
 
-<a id="org0308a33"></a>
+<a id="org841fa8d"></a>
 
 ## Spec files (capella.nim)
 
@@ -56,7 +56,7 @@ Functions at the bottom of the page were required for later compilation steps
 Better to copy them and try to remove later if possible
 
 
-<a id="org9d5a8d9"></a>
+<a id="org93c364b"></a>
 
 ## Fork file (forks.nim)
 
@@ -64,7 +64,7 @@ Find and duplicate all bellatrix (previous entry) functions and type names
 Better to search next and modify in this case, there are many hidden ones
 
 
-<a id="org50832d4"></a>
+<a id="org8a8b0a8"></a>
 
 ## Review
 
@@ -73,7 +73,7 @@ specversion had inconsistencies with the previous spec
 marked with TODO and left for the end
 
 
-<a id="org96d43f4"></a>
+<a id="org14b11a6"></a>
 
 ## Typing
 
@@ -83,7 +83,7 @@ these parts later when assured I could remove them (I could not),
 More helpers work and slowly tracking the compiler errors
 
 
-<a id="org6b5a16c"></a>
+<a id="org6c47389"></a>
 
 ## Duplication
 
@@ -96,7 +96,7 @@ Tried to generalise some functionality but was unable to
 easily because of typing errors.
 
 
-<a id="org2b30f71"></a>
+<a id="org0e7075d"></a>
 
 ### Duplication should be preferred
 
@@ -107,7 +107,7 @@ errors are not always helpful at telling you where the issue
 is as the compiler complains a lot about non-matching types.
 
 
-<a id="org3b5cbc9"></a>
+<a id="orgda99c04"></a>
 
 ## Rebase on `unstable`
 
@@ -117,7 +117,7 @@ Understand the scope is much more spread
 Search and replace prev + new fork everywhere
 
 
-<a id="org870ee63"></a>
+<a id="org78596b2"></a>
 
 ## Tracking compiler errors
 
@@ -134,7 +134,7 @@ these steps above will likely save you many compiler errors
 be sure to TODO tag the ones which differ from spec to spec
 
 
-<a id="orgab005bf"></a>
+<a id="orge2e15b4"></a>
 
 ## Ran into a serialization problem with the spec
 
@@ -144,7 +144,7 @@ There was a better implementation below which
 takes the version (in REST) from the JSON body
 
 
-<a id="org64ea657"></a>
+<a id="orge24f293"></a>
 
 ## Large amount of typing errors
 
@@ -161,7 +161,7 @@ Found some more missed areas from the first code sweep and fixed
 them up.
 
 
-<a id="org8b97db0"></a>
+<a id="org625eca5"></a>
 
 ## Polymorphic errors
 
@@ -172,7 +172,7 @@ Search `export {previous_fork_name}` and be sure that all of them are
 updated with your new fork name.
 
 
-<a id="org1b622ca"></a>
+<a id="orgf36c394"></a>
 
 ## Ambiguous calls
 
@@ -183,7 +183,7 @@ So far in the slow process of migration type ambiguity has been the single
 largest slowdown to progress.
 
 
-<a id="org87b79a5"></a>
+<a id="orgbad8329"></a>
 
 ## sizeof(U) !== sizeof(T)
 
@@ -197,4 +197,7 @@ Then rebuild. This should print out the typenames and the corresponding
 size when an isomorphicCast attempt is made during compile time.
 Hopefully this will allow you to narrow down exactly which types are
 causing the issue.
+
+Most of these issues are caused by a missing duplicate item in one of your spec
+files. It could also be in the file `beacon_chain_db_immutable.nim`
 

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,24 +1,25 @@
 
 # Table of Contents
 
-1.  [Bellatrix -> Capella (August 2022)](#orgb039cd2)
-    1.  [Setup and overview](#orga767886)
-    2.  [Spec files (capella.nim)](#org95a3d09)
-    3.  [Fork file (forks.nim)](#org220d1ea)
-    4.  [Review](#org9cd960e)
-    5.  [Typing](#orgf875bea)
-    6.  [Duplication](#org2b4c2ef)
-        1.  [Duplication should be preferred](#orgb5128a6)
-    7.  [Rebase on `unstable`](#org49f3e55)
-    8.  [Tracking compiler errors](#org2f23fbc)
-    9.  [Ran into a serialization problem with the spec](#orgf95b688)
-    10. [Large amount of typing errors](#org42725ab)
-    11. [Polymorphic errors](#org061c0ab)
-    12. [Ambiguous calls](#orgd80f4b0)
+1.  [Bellatrix -> Capella (August 2022)](#org32b378a)
+    1.  [Setup and overview](#orgd0d532f)
+    2.  [Spec files (capella.nim)](#org0308a33)
+    3.  [Fork file (forks.nim)](#org9d5a8d9)
+    4.  [Review](#org50832d4)
+    5.  [Typing](#org96d43f4)
+    6.  [Duplication](#org6b5a16c)
+        1.  [Duplication should be preferred](#org2b30f71)
+    7.  [Rebase on `unstable`](#org3b5cbc9)
+    8.  [Tracking compiler errors](#org870ee63)
+    9.  [Ran into a serialization problem with the spec](#orgab005bf)
+    10. [Large amount of typing errors](#org64ea657)
+    11. [Polymorphic errors](#org8b97db0)
+    12. [Ambiguous calls](#org1b622ca)
+    13. [sizeof(U) !== sizeof(T)](#org87b79a5)
 
 
 
-<a id="orgb039cd2"></a>
+<a id="org32b378a"></a>
 
 # Bellatrix -> Capella (August 2022)
 
@@ -37,7 +38,7 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 &#x2014;
 
 
-<a id="orga767886"></a>
+<a id="orgd0d532f"></a>
 
 ## Setup and overview
 
@@ -45,7 +46,7 @@ Started working on adding the relevant part of the spec files to the capella.nim
 More cleaning up of the spec files
 
 
-<a id="org95a3d09"></a>
+<a id="org0308a33"></a>
 
 ## Spec files (capella.nim)
 
@@ -55,7 +56,7 @@ Functions at the bottom of the page were required for later compilation steps
 Better to copy them and try to remove later if possible
 
 
-<a id="org220d1ea"></a>
+<a id="org9d5a8d9"></a>
 
 ## Fork file (forks.nim)
 
@@ -63,7 +64,7 @@ Find and duplicate all bellatrix (previous entry) functions and type names
 Better to search next and modify in this case, there are many hidden ones
 
 
-<a id="org9cd960e"></a>
+<a id="org50832d4"></a>
 
 ## Review
 
@@ -72,7 +73,7 @@ specversion had inconsistencies with the previous spec
 marked with TODO and left for the end
 
 
-<a id="orgf875bea"></a>
+<a id="org96d43f4"></a>
 
 ## Typing
 
@@ -82,7 +83,7 @@ these parts later when assured I could remove them (I could not),
 More helpers work and slowly tracking the compiler errors
 
 
-<a id="org2b4c2ef"></a>
+<a id="org6b5a16c"></a>
 
 ## Duplication
 
@@ -95,7 +96,7 @@ Tried to generalise some functionality but was unable to
 easily because of typing errors.
 
 
-<a id="orgb5128a6"></a>
+<a id="org2b30f71"></a>
 
 ### Duplication should be preferred
 
@@ -106,7 +107,7 @@ errors are not always helpful at telling you where the issue
 is as the compiler complains a lot about non-matching types.
 
 
-<a id="org49f3e55"></a>
+<a id="org3b5cbc9"></a>
 
 ## Rebase on `unstable`
 
@@ -116,7 +117,7 @@ Understand the scope is much more spread
 Search and replace prev + new fork everywhere
 
 
-<a id="org2f23fbc"></a>
+<a id="org870ee63"></a>
 
 ## Tracking compiler errors
 
@@ -133,7 +134,7 @@ these steps above will likely save you many compiler errors
 be sure to TODO tag the ones which differ from spec to spec
 
 
-<a id="orgf95b688"></a>
+<a id="orgab005bf"></a>
 
 ## Ran into a serialization problem with the spec
 
@@ -143,7 +144,7 @@ There was a better implementation below which
 takes the version (in REST) from the JSON body
 
 
-<a id="org42725ab"></a>
+<a id="org64ea657"></a>
 
 ## Large amount of typing errors
 
@@ -160,7 +161,7 @@ Found some more missed areas from the first code sweep and fixed
 them up.
 
 
-<a id="org061c0ab"></a>
+<a id="org8b97db0"></a>
 
 ## Polymorphic errors
 
@@ -171,7 +172,7 @@ Search `export {previous_fork_name}` and be sure that all of them are
 updated with your new fork name.
 
 
-<a id="orgd80f4b0"></a>
+<a id="org1b622ca"></a>
 
 ## Ambiguous calls
 
@@ -180,4 +181,20 @@ upgrade which need to be modified or in some way made non-ambiguous.
 
 So far in the slow process of migration type ambiguity has been the single
 largest slowdown to progress.
+
+
+<a id="org87b79a5"></a>
+
+## sizeof(U) !== sizeof(T)
+
+Go into datatypes/base.nim and uncomment the following lines:
+
+    # NOTE: Uncomment for debugging type size mismatch
+    echo alignLeft($T.typeof & ":", 50), T.sizeof
+    echo alignLeft($U.typeof & ":", 50), U.sizeof, "\n", repeat("-", 20)
+
+Then rebuild. This should print out the typenames and the corresponding
+size when an isomorphicCast attempt is made during compile time.
+Hopefully this will allow you to narrow down exactly which types are
+causing the issue.
 

--- a/beacon_chain/spec/datatypes/migration.md
+++ b/beacon_chain/spec/datatypes/migration.md
@@ -1,25 +1,26 @@
 
 # Table of Contents
 
-1.  [Bellatrix -> Capella (August 2022)](#orga9cb28e)
-    1.  [Setup and overview](#orgb55d43d)
-    2.  [Spec files (capella.nim)](#org841fa8d)
-    3.  [Fork file (forks.nim)](#org93c364b)
-    4.  [Review](#org8a8b0a8)
-    5.  [Typing](#org14b11a6)
-    6.  [Duplication](#org6c47389)
-        1.  [Duplication should be preferred](#org0e7075d)
-    7.  [Rebase on `unstable`](#orgda99c04)
-    8.  [Tracking compiler errors](#org78596b2)
-    9.  [Ran into a serialization problem with the spec](#orge2e15b4)
-    10. [Large amount of typing errors](#orge24f293)
-    11. [Polymorphic errors](#org625eca5)
-    12. [Ambiguous calls](#orgf36c394)
-    13. [sizeof(U) !== sizeof(T)](#orgbad8329)
+1.  [Bellatrix -> Capella (August 2022)](#org11abd63)
+    1.  [Getting stuck](#orgb751fa6)
+    2.  [Setup and overview](#org9d62310)
+    3.  [Spec files (capella.nim)](#org41b7d98)
+    4.  [Fork file (forks.nim)](#org73fa67a)
+    5.  [Review](#org20cf005)
+    6.  [Typing](#org6b1d016)
+    7.  [Duplication](#orgc3d7a1d)
+        1.  [Duplication should be preferred](#orgb9e257d)
+    8.  [Rebase on `unstable`](#org613acb7)
+    9.  [Tracking compiler errors](#orgf87b634)
+    10. [Ran into a serialization problem with the spec](#orgb77b6d5)
+    11. [Large amount of typing errors](#org9108b4c)
+    12. [Polymorphic errors](#org4b62395)
+    13. [Ambiguous calls](#org53b0c3a)
+    14. [sizeof(U) !== sizeof(T)](#org6973085)
 
 
 
-<a id="orga9cb28e"></a>
+<a id="org11abd63"></a>
 
 # Bellatrix -> Capella (August 2022)
 
@@ -38,7 +39,17 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 &#x2014;
 
 
-<a id="orgb55d43d"></a>
+<a id="orgb751fa6"></a>
+
+## Getting stuck
+
+If you run into some difficult type or other error that you can&rsquo;t process.
+Try to compile a different part of the project using the command:
+
+`./env.sh nim c beacon_chain/foo.nim`
+
+
+<a id="org9d62310"></a>
 
 ## Setup and overview
 
@@ -46,7 +57,7 @@ Started working on adding the relevant part of the spec files to the capella.nim
 More cleaning up of the spec files
 
 
-<a id="org841fa8d"></a>
+<a id="org41b7d98"></a>
 
 ## Spec files (capella.nim)
 
@@ -56,7 +67,7 @@ Functions at the bottom of the page were required for later compilation steps
 Better to copy them and try to remove later if possible
 
 
-<a id="org93c364b"></a>
+<a id="org73fa67a"></a>
 
 ## Fork file (forks.nim)
 
@@ -64,7 +75,7 @@ Find and duplicate all bellatrix (previous entry) functions and type names
 Better to search next and modify in this case, there are many hidden ones
 
 
-<a id="org8a8b0a8"></a>
+<a id="org20cf005"></a>
 
 ## Review
 
@@ -73,7 +84,7 @@ specversion had inconsistencies with the previous spec
 marked with TODO and left for the end
 
 
-<a id="org14b11a6"></a>
+<a id="org6b1d016"></a>
 
 ## Typing
 
@@ -83,7 +94,7 @@ these parts later when assured I could remove them (I could not),
 More helpers work and slowly tracking the compiler errors
 
 
-<a id="org6c47389"></a>
+<a id="orgc3d7a1d"></a>
 
 ## Duplication
 
@@ -96,7 +107,7 @@ Tried to generalise some functionality but was unable to
 easily because of typing errors.
 
 
-<a id="org0e7075d"></a>
+<a id="orgb9e257d"></a>
 
 ### Duplication should be preferred
 
@@ -107,7 +118,7 @@ errors are not always helpful at telling you where the issue
 is as the compiler complains a lot about non-matching types.
 
 
-<a id="orgda99c04"></a>
+<a id="org613acb7"></a>
 
 ## Rebase on `unstable`
 
@@ -117,7 +128,7 @@ Understand the scope is much more spread
 Search and replace prev + new fork everywhere
 
 
-<a id="org78596b2"></a>
+<a id="orgf87b634"></a>
 
 ## Tracking compiler errors
 
@@ -134,7 +145,7 @@ these steps above will likely save you many compiler errors
 be sure to TODO tag the ones which differ from spec to spec
 
 
-<a id="orge2e15b4"></a>
+<a id="orgb77b6d5"></a>
 
 ## Ran into a serialization problem with the spec
 
@@ -144,7 +155,7 @@ There was a better implementation below which
 takes the version (in REST) from the JSON body
 
 
-<a id="orge24f293"></a>
+<a id="org9108b4c"></a>
 
 ## Large amount of typing errors
 
@@ -161,7 +172,7 @@ Found some more missed areas from the first code sweep and fixed
 them up.
 
 
-<a id="org625eca5"></a>
+<a id="org4b62395"></a>
 
 ## Polymorphic errors
 
@@ -172,7 +183,7 @@ Search `export {previous_fork_name}` and be sure that all of them are
 updated with your new fork name.
 
 
-<a id="orgf36c394"></a>
+<a id="org53b0c3a"></a>
 
 ## Ambiguous calls
 
@@ -183,7 +194,7 @@ So far in the slow process of migration type ambiguity has been the single
 largest slowdown to progress.
 
 
-<a id="orgbad8329"></a>
+<a id="org6973085"></a>
 
 ## sizeof(U) !== sizeof(T)
 

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -120,3 +120,6 @@ Then rebuild. This should print out the typenames and the corresponding
 size when an isomorphicCast attempt is made during compile time.
 Hopefully this will allow you to narrow down exactly which types are
 causing the issue.
+
+Most of these issues are caused by a missing duplicate item in one of your spec
+files. It could also be in the file ~beacon_chain_db_immutable.nim~

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -1,0 +1,93 @@
+#+title: Migration Bellatrix -> Capella (2022)
+
+* Bellatrix -> Capella (August 2022)
+
+In this guide I mostly lay out the problems I ran into
+while making the forward migration.
+
+In general I would suggest getting the spec/datatypes/\* files
+done first and them performing a search-and replace sweep on the
+whole project.
+
+Look for all complex matches and then prepare macros for different
+files to sweep.
+
+Stop at unviable areas, tag with TODO and get it to compile first.
+
+---
+
+** Setup and overview
+Started working on adding the relevant part of the spec files to the capella.nim I added
+More cleaning up of the spec files
+
+** Spec files (capella.nim)
+Here it was useful to copy from previous spec files rather than the spec itself
+mostly because the spec file types can differ slightly
+Functions at the bottom of the page were required for later compilation steps
+Better to copy them and try to remove later if possible
+
+** Fork file (forks.nim)
+Find and duplicate all bellatrix (previous entry) functions and type names
+Better to search next and modify in this case, there are many hidden ones
+
+** Review
+Found a few places that should be checked later because the previous
+specversion had inconsistencies with the previous spec
+marked with TODO and left for the end
+
+** Typing
+Started working on moving some types into helper and rest_types
+Sorted code in datatypes/capella.nim, and Added TODO to cleanup
+these parts later when assured I could remove them (I could not),
+More helpers work and slowly tracking the compiler errors
+
+** Duplication
+Duplication starts with finding functions that match your
+previous fork name and duplicating them. I found that
+quick-search and replace (in selected region) was very
+helpful here.
+
+Tried to generalise some functionality but was unable to
+easily because of typing errors. \*Duplication should be
+preferred here because it prevents errors with previous forks.
+
+Compiler errors tracked me to more duplicates, however these
+errors are not always helpful at telling you where the issue
+is as the compiler complains a lot about non-matching types.
+
+** Rebase on ~unstable~
+which was thankfully easy and required a few easy refactor
+
+Understand the scope is much more spread
+Search and replace prev + new fork everywhere
+
+** Tracking compiler errors
+In general these are helpful at this stage and tell you where
+to start looking. However,
+
+at this stage it would be more helpful to
+start combing through files. I suggest:
+- prepare a list of files containing ~complex(prev_fork)~ declarations
+- comb those files using a macro for cases one by one
+
+these steps above will likely save you many compiler errors
+be sure to TODO tag the ones which differ from spec to spec
+
+** Ran into a serialization problem with the spec
+seemed likely there was no spec version present,
+but the code was a bit out of date in one part.
+There was a better implementation below which
+takes the version (in REST) from the JSON body
+
+** Large amount of typing errors
+This was likely because I culled out some
+important functions from ~capella.nim~ too early.
+
+At this point I also ran into ~sizeof(U) or sizeof(T)~ problems
+which was caused because the spec is duplicated in a few places
+and also made immutable. All areas must be updated correctly.
+
+More typing problems, this time with ~shortLog~ who's asking
+for a BeaconBlock and getting one, but does not seem happy.
+Found some more missed areas from the first code sweep and fixed
+them up.

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -16,6 +16,12 @@ Stop at unviable areas, tag with TODO and get it to compile first.
 
 ---
 
+** Getting stuck
+If you run into some difficult type or other error that you can't process.
+Try to compile a different part of the project using the command:
+
+~./env.sh nim c beacon_chain/foo.nim~
+
 ** Setup and overview
 Started working on adding the relevant part of the spec files to the capella.nim I added
 More cleaning up of the spec files

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -107,3 +107,16 @@ upgrade which need to be modified or in some way made non-ambiguous.
 
 So far in the slow process of migration type ambiguity has been the single
 largest slowdown to progress.
+
+** sizeof(U) !== sizeof(T)
+Go into datatypes/base.nim and uncomment the following lines:
+#+begin_src nim
+# NOTE: Uncomment for debugging type size mismatch
+echo alignLeft($T.typeof & ":", 50), T.sizeof
+echo alignLeft($U.typeof & ":", 50), U.sizeof, "\n", repeat("-", 20)
+#+end_src
+
+Then rebuild. This should print out the typenames and the corresponding
+size when an isomorphicCast attempt is made during compile time.
+Hopefully this will allow you to narrow down exactly which types are
+causing the issue.

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -100,3 +100,10 @@ them from some other file.
 
 Search ~export {previous_fork_name}~ and be sure that all of them are
 updated with your new fork name.
+
+** Ambiguous calls
+I found that some places the spec has new features from the bellatrix
+upgrade which need to be modified or in some way made non-ambiguous.
+
+So far in the slow process of migration type ambiguity has been the single
+largest slowdown to progress.

--- a/beacon_chain/spec/datatypes/migration.org
+++ b/beacon_chain/spec/datatypes/migration.org
@@ -48,8 +48,10 @@ quick-search and replace (in selected region) was very
 helpful here.
 
 Tried to generalise some functionality but was unable to
-easily because of typing errors. \*Duplication should be
-preferred here because it prevents errors with previous forks.
+easily because of typing errors.
+
+*** Duplication should be preferred
+As it prevents errors with previous forks.
 
 Compiler errors tracked me to more duplicates, however these
 errors are not always helpful at telling you where the issue
@@ -91,3 +93,10 @@ More typing problems, this time with ~shortLog~ who's asking
 for a BeaconBlock and getting one, but does not seem happy.
 Found some more missed areas from the first code sweep and fixed
 them up.
+
+** Polymorphic errors
+Sometimes we don't import the spec files directly, but rather export
+them from some other file.
+
+Search ~export {previous_fork_name}~ and be sure that all of them are
+updated with your new fork name.

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -273,6 +273,9 @@ type
     BeaconBlockBody |
     SigVerifiedBeaconBlockBody |
     TrustedBeaconBlockBody
+  # NOTE: for nicer errors
+  SomePhase0BeaconBlock* =
+    SomeBeaconBlock
 
   EpochInfo* = object
     ## Information about the outcome of epoch processing
@@ -285,7 +288,7 @@ func clear*(info: var EpochInfo) =
   info.validators.setLen(0)
   info.balances = TotalBalances()
 
-func shortLog*(v: SomeBeaconBlock): auto =
+func shortLog*(v: SomePhase0BeaconBlock): auto =
   (
     slot: shortLog(v.slot),
     proposer_index: v.proposer_index,

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -752,10 +752,8 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: Eth2Digest) {.
      raises: [IOError, Defect].} =
   writeValue(writer, hexOriginal(value.data))
 
-type ForkyBloomLogs = bellatrix.BloomLogs | capella.BloomLogs
-
 ## BloomLogs
-proc readValue*(reader: var JsonReader[RestJson], value: var ForkyBloomLogs) {.
+proc readValue*(reader: var JsonReader[RestJson], value: var BloomLogs) {.
      raises: [IOError, SerializationError, Defect].} =
   try:
     hexToByteArray(reader.readValue(string), value.data)
@@ -763,7 +761,7 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ForkyBloomLogs) {.
     raiseUnexpectedValue(reader,
                          "BloomLogs value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: ForkyBloomLogs) {.
+proc writeValue*(writer: var JsonWriter[RestJson], value: BloomLogs) {.
      raises: [IOError, Defect].} =
   writeValue(writer, hexOriginal(value.data))
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -12,7 +12,7 @@ import stew/[assign2, results, base10, byteutils], presto/common,
        chronicles
 import ".."/[eth2_ssz_serialization, forks, keystore],
        ".."/../consensus_object_pools/block_pools_types,
-       ".."/datatypes/[phase0, altair, bellatrix],
+       ".."/datatypes/[phase0, altair, bellatrix, capella],
        ".."/mev/bellatrix_mev,
        ".."/../validators/slashing_protection_common,
        "."/[rest_types, rest_keymanager_types]

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1015,12 +1015,12 @@ proc writeValue*[BlockType: Web3SignerForkedBeaconBlock|ForkedBeaconBlock](
     writer.writeField("data", value.capellaData)
   writer.endRecord()
 
-proc extractBodyKind(reader: JsonReader[RestJson]): BeaconBlockFork =
+proc extractBodyKind(reader: var JsonReader[RestJson]): BeaconBlockFork =
   ## Check known keys added to each block type in a fork
   ## We run a first pass so we can understand which types we
   ## should be dealing with to route code typing as needed
 
-  let result: BeaconBlockFork = BeaconBlockFork.Phase0
+  result = BeaconBlockFork.Phase0
 
   for fieldName in readObjectFields(reader):
     case fieldName:

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1027,7 +1027,7 @@ proc extractBodyKind(reader: JsonReader[RestJson]): BeaconBlockFork =
     of "bls_to_execution_changes":
       result = BeaconBlockFork.Capella
     of "execution_payload":
-      result = max(result, BeaconBlockFork.Capella)
+      result = max(result, BeaconBlockFork.Bellatrix)
     of "sync_aggregate":
       result = max(result, BeaconBlockFork.Altair)
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1021,17 +1021,21 @@ proc extractBodyKind(reader: var JsonReader[RestJson]): BeaconBlockFork
   ## Check known keys added to each block type in a fork
   ## We run a first pass so we can understand which types we
   ## should be dealing with to route code typing as needed
-
-  result = BeaconBlockFork.Phase0
-
   for fieldName in readObjectFields(reader):
-    case fieldName:
-    of "bls_to_execution_changes":
-      result = BeaconBlockFork.Capella
-    of "execution_payload":
-      result = max(result, BeaconBlockFork.Bellatrix)
-    of "sync_aggregate":
-      result = max(result, BeaconBlockFork.Altair)
+    case fieldName
+    of "version":
+      let version = reader.readValue(string)
+      case version
+      of "phase0":
+        return BeaconBlockFork.Phase0
+      of "altair":
+        return BeaconBlockFork.Altair
+      of "bellatrix":
+        return BeaconBlockFork.Bellatrix
+      of "capella":
+        return BeaconBlockFork.Capella
+      else:
+        reader.raiseUnexpectedValue("Incorrect version field value")
 
 ## RestPublishedBeaconBlockBody
 proc readValue*(reader: var JsonReader[RestJson],
@@ -1393,6 +1397,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         version = some(BeaconBlockFork.Altair)
       of "bellatrix":
         version = some(BeaconBlockFork.Bellatrix)
+      of "capella":
+        version = some(BeaconBlockFork.Capella)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
@@ -1499,6 +1505,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       of "phase0": some(BeaconStateFork.Phase0)
       of "altair": some(BeaconStateFork.Altair)
       of "bellatrix": some(BeaconStateFork.Bellatrix)
+      of "capella": some(BeaconStateFork.Capella)
       else: reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
       if data.isSome():

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -12,7 +12,7 @@ else:
 import
   chronos, presto/client, chronicles,
   ".."/".."/validators/slashing_protection_common,
-  ".."/datatypes/[phase0, altair, bellatrix],
+  ".."/datatypes/[phase0, altair, bellatrix, capella],
   ".."/[helpers, forks, keystore, eth2_ssz_serialization],
   "."/[rest_types, rest_common, eth2_rest_serialization]
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -20,7 +20,7 @@ import
   std/json,
   stew/base10, web3/ethtypes,
   ".."/forks,
-  ".."/datatypes/[phase0, altair, bellatrix],
+  ".."/datatypes/[phase0, altair, bellatrix, capella],
   ".."/mev/bellatrix_mev
 
 export forks, phase0, altair, bellatrix, bellatrix_mev
@@ -252,9 +252,10 @@ type
 
   RestPublishedBeaconBlockBody* = object
     case kind*: BeaconBlockFork
-    of BeaconBlockFork.Phase0:    phase0Body*: phase0.BeaconBlockBody
-    of BeaconBlockFork.Altair:    altairBody*: altair.BeaconBlockBody
+    of BeaconBlockFork.Phase0:    phase0Body*:    phase0.BeaconBlockBody
+    of BeaconBlockFork.Altair:    altairBody*:    altair.BeaconBlockBody
     of BeaconBlockFork.Bellatrix: bellatrixBody*: bellatrix.BeaconBlockBody
+    of BeaconBlockFork.Capella:   capellaBody*:   capella.BeaconBlockBody
 
   RestSpec* = object
     # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/presets/mainnet/phase0.yaml

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -311,6 +311,15 @@ type
     BYTES_PER_LOGS_BLOOM*: uint64
     MAX_EXTRA_DATA_BYTES*: uint64
 
+    # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/presets/mainnet/capella.yaml
+    INACTIVITY_PENALTY_QUOTIENT_CAPELLA*: uint64
+    MIN_SLASHING_PENALTY_QUOTIENT_CAPELLA*: uint64
+    PROPORTIONAL_SLASHING_MULTIPLIER_CAPELLA*: uint64
+    MAX_WITHDRAWALS_PER_PAYLOAD*: uint64
+    MAX_BLS_TO_EXECUTION_CHANGES*: uint64
+    WITHDRAWALS_QUEUE_LIMIT*: uint64
+    DOMAIN_BLS_TO_EXECUTION_CHANGE*: DomainType
+
     # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/configs/mainnet.yaml
     PRESET_BASE*: string
     CONFIG_NAME*: string

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -23,7 +23,7 @@ import
   ".."/datatypes/[phase0, altair, bellatrix, capella],
   ".."/mev/bellatrix_mev
 
-export forks, phase0, altair, bellatrix, bellatrix_mev
+export forks, phase0, altair, bellatrix, bellatrix_mev, capella
 
 const
   # https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/states/validator_balances.yaml#L17

--- a/beacon_chain/spec/eth2_ssz_serialization.nim
+++ b/beacon_chain/spec/eth2_ssz_serialization.nim
@@ -16,7 +16,7 @@ else:
 import
   ssz_serialization,
   ./ssz_codec,
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella],
   ./eth2_merkleization
 
 export phase0, altair, ssz_codec, ssz_serialization, eth2_merkleization

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -133,13 +133,17 @@ type
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
     of BeaconBlockFork.Capella:   capellaData*:   capella.BeaconBlock
 
-  ForkyExecutionPayload* = object
+  ForkyExecutionPayload* =
     bellatrix.ExecutionPayload |
     capella.ExecutionPayload
 
-  ForkyExecutionPayloadHeader* = object
+  ForkyExecutionPayloadHeader* =
     bellatrix.ExecutionPayloadHeader |
     capella.ExecutionPayloadHeader
+
+  ForkyExecutePayload* =
+    bellatrix.ExecutePayload |
+    capella.ExecutePayload
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: BeaconBlockFork

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -394,6 +394,7 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
   of BeaconStateFork.Capella:
     const stateFork {.inject, used.} = BeaconStateFork.Capella
+    template forkyState: untyped {.inject, used.} = x.capellaData
     template state: untyped {.inject, used.} = x.capellaData
     body
   of BeaconStateFork.Bellatrix:

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -442,7 +442,7 @@ func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
   if tgt.kind == src.kind:
     case tgt.kind
     of BeaconStateFork.Capella:
-      assign(tgt.capellaData, src.capellaData):
+      assign(tgt.capellaData,   src.capellaData):
     of BeaconStateFork.Bellatrix:
       assign(tgt.bellatrixData, src.bellatrixData):
     of BeaconStateFork.Altair:
@@ -471,6 +471,11 @@ func getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
 
 func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
   withState(x): forkyState.root = root
+
+template ExecutionPayloadHeader(state: bellatrix.BeaconState): typedesc[bellatrix.ExecutionPayloadHeader] =
+  bellatrix.ExecutionPayloadHeader
+template getExecutionPayloadHeader(state: capella.BeaconState): typedesc[capella.ExecutionPayloadHeader] =
+  capella.ExecutionPayloadHeader
 
 func stateForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconStateFork =
   ## Return the current fork for the given epoch.

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -730,7 +730,7 @@ func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   case cfg.stateForkAtEpoch(epoch)
   # TODO: Is Capella a FAR_FUTURE?
   of BeaconStateFork.Capella:   FAR_FUTURE_EPOCH
-  of BeaconStateFork.Bellatrix: FAR_FUTURE_EPOCH
+  of BeaconStateFork.Bellatrix: cfg.CAPELLA_FORK_EPOCH
   of BeaconStateFork.Altair:    cfg.BELLATRIX_FORK_EPOCH
   of BeaconStateFork.Phase0:    cfg.ALTAIR_FORK_EPOCH
 

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -705,7 +705,7 @@ func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   of BeaconStateFork.Altair:    cfg.BELLATRIX_FORK_EPOCH
   of BeaconStateFork.Phase0:    cfg.ALTAIR_FORK_EPOCH
 
-func getForkSchedule*(cfg: RuntimeConfig): array[3, Fork] =
+func getForkSchedule*(cfg: RuntimeConfig): array[4, Fork] =
   ## This procedure returns list of known and/or scheduled forks.
   ##
   ## This procedure is used by HTTP REST framework and validator client.

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -15,7 +15,7 @@ import
   chronicles,
   ../extras,
   "."/[block_id, eth2_merkleization, eth2_ssz_serialization, presets],
-  ./datatypes/[phase0, altair, bellatrix, capella]
+  ./datatypes/[phase0, altair, bellatrix, capella],
   ./mev/bellatrix_mev
 
 export
@@ -134,6 +134,7 @@ type
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: BeaconBlockHeader
+    of BeaconBlockFork.Capella:   capellaData*: BeaconBlockHeader
 
   ForkedTrustedBeaconBlock* = object
     case kind*: BeaconBlockFork

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -218,6 +218,9 @@ template toFork*[T: altair.BeaconState | altair.HashedBeaconState](
 template toFork*[T: bellatrix.BeaconState | bellatrix.HashedBeaconState](
     t: type T): BeaconStateFork =
   BeaconStateFork.Bellatrix
+template toFork*[T: capella.BeaconState | capella.HashedBeaconState](
+    t: type T): BeaconStateFork =
+  BeaconStateFork.Capella
 
 # TODO these cause stack overflows due to large temporaries getting allocated
 # template init*(T: type ForkedHashedBeaconState, data: phase0.HashedBeaconState): T =
@@ -233,6 +236,8 @@ template init*(T: type ForkedBeaconBlock, blck: altair.BeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedBeaconBlock, blck: bellatrix.BeaconBlock): T =
   T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedBeaconBlock, blck: capella.BeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template init*(T: type ForkedTrustedBeaconBlock, blck: phase0.TrustedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
@@ -240,6 +245,8 @@ template init*(T: type ForkedTrustedBeaconBlock, blck: altair.TrustedBeaconBlock
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedTrustedBeaconBlock, blck: bellatrix.TrustedBeaconBlock): T =
   T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedTrustedBeaconBlock, blck: capella.TrustedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, blck: phase0.SignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
@@ -247,6 +254,8 @@ template init*(T: type ForkedSignedBeaconBlock, blck: altair.SignedBeaconBlock):
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: bellatrix.SignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedSignedBeaconBlock, blck: capella.SignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
                blockRoot: Eth2Digest, signature: ValidatorSig): T =
@@ -266,20 +275,29 @@ template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
       bellatrixData: bellatrix.SignedBeaconBlock(message: forked.bellatrixData,
                                                  root: blockRoot,
                                                  signature: signature))
+  of BeaconBlockFork.Capella:
+    T(kind: BeaconBlockFork.Capella,
+      capellaData: capella.SignedBeaconBlock(message: forked.capellaData,
+                                                 root: blockRoot,
+                                                 signature: signature))
 
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: phase0.MsgTrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: altair.MsgTrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: bellatrix.MsgTrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Bellatrix,  bellatrixData: blck)
+  T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: capella.MsgTrustedSignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: phase0.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: altair.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: bellatrix.TrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Bellatrix,  bellatrixData: blck)
+  T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedTrustedSignedBeaconBlock, blck: capella.TrustedSignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template toString*(kind: BeaconBlockFork): string =
   case kind
@@ -289,6 +307,8 @@ template toString*(kind: BeaconBlockFork): string =
     "altair"
   of BeaconBlockFork.Bellatrix:
     "bellatrix"
+  of BeaconBlockFork.Capella:
+    "capella"
 
 template toString*(kind: BeaconStateFork): string =
   case kind
@@ -298,6 +318,8 @@ template toString*(kind: BeaconStateFork): string =
     "altair"
   of BeaconStateFork.Bellatrix:
     "bellatrix"
+  of BeaconStateFork.Capella:
+    "capella"
 
 template toFork*[T:
     phase0.BeaconBlock |
@@ -326,6 +348,15 @@ template toFork*[T:
     bellatrix.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Bellatrix
+template toFork*[T:
+    capella.BeaconBlock |
+    capella.SignedBeaconBlock |
+    capella.TrustedBeaconBlock |
+    capella.SigVerifiedSignedBeaconBlock |
+    capella.MsgTrustedSignedBeaconBlock |
+    capella.TrustedSignedBeaconBlock](
+    t: type T): BeaconBlockFork =
+  BeaconBlockFork.Capella
 
 template init*(T: type ForkedEpochInfo, info: phase0.EpochInfo): T =
   T(kind: EpochInfoFork.Phase0, phase0Data: info)
@@ -334,6 +365,10 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
+  of BeaconStateFork.Capella:
+    const stateFork {.inject, used.} = BeaconStateFork.Capella
+    template state: untyped {.inject, used.} = x.capellaData
+    body
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template forkyState: untyped {.inject, used.} = x.bellatrixData
@@ -415,7 +450,8 @@ func stateForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconStateFork =
     doAssert BeaconStateFork.Altair    > BeaconStateFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconStateFork.Bellatrix
+  if   epoch >= cfg.CAPELLA_FORK_EPOCH:   BeaconStateFork.Capella
+  elif epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconStateFork.Bellatrix
   elif epoch >= cfg.ALTAIR_FORK_EPOCH:    BeaconStateFork.Altair
   else:                                   BeaconStateFork.Phase0
 
@@ -427,7 +463,9 @@ func blockForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconBlockFork =
 
 func stateForkForDigest*(
     forkDigests: ForkDigests, forkDigest: ForkDigest): Opt[BeaconStateFork] =
-  if   forkDigest == forkDigests.bellatrix:
+  if   forkDigest == forkDigests.capella:
+    ok BeaconStateFork.Capella
+  elif forkDigest == forkDigests.bellatrix:
     ok BeaconStateFork.Bellatrix
   elif forkDigest == forkDigests.altair:
     ok BeaconStateFork.Altair
@@ -439,6 +477,8 @@ func stateForkForDigest*(
 func atStateFork*(
     forkDigests: ForkDigests, stateFork: BeaconStateFork): ForkDigest =
   case stateFork
+  of BeaconStateFork.Capella:
+    forkDigests.capella
   of BeaconStateFork.Bellatrix:
     forkDigests.bellatrix
   of BeaconStateFork.Altair:
@@ -503,6 +543,10 @@ template withBlck*(
   of BeaconBlockFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template blck: untyped {.inject.} = x.bellatrixData
+    body
+  of BeaconBlockFork.Capella:
+    const stateFork {.inject, used.} = BeaconStateFork.Capella
+    template blck: untyped {.inject.} = x.capellaData
     body
 
 func proposer_index*(x: ForkedBeaconBlock): uint64 =

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -51,6 +51,12 @@ type
     bellatrix.BeaconState |
     capella.BeaconState
 
+  # Beacon state which does not include the base fork
+  ForkyUpgradedBeaconState* =
+    altair.BeaconState |
+    bellatrix.BeaconState |
+    capella.BeaconState
+
   ForkyHashedBeaconState* =
     phase0.HashedBeaconState |
     altair.HashedBeaconState |

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -15,7 +15,7 @@ import
   chronicles,
   ../extras,
   "."/[block_id, eth2_merkleization, eth2_ssz_serialization, presets],
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella]
   ./mev/bellatrix_mev
 
 export
@@ -42,7 +42,8 @@ type
   BeaconStateFork* {.pure.} = enum
     Phase0,
     Altair,
-    Bellatrix
+    Bellatrix,
+    Capella
 
   ForkyBeaconState* =
     phase0.BeaconState |
@@ -59,26 +60,31 @@ type
     of BeaconStateFork.Phase0:    phase0Data*:    phase0.HashedBeaconState
     of BeaconStateFork.Altair:    altairData*:    altair.HashedBeaconState
     of BeaconStateFork.Bellatrix: bellatrixData*: bellatrix.HashedBeaconState
+    of BeaconStateFork.Capella:   capellaData*:   capella.HashedBeaconState
 
   BeaconBlockFork* {.pure.} = enum
     Phase0
     Altair
     Bellatrix
+    Capella
 
   ForkyBeaconBlockBody* =
     phase0.BeaconBlockBody |
     altair.BeaconBlockBody |
-    bellatrix.BeaconBlockBody
+    bellatrix.BeaconBlockBody |
+    capella.BeaconBlockBody
 
   ForkySigVerifiedBeaconBlockBody* =
     phase0.SigVerifiedBeaconBlockBody |
     altair.SigVerifiedBeaconBlockBody |
-    bellatrix.SigVerifiedBeaconBlockBody
+    bellatrix.SigVerifiedBeaconBlockBody |
+    capella.SigVerifiedBeaconBlockBody
 
   ForkyTrustedBeaconBlockBody* =
     phase0.TrustedBeaconBlockBody |
     altair.TrustedBeaconBlockBody |
-    bellatrix.TrustedBeaconBlockBody
+    bellatrix.TrustedBeaconBlockBody |
+    capella.TrustedBeaconBlockBody
 
   SomeForkyBeaconBlockBody* =
     ForkyBeaconBlockBody |
@@ -88,17 +94,20 @@ type
   ForkyBeaconBlock* =
     phase0.BeaconBlock |
     altair.BeaconBlock |
-    bellatrix.BeaconBlock
+    bellatrix.BeaconBlock |
+    capella.BeaconBlock
 
   ForkySigVerifiedBeaconBlock* =
     phase0.SigVerifiedBeaconBlock |
     altair.SigVerifiedBeaconBlock |
-    bellatrix.SigVerifiedBeaconBlock
+    bellatrix.SigVerifiedBeaconBlock |
+    capella.SigVerifiedBeaconBlock
 
   ForkyTrustedBeaconBlock* =
     phase0.TrustedBeaconBlock |
     altair.TrustedBeaconBlock |
-    bellatrix.TrustedBeaconBlock
+    bellatrix.TrustedBeaconBlock |
+    capella.TrustedBeaconBlock
 
   SomeForkyBeaconBlock* =
     ForkyBeaconBlock |
@@ -110,6 +119,7 @@ type
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.BeaconBlock
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -122,44 +132,52 @@ type
     of BeaconBlockFork.Phase0:    phase0Data*:     phase0.TrustedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:     altair.TrustedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*:  bellatrix.TrustedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:    capella.TrustedBeaconBlock
 
   ForkySignedBeaconBlock* =
     phase0.SignedBeaconBlock |
     altair.SignedBeaconBlock |
-    bellatrix.SignedBeaconBlock
+    bellatrix.SignedBeaconBlock |
+    capella.SignedBeaconBlock
 
   ForkedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.SignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.SignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.SignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.SignedBeaconBlock
 
   ForkySigVerifiedSignedBeaconBlock* =
     phase0.SigVerifiedSignedBeaconBlock |
     altair.SigVerifiedSignedBeaconBlock |
-    bellatrix.SigVerifiedSignedBeaconBlock
+    bellatrix.SigVerifiedSignedBeaconBlock |
+    capella.SigVerifiedSignedBeaconBlock
 
   ForkyMsgTrustedSignedBeaconBlock* =
     phase0.MsgTrustedSignedBeaconBlock |
     altair.MsgTrustedSignedBeaconBlock |
-    bellatrix.MsgTrustedSignedBeaconBlock
+    bellatrix.MsgTrustedSignedBeaconBlock |
+    capella.MsgTrustedSignedBeaconBlock
 
   ForkyTrustedSignedBeaconBlock* =
     phase0.TrustedSignedBeaconBlock |
     altair.TrustedSignedBeaconBlock |
-    bellatrix.TrustedSignedBeaconBlock
+    bellatrix.TrustedSignedBeaconBlock |
+    capella.TrustedSignedBeaconBlock
 
   ForkedMsgTrustedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.MsgTrustedSignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.MsgTrustedSignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.MsgTrustedSignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.MsgTrustedSignedBeaconBlock
 
   ForkedTrustedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.TrustedSignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.TrustedSignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.TrustedSignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.TrustedSignedBeaconBlock
 
   SomeForkySignedBeaconBlock* =
     ForkySignedBeaconBlock |
@@ -170,11 +188,17 @@ type
   EpochInfoFork* {.pure.} = enum
     Phase0
     Altair
+    # TODO: Should be here?
+    # Bellatrix
+    # Capella
 
   ForkedEpochInfo* = object
     case kind*: EpochInfoFork
     of EpochInfoFork.Phase0: phase0Data*: phase0.EpochInfo
     of EpochInfoFork.Altair: altairData*: altair.EpochInfo
+    # TODO: Should be here?
+    # Bellatrix
+    # Capella
 
   ForkyEpochInfo* = phase0.EpochInfo | altair.EpochInfo
 
@@ -353,6 +377,8 @@ template withEpochInfo*(
 func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
   if tgt.kind == src.kind:
     case tgt.kind
+    of BeaconStateFork.Capella:
+      assign(tgt.capellaData, src.capellaData):
     of BeaconStateFork.Bellatrix:
       assign(tgt.bellatrixData, src.bellatrixData):
     of BeaconStateFork.Altair:
@@ -371,6 +397,7 @@ template getStateField*(x: ForkedHashedBeaconState, y: untyped): untyped =
   # ```
   # Without `unsafeAddr`, the `validators` list would be copied to a temporary variable.
   (case x.kind
+  of BeaconStateFork.Capella:   unsafeAddr x.capellaData.data.y
   of BeaconStateFork.Bellatrix: unsafeAddr x.bellatrixData.data.y
   of BeaconStateFork.Altair:    unsafeAddr x.altairData.data.y
   of BeaconStateFork.Phase0:    unsafeAddr x.phase0Data.data.y)[]

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -133,17 +133,20 @@ type
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
     of BeaconBlockFork.Capella:   capellaData*:   capella.BeaconBlock
 
-  ForkedExecutionPayloadHeader* = object
-    case kind*: WithExecutionPayloadHeader
-    of WithExecutionPayloadHeader.Bellatrix: bellatrixData*: bellatrix.ExecutionPayloadHeader
-    of WithExecutionPayloadHeader.Capella:   capellaData*:   capella.ExecutionPayloadHeader
+  ForkyExecutionPayload* = object
+    bellatrix.ExecutionPayload |
+    capella.ExecutionPayload
+
+  ForkyExecutionPayloadHeader* = object
+    bellatrix.ExecutionPayloadHeader |
+    capella.ExecutionPayloadHeader
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: BeaconBlockHeader
-    of BeaconBlockFork.Capella:   capellaData*: BeaconBlockHeader
+    of BeaconBlockFork.Capella:   capellaData*:   BeaconBlockHeader
 
   ForkedTrustedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -788,7 +791,7 @@ func toBeaconBlockFork*(fork: BeaconStateFork): BeaconBlockFork =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#compute_fork_data_root
 func toExecutionPayloadHeader(state: bellatrix.BeaconState | capella.BeaconState):
-     ForkedExecutionPayloadHeader =
+     ForkyExecutionPayloadHeader =
   case state:
   of bellatrix.BeaconState: bellatrix.ExecutionPayloadHeader
   of capella.BeaconState:   capella.ExecutionPayloadHeader

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -76,6 +76,10 @@ type
     Bellatrix
     Capella
 
+  WithExecutionPayloadHeader* {.pure.} = enum
+    Bellatrix
+    Capella
+
   ForkyBeaconBlockBody* =
     phase0.BeaconBlockBody |
     altair.BeaconBlockBody |
@@ -128,6 +132,11 @@ type
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
     of BeaconBlockFork.Capella:   capellaData*:   capella.BeaconBlock
+
+  ForkedExecutionPayloadHeader* = object
+    case kind*: WithExecutionPayloadHeader
+    of WithExecutionPayloadHeader.Bellatrix: bellatrixData*: bellatrix.ExecutionPayloadHeader
+    of WithExecutionPayloadHeader.Capella:   capellaData*:   capella.ExecutionPayloadHeader
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: BeaconBlockFork
@@ -778,6 +787,13 @@ func toBeaconBlockFork*(fork: BeaconStateFork): BeaconBlockFork =
   of BeaconStateFork.Capella:   BeaconBlockFork.Capella
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#compute_fork_data_root
+func toExecutionPayloadHeader(state: bellatrix.BeaconState | capella.BeaconState):
+     ForkedExecutionPayloadHeader =
+  case state:
+  of bellatrix.BeaconState: bellatrix.ExecutionPayloadHeader
+  of capella.BeaconState:   capella.ExecutionPayloadHeader
+
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/beacon-chain.md#compute_fork_data_root
 func compute_fork_data_root*(current_version: Version,
     genesis_validators_root: Eth2Digest): Eth2Digest =
   ## Return the 32-byte fork data root for the ``current_version`` and

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -19,7 +19,7 @@ import
   ./mev/bellatrix_mev
 
 export
-  extras, block_id, phase0, altair, bellatrix, eth2_merkleization,
+  extras, block_id, phase0, altair, bellatrix, capella, eth2_merkleization,
   eth2_ssz_serialization, presets
 
 # This file contains helpers for dealing with forks - we have two ways we can

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -366,7 +366,7 @@ func compute_timestamp_at_slot*(state: ForkyBeaconState, slot: Slot): uint64 =
   let slots_since_genesis = slot - GENESIS_SLOT
   state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT
 
-proc emptyPayloadToBlockHeader*(payload: ExecutionPayload): ExecutionBlockHeader =
+proc emptyPayloadToBlockHeader*(payload: bellatrix.ExecutionPayload | capella.ExecutionPayload): ExecutionBlockHeader =
   ## This function assumes that the payload is empty!
   doAssert payload.transactions.len == 0
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -343,6 +343,23 @@ func is_execution_enabled*(
           bellatrix.SigVerifiedBeaconBlockBody): bool =
   is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#is_merge_transition_block
+func is_merge_transition_block(
+    state: capella.BeaconState,
+    body: capella.BeaconBlockBody | capella.TrustedBeaconBlockBody |
+          capella.SigVerifiedBeaconBlockBody): bool =
+  const defaultCapellaExecutionPayload = default(capella.ExecutionPayload)
+  not is_merge_transition_complete(state) and
+    body.execution_payload != defaultCapellaExecutionPayload
+
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/capella/beacon-chain.md#is_execution_enabled
+func is_execution_enabled*(
+    state: capella.BeaconState,
+    body: capella.BeaconBlockBody | capella.TrustedBeaconBlockBody |
+          capella.SigVerifiedBeaconBlockBody): bool =
+  is_merge_transition_block(state, body) or is_merge_transition_complete(state)
+
+
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
 func compute_timestamp_at_slot*(state: ForkyBeaconState, slot: Slot): uint64 =
   # Note: This function is unsafe with respect to overflows and underflows.

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -308,15 +308,11 @@ template is_better_update*[A, B: SomeLightClientUpdate](
     new_update: A, old_update: B): bool =
   is_better_data(toMeta(new_update), toMeta(old_update))
 
+
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
 func is_merge_transition_complete*(state: bellatrix.BeaconState | capella.BeaconState): bool =
-  case state:
-    of BeaconStateFork.Bellatrix:
-      const defaultExecutionPayloadHeader = default(bellatrix.ExecutionPayloadHeader)
-      state.latest_execution_payload_header != defaultExecutionPayloadHeader
-    of BeaconStateFork.Capella:
-      const defaultExecutionPayloadHeader = default(capella.ExecutionPayloadHeader)
-      state.latest_execution_payload_header != defaultExecutionPayloadHeader
+  const defaultExecutionPayloadHeader = default(state.toExecutionPayloadHeader())
+  state.latest_execution_payload_header != defaultExecutionPayloadHeader
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#helpers
 func is_execution_block*(blck: SomeForkyBeaconBlock): bool =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -20,7 +20,7 @@ import
   chronicles,
   eth/eip1559, eth/common/eth_types,
   # Internal
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella],
   "."/[eth2_merkleization, forks, ssz_codec]
 
 # TODO although eth2_merkleization already exports ssz_codec, *sometimes* code

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -373,7 +373,7 @@ proc emptyPayloadToBlockHeader*(payload: ExecutionPayload): ExecutionBlockHeader
   )
 
 #
-# TODO: Use a base builder function for the following:
+# TODO: @tavurth Use a base builder function for the following:
 #
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py#L1-L31

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -310,8 +310,12 @@ template is_better_update*[A, B: SomeLightClientUpdate](
 
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
-func is_merge_transition_complete*(state: bellatrix.BeaconState | capella.BeaconState): bool =
-  const defaultExecutionPayloadHeader = default(state.toExecutionPayloadHeader())
+func is_merge_transition_complete*(state: bellatrix.BeaconState): bool =
+  const defaultExecutionPayloadHeader = default(bellatrix.ExecutionPayloadHeader)
+  state.latest_execution_payload_header != defaultExecutionPayloadHeader
+
+func is_merge_transition_complete*(state: capella.BeaconState): bool =
+  const defaultExecutionPayloadHeader = default(capella.ExecutionPayloadHeader)
   state.latest_execution_payload_header != defaultExecutionPayloadHeader
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/sync/optimistic.md#helpers
@@ -369,7 +373,7 @@ proc emptyPayloadToBlockHeader*(payload: ExecutionPayload): ExecutionBlockHeader
   )
 
 #
-# TODO: @tavurth Use a base builder function for the following:
+# TODO: @tavurth Perhaps use a base builder function for the following:
 #
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.10/tests/core/pyspec/eth2spec/test/helpers/execution_payload.py#L1-L31

--- a/beacon_chain/spec/presets/mainnet.nim
+++ b/beacon_chain/spec/presets/mainnet.nim
@@ -1,4 +1,4 @@
 import
-  ./mainnet/[altair_preset, bellatrix_preset, phase0_preset]
+  ./mainnet/[altair_preset, bellatrix_preset, capella_preset, phase0_preset]
 
-export altair_preset, bellatrix_preset, phase0_preset
+export altair_preset, bellatrix_preset, capella_preset, phase0_preset

--- a/beacon_chain/spec/presets/mainnet/capella_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/capella_preset.nim
@@ -1,0 +1,29 @@
+# Mainnet preset - Capella
+
+
+type
+  DomainType = distinct array[4, byte]
+
+
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/presets/mainnet/capella.yaml
+const
+  # TODO: @tavurth currently same as capella
+  # ---------------------------------------------------------------
+  # 2**24 (= 16,777,216)
+  INACTIVITY_PENALTY_QUOTIENT_CAPELLA*: uint64 = 16777216
+  # 2**5 (= 32)
+  MIN_SLASHING_PENALTY_QUOTIENT_CAPELLA*: uint64 = 32
+  # 3
+  PROPORTIONAL_SLASHING_MULTIPLIER_CAPELLA*: uint64 = 3
+
+
+  # Execution
+  # ---------------------------------------------------------------
+  # 2**4 (= 16)
+  MAX_WITHDRAWALS_PER_PAYLOAD*: uint64 = 16
+  # 2**4 (= 16)
+  MAX_BLS_TO_EXECUTION_CHANGES*: uint64 = 16
+  # 2**40 (= 1,099,511,627,776)
+  WITHDRAWALS_QUEUE_LIMIT*: uint64 = (uint64) 1_099_511_627_776
+  # DomainType('0x0A000000')
+  DOMAIN_BLS_TO_EXECUTION_CHANGE*: DomainType = DomainType([byte 0x0A, 0x00, 0x00, 0x00])

--- a/beacon_chain/spec/presets/minimal.nim
+++ b/beacon_chain/spec/presets/minimal.nim
@@ -1,4 +1,4 @@
 import
-  ./minimal/[altair_preset, bellatrix_preset, phase0_preset]
+  ./minimal/[altair_preset, bellatrix_preset, capella_preset, phase0_preset]
 
-export altair_preset, bellatrix_preset, phase0_preset
+export altair_preset, bellatrix_preset, capella_preset, phase0_preset

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -20,7 +20,7 @@ else:
 ## functions.
 
 import
-  ./datatypes/[phase0, altair, bellatrix], ./mev/bellatrix_mev, ./helpers,
+  ./datatypes/[phase0, altair, bellatrix, capella], ./mev/bellatrix_mev, ./helpers,
   ./eth2_merkleization
 
 export phase0, altair

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -52,7 +52,7 @@ import
     beaconstate, eth2_merkleization, forks, helpers, signatures,
     state_transition_block, state_transition_epoch, validator]
 
-export results, extras, phase0, altair, bellatrix
+export results, extras, phase0, altair, bellatrix, capella
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 proc verify_block_signature(

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -47,7 +47,7 @@ import
   chronicles,
   stew/results,
   ../extras,
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella],
   "."/[
     beaconstate, eth2_merkleization, forks, helpers, signatures,
     state_transition_block, state_transition_epoch, validator]

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -303,7 +303,7 @@ proc process_deposit*(cfg: RuntimeConfig,
         static: doAssert state.balances.maxLen == state.validators.maxLen
         raiseAssert "adding validator succeeded, so should balances"
 
-      when state is altair.BeaconState or state is bellatrix.BeaconState:
+      when state is altair.BeaconState or state is bellatrix.BeaconState or state is capella.BeaconState:
         if not state.previous_epoch_participation.add(ParticipationFlags(0)):
           return err("process_deposit: too many validators (previous_epoch_participation)")
         if not state.current_epoch_participation.add(ParticipationFlags(0)):

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -486,7 +486,7 @@ proc process_sync_aggregate*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#process_execution_payload
 proc process_execution_payload*(
-    state: var bellatrix.BeaconState | capella.BeaconState, payload: ForkyExecutionPayloadHeader,
+    state: var bellatrix.BeaconState | capella.BeaconState, payload: ForkyExecutionPayload,
     notify_new_payload: ExecutePayload): Result[void, cstring] =
   ## Verify consistency of the parent hash with respect to the previous
   ## execution payload header

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -486,7 +486,7 @@ proc process_sync_aggregate*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#process_execution_payload
 proc process_execution_payload*(
-    state: var bellatrix.BeaconState | capella.BeaconState, payload: ForkedExecutionPayloadHeader,
+    state: var bellatrix.BeaconState | capella.BeaconState, payload: ForkyExecutionPayloadHeader,
     notify_new_payload: ExecutePayload): Result[void, cstring] =
   ## Verify consistency of the parent hash with respect to the previous
   ## execution payload header

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -26,7 +26,7 @@ import
   std/[algorithm, sequtils, sets, tables],
   chronicles, metrics,
   ../extras,
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella],
   "."/[beaconstate, eth2_merkleization, helpers, validator, signatures]
 
 export extras, phase0, altair
@@ -483,9 +483,10 @@ proc process_sync_aggregate*(
 
   ok()
 
+
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#process_execution_payload
 proc process_execution_payload*(
-    state: var bellatrix.BeaconState, payload: ExecutionPayload,
+    state: var bellatrix.BeaconState | capella.BeaconState, payload: ForkedExecutionPayloadHeader,
     notify_new_payload: ExecutePayload): Result[void, cstring] =
   ## Verify consistency of the parent hash with respect to the previous
   ## execution payload header

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -598,6 +598,7 @@ proc process_block*(
 # copy of datatypes/altair.nim
 type SomeAltairBlock =
   altair.BeaconBlock | altair.SigVerifiedBeaconBlock | altair.TrustedBeaconBlock
+
 proc process_block*(
     cfg: RuntimeConfig,
     state: var altair.BeaconState, blck: SomeAltairBlock, flags: UpdateFlags,

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -895,6 +895,8 @@ func get_adjusted_total_slashing_balance*(
       PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR
     elif state is bellatrix.BeaconState:
       PROPORTIONAL_SLASHING_MULTIPLIER_BELLATRIX
+    elif state is capella.BeaconState:
+      PROPORTIONAL_SLASHING_MULTIPLIER_CAPELLA
     else:
       {.fatal: "process_slashings: incorrect BeaconState type".}
   min(sum(state.slashings.data) * multiplier, total_balance)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -13,7 +13,7 @@ else:
 
 import
   std/[options, math, tables],
-  ./datatypes/[phase0, altair, bellatrix],
+  ./datatypes/[phase0, altair, bellatrix, capella],
   ./helpers
 
 export helpers

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -14,7 +14,7 @@ import
   std/[options, tables, sets, macros],
   chronicles, chronos, snappy/codec,
   stew/ranges/bitranges, libp2p/switch,
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/[helpers, forks, network],
   ".."/[beacon_clock],
   ../networking/eth2_network,

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -8,7 +8,7 @@
 import
   std/sets,
   metrics, chronicles,
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/eth2_apis/rest_types,
   ../validators/activity_metrics,
   "."/[common, api, block_service]

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -430,7 +430,7 @@ proc getExecutionPayload(
     epoch: Epoch,
     validator_index: ValidatorIndex,
     pubkey: ValidatorPubKey):
-    Future[Opt[ExecutionPayload]] {.async.} =
+    Future[bellatrix.ExecutionPayload | capella.ExecutionPayload] {.async.} =
   # https://github.com/ethereum/consensus-specs/blob/v1.1.10/specs/bellatrix/validator.md#executionpayload
 
   # Only current hardfork with execution payloads is Bellatrix & Capella
@@ -530,7 +530,10 @@ proc makeBeaconBlockForHeadAndSlot*(
     node: BeaconNode, randao_reveal: ValidatorSig,
     validator_index: ValidatorIndex, graffiti: GraffitiBytes, head: BlockRef,
     slot: Slot,
-    execution_payload: Opt[ExecutionPayload] = Opt.none(ExecutionPayload),
+    execution_payload:
+      Opt[bellatrix.ExecutionPayload] | Opt[capella.ExecutionPayload]
+        = Opt.none(bellatrix.ExecutionPayload),
+
     transactions_root: Opt[Eth2Digest] = Opt.none(Eth2Digest),
     execution_payload_root: Opt[Eth2Digest] = Opt.none(Eth2Digest)):
     Future[ForkedBlockResult] {.async.} =
@@ -662,7 +665,9 @@ proc makeBeaconBlockForHeadAndSlot*(
 proc getBlindedExecutionPayload(
     node: BeaconNode, slot: Slot, executionBlockRoot: Eth2Digest,
     pubkey: ValidatorPubKey):
-    Future[Result[ExecutionPayloadHeader, cstring]] {.async.} =
+    Future[
+      Result[bellatrix.ExecutionPayloadHeader | capella.ExecutionPayloadHeader, cstring]
+    ] {.async.} =
   if node.payloadBuilderRestClient.isNil:
     return err "getBlindedBeaconBlock: nil REST client"
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -347,7 +347,7 @@ proc forkchoice_updated(state: bellatrix.BeaconState,
     payloadId = forkchoiceResponse.payloadId
 
   return if payloadId.isSome:
-    some(bellatrix.PayloadID(payloadId.get))
+    some(payloadId.get())
   else:
     none(bellatrix.PayloadID)
 
@@ -371,7 +371,7 @@ proc forkchoice_updated(state: capella.BeaconState,
     payloadId = forkchoiceResponse.payloadId
 
   return if payloadId.isSome:
-    some(capella.PayloadID(payloadId.get))
+    some(payloadId.get())
   else:
     none(capella.PayloadID)
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -383,7 +383,7 @@ proc get_execution_payload(
     default(bellatrix.ExecutionPayload)
   else:
     asConsensusExecutionPayload(
-      payload_id.get(),
+      payload_id,
       await execution_engine.getPayload(payload_id.get))
 
 proc get_execution_payload(
@@ -394,7 +394,7 @@ proc get_execution_payload(
     default(capella.ExecutionPayload)
   else:
     asConsensusExecutionPayload(
-      payload_id.get(),
+      payload_id,
       await execution_engine.getPayload(payload_id.get))
 
 # TODO remove in favor of consensusManager copy

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -28,7 +28,7 @@ import
   web3/ethtypes,
 
   # Local modules
-  ../spec/datatypes/[phase0, altair, bellatrix],
+  ../spec/datatypes/[phase0, altair, bellatrix, capella],
   ../spec/[
     eth2_merkleization, forks, helpers, network, signatures, state_transition,
     validator],

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -383,7 +383,7 @@ proc get_execution_payload(
     default(bellatrix.ExecutionPayload)
   else:
     asConsensusExecutionPayload(
-      payload_id,
+      payload_id.get(),
       await execution_engine.getPayload(payload_id.get))
 
 proc get_execution_payload(
@@ -394,7 +394,7 @@ proc get_execution_payload(
     default(capella.ExecutionPayload)
   else:
     asConsensusExecutionPayload(
-      payload_id,
+      payload_id.get(),
       await execution_engine.getPayload(payload_id.get))
 
 # TODO remove in favor of consensusManager copy

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -5,7 +5,7 @@ import
   snappy,
   ../research/simutils,
   ../beacon_chain/spec/eth2_apis/eth2_rest_serialization,
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain/spec/[
     eth2_ssz_serialization, forks, helpers, state_transition],
   ../beacon_chain/networking/network_metadata

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -84,6 +84,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
   of BeaconStateFork.Phase0:    SSZ.saveFile(filename, value.phase0Data.data)
   of BeaconStateFork.Altair:    SSZ.saveFile(filename, value.altairData.data)
   of BeaconStateFork.Bellatrix: SSZ.saveFile(filename, value.bellatrixData.data)
+  of BeaconStateFork.Capella:   SSZ.saveFile(filename, value.capellaData.data)
 
 proc loadFile(filename: string, T: type): T =
   let
@@ -205,12 +206,15 @@ proc doSSZ(conf: NcliConf) =
   of "phase0_signed_block": printit(phase0.SignedBeaconBlock)
   of "altair_signed_block": printit(altair.SignedBeaconBlock)
   of "bellatrix_signed_block": printit(bellatrix.SignedBeaconBlock)
+  of "capella_signed_block": printit(capella.SignedBeaconBlock)
   of "phase0_block": printit(phase0.BeaconBlock)
   of "altair_block": printit(altair.BeaconBlock)
   of "bellatrix_block": printit(bellatrix.BeaconBlock)
+  of "capella_block": printit(capella.BeaconBlock)
   of "phase0_block_body": printit(phase0.BeaconBlockBody)
   of "altair_block_body": printit(altair.BeaconBlockBody)
   of "bellatrix_block_body": printit(bellatrix.BeaconBlockBody)
+  of "capella_block_body": printit(capella.BeaconBlockBody)
   of "block_header": printit(BeaconBlockHeader)
   of "deposit": printit(Deposit)
   of "deposit_data": printit(DepositData)
@@ -218,6 +222,7 @@ proc doSSZ(conf: NcliConf) =
   of "phase0_state": printit(phase0.BeaconState)
   of "altair_state": printit(altair.BeaconState)
   of "bellatrix_state": printit(bellatrix.BeaconState)
+  of "capella_state": printit(capella.BeaconState)
   of "proposer_slashing": printit(ProposerSlashing)
   of "voluntary_exit": printit(VoluntaryExit)
 

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -13,6 +13,7 @@ import
     datatypes/phase0,
     datatypes/altair,
     datatypes/bellatrix,
+    datatypes/capella,
     beaconstate,
     state_transition_epoch,
     state_transition_block,
@@ -212,7 +213,7 @@ proc collectEpochRewardsAndPenalties*(
 
 proc collectEpochRewardsAndPenalties*(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
-    state: var (altair.BeaconState | bellatrix.BeaconState),
+    state: var (altair.BeaconState | bellatrix.BeaconState | capella.BeaconState),
     cache: var StateCache, cfg: RuntimeConfig, flags: UpdateFlags) =
   if get_current_epoch(state) == GENESIS_EPOCH:
     return

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -12,7 +12,7 @@ import
   ../beacon_chain/networking/network_metadata,
   ../beacon_chain/[beacon_chain_db, era_db],
   ../beacon_chain/consensus_object_pools/[blockchain_dag],
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain/spec/[
     beaconstate, state_transition, state_transition_epoch, validator,
     ssz_codec],

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -22,7 +22,7 @@ import
   ../tests/testblockutil,
   ../beacon_chain/spec/[
     beaconstate, forks, helpers, signatures, state_transition],
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain/[beacon_chain_db, beacon_clock],
   ../beacon_chain/eth1/eth1_monitor,
   ../beacon_chain/validators/validator_pool,

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -18,7 +18,7 @@ import
   ../beacon_chain/networking/network_metadata,
   ../beacon_chain/[beacon_clock, sszdump],
   ../beacon_chain/spec/eth2_apis/eth2_rest_serialization,
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain/spec/[
     beaconstate, crypto, forks, helpers, signatures, state_transition],
   ../beacon_chain/validators/[keystore_management, validator_pool]

--- a/scripts/compile_nim_program.sh
+++ b/scripts/compile_nim_program.sh
@@ -38,8 +38,8 @@ build/generate_makefile "nimcache/release/${BINARY}/${PROJECT_NAME}.json" "nimca
 if uname | grep -qi darwin || [[ -n "${FORCE_DSYMUTIL}" ]]; then
   [[ -z "${DSYMUTIL}" ]] && DSYMUTIL="dsymutil"
   # Scary warnings in large volume: https://github.com/status-im/nimbus-eth2/issues/3076
-  "${DSYMUTIL}" build/${BINARY} 2>&1 \
-    | grep -v "failed to insert symbol" \
-    | grep -v "could not find object file symbol for symbol" \
-    || true
+  "${DSYMUTIL}" build/${BINARY} 2>&1 |
+    grep -v "failed to insert symbol" |
+    grep -v "could not find object file symbol for symbol" ||
+    true
 fi

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -9,7 +9,7 @@ import
   # Standard library
   std/[os, strutils, typetraits],
   # Internals
-  ../../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../../beacon_chain/spec/[
     eth2_merkleization, eth2_ssz_serialization, forks],
   # Status libs,

--- a/tests/mocking/mock_blocks.nim
+++ b/tests/mocking/mock_blocks.nim
@@ -9,7 +9,7 @@ import
   # Beacon chain internals
   ../../beacon_chain/spec/
     [forks, helpers, signatures, state_transition, validator],
-  ../../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   # Test utilities
   ../testblockutil
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -12,7 +12,7 @@ import
   unittest2, snappy,
   ../beacon_chain/[beacon_chain_db, interop],
   ../beacon_chain/spec/[beaconstate, forks, state_transition],
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella],
   ../beacon_chain/consensus_object_pools/blockchain_dag,
   eth/db/kvstore,
   # test utilies

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -42,6 +42,13 @@ proc getBellatrixStateRef(db: BeaconChainDB, root: Eth2Digest):
   if db.getState(root, res[], noRollback):
     return res
 
+proc getCapellaStateRef(db: BeaconChainDB, root: Eth2Digest):
+    capella.NilableBeaconStateRef =
+  # load beaconstate the way the block pool does it - into an existing instance
+  let res = (capella.BeaconStateRef)()
+  if db.getState(root, res[], noRollback):
+    return res
+
 func withDigest(blck: phase0.TrustedBeaconBlock):
     phase0.TrustedSignedBeaconBlock =
   phase0.TrustedSignedBeaconBlock(
@@ -59,6 +66,13 @@ func withDigest(blck: altair.TrustedBeaconBlock):
 func withDigest(blck: bellatrix.TrustedBeaconBlock):
     bellatrix.TrustedSignedBeaconBlock =
   bellatrix.TrustedSignedBeaconBlock(
+    message: blck,
+    root: hash_tree_root(blck)
+  )
+
+func withDigest(blck: capella.TrustedBeaconBlock):
+    capella.TrustedSignedBeaconBlock =
+  capella.TrustedSignedBeaconBlock(
     message: blck,
     root: hash_tree_root(blck)
   )
@@ -82,6 +96,7 @@ let
   testStatesPhase0    = getTestStates(BeaconStateFork.Phase0)
   testStatesAltair    = getTestStates(BeaconStateFork.Altair)
   testStatesBellatrix = getTestStates(BeaconStateFork.Bellatrix)
+  testStatesCapella   = getTestStates(BeaconStateFork.Capella)
 
 suite "Beacon chain DB" & preset():
   test "empty database" & preset():
@@ -119,6 +134,7 @@ suite "Beacon chain DB" & preset():
       not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
       not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
       not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
+      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
       db.getBlock(root, phase0.TrustedSignedBeaconBlock).isErr()
       not db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
       not db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)

--- a/tests/test_eth1_monitor.nim
+++ b/tests/test_eth1_monitor.nim
@@ -499,5 +499,5 @@ suite "Eth1 monitor":
     for executionPayload in executionPayloads:
       check:
         executionPayload == asConsensusExecutionPayload(
-          bellatrix.PayloadID(),
+          bellatrix,
           asEngineExecutionPayload(executionPayload))

--- a/tests/test_eth1_monitor.nim
+++ b/tests/test_eth1_monitor.nim
@@ -499,4 +499,5 @@ suite "Eth1 monitor":
     for executionPayload in executionPayloads:
       check:
         executionPayload == asConsensusExecutionPayload(
+          bellatrix.PayloadID(),
           asEngineExecutionPayload(executionPayload))

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -2,7 +2,7 @@ import
   unittest2,
   stew/byteutils,
   ../beacon_chain/spec/[forks, helpers],
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix]
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella]
 
 {.used.}
 


### PR DESCRIPTION

# Table of Contents

1.  [Bellatrix -> Capella (August 2022)](#org5a7261e)
    1.  [Getting stuck](#org835ddfe)
    2.  [Setup and overview](#orgbaf02eb)
    3.  [Spec files (capella.nim)](#org843501a)
    4.  [Fork file (forks.nim)](#org39f67a2)
    5.  [Review](#org6603b1e)
    6.  [Typing](#org50b8842)
    7.  [Duplication](#org7846de1)
        1.  [Duplication should be preferred](#org055837f)
    8.  [Rebase on `unstable`](#org1d98c5f)
    9.  [Tracking compiler errors](#orge9b96e9)
    10. [Ran into a serialization problem with the spec](#orgc07342f)
    11. [Large amount of typing errors](#org2334a4b)
    12. [Polymorphic errors](#orgedb1c82)
    13. [Ambiguous calls](#org2df0fac)
    14. [sizeof(U) !== sizeof(T)](#org883415d)



<a id="org5a7261e"></a>

# Bellatrix -> Capella (August 2022)

In this guide I mostly lay out the problems I ran into
while making the forward migration.

In general I would suggest getting the spec/datatypes/\\\* files
done first and them performing a search-and replace sweep on the
whole project.

Look for all complex matches and then prepare macros for different
files to sweep.

Stop at unviable areas, tag with TODO and get it to compile first.

&#x2014;


<a id="org835ddfe"></a>

## Getting stuck

If you run into some difficult type or other error that you can&rsquo;t process.
Try to compile a different part of the project using the command:

`./env.sh nim c beacon_chain/foo.nim`


<a id="orgbaf02eb"></a>

## Setup and overview

Started working on adding the relevant part of the spec files to the capella.nim I added
More cleaning up of the spec files


<a id="org843501a"></a>

## Spec files (capella.nim)

Here it was useful to copy from previous spec files rather than the spec itself
mostly because the spec file types can differ slightly
Functions at the bottom of the page were required for later compilation steps
Better to copy them and try to remove later if possible


<a id="org39f67a2"></a>

## Fork file (forks.nim)

Find and duplicate all bellatrix (previous entry) functions and type names
Better to search next and modify in this case, there are many hidden ones


<a id="org6603b1e"></a>

## Review

Found a few places that should be checked later because the previous
specversion had inconsistencies with the previous spec
marked with TODO and left for the end


<a id="org50b8842"></a>

## Typing

Started working on moving some types into helper and rest<sub>types</sub>
Sorted code in datatypes/capella.nim, and Added TODO to cleanup
these parts later when assured I could remove them (I could not),
More helpers work and slowly tracking the compiler errors


<a id="org7846de1"></a>

## Duplication

Duplication starts with finding functions that match your
previous fork name and duplicating them. I found that
quick-search and replace (in selected region) was very
helpful here.

Tried to generalise some functionality but was unable to
easily because of typing errors.


<a id="org055837f"></a>

### Duplication should be preferred

As it prevents errors with previous forks.

Compiler errors tracked me to more duplicates, however these
errors are not always helpful at telling you where the issue
is as the compiler complains a lot about non-matching types.


<a id="org1d98c5f"></a>

## Rebase on `unstable`

which was thankfully easy and required a few easy refactor

Understand the scope is much more spread
Search and replace prev + new fork everywhere


<a id="orge9b96e9"></a>

## Tracking compiler errors

In general these are helpful at this stage and tell you where
to start looking. However,

at this stage it would be more helpful to
start combing through files. I suggest:

-   prepare a list of files containing `complex(prev_fork)` declarations
-   comb those files using a macro for cases one by one

these steps above will likely save you many compiler errors
be sure to TODO tag the ones which differ from spec to spec


<a id="orgc07342f"></a>

## Ran into a serialization problem with the spec

seemed likely there was no spec version present,
but the code was a bit out of date in one part.
There was a better implementation below which
takes the version (in REST) from the JSON body


<a id="org2334a4b"></a>

## Large amount of typing errors

This was likely because I culled out some
important functions from `capella.nim` too early.

At this point I also ran into `sizeof(U) or sizeof(T)` problems
which was caused because the spec is duplicated in a few places
and also made immutable. All areas must be updated correctly.

More typing problems, this time with `shortLog` who&rsquo;s asking
for a BeaconBlock and getting one, but does not seem happy.
Found some more missed areas from the first code sweep and fixed
them up.


<a id="orgedb1c82"></a>

## Polymorphic errors

Sometimes we don&rsquo;t import the spec files directly, but rather export
them from some other file.

Search `export {previous_fork_name}` and be sure that all of them are
updated with your new fork name.


<a id="org2df0fac"></a>

## Ambiguous calls

I found that some places the spec has new features from the bellatrix
upgrade which need to be modified or in some way made non-ambiguous.

So far in the slow process of migration type ambiguity has been the single
largest slowdown to progress.


<a id="org883415d"></a>

## sizeof(U) !== sizeof(T)

Go into datatypes/base.nim and uncomment the following lines:

    # NOTE: Uncomment for debugging type size mismatch
    echo alignLeft($T.typeof & ":", 50), T.sizeof
    echo alignLeft($U.typeof & ":", 50), U.sizeof, "\n", repeat("-", 20)

Then rebuild. This should print out the typenames and the corresponding
size when an isomorphicCast attempt is made during compile time.
Hopefully this will allow you to narrow down exactly which types are
causing the issue.

Most of these issues are caused by a missing duplicate item in one of your spec
files. It could also be in the file `beacon_chain_db_immutable.nim`

