### PR TITLE
Tighten libp2p request quotas

### DIFF
--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -26,17 +26,15 @@ logScope:
 
 const
   MAX_REQUEST_BLOCKS* = 1024
-  blockByRootLookupCost = allowedOpsPerSecondCost(50)
-  blockResponseCost = allowedOpsPerSecondCost(100)
-  blockByRangeLookupCost = allowedOpsPerSecondCost(20)
+
+  blockResponseCost = allowedOpsPerSecondCost(64) # Allow syncing ~64 blocks/sec (minus request costs)
 
   # https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/altair/light-client/p2p-interface.md#configuration
   MAX_REQUEST_LIGHT_CLIENT_UPDATES* = 128
-  lightClientEmptyResponseCost = allowedOpsPerSecondCost(50)
-  lightClientBootstrapLookupCost = allowedOpsPerSecondCost(5)
-  lightClientBootstrapResponseCost = allowedOpsPerSecondCost(100)
-  lightClientUpdateResponseCost = allowedOpsPerSecondCost(100)
-  lightClientUpdateByRangeLookupCost = allowedOpsPerSecondCost(20)
+  lightClientBootstrapResponseCost = allowedOpsPerSecondCost(1)
+    ## Only one bootstrap per peer should ever be needed - no need to allow more
+  lightClientUpdateResponseCost = allowedOpsPerSecondCost(1000)
+    ## Updates are tiny - we can allow lots of them
   lightClientFinalityUpdateResponseCost = allowedOpsPerSecondCost(100)
   lightClientOptimisticUpdateResponseCost = allowedOpsPerSecondCost(100)
 
