### PR TITLE
Fix VC-based sync subnet subscriptions

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -58,7 +58,6 @@ type
     onContributionReceived*: OnSyncContributionCallback
 
     rng: ref HmacDrbgContext
-    syncCommitteeSubscriptions*: Table[ValidatorPubKey, Epoch]
 
 func hash*(x: SyncCommitteeMsgKey): Hash =
   hashAllFields(x)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -683,8 +683,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         getStateField(node.dag.headState, validators).item(
           item.validator_index).pubkey
 
-      node.syncCommitteeMsgPool
-            .syncCommitteeSubscriptions[validator_pubkey] = item.until_epoch
+      node.consensusManager[].actionTracker.registerSyncDuty(
+        validator_pubkey, item.until_epoch)
 
       node.validatorMonitor[].addAutoMonitor(
         validator_pubkey, ValidatorIndex(item.validator_index))

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -53,3 +53,39 @@ suite "subnet tracker":
     check:
       tracker.stabilitySubnets(Slot(0)).countOnes() == 0
       tracker.aggregateSubnets(Slot(0)).countOnes() == 0
+
+  test "should register sync committee duties":
+    var
+      tracker = ActionTracker.init(rng, false)
+      pk0 = ValidatorPubKey.fromHex("0xb4102a1f6c80e5c596a974ebd930c9f809c3587dc4d1d3634b77ff66db71e376dbc86c3252c6d140ce031f4ec6167798").get()
+      pk1 = ValidatorPubKey.fromHex("0xa00d2954717425ce047e0928e5f4ec7c0e3bbe1058db511303fd659770ddace686ee2e22ac180422e516f4c503eb2228").get()
+
+    check:
+      not tracker.hasSyncDuty(pk0, Epoch(1024))
+
+    tracker.lastSyncUpdate = Opt.some(SyncCommitteePeriod(42))
+    tracker.registerSyncDuty(pk0, Epoch(1024))
+    check:
+      tracker.lastSyncUpdate.isNone()
+      not tracker.hasSyncDuty(pk0, Epoch(1024))
+      not tracker.hasSyncDuty(pk1, Epoch(1023))
+      tracker.hasSyncDuty(pk0, Epoch(1023))
+
+    tracker.registerSyncDuty(pk0, Epoch(1022))
+
+    check: # Should not overwrite longer duties
+      tracker.hasSyncDuty(pk0, Epoch(1023))
+
+    tracker.registerSyncDuty(pk0, Epoch(1025))
+    check: # Should update existing duties
+      tracker.hasSyncDuty(pk0, Epoch(1024))
+
+    tracker.updateSlot(Epoch(1025).start_slot)
+
+    check: # should prune old duties on updateSlot
+      not tracker.hasSyncDuty(pk0, Epoch(1024))
+
+    tracker.registerSyncDuty(pk0, Epoch(1025))
+
+    check: # should not add old duties
+      not tracker.hasSyncDuty(pk0, Epoch(1024))


### PR DESCRIPTION
* move duty tracking code to `ActionTracker`
* fix earlier duties overwriting later ones
* re-run subnet selection when new duty appears
* log upcoming duties as soon as they're known (vs 4 epochs before)