### PR TITLE
VC: some fixes

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -211,6 +211,8 @@ proc new*(T: type ValidatorClientRef,
       nodesAvailable: newAsyncEvent(),
       forksAvailable: newAsyncEvent(),
       gracefulExit: newAsyncEvent(),
+      indicesAvailable: newAsyncEvent(),
+      dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()),
       sigintHandleFut: waitSignal(SIGINT),
       sigtermHandleFut: waitSignal(SIGTERM)
     )
@@ -222,7 +224,9 @@ proc new*(T: type ValidatorClientRef,
       graffitiBytes: config.graffiti.get(defaultGraffitiBytes()),
       nodesAvailable: newAsyncEvent(),
       forksAvailable: newAsyncEvent(),
+      indicesAvailable: newAsyncEvent(),
       gracefulExit: newAsyncEvent(),
+      dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()),
       sigintHandleFut: newFuture[void]("sigint_placeholder"),
       sigtermHandleFut: newFuture[void]("sigterm_placeholder")
     )

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -57,6 +57,8 @@ proc lazyWaiter(node: BeaconNodeServerRef, request: FutureBase) {.async.} =
 proc lazyWait(nodes: seq[BeaconNodeServerRef], requests: seq[FutureBase],
               timerFut: Future[void]) {.async.} =
   doAssert(len(nodes) == len(requests))
