### PR TITLE
local_launch_testnet: use -SIGKILL instead of -9

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -390,7 +390,7 @@ kill_by_port() {
       echo -n "Found old process listening on port ${PORT}, with PID ${PID}. "
       if [[ "${KILL_OLD_PROCESSES}" == "1" ]]; then
         echo "Killing it."
-        kill -9 "${PID}" || true
+        kill -SIGKILL "${PID}" || true
       else
         echo "Aborting."
         exit 1
@@ -645,7 +645,7 @@ cleanup() {
 
   for proc in "${PROCS_TO_KILL[@]}"
   do
-    pkill -f -9 -P $$ "${proc}" || true
+    pkill -SIGKILL -f -P $$ "${proc}" || true
   done
 
   # Delete all binaries we just built, because these are unusable outside this


### PR DESCRIPTION
Moving the `-f` flag after the signal flag will resolve this error:
```
pkill: illegal option -- 9
usage: pkill [-signal] [-ILfilnovx] [-F pidfile] [-G gid]
             [-P ppid] [-U uid] [-g pgrp] [-t tty] [-u euid]
             pattern ...
```
Also using `-SIGKILL` is more explicit than `-9`.