### PR TITLE
rm optimistic candidate block check from LC

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -82,15 +82,10 @@ proc initLightClient*(
       genesis_validators_root, LightClientFinalizationMode.Strict)
 
   if config.syncLightClient:
-    proc onFinalizedHeader(
-        lightClient: LightClient, finalizedHeader: BeaconBlockHeader) =
-      optimisticProcessor.setFinalizedHeader(finalizedHeader)
-
     proc onOptimisticHeader(
         lightClient: LightClient, optimisticHeader: BeaconBlockHeader) =
       optimisticProcessor.setOptimisticHeader(optimisticHeader)
 
-    lightClient.onFinalizedHeader = onFinalizedHeader
     lightClient.onOptimisticHeader = onOptimisticHeader
     lightClient.trustedBlockRoot = config.trustedBlockRoot
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -125,7 +125,6 @@ programMain:
       lightClient: LightClient, finalizedHeader: BeaconBlockHeader) =
     info "New LC finalized header",
       finalized_header = shortLog(finalizedHeader)
-    optimisticProcessor.setFinalizedHeader(finalizedHeader)
 
   proc onOptimisticHeader(
       lightClient: LightClient, optimisticHeader: BeaconBlockHeader) =


### PR DESCRIPTION
The optimistic candidate block check that only imports a new block into the EL client if its parent block also had execution enabled is not needed anymore, as mainnet has merged and the attack period is over.