### PR TITLE
add Capella support to Forked*

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -231,6 +231,22 @@ ConsensusSpecPreset-mainnet
   ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/block_lookup_failed Skip
   ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_early_for_merge Skip
   ForkChoice - mainnet/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_late_for_merge  Skip
+  ForkChoice - mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_grea Skip
+  ForkChoice - mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_ Skip
+  ForkChoice - mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest Skip
+  ForkChoice - mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att Skip
+  ForkChoice - mainnet/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/chain_no_attestations       Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/discard_equivocations       Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/genesis                     Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w Skip
+  ForkChoice - mainnet/capella/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest Skip
+  ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/basic                       Skip
+  ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    Skip
+  ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
+  ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost              Skip
+  ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl Skip
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_n OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
@@ -253,12 +269,16 @@ ConsensusSpecPreset-mainnet
 + Light client - Single merkle proof - mainnet/bellatrix/light_client/single_merkle_proof/py OK
 + Light client - Single merkle proof - mainnet/bellatrix/light_client/single_merkle_proof/py OK
 + Light client - Single merkle proof - mainnet/bellatrix/light_client/single_merkle_proof/py OK
+  Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/pysp Skip
+  Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/pysp Skip
+  Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/pysp Skip
 + Slots - double_empty_epoch                                                                 OK
 + Slots - empty_epoch                                                                        OK
 + Slots - over_epoch_boundary                                                                OK
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
 + Sync - mainnet/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
