### PR TITLE
implement v1.2.0 optimistic sync tests

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -277,6 +277,11 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SCRYPT] Network Keystore encryption                                                       OK
 ```
 OK: 12/12 Fail: 0/12 Skip: 0/12
+## Latest valid hash [Preset: mainnet]
+```diff
++ LVH searching                                                                              OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Light client [Preset: mainnet]
 ```diff
 + Init from checkpoint                                                                       OK
@@ -585,4 +590,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 326/331 Fail: 0/331 Skip: 5/331
+OK: 327/332 Fail: 0/332 Skip: 5/332

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -224,6 +224,7 @@ ConsensusSpecPreset-mainnet
 + Slots - over_epoch_boundary                                                                OK
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
++ Sync - mainnet/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: mainne OK
@@ -439,7 +440,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 429/436 Fail: 0/436 Skip: 7/436
+OK: 430/437 Fail: 0/437 Skip: 7/437
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1292,4 +1293,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 33/33 Fail: 0/33 Skip: 0/33
 
 ---TOTAL---
-OK: 1115/1122 Fail: 0/1122 Skip: 7/1122
+OK: 1116/1123 Fail: 0/1123 Skip: 7/1123

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -264,6 +264,7 @@ ConsensusSpecPreset-minimal
 + Slots - over_epoch_boundary                                                                OK
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
++ Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: minima OK
@@ -497,7 +498,7 @@ ConsensusSpecPreset-minimal
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 487/494 Fail: 0/494 Skip: 7/494
+OK: 488/495 Fail: 0/495 Skip: 7/495
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1391,4 +1392,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 36/36 Fail: 0/36 Skip: 0/36
 
 ---TOTAL---
-OK: 1206/1213 Fail: 0/1213 Skip: 7/1213
+OK: 1207/1214 Fail: 0/1214 Skip: 7/1214

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1898,9 +1898,9 @@ proc updateHead*(
         dag.finalizedHead.blck.root, stateRoot, dag.finalizedHead.slot.epoch)
       dag.onFinHappened(dag, data)
 
-proc getEarliestInvalidRoot*(
+proc getEarliestInvalidBlockRoot*(
     dag: ChainDAGRef, initialSearchRoot: Eth2Digest,
-    latestValidHash: Eth2Digest, defaultEarliestInvalidRoot: Eth2Digest):
+    latestValidHash: Eth2Digest, defaultEarliestInvalidBlockRoot: Eth2Digest):
     Eth2Digest =
   # Earliest within a chain/fork in question, per LVH definition. Intended to
   # be called with `initialRoot` as the parent of the block regarding which a
@@ -1920,14 +1920,14 @@ proc getEarliestInvalidRoot*(
   # parent of the reported invalid block
   if  curBlck.executionBlockRoot.isSome and
       curBlck.executionBlockRoot.get == latestValidHash:
-    return defaultEarliestInvalidRoot
+    return defaultEarliestInvalidBlockRoot
 
   while true:
     # This was supposed to have been either caught by the pre-loop check or the
     # parent check.
     if  curBlck.executionBlockRoot.isSome and
         curBlck.executionBlockRoot.get == latestValidHash:
-      doAssert false, "getEarliestInvalidRoot: unexpected LVH in loop body"
+      doAssert false, "getEarliestInvalidBlockRoot: unexpected LVH in loop body"
 
     if (curBlck.parent.isNil) or
        curBlck.parent.executionBlockRoot.get(latestValidHash) ==

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1929,9 +1929,7 @@ proc getEarliestInvalidRoot*(
       doAssert false, "getEarliestInvalidRoot: unexpected LVH in loop body"
 
     if (curBlck.parent.isNil) or
-       curBlck.parent.executionBlockRoot.isNone or
-       (curBlck.parent.executionBlockRoot.isSome and
-        curBlck.parent.executionBlockRoot.get == lvh):
+       curBlck.parent.executionBlockRoot.get(lvh) == lvh:
       break
     curBlck = curBlck.parent
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1899,8 +1899,9 @@ proc updateHead*(
       dag.onFinHappened(dag, data)
 
 proc getEarliestInvalidRoot*(
-    dag: ChainDAGRef, initialSearchRoot: Eth2Digest, lvh: Eth2Digest,
-    defaultEarliestInvalidRoot: Eth2Digest): Eth2Digest =
+    dag: ChainDAGRef, initialSearchRoot: Eth2Digest,
+    latestValidHash: Eth2Digest, defaultEarliestInvalidRoot: Eth2Digest):
+    Eth2Digest =
   # Earliest within a chain/fork in question, per LVH definition. Intended to
   # be called with `initialRoot` as the parent of the block regarding which a
   # newPayload or forkchoiceUpdated execution_status has been received as the
@@ -1918,18 +1919,19 @@ proc getEarliestInvalidRoot*(
   # Only allow this special case outside loop; it's when the LVH is the direct
   # parent of the reported invalid block
   if  curBlck.executionBlockRoot.isSome and
-      curBlck.executionBlockRoot.get == lvh:
+      curBlck.executionBlockRoot.get == latestValidHash:
     return defaultEarliestInvalidRoot
 
   while true:
     # This was supposed to have been either caught by the pre-loop check or the
     # parent check.
     if  curBlck.executionBlockRoot.isSome and
-        curBlck.executionBlockRoot.get == lvh:
+        curBlck.executionBlockRoot.get == latestValidHash:
       doAssert false, "getEarliestInvalidRoot: unexpected LVH in loop body"
 
     if (curBlck.parent.isNil) or
-       curBlck.parent.executionBlockRoot.get(lvh) == lvh:
+       curBlck.parent.executionBlockRoot.get(latestValidHash) ==
+         latestValidHash:
       break
     curBlck = curBlck.parent
 

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -241,7 +241,7 @@ proc updateExecutionClientHead(
     # This is a CL root, not EL hash
     let earliestKnownInvalidRoot =
       if latestValidHash.isSome:
-        self.dag.getEarliestInvalidRoot(
+        self.dag.getEarliestInvalidBlockRoot(
           newHead.blck.root, latestValidHash.get.asEth2Digest,
           newHead.blck.root)
       else:

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -247,12 +247,9 @@ proc updateExecutionClientHead(
       else:
         newHead.blck.root
 
-    self.attestationPool[].forkChoice.mark_root_invalid(
-      earliestKnownInvalidRoot)
+    self.attestationPool[].forkChoice.mark_root_invalid(newHead.blck.root)
     self.dag.markBlockInvalid(newHead.blck.root)
-    self.dag.markBlockInvalid(earliestKnownInvalidRoot)
     self.quarantine[].addUnviable(newHead.blck.root)
-    self.quarantine[].addUnviable(earliestKnownInvalidRoot)
     return Opt.none(void)
   of PayloadExecutionStatus.accepted, PayloadExecutionStatus.syncing:
     self.dag.optimisticRoots.incl newHead.blck.root

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -442,6 +442,7 @@ func mark_root_invalid*(self: var ForkChoice, root: Eth2Digest) =
         self.backend.proto_array.nodes.offset
     if nodePhysicalIdx < self.backend.proto_array.nodes.buf.len:
       self.backend.proto_array.nodes.buf[nodePhysicalIdx].invalid = true
+    self.backend.proto_array.propagateInvalidity(nodePhysicalIdx)
   # Best-effort; attempts to mark unknown roots invalid harmlessly ignored
   except KeyError:
     discard

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -178,7 +178,7 @@ proc expectValidForkchoiceUpdated(
     eth1Monitor: Eth1Monitor,
     headBlockRoot, safeBlockRoot, finalizedBlockRoot: Eth2Digest
 ): Future[void] {.async.} =
-  let payloadExecutionStatus =
+  let (payloadExecutionStatus, _) =
     await eth1Monitor.runForkchoiceUpdated(
       headBlockRoot, safeBlockRoot, finalizedBlockRoot)
   if payloadExecutionStatus != PayloadExecutionStatus.valid:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -225,7 +225,7 @@ proc stepOnBlock(
       # future.
       let lvh = invalidatedRoots.getOrDefault(
         executionPayloadHash, static(default(Eth2Digest)))
-      fkChoice[].mark_root_invalid(dag.getEarliestInvalidRoot(
+      fkChoice[].mark_root_invalid(dag.getEarliestInvalidBlockRoot(
         signedBlock.message.parent_root, lvh, executionPayloadHash))
 
       return err BlockError.Invalid

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -39,6 +39,7 @@ type
     opOnBlock
     opOnMergeBlock
     opOnAttesterSlashing
+    opInvalidateRoot
     opChecks
 
   Operation = object
@@ -55,6 +56,9 @@ type
       powBlock: PowBlock
     of opOnAttesterSlashing:
       attesterSlashing: AttesterSlashing
+    of opInvalidateRoot:
+      invalidatedRoot: Eth2Digest
+      latestValidHash: Eth2Digest
     of opChecks:
       checks: JsonNode
 
@@ -156,6 +160,13 @@ proc loadOps(path: string, fork: BeaconStateFork): seq[Operation] =
       )
       result.add Operation(kind: opOnAttesterSlashing,
         attesterSlashing: attesterSlashing)
+    elif step.hasKey"payload_status":
+      if step["payload_status"]["status"].getStr() == "INVALID":
+        result.add Operation(kind: opInvalidateRoot,
+          valid: true,
+          invalidatedRoot: Eth2Digest.fromHex(step["block_hash"].getStr()),
+          latestValidHash: Eth2Digest.fromHex(
+            step["payload_status"]["latest_valid_hash"].getStr()))
     elif step.hasKey"checks":
       result.add Operation(kind: opChecks,
         checks: step["checks"])
@@ -165,7 +176,7 @@ proc loadOps(path: string, fork: BeaconStateFork): seq[Operation] =
     if step.hasKey"valid":
       doAssert step.len == 2
       result[^1].valid = step["valid"].getBool()
-    elif not step.hasKey"checks":
+    elif not step.hasKey"checks" and not step.hasKey"payload_status":
       doAssert step.len == 1
       result[^1].valid = true
 
@@ -176,7 +187,9 @@ proc stepOnBlock(
        state: var ForkedHashedBeaconState,
        stateCache: var StateCache,
        signedBlock: ForkySignedBeaconBlock,
-       time: BeaconTime): Result[BlockRef, BlockError] =
+       time: BeaconTime,
+       invalidatedRoots: Table[Eth2Digest, Eth2Digest]):
+       Result[BlockRef, BlockError] =
   # 1. Move state to proper slot.
   doAssert dag.updateState(
     state,
@@ -192,6 +205,30 @@ proc stepOnBlock(
     type TrustedBlock = altair.TrustedSignedBeaconBlock
   else:
     type TrustedBlock = bellatrix.TrustedSignedBeaconBlock
+
+  # In normal Nimbus flow, for this (effectively) newPayload-based INVALID, it
+  # is checked even before entering the DAG, by the block processor. Currently
+  # the optimistic sync test(s) don't include a later-fcU-INVALID case. Whilst
+  # this wouldn't be part of this check, presumably, their FC test vector step
+  # would also have `true` validity because it'd not be known they weren't, so
+  # adding this mock of the block processor is realistic and sufficient.
+  when not (
+      signedBlock is phase0.SignedBeaconBlock or
+      signedBlock is altair.SignedBeaconBlock):
+    let executionPayloadHash =
+      signedBlock.message.body.execution_payload.block_hash
+    if executionPayloadHash in invalidatedRoots:
+      # Mocks fork choice INVALID list application. These tests sequence this
+      # in a way the block processor does not, specifying each payload_status
+      # before the block itself, while Nimbus fork choice treats invalidating
+      # a non-existent block root as a no-op and does not remember it for the
+      # future.
+      let lvh = invalidatedRoots.getOrDefault(
+        executionPayloadHash, static(default(Eth2Digest)))
+      fkChoice[].mark_root_invalid(dag.getEarliestInvalidRoot(
+        signedBlock.message.parent_root, lvh, executionPayloadHash))
+
+      return err BlockError.Invalid
 
   let blockAdded = dag.addHeadBlock(verifier, signedBlock) do (
       blckRef: BlockRef, signedBlock: TrustedBlock,
@@ -278,6 +315,7 @@ proc doRunTest(path: string, fork: BeaconStateFork) =
 
   let steps = loadOps(path, fork)
   var time = stores.fkChoice.checkpoints.time
+  var invalidatedRoots: Table[Eth2Digest, Eth2Digest]
 
   let state = newClone(stores.dag.headState)
   var stateCache = StateCache()
@@ -298,7 +336,7 @@ proc doRunTest(path: string, fork: BeaconStateFork) =
         let status = stepOnBlock(
           stores.dag, stores.fkChoice,
           verifier, state[], stateCache,
-          blck, time)
+          blck, time, invalidatedRoots)
         doAssert status.isOk == step.valid
     of opOnAttesterSlashing:
       let indices =
@@ -307,12 +345,14 @@ proc doRunTest(path: string, fork: BeaconStateFork) =
         for idx in indices.get:
           stores.fkChoice[].process_equivocation(idx)
       doAssert indices.isOk == step.valid
+    of opInvalidateRoot:
+      invalidatedRoots[step.invalidatedRoot] = step.latestValidHash
     of opChecks:
       stepChecks(step.checks, stores.dag, stores.fkChoice, time)
     else:
       doAssert false, "Unsupported"
 
-proc runTest(path: string, fork: BeaconStateFork) =
+proc runTest(testType: static[string], path: string, fork: BeaconStateFork) =
   const SKIP = [
     # protoArray can handle blocks in the future gracefully
     # spec: https://github.com/ethereum/consensus-specs/blame/v1.1.3/specs/phase0/fork-choice.md#L349
@@ -327,7 +367,7 @@ proc runTest(path: string, fork: BeaconStateFork) =
     "all_valid",
   ]
 
-  test "ForkChoice - " & path.relativePath(SszTestsDir):
+  test testType & " - " & path.relativePath(SszTestsDir):
     when defined(windows):
       # Some test files have very long paths
       skip()
@@ -337,17 +377,21 @@ proc runTest(path: string, fork: BeaconStateFork) =
       else:
         doRunTest(path, fork)
 
-suite "EF - ForkChoice" & preset():
-  const presetPath = SszTestsDir/const_preset
-  for kind, path in walkDir(presetPath, relative = true, checkDir = true):
-    let testsPath = presetPath/path/"fork_choice"
-    if kind != pcDir or not dirExists(testsPath):
-      continue
-    let fork = forkForPathComponent(path).valueOr:
-      raiseAssert "Unknown test fork: " & testsPath
-    for kind, path in walkDir(testsPath, relative = true, checkDir = true):
-      let basePath = testsPath/path/"pyspec_tests"
-      if kind != pcDir:
+template fcSuite(suiteName: static[string], testPathElem: static[string]) =
+  suite "EF - " & suiteName & preset():
+    const presetPath = SszTestsDir/const_preset
+    for kind, path in walkDir(presetPath, relative = true, checkDir = true):
+      let testsPath = presetPath/path/testPathElem
+      if kind != pcDir or not dirExists(testsPath):
         continue
-      for kind, path in walkDir(basePath, relative = true, checkDir = true):
-        runTest(basePath/path, fork)
+      let fork = forkForPathComponent(path).valueOr:
+        raiseAssert "Unknown test fork: " & testsPath
+      for kind, path in walkDir(testsPath, relative = true, checkDir = true):
+        let basePath = testsPath/path/"pyspec_tests"
+        if kind != pcDir:
+          continue
+        for kind, path in walkDir(basePath, relative = true, checkDir = true):
+          runTest(suiteName, basePath/path, fork)
+
+fcSuite("ForkChoice", "fork_choice")
+fcSuite("Sync", "sync")

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -898,7 +898,7 @@ suite "Latest valid hash" & preset():
       # but returns CL block hash, because that's what fork choice and other
       # Nimbus components mostly use as a coordinate system. Since b1 is set
       # to be valid here by being the LVH, it means that b2 must be invalid.
-      dag.getEarliestInvalidRoot(
+      dag.getEarliestInvalidBlockRoot(
         b2Add[].root, b1.message.body.execution_payload.block_hash,
           fallbackEarliestInvalid) == b2Add[].root
 
@@ -908,6 +908,6 @@ suite "Latest valid hash" & preset():
       # a manually specified fallback (CL) block root to use, because it does
       # not have access to this information otherwise, because the very first
       # newest block in the chain it's examining is already valid.
-      dag.getEarliestInvalidRoot(
+      dag.getEarliestInvalidBlockRoot(
         b2Add[].root, b2.message.body.execution_payload.block_hash,
           fallbackEarliestInvalid) == fallbackEarliestInvalid


### PR DESCRIPTION
This also requires
- implementing latest valid hash support, hitherto treated as a noncritical optimization
- adding merge (not just Bellatrix) support to the test block infrastructure
- covering some additional LVH cases the EF consensus spec tests don't