### PR TITLE
fix best LC updates when backfilling

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -305,9 +305,7 @@ proc initLightClientUpdateForPeriod(
     if signatureBid.slot == FAR_FUTURE_SLOT:
       signatureBid = maxParticipantsBid
     else:
-      let
-        nextLowSlot = signatureBid.slot + 1
-        signatureRes = dag.maxParticipantsBlock(highBid, nextLowSlot)
+      let signatureRes = dag.maxParticipantsBlock(highBid, signatureBid.slot)
       if signatureRes.res.isErr:
         res.err()
       signatureBid = signatureRes.bid.valueOr:
@@ -337,7 +335,7 @@ proc initLightClientUpdateForPeriod(
             continue
         else:
           continue
-    if finalizedBid.slot >= lowSlot:
+    if finalizedBsi.bid.slot >= lowSlot:
       finalizedBid = finalizedBsi.bid
       break
     if signatureBid == maxParticipantsBid:


### PR DESCRIPTION
When backfilling LC updates (`--light-client-data-import-mode=full`), the highest participation update is computed without ensuring that the finalized header is in the same period. Updates sharing same period for both finalized and attested headers should be preferred. Fixes a bug leading to suboptimal update selection.