### PR TITLE
add `sszResponsePlain` for pre-encoded SSZ data

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -147,7 +147,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           # in current version of database.
           return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
-                                          $error)
+                                         $error)
 
     node.withStateForBlockSlotId(bslot):
       return RestApiResponse.jsonResponseWOpt(
@@ -820,7 +820,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if not node.dag.getBlockSSZ(bid, data):
           return RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
-        RestApiResponse.response(data, Http200, $sszMediaType)
+        RestApiResponse.sszResponsePlain(data)
       elif contentType == jsonMediaType:
         let bdata = node.dag.getForkedBlock(bid).valueOr:
           return RestApiResponse.jsonError(Http404, BlockNotFoundError)
@@ -862,8 +862,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           fork = node.dag.cfg.blockForkAtEpoch(bid.slot.epoch)
           headers = [("eth-consensus-version", fork.toString())]
 
-        RestApiResponse.response(data, Http200, $sszMediaType,
-                                 headers = headers)
+        RestApiResponse.sszResponsePlain(data, headers)
       elif contentType == jsonMediaType:
         let bdata = node.dag.getForkedBlock(bid).valueOr:
           return RestApiResponse.jsonError(Http404, BlockNotFoundError)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -465,8 +465,14 @@ proc jsonErrorList*(t: typedesc[RestApiResponse],
         default
   RestApiResponse.error(status, data, "application/json")
 
+proc sszResponsePlain*(t: typedesc[RestApiResponse], res: seq[byte],
+                       headers: openArray[RestKeyValueTuple] = []
+                      ): RestApiResponse =
+  RestApiResponse.response(res, Http200, "application/octet-stream",
+                           headers = headers)
+
 proc sszResponse*(t: typedesc[RestApiResponse], data: auto,
-                  headers: openArray[tuple[key: string, value: string]]
+                  headers: openArray[RestKeyValueTuple] = []
                  ): RestApiResponse =
   let res =
     block:


### PR DESCRIPTION
For pre-encoded JSON REST responses we have `jsonResponsePlain`. Adds a `sszResponsePlain` function to serve similar purpose for SSZ. This avoids caller having to explicitly specify Http200 and media type.