### PR TITLE
use v1.3.0-alpha.0 test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -697,7 +697,9 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_over_max                        OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_under_max                       OK
-+ [Valid]   EF - Altair - Operations - Deposit - success_top_up                              OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__less_effective_balance      OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__max_effective_balance       OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__zero_balance                OK
 + [Valid]   EF - Altair - Operations - Deposit - valid_sig_but_forked_state                  OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - deposit_with_bad_fork_version__valid_ine OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - deposit_with_genesis_fork_version__valid OK
@@ -713,7 +715,9 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_over_max                     OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_under_max                    OK
-+ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up                           OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__less_effective_balance   OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__max_effective_balance    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__zero_balance             OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - valid_sig_but_forked_state               OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_new_deposit                    OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
@@ -726,10 +730,12 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_over_max                       OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_under_max                      OK
-+ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__less_effective_balance     OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__max_effective_balance      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__zero_balance               OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
+OK: 54/54 Fail: 0/54 Skip: 0/54
 ## EF - Altair - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -1293,4 +1299,4 @@ OK: 44/44 Fail: 0/44 Skip: 0/44
 OK: 33/33 Fail: 0/33 Skip: 0/33
 
 ---TOTAL---
-OK: 1116/1123 Fail: 0/1123 Skip: 7/1123
+OK: 1122/1129 Fail: 0/1129 Skip: 7/1129

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -259,6 +259,7 @@ ConsensusSpecPreset-minimal
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/supply_sync_committ OK
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
 + Light client - Update ranking - minimal/bellatrix/light_client/update_ranking/pyspec_tests OK
++ Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u OK
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
@@ -498,7 +499,7 @@ ConsensusSpecPreset-minimal
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 488/495 Fail: 0/495 Skip: 7/495
+OK: 489/496 Fail: 0/496 Skip: 7/496
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -755,7 +756,9 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_non_versioned_withdrawal_creden OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_over_max                        OK
 + [Valid]   EF - Altair - Operations - Deposit - new_deposit_under_max                       OK
-+ [Valid]   EF - Altair - Operations - Deposit - success_top_up                              OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__less_effective_balance      OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__max_effective_balance       OK
++ [Valid]   EF - Altair - Operations - Deposit - success_top_up__zero_balance                OK
 + [Valid]   EF - Altair - Operations - Deposit - valid_sig_but_forked_state                  OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - deposit_with_bad_fork_version__valid_ine OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - deposit_with_genesis_fork_version__valid OK
@@ -771,7 +774,9 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_non_versioned_withdrawal_cre OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_over_max                     OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - new_deposit_under_max                    OK
-+ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up                           OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__less_effective_balance   OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__max_effective_balance    OK
++ [Valid]   EF - Bellatrix - Operations - Deposit - success_top_up__zero_balance             OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - valid_sig_but_forked_state               OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_new_deposit                    OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - invalid_sig_other_version                  OK
@@ -784,10 +789,12 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_non_versioned_withdrawal_crede OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_over_max                       OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - new_deposit_under_max                      OK
-+ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up                             OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__less_effective_balance     OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__max_effective_balance      OK
++ [Valid]   EF - Phase 0 - Operations - Deposit - success_top_up__zero_balance               OK
 + [Valid]   EF - Phase 0 - Operations - Deposit - valid_sig_but_forked_state                 OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
+OK: 54/54 Fail: 0/54 Skip: 0/54
 ## EF - Altair - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -1392,4 +1399,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 36/36 Fail: 0/36 Skip: 0/36
 
 ---TOTAL---
-OK: 1207/1214 Fail: 0/1214 Skip: 7/1214
+OK: 1214/1221 Fail: 0/1221 Skip: 7/1221

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -77,7 +77,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.2.0"
+const SPEC_VERSION* = "1.3.0-alpha.0"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -136,6 +136,9 @@ runSuite(ParticipationFlagDir, "Participation flag updates"):
 
 # These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-runSuite(SyncCommitteeDir, "Sync committee updates"):
-  process_sync_committee_updates(state)
-  Result[void, cstring].ok()
+when const_preset == "minimal":
+  runSuite(SyncCommitteeDir, "Sync committee updates"):
+    process_sync_committee_updates(state)
+    Result[void, cstring].ok()
+else:
+  doAssert not dirExists(SyncCommitteeDir)

