### PR TITLE
remove rest of `withState.state` usage

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -674,7 +674,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
                               state: ForkedHashedBeaconState,
                               cache: var StateCache): seq[Attestation] =
   withState(state):
-    pool.getAttestationsForBlock(state, cache)
+    pool.getAttestationsForBlock(forkyState, cache)
 
 func bestValidation(aggregates: openArray[Validation]): (int, int) =
   # Look for best validation based on number of votes in the aggregate

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -313,23 +313,14 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template forkyState: untyped {.inject, used.} = x.bellatrixData
-    template state: untyped {.inject, used.} =
-      static: doAssert false
-      x.bellatrixData
     body
   of BeaconStateFork.Altair:
     const stateFork {.inject, used.} = BeaconStateFork.Altair
     template forkyState: untyped {.inject, used.} = x.altairData
-    template state: untyped {.inject, used.} =
-      static: doAssert false
-      x.altairData
     body
   of BeaconStateFork.Phase0:
     const stateFork {.inject, used.} = BeaconStateFork.Phase0
     template forkyState: untyped {.inject, used.} = x.phase0Data
-    template state: untyped {.inject, used.} =
-      static: doAssert false
-      x.phase0Data
     body
 
 template withEpochInfo*(x: ForkedEpochInfo, body: untyped): untyped =

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -313,17 +313,23 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template forkyState: untyped {.inject, used.} = x.bellatrixData
-    template state: untyped {.inject, used.} = x.bellatrixData
+    template state: untyped {.inject, used.} =
+      static: doAssert false
+      x.bellatrixData
     body
   of BeaconStateFork.Altair:
     const stateFork {.inject, used.} = BeaconStateFork.Altair
     template forkyState: untyped {.inject, used.} = x.altairData
-    template state: untyped {.inject, used.} = x.altairData
+    template state: untyped {.inject, used.} =
+      static: doAssert false
+      x.altairData
     body
   of BeaconStateFork.Phase0:
     const stateFork {.inject, used.} = BeaconStateFork.Phase0
     template forkyState: untyped {.inject, used.} = x.phase0Data
-    template state: untyped {.inject, used.} = x.phase0Data
+    template state: untyped {.inject, used.} =
+      static: doAssert false
+      x.phase0Data
     body
 
 template withEpochInfo*(x: ForkedEpochInfo, body: untyped): untyped =

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -324,7 +324,7 @@ proc makeSyncAggregate(
     slot =
       getStateField(state, slot)
     latest_block_root =
-      withState(state): state.latest_block_root
+      withState(state): forkyState.latest_block_root
     syncCommitteePool = newClone(SyncCommitteeMsgPool.init(keys.newRng()))
 
   type


### PR DESCRIPTION
As an intermediate state to test across all supported configurations to ensure that all of the usages were caught in both 1.2 and 1.6 Nim template/symbol resolution setups,
```nim
    template state: untyped {.inject, used.} =
      static: doAssert false
      x.bellatrixData
```
is in the first commit here.

If/once that passes CI, the `template state`s will be removed entirely from `withState` and this PR will be able to be safely merged.

Edit: CI worked, so it's fine for merging once it's green in CI again.