### PR TITLE
detect mismatch of config and binary

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -98,7 +98,7 @@ type
     indices*: Table[Eth2Digest, Index]
     currentEpochTips*: Table[Index, FinalityCheckpoints]
     previousProposerBoostRoot*: Eth2Digest
-    previousProposerBoostScore*: int64
+    previousProposerBoostScore*: uint64
 
   ProtoNode* = object
     root*: Eth2Digest

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1431,7 +1431,7 @@ proc getLowSubnets(node: Eth2Node, epoch: Epoch): (AttnetBits, SyncnetBits) =
       notHighOutgoingSubnets
 
   return (
-    findLowSubnets(getAttestationTopic, SubnetId, ATTESTATION_SUBNET_COUNT),
+    findLowSubnets(getAttestationTopic, SubnetId, ATTESTATION_SUBNET_COUNT.int),
     # We start looking one epoch before the transition in order to allow
     # some time for the gossip meshes to get healthy:
     if epoch + 1 >= node.cfg.ALTAIR_FORK_EPOCH:

--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -1,3 +1,4 @@
+# beacon_chain
 # Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -8,7 +9,6 @@ import stew/[byteutils, base10], chronicles
 import ".."/beacon_node,
        ".."/spec/forks,
        "."/rest_utils
-from ../fork_choice/proto_array import PROPOSER_SCORE_BOOST
 
 export rest_utils
 
@@ -178,7 +178,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           CHURN_LIMIT_QUOTIENT:
             Base10.toString(cfg.CHURN_LIMIT_QUOTIENT),
           PROPOSER_SCORE_BOOST:
-            Base10.toString(uint64(PROPOSER_SCORE_BOOST)),
+            Base10.toString(PROPOSER_SCORE_BOOST),
           DEPOSIT_CHAIN_ID:
             Base10.toString(cfg.DEPOSIT_CHAIN_ID),
           DEPOSIT_NETWORK_ID:
@@ -248,7 +248,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION:
             Base10.toString(EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION),
           ATTESTATION_SUBNET_COUNT:
-            Base10.toString(uint64(ATTESTATION_SUBNET_COUNT)),
+            Base10.toString(ATTESTATION_SUBNET_COUNT),
 
           # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/altair/validator.md#constants
           TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE:

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -50,9 +50,6 @@ const
   INTERVALS_PER_SLOT* = 3
 
   FAR_FUTURE_BEACON_TIME* = BeaconTime(ns_since_genesis: int64.high())
-  FAR_FUTURE_SLOT* = Slot(not 0'u64)
-  # FAR_FUTURE_EPOCH* = Epoch(not 0'u64) # in presets
-  FAR_FUTURE_PERIOD* = SyncCommitteePeriod(not 0'u64)
 
   NANOSECONDS_PER_SLOT = SECONDS_PER_SLOT * 1_000_000_000'u64
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -94,9 +94,6 @@ const
   DEPOSIT_CONTRACT_TREE_DEPTH* = 32
   BASE_REWARDS_PER_EPOCH* = 4
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#misc
-  ATTESTATION_SUBNET_COUNT* = 64
-
   DEPOSIT_CONTRACT_LIMIT* = Limit(1'u64 shl DEPOSIT_CONTRACT_TREE_DEPTH)
 
 template maxSize*(n: int) {.pragma.}
@@ -132,10 +129,6 @@ template maxSize*(n: int) {.pragma.}
 # - broke the compiler in SSZ and nim-serialization
 
 type
-  # Domains
-  # ---------------------------------------------------------------
-  DomainType* = distinct array[4, byte]
-
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#custom-types
   Eth2Domain* = array[32, byte]
 
@@ -461,7 +454,7 @@ type
     attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
 
-  AttnetBits* = BitArray[ATTESTATION_SUBNET_COUNT]
+  AttnetBits* = BitArray[int ATTESTATION_SUBNET_COUNT]
 
 type
   # Caches for computing justificiation, rewards and penalties - based on
@@ -512,22 +505,6 @@ type
     delta*: RewardDelta
 
     flags*: set[RewardFlags]
-
-const
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#domain-types
-  DOMAIN_BEACON_PROPOSER* = DomainType([byte 0x00, 0x00, 0x00, 0x00])
-  DOMAIN_BEACON_ATTESTER* = DomainType([byte 0x01, 0x00, 0x00, 0x00])
-  DOMAIN_RANDAO* = DomainType([byte 0x02, 0x00, 0x00, 0x00])
-  DOMAIN_DEPOSIT* = DomainType([byte 0x03, 0x00, 0x00, 0x00])
-  DOMAIN_VOLUNTARY_EXIT* = DomainType([byte 0x04, 0x00, 0x00, 0x00])
-  DOMAIN_SELECTION_PROOF* = DomainType([byte 0x05, 0x00, 0x00, 0x00])
-  DOMAIN_AGGREGATE_AND_PROOF* = DomainType([byte 0x06, 0x00, 0x00, 0x00])
-  DOMAIN_APPLICATION_MASK* = DomainType([byte 0x00, 0x00, 0x00, 0x01])
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#domain-types
-  DOMAIN_SYNC_COMMITTEE* = DomainType([byte 0x07, 0x00, 0x00, 0x00])
-  DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF* = DomainType([byte 0x08, 0x00, 0x00, 0x00])
-  DOMAIN_CONTRIBUTION_AND_PROOF* = DomainType([byte 0x09, 0x00, 0x00, 0x00])
 
 func getImmutableValidatorData*(validator: Validator): ImmutableValidatorData2 =
   let cookedKey = validator.pubkey.loadValid()  # `Validator` has valid key
@@ -902,7 +879,7 @@ static:
   # Sanity checks - these types should be trivial enough to copy with memcpy
   doAssert supportsCopyMem(Validator)
   doAssert supportsCopyMem(Eth2Digest)
-  doAssert ATTESTATION_SUBNET_COUNT <= high(distinctBase SubnetId).int
+  doAssert ATTESTATION_SUBNET_COUNT <= high(distinctBase SubnetId)
 
 func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
   for name, value in x.fieldPairs:

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -28,9 +28,6 @@ import
 export json_serialization, base
 
 const
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#transition-settings
-  TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH* = FAR_FUTURE_EPOCH
-
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-1
   FORKCHOICEUPDATED_TIMEOUT* = 8.seconds
 

--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -33,7 +33,7 @@ const
   DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF* = DomainType([byte 0x08, 0x00, 0x00, 0x00])
   DOMAIN_CONTRIBUTION_AND_PROOF* = DomainType([byte 0x09, 0x00, 0x00, 0x00])
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#transition-settings
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/bellatrix/beacon-chain.md#transition-settings
   TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH* = FAR_FUTURE_EPOCH
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/fork-choice.md#configuration

--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -1,0 +1,43 @@
+# beacon_chain
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+type
+  Slot* = distinct uint64
+  Epoch* = distinct uint64
+  SyncCommitteePeriod* = distinct uint64
+
+  DomainType* = distinct array[4, byte]
+
+const
+  # 2^64 - 1 in spec
+  FAR_FUTURE_SLOT* = Slot(not 0'u64)
+  FAR_FUTURE_EPOCH* = Epoch(not 0'u64)
+  FAR_FUTURE_PERIOD* = SyncCommitteePeriod(not 0'u64)
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/beacon-chain.md#domain-types
+  DOMAIN_BEACON_PROPOSER* = DomainType([byte 0x00, 0x00, 0x00, 0x00])
+  DOMAIN_BEACON_ATTESTER* = DomainType([byte 0x01, 0x00, 0x00, 0x00])
+  DOMAIN_RANDAO* = DomainType([byte 0x02, 0x00, 0x00, 0x00])
+  DOMAIN_DEPOSIT* = DomainType([byte 0x03, 0x00, 0x00, 0x00])
+  DOMAIN_VOLUNTARY_EXIT* = DomainType([byte 0x04, 0x00, 0x00, 0x00])
+  DOMAIN_SELECTION_PROOF* = DomainType([byte 0x05, 0x00, 0x00, 0x00])
+  DOMAIN_AGGREGATE_AND_PROOF* = DomainType([byte 0x06, 0x00, 0x00, 0x00])
+  DOMAIN_APPLICATION_MASK* = DomainType([byte 0x00, 0x00, 0x00, 0x01])
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/beacon-chain.md#domain-types
+  DOMAIN_SYNC_COMMITTEE* = DomainType([byte 0x07, 0x00, 0x00, 0x00])
+  DOMAIN_SYNC_COMMITTEE_SELECTION_PROOF* = DomainType([byte 0x08, 0x00, 0x00, 0x00])
+  DOMAIN_CONTRIBUTION_AND_PROOF* = DomainType([byte 0x09, 0x00, 0x00, 0x00])
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/bellatrix/beacon-chain.md#transition-settings
+  TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH* = FAR_FUTURE_EPOCH
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/fork-choice.md#configuration
+  PROPOSER_SCORE_BOOST*: uint64 = 40
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#misc
+  ATTESTATION_SUBNET_COUNT*: uint64 = 64

--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -149,7 +149,7 @@ proc updateSlot*(tracker: var ActionTracker, wallSlot: Slot) =
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/phase0/validator.md#phase-0-attestation-subnet-stability
   let expectedSubnets =
-    min(ATTESTATION_SUBNET_COUNT, tracker.knownValidators.len)
+    min(ATTESTATION_SUBNET_COUNT.int, tracker.knownValidators.len)
 
   let epoch = wallSlot.epoch
   block:

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -71,10 +71,10 @@ procSuite "Eth2 specific discovery tests":
     await node2.closeWait()
 
   asyncTest "Invalid attnets field":
-    var invalidAttnets: BitArray[ATTESTATION_SUBNET_COUNT div 2]
+    var invalidAttnets: BitArray[ATTESTATION_SUBNET_COUNT.int div 2]
     invalidAttnets.setBit(15)
     # TODO: This doesn't fail actually.
-    # var invalidAttnets2: BitArray[ATTESTATION_SUBNET_COUNT * 2]
+    # var invalidAttnets2: BitArray[ATTESTATION_SUBNET_COUNT.int * 2]
     # invalidAttnets2.setBit(15)
     var attnets: AttnetBits
     attnets.setBit(15)


### PR DESCRIPTION
When loading configuration that sets keys that Nimbus bakes into the binary at compile-time, raise an error if the config is incompatible instead of ignoring the conflicting value.