+  if len(nodes) == 0:
+    return
 
   var futures: seq[Future[void]]
   for index in 0 ..< len(requests):

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -2047,3 +2047,43 @@ proc getValidatorsActivity*(
               if activity[index].active:
                 activities[index].active = true
     return GetValidatorsActivityResponse(data: activities)
+
+proc prepareBeaconProposer*(
+       vc: ValidatorClientRef,
+       data: seq[PrepareBeaconProposer]
+     ): Future[int] {.async.} =
+  logScope: request = "prepareBeaconProposer"
+  let resp = vc.onceToAll(RestPlainResponse, SlotDuration,
+                          {BeaconNodeRole.BlockProposalPublish},
+                          prepareBeaconProposer(it, data))
+  if len(resp.data) == 0:
+    # We did not get any response from beacon nodes.
+    case resp.status
+    of ApiOperation.Success:
+      # This should not be happened, there should be present at least one
+      # successfull response.
+      return 0
+    of ApiOperation.Timeout:
+      debug "Unable to perform beacon proposer preparation request in time",
+            timeout = SlotDuration
+      return 0
+    of ApiOperation.Interrupt:
+      debug "Beacon proposer's preparation request was interrupted"
+      return 0
+    of ApiOperation.Failure:
+      debug "Unexpected error happened while preparing beacon proposers"
+      return 0
+  else:
+    var count = 0
+    for apiResponse in resp.data:
+      if apiResponse.data.isErr():
+        debug "Unable to perform beacon proposer preparation request",
+              endpoint = apiResponse.node, error = apiResponse.data.error()
+      else:
+        let response = apiResponse.data.get()
+        if response.status == 200:
+          inc(count)
+        else:
+          debug "Beacon proposer preparation failed", status = response.status,
+                endpoint = apiResponse.node
+    return count

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -275,6 +275,11 @@ chronicles.expandIt(RestAttesterDuty):
   committees_at_slot = it.committees_at_slot
   validator_committee_index = it.validator_committee_index
 
+chronicles.expandIt(SyncCommitteeDuty):
+  pubkey = shortLog(it.pubkey)
+  validator_index = it.validator_index
+  validator_sync_committee_index = it.validator_sync_committee_index
+
 proc stop*(csr: ClientServiceRef) {.async.} =
   debug "Stopping service", service = csr.name
   if csr.state == ServiceState.Running:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -13,7 +13,8 @@ import
   metrics, metrics/chronos_httpserver,
   ".."/spec/datatypes/[phase0, altair],
   ".."/spec/[eth2_merkleization, helpers, signatures, validator],
-  ".."/spec/eth2_apis/[eth2_rest_serialization, rest_beacon_client],
+  ".."/spec/eth2_apis/[eth2_rest_serialization, rest_beacon_client,
+                       dynamic_fee_recipients],
   ".."/validators/[keystore_management, validator_pool, slashing_protection],
   ".."/[conf, beacon_clock, version, nimbus_binary_common]
 
@@ -22,7 +23,8 @@ export
   nimbus_binary_common, version, conf, options, tables, results, base10,
   byteutils, presto_client, eth2_rest_serialization, rest_beacon_client,
   phase0, altair, helpers, signatures, validator, eth2_merkleization,
-  beacon_clock, keystore_management, slashing_protection, validator_pool
+  beacon_clock, keystore_management, slashing_protection, validator_pool,
+  dynamic_fee_recipients
 
 const
   SYNC_TOLERANCE* = 4'u64
@@ -166,12 +168,14 @@ type
     forks*: seq[Fork]
     forksAvailable*: AsyncEvent
     nodesAvailable*: AsyncEvent
+    indicesAvailable*: AsyncEvent
     gracefulExit*: AsyncEvent
     attesters*: AttesterMap
     proposers*: ProposerMap
     syncCommitteeDuties*: SyncCommitteeDutiesMap
     beaconGenesis*: RestGenesis
     proposerTasks*: Table[Slot, seq[ProposerTask]]
+    dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
     rng*: ref HmacDrbgContext
 
   ValidatorClientRef* = ref ValidatorClient
@@ -704,3 +708,31 @@ proc doppelgangerFilter*(
     else:
       pending.add(validatorLog(vkey, vindex))
   (ready, pending)
+
+proc getFeeRecipient*(vc: ValidatorClientRef, pubkey: ValidatorPubKey,
+                      validatorIdx: ValidatorIndex,
+                      epoch: Epoch): Opt[Eth1Address] =
+  let dynamicRecipient = vc.dynamicFeeRecipientsStore[].getDynamicFeeRecipient(
+                           validatorIdx, epoch)
+  if dynamicRecipient.isSome():
+    Opt.some(dynamicRecipient.get())
+  else:
+    let staticRecipient = getSuggestedFeeRecipient(
+      vc.config.validatorsDir, pubkey, vc.config.defaultFeeRecipient)
+    if staticRecipient.isOk():
+      Opt.some(staticRecipient.get())
+    else:
+      Opt.none(Eth1Address)
+
+proc prepareProposersList*(vc: ValidatorClientRef,
+                           epoch: Epoch): seq[PrepareBeaconProposer] =
+  var res: seq[PrepareBeaconProposer]
+  for validator in vc.attachedValidators[].items():
+    if validator.index.isSome():
+      let
+        index = validator.index.get()
+        feeRecipient = vc.getFeeRecipient(validator.pubkey, index, epoch)
+      if feeRecipient.isSome():
+        res.add(PrepareBeaconProposer(validator_index: index,
+                                      fee_recipient: feeRecipient.get()))
+  res

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -420,19 +420,6 @@ proc getSyncCommitteeDutiesForSlot*(vc: ValidatorClientRef,
       res.add(duty[])
   res
 
-proc removeOldSyncPeriodDuties*(vc: ValidatorClientRef,
-                                slot: Slot) =
-  if slot.is_sync_committee_period:
-    let epoch = slot.epoch()
-    var prunedDuties = SyncCommitteeDutiesMap()
-    for key, item in vc.syncCommitteeDuties:
-      var curPeriodDuties = EpochSyncDuties()
-      for epochKey, epochDuty in item.duties:
-        if epochKey >= epoch:
-          curPeriodDuties.duties[epochKey] = epochDuty
-      prunedDuties[key] = curPeriodDuties
-    vc.syncCommitteeDuties = prunedDuties
-
 proc getDurationToNextAttestation*(vc: ValidatorClientRef,
                                    slot: Slot): string =
   var minSlot = FAR_FUTURE_SLOT

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -632,7 +632,8 @@ proc mainLoop(service: DutiesServiceRef) {.async.} =
     # become safe to combine loops, breaks and exception handlers.
     let breakLoop =
       try:
-        discard await race(attestFut, proposeFut, indicesFut, syncFut)
+        discard await race(attestFut, proposeFut, indicesFut, syncFut,
+                           prepareFut)
         checkAndRestart(AttesterLoop, attestFut, service.attesterDutiesLoop())
         checkAndRestart(ProposerLoop, proposeFut, service.proposerDutiesLoop())
         checkAndRestart(IndicesLoop, indicesFut, service.validatorIndexLoop())

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -88,6 +88,7 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
       missing.add(validatorLog(item.validator.pubkey, item.index))
     else:
       validator.index = Opt.some(item.index)
+      validator.activationEpoch = Opt.some(item.validator.activation_epoch)
       updated.add(validatorLog(item.validator.pubkey, item.index))
       list.add(validator)
 

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -360,10 +360,9 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
   await service.produceAndPublishContributions(slot, beaconBlockRoot, duties)
 
 proc spawnSyncCommitteeTasks(service: SyncCommitteeServiceRef, slot: Slot) =
-  let vc = service.client
-
-  removeOldSyncPeriodDuties(vc, slot)
-  let duties = vc.getSyncCommitteeDutiesForSlot(slot + 1)
+  let
+    vc = service.client
+    duties = vc.getSyncCommitteeDutiesForSlot(slot + 1)
 
   asyncSpawn service.publishSyncMessagesAndContributions(slot, duties)
 

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -55,6 +55,9 @@ type
     # assumed that a valid index is stored here!
     index*: Opt[ValidatorIndex]
 
+    # Epoch when validator activated.
+    activationEpoch*: Opt[Epoch]
+
     # Cache the latest slot signature - the slot signature is used to determine
     # if the validator will be aggregating (in the near future)
     slotSignature*: Opt[tuple[slot: Slot, signature: ValidatorSig]]


### PR DESCRIPTION
1. Optimize doppelganger protection to skip protection for validators which are not activated yet.
2. Cache sync committee duties to avoid spam of `prepareSyncCommitteeSubnets()` calls.
3. Fix lazy missing `lazyWait()` for `firstSuccessParallel()` template.
4. Address #4087.