### PR TITLE
point to Goerli/Prater launchpad requiring much less ETH

### DIFF
--- a/docs/the_nimbus_book/src/deposit.md
+++ b/docs/the_nimbus_book/src/deposit.md
@@ -6,7 +6,7 @@ To make a deposit, you will need to generate keys then submit a deposit transact
     The process of setting up a validator is also documented at the Ethereum launchpad site:
 
     * [Mainnet](https://launchpad.ethereum.org/)
-    * [Prater](https://prater.launchpad.ethereum.org/)
+    * [Goerli/Prater EthStaker Launchpad](https://goerli.launchpad.ethstaker.cc/en/) or [Goerli/Prater EF Launchpad](https://prater.launchpad.ethereum.org/)
 
 !!! tip
     Use Prater to stress test / future proof  your set up against peak mainnet load. See [here](./prater.md) for all you need to know


### PR DESCRIPTION
It's become more challenging to obtain the 32 ETH to stake on Goerli/Prater. EthStaker has set up an alternate launchpad which effectively contributes its own Goerli ETH to the process, enabling people to continue to effectively use Goerli/Prater as a test network with the existing faucet mechanism which tend to be unwilling to give out dozens of Goerli ETH at once.