### PR TITLE
Highlight execution client for optimistically synced node

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1200,7 +1200,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
   # Update upcoming actions - we do this every slot in case a reorg happens
   let head = node.dag.head
-  if node.isSynced(head):
+  if node.isSynced(head) == SyncStatus.synced:
     withState(node.dag.headState):
       if node.consensusManager[].actionTracker.needsUpdate(
           forkyState, slot.epoch + 1):

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -36,7 +36,7 @@ func match(data: openArray[char], charset: set[char]): int =
 proc getSyncedHead*(node: BeaconNode, slot: Slot): Result[BlockRef, cstring] =
   let head = node.dag.head
 
-  if slot > head.slot and not node.isSynced(head):
+  if slot > head.slot and node.isSynced(head) != SyncStatus.synced:
     return err("Requesting way ahead of the current head")
 
   ok(head)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -265,7 +265,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonResponseWOpt(res, optimistic)
     elif qSyncPeriod > headSyncPeriod:
       # The requested epoch may still be too far in the future.
-      if not(node.isSynced(node.dag.head)):
+      if node.isSynced(node.dag.head) != SyncStatus.synced:
         return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
       else:
         return RestApiResponse.jsonError(Http400, EpochFromFutureError)
@@ -566,7 +566,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            InvalidSubscriptionRequestValueError,
                                            $dres.error())
         dres.get()
-    if not(node.isSynced(node.dag.head)):
+    if node.isSynced(node.dag.head) != SyncStatus.synced:
       return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
 
     let

--- a/beacon_chain/validator_client/fallback_service.nim
+++ b/beacon_chain/validator_client/fallback_service.nim
@@ -207,7 +207,7 @@ proc checkSync(vc: ValidatorClientRef,
                head_slot = syncInfo.head_slot, is_opimistic = optimistic
           RestBeaconNodeStatus.Online
         else:
-          warn "Beacon node is optimistically synced only",
+          warn "Execution client not in sync (beacon node optimistically synced)",
                sync_distance = syncInfo.sync_distance,
                head_slot = syncInfo.head_slot, is_opimistic = optimistic
           RestBeaconNodeStatus.NotSynced


### PR DESCRIPTION
...such that the user knows where to look