### PR TITLE
Post merge polish

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -597,6 +597,14 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
       terminalBlockHash = executionCfg.terminalBlockHash,
       terminalBlockNumber = executionCfg.terminalBlockNumber.uint64
 
+  if executionCfg.terminalBlockHash == default BlockHash:
+    # If TERMINAL_BLOCK_HASH is stubbed with
+    # 0x0000000000000000000000000000000000000000000000000000000000000000 then
+    # TERMINAL_BLOCK_HASH and TERMINAL_BLOCK_NUMBER parameters MUST NOT take
+    # an effect.
+    trace "Engine API using stub hash"
+    return EtcStatus.match
+
   if p.terminalBlockNumber.isSome and p.terminalBlockHash.isSome:
     var res = EtcStatus.match
 
@@ -612,13 +620,6 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
       res = EtcStatus.mismatch
     return res
   else:
-    if executionCfg.terminalBlockHash == default BlockHash:
-      # If TERMINAL_BLOCK_HASH is stubbed with
-      # 0x0000000000000000000000000000000000000000000000000000000000000000 then
-      # TERMINAL_BLOCK_HASH and TERMINAL_BLOCK_NUMBER parameters MUST NOT take
-      # an effect.
-      return EtcStatus.match
-
     p.terminalBlockNumber = some executionCfg.terminalBlockNumber
     p.terminalBlockHash = some executionCfg.terminalBlockHash
     return EtcStatus.localConfigurationUpdated

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -592,7 +592,7 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
   if not p.exchangedConfiguration:
     # Log successful engine configuration exchange once at startup
     p.exchangedConfiguration = true
-    info "Exchanged engine configuration",
+    notice "Successfully connected to Execution Layer. Exchanged engine configuration",
       ttd = executionCfg.terminalTotalDifficulty,
       terminalBlockHash = executionCfg.terminalBlockHash,
       terminalBlockNumber = executionCfg.terminalBlockNumber.uint64

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1662,7 +1662,7 @@ proc start*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
   if node.eth1Monitor != nil:
     node.eth1Monitor.start()
   else:
-    notice "Running without execution chain monitor, block producation partially disabled"
+    notice "Running without an execution client, block production partially disabled"
 
   node.run()
 


### PR DESCRIPTION
Some post-merge polish after looking at some log files:

- Say that we are connected to an Execution Client (not just Engine API which is a technical term users don't care about)
- Use Execution/Consensus instead of eth1 / eth2 in user logs (not done for debug)

One thing that was recurring as well is the people not updating --web3-url=http://localhost:8545 to --web3-url=http://localhost:8551 (or websocket).

I think we need to add a log whether we are connected as a mere web3 (to monitor deposits), or as a fully-fledged CL. Though now that mainnet is switch to PoS, maybe there is no interest at all in pre-PoS with deposit monitoring as all chains of interest have moved to PoS? Or use a different consensus algorithms already integrated within an EL (for rollups for example).

Notably missing: do we send a stub to the ELs on mainnet or do we like today send the actual expected values?