### PR TITLE
cancel non-started finalization testnets on cancel

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -89,6 +89,7 @@ pipeline {
         }
       }
     }
+  }
 
   post {
     always {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -78,19 +78,19 @@ pipeline {
       stages {  /* parallel builds of minimal / mainnet not yet supported */
         stage('minimal') {
           steps { timeout(26) {
-            launchLocalTestnet('minimal')
+            sh 'make local-testnet-minimal'
           } }
           post { always {
-            collectLocalTestnetArtifacts('minimal')
+            sh 'tar cjf local-testnet-minimal.tar.gz local-testnet-minimal/*.txt'
           } }
         }
 
         stage('mainnet') {
           steps { timeout(62) {
-            launchLocalTestnet('mainnet')
+            sh 'make local-testnet-mainnet'
           } }
           post { always {
-            collectLocalTestnetArtifacts('mainnet')
+            sh 'tar cjf local-testnet-mainnet.tar.gz local-testnet-mainnet/*.txt'
           } }
         }
       }
@@ -108,14 +108,6 @@ pipeline {
       )
     }
   }
-}
-
-def launchLocalTestnet(String name) {
-  sh "make local-testnet-${name}"
-}
-
-def collectLocalTestnetArtifacts(String name) {
-  sh "tar cjf local-testnet-${name}.tar.gz local-testnet-${name}/*.txt"
 }
 
 def isMainBranch() {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -90,15 +90,11 @@ pipeline {
       }
     }
 
-    stage('Upload') {
-      steps { timeout(5) {
-        archiveArtifacts('*.tar.gz')
-      } }
-    }
-  }
-
   post {
     always {
+      catchError { timeout(5) {
+        archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+      } }
       cleanWs(
         disableDeferredWipeout: true,
         deleteDirs: true
@@ -109,15 +105,11 @@ pipeline {
 
 def launchLocalTestnet(String name) {
   /* We want to mark job as failed, but save the results. */
-  catchError(
-    message: "Local ${name} testnet finalization failure!",
-    buildResult: 'FAILURE',
-    stageResult: 'FAILURE'
-  ) {
+  try {
     sh "make local-testnet-${name}"
+  } finally {
+    sh "tar cjf local-testnet-${name}.tar.gz local-testnet-${name}/*.txt"
   }
-  /* Archive test results regardless of outcome. */
-  sh "tar cjf local-testnet-${name}.tar.gz local-testnet-${name}/*.txt"
 }
 
 def isMainBranch() {

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -77,25 +77,31 @@ pipeline {
     stage('Finalizations') {
       stages {  /* parallel builds of minimal / mainnet not yet supported */
         stage('minimal') {
-          steps { script { timeout(26) {
+          steps { timeout(26) {
             launchLocalTestnet('minimal')
-          } } }
+          } }
+          post { always {
+            collectLocalTestnetArtifacts('minimal')
+          } }
         }
 
         stage('mainnet') {
-          steps { script { timeout(62) {
+          steps { timeout(62) {
             launchLocalTestnet('mainnet')
-          } } }
+          } }
+          post { always {
+            collectLocalTestnetArtifacts('mainnet')
+          } }
         }
       }
+      post { always { timeout(5) {
+        archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+      } } }
     }
   }
 
   post {
     always {
-      catchError { timeout(5) {
-        archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
-      } }
       cleanWs(
         disableDeferredWipeout: true,
         deleteDirs: true
@@ -105,12 +111,11 @@ pipeline {
 }
 
 def launchLocalTestnet(String name) {
-  /* We want to mark job as failed, but save the results. */
-  try {
-    sh "make local-testnet-${name}"
-  } finally {
-    sh "tar cjf local-testnet-${name}.tar.gz local-testnet-${name}/*.txt"
-  }
+  sh "make local-testnet-${name}"
+}
+
+def collectLocalTestnetArtifacts(String name) {
+  sh "tar cjf local-testnet-${name}.tar.gz local-testnet-${name}/*.txt"
 }
 
 def isMainBranch() {


### PR DESCRIPTION
When cancelling the `minimal` CI finalization testnet on Jenkins, the internal Jenkins cancellation exception is being caught by `catchError` and the `mainnet` CI finalization testnet will still run. Replacing the logic with `try` / `finally` instead, and moving the `archiveArtifacts` step to the post-build (to run that even on cancellation / failure).