### PR TITLE
use LRU strategy for shuffling/epoch caches

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -65,9 +65,9 @@ type
     # unnecessary overhead.
     data*: BlockRef
 
-  LRUCache*[I: static[uint8], T] = object
-    items*: array[I, tuple[value: T, next: uint8]]
-    mru*: uint8
+  LRUCache*[I: static[int], T] = object
+    entries*: array[I, tuple[value: T, lastUsed: uint32]]
+    timestamp*: uint32
 
   ChainDAGRef* = ref object
     ## ChainDAG validates, stores and serves chain history of valid blocks
@@ -193,9 +193,9 @@ type
 
     cfg*: RuntimeConfig
 
-    shufflingRefs*: LRUCache[16'u8, ShufflingRef]
+    shufflingRefs*: LRUCache[16, ShufflingRef]
 
-    epochRefs*: LRUCache[32'u8, EpochRef]
+    epochRefs*: LRUCache[32, EpochRef]
       ## Cached information about a particular epoch ending with the given
       ## block - we limit the number of held EpochRefs to put a cap on
       ## memory usage

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -65,6 +65,10 @@ type
     # unnecessary overhead.
     data*: BlockRef
 
+  LRUCache*[I: static[uint8], T] = object
+    items*: array[I, tuple[value: T, next: uint8]]
+    mru*: uint8
+
   ChainDAGRef* = ref object
     ## ChainDAG validates, stores and serves chain history of valid blocks
     ## according to the beacon chain state transtion. From genesis to the
@@ -189,9 +193,9 @@ type
 
     cfg*: RuntimeConfig
 
-    shufflingRefs*: array[16, ShufflingRef]
+    shufflingRefs*: LRUCache[16'u8, ShufflingRef]
 
-    epochRefs*: array[32, EpochRef]
+    epochRefs*: LRUCache[32'u8, EpochRef]
       ## Cached information about a particular epoch ending with the given
       ## block - we limit the number of held EpochRefs to put a cap on
       ## memory usage

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -306,9 +306,6 @@ func put[I, T](cache: var LRUCache[I, T], value: T) =
         lru = i
         if min == 0:
           break
-    if min != 0:
-      {.noSideEffect.}:
-        debug "Cache full - evicting LRU", cache = typeof(T).name, capacity = I
 
   template e: untyped = cache.entries[lru]
   e.value = value

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -525,8 +525,8 @@ suite "chain DAG finalization tests" & preset():
       not finalER.isErr()
 
     block:
-      for er in dag.epochRefs:
-        check: er == nil or er.epoch >= dag.finalizedHead.slot.epoch
+      for er in dag.epochRefs.items:
+        check: er.value == nil or er.value.epoch >= dag.finalizedHead.slot.epoch
 
     block:
       let tmpStateData = assignClone(dag.headState)

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -525,7 +525,7 @@ suite "chain DAG finalization tests" & preset():
       not finalER.isErr()
 
     block:
-      for er in dag.epochRefs.items:
+      for er in dag.epochRefs.entries:
         check: er.value == nil or er.value.epoch >= dag.finalizedHead.slot.epoch
 
     block:


### PR DESCRIPTION
When EL `newPayload` is slow (e.g., Raspberry Pi with Besu), the epoch and shuffling caches tend to fill up with multiple copies per epoch when processing gossip and performing validator duties close to wall slot. The old strategy of evicting oldest epoch led to the same item being evicted over and over, leading to blocking of over 5 minutes in extreme cases where alternate epochs/shuffling got loaded repeatedly. Changing the cache eviction strategy to least-recently-used seems to improve the situation drastically. A simple implementation was selected based on single linked-list without a hashtable.