### PR TITLE
update to v1 of LC REST API

### DIFF
--- a/beacon_chain/rpc/rest_event_api.nim
+++ b/beacon_chain/rpc/rest_event_api.nim
@@ -86,7 +86,6 @@ proc eventHandler*[T](response: HttpResponseRef,
 
 proc installEventApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Events/eventstream
-  # https://github.com/ethereum/beacon-APIs/pull/181
   router.api(MethodGet, "/eth/v1/events") do (
     topics: seq[EventTopic]) -> RestApiResponse:
     let eventTopics =
@@ -151,12 +150,12 @@ proc installEventApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if EventTopic.LightClientFinalityUpdate in eventTopics:
           doAssert node.dag.lcDataStore.serve
           let handler = response.eventHandler(node.eventBus.finUpdateQueue,
-                                              "light_client_finality_update_v0")
+                                              "light_client_finality_update")
           res.add(handler)
         if EventTopic.LightClientOptimisticUpdate in eventTopics:
           doAssert node.dag.lcDataStore.serve
           let handler = response.eventHandler(node.eventBus.optUpdateQueue,
-                                              "light_client_optimistic_update_v0")
+                                              "light_client_optimistic_update")
           res.add(handler)
         res
 

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -17,9 +17,9 @@ import ../beacon_node,
 logScope: topics = "rest_light_client"
 
 proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
-  # https://github.com/ethereum/beacon-APIs/pull/181
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getLightClientBootstrap
   router.api(MethodGet,
-             "/eth/v0/beacon/light_client/bootstrap/{block_root}") do (
+             "/eth/v1/beacon/light_client/bootstrap/{block_root}") do (
     block_root: Eth2Digest) -> RestApiResponse:
     doAssert node.dag.lcDataStore.serve
     let contentType =
@@ -52,9 +52,9 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
-  # https://github.com/ethereum/beacon-APIs/pull/181
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getLightClientUpdatesByRange
   router.api(MethodGet,
-             "/eth/v0/beacon/light_client/updates") do (
+             "/eth/v1/beacon/light_client/updates") do (
     start_period: Option[SyncCommitteePeriod], count: Option[uint64]
     ) -> RestApiResponse:
     doAssert node.dag.lcDataStore.serve
@@ -113,9 +113,9 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
-  # https://github.com/ethereum/beacon-APIs/pull/181
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getLightClientFinalityUpdate
   router.api(MethodGet,
-             "/eth/v0/beacon/light_client/finality_update") do (
+             "/eth/v1/beacon/light_client/finality_update") do (
     ) -> RestApiResponse:
     doAssert node.dag.lcDataStore.serve
     let contentType =
@@ -142,9 +142,9 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
-  # https://github.com/ethereum/beacon-APIs/pull/181
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getLightClientOptimisticUpdate
   router.api(MethodGet,
-             "/eth/v0/beacon/light_client/optimistic_update") do (
+             "/eth/v1/beacon/light_client/optimistic_update") do (
     ) -> RestApiResponse:
     doAssert node.dag.lcDataStore.serve
     let contentType =

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2657,9 +2657,9 @@ proc decodeString*(t: typedesc[EventTopic],
     ok(EventTopic.ChainReorg)
   of "contribution_and_proof":
     ok(EventTopic.ContributionAndProof)
-  of "light_client_finality_update_v0":
+  of "light_client_finality_update":
     ok(EventTopic.LightClientFinalityUpdate)
-  of "light_client_optimistic_update_v0":
+  of "light_client_optimistic_update":
     ok(EventTopic.LightClientOptimisticUpdate)
   else:
     err("Incorrect event's topic value")

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -2458,6 +2458,82 @@
     "response": {"status": {"operator": "equals", "value": "400"}}
   },
   {
+    "topics": ["beacon", "beacon_light_client_bootstrap_blockroot"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/bootstrap/0x0000000000000000000000000000000000000000000000000000000000000000",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "404"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_bootstrap_blockroot"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/bootstrap/head",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "400"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_updates"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/updates?start_period=0&count=50",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {
+      "status": {"operator": "equals", "value": "200"},
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "body": [{"operator": "jstructcmps", "start": [],"value": [[]]}]
+    }
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_updates"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/updates?start_period=X&count=50",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "400"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_updates"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/updates?start_period=0&count=X",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "400"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_updates"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/updates?count=50",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "400"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_updates"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/updates?start_period=0",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "400"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_finality_update"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/finality_update",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "404"}}
+  },
+  {
+    "topics": ["beacon", "beacon_light_client_optimistic_update"],
+    "request": {
+      "url": "/eth/v1/beacon/light_client/optimistic_update",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {"status": {"operator": "equals", "value": "404"}}
+  },
+  {
     "topics": ["beacon", "pool_attestations"],
     "request": {
       "url": "/eth/v1/beacon/pool/attestations",

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -19,7 +19,7 @@ const
                        $RestTesterPatch
   RestTesterIdent* = "RestTester/$1 ($2/$3)" % [RestTesterVersion,
                                                 hostCPU, hostOS]
-  RestTesterCopyright* = "Copyright(C) 2021" &
+  RestTesterCopyright* = "Copyright(C) 2021-2022" &
                         " Status Research & Development GmbH"
   RestTesterHeader* = RestTesterName & ", Version " & RestTesterVersion &
                       " [" & hostOS & ": " & hostCPU & "]\r\n" &


### PR DESCRIPTION
The LC REST API has been merged into the ethereum/beacon-APIs specs:
- https://github.com/ethereum/beacon-APIs/pull/247

Update URLs to v1 and update REST tests. Note that REST tests do not start with Altair, so the tested BN will return empty / error responses.