### PR TITLE
fix order of current/previous dependent root in REST SSE

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1832,8 +1832,8 @@ proc updateHead*(
         # TODO (cheatfate): Proper implementation required
         data = HeadChangeInfoObject.init(dag.head.slot, dag.head.root,
                                          getStateRoot(dag.headState),
-                                         epochTransition, depRoot,
-                                         prevDepRoot)
+                                         epochTransition, prevDepRoot,
+                                         depRoot)
       dag.onHeadChanged(data)
 
   withState(dag.headState):

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1023,8 +1023,7 @@ func proposer_dependent_root*(state: ForkyHashedBeaconState): Eth2Digest =
   state.dependent_root(state.data.slot.epoch)
 
 func attester_dependent_root*(state: ForkyHashedBeaconState): Eth2Digest =
-  let epoch = state.data.slot.epoch
-  state.dependent_root(if epoch == Epoch(0): epoch else: epoch - 1)
+  state.dependent_root(state.data.slot.epoch.get_previous_epoch)
 
 func latest_block_id*(state: ForkyHashedBeaconState): BlockId =
   ## Block id of the latest block applied to this state


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/4119

https://github.com/status-im/nimbus-eth2/blob/4b3768c3a1f58abe1570271d74ca521be2953e32/beacon_chain/consensus_object_pools/blockchain_dag.nim#L1828-L1836
calls `init` with the `attester_dependent_root`, defined as depending root of `get_previous_epoch`, as the second dependent root parameter, while
https://github.com/status-im/nimbus-eth2/blob/667c3c97ebe3c40fd724cf80c991410e1cd32900/beacon_chain/consensus_object_pools/block_pools_types.nim#L384-L395
expects it to be first.