### PR TITLE
State-only checkpoint state startup

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -449,6 +449,11 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + roundtrip                                                                                  OK
 ```
 OK: 2/2 Fail: 0/2 Skip: 0/2
+## Starting states
+```diff
++ Starting state without block                                                               OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Sync committee pool
 ```diff
 + Aggregating votes                                                                          OK
@@ -598,4 +603,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 331/336 Fail: 0/336 Skip: 5/336
+OK: 332/337 Fail: 0/337 Skip: 5/337

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1101,6 +1101,21 @@ proc getState*(
     db.immutableValidators, db.statesNoVal[T.toFork], key.data, output,
     rollback)
 
+proc getState*(
+    db: BeaconChainDB, fork: BeaconStateFork, state_root: Eth2Digest,
+    state: var ForkedHashedBeaconState, rollback: RollbackProc): bool =
+  if state.kind != fork:
+    # Avoid temporary (!)
+    state = (ref ForkedHashedBeaconState)(kind: fork)[]
+
+  withState(state):
+    if not db.getState(state_root, forkyState.data, rollback):
+      return false
+
+    forkyState.root = state_root
+
+  true
+
 proc getStateRoot(db: BeaconChainDBV0,
                    root: Eth2Digest,
                    slot: Slot): Opt[Eth2Digest] =

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -312,6 +312,7 @@ type
         name: "finalized-checkpoint-state" .}: Option[InputFile]
 
       finalizedCheckpointBlock* {.
+        hidden
         desc: "SSZ file specifying a recent finalized block"
         name: "finalized-checkpoint-block" .}: Option[InputFile]
 
@@ -763,10 +764,16 @@ type
         name: "trusted-node-url"
       .}: string
 
-      blockId* {.
-        desc: "Block id to sync to - this can be a block root, slot number, \"finalized\" or \"head\""
-        defaultValue: "finalized"
+      stateId* {.
+        desc: "State id to sync to - this can be \"finalized\", a slot number or state hash or \"head\""
+        defaultValue: "finalized",
+        name: "state-id"
       .}: string
+
+      blockId* {.
+        hidden
+        desc: "Block id to sync to - this can be a block root, slot number, \"finalized\" or \"head\" (deprecated)"
+      .}: Option[string]
 
       backfillBlocks* {.
         desc: "Backfill blocks directly from REST server instead of fetching via API"

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -17,7 +17,6 @@ import
   web3/[ethtypes, conversions],
   chronicles,
   eth/common/eth_types_json_serialization,
-  ssz_serialization/navigator,
   ../spec/eth2_ssz_serialization,
   ../spec/datatypes/phase0
 
@@ -264,7 +263,3 @@ proc getRuntimeConfig*(
   if eth2Network.isSome:
     return getMetadataForNetwork(eth2Network.get).cfg
   defaultRuntimeConfig
-
-proc extractGenesisValidatorRootFromSnapshot*(
-    snapshot: string): Eth2Digest {.raises: [Defect, IOError, SszError].} =
-  sszMount(snapshot, phase0.BeaconState).genesis_validators_root[]

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -24,7 +24,7 @@ type
     slots: seq[Option[Eth2Digest]]
 
 proc updateSlots(cache: var DbCache, slot: Slot) =
-  if cache.slots.len() < slot.int + 1:
+  if cache.slots.lenu64() < slot:
     cache.slots.setLen(slot.int + 1)
 
 proc updateSlots(cache: var DbCache, root: Eth2Digest, slot: Slot) =

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -23,13 +23,16 @@ type
     summaries: Table[Eth2Digest, BeaconBlockSummary]
     slots: seq[Option[Eth2Digest]]
 
+proc updateSlots(cache: var DbCache, slot: Slot) =
+  if cache.slots.len() < slot.int + 1:
+    cache.slots.setLen(slot.int + 1)
+
 proc updateSlots(cache: var DbCache, root: Eth2Digest, slot: Slot) =
   # The slots mapping stores one linear block history - we construct it by
   # starting from a given root/slot and walking the known parents as far back
   # as possible which ensures that all blocks belong to the same history
 
-  if cache.slots.len() < slot.int + 1:
-    cache.slots.setLen(slot.int + 1)
+  cache.updateSlots(slot)
 
   var
     root = root
@@ -53,9 +56,6 @@ proc updateSlots(cache: var DbCache, root: Eth2Digest, slot: Slot) =
       return
 
 proc update(cache: var DbCache, blck: ForkySignedBeaconBlock) =
-  let
-    slot = blck.message.slot
-
   if blck.root notin cache.summaries:
     cache.summaries[blck.root] = blck.message.toBeaconBlockSummary()
 
@@ -66,10 +66,14 @@ proc isKnown(cache: DbCache, slot: Slot): bool =
 
 proc doTrustedNodeSync*(
     cfg: RuntimeConfig, databaseDir: string, restUrl: string,
-    blockId: string, backfill: bool, reindex: bool,
+    stateId: string, backfill: bool, reindex: bool,
     genesisState: ref ForkedHashedBeaconState = nil) {.async.} =
+  logScope:
+    restUrl
+    stateId
+
   notice "Starting trusted node sync",
-    databaseDir, restUrl, blockId, backfill, reindex
+    databaseDir, backfill, reindex
 
   let
     db = BeaconChainDB.new(databaseDir, inMemory = false)
@@ -96,7 +100,7 @@ proc doTrustedNodeSync*(
       FAR_FUTURE_SLOT
 
   var client = RestClientRef.new(restUrl).valueOr:
-    error "Cannot connect to server", url = restUrl, error = error
+    error "Cannot connect to server", error = error
     quit 1
 
   proc downloadBlock(slot: Slot):
@@ -122,167 +126,107 @@ proc doTrustedNodeSync*(
 
     raise lastError
 
-  let
-    localGenesisRoot = db.getGenesisBlock().valueOr:
-      let genesisState =
-        if genesisState != nil:
-          genesisState
-        else:
-          notice "Downloading genesis state", restUrl
-          let state = try:
-            await client.getStateV2(
-              StateIdent.init(StateIdentType.Genesis), cfg)
-          except CatchableError as exc:
-            error "Unable to download genesis state",
-              error = exc.msg, restUrl
-            quit 1
+  # If possible, we'll store the genesis state in the database - this is not
+  # strictly necessary but renders the resulting database compatible with
+  # versions prior to 22.11 and makes reindexing possible
+  let genesisState =
+    if (let genesisRoot = db.getGenesisBlock(); genesisRoot.isSome()):
+      let
+        genesisBlock = db.getForkedBlock(genesisRoot.get()).valueOr:
+          error "Cannot load genesis block from database",
+            genesisRoot = genesisRoot.get()
+          quit 1
+        genesisStateRoot = getForkedBlockField(genesisBlock, state_root)
+        stateFork = cfg.stateForkAtEpoch(GENESIS_EPOCH)
 
-          if isNil(state):
-            error "Server is missing genesis state",
-              restUrl
-            quit 1
-          state
+        tmp = (ref ForkedHashedBeaconState)(kind: stateFork)
+      if not db.getState(stateFork, genesisStateRoot, tmp[], noRollback):
+        error "Cannot load genesis state from database",
+          genesisStateRoot
+        quit 1
 
-      withState(genesisState[]):
-        info "Writing genesis state",
-          stateRoot = shortLog(forkyState.root),
-          genesis_validators_root =
-            shortLog(forkyState.data.genesis_validators_root)
+      if (genesisState != nil) and
+          (getStateRoot(tmp[]) != getStateRoot(genesisState[])):
+        error "Unexpected genesis state in database, is this the same network?",
+          databaseRoot = getStateRoot(tmp[]),
+          genesisRoot = getStateRoot(genesisState[])
+        quit 1
+      tmp
+    else:
+      let tmp = if genesisState != nil:
+        genesisState
+      else:
+        notice "Downloading genesis state", restUrl
+        try:
+          await client.getStateV2(
+            StateIdent.init(StateIdentType.Genesis), cfg)
+        except CatchableError as exc:
+          info "Unable to download genesis state",
+            error = exc.msg, restUrl
+          nil
 
-        db.putState(forkyState)
-
-        let blck = get_initial_beacon_block(forkyState)
-
-        info "Writing genesis block",
-          blockRoot = shortLog(blck.root),
-          blck = shortLog(blck.message)
-        db.putBlock(blck)
-        db.putGenesisBlock(blck.root)
-
-        dbCache.update(blck.asSigned())
-        blck.root
-
-    remoteGenesisRoot = try:
-      (await client.getBlockRoot(
-        BlockIdent.init(BlockIdentType.Genesis))).data.data.root
-    except CatchableError as exc:
-      error "Unable to download genesis block root",
-        error = exc.msg, restUrl
-      quit 1
-
-  if remoteGenesisRoot != localGenesisRoot:
-    error "Server genesis block root does not match local genesis, is the server serving the same chain?",
-      localGenesisRoot = shortLog(localGenesisRoot),
-      remoteGenesisRoot = shortLog(remoteGenesisRoot)
-    quit 1
+      if isNil(tmp):
+        notice "Server is missing genesis state, node will not be able to reindex history",
+          restUrl
+      tmp
 
   let (checkpointSlot, checkpointRoot) = if dbHead.isNone:
-    notice "Downloading checkpoint block", restUrl, blockId
+    notice "Downloading checkpoint state"
 
-    let checkpointBlock = block:
-      # Finding a checkpoint block is tricky: we need the block to fall on an
-      # epoch boundary and when making the first request, we don't know exactly
-      # what slot we'll get - to find it, we'll keep walking backwards for a
-      # reasonable number of tries
-      var
-        checkpointBlock: ref ForkedSignedBeaconBlock
-        id = BlockIdent.decodeString(blockId).valueOr:
-          error "Cannot decode checkpoint block id, must be a slot, hash, 'finalized' or 'head'",
-            blockId
-          quit 1
-        found = false
-
-      for i in 0..<10:
-        let blck = try:
-          await client.getBlockV2(id, cfg)
-        except CatchableError as exc:
-          error "Unable to download checkpoint block",
-            error = exc.msg, restUrl
-          quit 1
-
-        if blck.isNone():
-          # Server returned 404 - no block was found at the given id, so we need
-          # to try an earlier slot - assuming we know of one!
-          if id.kind == BlockQueryKind.Slot:
-            let slot = id.slot
-            id = BlockIdent.init((id.slot.epoch() - 1).start_slot)
-
-            info "No block found at given slot, trying an earlier epoch",
-              slot, id
-            continue
-          else:
-            error "Cannot find a block at given block id, and cannot compute an earlier slot",
-              id, blockId
+    let
+      state = try:
+        let id = block:
+          let tmp = StateIdent.decodeString(stateId).valueOr:
+            error "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
             quit 1
-
-        checkpointBlock = blck.get()
-
-        let checkpointSlot = getForkedBlockField(checkpointBlock[], slot)
-        if checkpointSlot.is_epoch():
-          found = true
-          break
-
-        id = BlockIdent.init((checkpointSlot.epoch() - 1).start_slot)
-
-        info "Downloaded checkpoint block does not fall on epoch boundary, trying an earlier epoch",
-          checkpointSlot, id
-
-      if not found:
-        # The ChainDAG requires that the tail falls on an epoch boundary, or it
-        # will be unable to load the corresponding state - this could be fixed, but
-        # for now, we ask the user to fix it instead
-        error "A checkpoint block from the first slot of an epoch could not be found with the given block id - pass an epoch slot with a block using the --block-id parameter",
-          blockId
+          if tmp.kind == StateQueryKind.Slot:
+            if not tmp.slot.is_epoch():
+              notice "Rounding given slot to epoch"
+              StateIdent.init(tmp.slot.epoch().start_slot)
+            else:
+              tmp
+          else:
+            tmp
+        await client.getStateV2(id, cfg)
+      except CatchableError as exc:
+        error "Unable to download checkpoint state",
+          error = exc.msg
         quit 1
-      checkpointBlock
 
-    let checkpointSlot = getForkedBlockField(checkpointBlock[], slot)
-    if checkpointBlock[].root in dbCache.summaries:
-      notice "Checkpoint block is already known, skipping checkpoint state download"
+    if state == nil:
+      error "No state found a given checkpoint",
+        stateId
+      quit 1
 
-      withBlck(checkpointBlock[]):
-        dbCache.updateSlots(blck.root, blck.message.slot)
+    if not getStateField(state[], slot).is_epoch():
+      error "State slot must fall on an epoch boundary",
+        slot = getStateField(state[], slot),
+        offset = getStateField(state[], slot) -
+          getStateField(state[], slot).epoch.start_slot
+      quit 1
 
+    if genesisState != nil:
+      if getStateField(state[], genesis_validators_root) !=
+          getStateField(genesisState[], genesis_validators_root):
+        error "Checkpoint state does not match genesis",
+          rootInCheckpoint = getStateField(state[], genesis_validators_root),
+          rootInGenesis = getStateField(genesisState[], genesis_validators_root)
+        quit 1
+
+      withState(genesisState[]):
+        let blck = get_initial_beacon_block(forkyState)
+        dbCache.update(blck.asSigned())
+
+      ChainDAGRef.preInit(db, genesisState[])
+
+      if getStateField(genesisState[], slot) != getStateField(state[], slot):
+        ChainDAGRef.preInit(db, state[])
     else:
-      notice "Downloading checkpoint state", restUrl, checkpointSlot
+      ChainDAGRef.preInit(db, state[])
 
-      let
-        state = try:
-          await client.getStateV2(StateIdent.init(checkpointSlot), cfg)
-        except CatchableError as exc:
-          error "Unable to download checkpoint state",
-            error = exc.msg, restUrl, checkpointSlot
-          quit 1
+    let latest_bid = state[].latest_block_id()
 
-      if isNil(state):
-        notice "No state found at given checkpoint", checkpointSlot
-        quit 1
-
-      withState(state[]):
-        let latest_block_root = forkyState.latest_block_root
-
-        if latest_block_root != checkpointBlock[].root:
-          error "Checkpoint state does not match checkpoint block, server error?",
-            blockRoot = shortLog(checkpointBlock[].root),
-            blck = shortLog(checkpointBlock[]),
-            stateBlockRoot = shortLog(latest_block_root)
-          quit 1
-
-        info "Writing checkpoint state",
-          stateRoot = shortLog(forkyState.root)
-        db.putState(forkyState)
-
-      withBlck(checkpointBlock[]):
-        info "Writing checkpoint block",
-          blockRoot = shortLog(blck.root),
-          blck = shortLog(blck.message)
-
-        db.putBlock(blck.asTrusted())
-        db.putHeadBlock(blck.root)
-        db.putTailBlock(blck.root)
-
-        dbCache.update(blck)
-    (checkpointSlot, checkpointBlock[].root)
+    (latest_bid.slot, latest_bid.root)
   else:
     notice "Skipping checkpoint download, database already exists (remove db directory to get a fresh snapshot)",
       databaseDir, head = shortLog(dbHead.get())
@@ -295,15 +239,18 @@ proc doTrustedNodeSync*(
       err = v.error()
     quit 1
 
-  let missingSlots = block:
-    var total = 0
-    for i in 0..<checkpointSlot.int:
-      if dbCache.slots[i].isNone():
-        total += 1
-    total
+  dbCache.updateSlots(checkpointSlot)
+
+  let
+    missingSlots = block:
+      var total = 0
+      for i in 0..<checkpointSlot.int:
+        if not dbCache.isKnown(Slot(i)):
+          total += 1
+      total
 
   let canReindex = if missingSlots == 0:
-    info "Database fully backfilled"
+    info "Database backfilled"
     true
   elif backfill:
     notice "Downloading historical blocks - you can interrupt this process at any time and it automatically be completed when you start the beacon node",
@@ -331,35 +278,43 @@ proc doTrustedNodeSync*(
           blck = shortLog(blck.message),
           blockRoot = shortLog(blck.root)
 
-        var childSlot = blck.message.slot + 1
-        while true:
-          if childSlot >= dbCache.slots.lenu64():
-            error "Downloaded block does not match checkpoint history"
+        if blck.message.slot == checkpointSlot:
+          if blck.root != checkpointRoot:
+            error "Downloaded block does not match checkpoint history",
+              blck = shortLog(blck),
+              expectedRoot = shortLog(checkpointRoot)
+
             quit 1
-
-          if not dbCache.slots[childSlot.int].isSome():
-            # Should never happen - we download slots backwards
-            error "Downloaded block does not match checkpoint history"
-            quit 1
-
-          let knownRoot = dbCache.slots[childSlot.int].get()
-          if knownRoot == ZERO_HASH:
-            childSlot += 1
-            continue
-
-          dbCache.summaries.withValue(knownRoot, summary):
-            if summary[].parent_root != blck.root:
-              error "Downloaded block does not match checkpoint history",
-                blockRoot = shortLog(blck.root),
-                expectedRoot = shortLog(summary[].parent_root)
+        else:
+          var childSlot = blck.message.slot + 1
+          while true:
+            if childSlot >= dbCache.slots.lenu64():
+              error "Downloaded block does not match checkpoint history"
               quit 1
 
-            break
+            if not dbCache.slots[childSlot.int].isSome():
+              # Should never happen - we download slots backwards
+              error "Downloaded block does not match checkpoint history"
+              quit 1
 
-          # This shouldn't happen - we should have downloaded the child and
-          # updated knownBlocks before here
-          error "Expected child block not found in checkpoint history"
-          quit 1
+            let knownRoot = dbCache.slots[childSlot.int].get()
+            if knownRoot == ZERO_HASH:
+              childSlot += 1
+              continue
+
+            dbCache.summaries.withValue(knownRoot, summary):
+              if summary[].parent_root != blck.root:
+                error "Downloaded block does not match checkpoint history",
+                  blockRoot = shortLog(blck.root),
+                  expectedRoot = shortLog(summary[].parent_root)
+                quit 1
+
+              break
+
+            # This shouldn't happen - we should have downloaded the child and
+            # updated knownBlocks before here
+            error "Expected child block not found in checkpoint history"
+            quit 1
 
         if blck.root notin dbCache.summaries:
           db.putBlock(blck.asTrusted())
@@ -435,5 +390,5 @@ when isMainModule:
   let backfill = os.paramCount() > 4 and os.paramStr(5) == "true"
 
   waitFor doTrustedNodeSync(
-    getRuntimeConfig(some os.paramStr(1)), os.paramStr(2), os.paramStr(3), os.paramStr(4),
-    backfill)
+    getRuntimeConfig(some os.paramStr(1)), os.paramStr(2), os.paramStr(3),
+    os.paramStr(4), backfill, false)

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -179,12 +179,9 @@ proc doTrustedNodeSync*(
           let tmp = StateIdent.decodeString(stateId).valueOr:
             error "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
             quit 1
-          if tmp.kind == StateQueryKind.Slot:
-            if not tmp.slot.is_epoch():
-              notice "Rounding given slot to epoch"
-              StateIdent.init(tmp.slot.epoch().start_slot)
-            else:
-              tmp
+          if tmp.kind == StateQueryKind.Slot and not tmp.slot.is_epoch():
+            notice "Rounding given slot to epoch"
+            StateIdent.init(tmp.slot.epoch().start_slot)
           else:
             tmp
         await client.getStateV2(id, cfg)
@@ -244,8 +241,8 @@ proc doTrustedNodeSync*(
   let
     missingSlots = block:
       var total = 0
-      for i in 0..<checkpointSlot.int:
-        if not dbCache.isKnown(Slot(i)):
+      for slot in Slot(0)..<checkpointSlot:
+        if not dbCache.isKnown(slot):
           total += 1
       total
 

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -60,7 +60,6 @@ The following options are available:
                                this functionality [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.
-     --finalized-checkpoint-block  SSZ file specifying a recent finalized block.
      --node-name               A name for this node that will appear in the logs. If you set this to 'auto', a
                                persistent automatically generated ID will be selected for each --data-dir
                                folder.

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -93,31 +93,27 @@ You can also resume the trusted node backfill at any time by simply running the 
 
 ### Modify sync point
 
-By default, the node will sync up to the latest finalized checkpoint of the node that you're syncing with. While you can choose a different sync point using a block hash or a slot number, this block must fall on an epoch boundary:
+By default, the node will sync up to the latest finalized checkpoint of the node that you're syncing with. While you can choose a different sync point using a state hash or a slot number, this state must fall on an epoch boundary:
 
 ```sh
 build/nimbus_beacon_node trustedNodeSync \
   --network:mainnet \
   --data-dir=build/data/shared_mainnet_0 \
