### PR TITLE
clean up exchange configuration handling

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -559,7 +559,7 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
   if dataProvider.isNil:
     return EtcStatus.exchangeError
 
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_exchangetransitionconfigurationv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#engine_exchangetransitionconfigurationv1
   let consensusCfg = TransitionConfigurationV1(
     terminalTotalDifficulty: p.depositsChain.cfg.TERMINAL_TOTAL_DIFFICULTY,
     terminalBlockHash: p.depositsChain.cfg.TERMINAL_BLOCK_HASH,

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -559,6 +559,7 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
   if dataProvider.isNil:
     return EtcStatus.exchangeError
 
+  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_exchangetransitionconfigurationv1
   let consensusCfg = TransitionConfigurationV1(
     terminalTotalDifficulty: p.depositsChain.cfg.TERMINAL_TOTAL_DIFFICULTY,
     terminalBlockHash: p.depositsChain.cfg.TERMINAL_BLOCK_HASH,

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -38,8 +38,7 @@ type
 
     # Transition
     TERMINAL_TOTAL_DIFFICULTY*: UInt256
-    TERMINAL_BLOCK_HASH*: BlockHash
-    # TODO TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH*: Epoch
+    TERMINAL_BLOCK_HASH*: BlockHash # TODO use in eht1monitor
 
     # Genesis
     MIN_GENESIS_ACTIVE_VALIDATOR_COUNT*: uint64


### PR DESCRIPTION
Per spec, we should not be sending our detected terminal block to EL - the EL configuration exchange should only look at values from configuration and report mismatches.

* note TODO about usage of terminal block hash configuration