### PR TITLE
Sync committee subscription fixes.

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -73,7 +73,6 @@ type
   BlockServiceRef* = ref object of ClientServiceRef
 
   SyncCommitteeServiceRef* = ref object of ClientServiceRef
-    firstSubscription*: bool
 
   DoppelgangerServiceRef* = ref object of ClientServiceRef
     enabled*: bool

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -73,6 +73,7 @@ type
   BlockServiceRef* = ref object of ClientServiceRef
 
   SyncCommitteeServiceRef* = ref object of ClientServiceRef
+    firstSubscription*: bool
 
   DoppelgangerServiceRef* = ref object of ClientServiceRef
     enabled*: bool

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -425,10 +425,11 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef) {.async.} =
           res
 
       if len(subscriptions) > 0:
-        let res = await vc.prepareBeaconCommitteeSubnet(subscriptions,
-                                                        ApiStrategyKind.First)
-        if not(res):
-          error "Failed to subscribe validators"
+        let res = await vc.prepareBeaconCommitteeSubnet(subscriptions),
+        if res == 0:
+          error "Failed to subscribe validators to beacon committee subnets",
+                slot = currentSlot, epoch = currentEpoch,
+                subscriptions_count = len(subscriptions)
 
     vc.pruneAttesterDuties(currentEpoch)
 
@@ -470,10 +471,11 @@ proc pollForSyncCommitteeDuties* (vc: ValidatorClientRef) {.async.} =
                 res.add(sub)
           res
       if len(subscriptions) > 0:
-        let res = await vc.prepareSyncCommitteeSubnets(subscriptions,
-                                                       ApiStrategyKind.First)
-        if not(res):
-          error "Failed to subscribe validators"
+        let res = await vc.prepareSyncCommitteeSubnets(subscriptions)
+        if res != 0:
+          error "Failed to subscribe validators to sync committee subnets",
+                slot = currentSlot, epoch = currentEpoch,
+                subscriptions_count = len(subscriptions)
 
       vc.pruneSyncCommitteeDuties(currentSlot)
 

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -425,7 +425,7 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef) {.async.} =
           res
 
       if len(subscriptions) > 0:
-        let res = await vc.prepareBeaconCommitteeSubnet(subscriptions),
+        let res = await vc.prepareBeaconCommitteeSubnet(subscriptions)
         if res == 0:
           error "Failed to subscribe validators to beacon committee subnets",
                 slot = currentSlot, epoch = currentEpoch,

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -15,7 +15,6 @@ import
 
 const
   ServiceName = "sync_committee_service"
-  SUBSCRIPTION_LOOKAHEAD_EPOCHS = 4'u64
 
 logScope: service = ServiceName
 
@@ -360,51 +359,11 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
     debug "Producing contribution and proofs", delay = delay
   await service.produceAndPublishContributions(slot, beaconBlockRoot, duties)
 
-  # RestSyncCommitteeSubscription* = object
-  #   validator_index*: ValidatorIndex
-  #   sync_committee_indices*: seq[IndexInSyncCommittee]
-  #   until_epoch*: Epoch
-
-proc subscribeSyncCommitteeSubnets(service: SyncCommitteeServiceRef,
-                                   currentSlot: Slot) {.async.} =
-  let
-    vc = service.client
-    dutySlots =
-      block:
-        var res: seq[tuple[slot: Slot, period: SyncCommitteePeriod]]
-        let currentPeriod = sync_committee_period(currentSlot)
-        if service.firstSubscription or
-           currentSlot.since_epoch_start() == 0'u64:
-          res.add((currentSlot, currentPeriod))
-        let
-          lookAheadSlot = currentSlot +
-                      SUBSCRIPTION_LOOKAHEAD_EPOCHS * SLOTS_PER_EPOCH
-          lookAheadPeriod = sync_committee_period(lookAheadSlot)
-        if lookAheadPeriod > currentPeriod:
-          res.add((lookAheadSlot, lookAheadPeriod))
-        res
-    subscriptions =
-      block:
-        var res: seq[RestSyncCommitteeSubscription]
-        for (slot, period) in dutySlots.items():
-          let
-            untilEpoch = start_epoch(period + 1'u64)
-            duties = vc.getSyncCommitteeDutiesForSlot(slot)
-          for duty in duties:
-            res.add(RestSyncCommitteeSubscription(
-              validator_index: duty.validator_index
-              sync_committee_indices: duty.validator_sync_committee_indices
-              until_epoch: untilEpoch
-            ))
-        res
-
-
 proc spawnSyncCommitteeTasks(service: SyncCommitteeServiceRef, slot: Slot) =
   let
     vc = service.client
     duties = vc.getSyncCommitteeDutiesForSlot(slot + 1)
 
-  asyncSpawn service.subscribeSyncCommitteeSubnets(slot)
   asyncSpawn service.publishSyncMessagesAndContributions(slot, duties)
 
 proc mainLoop(service: SyncCommitteeServiceRef) {.async.} =
@@ -442,8 +401,7 @@ proc init*(t: typedesc[SyncCommitteeServiceRef],
            vc: ValidatorClientRef): Future[SyncCommitteeServiceRef] {.async.} =
   logScope: service = ServiceName
   let res = SyncCommitteeServiceRef(name: ServiceName, client: vc,
-                                    state: ServiceState.Initialized,
-                                    firstSubscription: true)
+                                    state: ServiceState.Initialized)
   debug "Initializing service"
   return res
 


### PR DESCRIPTION
* Optimize server `/eth/v1/validator/sync_committee_subscriptions` call. There is no need to create sequence.
* Fix `prepareBeaconCommitteeSubnet()` should be sent to all corresponding beacon nodes.
* Fix `prepareSyncCommitteeSubnets()` should  be sent to all corresponding beacon nodes.
* Show error response in log for calls.