### PR TITLE
rm unused `dump` function for `KeystoresAndSlashingProtection`

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2166,13 +2166,6 @@ proc readValue*(reader: var JsonReader[RestJson],
   value = RestActivityItem(index: index.get(), epoch: epoch.get(),
                            active: active.get())
 
-proc dump*(value: KeystoresAndSlashingProtection): string {.
-     raises: [IOError, SerializationError, Defect].} =
-  var stream = memoryOutput()
-  var writer = JsonWriter[RestJson].init(stream)
-  writer.writeValue(value)
-  stream.getOutput(string)
-
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: HeadChangeInfoObject) {.
      raises: [IOError, Defect].} =


### PR DESCRIPTION
In `eth2_rest_serialization` there was a `dump` function for `KeystoresAndSlashingProtection` that does not seem to be used. Removes that unused function.