### PR TITLE
rename `PeerScoreXyzBlocks` -> `PeerScoreXyzValues`

### DIFF
--- a/beacon_chain/networking/peer_scores.nim
+++ b/beacon_chain/networking/peer_scores.nim
@@ -28,15 +28,15 @@ const
     ## Peer's latest head is lower then ours.
   PeerScoreGoodStatus* = 50
     ## Peer's `status` answer is fine.
-  PeerScoreNoBlocks* = -100
+  PeerScoreNoValues* = -100
     ## Peer did not respond in time to a request.
-  PeerScoreGoodBlocks* = 100
+  PeerScoreGoodValues* = 100
     ## Peer's answer to our request is fine.
-  PeerScoreBadBlocks* = -1000
+  PeerScoreBadValues* = -1000
     ## Peer's response contains incorrect data.
   PeerScoreBadResponse* = -1000
     ## Peer's response is not in requested range.
-  PeerScoreMissingBlocks* = -25
+  PeerScoreMissingValues* = -25
     ## Peer response contains too much missing data - this can happen either
     ## because a long reorg happened or the peer is falsely trying to convince
     ## us that a long reorg happened.

--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -245,29 +245,29 @@ proc workerTask[E](
             # Descore, received data is malformed
             warn "Received invalid value", value = val.shortLog,
               endpoint = E.name, peer, peer_score = peer.getScore()
-            peer.updateScore(PeerScoreBadBlocks)
+            peer.updateScore(PeerScoreBadValues)
             return didProgress
         else:
           # Reward, peer returned something useful
           applyReward = true
           didProgress = true
       if applyReward:
-        peer.updateScore(PeerScoreGoodBlocks)
+        peer.updateScore(PeerScoreGoodValues)
     else:
-      peer.updateScore(PeerScoreNoBlocks)
+      peer.updateScore(PeerScoreNoValues)
       debug "Failed to receive value on request", value,
         endpoint = E.name, peer, peer_score = peer.getScore()
   except ResponseError as exc:
     warn "Received invalid response", error = exc.msg,
       endpoint = E.name, peer, peer_score = peer.getScore()
-    peer.updateScore(PeerScoreBadBlocks)
+    peer.updateScore(PeerScoreBadValues)
   except CancelledError as exc:
     raise exc
   except PeerPoolError as exc:
     debug "Failed to acquire peer", exc = exc.msg
   except CatchableError as exc:
     if peer != nil:
-      peer.updateScore(PeerScoreNoBlocks)
+      peer.updateScore(PeerScoreNoValues)
       debug "Unexpected exception while receiving value", exc = exc.msg,
         endpoint = E.name, peer, peer_score = peer.getScore()
     raise exc

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -110,7 +110,7 @@ proc fetchAncestorBlocksFromNetwork(rman: RequestManager,
               notice "Received invalid block",
                 peer = peer, blocks = shortLog(items),
                 peer_score = peer.getScore()
-              peer.updateScore(PeerScoreBadBlocks)
+              peer.updateScore(PeerScoreBadValues)
 
               return # Stop processing this junk...
           else:
@@ -123,17 +123,17 @@ proc fetchAncestorBlocksFromNetwork(rman: RequestManager,
           peer.updateScore(PeerScoreUnviableFork)
         elif gotGoodBlock:
           # We reward peer only if it returns something.
-          peer.updateScore(PeerScoreGoodBlocks)
+          peer.updateScore(PeerScoreGoodValues)
 
       else:
         peer.updateScore(PeerScoreBadResponse)
     else:
-      peer.updateScore(PeerScoreNoBlocks)
+      peer.updateScore(PeerScoreNoValues)
 
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    peer.updateScore(PeerScoreNoBlocks)
+    peer.updateScore(PeerScoreNoValues)
     debug "Error while fetching ancestor blocks", exc = exc.msg,
           items = shortLog(items), peer = peer, peer_score = peer.getScore()
     raise exc

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -351,7 +351,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
         # However, we include the `backfill` slot in backward sync requests.
         # If we receive an empty response to a request covering that slot,
         # we know that the response is incomplete and can descore.
-        peer.updateScore(PeerScoreNoBlocks)
+        peer.updateScore(PeerScoreNoValues)
         man.queue.push(req)
         debug "Response does not include known-to-exist block", request = req
         return
@@ -361,7 +361,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       await man.queue.push(req, data, proc() =
         man.workers[index].status = SyncWorkerStatus.Processing)
     else:
-      peer.updateScore(PeerScoreNoBlocks)
+      peer.updateScore(PeerScoreNoValues)
       man.queue.push(req)
       debug "Failed to receive blocks on request", request = req
       return

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -694,7 +694,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
           notice "Received invalid sequence of blocks", request = req,
                   blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data)
-          req.item.updateScore(PeerScoreBadBlocks)
+          req.item.updateScore(PeerScoreBadValues)
           break
 
     # When errors happen while processing blocks, we retry the same request
@@ -708,12 +708,12 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
       if goodBlock.isSome():
         # If there no error and response was not empty we should reward peer
         # with some bonus score - not for duplicate blocks though.
-        item.request.item.updateScore(PeerScoreGoodBlocks)
+        item.request.item.updateScore(PeerScoreGoodValues)
         item.request.item.updateStats(SyncResponseKind.Good, 1'u64)
 
         # BlockProcessor reports good block, so we can reward all the peers
         # who sent us empty responses.
-        sq.rewardForGaps(PeerScoreGoodBlocks)
+        sq.rewardForGaps(PeerScoreGoodValues)
         sq.gapList.reset()
       else:
         # Response was empty
@@ -757,7 +757,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
           gapsCount = len(sq.gapList)
 
         # We should penalize all the peers which responded with gaps.
-        sq.rewardForGaps(PeerScoreMissingBlocks)
+        sq.rewardForGaps(PeerScoreMissingValues)
         sq.gapList.reset()
 
         case sq.kind
@@ -772,7 +772,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
                   blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data),
                   gaps_count = gapsCount
-            req.item.updateScore(PeerScoreMissingBlocks)
+            req.item.updateScore(PeerScoreMissingValues)
           else:
             if safeSlot < req.slot:
               let rewindSlot = sq.getRewindPoint(failSlot, safeSlot)
@@ -789,7 +789,7 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
                   blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data),
                   gaps_count = gapsCount
-              req.item.updateScore(PeerScoreBadBlocks)
+              req.item.updateScore(PeerScoreBadValues)
         of SyncQueueKind.Backward:
           if safeSlot > failSlot:
             let rewindSlot = sq.getRewindPoint(failSlot, safeSlot)
@@ -799,12 +799,12 @@ proc push*[T](sq: SyncQueue[T], sr: SyncRequest[T],
                  finalized_slot = safeSlot, blocks_count = len(item.data),
                  blocks_map = getShortMap(req, item.data)
             resetSlot = some(rewindSlot)
-            req.item.updateScore(PeerScoreMissingBlocks)
+            req.item.updateScore(PeerScoreMissingValues)
           else:
             error "Unexpected missing parent at safe slot", request = req,
                   to_slot = safeSlot, blocks_count = len(item.data),
                   blocks_map = getShortMap(req, item.data)
-            req.item.updateScore(PeerScoreBadBlocks)
+            req.item.updateScore(PeerScoreBadValues)
 
         if resetSlot.isSome():
           await sq.resetWait(resetSlot)

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -508,7 +508,7 @@ suite "SyncManager test suite":
             response.delete(response.len - 2)
           of SyncQueueKind.Backward:
             response.delete(1)
-          expectedScore += PeerScoreMissingBlocks
+          expectedScore += PeerScoreMissingValues
         if response.len >= 1:
           # Ensure requested values are past `safeSlot`
           case kkind


### PR DESCRIPTION
The various `PeerScore` constants are used for both beacon blocks and LC objects, and will likely also find use for EIP4844 blob sidecars. Renaming them to use more generically applicable names not referring to blocks explicitly aymore.