### PR TITLE
add hooks for observing LC progress

### DIFF
--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -283,7 +283,7 @@ template withReportedProgress(
     let
       previousWasInitialized = store[].isSome
       previousNextCommitteeKnown =
-        if store[].sSome:
+        if store[].isSome:
           store[].get.is_next_sync_committee_known
         else:
           false

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -282,6 +282,11 @@ template withReportedProgress(
   block:
     let
       previousWasInitialized = store[].isSome
+      previousNextCommitteeKnown =
+        if store[].sSome:
+          store[].get.is_next_sync_committee_known
+        else:
+          false
       previousFinalized =
         if store[].isSome:
           store[].get.finalized_header
@@ -306,18 +311,22 @@ template withReportedProgress(
         self.onStoreInitialized()
         self.onStoreInitialized = nil
 
-    if store[].get.optimistic_header != previousOptimistic:
-      didProgress = true
-      when obj isnot SomeLightClientUpdateWithFinality:
-        didSignificantProgress = true
-      if self.onOptimisticHeader != nil:
-        self.onOptimisticHeader()
+    if store[].isSome:
+      if store[].get.optimistic_header != previousOptimistic:
+        didProgress = true
+        when obj isnot SomeLightClientUpdateWithFinality:
+          didSignificantProgress = true
+        if self.onOptimisticHeader != nil:
+          self.onOptimisticHeader()
 
-    if store[].get.finalized_header != previousFinalized:
-      didProgress = true
-      didSignificantProgress = true
-      if self.onFinalizedHeader != nil:
-        self.onFinalizedHeader()
+      if store[].get.finalized_header != previousFinalized:
+        didProgress = true
+        didSignificantProgress = true
+        if self.onFinalizedHeader != nil:
+          self.onFinalizedHeader()
+
+      if store[].get.is_next_sync_committee_known != previousNextCommitteeKnown:
+        didProgress = true
 
     if didProgress:
       when obj is Nothing:


### PR DESCRIPTION
For Fluffy injection, add observer callbacks that get called whenever new light client data is sucecssfully processed.

```
  proc onLightClientObject(
      lightClient: LightClient, obj: SomeLightClientObject) =
    info "New LC object", obj

  lightClient.bootstrapObserver =
    proc(lightClient: LightClient, obj: altair.LightClientBootstrap) =
      lightClient.onLightClientObject(obj)
  lightClient.updateObserver =
    proc(lightClient: LightClient, obj: altair.LightClientUpdate) =
      lightClient.onLightClientObject(obj)
  lightClient.finalityUpdateObserver =
    proc(lightClient: LightClient, obj: altair.LightClientFinalityUpdate) =
      lightClient.onLightClientObject(obj)
  lightClient.optimisticUpdateObserver =
    proc(lightClient: LightClient, obj: altair.LightClientOptimisticUpdate) =
      lightClient.onLightClientObject(obj)
```