### PR TITLE
use mainnet as default config

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -258,8 +258,27 @@ proc getMetadataForNetwork*(
 
   metadata
 
+
 proc getRuntimeConfig*(
     eth2Network: Option[string]): RuntimeConfig {.raises: [Defect, IOError].} =
+  ## Returns the run-time config for a network specified on the command line
+  ## If the network is not explicitly specified, the function will act as the
+  ## regular Nimbus binary, returning the mainnet config.
+  ##
+  ## TODO the assumption that the input variable is a CLI config option is not
+  ## quite appropriate in such as low-level function. The "assume mainnet by
+  ## default" behavior is something that should be handled closer to the `conf`
+  ## layer.
   if eth2Network.isSome:
     return getMetadataForNetwork(eth2Network.get).cfg
-  defaultRuntimeConfig
+
+  when const_preset == "mainnet":
+    when defined(gnosisChainBinary):
+      gnosisMetadata.cfg
+    else:
+      mainnetMetadata.cfg
+  else:
+    # This is a non-standard build (i.e. minimal), and the function was most
+    # likely executed in a test. The best we can do is return a fully default
+    # config:
+    defaultRuntimeConfig


### PR DESCRIPTION
Without this, tools like `ncli_db` require command line parameter to process mainnet blocks, which is a regression since the merge - this is a subset of #4147.