### PR TITLE
fix effective merge conflict between #s 4357 and 4358 around `Withdrawal` symbol

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -354,8 +354,8 @@ func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV2):
     capella.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): bellatrix.Transaction =
     bellatrix.Transaction.init(tt.distinctBase)
-  template getConsensusWithdrawal(w: WithdrawalV1): Withdrawal =
-    Withdrawal(
+  template getConsensusWithdrawal(w: WithdrawalV1): capella.Withdrawal =
+    capella.Withdrawal(
       index: w.index.uint64,
       validator_index: w.validatorIndex.uint64,
       address: ExecutionAddress(data: w.address.distinctBase),
@@ -380,7 +380,7 @@ func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV2):
     block_hash: rpcExecutionPayload.blockHash.asEth2Digest,
     transactions: List[bellatrix.Transaction, MAX_TRANSACTIONS_PER_PAYLOAD].init(
       mapIt(rpcExecutionPayload.transactions, it.getTransaction)),
-    withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD].init(
+    withdrawals: List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD].init(
       mapIt(rpcExecutionPayload.withdrawals, it.getConsensusWithdrawal)))
 
 func asEngineExecutionPayload*(executionPayload: bellatrix.ExecutionPayload):


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/4357 and https://github.com/status-im/nimbus-eth2/pull/4358 both introduce a `Withdrawal` symbol into `eth1_monitor` scope. Either alone is fine, but both together create an ambiguity in the bare `Withdrawal` symbol use from the latter. This PR disambiguates which `Withdrawal` to use.