### PR TITLE
add eip4844 fork choice tests and remove test vector workarounds

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -323,6 +323,22 @@ ConsensusSpecPreset-mainnet
   ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
 + ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost              OK
 + ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
++ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_grea OK
++ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_ OK
++ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest OK
++ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att OK
++ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/chain_no_attestations       OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/discard_equivocations       OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/genesis                     OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w OK
++ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest OK
++ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/basic                       OK
++ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    OK
+  ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
++ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost              OK
++ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_n OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
@@ -358,6 +374,7 @@ ConsensusSpecPreset-mainnet
 + Slots - slots_2                                                                            OK
 + Sync - mainnet/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - mainnet/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
++ Sync - mainnet/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + [Invalid] EF - Altair - Sanity - Blocks - expected_deposit_in_block [Preset: mainnet]      OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_block_sig [Preset: mainnet]              OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
@@ -744,7 +761,7 @@ ConsensusSpecPreset-mainnet
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 733/741 Fail: 0/741 Skip: 8/741
+OK: 749/758 Fail: 0/758 Skip: 9/758
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -2419,4 +2436,4 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 OK: 51/51 Fail: 0/51 Skip: 0/51
 
 ---TOTAL---
-OK: 2125/2133 Fail: 0/2133 Skip: 8/2133
+OK: 2141/2150 Fail: 0/2150 Skip: 9/2150

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -363,6 +363,30 @@ ConsensusSpecPreset-minimal
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_update_justified_c OK
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost              OK
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
++ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest OK
++ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att OK
++ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/chain_no_attestations       OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/discard_equivocations       OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/filtered_block_tree         OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/genesis                     OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w OK
++ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/basic                       OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justi OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_j OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_justified_is_later_than OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_before_finalized   OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_checkpoints        OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo OK
+  ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_update_justified_c OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost              OK
++ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
@@ -422,6 +446,7 @@ ConsensusSpecPreset-minimal
 + Slots - slots_2                                                                            OK
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
++ Sync - minimal/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + [Invalid] EF - Altair - Sanity - Blocks - expected_deposit_in_block [Preset: minimal]      OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_block_sig [Preset: minimal]              OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
@@ -838,7 +863,7 @@ ConsensusSpecPreset-minimal
 + fork_random_low_balances                                                                   OK
 + fork_random_misc_balances                                                                  OK
 ```
-OK: 827/835 Fail: 0/835 Skip: 8/835
+OK: 851/860 Fail: 0/860 Skip: 9/860
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - after_epoch_slots                       OK
@@ -2591,4 +2616,4 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 OK: 52/52 Fail: 0/52 Skip: 0/52
 
 ---TOTAL---
-OK: 2281/2289 Fail: 0/2289 Skip: 8/2289
+OK: 2305/2314 Fail: 0/2314 Skip: 9/2314

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -48,7 +48,9 @@ proc initLightClient*(
         dag = node.dag.head.bid,
         wallSlot = node.currentSlot
       withBlck(signedBlock):
-        when stateFork >= BeaconStateFork.Bellatrix:
+        when stateFork == BeaconStateFork.EIP4844:
+          raiseAssert $eip4844ImplementationMissing & ": beacon_node_light_client.nim:initLightClient"
+        elif stateFork >= BeaconStateFork.Bellatrix:
           if blck.message.is_execution_block:
             template payload(): auto = blck.message.body.execution_payload
 

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -405,6 +405,8 @@ func covers*(
 
   false
 
+from ../spec/datatypes/eip4844 import HashedBeaconState, shortLog
+
 proc addForkChoice*(pool: var AttestationPool,
                     epochRef: EpochRef,
                     blckRef: BlockRef,
@@ -480,8 +482,6 @@ func init(T: type AttestationCache, state: phase0.HashedBeaconState): T =
     result.add(
       state.data.current_epoch_attestations[i].data,
       state.data.current_epoch_attestations[i].aggregation_bits)
-
-from ../spec/datatypes/eip4844 import HashedBeaconState
 
 func init(
     T: type AttestationCache,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -332,6 +332,14 @@ proc getExecutionValidity(
     error "getExecutionValidity: newPayload failed", err = err.msg
     return NewPayloadStatus.noResponse
 
+from ../spec/datatypes/eip4844 import SignedBeaconBlock, asTrusted, shortLog
+
+proc getExecutionValidity(
+    eth1Monitor: Eth1Monitor,
+    blck: eip4844.SignedBeaconBlock):
+    Future[NewPayloadStatus] {.async.} =
+  raiseAssert $eip4844ImplementationMissing & ": block_processor.nim:getExecutionValidity"
+
 proc storeBlock*(
     self: ref BlockProcessor, src: MsgSource, wallTime: BeaconTime,
     signedBlock: ForkySignedBeaconBlock, queueTick: Moment = Moment.now(),

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -387,6 +387,14 @@ proc validateBeaconBlock*(
 
   ok()
 
+from ../spec/datatypes/eip4844 import SignedBeaconBlock
+
+proc validateBeaconBlock*(
+    dag: ChainDAGRef, quarantine: ref Quarantine,
+    signed_beacon_block: eip4844.SignedBeaconBlock,
+    wallTime: BeaconTime, flags: UpdateFlags): Result[void, ValidationError] =
+  raiseAssert $eip4844ImplementationMissing & ": gossip_validation.nim: validateBeaconBlock not how EIP4844 works anymore"
+
 # https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
 proc validateAttestation*(
     pool: ref AttestationPool,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2632,9 +2632,19 @@ proc broadcastBeaconBlock*(
   let topic = getBeaconBlocksTopic(node.forkDigests.capella)
   node.broadcast(topic, blck)
 
+from ../spec/datatypes/eip4844 import SignedBeaconBlock
+
+proc broadcastBeaconBlock*(
+    node: Eth2Node, blck: eip4844.SignedBeaconBlock): Future[SendResult] =
+  raiseAssert $eip4844ImplementationMissing & ": eth2_network.nim:broadcastBeaconBlock EIP4844 uses different approach (1)"
+
 proc broadcastBeaconBlock*(
     node: Eth2Node, forked: ForkedSignedBeaconBlock): Future[SendResult] =
-  withBlck(forked): node.broadcastBeaconBlock(blck)
+  withBlck(forked):
+    when stateFork == BeaconStateFork.EIP4844:
+      raiseAssert $eip4844ImplementationMissing & ": eth2_network.nim:broadcastBeaconBlock EIP4844 uses different approach (2)"
+    else:
+      node.broadcastBeaconBlock(blck)
 
 proc broadcastSyncCommitteeMessage*(
     node: Eth2Node, msg: SyncCommitteeMessage,

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -77,7 +77,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-alpha.1"
+const SPEC_VERSION* = "1.3.0-alpha.1-hotfix.2"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -675,8 +675,8 @@ template withBlck*(
     template blck: untyped {.inject.} = x.capellaData
     body
   of BeaconBlockFork.EIP4844:
-    const stateFork {.inject, used.} = BeaconStateFork.Capella
-    template blck: untyped {.inject.} = x.capellaData
+    const stateFork {.inject, used.} = BeaconStateFork.EIP4844
+    template blck: untyped {.inject.} = x.eip4844Data
     body
 
 func proposer_index*(x: ForkedBeaconBlock): uint64 =

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -805,15 +805,6 @@ func tx_peek_blob_versioned_hashes(opaque_tx: Transaction):
   for x in countup(blob_versioned_hashes_offset.int, len(opaque_tx) - 1, 32):
     var versionedHash: VersionedHash
     versionedHash[0 .. 31] = opaque_tx.asSeq.toOpenArray(x, x + 31)
-
-    # TODO there's otherwise a mismatch here where test vectors show valid but
-    # the first byte is 0?
-    # `kzg_commitment_to_versioned_hash` is very clear about the equivalent
-    # first byte having to be 0x01 for it ever to match
-    # this is not in spec per se though
-    if versionedHash[0] == 0:
-      versionedHash[0] = 0x01'u8
-
     res.add versionedHash
   ok res
 

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -46,6 +46,8 @@ proc fetchDepositSnapshot(client: RestClientRef):
 
   return ok snapshot
 
+from ./spec/datatypes/eip4844 import asSigVerified, shortLog
+
 proc doTrustedNodeSync*(
     cfg: RuntimeConfig,
     databaseDir: string,

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -839,6 +839,8 @@ proc makeBlindedBeaconBlockForHeadAndSlot*(
   return ok constructPlainBlindedBlock[BlindedBeaconBlock](
     forkedBlck, executionPayloadHeader)
 
+from ../spec/datatypes/eip4844 import shortLog
+
 proc proposeBlock(node: BeaconNode,
                   validator: AttachedValidator,
                   validator_index: ValidatorIndex,
@@ -938,6 +940,9 @@ proc proposeBlock(node: BeaconNode,
             message: blck, signature: signature, root: blockRoot)
         elif blck is capella.BeaconBlock:
           capella.SignedBeaconBlock(
+            message: blck, signature: signature, root: blockRoot)
+        elif blck is eip4844.BeaconBlock:
+          eip4844.SignedBeaconBlock(
             message: blck, signature: signature, root: blockRoot)
         else:
           static: doAssert "Unknown SignedBeaconBlock type"

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -725,6 +725,8 @@ proc registerAttestationInBlock*(
       update_if_lt(
         epochSummary.attestation_min_block_inclusion_distance, inclusion_lag)
 
+from ../spec/datatypes/eip4844 import shortLog
+
 proc registerBeaconBlock*(
     self: var ValidatorMonitor,
     src: MsgSource,

--- a/tests/consensus_spec/altair/test_fixture_fork.nim
+++ b/tests/consensus_spec/altair/test_fixture_fork.nim
@@ -8,8 +8,6 @@
 {.used.}
 
 import
-  # Standard library
-  os,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, helpers],
   ../../../beacon_chain/spec/datatypes/[phase0, altair],
@@ -17,6 +15,8 @@ import
   ../../testutil,
   ../fixtures_utils,
   ../../helpers/debug_state
+
+from std/os import walkDir, `/`
 
 const OpForkDir = SszTestsDir/const_preset/"altair"/"fork"/"fork"/"pyspec_tests"
 

--- a/tests/consensus_spec/bellatrix/test_fixture_fork.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_fork.nim
@@ -8,8 +8,6 @@
 {.used.}
 
 import
-  # Standard library
-  os,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, helpers],
   ../../../beacon_chain/spec/datatypes/[altair, bellatrix],
@@ -17,6 +15,8 @@ import
   ../../testutil,
   ../fixtures_utils,
   ../../helpers/debug_state
+
+from std/os import walkDir, `/`
 
 const OpForkDir = SszTestsDir/const_preset/"bellatrix"/"fork"/"fork"/"pyspec_tests"
 

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -8,8 +8,6 @@
 {.used.}
 
 import
-  # Standard library
-  std/[os, sequtils, sets, strutils],
   # Utilities
   chronicles,
   unittest2,
@@ -21,6 +19,10 @@ import
   ../../testutil,
   ../fixtures_utils,
   ../../helpers/debug_state
+
+from std/os import fileExists, walkDir, `/`
+from std/sequtils import mapIt, toSeq
+from std/strutils import contains
 
 const
   OpDir                 = SszTestsDir/const_preset/"bellatrix"/"operations"

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -8,9 +8,6 @@
 {.used.}
 
 import
-  # Standard library
-  os, strutils, streams, strformat,
-  macros, sets,
   # Third-party
   yaml,
   # Beacon chain internals
@@ -19,6 +16,11 @@ import
   snappy,
   # Test utilities
   ../../testutil, ../fixtures_utils
+
+from std/os import dirExists, pcDir, walkDir, `/`
+from std/streams import close, openFileStream
+from std/strformat import `&`
+from std/strutils import toLowerAscii
 
 # SSZ tests of consensus objects (minimal/mainnet preset specific)
 

--- a/tests/consensus_spec/capella/test_fixture_transition.nim
+++ b/tests/consensus_spec/capella/test_fixture_transition.nim
@@ -9,8 +9,6 @@
 
 import
   yaml,
-  # Standard library
-  std/[os, sequtils, strutils],
   # Status internal
   faststreams, streams,
   # Beacon chain internals
@@ -19,6 +17,9 @@ import
   # Test utilities
   ../../testutil,
   ../fixtures_utils
+
+from std/os import walkDir, walkPattern, `/`
+from std/sequtils import toSeq
 
 const
   TransitionDir = SszTestsDir/const_preset/"capella"/"transition"/"core"/"pyspec_tests"

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -423,12 +423,6 @@ template fcSuite(suiteName: static[string], testPathElem: static[string]) =
       let testsPath = presetPath/path/testPathElem
       if kind != pcDir or not dirExists(testsPath):
         continue
-      if path.contains("eip4844"):
-        # TODO 1.3.0-alpha.1 test prestates have forks of
-        # (previous_version: 02000000, current_version: 04000000, epoch: 0)
-        # which is probably broken, and chaindag certainly doesn't like
-        discard $eip4844ImplementationMissing & ": re-enable when test pre-state forks fixed"
-        continue
       let fork = forkForPathComponent(path).valueOr:
         raiseAssert "Unknown test fork: " & testsPath
       for kind, path in walkDir(testsPath, relative = true, checkDir = true):


### PR DESCRIPTION
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.3.0-alpha.1-hotfix.2 fixes the issues that were being seen, so now EIP4844 tests can be/are straightforwardly implemented, in their entirety as much as the other forks.