### PR TITLE
newPayload `INVALIDATED` should be `unviableFork`

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -300,7 +300,7 @@ template toGaugeValue(x: Quantity): int64 =
 func compute_time_at_slot(genesis_time: uint64, slot: Slot): uint64 =
   genesis_time + slot * SECONDS_PER_SLOT
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.1/specs/phase0/validator.md#get_eth1_data
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/phase0/validator.md#get_eth1_data
 func voting_period_start_time(state: ForkedHashedBeaconState): uint64 =
   let eth1_voting_period_start_slot =
     getStateField(state, slot) - getStateField(state, slot) mod

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -560,7 +560,8 @@ proc runQueueProcessingLoop*(self: ref BlockProcessor) {.async.} =
       # Every loop iteration ends with some version of blck.resfut.complete(),
       # including processBlock(), otherwise the sync manager stalls.
       if not blck.resfut.isNil:
-        blck.resfut.complete(Result[void, BlockError].err(BlockError.Invalid))
+        blck.resfut.complete(
+          Result[void, BlockError].err(BlockError.UnviableFork))
     else:
       self[].processBlock(
         blck,

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -179,7 +179,7 @@ func apply_light_client_update(
     didProgress = true
   didProgress
 
-# https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/light-client/sync-protocol.md#process_light_client_store_force_update
+# https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/altair/light-client/sync-protocol.md#process_light_client_store_force_update
 type
   ForceUpdateResult* = enum
     NoUpdate,


### PR DESCRIPTION
This makes it more consistent with `forkchoiceUpdated` `INVALIDATED`s and also accounts for where a sequence of optimistically synced `NOT_VALIDATED` blocks are followed by an `INVALIDATED` block. In that case, all the block processor knows is that the block or one of its ancestors is invalid. It does not know that the block itself, in isolation, is invalid.

This changes the peer descoring, but in a way consistently with `forkchoiceUpdated`.