### PR TITLE
properly stop EL instances from prior testnets

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -399,7 +399,8 @@ kill_by_port() {
   done
 }
 
-
+GETH_NUM_NODES="$(( NUM_NODES + LC_NODES ))"
+NIMBUSEL_NUM_NODES="$(( NUM_NODES + LC_NODES ))"
 
 # kill lingering processes from a previous run
 if [[ "${OS}" != "windows" ]]; then
@@ -408,7 +409,7 @@ if [[ "${OS}" != "windows" ]]; then
 
   #Stop geth nodes
   if [[ "${RUN_GETH}" == "1" ]]; then
-    for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
+    for NUM_NODE in $(seq 0 $(( GETH_NUM_NODES - 1 ))); do
       for PORT in $(( NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_NET_PORT )) \
                     $(( NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_HTTP_PORT )) \
                     $(( NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_WS_PORT )) \
@@ -421,7 +422,7 @@ if [[ "${OS}" != "windows" ]]; then
 
   #Stop Nimbus EL nodes
   if [[ "${RUN_NIMBUS}" == "1" ]]; then
-    for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
+    for NUM_NODE in $(seq 0 $(( NIMBUSEL_NUM_NODES - 1 ))); do
       for PORT in $(( NUM_NODE * NIMBUSEL_PORT_OFFSET + NIMBUSEL_BASE_NET_PORT )) \
                     $(( NUM_NODE * NIMBUSEL_PORT_OFFSET + NIMBUSEL_BASE_HTTP_PORT )) \
                     $(( NUM_NODE * NIMBUSEL_PORT_OFFSET + NIMBUSEL_BASE_WS_PORT )) \
@@ -504,9 +505,6 @@ download_eth2() {
     REUSE_BINARIES=1
   fi
 }
-
-GETH_NUM_NODES="$(( NUM_NODES + LC_NODES ))"
-NIMBUSEL_NUM_NODES="$(( NUM_NODES + LC_NODES ))"
 
 if [[ "${RUN_GETH}" == "1" ]]; then
   if [[ ! -e "${GETH_BINARY}" ]]; then


### PR DESCRIPTION
Launching multiple local testnet simulation sequentially can lead to existing EL processes from prior failed/aborted runs not being stopped properly, subsequently leading to hard-to-debug CI test failures. Fixing the cleanup logic addresses this problem.