### PR TITLE
Support for obtaining deposit snapshots during trustedNodeSync

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,8 @@ root = true
 [*.nim]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = false
 
 [*.sh]
 indent_style = space
@@ -11,4 +13,3 @@ indent_size = 2
 [Makefile]
 ident_size = 2
 ident_style = tab
-

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -120,6 +120,14 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
+## DepositTreeSnapshot
+```diff
++ Migration                                                                                  OK
++ SSZ                                                                                        OK
++ depositCount                                                                               OK
++ isValid                                                                                    OK
+```
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Discovery fork ID
 ```diff
 + Expected fork IDs                                                                          OK
@@ -615,4 +623,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 340/345 Fail: 0/345 Skip: 5/345
+OK: 344/349 Fail: 0/349 Skip: 5/349

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -784,6 +784,11 @@ type
         desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
         defaultValue: false .}: bool
 
+      downloadDepositSnapshot* {.
+        desc: "Also try to download a snapshot of the deposit contract state"
+        defaultValue: false
+        name: "with-deposit-snapshot" .}: bool
+
   ValidatorClientConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -73,7 +73,7 @@ type
 
   ChainDAGRef* = ref object
     ## ChainDAG validates, stores and serves chain history of valid blocks
-    ## according to the beacon chain state transtion. From genesis to the
+    ## according to the beacon chain state transition. From genesis to the
     ## finalization point, block history is linear - from there, it branches out
     ## into a dag with several heads, one of which is considered canonical.
     ##
@@ -112,7 +112,7 @@ type
     ##          |         |               |
     ##          db.finalizedBlocks        dag.forkBlocks
     ##
-    ## The archive is the the part of finalized history for which we no longer
+    ## The archive is the part of finalized history for which we no longer
     ## recreate states quickly because we don't have a reasonable state to
     ## start replay from - when starting from a checkpoint, this is the typical
     ## case - recreating history requires either replaying from genesis or

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -90,8 +90,12 @@ programMain:
     eth1Monitor =
       if config.web3Urls.len > 0:
         let res = Eth1Monitor.init(
-          cfg, db = nil, getBeaconTime, config.web3Urls,
-          none(DepositContractSnapshot), metadata.eth1Network,
+          cfg,
+          metadata.depositContractDeployedAt,
+          db = nil,
+          getBeaconTime,
+          config.web3Urls,
+          metadata.eth1Network,
           forcePolling = false,
           rng[].loadJwtSecret(config, allowCreate = false),
           # TTD is not relevant for the light client, so it's safe

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -178,6 +178,8 @@ const
     "Unable to produce contribution using the passed parameters"
   InternalServerError* =
     "Internal server error"
+  NoFinalizedSnapshotAvailableError* =
+    "No Finalized Snapshot Available"
   NoImplementationError* =
     "Not implemented yet"
   KeystoreAdditionFailure =

--- a/beacon_chain/spec/deposit_snapshots.nim
+++ b/beacon_chain/spec/deposit_snapshots.nim
@@ -1,0 +1,54 @@
+from std/sequtils import all
+from stew/objects import isZeroMemory
+
+import ./eth2_merkleization
+from ./datatypes/base import Eth1Data, DepositContractState
+from ./digest import Eth2Digest
+
+export
+  depositCountBytes, depositCountU64
+
+type
+  OldDepositContractSnapshot* = object
+    eth1Block*: Eth2Digest
+    depositContractState*: DepositContractState
+
+  DepositTreeSnapshot* = object
+    ## https://eips.ethereum.org/EIPS/eip-4881
+    eth1Block*: Eth2Digest
+    depositContractState*: DepositContractState
+    blockHeight*: uint64
+
+func toDepositTreeSnapshot*(d: OldDepositContractSnapshot,
+                            blockHeight: uint64): DepositTreeSnapshot =
+  DepositTreeSnapshot(
+    eth1Block: d.eth1Block,
+    depositContractState: d.depositContractState,
+    blockHeight: blockHeight)
+
+func toOldDepositContractSnapshot*(d: DepositTreeSnapshot): OldDepositContractSnapshot =
+  OldDepositContractSnapshot(eth1Block: d.eth1Block,
+                             depositContractState: d.depositContractState)
+
+template getDepositCountU64*(d: OldDepositContractSnapshot |
+                                DepositTreeSnapshot): uint64 =
+  depositCountU64(d.depositContractState.deposit_count)
+
+func getDepositRoot*(d: OldDepositContractSnapshot |
+                        DepositTreeSnapshot): Eth2Digest =
+  let merk = DepositsMerkleizer.init(d.depositContractState)
+  let hash = merk.getFinalHash()
+  # TODO: mixInLength should accept unsigned int instead of int as
+  # this right now cuts in half the theoretical number of deposits.
+  return mixInLength(hash, int(merk.totalChunks))
+
+func isValid*(d: DepositTreeSnapshot, wantedDepositRoot: Eth2Digest): bool =
+  ## `isValid` requires the snapshot to be self-consistent and
+  ## to point to a specific Ethereum block
+  return not (d.eth1Block.isZeroMemory or
+              d.blockHeight == 0 or
+              d.getDepositRoot() != wantedDepositRoot)
+
+func matches*(snapshot: DepositTreeSnapshot, eth1_data: Eth1Data): bool =
+  snapshot.getDepositCountU64() == eth1_data.deposit_count and
+  snapshot.getDepositRoot() == eth1_data.deposit_root

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -273,3 +273,8 @@ proc submitPoolVoluntaryExit*(body: SignedVoluntaryExit): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/pool/voluntary_exits",
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolVoluntaryExit
+
+proc getDepositSnapshot*(): RestResponse[GetDepositSnapshotResponse] {.
+     rest, endpoint: "/eth/v1/beacon/deposit_snapshot",
+     meth: MethodGet.}
+  ## https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4881.md

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -439,6 +439,13 @@ type
     chain_id*: string
     address*: string
 
+  RestDepositSnapshot* = object
+    finalized*: array[DEPOSIT_CONTRACT_TREE_DEPTH, Eth2Digest]
+    deposit_root*: Eth2Digest
+    deposit_count*: uint64
+    execution_block_hash*: Eth2Digest
+    execution_block_height*: uint64
+
   RestBlockInfo* = object
     slot*: Slot
     blck* {.serializedFieldName: "block".}: Eth2Digest
@@ -581,6 +588,7 @@ type
   GetBlockRootResponse* = DataEnclosedObject[RestRoot]
   GetDebugChainHeadsResponse* = DataEnclosedObject[seq[RestChainHead]]
   GetDepositContractResponse* = DataEnclosedObject[RestDepositContract]
+  GetDepositSnapshotResponse* = DataEnclosedObject[RestDepositSnapshot]
   GetEpochCommitteesResponse* = DataEnclosedObject[seq[RestBeaconStatesCommittees]]
   GetForkScheduleResponse* = DataEnclosedObject[seq[Fork]]
   GetGenesisResponse* = DataEnclosedObject[RestGenesis]

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -254,7 +254,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
        blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
        replay = true):
   let
-    (genesisState, depositContractSnapshot) = loadGenesis(validators, false)
+    (genesisState, depositTreeSnapshot) = loadGenesis(validators, false)
     genesisTime = float getStateField(genesisState[], genesis_time)
 
   var
@@ -270,13 +270,13 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
   defer: db.close()
 
   ChainDAGRef.preInit(db, genesisState[])
-  putInitialDepositContractSnapshot(db, depositContractSnapshot)
+  db.putDepositTreeSnapshot(depositTreeSnapshot)
 
   var
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
     eth1Chain = Eth1Chain.init(cfg, db)
-    merkleizer = DepositsMerkleizer.init(depositContractSnapshot.depositContractState)
+    merkleizer = DepositsMerkleizer.init(depositTreeSnapshot.depositContractState)
     taskpool = Taskpool.new()
     verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
     quarantine = newClone(Quarantine.init())

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -96,7 +96,7 @@ RUN_GETH="0"
 DL_GETH="0"
 DL_ETH2="0"
 BEACON_NODE_COMMAND="./build/nimbus_beacon_node"
-
+WEB3_ARG=()
 CLEANUP_DIRS=()
 
 #NIMBUS EL VARS
@@ -737,7 +737,7 @@ else
   ganache-cli --blockTime 17 --gasLimit 100000000 -e 100000 --verbose > "${DATA_DIR}/log_ganache.txt" 2>&1 &
   PIDS="${PIDS},$!"
 
-  WEB3_ARG="--web3-url=ws://localhost:8545"
+  WEB3_ARG=("--web3-url=ws://localhost:8545")
 
   echo "Deploying deposit contract"
   DEPLOY_CMD_OUTPUT=$(./build/deposit_contract deploy $WEB3_ARG)
@@ -756,7 +756,7 @@ else
   ./build/deposit_contract sendDeposits \
     --deposits-file="${DEPOSITS_FILE}" \
     --min-delay=$MIN_DELAY --max-delay=$MAX_DELAY \
-    $WEB3_ARG \
+    "${WEB3_ARG[@]}" \
     --deposit-contract=${DEPOSIT_CONTRACT_ADDRESS} > "${DATA_DIR}/log_deposit_maker.txt" 2>&1 &
 
   PIDS="${PIDS},$!"

--- a/scripts/test_merge_node.nim
+++ b/scripts/test_merge_node.nim
@@ -58,7 +58,7 @@ proc run() {.async.} =
   let
     eth1Monitor = Eth1Monitor.init(
       defaultRuntimeConfig, db = nil, nil, @[paramStr(1)],
-      none(DepositContractSnapshot), none(Eth1Network), false,
+      none(DepositTreeSnapshot), none(Eth1Network), false,
       some readJwtSecret(paramStr(2)).get)
 
   await eth1Monitor.ensureDataProvider()

--- a/scripts/test_merge_vectors.nim
+++ b/scripts/test_merge_vectors.nim
@@ -60,7 +60,7 @@ proc run() {.async.} =
     jwtSecret = some readJwtSecret("jwt.hex").get
     eth1Monitor = Eth1Monitor.init(
       defaultRuntimeConfig, db = nil, nil, @[web3Url],
-      none(DepositContractSnapshot), none(Eth1Network),
+      none(DepositTreeSnapshot), none(Eth1Network),
       false, jwtSecret)
     web3Provider = (await Web3DataProvider.new(
       default(Eth1Address), web3Url, jwtSecret)).get

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -43,6 +43,7 @@ import # Unit test
   ./test_key_splitting,
   ./test_remote_keystore,
   ./test_serialization,
+  ./test_deposit_snapshots,
   ./fork_choice/tests_fork_choice,
   ./consensus_spec/all_tests as consensus_all_tests,
   ./slashing_protection/test_fixtures,

--- a/tests/test_deposit_snapshots.nim
+++ b/tests/test_deposit_snapshots.nim
@@ -1,0 +1,186 @@
+{.used.}
+
+import
+  std/[os, random, strutils, times],
+  chronos, stew/results, unittest2, chronicles,
+  ../../beacon_chain/beacon_chain_db,
+  ../../beacon_chain/spec/deposit_snapshots
+
+from eth/db/kvstore import kvStore
+from nimcrypto import toDigest
+from snappy import encode
+from stew/byteutils import hexToSeqByte
+
+const ROOT = "342cecb5a18945fbbda7c62ede3016f3"
+
+template databaseRoot: string = getTempDir().joinPath(ROOT)
+template key1: array[1, byte] = [byte(kOldDepositContractSnapshot)]
+template key2: array[1, byte] = [byte(kDepositTreeSnapshot)]
+
+type
+  DepositSnapshotUpgradeProc = proc(old: OldDepositContractSnapshot): DepositTreeSnapshot
+                                   {.gcsafe, raises: [Defect].}
+
+proc ifNecessaryMigrateDCS(db: BeaconChainDB,
+                           upgradeProc: DepositSnapshotUpgradeProc) =
+  if not db.hasDepositTreeSnapshot():
+    let oldSnapshot = db.getUpgradableDepositSnapshot()
+    if oldSnapshot.isSome:
+      db.putDepositTreeSnapshot upgradeProc(oldSnapshot.get)
+
+# Hexlified copy of
+# eth2-networks/shared/mainnet/genesis_deposit_contract_snapshot.ssz
+let ds1: seq[byte] = hexToSeqByte(
+  """
+  eeea1373d4aa9e099d7c9deddb694db9aeb4577755ef83f9b6345ce4357d9abfca3bfce2c
+  304c4f52e0c83f96daf8c98a05f80281b62cf08f6be9c1bc10c0adbabcf2f74605a9eb36c
+  f243bb5009259a3717d44df3caf02acc53ab49cfd2eeb6d4079d31e57638b3a6928ff3940
+  d0d06545ae164278597bb8d46053084c335eaf9585ef52fc5eaf1f11718df7988d3f414d8
+  b0be2e56e15d7ade9f5ee4cc7ee4a4c96f16c3a300034788ba8bf79c3125a697488006a4a
+  4288c38fdc4e9891891cae036d14b83ff1523749d4fabf5c91e8d455dce2f14eae3408dce
+  22f901efc7858ccad1a32af9e9796d3026ba18925103cad44cba4bdc1f3d3c23be125bba1
+  811f1e08405d5d180444147397ea0d4aebf12edff5cebc52cb05983c8d4bd2d4a93d66676
+  459ab2c5ca9d553a5c5599cc6992ed90edc939c51cc99d1820b5691914bfcab6eb8016c51
+  77e9e8f006e7893ea46b232b91b1f923b05273a927cd6d0aa14720bc149ce68f20809d6fe
+  55816acf09e72c14b54637dea24eb961558a7ac726d03ced287a817fa8fea71c90bd89955
+  b093d7c5908305177efa8289457190435298b2d5b2b67543e4dceaf2c8b7fdbdac12836a7
+  0ed910c34abcd10b3ddf53f640c85e35fef7e7ba4ab8c561fe9f1d763a32c65a1fbad5756
+  6bda135236257aa502116cb72c9347d10dca1b64a342b41a829cc7ba95e71499f57be2be3
+  cd00000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  0000000000000000000000000000000000000000000000000000000000000000000000000
+  00000000000000000000000000000000000000000000000000000005251
+  """.replace(" ", "").replace("\n", "")
+)
+
+const
+  ds1Root = toDigest("1a4c3cce02935defd159e4e207890ae26a325bf03e205c9ee94ca040ecce008a")
+
+proc fixture1() =
+  ## Inserts a OldDepositContractSnapshot fixture.
+  let
+    compressed = snappy.encode(ds1)
+    db = SqStoreRef.init(databaseRoot, "nbc").expect("")
+    kv = kvStore(db.openKvStore("key_values", true).expect(""))
+  kv.put(key1, compressed).expect("")
+  db.close()
+
+proc inspectDCS(snapshot: OldDepositContractSnapshot | DepositTreeSnapshot) =
+  ## Inspects a DCS and checks if all of its data corresponds to
+  ## what's encoded in ds1.
+  const zero = toDigest("0000000000000000000000000000000000000000000000000000000000000000")
+  const root = toDigest("1a4c3cce02935defd159e4e207890ae26a325bf03e205c9ee94ca040ecce008a")
+  const want = [
+    "ca3bfce2c304c4f52e0c83f96daf8c98a05f80281b62cf08f6be9c1bc10c0adb",
+    "abcf2f74605a9eb36cf243bb5009259a3717d44df3caf02acc53ab49cfd2eeb6",
+    "d4079d31e57638b3a6928ff3940d0d06545ae164278597bb8d46053084c335ea",
+    "f9585ef52fc5eaf1f11718df7988d3f414d8b0be2e56e15d7ade9f5ee4cc7ee4",
+    "a4c96f16c3a300034788ba8bf79c3125a697488006a4a4288c38fdc4e9891891",
+    "cae036d14b83ff1523749d4fabf5c91e8d455dce2f14eae3408dce22f901efc7",
+    "858ccad1a32af9e9796d3026ba18925103cad44cba4bdc1f3d3c23be125bba18",
+    "11f1e08405d5d180444147397ea0d4aebf12edff5cebc52cb05983c8d4bd2d4a",
+    "93d66676459ab2c5ca9d553a5c5599cc6992ed90edc939c51cc99d1820b56919",
+    "14bfcab6eb8016c5177e9e8f006e7893ea46b232b91b1f923b05273a927cd6d0",
+    "aa14720bc149ce68f20809d6fe55816acf09e72c14b54637dea24eb961558a7a",
+    "c726d03ced287a817fa8fea71c90bd89955b093d7c5908305177efa828945719",
+    "0435298b2d5b2b67543e4dceaf2c8b7fdbdac12836a70ed910c34abcd10b3ddf",
+    "53f640c85e35fef7e7ba4ab8c561fe9f1d763a32c65a1fbad57566bda1352362",
+    "57aa502116cb72c9347d10dca1b64a342b41a829cc7ba95e71499f57be2be3cd",
+  ]
+  # Check eth1Block.
+  check($snapshot.eth1Block == "eeea1373d4aa9e099d7c9deddb694db9aeb4577755ef83f9b6345ce4357d9abf")
+  # Check branch.
+  for i in 0..want.high():
+    check($snapshot.depositContractState.branch[i] == want[i])
+  for i in (want.high() + 1)..31:
+    check(snapshot.depositContractState.branch[i] == zero)
+  # Check deposit_count.
+  check(snapshot.getDepositCountU64() == 21073)
+  # Check deposit root.
+  check(snapshot.getDepositRoot == root)
+
+proc inspectDCS(snapshot: DepositTreeSnapshot, wantedBlockHeight: uint64) =
+  inspectDCS(snapshot)
+  check(snapshot.blockHeight == wantedBlockHeight)
+
+suite "DepositTreeSnapshot":
+  setup:
+    randomize()
+
+  teardown:
+    # removeDir(databaseRoot)
+    discard
+
+  test "SSZ":
+    var snapshot = OldDepositContractSnapshot()
+    check(decodeSSZ(ds1, snapshot))
+    inspectDCS(snapshot)
+
+  test "Migration":
+    # Start with a fresh database.
+    removeDir(databaseRoot)
+    createDir(databaseRoot)
+    # Make sure there's no DepositTreeSnapshot yet.
+    let db = BeaconChainDB.new(databaseRoot, inMemory=false)
+    check(db.getDepositTreeSnapshot().isErr())
+    # Setup fixture.
+    fixture1()
+    # Make sure there's still no DepositTreeSnapshot as
+    # BeaconChainDB::getDepositTreeSnapshot() checks only for DCSv2.
+    check(db.getDepositTreeSnapshot().isErr())
+    # Migrate DB.
+    db.ifNecessaryMigrateDCS do (d: OldDepositContractSnapshot) -> DepositTreeSnapshot:
+      d.toDepositTreeSnapshot(11052984)
+    # Make sure now there actually is a snapshot.
+    check(db.getDepositTreeSnapshot().isOk())
+    # Inspect content.
+    let snapshot = db.getDepositTreeSnapshot().expect("")
+    inspectDCS(snapshot, 11052984)
+
+  test "depositCount":
+    let now = getTime()
+    var rand = initRand(12345678)
+    for i in 1..1000:
+      let n = rand.next()
+      let m = n mod 4294967296'u64
+      check(depositCountU64(depositCountBytes(m)) == m)
+
+  test "isValid":
+    const ZERO = toDigest("0000000000000000000000000000000000000000000000000000000000000000")
+    # Use our hard-coded ds1 as a model.
+    var model: OldDepositContractSnapshot
+    check(decodeSSZ(ds1, model))
+    # Check blockHeight.
+    var dcs = model.toDepositTreeSnapshot(0)
+    check(not dcs.isValid(ds1Root))
+    dcs.blockHeight = 11052984
+    check(dcs.isValid(ds1Root))
+    # Check eth1Block.
+    dcs.eth1Block = ZERO
+    check(not dcs.isValid(ds1Root))
+    dcs.eth1Block = model.eth1Block
+    check(dcs.isValid(ds1Root))
+    # Check branch.
+    for i in 0..len(dcs.depositContractState.branch)-1:
+      dcs.depositContractState.branch[i] = ZERO
+    check(not dcs.isValid(ds1Root))
+    dcs.depositContractState.branch = model.depositContractState.branch
+    check(dcs.isValid(ds1Root))
+    # Check deposit count.
+    for i in 0..len(dcs.depositContractState.deposit_count)-1:
+      dcs.depositContractState.deposit_count[i] = 0
+    check(not dcs.isValid(ds1Root))
+    dcs.depositContractState.deposit_count = model.depositContractState.deposit_count
+    check(dcs.isValid(ds1Root))

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -283,17 +283,9 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   except Exception as exc: # TODO fix confutils exceptions
     raiseAssert exc.msg
 
-  let metadata = loadEth2NetworkMetadata(dataDir)
-
-  let node = BeaconNode.init(
-    metadata.cfg,
-    rng,
-    runNodeConf,
-    metadata.depositContractDeployedAt,
-    metadata.eth1Network,
-    metadata.genesisData,
-    metadata.genesisDepositsSnapshot
-  )
+  let
+    metadata = loadEth2NetworkMetadata(dataDir)
+    node = BeaconNode.init(rng, runNodeConf, metadata)
 
   node.start() # This will run until the node is terminated by
                #  setting its `bnStatus` to `Stopping`.


### PR DESCRIPTION
Other changes:

* More optimal search for TTD block.

* Add timeouts to all REST requests during trusted node sync. Fixes #4037

* Removed support for storing a deposit snapshot in the network metadata.