### PR TITLE
more `withState` `state` -> `forkyState`

### DIFF
--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -84,7 +84,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
         elif contentType == sszMediaType:
           let headers = [("eth-consensus-version", state.kind.toString())]
           withState(state):
-            RestApiResponse.sszResponse(state.data, headers)
+            RestApiResponse.sszResponse(forkyState.data, headers)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)
     return RestApiResponse.jsonError(Http404, StateNotFoundError)

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -222,11 +222,11 @@ func syncCommitteeParticipants*(forkedState: ForkedHashedBeaconState,
     when stateFork >= BeaconStateFork.Altair:
       let
         epochPeriod = sync_committee_period(epoch)
-        curPeriod = sync_committee_period(state.data.slot)
+        curPeriod = sync_committee_period(forkyState.data.slot)
       if epochPeriod == curPeriod:
-        ok(@(state.data.current_sync_committee.pubkeys.data))
+        ok(@(forkyState.data.current_sync_committee.pubkeys.data))
       elif epochPeriod == curPeriod + 1:
-        ok(@(state.data.next_sync_committee.pubkeys.data))
+        ok(@(forkyState.data.next_sync_committee.pubkeys.data))
       else:
         err("Epoch is outside the sync committee period of the state")
     else:
@@ -268,12 +268,12 @@ proc getStateOptimistic*(node: BeaconNode,
       # A state is optimistic iff the block which created it is
       withState(state):
         # The block root which created the state at slot `n` is at slot `n-1`
-        if state.data.slot == GENESIS_SLOT:
+        if forkyState.data.slot == GENESIS_SLOT:
           some[bool](false)
         else:
-          doAssert state.data.slot > 0
+          doAssert forkyState.data.slot > 0
           some[bool](node.dag.is_optimistic(
-            get_block_root_at_slot(state.data, state.data.slot - 1)))
+            get_block_root_at_slot(forkyState.data, forkyState.data.slot - 1)))
   else:
     none[bool]()
 

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -248,8 +248,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       let res = withState(node.dag.headState):
         when stateFork >= BeaconStateFork.Altair:
           produceResponse(indexList,
-                          state.data.current_sync_committee.pubkeys.data,
-                          state.data.validators.asSeq)
+                          forkyState.data.current_sync_committee.pubkeys.data,
+                          forkyState.data.validators.asSeq)
         else:
           emptyResponse()
       return RestApiResponse.jsonResponseWOpt(res, optimistic)
@@ -258,8 +258,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       let res = withState(node.dag.headState):
         when stateFork >= BeaconStateFork.Altair:
           produceResponse(indexList,
-                          state.data.next_sync_committee.pubkeys.data,
-                          state.data.validators.asSeq)
+                          forkyState.data.next_sync_committee.pubkeys.data,
+                          forkyState.data.validators.asSeq)
         else:
           emptyResponse()
       return RestApiResponse.jsonResponseWOpt(res, optimistic)
@@ -289,8 +289,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         let res = withState(state):
           when stateFork >= BeaconStateFork.Altair:
             produceResponse(indexList,
-                            state.data.current_sync_committee.pubkeys.data,
-                            state.data.validators.asSeq)
+                            forkyState.data.current_sync_committee.pubkeys.data,
+                            forkyState.data.validators.asSeq)
           else:
             emptyResponse()
         return RestApiResponse.jsonResponseWOpt(res, optimistic)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -966,7 +966,7 @@ func latest_block_root*(state: ForkyHashedBeaconState): Eth2Digest =
   latest_block_root(state.data, state.root)
 
 func latest_block_root*(state: ForkedHashedBeaconState): Eth2Digest =
-  withState(state): latest_block_root(state)
+  withState(state): latest_block_root(forkyState)
 
 func get_sync_committee_cache*(
     state: altair.BeaconState | bellatrix.BeaconState, cache: var StateCache):
@@ -1034,7 +1034,7 @@ func latest_block_id*(state: ForkyHashedBeaconState): BlockId =
 
 func latest_block_id*(state: ForkedHashedBeaconState): BlockId =
   ## Block id of the latest block applied to this state
-  withState(state): state.latest_block_id()
+  withState(state): forkyState.latest_block_id()
 
 func matches_block*(
     state: ForkyHashedBeaconState, block_root: Eth2Digest): bool =
