### PR TITLE
rm require engine API check

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -173,9 +173,9 @@ type
       name: "web3-force-polling" .}: bool
 
     requireEngineAPI* {.
-      defaultValue: true
+      hidden  # Deprecated > 22.9
       desc: "Require Nimbus to be configured with an Engine API end-point after the Bellatrix fork epoch"
-      name: "require-engine-api-in-bellatrix" .}: bool
+      name: "require-engine-api-in-bellatrix" .}: Option[bool]
 
     nonInteractive* {.
       desc: "Do not display interative prompts. Quit on missing configuration"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -541,8 +541,7 @@ proc init*(T: type BeaconNode,
           getDepositContractSnapshot(),
           eth1Network,
           config.web3ForcePolling,
-          optJwtSecret,
-          config.requireEngineAPI)
+          optJwtSecret)
 
         eth1Monitor.loadPersistedDeposits()
 
@@ -643,8 +642,7 @@ proc init*(T: type BeaconNode,
       getDepositContractSnapshot(),
       eth1Network,
       config.web3ForcePolling,
-      optJwtSecret,
-      config.requireEngineAPI)
+      optJwtSecret)
 
   if config.rpcEnabled:
     warn "Nimbus's JSON-RPC server has been removed. This includes the --rpc, --rpc-port, and --rpc-address configuration options. https://nimbus.guide/rest-api.html shows how to enable and configure the REST Beacon API server which replaces it."
@@ -1805,6 +1803,12 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
       bls_backend = $BLS_BACKEND,
       cmdParams = commandLineParams(),
       config
+
+  template ignoreDeprecatedOption(option: untyped): untyped =
+    if config.option.isSome:
+      warn "Config option is deprecated",
+        option = config.option.get
+  ignoreDeprecatedOption requireEngineAPI
 
   createPidFile(config.dataDir.string / "beacon_node.pid")
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -64,8 +64,7 @@ programMain:
           cfg, db = nil, getBeaconTime, config.web3Urls,
           none(DepositContractSnapshot), metadata.eth1Network,
           forcePolling = false,
-          rng[].loadJwtSecret(config, allowCreate = false),
-          true)
+          rng[].loadJwtSecret(config, allowCreate = false))
         waitFor res.ensureDataProvider()
         res
       else:

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -35,8 +35,6 @@ The following options are available:
      --secrets-dir             A directory containing validator keystore passwords.
      --wallets-dir             A directory containing wallet files.
      --web3-url                One or more execution layer Web3 provider URLs.
-     --require-engine-api-in-bellatrix  Require Nimbus to be configured with an Engine API end-point after the Bellatrix
-                               fork epoch [=true].
      --non-interactive         Do not display interative prompts. Quit on missing configuration.
      --netkey-file             Source of network (secp256k1) private key file (random|<path>) [=random].
      --insecure-netkey-password  Use pre-generated INSECURE password for network private key file [=false].
@@ -113,6 +111,8 @@ The following options are available:
      --validator-monitor-totals  Publish metrics to single 'totals' label for better collection performance when
                                monitoring many validators (BETA) [=false].
      --suggested-fee-recipient  Suggested fee recipient.
+     --payload-builder         Enable external payload builder [=false].
+     --payload-builder-url     Payload builder URL.
 
 ...
 ```

--- a/scripts/test_merge_node.nim
+++ b/scripts/test_merge_node.nim
@@ -59,7 +59,7 @@ proc run() {.async.} =
     eth1Monitor = Eth1Monitor.init(
       defaultRuntimeConfig, db = nil, nil, @[paramStr(1)],
       none(DepositContractSnapshot), none(Eth1Network), false,
-      some readJwtSecret(paramStr(2)).get, true)
+      some readJwtSecret(paramStr(2)).get)
 
   await eth1Monitor.ensureDataProvider()
   try:

--- a/scripts/test_merge_vectors.nim
+++ b/scripts/test_merge_vectors.nim
@@ -61,7 +61,7 @@ proc run() {.async.} =
     eth1Monitor = Eth1Monitor.init(
       defaultRuntimeConfig, db = nil, nil, @[web3Url],
       none(DepositContractSnapshot), none(Eth1Network),
-      false, jwtSecret, true)
+      false, jwtSecret)
     web3Provider = (await Web3DataProvider.new(
       default(Eth1Address), web3Url, jwtSecret)).get
 


### PR DESCRIPTION
The `eth1_monitor` check to require engine API from bellatrix onward has issues in setups where the EL and CL are started simultaneously because the EL may not be ready to answer requests by the time that the check is performed. This can be observed, e.g., on Raspberry Pi 4 when using Besu as the EL client. Now that the merge transition happened, the check is also not that useful anymore, as users have other ways to know that their setup is not working correctly (e.g., repeated exchange logs)