### PR TITLE
add `lodestar` to known lib p2p agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ DEPOSITS_DELAY := 0
 #- "--define:release" cannot be added to "config.nims"
 #- disable Nim's default parallelisation because it starts too many processes for too little gain
 #- https://github.com/status-im/nim-libp2p#use-identify-metrics
-NIM_PARAMS += -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,prysm,teku
+NIM_PARAMS += -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,lodestar,prysm,teku
 
 ifeq ($(USE_LIBBACKTRACE), 0)
 NIM_PARAMS += -d:disable_libbacktrace


### PR DESCRIPTION
Lodestar is switching from `js-libp2p/0.36.2` to `lodestar/version`. Collect metrics on Lodestar peers following that scheme. https://github.com/status-im/nimbus-eth2/issues/4106