@@ -1044,7 +1044,7 @@ func matches_block*(
 
 func matches_block*(
     state: ForkedHashedBeaconState, block_root: Eth2Digest): bool =
-  withState(state): state.matches_block(block_root)
+  withState(state): forkyState.matches_block(block_root)
 
 func matches_block_slot*(
     state: ForkyHashedBeaconState, block_root: Eth2Digest, slot: Slot): bool =
@@ -1053,7 +1053,7 @@ func matches_block_slot*(
   slot == state.data.slot and block_root == state.latest_block_root
 func matches_block_slot*(
     state: ForkedHashedBeaconState, block_root: Eth2Digest, slot: Slot): bool =
-  withState(state): state.matches_block_slot(block_root, slot)
+  withState(state): forkyState.matches_block_slot(block_root, slot)
 
 func can_advance_slots*(
     state: ForkyHashedBeaconState, block_root: Eth2Digest, target_slot: Slot): bool =
@@ -1062,4 +1062,4 @@ func can_advance_slots*(
   target_slot >= state.data.slot and block_root == state.latest_block_root
 func can_advance_slots*(
     state: ForkedHashedBeaconState, block_root: Eth2Digest, target_slot: Slot): bool =
-  withState(state): state.can_advance_slots(block_root, target_slot)
+  withState(state): forkyState.can_advance_slots(block_root, target_slot)

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -141,12 +141,13 @@ proc doTrustedNodeSync*(
 
       withState(genesisState[]):
         info "Writing genesis state",
-          stateRoot = shortLog(state.root),
-          genesis_validators_root = shortLog(state.data.genesis_validators_root)
+          stateRoot = shortLog(forkyState.root),
+          genesis_validators_root =
+            shortLog(forkyState.data.genesis_validators_root)
 
-        db.putState(state)
+        db.putState(forkyState)
 
-        let blck = get_initial_beacon_block(state)
+        let blck = get_initial_beacon_block(forkyState)
 
         info "Writing genesis block",
           blockRoot = shortLog(blck.root),
@@ -254,7 +255,7 @@ proc doTrustedNodeSync*(
         quit 1
 
       withState(state[]):
-        let latest_block_root = state.latest_block_root
+        let latest_block_root = forkyState.latest_block_root
 
         if latest_block_root != checkpointBlock[].root:
           error "Checkpoint state does not match checkpoint block, server error?",
@@ -264,8 +265,8 @@ proc doTrustedNodeSync*(
           quit 1
 
         info "Writing checkpoint state",
-          stateRoot = shortLog(state.root)
-        db.putState(state)
+          stateRoot = shortLog(forkyState.root)
+        db.putState(forkyState)
 
       withBlck(checkpointBlock[]):
         info "Writing checkpoint block",

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1321,11 +1321,12 @@ proc registerValidators(node: BeaconNode, epoch: Epoch) {.async.} =
       # Builders should verify that `pubkey` corresponds to an active or
       # pending validator
       withState(node.dag.headState):
-        if distinctBase(validator.index.get) >= state.data.validators.lenu64:
+        if  distinctBase(validator.index.get) >=
+            forkyState.data.validators.lenu64:
           continue
 
         if node.currentSlot().epoch >=
-            state.data.validators.item(validator.index.get).exit_epoch:
+            forkyState.data.validators.item(validator.index.get).exit_epoch:
           continue
 
       if validator.externalBuilderRegistration.isSome:

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -57,8 +57,10 @@ func copyParticipationFlags*(auxiliaryState: var AuxiliaryState,
   withState(forkedState):
     when stateFork > BeaconStateFork.Phase0:
       template flags: untyped = auxiliaryState.epochParticipationFlags
-      flags.currentEpochParticipation = state.data.current_epoch_participation
-      flags.previousEpochParticipation = state.data.previous_epoch_participation
+      flags.currentEpochParticipation =
+        forkyState.data.current_epoch_participation
+      flags.previousEpochParticipation =
+        forkyState.data.previous_epoch_participation
 
 proc getUnaggregatedFilesEpochRange*(dir: string):
     tuple[firstEpoch, lastEpoch: Epoch] =

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -296,13 +296,13 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
           dbBenchmark.putBlock(b)
 
       withState(stateData[]):
-        if state.data.slot.is_epoch and conf.storeStates:
-          if state.data.slot.epoch < 2:
-            dbBenchmark.putState(state.root, state.data)
+        if forkyState.data.slot.is_epoch and conf.storeStates:
+          if forkyState.data.slot.epoch < 2:
+            dbBenchmark.putState(forkyState.root, forkyState.data)
             dbBenchmark.checkpoint()
           else:
             withTimer(timers[tDbStore]):
-              dbBenchmark.putState(state.root, state.data)
+              dbBenchmark.putState(forkyState.root, forkyState.data)
               dbBenchmark.checkpoint()
 
             withTimer(timers[tDbLoad]):


### PR DESCRIPTION
Followup to https://github.com/status-im/nimbus-eth2/pull/4026 (explanation), https://github.com/status-im/nimbus-eth2/pull/4038 (first round of updates), and https://github.com/status-im/nimbus-eth2/pull/4104 (second round of updates).

This completes the test suite, `state_sim`, `block_sim`, and `nimbus_beacon_node` in pure compilation-or-not terms, but to finish removing the `state` accessor, it needs to be audited for any remaining `withState(state): foo(state)` cases where they'll compile but not run correctly. Those work fine now, still, because the accessor template is still there.

Furthermore, some of the other `make` targets such as `ncli_db` will require a few more changes, with again an audit for the `withState(state): foo(state)` pattern in some contexts where it compiles successfully but to incorrect code.

This PR, on its own, is safe from such issues.