### PR TITLE
remove i386 windows from daily CI

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,8 +19,6 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-          - os: windows
-            cpu: i386
         branch: [version-1-2, version-1-6, devel]
         include:
           - target:
@@ -72,18 +70,6 @@ jobs:
           EOF
           chmod 755 external/bin/gcc external/bin/g++
           echo "${{ github.workspace }}/external/bin" >> $GITHUB_PATH
-
-      - name: MSYS2 (Windows i386)
-        if: runner.os == 'Windows' && matrix.target.cpu == 'i386'
-        uses: msys2/setup-msys2@v2
-        with:
-          path-type: inherit
-          msystem: MINGW32
-          install: >-
-            base-devel
-            git
-            mingw-w64-i686-toolchain
-            mingw-w64-i686-cmake
 
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'


### PR DESCRIPTION
This was failing *forever* (yes, literally).

As discussed on Discord, i386 Windows is EOL, there's no reason to run it.

----

Also, this should help us to easier spot when daily CI job is "really failing", and not just assume that it is red because of i386 Windows.