### PR TITLE
Bugfix: The VC was producing invalid sync committee contributions

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -216,7 +216,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           # state, it's not possible that it will sit on the sync committee.
           # Since this API must omit results for validators that don't have
           # duties, we can simply ingnore this requested index.
-          # (we won't bother to validate it agains a more recent state).
+          # (we won't bother to validate it against a more recent state).
           continue
 
         let requestedValidatorPubkey =
@@ -709,15 +709,15 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       let res = slot.get()
       if res.isErr():
         return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
-                                          $res.error())
+                                         $res.error())
       let rslot = res.get()
       if epoch(rslot) < node.dag.cfg.ALTAIR_FORK_EPOCH:
         return RestApiResponse.jsonError(Http400,
-                                          SlotFromTheIncorrectForkError)
+                                         SlotFromTheIncorrectForkError)
       rslot
     if qslot <= node.dag.finalizedHead.slot:
       return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
-                                        "Slot already finalized")
+                                       "Slot already finalized")
     let qindex =
       if subcommittee_index.isNone():
         return RestApiResponse.jsonError(Http400,
@@ -726,8 +726,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         let res = subcommittee_index.get()
         if res.isErr():
           return RestApiResponse.jsonError(Http400,
-                                            InvalidSubCommitteeIndexValueError,
-                                            $res.error())
+                                           InvalidSubCommitteeIndexValueError,
+                                           $res.error())
         res.get()
     let qroot =
       if beacon_block_root.isNone():

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -811,7 +811,7 @@ dump_logs() {
 
 dump_logtrace() {
   if [[ "$ENABLE_LOGTRACE" == "1" ]]; then
-    find "${DATA_DIR}" -maxdepth 1 -type f -regex '.*/log[0-9]+.txt' | sed -e"s/${DATA_DIR}\//--nodes=/" | sort | xargs ./build/logtrace aggasr --log-dir="${DATA_DIR}" || true
+    find "${DATA_DIR}" -maxdepth 1 -type f -regex '.*/log[0-9]+.txt' | sed -e"s/${DATA_DIR}\//--nodes=/" | sort | xargs ./build/logtrace localSimChecks --log-dir="${DATA_DIR}" --const-preset=${CONST_PRESET} || true
   fi
 }
 


### PR DESCRIPTION
Since the sync committee duties are no longer updated on every slot and previously the sync committee aggregators selection proofs were generated during the duties update, this now resulted in the client using stale selection proofs (they must be generated at each slot).

The fix consists of moving the selection proof generation logic in a different function which is properly executed on each slot.

Other changes:

* The logtrace tool has been enhanced with a framework for adding new simpler log aggregation and analysis algorithms. The default CI testnet simulation will now ensure that the blocks in the network have reasonable sync committee participation.