### PR TITLE
rm unused `GraffitiBytes` reader

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -799,13 +799,6 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: GraffitiBytes)
                 {.raises: [IOError, Defect].} =
   writeValue(writer, hexOriginal(distinctBase(value)))
 
-proc readValue*(reader: var JsonReader[RestJson], T: type GraffitiBytes): T
-               {.raises: [IOError, SerializationError, Defect].} =
-  try:
-    init(GraffitiBytes, reader.readValue(string))
-  except ValueError as err:
-    reader.raiseUnexpectedValue err.msg
-
 ## Version
 proc readValue*(
     reader: var JsonReader[RestJson],


### PR DESCRIPTION
All REST `readValue` parsers have the signature:
```nim
proc readValue*(reader: var JsonReader[RestJson], value: var T) {.
     raises: [IOError, SerializationError, Defect].} =
```

Only for `GraffitiBytes`, there also exists an overload with signature:
```nim
proc readValue*(reader: var JsonReader[RestJson], T: type GraffitiBytes): T
               {.raises: [IOError, SerializationError, Defect].}
```

This additional overload seems unused, and also incorrect for REST, as REST always sends Graffiti as a hex string. `GraffitiBytes.init` is used for other purposes such as command line parsing.

Removes the additional `GraffitiBytes` overload.