### PR TITLE
make deployment phase configurable

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -113,6 +113,12 @@ type
     # migrateAll = "Export and remove the whole validator slashing protection DB."
     # migrate = "Export and remove specified validators from Nimbus."
 
+  DeploymentPhase* {.pure.} = enum
+    Devnet = "devnet"
+    Testnet = "testnet"
+    Mainnet = "mainnet"
+    None = "none"
+
   BeaconNodeConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"
@@ -514,6 +520,13 @@ type
         defaultValue: MaxEmptySlotCount
         defaultValueDesc: "50"
         name: "sync-horizon" .}: uint64
+
+      deploymentPhase* {.
+        hidden
+        desc: "Configures the deployment phase"
+        defaultValue: DeploymentPhase.Mainnet
+        defaultValueDesc: $DeploymentPhase.Mainnet
+        name: "deployment-phase" .}: DeploymentPhase
 
       # TODO nim-confutils on 32-bit platforms overflows decoding integers
       # requiring 64-bit representations and doesn't build when specifying

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -79,15 +79,6 @@ type
     else:
       incompatibilityDesc*: string
 
-type DeploymentPhase* {.pure.} = enum
-  None,
-  Devnet,
-  Testnet,
-  Mainnet
-
-func deploymentPhase*(genesisData: string): DeploymentPhase =
-  DeploymentPhase.Devnet
-
 const
   eth2NetworksDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/eth2-networks"
   mergeTestnetsDir = currentSourcePath.parentDir.replace('\\', '/') & "/../../vendor/merge-testnets"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -624,7 +624,7 @@ proc init*(T: type BeaconNode,
     dag = loadChainDag(
       config, cfg, db, eventBus,
       validatorMonitor, networkGenesisValidatorsRoot,
-      genesisStateContents.deploymentPhase <= DeploymentPhase.Testnet)
+      config.deploymentPhase <= DeploymentPhase.Testnet)
     genesisTime = getStateField(dag.headState, genesis_time)
     beaconClock = BeaconClock.init(genesisTime)
     getBeaconTime = beaconClock.getBeaconTimeFn()


### PR DESCRIPTION
Allow config of deployment phase via config instead of attempting to derive from genesis content (when running relevant testnets), so that we don't have to keep maintaining the list inside the binary.