### PR TITLE
remove unused `sync_queue` types

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -77,8 +77,7 @@ type
     stamp*: chronos.Moment
     slots*: uint64
 
-  SyncManagerError* = object of CatchableError
-  BeaconBlocksRes* = NetRes[List[ref ForkedSignedBeaconBlock, MAX_REQUEST_BLOCKS]]
+  BeaconBlocksRes = NetRes[List[ref ForkedSignedBeaconBlock, MAX_REQUEST_BLOCKS]]
 
 proc now*(sm: typedesc[SyncMoment], slots: uint64): SyncMoment {.inline.} =
   SyncMoment(stamp: now(chronos.Moment), slots: slots)

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -79,9 +79,6 @@ type
     blockVerifier: BlockVerifier
     ident*: string
 
-  SyncManagerError* = object of CatchableError
-  BeaconBlocksRes* = NetRes[seq[ref ForkedSignedBeaconBlock]]
-
 chronicles.formatIt SyncQueueKind: toLowerAscii($it)
 
 template shortLog*[T](req: SyncRequest[T]): string =


### PR DESCRIPTION
`SyncManagerError` and `sync_queue.BeaconBlocksRes` are unused and can be removed for cleanup (verified with `{.deprecated.}`).