### PR TITLE
Light client decrease min time between queries

### DIFF
--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -382,7 +382,7 @@ func fetchTime(
       of NextPeriod:
         chronos.seconds(
           (SLOTS_PER_SYNC_COMMITTEE_PERIOD * SECONDS_PER_SLOT).int64)
-    minDelay = max(remainingTime div 8, chronos.seconds(30))
+    minDelay = max(remainingTime div 8, chronos.seconds(10))
     jitterSeconds = (minDelay * 2).seconds
     jitterDelay = chronos.seconds(self.rng[].rand(jitterSeconds).int64)
   return wallTime + minDelay + jitterDelay


### PR DESCRIPTION
As it currently stands light client takes a bit long to start. Main reason is that currently not that many peers serve light client data (especially on testnets like goerli) and light client can't retrieve bootstrap. The other reason is that querying 2 random peers every 1min(at most) makes it pretty slow to cycle through all available peers.

This fix decreases time between queries to 20s (at most).

I have experimented with other more complex fixes, like keeping table of peers which recently failed provide data and avoid asking them, but ultimately the most impactful and simple fix was to decrease query interval.