### PR TITLE
set fee recipient in empty payload fallback

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -2,6 +2,7 @@ AllTests-mainnet
 ===
 ## Attestation pool processing [Preset: mainnet]
 ```diff
++ Attestation from different branch [Preset: mainnet]                                        OK
 + Attestations may arrive in any order [Preset: mainnet]                                     OK
 + Attestations may overlap, bigger first [Preset: mainnet]                                   OK
 + Attestations may overlap, smaller first [Preset: mainnet]                                  OK
@@ -14,7 +15,7 @@ AllTests-mainnet
 + Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 + Working with aggregates [Preset: mainnet]                                                  OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
+OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Backfill
 ```diff
 + Init without genesis / block                                                               OK
@@ -439,10 +440,11 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Spec helpers
 ```diff
++ build_empty_execution_payload                                                              OK
 + build_proof - BeaconState                                                                  OK
 + integer_squareroot                                                                         OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Specific field types
 ```diff
 + root update                                                                                OK
@@ -603,4 +605,4 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 332/337 Fail: 0/337 Skip: 5/337
+OK: 334/339 Fail: 0/339 Skip: 5/339

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -381,7 +381,8 @@ proc emptyPayloadToBlockHeader*(
   )
 
 func build_empty_execution_payload*(
-    state: bellatrix.BeaconState): bellatrix.ExecutionPayload =
+    state: bellatrix.BeaconState,
+    feeRecipient: Eth1Address): bellatrix.ExecutionPayload =
   ## Assuming a pre-state of the same slot, build a valid ExecutionPayload
   ## without any transactions.
   let
@@ -394,6 +395,7 @@ func build_empty_execution_payload*(
 
   var payload = bellatrix.ExecutionPayload(
     parent_hash: latest.block_hash,
+    fee_recipient: bellatrix.ExecutionAddress(data: distinctBase(feeRecipient)),
     state_root: latest.state_root, # no changes to the state
     receipts_root: EMPTY_ROOT_HASH,
     block_number: latest.block_number + 1,

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -69,6 +69,7 @@ suite "Spec helpers":
     const recipient1 = default(Eth1Address)
 
     var recipient2: Eth1Address
+    randomize(123)
     let p = cast[ptr UncheckedArray[byte]](addr recipient2)
     for i in 0 ..< sizeof(recipient2):
       p[i] = byte.rand()

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -8,13 +8,12 @@
 {.used.}
 
 import
-  # Standard library
-  std/random,
   # Status libraries
   stew/bitops2,
+  web3/ethtypes,
   # Beacon chain internals
   ../beacon_chain/spec/[forks, helpers, state_transition],
-  ../beacon_chain/spec/datatypes/bellatrix,
+  ../beacon_chain/eth1/eth1_monitor,
   # Test utilities
   ./unittest2, mocking/mock_genesis
 
@@ -67,20 +66,15 @@ suite "Spec helpers":
     cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
     cfg.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
 
-    const recipient1 = default(Eth1Address)
-
-    var recipient2: Eth1Address
-    randomize(123)
-    let p = cast[ptr UncheckedArray[byte]](addr recipient2)
-    for i in 0 ..< sizeof(recipient2):
-      p[i] = byte.rand()
-
+    const
+      rec1 = default(Eth1Address)
+      rec2 = Eth1Address.fromHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")
     let
       state = newClone(initGenesisState(cfg = cfg).bellatrixData)
-      payload1 = build_empty_execution_payload(state[].data, recipient1)
-      payload2 = build_empty_execution_payload(state[].data, recipient2)
+      payload1 = build_empty_execution_payload(state[].data, rec1)
+      payload2 = build_empty_execution_payload(state[].data, rec2)
     check:
       payload1.fee_recipient ==
-        bellatrix.ExecutionAddress(data: distinctBase(recipient1))
+        bellatrix.ExecutionAddress(data: distinctBase(rec1))
       payload2.fee_recipient ==
-        bellatrix.ExecutionAddress(data: distinctBase(recipient2))
+        bellatrix.ExecutionAddress(data: distinctBase(rec2))

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -66,15 +66,13 @@ suite "Spec helpers":
     cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
     cfg.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
 
-    const
-      rec1 = default(Eth1Address)
-      rec2 = Eth1Address.fromHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")
-    let
-      state = newClone(initGenesisState(cfg = cfg).bellatrixData)
-      payload1 = build_empty_execution_payload(state[].data, rec1)
-      payload2 = build_empty_execution_payload(state[].data, rec2)
-    check:
-      payload1.fee_recipient ==
-        bellatrix.ExecutionAddress(data: distinctBase(rec1))
-      payload2.fee_recipient ==
-        bellatrix.ExecutionAddress(data: distinctBase(rec2))
+    let state = newClone(initGenesisState(cfg = cfg).bellatrixData)
+
+    template testCase(recipient: Eth1Address): untyped =
+      block:
+        let payload = build_empty_execution_payload(state[].data, recipient)
+        check payload.fee_recipient ==
+          bellatrix.ExecutionAddress(data: distinctBase(recipient))
+
+    testCase default(Eth1Address)
+    testCase Eth1Address.fromHex("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -14,6 +14,7 @@ import
   stew/bitops2,
   # Beacon chain internals
   ../beacon_chain/spec/[forks, helpers, state_transition],
+  ../beacon_chain/spec/datatypes/bellatrix,
   # Test utilities
   ./unittest2, mocking/mock_genesis
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -145,7 +145,8 @@ proc addTestBlock*(
         if  forkyState.data.slot >
             cfg.BELLATRIX_FORK_EPOCH * SLOTS_PER_EPOCH + 10:
           if is_merge_transition_complete(forkyState.data):
-            build_empty_execution_payload(forkyState.data)
+            const feeRecipient = default(Eth1Address)
+            build_empty_execution_payload(forkyState.data, feeRecipient)
           else:
             build_empty_merge_execution_payload(forkyState.data)
         else:


### PR DESCRIPTION
When the EL/Builder fails to produce an execution payload, we fall back to an empty `ExecutionPayload`. Even though it contains no transactions it should refer to the configured fee recipient. This is useful for privacy reasons (do not reveal the reason for the empty payload) and for compliance with additional fee recipient rules by staking pools.