### PR TITLE
fix crash when calling MEV rpc with MEV disabled

### DIFF
--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -48,6 +48,9 @@ proc unblindAndRouteBlockMEV*(
     Future[Result[Opt[BlockRef], string]] {.async.} =
   # By time submitBlindedBlock is called, must already have done slashing
   # protection check
+  if node.payloadBuilderRestClient.isNil:
+    return err "unblindAndRouteBlockMEV: nil REST client"
+
   let unblindedPayload =
     try:
       awaitWithTimeout(


### PR DESCRIPTION
Avoid `/eth/v1/beacon/blinded_blocks` crash without `--payload-builder`.