### PR TITLE
Fix the REST API navigation typo

### DIFF
--- a/docs/the_nimbus_book/mkdocs.yml
+++ b/docs/the_nimbus_book/mkdocs.yml
@@ -97,7 +97,7 @@ nav:
       - 'logging.md'
       - 'validator-client-options.md'
       - 'validator-monitor.md'
-    - "REST API:s":
+    - "REST APIs":
       - 'rest-api.md'
       - 'keymanager-api.md'
     - Storage:


### PR DESCRIPTION
This is a minor fix to the API table of content in the Nimbus guide.