--- a/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
@@ -134,6 +134,9 @@ runSuite(ParticipationFlagDir, "Participation flag updates"):
 
 # These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-runSuite(SyncCommitteeDir, "Sync committee updates"):
-  process_sync_committee_updates(state)
-  Result[void, cstring].ok()
+when const_preset == "minimal":
+  runSuite(SyncCommitteeDir, "Sync committee updates"):
+    process_sync_committee_updates(state)
+    Result[void, cstring].ok()
+else:
+  doAssert not dirExists(SyncCommitteeDir)

--- a/tests/consensus_spec/capella/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/capella/test_fixture_state_transition_epoch.nim
@@ -136,6 +136,9 @@ runSuite(ParticipationFlagDir, "Participation flag updates"):
 
 # These are only for minimal, not mainnet
 const SyncCommitteeDir = RootDir/"sync_committee_updates"/"pyspec_tests"
-runSuite(SyncCommitteeDir, "Sync committee updates"):
-  process_sync_committee_updates(state)
-  Result[void, cstring].ok()
+when const_preset == "minimal":
+  runSuite(SyncCommitteeDir, "Sync committee updates"):
+    process_sync_committee_updates(state)
+    Result[void, cstring].ok()
+else:
+  doAssert not dirExists(SyncCommitteeDir)

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -383,6 +383,9 @@ template fcSuite(suiteName: static[string], testPathElem: static[string]) =
       if kind != pcDir or not dirExists(testsPath):
         continue
       let fork = forkForPathComponent(path).valueOr:
+        if path.contains("capella"):
+          # TODO forkForPathComponent relies on ForkedFoo
+          continue
         raiseAssert "Unknown test fork: " & testsPath
       for kind, path in walkDir(testsPath, relative = true, checkDir = true):
         let basePath = testsPath/path/"pyspec_tests"

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -52,6 +52,8 @@ proc runTest(path: string, fork: BeaconStateFork) =
           get_subtree_index(proof.leaf_index),
           forkyState.root)
 
+from strutils import contains
+
 suite "EF - Light client - Single merkle proof" & preset():
   const presetPath = SszTestsDir/const_preset
   for kind, path in walkDir(presetPath, relative = true, checkDir = true):
@@ -60,6 +62,9 @@ suite "EF - Light client - Single merkle proof" & preset():
       continue
     let
       fork = forkForPathComponent(path).valueOr:
+        if path.contains("capella"):
+          # TODO forkForPathComponent relies on ForkedFoo
+          continue
         raiseAssert "Unknown test fork: " & testsPath
       basePath = testsPath/"pyspec_tests"
     for kind, path in walkDir(basePath, relative = true, checkDir = true):

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -116,6 +116,8 @@ proc runTest(path: string) =
         store.optimistic_header.slot == step.checks.optimistic_slot
         hash_tree_root(store.optimistic_header) == step.checks.optimistic_root
 
+from strutils import contains
+
 suite "EF - Light client - Sync" & preset():
   const presetPath = SszTestsDir/const_preset
   for kind, path in walkDir(presetPath, relative = true, checkDir = true):
@@ -124,4 +126,8 @@ suite "EF - Light client - Sync" & preset():
     if kind != pcDir or not dirExists(basePath):
       continue
     for kind, path in walkDir(basePath, relative = true, checkDir = true):
+      let combinedPath = basePath/path
+      if combinedPath.contains("capella"):
+        # TODO
+        continue
       runTest(basePath/path)

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -317,7 +317,7 @@ proc startValidatorClient {.async, thread.} =
     "--keymanager=true",
     "--keymanager-address=127.0.0.1",
     "--keymanager-port=" & $keymanagerPortVC,
-    "--keymanager-token-file=" & tokenFilePath], TaintedString it))
+    "--keymanager-token-file=" & tokenFilePath], it))
   except:
     quit 1
 


### PR DESCRIPTION
Deliberately minimal, to demonstrate that it's safe to use in place of v1.2.0 without any changes to existing phase 0/Altair/Bellatrix code.

Semantic changes will show up in other PRs.

The `forkForPathComponent` dependencies aren't totally real, but end up effectively requiring restaging changes to those until the `forks` system knows about Capella, regardless of whether the tests as a whole can run.