### PR TITLE
only support x86 CPUs supported by non-EOL macOS software

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -87,18 +87,19 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # https://support.apple.com/kb/SP777
-      # "macOS Mojave - Technical Specifications": EOL as of 2021-10
-      # https://support.apple.com/kb/SP803
-      # "macOS Catalina - Technical Specifications" lists current oldest
-      # supported models: MacBook Air (Mid 2012 or newer), MacBook Pro
-      # (Mid 2012 or newer), Mac mini (Late 2012 or newer), and iMac (Late 2012
-      # or newer). These all have Ivy Bridge CPUs or newer.
+      # https://support.apple.com/kb/sp803
+      # "macOS Catalina - Technical Specifications": EOL as of 2022-09
+      # https://support.apple.com/kb/sp833
+      # "macOS Big Sur - Technical Specifications" lists current oldest
+      # supported models: MacBook (2015 or later), MacBook Air (2013 or later),
+      # MacBook Pro (Late 2013 or later), Mac mini (2014 or later), iMac (2014
+      # or later), iMac Pro (2017 or later), Mac Pro (2013 or later).
       #
-      # This ensures AVX, AES, PCLMUL, FSGSBASE, RDRND, and F16C instruction
-      # set support.
-      switch("passC", "-march=ivybridge")
-      switch("passL", "-march=ivybridge")
+      # These all have Haswell or newer CPUs.
+      #
+      # This ensures AVX2, AES-NI, PCLMUL, BMI1, and BMI2 instruction set support.
+      switch("passC", "-march=haswell -mtune=generic")
+      switch("passL", "-march=haswell -mtune=generic")
     else:
       switch("passC", "-mssse3")
       switch("passL", "-mssse3")


### PR DESCRIPTION
Can't assume ADX yet, but start using BMI2 if available and supported by BLST for the [`MULX`](https://www.felixcloutier.com/x86/mulx) instruction; https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#bmi2--adx discusses this.