### PR TITLE
use safer case object transitions to reduce UB

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -438,14 +438,18 @@ template withEpochInfo*(x: ForkedEpochInfo, body: untyped): untyped =
 
 template withEpochInfo*(
     state: phase0.BeaconState, x: var ForkedEpochInfo, body: untyped): untyped =
-  x.kind = EpochInfoFork.Phase0
+  if x.kind != EpochInfoFork.Phase0:
+    # Rare, should never happen even, so efficiency a non-issue
+    x = ForkedEpochInfo(kind: EpochInfoFork.Phase0)
   template info: untyped {.inject.} = x.phase0Data
   body
 
 template withEpochInfo*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState,
     x: var ForkedEpochInfo, body: untyped): untyped =
-  x.kind = EpochInfoFork.Altair
+  if x.kind != EpochInfoFork.Altair:
+    # Rare, so efficiency not critical
+    x = ForkedEpochInfo(kind: EpochInfoFork.Altair)
   template info: untyped {.inject.} = x.altairData
   body
 


### PR DESCRIPTION
As https://github.com/nim-lang/Nim/issues/20972 documents, and even more pointedly suggests because its repro non-coincidentally uses `ForkedEpochInfo` as its example case object, this does occur in the wild in Nimbus as undefined behavior due to a Nim bug in how it gets compiled.

However, while arguably the status quo avoids the most direct runtime failures of accessing an incorrect branch of this case object, it doesn't really do much else useful to blindly assign the `kind` to whatever the `withEpochInfo` overload requires, because it doesn't create the correct set of information based on which to use said case object branch.

Furthermore, transitions in this object should be very rare, ideally happen once per case object. Micro-optimizing for a few microseconds faster discriminant change at the cost of introducing UB, or even if the Nim bug is fixed, requiring old-style case object handling which the Nim manual explicitly deprecates, seems like a less-than-optimal trade.