### PR TITLE
docs: add note about data-dir

### DIFF
--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -18,6 +18,9 @@ It is possibly to use trusted node sync with a third-party API provider -- see [
 !!! tip
     Make sure to replace `http://localhost:5052` in the commands below with the appropriate endpoint of the trusted beacon node. `http://localhost:5052` is the default endpoint exposed by Nimbus, but this is not consistent across all clients.
 
+!!! note ""
+    The path specified for data-dir must be an empty directory
+
     For example, if your trusted node is a [Prysm node](https://docs.prylabs.network/docs/how-prysm-works/ethereum-public-api#performing-requests-against-a-local-prysm-node), it exposes `127.0.0.1:3500` by default. Which means you would run the commands below with `--trusted-node-url=http://127.0.0.1:3500`
 
 === "Mainnet"


### PR DESCRIPTION
The trusted node sync has to be executed over an empty `data-dir`. Added this as a note in the docs.