+  Sync - mainnet/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                Skip
 + [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: mainne OK
@@ -474,7 +494,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 464/471 Fail: 0/471 Skip: 7/471
+OK: 464/491 Fail: 0/491 Skip: 27/491
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1806,4 +1826,4 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 OK: 14/14 Fail: 0/14 Skip: 0/14
 
 ---TOTAL---
-OK: 1553/1560 Fail: 0/1560 Skip: 7/1560
+OK: 1553/1580 Fail: 0/1580 Skip: 27/1580

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -255,6 +255,30 @@ ConsensusSpecPreset-minimal
   ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/block_lookup_failed Skip
   ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_early_for_merge Skip
   ForkChoice - minimal/bellatrix/fork_choice/on_merge_block/pyspec_tests/too_late_for_merge  Skip
+  ForkChoice - minimal/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest Skip
+  ForkChoice - minimal/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att Skip
+  ForkChoice - minimal/capella/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/chain_no_attestations       Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/discard_equivocations       Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/filtered_block_tree         Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/genesis                     Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w Skip
+  ForkChoice - minimal/capella/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/basic                       Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justi Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_j Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/new_justified_is_later_than Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_before_finalized   Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_checkpoints        Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_update_justified_c Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost              Skip
+  ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl Skip
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
@@ -285,6 +309,9 @@ ConsensusSpecPreset-minimal
 + Light client - Single merkle proof - minimal/bellatrix/light_client/single_merkle_proof/py OK
 + Light client - Single merkle proof - minimal/bellatrix/light_client/single_merkle_proof/py OK
 + Light client - Single merkle proof - minimal/bellatrix/light_client/single_merkle_proof/py OK
+  Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/pysp Skip
+  Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/pysp Skip
+  Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/pysp Skip
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/advance_finality_witho OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/light_client_sync      OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/supply_sync_committee_ OK
@@ -300,6 +327,7 @@ ConsensusSpecPreset-minimal
 + Slots - slots_1                                                                            OK
 + Slots - slots_2                                                                            OK
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
+  Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                Skip
 + [Invalid] EF - Altair - Sanity - Blocks - double_same_proposer_slashings_same_block [Prese OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_similar_proposer_slashings_same_block [Pr OK
 + [Invalid] EF - Altair - Sanity - Blocks - double_validator_exit_same_block [Preset: minima OK
@@ -533,7 +561,7 @@ ConsensusSpecPreset-minimal
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 523/530 Fail: 0/530 Skip: 7/530
+OK: 523/558 Fail: 0/558 Skip: 35/558
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -1925,4 +1953,4 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 OK: 14/14 Fail: 0/14 Skip: 0/14
 
 ---TOTAL---
-OK: 1660/1667 Fail: 0/1667 Skip: 7/1667
+OK: 1660/1695 Fail: 0/1695 Skip: 35/1695

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -25,6 +25,8 @@ import
   ../fork_choice/fork_choice,
   ../beacon_clock
 
+from ../spec/datatypes/capella import HashedBeaconState, shortLog
+
 export tables, results, phase0, altair, bellatrix, blockchain_dag, fork_choice
 
 const
@@ -144,7 +146,9 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
           var unrealized: FinalityCheckpoints
           if enableTestFeatures in dag.updateFlags and blckRef == dag.head:
             unrealized = withState(dag.headState):
-              when stateFork >= BeaconStateFork.Altair:
+              when stateFork >= BeaconStateFork.Capella:
+                raiseAssert $capellaImplementationMissing
+              elif stateFork >= BeaconStateFork.Altair:
                 forkyState.data.compute_unrealized_finality()
               else:
                 var cache: StateCache
@@ -580,6 +584,9 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
         AttestationCache.init(state)
       elif state is altair.HashedBeaconState or state is bellatrix.HashedBeaconState:
         AttestationCache.init(state, cache)
+      elif state is capella.HashedBeaconState:
+        if true: raiseAssert $capellaImplementationMissing
+        default(AttestationCache)
       else:
         static: doAssert false
 
@@ -644,6 +651,9 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
       elif state is phase0.HashedBeaconState:
         state.data.previous_epoch_attestations.maxLen -
           state.data.previous_epoch_attestations.len()
+      elif state is capella.HashedBeaconState:
+        if true: raiseAssert $capellaImplementationMissing
+        int(capellaImplementationMissing)
       else:
         raiseAssert "invalid HashedBeaconState fork"
 

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -18,6 +18,9 @@ import
     state_transition, state_transition_epoch],
   "."/[block_dag, blockchain_dag, blockchain_dag_light_client]
 
+# TODO remove when forks re-exports this
+from ../spec/datatypes/capella import asSigVerified, asTrusted, shortLog
+
 export results, signatures_batch, block_dag, blockchain_dag
 
 # Clearance
@@ -36,7 +39,7 @@ proc addResolvedHeadBlock(
        trustedBlock: ForkyTrustedSignedBeaconBlock,
        blockVerified: bool,
        parent: BlockRef, cache: var StateCache,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded,
+       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded | OnCapellaBlockAdded,
        stateDataDur, sigVerifyDur, stateVerifyDur: Duration
      ): BlockRef =
   doAssert state.matches_block_slot(
@@ -104,7 +107,9 @@ proc addResolvedHeadBlock(
     var unrealized: FinalityCheckpoints
     if enableTestFeatures in dag.updateFlags:
       unrealized = withState(state):
-        when stateFork >= BeaconStateFork.Altair:
+        when stateFork >= BeaconStateFork.Capella:
+          raiseAssert $capellaImplementationMissing
+        elif stateFork >= BeaconStateFork.Altair:
           forkyState.data.compute_unrealized_finality()
         else:
           forkyState.data.compute_unrealized_finality(cache)
@@ -162,7 +167,7 @@ proc addHeadBlock*(
     signedBlock: ForkySignedBeaconBlock,
     blockVerified: bool,
     onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded
+                  OnBellatrixBlockAdded | OnCapellaBlockAdded
     ): Result[BlockRef, BlockError] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.
@@ -292,7 +297,7 @@ proc addHeadBlock*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock,
     onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded
+                  OnBellatrixBlockAdded | OnCapellaBlockAdded
     ): Result[BlockRef, BlockError] =
   addHeadBlock(
     dag, verifier, signedBlock, blockVerified = true, onBlockAdded)

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -39,7 +39,7 @@ proc addResolvedHeadBlock(
        trustedBlock: ForkyTrustedSignedBeaconBlock,
        blockVerified: bool,
        parent: BlockRef, cache: var StateCache,
-       onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded | OnCapellaBlockAdded,
+       onBlockAdded: OnForkyBlockAdded,
        stateDataDur, sigVerifyDur, stateVerifyDur: Duration
      ): BlockRef =
   doAssert state.matches_block_slot(
@@ -166,8 +166,7 @@ proc addHeadBlock*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock,
     blockVerified: bool,
-    onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded | OnCapellaBlockAdded
+    onBlockAdded: OnForkyBlockAdded
     ): Result[BlockRef, BlockError] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.
@@ -296,8 +295,7 @@ proc addHeadBlock*(
 proc addHeadBlock*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock,
-    onBlockAdded: OnPhase0BlockAdded | OnAltairBlockAdded |
-                  OnBellatrixBlockAdded | OnCapellaBlockAdded
+    onBlockAdded: OnForkyBlockAdded
     ): Result[BlockRef, BlockError] =
   addHeadBlock(
     dag, verifier, signedBlock, blockVerified = true, onBlockAdded)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -15,6 +15,9 @@ import
   ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/forks
 
+# TODO remove once forks re-exports these
+from ../spec/datatypes/capella import SomeBeaconBlock, TrustedBeaconBlock
+
 export chronicles, forks
 
 type
@@ -67,7 +70,8 @@ func init*(
 
 func init*(
     T: type BlockRef, root: Eth2Digest,
-    blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock): BlockRef =
+    blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock |
+          capella.SomeBeaconBlock | capella.TrustedBeaconBlock): BlockRef =
   BlockRef.init(
     root, some Eth2Digest(blck.body.execution_payload.block_hash), blck.slot)
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -311,6 +311,10 @@ type
     epochRef: EpochRef,
     unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 
+  OnForkyBlockAdded* =
+    OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded |
+    OnCapellaBlockAdded
+
   HeadChangeInfoObject* = object
     slot*: Slot
     block_root* {.serializedFieldName: "block".}: Eth2Digest

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -22,6 +22,8 @@ import
   ../validators/validator_monitor,
   ./block_dag, block_pools_types_light_client
 
+from ../spec/datatypes/capella import TrustedSignedBeaconBlock
+
 from "."/vanity_logs/pandas import VanityLogs
 
 export
@@ -300,6 +302,12 @@ type
   OnBellatrixBlockAdded* = proc(
     blckRef: BlockRef,
     blck: bellatrix.TrustedSignedBeaconBlock,
+    epochRef: EpochRef,
+    unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
+
+  OnCapellaBlockAdded* = proc(
+    blckRef: BlockRef,
+    blck: capella.TrustedSignedBeaconBlock,
     epochRef: EpochRef,
     unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -20,6 +20,8 @@ import
   ".."/[beacon_chain_db, era_db],
   "."/[block_pools_types, block_quarantine]
 
+from ../spec/datatypes/capella import shortLog
+
 export
   eth2_merkleization, eth2_ssz_serialization,
   block_pools_types, results, beacon_chain_db
@@ -842,6 +844,8 @@ proc applyBlock(
     state_transition(
       dag.cfg, state, data, cache, info,
       dag.updateFlags + {slotProcessed}, noRollback)
+  of BeaconBlockFork.Capella:
+    raiseAssert $capellaImplementationMissing
 
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
@@ -998,6 +1002,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of BeaconStateFork.Phase0: genesisFork(cfg)
       of BeaconStateFork.Altair: altairFork(cfg)
       of BeaconStateFork.Bellatrix: bellatrixFork(cfg)
+      of BeaconStateFork.Capella: capellaFork(cfg)
     stateFork = getStateField(dag.headState, fork)
 
   if stateFork != configFork:

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -365,6 +365,8 @@ iterator getBlockIds*(
       let stateSlot = (slot.era() + 1).start_slot()
       if not getPartialState(db, historical_roots, stateSlot, state[]):
         state = nil # No `return` in iterators
+    of BeaconStateFork.Capella:
+      raiseAssert $capellaImplementationMissing
 
     if state == nil:
       break

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -286,6 +286,14 @@ proc newExecutionPayload*(
     error "newPayload failed", msg = err.msg
     return Opt.none PayloadExecutionStatus
 
+# TODO when forks re-exports this, remove
+from ../spec/datatypes/capella import ExecutionPayload
+
+proc newExecutionPayload*(
+    eth1Monitor: Eth1Monitor, executionPayload: capella.ExecutionPayload):
+    Future[Opt[PayloadExecutionStatus]] {.async.} =
+  raiseAssert $capellaImplementationMissing
+
 proc getExecutionValidity(
     eth1Monitor: Eth1Monitor,
     blck: phase0.SignedBeaconBlock | altair.SignedBeaconBlock):
@@ -326,6 +334,15 @@ proc getExecutionValidity(
   except CatchableError as err:
     error "getExecutionValidity: newPayload failed", err = err.msg
     return NewPayloadStatus.noResponse
+
+# TODO drop when forks re-exports all this
+from ../spec/datatypes/capella import SignedBeaconBlock, asTrusted, shortLog
+
+proc getExecutionValidity(
+    eth1Monitor: Eth1Monitor,
+    blck: capella.SignedBeaconBlock):
+    Future[NewPayloadStatus] {.async.} =
+  raiseAssert $capellaImplementationMissing
 
 proc storeBlock*(
     self: ref BlockProcessor, src: MsgSource, wallTime: BeaconTime,

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -24,6 +24,8 @@ import
   ".."/[beacon_clock],
   ./batch_validation
 
+from ../spec/datatypes/capella import SignedBeaconBlock
+
 from libp2p/protocols/pubsub/pubsub import ValidationResult
 
 export results, ValidationResult
@@ -384,6 +386,12 @@ proc validateBeaconBlock*(
     return errReject("BeaconBlock: Invalid proposer signature")
 
   ok()
+
+proc validateBeaconBlock*(
+    dag: ChainDAGRef, quarantine: ref Quarantine,
+    signed_beacon_block: capella.SignedBeaconBlock,
+    wallTime: BeaconTime, flags: UpdateFlags): Result[void, ValidationError] =
+  raiseAssert $capellaImplementationMissing
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
 proc validateAttestation*(

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2625,6 +2625,14 @@ proc broadcastBeaconBlock*(
   let topic = getBeaconBlocksTopic(node.forkDigests.bellatrix)
   node.broadcast(topic, blck)
 
+# TODO when forks re-exports this, use that instead and rm this
+from ../spec/datatypes/capella import SignedBeaconBlock
+
+proc broadcastBeaconBlock*(
+    node: Eth2Node, blck: capella.SignedBeaconBlock): Future[SendResult] =
+  let topic = getBeaconBlocksTopic(node.forkDigests.capella)
+  node.broadcast(topic, blck)
+
 proc broadcastBeaconBlock*(
     node: Eth2Node, forked: ForkedSignedBeaconBlock): Future[SendResult] =
   withBlck(forked): node.broadcastBeaconBlock(blck)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -759,7 +759,8 @@ func forkDigests(node: BeaconNode): auto =
   let forkDigestsArray: array[BeaconStateFork, auto] = [
     node.dag.forkDigests.phase0,
     node.dag.forkDigests.altair,
-    node.dag.forkDigests.bellatrix]
+    node.dag.forkDigests.bellatrix,
+    node.dag.forkDigests.capella]
   forkDigestsArray
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/phase0/validator.md#phase-0-attestation-subnet-stability
@@ -1108,7 +1109,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   const removeMessageHandlers: array[BeaconStateFork, auto] = [
     removePhase0MessageHandlers,
     removeAltairMessageHandlers,
-    removeAltairMessageHandlers  # with different forkDigest
+    removeAltairMessageHandlers,  # with different forkDigest
+    if capellaImplementationMissing: removeAltairMessageHandlers else: removeAltairMessageHandlers
   ]
 
   for gossipFork in oldGossipForks:
@@ -1117,7 +1119,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   const addMessageHandlers: array[BeaconStateFork, auto] = [
     addPhase0MessageHandlers,
     addAltairMessageHandlers,
-    addAltairMessageHandlers  # with different forkDigest
+    addAltairMessageHandlers,  # with different forkDigest
+    if capellaImplementationMissing: addAltairMessageHandlers else: addAltairMessageHandlers
   ]
 
   for gossipFork in newGossipForks:

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -276,6 +276,9 @@ proc getStateOptimistic*(node: BeaconNode,
           doAssert forkyState.data.slot > 0
           some[bool](node.dag.is_optimistic(
             get_block_root_at_slot(forkyState.data, forkyState.data.slot - 1)))
+    of BeaconStateFork.Capella:
+      if true: raiseAssert $capellaImplementationMissing
+      none[bool]()
   else:
     none[bool]()
 
@@ -288,6 +291,9 @@ proc getBlockOptimistic*(node: BeaconNode,
       some[bool](false)
     of BeaconBlockFork.Bellatrix:
       some[bool](node.dag.is_optimistic(blck.root))
+    of BeaconBlockFork.Capella:
+      if true: raiseAssert $capellaImplementationMissing
+      none[bool]()
   else:
     none[bool]()
 
@@ -298,6 +304,9 @@ proc getBlockRefOptimistic*(node: BeaconNode, blck: BlockRef): bool =
     false
   of BeaconBlockFork.Bellatrix:
     node.dag.is_optimistic(blck.root)
+  of BeaconBlockFork.Capella:
+    if true: raiseAssert $capellaImplementationMissing
+    true
 
 const
   jsonMediaType* = MediaType.init("application/json")

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -361,6 +361,18 @@ func get_initial_beacon_block*(state: bellatrix.HashedBeaconState):
   bellatrix.TrustedSignedBeaconBlock(
     message: message, root: hash_tree_root(message))
 
+# https://github.com/ethereum/consensus-specs/blob/v1.1.7/specs/merge/beacon-chain.md#testing
+func get_initial_beacon_block*(state: capella.HashedBeaconState):
+    capella.TrustedSignedBeaconBlock =
+  # The genesis block is implicitly trusted
+  let message = capella.TrustedBeaconBlock(
+    slot: state.data.slot,
+    state_root: state.root)
+    # parent_root, randao_reveal, eth1_data, signature, and body automatically
+    # initialized to default values.
+  capella.TrustedSignedBeaconBlock(
+    message: message, root: hash_tree_root(message))
+
 func get_initial_beacon_block*(state: ForkedHashedBeaconState):
     ForkedTrustedSignedBeaconBlock =
   withState(state):

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -976,3 +976,9 @@ func checkForkConsistency*(cfg: RuntimeConfig) =
   assertForkEpochOrder(cfg.ALTAIR_FORK_EPOCH, cfg.BELLATRIX_FORK_EPOCH)
   assertForkEpochOrder(cfg.BELLATRIX_FORK_EPOCH, cfg.CAPELLA_FORK_EPOCH)
   assertForkEpochOrder(cfg.CAPELLA_FORK_EPOCH, cfg.SHARDING_FORK_EPOCH)
+
+# This is a readily/uniquely searchable token of where a false assertion is
+# due to Capella implementation missing. checkForkConsistency() checks that
+# Nimbus does not actually run any non-FAR_FUTURE_EPOCH Capella network, so
+# such cases won't be hit.
+const capellaImplementationMissing* = false

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -19,7 +19,6 @@ else:
   {.push raises: [].}
 
 import
-  stew/byteutils,
   json_serialization,
   ssz_serialization/types as sszTypes,
   ../digest,
@@ -364,26 +363,6 @@ type
 
   BoolReturnSuccessRPC = object
     success*: bool
-
-func fromHex*(T: typedesc[BloomLogs], s: string): T {.
-     raises: [Defect, ValueError].} =
-  hexToByteArray(s, result.data)
-
-func fromHex*(T: typedesc[ExecutionAddress], s: string): T {.
-     raises: [Defect, ValueError].} =
-  hexToByteArray(s, result.data)
-
-proc writeValue*(writer: var JsonWriter, value: ExecutionAddress) {.
-     raises: [Defect, IOError].} =
-  writer.writeValue to0xHex(value.data)
-
-proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
-     raises: [Defect, IOError, SerializationError].} =
-  try:
-    hexToByteArray(reader.readValue(string), value.data)
-  except ValueError:
-    raiseUnexpectedValue(reader,
-                         "ExecutionAddress value should be a valid hex string")
 
 func shortLog*(v: SomeBeaconBlock): auto =
   (

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -959,6 +959,8 @@ proc readValue*[BlockType: ForkedBeaconBlock](
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect bellatrix block format")
     value = ForkedBeaconBlock.init(res.get()).BlockType
+  of BeaconBlockFork.Capella:
+    reader.raiseUnexpectedValue($capellaImplementationMissing)
 
 proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
     reader: var JsonReader[RestJson],
@@ -1012,6 +1014,8 @@ proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
     value = Web3SignerForkedBeaconBlock(
       kind: BeaconBlockFork.Bellatrix,
       bellatrixData: res.get())
+  of BeaconBlockFork.Capella:
+    reader.raiseUnexpectedValue($capellaImplementationMissing)
 
 proc writeValue*[
     BlockType: Web3SignerForkedBeaconBlock|ForkedBeaconBlock|ForkedBlindedBeaconBlock](
@@ -1035,6 +1039,8 @@ proc writeValue*[
   of BeaconBlockFork.Bellatrix:
     writer.writeField("version", forkIdentifier "bellatrix")
     writer.writeField("data", value.bellatrixData)
+  of BeaconBlockFork.Capella:
+    raiseAssert $capellaImplementationMissing
   writer.endRecord()
 
 ## RestPublishedBeaconBlockBody
@@ -1054,7 +1060,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     voluntary_exits: Option[
       List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]]
     sync_aggregate: Option[SyncAggregate]
-    execution_payload: Option[ExecutionPayload]
+    execution_payload: Option[bellatrix.ExecutionPayload]
 
   for fieldName in readObjectFields(reader):
     case fieldName
@@ -1113,7 +1119,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       if execution_payload.isSome():
         reader.raiseUnexpectedField("Multiple `execution_payload` fields found",
                                     "RestPublishedBeaconBlockBody")
-      execution_payload = some(reader.readValue(ExecutionPayload))
+      execution_payload = some(reader.readValue(bellatrix.ExecutionPayload))
     else:
       unrecognizedFieldWarning()
 
@@ -1188,6 +1194,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         execution_payload: execution_payload.get()
       )
     )
+  of BeaconBlockFork.Capella:
+    reader.raiseUnexpectedValue($capellaImplementationMissing)
 
 ## RestPublishedBeaconBlock
 proc readValue*(reader: var JsonReader[RestJson],
@@ -1274,6 +1282,8 @@ proc readValue*(reader: var JsonReader[RestJson],
           body: body.bellatrixBody
         )
       )
+    of BeaconBlockFork.Capella:
+      reader.raiseUnexpectedValue($capellaImplementationMissing)
   )
 
 ## RestPublishedSignedBeaconBlock
@@ -1326,6 +1336,8 @@ proc readValue*(reader: var JsonReader[RestJson],
           signature: signature.get()
         )
       )
+    of BeaconBlockFork.Capella:
+      reader.raiseUnexpectedValue($capellaImplementationMissing)
   )
 
 ## ForkedSignedBeaconBlock
@@ -1402,6 +1414,8 @@ proc readValue*(reader: var JsonReader[RestJson],
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect bellatrix block format")
     value = ForkedSignedBeaconBlock.init(res.get())
+  of BeaconBlockFork.Capella:
+    reader.raiseUnexpectedValue($capellaImplementationMissing)
   withBlck(value):
     blck.root = hash_tree_root(blck.message)
 
@@ -1419,6 +1433,8 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   of BeaconBlockFork.Bellatrix:
     writer.writeField("version", "bellatrix")
     writer.writeField("data", value.bellatrixData)
+  of BeaconBlockFork.Capella:
+    raiseAssert $capellaImplementationMissing
   writer.endRecord()
 
 # ForkedHashedBeaconState is used where a `ForkedBeaconState` normally would
@@ -1500,6 +1516,8 @@ proc readValue*(reader: var JsonReader[RestJson],
     except SerializationError:
       reader.raiseUnexpectedValue("Incorrect altair beacon state format")
     toValue(bellatrixData)
+  of BeaconStateFork.Capella:
+    reader.raiseUnexpectedValue($capellaImplementationMissing)
 
 proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconState)
                 {.raises: [IOError, Defect].} =
@@ -1514,6 +1532,8 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconStat
   of BeaconStateFork.Bellatrix:
     writer.writeField("version", "bellatrix")
     writer.writeField("data", value.bellatrixData.data)
+  of BeaconStateFork.Capella:
+    raiseAssert $capellaImplementationMissing
   writer.endRecord()
 
 ## Web3SignerRequest
@@ -2403,6 +2423,8 @@ proc decodeBody*(
         except CatchableError:
           return err("Unexpected deserialization error")
       ok(RestPublishedSignedBeaconBlock(ForkedSignedBeaconBlock.init(blck)))
+    of BeaconBlockFork.Capella:
+      return err($capellaImplementationMissing)
   else:
     return err("Unsupported or invalid content media type")
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -23,7 +23,9 @@ import
   ".."/datatypes/[phase0, altair, bellatrix],
   ".."/mev/bellatrix_mev
 
-export forks, phase0, altair, bellatrix, bellatrix_mev
+from ".."/datatypes/capella import BeaconBlockBody
+
+export forks, phase0, altair, bellatrix, capella, bellatrix_mev
 
 const
   # https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/states/validator_balances.yaml#L17
@@ -263,6 +265,7 @@ type
     of BeaconBlockFork.Phase0:    phase0Body*: phase0.BeaconBlockBody
     of BeaconBlockFork.Altair:    altairBody*: altair.BeaconBlockBody
     of BeaconBlockFork.Bellatrix: bellatrixBody*: bellatrix.BeaconBlockBody
+    of BeaconBlockFork.Capella:   cappellaBody*: capella.BeaconBlockBody
 
   RestSpec* = object
     # https://github.com/ethereum/consensus-specs/blob/v1.2.0/presets/mainnet/phase0.yaml

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -18,6 +18,8 @@ import
   ./datatypes/[phase0, altair, bellatrix, capella],
   ./mev/bellatrix_mev
 
+# TODO re-export capella, but for now it could cause knock-on effects, so stage
+# it sequentially
 export
   extras, block_id, phase0, altair, bellatrix, eth2_merkleization,
   eth2_ssz_serialization, presets
@@ -42,7 +44,8 @@ type
   BeaconStateFork* {.pure.} = enum
     Phase0,
     Altair,
-    Bellatrix
+    Bellatrix,
+    Capella
 
   ForkyBeaconState* =
     phase0.BeaconState |
@@ -53,18 +56,21 @@ type
   ForkyHashedBeaconState* =
     phase0.HashedBeaconState |
     altair.HashedBeaconState |
-    bellatrix.HashedBeaconState
+    bellatrix.HashedBeaconState |
+    capella.HashedBeaconState
 
   ForkedHashedBeaconState* = object
     case kind*: BeaconStateFork
     of BeaconStateFork.Phase0:    phase0Data*:    phase0.HashedBeaconState
     of BeaconStateFork.Altair:    altairData*:    altair.HashedBeaconState
     of BeaconStateFork.Bellatrix: bellatrixData*: bellatrix.HashedBeaconState
+    of BeaconStateFork.Capella:   capellaData*:   capella.HashedBeaconState
 
   BeaconBlockFork* {.pure.} = enum
     Phase0
     Altair
-    Bellatrix
+    Bellatrix,
+    Capella
 
   ForkyBeaconBlockBody* =
     phase0.BeaconBlockBody |
@@ -95,12 +101,14 @@ type
   ForkySigVerifiedBeaconBlock* =
     phase0.SigVerifiedBeaconBlock |
     altair.SigVerifiedBeaconBlock |
-    bellatrix.SigVerifiedBeaconBlock
+    bellatrix.SigVerifiedBeaconBlock |
+    capella.SigVerifiedBeaconBlock
 
   ForkyTrustedBeaconBlock* =
     phase0.TrustedBeaconBlock |
     altair.TrustedBeaconBlock |
-    bellatrix.TrustedBeaconBlock
+    bellatrix.TrustedBeaconBlock |
+    capella.TrustedBeaconBlock
 
   SomeForkyBeaconBlock* =
     ForkyBeaconBlock |
@@ -112,62 +120,73 @@ type
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.BeaconBlock
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: BeaconBlockHeader
+    of BeaconBlockFork.Capella:   capellaData*:   BeaconBlockHeader
 
   ForkedBlindedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.BeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.BeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: BlindedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   BlindedBeaconBlock
 
   ForkedTrustedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:     phase0.TrustedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:     altair.TrustedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*:  bellatrix.TrustedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:    capella.TrustedBeaconBlock
 
   ForkySignedBeaconBlock* =
     phase0.SignedBeaconBlock |
     altair.SignedBeaconBlock |
-    bellatrix.SignedBeaconBlock
+    bellatrix.SignedBeaconBlock |
+    capella.SignedBeaconBlock
 
   ForkedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.SignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.SignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.SignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.SignedBeaconBlock
 
   ForkySigVerifiedSignedBeaconBlock* =
     phase0.SigVerifiedSignedBeaconBlock |
     altair.SigVerifiedSignedBeaconBlock |
-    bellatrix.SigVerifiedSignedBeaconBlock
+    bellatrix.SigVerifiedSignedBeaconBlock |
+    capella.SigVerifiedSignedBeaconBlock
 
   ForkyMsgTrustedSignedBeaconBlock* =
     phase0.MsgTrustedSignedBeaconBlock |
     altair.MsgTrustedSignedBeaconBlock |
-    bellatrix.MsgTrustedSignedBeaconBlock
+    bellatrix.MsgTrustedSignedBeaconBlock |
+    capella.MsgTrustedSignedBeaconBlock
 
   ForkyTrustedSignedBeaconBlock* =
     phase0.TrustedSignedBeaconBlock |
     altair.TrustedSignedBeaconBlock |
-    bellatrix.TrustedSignedBeaconBlock
+    bellatrix.TrustedSignedBeaconBlock |
+    capella.TrustedSignedBeaconBlock
 
   ForkedMsgTrustedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.MsgTrustedSignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.MsgTrustedSignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.MsgTrustedSignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.MsgTrustedSignedBeaconBlock
 
   ForkedTrustedSignedBeaconBlock* = object
     case kind*: BeaconBlockFork
     of BeaconBlockFork.Phase0:    phase0Data*:    phase0.TrustedSignedBeaconBlock
     of BeaconBlockFork.Altair:    altairData*:    altair.TrustedSignedBeaconBlock
     of BeaconBlockFork.Bellatrix: bellatrixData*: bellatrix.TrustedSignedBeaconBlock
+    of BeaconBlockFork.Capella:   capellaData*:   capella.TrustedSignedBeaconBlock
 
   SomeForkySignedBeaconBlock* =
     ForkySignedBeaconBlock |
@@ -202,6 +221,9 @@ template toFork*[T: altair.BeaconState | altair.HashedBeaconState](
 template toFork*[T: bellatrix.BeaconState | bellatrix.HashedBeaconState](
     t: type T): BeaconStateFork =
   BeaconStateFork.Bellatrix
+template toFork*[T: capella.BeaconState | capella.HashedBeaconState](
+    t: type T): BeaconStateFork =
+  BeaconStateFork.Capella
 
 # TODO these cause stack overflows due to large temporaries getting allocated
 # template init*(T: type ForkedHashedBeaconState, data: phase0.HashedBeaconState): T =
@@ -231,6 +253,8 @@ template init*(T: type ForkedSignedBeaconBlock, blck: altair.SignedBeaconBlock):
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: bellatrix.SignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedSignedBeaconBlock, blck: capella.SignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
                blockRoot: Eth2Digest, signature: ValidatorSig): T =
@@ -250,20 +274,29 @@ template init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
       bellatrixData: bellatrix.SignedBeaconBlock(message: forked.bellatrixData,
                                                  root: blockRoot,
                                                  signature: signature))
+  of BeaconBlockFork.Capella:
+    T(kind: BeaconBlockFork.Capella,
+      capellaData: capella.SignedBeaconBlock(message: forked.capellaData,
+                                             root: blockRoot,
+                                             signature: signature))
 
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: phase0.MsgTrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
+  T(kind: BeaconBlockFork.Phase0,    phase0Data: blck)
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: altair.MsgTrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Altair, altairData: blck)
+  T(kind: BeaconBlockFork.Altair,    altairData: blck)
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: bellatrix.MsgTrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Bellatrix,  bellatrixData: blck)
+  T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: capella.MsgTrustedSignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella,   capellaData: blck)
 
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: phase0.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Phase0, phase0Data: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: altair.TrustedSignedBeaconBlock): T =
   T(kind: BeaconBlockFork.Altair, altairData: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: bellatrix.TrustedSignedBeaconBlock): T =
-  T(kind: BeaconBlockFork.Bellatrix,  bellatrixData: blck)
+  T(kind: BeaconBlockFork.Bellatrix, bellatrixData: blck)
+template init*(T: type ForkedTrustedSignedBeaconBlock, blck: capella.TrustedSignedBeaconBlock): T =
+  T(kind: BeaconBlockFork.Capella, capellaData: blck)
 
 template toString*(kind: BeaconBlockFork): string =
   case kind
@@ -273,6 +306,8 @@ template toString*(kind: BeaconBlockFork): string =
     "altair"
   of BeaconBlockFork.Bellatrix:
     "bellatrix"
+  of BeaconBlockFork.Capella:
+    "capella"
 
 template toString*(kind: BeaconStateFork): string =
   case kind
@@ -282,6 +317,8 @@ template toString*(kind: BeaconStateFork): string =
     "altair"
   of BeaconStateFork.Bellatrix:
     "bellatrix"
+  of BeaconStateFork.Capella:
+    "capella"
 
 template toFork*[T:
     phase0.BeaconBlock |
@@ -310,6 +347,15 @@ template toFork*[T:
     bellatrix.TrustedSignedBeaconBlock](
     t: type T): BeaconBlockFork =
   BeaconBlockFork.Bellatrix
+template toFork*[T:
+    capella.BeaconBlock |
+    capella.SignedBeaconBlock |
+    capella.TrustedBeaconBlock |
+    capella.SigVerifiedSignedBeaconBlock |
+    capella.MsgTrustedSignedBeaconBlock |
+    capella.TrustedSignedBeaconBlock](
+    t: type T): BeaconBlockFork =
+  BeaconBlockFork.Capella
 
 template init*(T: type ForkedEpochInfo, info: phase0.EpochInfo): T =
   T(kind: EpochInfoFork.Phase0, phase0Data: info)
@@ -318,6 +364,10 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
+  of BeaconStateFork.Capella:
+    const stateFork {.inject, used.} = BeaconStateFork.Capella
+    template forkyState: untyped {.inject, used.} = x.capellaData
+    body
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template forkyState: untyped {.inject, used.} = x.bellatrixData
@@ -349,8 +399,8 @@ template withEpochInfo*(
   body
 
 template withEpochInfo*(
-    state: altair.BeaconState | bellatrix.BeaconState, x: var ForkedEpochInfo,
-    body: untyped): untyped =
+    state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState,
+    x: var ForkedEpochInfo, body: untyped): untyped =
   x.kind = EpochInfoFork.Altair
   template info: untyped {.inject.} = x.altairData
   body
@@ -358,6 +408,8 @@ template withEpochInfo*(
 func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
   if tgt.kind == src.kind:
     case tgt.kind
+    of BeaconStateFork.Capella:
+      assign(tgt.capellaData, src.capellaData):
     of BeaconStateFork.Bellatrix:
       assign(tgt.bellatrixData, src.bellatrixData):
     of BeaconStateFork.Altair:
@@ -376,6 +428,7 @@ template getStateField*(x: ForkedHashedBeaconState, y: untyped): untyped =
   # ```
   # Without `unsafeAddr`, the `validators` list would be copied to a temporary variable.
   (case x.kind
+  of BeaconStateFork.Capella:   unsafeAddr x.capellaData.data.y
   of BeaconStateFork.Bellatrix: unsafeAddr x.bellatrixData.data.y
   of BeaconStateFork.Altair:    unsafeAddr x.altairData.data.y
   of BeaconStateFork.Phase0:    unsafeAddr x.phase0Data.data.y)[]
@@ -389,23 +442,28 @@ func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
 func stateForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconStateFork =
   ## Return the current fork for the given epoch.
   static:
+    doAssert BeaconStateFork.Capella   > BeaconStateFork.Bellatrix
     doAssert BeaconStateFork.Bellatrix > BeaconStateFork.Altair
     doAssert BeaconStateFork.Altair    > BeaconStateFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconStateFork.Bellatrix
+  if   epoch >= cfg.CAPELLA_FORK_EPOCH:   BeaconStateFork.Capella
+  elif epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconStateFork.Bellatrix
   elif epoch >= cfg.ALTAIR_FORK_EPOCH:    BeaconStateFork.Altair
   else:                                   BeaconStateFork.Phase0
 
 func blockForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): BeaconBlockFork =
   ## Return the current fork for the given epoch.
-  if   epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconBlockFork.Bellatrix
+  if   epoch >= cfg.CAPELLA_FORK_EPOCH:   BeaconBlockFork.Capella
+  elif epoch >= cfg.BELLATRIX_FORK_EPOCH: BeaconBlockFork.Bellatrix
   elif epoch >= cfg.ALTAIR_FORK_EPOCH:    BeaconBlockFork.Altair
   else:                                   BeaconBlockFork.Phase0
 
 func stateForkForDigest*(
     forkDigests: ForkDigests, forkDigest: ForkDigest): Opt[BeaconStateFork] =
-  if   forkDigest == forkDigests.bellatrix:
+  if   forkDigest == forkDigests.capella:
+    ok BeaconStateFork.Capella
+  elif forkDigest == forkDigests.bellatrix:
     ok BeaconStateFork.Bellatrix
   elif forkDigest == forkDigests.altair:
     ok BeaconStateFork.Altair
@@ -417,6 +475,8 @@ func stateForkForDigest*(
 func atStateFork*(
     forkDigests: ForkDigests, stateFork: BeaconStateFork): ForkDigest =
   case stateFork
+  of BeaconStateFork.Capella:
+    forkDigests.capella
   of BeaconStateFork.Bellatrix:
     forkDigests.bellatrix
   of BeaconStateFork.Altair:
@@ -482,6 +542,10 @@ template withBlck*(
     const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
     template blck: untyped {.inject.} = x.bellatrixData
     body
+  of BeaconBlockFork.Capella:
+    const stateFork {.inject, used.} = BeaconStateFork.Capella
+    template blck: untyped {.inject.} = x.capellaData
+    body
 
 func proposer_index*(x: ForkedBeaconBlock): uint64 =
   withBlck(x): blck.proposer_index
@@ -499,7 +563,8 @@ template getForkedBlockField*(
   (case x.kind
   of BeaconBlockFork.Phase0:    unsafeAddr x.phase0Data.message.y
   of BeaconBlockFork.Altair:    unsafeAddr x.altairData.message.y
-  of BeaconBlockFork.Bellatrix: unsafeAddr x.bellatrixData.message.y)[]
+  of BeaconBlockFork.Bellatrix: unsafeAddr x.bellatrixData.message.y
+  of BeaconBlockFork.Capella:   unsafeAddr x.capellaData.message.y)[]
 
 template signature*(x: ForkedSignedBeaconBlock |
                        ForkedMsgTrustedSignedBeaconBlock): ValidatorSig =
@@ -538,6 +603,11 @@ template withStateAndBlck*(
        ForkedTrustedSignedBeaconBlock,
     body: untyped): untyped =
   case s.kind
+  of BeaconStateFork.Capella:
+    const stateFork {.inject.} = BeaconStateFork.Capella
+    template forkyState: untyped {.inject.} = s.capellaData
+    template blck: untyped {.inject.} = b.capellaData
+    body
   of BeaconStateFork.Bellatrix:
     const stateFork {.inject.} = BeaconStateFork.Bellatrix
     template forkyState: untyped {.inject.} = s.bellatrixData
@@ -588,28 +658,35 @@ func altairFork*(cfg: RuntimeConfig): Fork =
     epoch: cfg.ALTAIR_FORK_EPOCH)
 
 func bellatrixFork*(cfg: RuntimeConfig): Fork =
-  # TODO in theory, the altair + merge forks could be in same epoch, so the
-  # previous fork version would be the GENESIS_FORK_VERSION
   Fork(
     previous_version: cfg.ALTAIR_FORK_VERSION,
     current_version: cfg.BELLATRIX_FORK_VERSION,
     epoch: cfg.BELLATRIX_FORK_EPOCH)
 
+func capellaFork*(cfg: RuntimeConfig): Fork =
+  Fork(
+    previous_version: cfg.BELLATRIX_FORK_VERSION,
+    current_version: cfg.CAPELLA_FORK_VERSION,
+    epoch: cfg.CAPELLA_FORK_EPOCH)
+
 func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
   case cfg.stateForkAtEpoch(epoch)
+  of BeaconStateFork.Capella:   cfg.capellaFork
   of BeaconStateFork.Bellatrix: cfg.bellatrixFork
   of BeaconStateFork.Altair:    cfg.altairFork
   of BeaconStateFork.Phase0:    cfg.genesisFork
 
 func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   case cfg.stateForkAtEpoch(epoch)
+  of BeaconStateFork.Capella:   cfg.CAPELLA_FORK_VERSION
   of BeaconStateFork.Bellatrix: cfg.BELLATRIX_FORK_VERSION
   of BeaconStateFork.Altair:    cfg.ALTAIR_FORK_VERSION
   of BeaconStateFork.Phase0:    cfg.GENESIS_FORK_VERSION
 
 func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   case cfg.stateForkAtEpoch(epoch)
-  of BeaconStateFork.Bellatrix: FAR_FUTURE_EPOCH
+  of BeaconStateFork.Capella:   FAR_FUTURE_EPOCH
+  of BeaconStateFork.Bellatrix: cfg.CAPELLA_FORK_EPOCH
   of BeaconStateFork.Altair:    cfg.BELLATRIX_FORK_EPOCH
   of BeaconStateFork.Phase0:    cfg.ALTAIR_FORK_EPOCH
 
@@ -676,6 +753,7 @@ func toBeaconBlockFork*(fork: BeaconStateFork): BeaconBlockFork =
   of BeaconStateFork.Phase0:    BeaconBlockFork.Phase0
   of BeaconStateFork.Altair:    BeaconBlockFork.Altair
   of BeaconStateFork.Bellatrix: BeaconBlockFork.Bellatrix
+  of BeaconStateFork.Capella:   BeaconBlockFork.Capella
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0/specs/phase0/beacon-chain.md#compute_fork_data_root
 func compute_fork_data_root*(current_version: Version,

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -581,3 +581,5 @@ proc makeBeaconBlock*(
   of BeaconStateFork.Phase0:    makeBeaconBlock(phase0)
   of BeaconStateFork.Altair:    makeBeaconBlock(altair)
   of BeaconStateFork.Bellatrix: makeBeaconBlock(bellatrix)
+  of BeaconStateFork.Capella:
+    raiseAssert $capellaImplementationMissing

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -715,3 +715,12 @@ proc process_block*(
     state, blck.body.sync_aggregate, total_active_balance, cache)
 
   ok()
+
+# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
+type SomeCapellaBlock =
+  capella.BeaconBlock | capella.SigVerifiedBeaconBlock | capella.TrustedBeaconBlock
+proc process_block*(
+    cfg: RuntimeConfig,
+    state: var capella.BeaconState, blck: SomeCapellaBlock,
+    flags: UpdateFlags, cache: var StateCache): Result[void, cstring]=
+  raiseAssert $capellaImplementationMissing

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -1685,6 +1685,8 @@ proc publishBlock*(
           publishBlock(it, data.altairData)
         of BeaconBlockFork.Bellatrix:
           publishBlock(it, data.bellatrixData)
+        of BeaconBlockFork.Capella:
+          raiseAssert $capellaImplementationMissing
       do:
         if apiResponse.isErr():
           debug ErrorMessage, endpoint = node, error = apiResponse.error()
@@ -1732,6 +1734,8 @@ proc publishBlock*(
         publishBlock(it, data.altairData)
       of BeaconBlockFork.Bellatrix:
         publishBlock(it, data.bellatrixData)
+      of BeaconBlockFork.Capella:
+        raiseAssert $capellaImplementationMissing
     do:
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -11,6 +11,9 @@ import
   ../spec/[beaconstate, forks, helpers],
   ../beacon_clock
 
+# TODO when forks re-exports capella, drop this
+from ../spec/datatypes/capella import shortLog
+
 when (NimMajor, NimMinor) < (1, 4):
   {.push raises: [Defect].}
 else:

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -305,6 +305,8 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
               Web3SignerForkedBeaconBlock(
                 kind: BeaconBlockFork.Bellatrix,
                 bellatrixData: blck.bellatrixData.toBeaconBlockHeader)
+            of BeaconBlockFork.Capella:
+              raiseAssert $capellaImplementationMissing
 
           request = Web3SignerRequest.init(
             fork, genesis_validators_root, web3SignerBlock)

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -84,6 +84,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
   of BeaconStateFork.Phase0:    SSZ.saveFile(filename, value.phase0Data.data)
   of BeaconStateFork.Altair:    SSZ.saveFile(filename, value.altairData.data)
   of BeaconStateFork.Bellatrix: SSZ.saveFile(filename, value.bellatrixData.data)
+  of BeaconStateFork.Capella:   SSZ.saveFile(filename, value.capellaData.data)
 
 proc loadFile(filename: string, T: type): T =
   let

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -19,6 +19,8 @@ import
     signatures],
   ../beacon_chain/consensus_object_pools/blockchain_dag
 
+from ../beacon_chain/spec/datatypes/capella import BeaconState
+
 type
   RewardsAndPenalties* = object
     source_outcome*: int64
@@ -266,7 +268,7 @@ proc collectEpochRewardsAndPenalties*(
 
 proc collectEpochRewardsAndPenalties*(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
-    state: var (altair.BeaconState | bellatrix.BeaconState),
+    state: var (altair.BeaconState | bellatrix.BeaconState | capella.BeaconState),
     cache: var StateCache, cfg: RuntimeConfig, flags: UpdateFlags) =
   if get_current_epoch(state) == GENESIS_EPOCH:
     return

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -252,6 +252,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       of BeaconBlockFork.Bellatrix:
         blocks[2].add dag.db.getBlock(
           blck.root, bellatrix.TrustedSignedBeaconBlock).get()
+      of BeaconBlockFork.Capella:
+        raiseAssert $capellaImplementationMissing
 
   let stateData = newClone(dag.headState)
 
@@ -316,12 +318,15 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
               of BeaconStateFork.Bellatrix:
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[2][].data, noRollback)
+              of BeaconStateFork.Capella:
+                raiseAssert $capellaImplementationMissing
 
             if forkyState.data.slot.epoch mod 16 == 0:
               let loadedRoot = case stateFork
                 of BeaconStateFork.Phase0:    hash_tree_root(loadedState[0][].data)
                 of BeaconStateFork.Altair:    hash_tree_root(loadedState[1][].data)
                 of BeaconStateFork.Bellatrix: hash_tree_root(loadedState[2][].data)
+                of BeaconStateFork.Capella:   raiseAssert $capellaImplementationMissing
               doAssert hash_tree_root(forkyState.data) == loadedRoot
 
   processBlocks(blocks[0])

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -401,6 +401,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     if blockRatio > 0.0:
       withTimer(timers[t]):
         case dag.cfg.stateForkAtEpoch(slot.epoch)
+        of BeaconStateFork.Capella:   raiseAssert $capellaImplementationMissing
         of BeaconStateFork.Bellatrix: proposeBellatrixBlock(slot)
         of BeaconStateFork.Altair:    proposeAltairBlock(slot)
         of BeaconStateFork.Phase0:    proposePhase0Block(slot)

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -159,7 +159,7 @@ cli do(validatorsDir: string, secretsDir: string,
           @[],
           BeaconBlockExits(),
           syncAggregate,
-          default(ExecutionPayload),
+          default(bellatrix.ExecutionPayload),
           noRollback,
           cache).get()
 
@@ -191,6 +191,8 @@ cli do(validatorsDir: string, secretsDir: string,
             fork, genesis_validators_root, slot, blockRoot,
             validators[proposer]).toValidatorSig())
         dump(".", signedBlock)
+      of BeaconBlockFork.Capella:
+        raiseAssert $capellaImplementationMissing
       notice "Block proposed", message, blockRoot
 
       aggregates.setLen(0)

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -44,6 +44,10 @@ func readValue*(r: var JsonReader, a: var seq[byte]) =
 func genesisTestRuntimeConfig*(stateFork: BeaconStateFork): RuntimeConfig =
   var res = defaultRuntimeConfig
   case stateFork
+  of BeaconStateFork.Capella:
+    res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
+    res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+    res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
   of BeaconStateFork.Bellatrix:
     res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
     res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
@@ -120,6 +124,9 @@ proc loadForkedState*(
   # prevent temporaries created by case objects
   let forkedState = new ForkedHashedBeaconState
   case fork
+  of BeaconStateFork.Capella:
+    doAssert capellaImplementationMissing
+    raiseAssert "capellaImplementationMissing"
   of BeaconStateFork.Bellatrix:
     let state = newClone(parseTest(path, SSZ, bellatrix.BeaconState))
     forkedState.kind = BeaconStateFork.Bellatrix

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -125,8 +125,7 @@ proc loadForkedState*(
   let forkedState = new ForkedHashedBeaconState
   case fork
   of BeaconStateFork.Capella:
-    doAssert capellaImplementationMissing
-    raiseAssert "capellaImplementationMissing"
+    raiseAssert $capellaImplementationMissing
   of BeaconStateFork.Bellatrix:
     let state = newClone(parseTest(path, SSZ, bellatrix.BeaconState))
     forkedState.kind = BeaconStateFork.Bellatrix

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -23,6 +23,10 @@ import
 
 proc runTest(path: string, fork: BeaconStateFork) =
   test "Light client - Single merkle proof - " & path.relativePath(SszTestsDir):
+    if capellaImplementationMissing or fork == BeaconStateFork.Capella:
+      skip()
+      return
+
     type
       TestProof = object
         leaf: string
@@ -52,8 +56,6 @@ proc runTest(path: string, fork: BeaconStateFork) =
           get_subtree_index(proof.leaf_index),
           forkyState.root)
 
-from strutils import contains
-
 suite "EF - Light client - Single merkle proof" & preset():
   const presetPath = SszTestsDir/const_preset
   for kind, path in walkDir(presetPath, relative = true, checkDir = true):
@@ -62,9 +64,6 @@ suite "EF - Light client - Single merkle proof" & preset():
       continue
     let
       fork = forkForPathComponent(path).valueOr:
-        if path.contains("capella"):
-          # TODO forkForPathComponent relies on ForkedFoo
-          continue
         raiseAssert "Unknown test fork: " & testsPath
       basePath = testsPath/"pyspec_tests"
     for kind, path in walkDir(basePath, relative = true, checkDir = true):

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -207,6 +207,8 @@ suite "Gossip validation - Extra": # Not based on preset config
             of BeaconBlockFork.Bellatrix:
               const nilCallback = OnBellatrixBlockAdded(nil)
               dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+            of BeaconBlockFork.Capella:
+              raiseAssert $capellaImplementationMissing
           check: added.isOk()
           dag.updateHead(added[], quarantine[])
         dag

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -67,6 +67,8 @@ suite "Light client" & preset():
           of BeaconBlockFork.Bellatrix:
             const nilCallback = OnBellatrixBlockAdded(nil)
             dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+          of BeaconBlockFork.Capella:
+            raiseAssert $capellaImplementationMissing
         check: added.isOk()
         dag.updateHead(added[], quarantine)
 

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -52,6 +52,8 @@ suite "Light client processor" & preset():
         of BeaconBlockFork.Bellatrix:
           const nilCallback = OnBellatrixBlockAdded(nil)
           dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+        of BeaconBlockFork.Capella:
+          raiseAssert $capellaImplementationMissing
       doAssert added.isOk()
       dag.updateHead(added[], quarantine[])
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -138,7 +138,9 @@ proc addTestBlock*(
 
   let execution_payload =
     withState(state):
-      when stateFork >= BeaconStateFork.Bellatrix:
+      when stateFork >= BeaconStateFork.Capella:
+        raiseAssert $capellaImplementationMissing
+      elif stateFork >= BeaconStateFork.Bellatrix:
         # Merge shortly after Bellatrix
         if  forkyState.data.slot >
             cfg.BELLATRIX_FORK_EPOCH * SLOTS_PER_EPOCH + 10:

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -11,6 +11,7 @@ else:
   {.push raises: [].}
 
 import
+  chronicles,
   std/options,
   ./mocking/mock_deposits,
   ./helpers/math_helpers,


### PR DESCRIPTION
- a large no-op, essentially, the goal of which is from this point to allow safe, incremental Capella development/fleshing-out within the `unstable` branch
- general pattern was to flesh out `spec/forks` to its almost Capella-final form, but the rest to stub where feasible, to preserve the no-op aspect in a PR which already in an essentially minimal form adds 500 lines and changes 42 files
- `capellaImplementationMissing` serves both as a `grep` (`rg`, `ag`, etc) anchor, but also as a compile-time anchor. Once the `capellaImplementationMissing`s in an area of the codebase is complete, and it compiles without it, it implies that the Capella aspects should be done there
- where the data is under internal control, it does `raiseAssert $capellaImplementationMissing` to be as visible as possible, because after all, `checkForkConsistency()` ensures that `nimbus_beacon_node` can't run yet with a Capella network:
https://github.com/status-im/nimbus-eth2/blob/3ef09ff596b54b02c6d71bc0291999f6e6f93429/beacon_chain/spec/datatypes/base.nim#L955-L958

However, `beacon_chain/spec/eth2_apis/eth2_rest_serialization` has places where otherwise, this would allow random unauthenticated external input to crash Nimbus at will, obviously suboptimal -- therefore it returns as a more controlled parsing error, but still both greppable and dependent on this symbol that allows compile-time checking. When writing, it stays with the `raiseAssert`, because that is under internal control and if that happens, that's a logic error.

- There's a change between Nim 1.2 and 1.6 whereby
```nim
proc f() =
  raiseAssert "foo"
  echo "hello world"
```
changes from an error around the unreachable `echo` statement in Nim 1.2 to a warning. Therefore, in several places, for compatibility between Nim 1.2 and 1.6, this PR uses:
```nim
proc f() =
  if true: raiseAssert "foo"
  echo "hello world"
```