### PR TITLE
add nim commit to the gauge

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -116,8 +116,8 @@ declareGauge next_action_wait,
 declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version", "commit"], name = "version"
 versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])
 
-declareGauge nimVersionGauge, "Nim version info", ["nim_version"], name = "Nim_version"
-nimVersionGauge.set(1, labelValues=[NimVersion])
+declareGauge nimVersionGauge, "Nim version info", ["version", "nim_commit"], name = "nim_version"
+nimVersionGauge.set(1, labelValues=[NimVersion, getNimGitHash()])
 
 logScope: topics = "beacnde"
 

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -24,6 +24,7 @@ const
 
   gitRevision* = strip(staticExec("git rev-parse --short HEAD"))[0..5]
 
+  nimFullBanner* = staticExec("nim --version")
   nimBanner* = staticExec("nim --version | grep Version")
 
   versionAsStr* =
@@ -31,16 +32,18 @@ const
 
   fullVersionStr* = "v" & versionAsStr & "-" & gitRevision & "-" & versionBlob
 
-func shortNimBanner*(): string =
+func getNimGitHash*(): string =
   const gitPrefix = "git hash: "
-  let tmp = splitLines(nimBanner)
+  let tmp = splitLines(nimFullBanner)
   if tmp.len == 0:
     return
-  var gitHash = ""
   for line in tmp:
     if line.startsWith(gitPrefix) and line.len > 8 + gitPrefix.len:
-      gitHash = line[gitPrefix.len..<gitPrefix.len + 8]
+      result = line[gitPrefix.len..<gitPrefix.len + 8]
 
+func shortNimBanner*(): string =
+  let gitHash = getNimGitHash()
+  let tmp = splitLines(nimFullBanner)
   if gitHash.len > 0:
     tmp[0] & " (" & gitHash & ")"
   else:


### PR DESCRIPTION
I was wrong in https://github.com/status-im/nimbus-eth2/pull/3937 — Nim commit _is_ useful :)

This also fixes `shortNimBanner` func, which was wrong before — it never produced `gitHash` because `nimBanner` only contains the line with version info.
Extracted that logic into `getNimGitHash`, so it could be use separately from `shortNimBanner` (which now correctly produces e.g. `Nim Compiler Version 1.6.7 [Linux: amd64] (09d85d8b)`)


And per @jakubgs's request, `nim_version` is now lowercase :)