### PR TITLE
correct typo

### DIFF
--- a/docs/the_auditors_handbook/src/02.1_nim_routines_proc_func_templates_macros.md
+++ b/docs/the_auditors_handbook/src/02.1_nim_routines_proc_func_templates_macros.md
@@ -31,7 +31,7 @@ The only exception being the standard library. Procedures from the standard libr
 Nim provides flexible call syntax, the following are possible:
 
 ```Nim
-prof foo(a: int) =
+proc foo(a: int) =
   discard
 
 foo(a)


### PR DESCRIPTION
This corrects a small typo

Note: The Auditors Handbook currently contains NO LINK at all to this repository

So editing it is harder than it needs to be