-  --blockId:0x239940f2537f5bbee1a3829f9058f4c04f49897e4d325145153ca89838dfc9e2
+  --state-id:1024
 ```
 
 ### Sync from checkpoint files
 
-If you have a state and a block file available, you can start the node using the finalized checkpoint options:
+If you have a state file available, you can start the node using the `--finalized-checkpoint-state`:
 
 ```sh
 # Obtain a state and a block from a Beacon API - these must be in SSZ format:
 curl -o state.32000.ssz \
   -H 'Accept: application/octet-stream' \
   http://localhost:5052/eth/v2/debug/beacon/states/32000
-curl -o block.32000.ssz \
-  -H 'Accept: application/octet-stream' \
-  http://localhost:5052/eth/v2/beacon/blocks/32000
 
-# Start the beacon node using the downloaded state and block as starting point
+# Start the beacon node using the downloaded state as starting point
 ./run-mainnet-beacon-node.sh \
-  --finalized-checkpoint-block=block.32000.ssz \
   --finalized-checkpoint-state=state.32000.ssz
 ```
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -65,7 +65,6 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
        replay = true):
   let
     (genesisState, depositContractSnapshot) = loadGenesis(validators, false)
-    genesisBlock = get_initial_beacon_block(genesisState[])
     genesisTime = float getStateField(genesisState[], genesis_time)
 
   var
@@ -79,7 +78,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   let db = BeaconChainDB.new("block_sim_db")
   defer: db.close()
 
-  ChainDAGRef.preInit(db, genesisState[], genesisState[], genesisBlock)
+  ChainDAGRef.preInit(db, genesisState[])
   putInitialDepositContractSnapshot(db, depositContractSnapshot)
 
   var

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -95,10 +95,7 @@ proc initialLoad(
     ))
   else: {.error: "Unknown block fork: " & name(BlockType).}
 
-  ChainDAGRef.preInit(
-    db,
-    forkedState[], forkedState[],
-    asTrusted(signedBlock))
+  ChainDAGRef.preInit(db, forkedState[])
 
   let
     validatorMonitor = newClone(ValidatorMonitor.init())

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -28,6 +28,10 @@ proc pruneAtFinalization(dag: ChainDAGRef) =
   if dag.needStateCachesAndForkChoicePruning():
     dag.pruneStateCachesDAG()
 
+type
+  AddHeadRes = Result[BlockRef, BlockError]
+  AddBackRes = Result[void, BlockError]
+
 suite "Block pool processing" & preset():
   setup:
     var
@@ -269,7 +273,7 @@ suite "Block pool processing" & preset():
       b11 = dag.addHeadBlock(verifier, b1, nilPhase0Callback)
 
     check:
-      b11.error == BlockError.Duplicate
+      b11 == AddHeadRes.err BlockError.Duplicate
       not b10[].isNil
 
   test "updateHead updates head and headState" & preset():
@@ -378,7 +382,7 @@ suite "Block pool altair processing" & preset():
       let
         bAdd = dag.addHeadBlock(verifier, b, nilAltairCallback)
       check:
-        bAdd.error() == BlockError.Invalid
+        bAdd == AddHeadRes.err BlockError.Invalid
 
     block: # Randao reveal
       var b = b2
@@ -386,7 +390,7 @@ suite "Block pool altair processing" & preset():
       let
         bAdd = dag.addHeadBlock(verifier, b, nilAltairCallback)
       check:
-        bAdd.error() == BlockError.Invalid
+        bAdd == AddHeadRes.err BlockError.Invalid
 
     block: # Attestations
       var b = b2
@@ -394,7 +398,7 @@ suite "Block pool altair processing" & preset():
       let
         bAdd = dag.addHeadBlock(verifier, b, nilAltairCallback)
       check:
-        bAdd.error() == BlockError.Invalid
+        bAdd == AddHeadRes.err BlockError.Invalid
 
     block: # SyncAggregate empty
       var b = b2
@@ -402,7 +406,7 @@ suite "Block pool altair processing" & preset():
       let
         bAdd = dag.addHeadBlock(verifier, b, nilAltairCallback)
       check:
-        bAdd.error() == BlockError.Invalid
+        bAdd == AddHeadRes.err BlockError.Invalid
 
     block: # SyncAggregate junk
       var b = b2
@@ -412,7 +416,7 @@ suite "Block pool altair processing" & preset():
       let
         bAdd = dag.addHeadBlock(verifier, b, nilAltairCallback)
       check:
-        bAdd.error() == BlockError.Invalid
+        bAdd == AddHeadRes.err BlockError.Invalid
 
 suite "chain DAG finalization tests" & preset():
   setup:
@@ -552,7 +556,7 @@ suite "chain DAG finalization tests" & preset():
       let status = dag.addHeadBlock(verifier, lateBlock, nilPhase0Callback)
       # This _should_ be Unviable, but we can't tell, from the data that we have
       # so MissingParent is the least wrong thing to reply
-      check: status.error == BlockError.UnviableFork
+      check: status == AddHeadRes.err BlockError.UnviableFork
 
     block:
       let
@@ -819,8 +823,8 @@ suite "Backfill":
       tailBlock = blocks[^1]
       genBlock = get_initial_beacon_block(genState[])
 
-    ChainDAGRef.preInit(
-        db, genState[], tailState[], tailBlock.asTrusted())
+    ChainDAGRef.preInit(db, genState[])
+    ChainDAGRef.preInit(db, tailState[])
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
@@ -867,12 +871,15 @@ suite "Backfill":
     badBlock.signature = blocks[^3].phase0Data.signature
 
     check:
-      dag.addBackfillBlock(badBlock).error == BlockError.Invalid
+      dag.addBackfillBlock(badBlock) == AddBackRes.err BlockError.Invalid
 
     check:
-      dag.addBackfillBlock(blocks[^3].phase0Data).error == BlockError.MissingParent
-      dag.addBackfillBlock(tailBlock.phase0Data).error == BlockError.Duplicate
-      dag.addBackfillBlock(genBlock.phase0Data.asSigned()).error == BlockError.MissingParent
+      dag.addBackfillBlock(blocks[^3].phase0Data) ==
+        AddBackRes.err BlockError.MissingParent
+      dag.addBackfillBlock(genBlock.phase0Data.asSigned()) ==
+        AddBackRes.err BlockError.MissingParent
+
+      dag.addBackfillBlock(tailBlock.phase0Data).isOk()
 
     check:
       dag.addBackfillBlock(blocks[^2].phase0Data).isOk()
@@ -901,7 +908,8 @@ suite "Backfill":
       check: dag.addBackfillBlock(blocks[blocks.len - i - 1].phase0Data).isOk()
 
     check:
-      dag.addBackfillBlock(genBlock.phase0Data.asSigned).error == BlockError.Duplicate
+      dag.addBackfillBlock(genBlock.phase0Data.asSigned) ==
+        AddBackRes.err BlockError.Duplicate
 
       dag.backfill.slot == GENESIS_SLOT
 
@@ -914,8 +922,8 @@ suite "Backfill":
     let
       tailBlock = blocks[^1]
 
-    ChainDAGRef.preInit(
-        db, genState[], tailState[], tailBlock.asTrusted())
+    ChainDAGRef.preInit(db, genState[])
+    ChainDAGRef.preInit(db, tailState[])
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
@@ -964,7 +972,7 @@ suite "Backfill":
     check:
       dag.addBackfillBlock(genBlock.phase0Data.asSigned).isOk()
       dag.addBackfillBlock(
-        genBlock.phase0Data.asSigned).error == BlockError.Duplicate
+        genBlock.phase0Data.asSigned) == AddBackRes.err BlockError.Duplicate
 
     var
       cache: StateCache
@@ -982,6 +990,120 @@ suite "Backfill":
       dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
     check:
       dag2.head.root == next.root
+
+suite "Starting states":
+  setup:
+    let
+      genState = (ref ForkedHashedBeaconState)(
+        kind: BeaconStateFork.Phase0,
+        phase0Data: initialize_hashed_beacon_state_from_eth1(
+          defaultRuntimeConfig, ZERO_HASH, 0,
+          makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
+          {skipBlsValidation}))
+      tailState = assignClone(genState[])
+      db = BeaconChainDB.new("", inMemory = true)
+      quarantine = newClone(Quarantine.init())
+
+  test "Starting state without block":
+    var
+      cache: StateCache
+      info: ForkedEpochInfo
+    let
+      genBlock = get_initial_beacon_block(genState[])
+      blocks = block:
+        var blocks: seq[ForkedSignedBeaconBlock]
+        while getStateField(tailState[], slot).uint64 + 1 < SLOTS_PER_EPOCH:
+          blocks.add addTestBlock(tailState[], cache)
+        blocks
+      tailBlock = blocks[^1]
+
+    check process_slots(
+      defaultRuntimeConfig, tailState[], Slot(SLOTS_PER_EPOCH), cache, info,
+      {}).isOk()
+
+    ChainDAGRef.preInit(db, tailState[])
+
+    let
+      validatorMonitor = newClone(ValidatorMonitor.init())
+      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+
+    # check that we can update head to itself
+    dag.updateHead(dag.head, quarantine[])
+
+    check:
+      dag.finalizedHead.toBlockSlotId()[] == BlockSlotId(
+        bid: dag.tail, slot: (dag.tail.slot.epoch+1).start_slot)
+      dag.getBlockRef(tailBlock.root).get().bid == dag.tail
+      dag.getBlockRef(blocks[^2].root).isNone()
+
+      dag.getBlockId(tailBlock.root).get() == dag.tail
+      dag.getBlockId(blocks[^2].root).isNone()
+
+      dag.getBlockIdAtSlot(Slot(0)).isNone() # no genesis stored in db
+      dag.getBlockIdAtSlot(Slot(1)).isNone()
+
+      # Should get EpochRef for the tail however
+      # dag.getEpochRef(dag.tail, dag.tail.slot.epoch, true).isOk()
+      dag.getEpochRef(dag.tail, dag.tail.slot.epoch + 1, true).isOk()
+
+      # Should not get EpochRef for random block
+      dag.getEpochRef(
+        BlockId(root: blocks[^2].root, slot: dag.tail.slot), # root/slot mismatch
+        dag.tail.slot.epoch, true).isErr()
+
+      dag.getEpochRef(dag.tail, dag.tail.slot.epoch + 1, true).isOk()
+
+      dag.getFinalizedEpochRef() != nil
+
+      dag.backfill == tailBlock.phase0Data.message.toBeaconBlockSummary()
+
+      # Check that we can propose right from the checkpoint state
+      dag.getProposalState(dag.head, dag.head.slot + 1, cache).isOk()
+
+    var
+      badBlock = blocks[^2].phase0Data
+    badBlock.signature = blocks[^3].phase0Data.signature
+    check:
+      dag.addBackfillBlock(badBlock) == AddBackRes.err BlockError.Invalid
+
+    check:
+      dag.addBackfillBlock(blocks[^3].phase0Data) ==
+        AddBackRes.err BlockError.MissingParent
+      dag.addBackfillBlock(genBlock.phase0Data.asSigned()) ==
+        AddBackRes.err BlockError.MissingParent
+
+      dag.addBackfillBlock(tailBlock.phase0Data) == AddBackRes.ok()
+
+    check:
+      dag.addBackfillBlock(blocks[^2].phase0Data).isOk()
+
+      dag.getBlockRef(tailBlock.root).get().bid == dag.tail
+      dag.getBlockRef(blocks[^2].root).isNone()
+
+      dag.getBlockId(tailBlock.root).get() == dag.tail
+      dag.getBlockId(blocks[^2].root).get().root == blocks[^2].root
+
+      dag.getBlockIdAtSlot(dag.tail.slot).get().bid == dag.tail
+
+      dag.backfill == blocks[^2].phase0Data.message.toBeaconBlockSummary()
+
+    check:
+      dag.addBackfillBlock(blocks[^3].phase0Data).isOk()
+
+      dag.getBlockIdAtSlot(dag.tail.slot - 2).get() ==
+        blocks[^3].toBlockId().atSlot()
+      dag.getBlockIdAtSlot(dag.tail.slot - 3).isNone
+
+    for i in 3..<blocks.len:
+      check: dag.addBackfillBlock(blocks[blocks.len - i - 1].phase0Data).isOk()
+
+    check:
+      dag.addBackfillBlock(genBlock.phase0Data.asSigned).isOk()
+
+      dag.backfill.slot == GENESIS_SLOT
+
+    check:
+      dag.getFinalizedEpochRef() != nil
 
 suite "Latest valid hash" & preset():
   setup:

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -178,9 +178,8 @@ suite "Light client" & preset():
 
     # Initialize new DAG from checkpoint
     let cpDb = BeaconChainDB.new("", inMemory = true)
-    ChainDAGRef.preInit(
-      cpDb, genesisState[],
-      dag.headState, dag.getForkedBlock(dag.head.bid).get)
+    ChainDAGRef.preInit(cpDb, genesisState[])
+    ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
     let cpDag = ChainDAGRef.init(
       cfg, cpDb, validatorMonitor, {},
       lcDataConfig = LightClientDataConfig(

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -16,12 +16,6 @@ import
 
 export beacon_chain_db, testblockutil, kvstore, kvstore_sqlite3
 
-proc makeTestDB*(
-    tailState: ForkedHashedBeaconState,
-    tailBlock: ForkedTrustedSignedBeaconBlock): BeaconChainDB =
-  result = BeaconChainDB.new("", inMemory = true)
-  ChainDAGRef.preInit(result, tailState, tailState, tailBlock)
-
 proc makeTestDB*(validators: Natural): BeaconChainDB =
   let
     genState = (ref ForkedHashedBeaconState)(
@@ -32,8 +26,9 @@ proc makeTestDB*(validators: Natural): BeaconChainDB =
         0,
         makeInitialDeposits(validators.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation}))
-    genBlock = get_initial_beacon_block(genState[])
-  makeTestDB(genState[], genBlock)
+
+  result = BeaconChainDB.new("", inMemory = true)
+  ChainDAGRef.preInit(result, genState[])
 
 proc getEarliestInvalidBlockRoot*(
     dag: ChainDAGRef, initialSearchRoot: Eth2Digest,


### PR DESCRIPTION
Currently, we require genesis and a checkpoint block and state to start from an arbitrary slot - this PR relaxes this requirement so that we can start with a state alone.

The current trusted-node-sync algorithm works by first downloading blocks until we find an epoch aligned non-empty slot, then downloads the state via slot.

However, current [proposals](https://github.com/ethereum/beacon-APIs/pull/226) for checkpointing prefer finalized state as the main reference - this allows more simple access control and caching on the server side - in particular, this should help checkpoint-syncing from sources that have a fast `finalized` state download (like teku) but are slow when accessing state via slot.

Earlier versions of Nimbus will not be able to read databases created without a checkpoint block and genesis. In most cases, backfilling makes the database compatible except where genesis is also missing (custom networks).

* backfill checkpoint block from libp2p instead of checkpoint source, when doing trusted node sync
* allow starting the client without genesis / checkpoint block
* perform epoch start slot lookahead when loading tail state, so as to deal with the case where the epoch start slot does not have a block
* replace `--blockId` with `--state-id` in TNS command line
* when replaying, also look at the parent of the last-known-block (even if we don't have the parent block data, we can still replay from a "parent" state) - in particular, this clears the way for implementing state pruning
* deprecate `--finalized-checkpoint-block` option (no longer needed)