### PR TITLE
fix check for attaching to pre-finalized parent

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -211,7 +211,7 @@ proc addHeadBlock*(
     # at this stage, but we can check if we've seen the parent block previously
     # and thus prevent requests for it to be downloaded again.
     let parentId = dag.getBlockId(blck.parent_root)
-    if parentId.isSome():
+    if parentId.isSome() and parentId.get.slot < dag.finalizedHead.slot:
       debug "Block unviable due to pre-finalized-checkpoint parent",
         parentId = parentId.get()
       return err(BlockError.UnviableFork)


### PR DESCRIPTION
When the BN's head is reorged while shut down, reloading the BN will not assign `BlockRef` to alternate branches. However, blocks from other branches are still present in the database, leading to their descendants incorrectly marked as `UnviableFork`. By restricting the check to blocks that have been finalized, they should be reported as `MissingParent` instead, eventually re-assigning a `BlockRef` to them.