@@ -311,9 +309,6 @@ p2pProtocol BeaconSync(version = 1,
       startIndex =
         dag.getBlockRange(startSlot, reqStep, blocks.toOpenArray(0, endIndex))
 
-    peer.updateRequestQuota(blockByRangeLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
     var
       found = 0
       bytes: seq[byte]
@@ -333,8 +328,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blocks[i])
           continue
 
-        peer.updateRequestQuota(blockResponseCost)
-        peer.awaitNonNegativeRequestQuota()
+        peer.awaitQuota(blockResponseCost)
+        peer.network.awaitQuota(blockResponseCost)
 
         await response.writeBytesSZ(uncompressedLen, bytes, []) # phase0 bytes
 
@@ -375,9 +370,6 @@ p2pProtocol BeaconSync(version = 1,
       found = 0
       bytes: seq[byte]
 
-    peer.updateRequestQuota(count.float * blockByRootLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
     for i in 0..<count:
       let
         blockRef = dag.getBlockRef(blockRoots[i]).valueOr:
@@ -400,8 +392,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef)
           continue
 
-        peer.updateRequestQuota(blockResponseCost)
-        peer.awaitNonNegativeRequestQuota()
+        peer.awaitQuota(blockResponseCost)
+        peer.network.awaitQuota(blockResponseCost)
 
         await response.writeBytesSZ(uncompressedLen, bytes, []) # phase0
         inc found
@@ -447,9 +439,6 @@ p2pProtocol BeaconSync(version = 1,
         dag.getBlockRange(startSlot, reqStep,
                           blocks.toOpenArray(0, endIndex))
 
-    peer.updateRequestQuota(blockByRangeLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
     var
       found = 0
       bytes: seq[byte]
@@ -468,8 +457,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blocks[i])
           continue
 
-        peer.updateRequestQuota(blockResponseCost)
-        peer.awaitNonNegativeRequestQuota()
+        peer.awaitQuota(blockResponseCost)
+        peer.network.awaitQuota(blockResponseCost)
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -507,9 +496,6 @@ p2pProtocol BeaconSync(version = 1,
       dag = peer.networkState.dag
       count = blockRoots.len
 
-    peer.updateRequestQuota(count.float * blockByRootLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
     var
       found = 0
       bytes: seq[byte]
@@ -532,8 +518,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef)
           continue
 
-        peer.updateRequestQuota(blockResponseCost)
-        peer.awaitNonNegativeRequestQuota()
+        peer.awaitQuota(blockResponseCost)
+        peer.network.awaitQuota(blockResponseCost)
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -555,20 +541,15 @@ p2pProtocol BeaconSync(version = 1,
     let dag = peer.networkState.dag
     doAssert dag.lcDataStore.serve
 
-    peer.updateRequestQuota(lightClientBootstrapLookupCost)
-    peer.awaitNonNegativeRequestQuota()
-
     let bootstrap = dag.getLightClientBootstrap(blockRoot)
     if bootstrap.isOk:
       let
         contextEpoch = bootstrap.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+      peer.awaitQuota(lightClientBootstrapResponseCost)
       await response.send(bootstrap.get, contextBytes)
     else:
-      peer.updateRequestQuota(lightClientEmptyResponseCost)
       raise newException(ResourceUnavailableError, LCBootstrapUnavailable)
-
-    peer.updateRequestQuota(lightClientBootstrapResponseCost)
 
     debug "LC bootstrap request done", peer, blockRoot
 
@@ -595,11 +576,6 @@ p2pProtocol BeaconSync(version = 1,
           min(headPeriod + 1 - startPeriod, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
       count = min(reqCount, maxSupportedCount)
       onePastPeriod = startPeriod + count
-    if count == 0:
-      peer.updateRequestQuota(lightClientEmptyResponseCost)
-
-    peer.updateRequestQuota(count.float * lightClientUpdateByRangeLookupCost)
-    peer.awaitNonNegativeRequestQuota()
 
     var found = 0
     for period in startPeriod..<onePastPeriod:
@@ -608,10 +584,10 @@ p2pProtocol BeaconSync(version = 1,
         let
           contextEpoch = update.get.contextEpoch
           contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+
+        peer.awaitQuota(lightClientUpdateResponseCost)
         await response.write(update.get, contextBytes)
         inc found
-
-    peer.updateRequestQuota(found.float * lightClientUpdateResponseCost)
 
     debug "LC updates by range request done", peer, startPeriod, count, found
 
@@ -625,19 +601,17 @@ p2pProtocol BeaconSync(version = 1,
     let dag = peer.networkState.dag
     doAssert dag.lcDataStore.serve
 
-    peer.awaitNonNegativeRequestQuota()
-
     let finality_update = dag.getLightClientFinalityUpdate()
     if finality_update.isSome:
       let
         contextEpoch = finality_update.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+
+      peer.awaitQuota(lightClientFinalityUpdateResponseCost)
       await response.send(finality_update.get, contextBytes)
     else:
-      peer.updateRequestQuota(lightClientEmptyResponseCost)
       raise newException(ResourceUnavailableError, LCFinUpdateUnavailable)
 
-    peer.updateRequestQuota(lightClientFinalityUpdateResponseCost)
 
     debug "LC finality update request done", peer
 
@@ -651,19 +625,16 @@ p2pProtocol BeaconSync(version = 1,
     let dag = peer.networkState.dag
     doAssert dag.lcDataStore.serve
 
-    peer.awaitNonNegativeRequestQuota()
-
     let optimistic_update = dag.getLightClientOptimisticUpdate()
     if optimistic_update.isSome:
       let
         contextEpoch = optimistic_update.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+
+      peer.awaitQuota(lightClientOptimisticUpdateResponseCost)
       await response.send(optimistic_update.get, contextBytes)
     else:
-      peer.updateRequestQuota(lightClientEmptyResponseCost)
       raise newException(ResourceUnavailableError, LCOptUpdateUnavailable)
-
-    peer.updateRequestQuota(lightClientOptimisticUpdateResponseCost)
 
     debug "LC optimistic update request done", peer
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -328,8 +328,9 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blocks[i])
           continue
 
-        peer.awaitQuota(blockResponseCost)
-        peer.network.awaitQuota(blockResponseCost)
+        # TODO extract from libp2pProtocol
+        peer.awaitQuota(blockResponseCost, "beacon_blocks_by_range/1")
+        peer.network.awaitQuota(blockResponseCost, "beacon_blocks_by_range/1")
 
         await response.writeBytesSZ(uncompressedLen, bytes, []) # phase0 bytes
 
@@ -392,8 +393,9 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef)
           continue
 
-        peer.awaitQuota(blockResponseCost)
-        peer.network.awaitQuota(blockResponseCost)
+        # TODO extract from libp2pProtocol
+        peer.awaitQuota(blockResponseCost, "beacon_blocks_by_root/1")
+        peer.network.awaitQuota(blockResponseCost, "beacon_blocks_by_root/1")
 
         await response.writeBytesSZ(uncompressedLen, bytes, []) # phase0
         inc found
@@ -457,8 +459,9 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blocks[i])
           continue
 
-        peer.awaitQuota(blockResponseCost)
-        peer.network.awaitQuota(blockResponseCost)
+        # TODO extract from libp2pProtocol
+        peer.awaitQuota(blockResponseCost, "beacon_blocks_by_range/2")
+        peer.network.awaitQuota(blockResponseCost, "beacon_blocks_by_range/2")
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -518,8 +521,9 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef)
           continue
 
-        peer.awaitQuota(blockResponseCost)
-        peer.network.awaitQuota(blockResponseCost)
+        # TODO extract from libp2pProtocol
+        peer.awaitQuota(blockResponseCost, "beacon_blocks_by_root/2")
+        peer.network.awaitQuota(blockResponseCost, "beacon_blocks_by_root/2")
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -546,7 +550,10 @@ p2pProtocol BeaconSync(version = 1,
       let
         contextEpoch = bootstrap.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
-      peer.awaitQuota(lightClientBootstrapResponseCost)
+
+      # TODO extract from libp2pProtocol
+      peer.awaitQuota(
+        lightClientBootstrapResponseCost, "light_client_bootstrap/1")
       await response.send(bootstrap.get, contextBytes)
     else:
       raise newException(ResourceUnavailableError, LCBootstrapUnavailable)
@@ -585,7 +592,9 @@ p2pProtocol BeaconSync(version = 1,
           contextEpoch = update.get.contextEpoch
           contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
 
-        peer.awaitQuota(lightClientUpdateResponseCost)
+        # TODO extract from libp2pProtocol
+        peer.awaitQuota(
+          lightClientUpdateResponseCost, "light_client_updates_by_range/1")
         await response.write(update.get, contextBytes)
         inc found
 
@@ -607,7 +616,9 @@ p2pProtocol BeaconSync(version = 1,
         contextEpoch = finality_update.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
 
-      peer.awaitQuota(lightClientFinalityUpdateResponseCost)
+      # TODO extract from libp2pProtocol
+      peer.awaitQuota(
+        lightClientFinalityUpdateResponseCost, "light_client_finality_update/1")
       await response.send(finality_update.get, contextBytes)
     else:
       raise newException(ResourceUnavailableError, LCFinUpdateUnavailable)
@@ -631,7 +642,9 @@ p2pProtocol BeaconSync(version = 1,
         contextEpoch = optimistic_update.get.contextEpoch
         contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
 
-      peer.awaitQuota(lightClientOptimisticUpdateResponseCost)
+      # TODO extract from libp2pProtocol
+      peer.awaitQuota(
+        lightClientOptimisticUpdateResponseCost, "light_client_optimistic_update/1")
       await response.send(optimistic_update.get, contextBytes)
     else:
       raise newException(ResourceUnavailableError, LCOptUpdateUnavailable)


### PR DESCRIPTION
To further tighten Nimbus against spam, this PR introduces a global quota for block requests (shared between peers) as well as a general per-peer request limit that applies to all libp2p requests.

* apply request quota before decoding message
* for high-bandwidth requests (blocks), apply a shared global quota which helps manage bandwidth for high-peer setups