### PR TITLE
use same style for sending block and state rsps

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -871,14 +871,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         let bdata = node.dag.getForkedBlock(bid).valueOr:
           return RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
-        let
-          fork = node.dag.cfg.blockForkAtEpoch(bid.slot.epoch)
-          headers = [("eth-consensus-version", fork.toString())]
-
         RestApiResponse.jsonResponseBlock(
           bdata.asSigned(),
-          node.getBlockOptimistic(bdata),
-          headers
+          node.getBlockOptimistic(bdata)
         )
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)


### PR DESCRIPTION
For JSON responses, "eth-consensus-version" header is handled in `eth2_rest_serialization` for states and `rest_beacon_api` for blocks. Align them to also be handled in `eth2_rest_serialization` for blocks.