### PR TITLE
use v1.2.0 consensus spec test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -689,6 +689,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Altair - Operations - Deposit - invalid_sig_other_version                   OK
 + [Valid]   EF - Altair - Operations - Deposit - invalid_sig_top_up                          OK
 + [Valid]   EF - Altair - Operations - Deposit - invalid_withdrawal_credentials_top_up       OK
++ [Valid]   EF - Altair - Operations - Deposit - key_validate_invalid_decompression          OK
++ [Valid]   EF - Altair - Operations - Deposit - key_validate_invalid_subgroup               OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_eth1_withdrawal_credentials     OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_max                             OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
@@ -703,6 +705,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_other_version                OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_top_up                       OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_withdrawal_credentials_top_up    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - key_validate_invalid_decompression       OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - key_validate_invalid_subgroup            OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_eth1_withdrawal_credentials  OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_max                          OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
@@ -714,6 +718,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_top_up                         OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_withdrawal_credentials_top_up      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - key_validate_invalid_decompression         OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - key_validate_invalid_subgroup              OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_eth1_withdrawal_credentials    OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_max                            OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
@@ -722,7 +728,7 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
-OK: 42/42 Fail: 0/42 Skip: 0/42
+OK: 48/48 Fail: 0/48 Skip: 0/48
 ## EF - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1286,4 +1292,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 33/33 Fail: 0/33 Skip: 0/33
 
 ---TOTAL---
-OK: 1109/1116 Fail: 0/1116 Skip: 7/1116
+OK: 1115/1122 Fail: 0/1122 Skip: 7/1122

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -747,6 +747,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Altair - Operations - Deposit - invalid_sig_other_version                   OK
 + [Valid]   EF - Altair - Operations - Deposit - invalid_sig_top_up                          OK
 + [Valid]   EF - Altair - Operations - Deposit - invalid_withdrawal_credentials_top_up       OK
++ [Valid]   EF - Altair - Operations - Deposit - key_validate_invalid_decompression          OK
++ [Valid]   EF - Altair - Operations - Deposit - key_validate_invalid_subgroup               OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_eth1_withdrawal_credentials     OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_max                             OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
@@ -761,6 +763,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_other_version                OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_sig_top_up                       OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - invalid_withdrawal_credentials_top_up    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - key_validate_invalid_decompression       OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - key_validate_invalid_subgroup            OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_eth1_withdrawal_credentials  OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_max                          OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
@@ -772,6 +776,8 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_top_up                         OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_withdrawal_credentials_top_up      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - key_validate_invalid_decompression         OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - key_validate_invalid_subgroup              OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_eth1_withdrawal_credentials    OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_max                            OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
@@ -780,7 +786,7 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
-OK: 42/42 Fail: 0/42 Skip: 0/42
+OK: 48/48 Fail: 0/48 Skip: 0/48
 ## EF - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1385,4 +1391,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 36/36 Fail: 0/36 Skip: 0/36
 
 ---TOTAL---
-OK: 1200/1207 Fail: 0/1207 Skip: 7/1207
+OK: 1206/1213 Fail: 0/1213 Skip: 7/1213

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -77,7 +77,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.2.0-rc.3"
+const SPEC_VERSION* = "1.2.0"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -136,9 +136,6 @@ runSuite(ParticipationFlagDir, "Participation flag updates"):
 
 # These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-when const_preset == "minimal":
-  runSuite(SyncCommitteeDir, "Sync committee updates"):
-    process_sync_committee_updates(state)
-    Result[void, cstring].ok()
-else:
-  doAssert not dirExists(SyncCommitteeDir)
+runSuite(SyncCommitteeDir, "Sync committee updates"):
+  process_sync_committee_updates(state)
+  Result[void, cstring].ok()

--- a/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
@@ -134,9 +134,6 @@ runSuite(ParticipationFlagDir, "Participation flag updates"):
 
 # These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-when const_preset == "minimal":
-  runSuite(SyncCommitteeDir, "Sync committee updates"):
-    process_sync_committee_updates(state)
-    Result[void, cstring].ok()
-else:
-  doAssert not dirExists(SyncCommitteeDir)
+runSuite(SyncCommitteeDir, "Sync committee updates"):
+  process_sync_committee_updates(state)
+  Result[void, cstring].ok()


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.2.0
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.2.0