### PR TITLE
Allow chain dag without genesis / block

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -17,10 +17,11 @@ AllTests-mainnet
 OK: 11/11 Fail: 0/11 Skip: 0/11
 ## Backfill
 ```diff
++ Init without genesis / block                                                               OK
 + backfill to genesis                                                                        OK
 + reload backfill position                                                                   OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -597,4 +598,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 330/335 Fail: 0/335 Skip: 5/335
+OK: 331/336 Fail: 0/336 Skip: 5/336

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -316,6 +316,37 @@ proc addBackfillBlock*(
 
   template blck(): untyped = signedBlock.message # shortcuts without copy
   template blockRoot(): untyped = signedBlock.root
+  template checkSignature =
+    # If the hash is correct, the block itself must be correct, but the root does
+    # not cover the signature, which we check next
+    if blck.slot == GENESIS_SLOT:
+      # The genesis block must have an empty signature (since there's no proposer)
+      if signedBlock.signature != ValidatorSig():
+        info "Invalid genesis block signature"
+        return err(BlockError.Invalid)
+    else:
+      let proposerKey = dag.validatorKey(blck.proposer_index)
+      if proposerKey.isNone():
+        # We've verified that the block root matches our expectations by following
+        # the chain of parents all the way from checkpoint. If all those blocks
+        # were valid, the proposer_index in this block must also be valid, and we
+        # should have a key for it but we don't: this is either a bug on our from
+        # which we cannot recover, or an invalid checkpoint state was given in which
+        # case we're in trouble.
+        fatal "Invalid proposer in backfill block - checkpoint state corrupt?",
+          head = shortLog(dag.head), tail = shortLog(dag.tail)
+
+        quit 1
+
+      if not verify_block_signature(
+          dag.forkAtEpoch(blck.slot.epoch),
+          getStateField(dag.headState, genesis_validators_root),
+          blck.slot,
+          signedBlock.root,
+          proposerKey.get(),
+          signedBlock.signature):
+        info "Block signature verification failed"
+        return err(BlockError.Invalid)
 
   let startTick = Moment.now()
 
@@ -324,9 +355,16 @@ proc addBackfillBlock*(
     if existing.isSome:
       if existing.get().bid.slot == blck.slot and
           existing.get().bid.root == blockRoot:
-        # We should not call the block added callback for blocks that already
-        # existed in the pool, as that may confuse consumers such as the fork
-        # choice.
+
+        # Special case: when starting with only a checkpoint state, we will not
+        # have the head block data in the database
+        if dag.getForkedBlock(existing.get().bid).isNone():
+          checkSignature()
+
+          debug "Block backfilled (checkpoint)"
+          dag.putBlock(signedBlock.asTrusted())
+          return ok()
+
         debug "Duplicate block"
         return err(BlockError.Duplicate)
 
@@ -368,36 +406,7 @@ proc addBackfillBlock*(
     debug "Block does not match expected backfill root"
     return err(BlockError.MissingParent) # MissingChild really, but ..
 
-  # If the hash is correct, the block itself must be correct, but the root does
-  # not cover the signature, which we check next
-  if blck.slot == GENESIS_SLOT:
-    # The genesis block must have an empty signature (since there's no proposer)
-    if signedBlock.signature != ValidatorSig():
-      info "Invalid genesis block signature"
-      return err(BlockError.Invalid)
-  else:
-    let proposerKey = dag.validatorKey(blck.proposer_index)
-    if proposerKey.isNone():
-      # We've verified that the block root matches our expectations by following
-      # the chain of parents all the way from checkpoint. If all those blocks
-      # were valid, the proposer_index in this block must also be valid, and we
-      # should have a key for it but we don't: this is either a bug on our from
-      # which we cannot recover, or an invalid checkpoint state was given in which
-      # case we're in trouble.
-      fatal "Invalid proposer in backfill block - checkpoint state corrupt?",
-        head = shortLog(dag.head), tail = shortLog(dag.tail)
-
-      quit 1
-
-    if not verify_block_signature(
-        dag.forkAtEpoch(blck.slot.epoch),
-        getStateField(dag.headState, genesis_validators_root),
-        blck.slot,
-        signedBlock.root,
-        proposerKey.get(),
-        signedBlock.signature):
-      info "Block signature verification failed"
-      return err(BlockError.Invalid)
+  checkSignature()
 
   let sigVerifyTick = Moment.now
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -277,7 +277,10 @@ proc initFullNode(
     dag.backfill.slot
 
   func getFrontfillSlot(): Slot =
-    dag.frontfill.slot
+    if dag.frontfill.isSome():
+      dag.frontfill.get().slot
+    else:
+      GENESIS_SLOT
 
   let
     quarantine = newClone(

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -80,7 +80,9 @@ proc getBlockSlotId*(node: BeaconNode,
     of StateIdentType.Head:
       ok(node.dag.head.bid.atSlot())
     of StateIdentType.Genesis:
-      ok(node.dag.genesis.atSlot())
+      let bid = node.dag.getBlockIdAtSlot(GENESIS_SLOT).valueOr:
+        return err("Genesis state not available / pruned")
+      ok bid
     of StateIdentType.Finalized:
       ok(node.dag.finalizedHead.toBlockSlotId().expect("not nil"))
     of StateIdentType.Justified:
@@ -98,7 +100,7 @@ proc getBlockId*(node: BeaconNode, id: BlockIdent): Opt[BlockId] =
     of BlockIdentType.Head:
       ok(node.dag.head.bid)
     of BlockIdentType.Genesis:
-      ok(node.dag.genesis)
+      node.dag.getBlockIdAtSlot(GENESIS_SLOT).map(proc(x: auto): auto = x.bid)
     of BlockIdentType.Finalized:
       ok(node.dag.finalizedHead.blck.bid)
   of BlockQueryKind.Root:

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -437,7 +437,7 @@ proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
 
 func atCanonicalSlot(dag: ChainDAGRef, bid: BlockId, slot: Slot): Opt[BlockSlotId] =
   if slot == 0:
-    ok dag.genesis.atSlot()
+    dag.getBlockIdAtSlot(GENESIS_SLOT)
   else:
     ok BlockSlotId.init((? dag.atSlot(bid, slot - 1)).bid, slot)
 

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -288,10 +288,8 @@ proc stepChecks(
       doAssert fkChoice.checkpoints.proposer_boost_root ==
         Eth2Digest.fromHex(val.getStr())
     elif check == "genesis_time":
-      # The fork choice is pruned regularly
-      # and does not store the genesis time,
-      # hence we check the DAG
-      doAssert dag.genesis.slot == Slot(val.getInt())
+      # We do not store genesis in fork choice..
+      discard
     else:
       doAssert false, "Unsupported check '" & $check & "'"
 

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -901,7 +901,6 @@ suite "Backfill":
       check: dag.addBackfillBlock(blocks[blocks.len - i - 1].phase0Data).isOk()
 
     check:
-      dag.addBackfillBlock(genBlock.phase0Data.asSigned).isOk()
       dag.addBackfillBlock(genBlock.phase0Data.asSigned).error == BlockError.Duplicate
 
       dag.backfill.slot == GENESIS_SLOT
@@ -947,6 +946,7 @@ suite "Backfill":
   test "Init without genesis / block":
     let
       tailBlock = blocks[^1]
+      genBlock = get_initial_beacon_block(genState[])
 
     ChainDAGRef.preInit(db, tailState[])
 
@@ -956,7 +956,15 @@ suite "Backfill":
 
     check:
       dag.getFinalizedEpochRef() != nil
-      dag.addBackfillBlock(blocks[^2].phase0Data).isOk()
+
+    for i in 0..<blocks.len:
+      check: dag.addBackfillBlock(
+        blocks[blocks.len - i - 1].phase0Data).isOk()
+
+    check:
+      dag.addBackfillBlock(genBlock.phase0Data.asSigned).isOk()
+      dag.addBackfillBlock(
+        genBlock.phase0Data.asSigned).error == BlockError.Duplicate
 
     var
       cache: StateCache


### PR DESCRIPTION
This PR enables the initialization of the dag without access to blocks or genesis state - it is a prerequisite for implementing a number of interesting features:

* checkpoint sync without any block download
* pruning of blocks and states