### PR TITLE
move `EpochParticipationFlags` serialization to others

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -149,30 +149,6 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 epochFlags: EpochParticipationFlags)
-                {.raises: [IOError, Defect].} =
-  for e in writer.stepwiseArrayCreation(epochFlags.asHashList):
-    writer.writeValue $e
-
-proc readValue*(reader: var JsonReader[RestJson],
-                epochFlags: var EpochParticipationFlags)
-               {.raises: [SerializationError, IOError, Defect].} =
-  # Please note that this function won't compute the cached hash tree roots
-  # immediately. They will be computed on the first HTR attempt.
-
-  for e in reader.readArray(string):
-    let parsed = try:
-      parseBiggestUInt(e)
-    except ValueError as err:
-      reader.raiseUnexpectedValue("A string-encoded 8-bit usigned integer value expected")
-
-    if parsed > uint8.high:
-      reader.raiseUnexpectedValue("The usigned integer value should fit in 8 bits")
-
-    if not epochFlags.data.add(uint8(parsed)):
-      reader.raiseUnexpectedValue("The participation flags list size exceeds limit")
-
 proc prepareJsonResponse*(t: typedesc[RestApiResponse], d: auto): seq[byte] =
   let res =
     block:
@@ -576,6 +552,34 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Epoch) {.
     value = Epoch(res.get())
   else:
     reader.raiseUnexpectedValue($res.error())
+
+## EpochParticipationFlags
+proc writeValue*(writer: var JsonWriter[RestJson],
+                 epochFlags: EpochParticipationFlags)
+                {.raises: [IOError, Defect].} =
+  for e in writer.stepwiseArrayCreation(epochFlags.asHashList):
+    writer.writeValue $e
+
+proc readValue*(reader: var JsonReader[RestJson],
+                epochFlags: var EpochParticipationFlags)
+               {.raises: [SerializationError, IOError, Defect].} =
+  # Please note that this function won't compute the cached hash tree roots
+  # immediately. They will be computed on the first HTR attempt.
+
+  for e in reader.readArray(string):
+    let parsed = try:
+      parseBiggestUInt(e)
+    except ValueError as err:
+      reader.raiseUnexpectedValue(
+        "A string-encoded 8-bit usigned integer value expected")
+
+    if parsed > uint8.high:
+      reader.raiseUnexpectedValue(
+        "The usigned integer value should fit in 8 bits")
+
+    if not epochFlags.data.add(uint8(parsed)):
+      reader.raiseUnexpectedValue(
+        "The participation flags list size exceeds limit")
 
 ## ValidatorIndex
 proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndex)


### PR DESCRIPTION
The REST `writeValue/readValue` serialization functions are grouped up with the exception of `EpochParticipationFlags`. Moving that to others.