### PR TITLE
update `ContentNotAcceptable` error description

### DIFF
--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -151,7 +151,7 @@ const
   InvalidLogLevelValueError* =
     "Invalid log level value error"
   ContentNotAcceptableError* =
-    "Could not find out accepted content type"
+    "Accepted media type not supported"
   InvalidAcceptError* =
     "Incorrect accept response type"
   MissingSubCommitteeIndexValueError* =


### PR DESCRIPTION
The `ContentNotAcceptableError` is triggered when client either requests an unsupported media type, or has form errors such as sending multiples. Updating the description to also indicate non-supported Accept headers.