### PR TITLE
Backfill only up to MIN_EPOCHS_FOR_BLOCK_REQUESTS blocks

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -410,6 +410,13 @@ proc addBackfillBlock*(
     debug "Block does not match expected backfill root"
     return err(VerifierError.MissingParent) # MissingChild really, but ..
 
+  if blck.slot < dag.horizon:
+    # This can happen as the horizon keeps moving - we'll discard it as
+    # duplicate since it would have duplicated an existing block had we been
+    # interested
+    debug "Block past horizon, dropping", horizon = dag.horizon
+    return err(VerifierError.Duplicate)
+
   checkSignature()
 
   let sigVerifyTick = Moment.now

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -365,6 +365,14 @@ template frontfill*(dagParam: ChainDAGRef): Opt[BlockId] =
   else:
     dag.genesis
 
+func horizon*(dag: ChainDAGRef): Slot =
+  ## The sync horizon that we target during backfill - ie we will not backfill
+  ## blocks older than this from the network
+  if dag.head.slot.epoch > dag.cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS:
+    start_slot(dag.head.slot.epoch - dag.cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS)
+  else:
+    GENESIS_SLOT
+
 template epoch*(e: EpochRef): Epoch = e.key.epoch
 
 func shortLog*(v: EpochKey): string =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1295,8 +1295,13 @@ proc getBlockRange*(
     head = shortLog(dag.head.root), requestedCount, startSlot, skipStep, headSlot
 
   if startSlot < dag.backfill.slot:
-    notice "Got request for pre-backfill slot",
-      startSlot, backfillSlot = dag.backfill.slot
+    if startSlot < dag.horizon:
+      # We will not backfill these
+      debug "Got request for pre-horizon slot",
+        startSlot, backfillSlot = dag.backfill.slot
+    else:
+      notice "Got request for pre-backfill slot",
+        startSlot, backfillSlot = dag.backfill.slot
     return output.len
 
   if headSlot <= startSlot or requestedCount == 0:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -319,6 +319,9 @@ proc getExecutionValidity(
   if not blck.message.is_execution_block:
     return NewPayloadStatus.valid  # vacuously
 
+  if eth1Monitor.isNil:
+    return NewPayloadStatus.noResponse
+
   try:
     # Minimize window for Eth1 monitor to shut down connection
     await eth1Monitor.ensureDataProvider()
@@ -363,13 +366,7 @@ proc storeBlock*(
     vm = self.validatorMonitor
     dag = self.consensusManager.dag
     payloadStatus =
-      if self.consensusManager.eth1Monitor.isNil:
-        if not self.optimistic:
-          warn "Attempting to process execution payload without execution client. Ensure --web3-url setting is correct and JWT is configured."
-        NewPayloadStatus.noResponse
-      else:
-        await self.consensusManager.eth1Monitor.getExecutionValidity(
-          signedBlock)
+      await self.consensusManager.eth1Monitor.getExecutionValidity(signedBlock)
     payloadValid = payloadStatus == NewPayloadStatus.valid
 
   # The block is certainly not missing any more
@@ -386,8 +383,9 @@ proc storeBlock*(
       # `processBlock` (indirectly). `validator_duties` does call `storeBlock`
       # directly, so is exposed to this, but only cares about whether there is
       # an error or not.
-      return err((
-        VerifierError.MissingParent, ProcessingStatus.notCompleted))
+      warn "Attempting to process execution payload without execution client. Ensure --web3-url setting is correct and JWT is configured."
+
+      return err((VerifierError.MissingParent, ProcessingStatus.notCompleted))
 
     # Client software MUST validate blockHash value as being equivalent to
     # Keccak256(RLP(ExecutionBlockHeader))

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -383,7 +383,8 @@ proc storeBlock*(
       # `processBlock` (indirectly). `validator_duties` does call `storeBlock`
       # directly, so is exposed to this, but only cares about whether there is
       # an error or not.
-      warn "Attempting to process execution payload without execution client. Ensure --web3-url setting is correct and JWT is configured."
+      if self[].consensusManager.eth1Monitor.isNil:
+        warn "Attempting to process execution payload without execution client. Ensure --web3-url setting is correct and JWT is configured."
 
       return err((VerifierError.MissingParent, ProcessingStatus.notCompleted))
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1619,6 +1619,9 @@ proc start*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
 
   waitFor node.initializeNetworking()
 
+  if node.eth1Monitor != nil:
+    node.eth1Monitor.start()
+
   node.run()
 
 func formatGwei(amount: uint64): string =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -271,10 +271,7 @@ proc initFullNode(
     dag.backfill.slot
 
   func getFrontfillSlot(): Slot =
-    if dag.frontfill.isSome():
-      dag.frontfill.get().slot
-    else:
-      GENESIS_SLOT
+    max(dag.frontfill.get(BlockId()).slot, dag.horizon)
 
   let
     quarantine = newClone(
@@ -445,10 +442,7 @@ proc init*(T: type BeaconNode,
   let optJwtSecret = rng[].loadJwtSecret(config, allowCreate = false)
 
   if config.web3Urls.len() == 0:
-    if cfg.BELLATRIX_FORK_EPOCH == FAR_FUTURE_EPOCH:
-      notice "Running without execution client - validator features partially disabled (see https://nimbus.guide/eth1.html)"
-    else:
-      notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
+    notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
 
   var eth1Monitor: Eth1Monitor
 
@@ -1624,11 +1618,6 @@ proc start*(node: BeaconNode) {.raises: [Defect, CatchableError].} =
     notice "Waiting for genesis", genesisIn = genesisTime.offset
 
   waitFor node.initializeNetworking()
-
-  if node.eth1Monitor != nil:
-    node.eth1Monitor.start()
-  else:
-    notice "Running without execution chain monitor, block producation partially disabled"
 
   node.run()
 

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -183,10 +183,19 @@ proc getBlocks*[A, B](man: SyncManager[A, B], peer: A,
     return
 
 proc remainingSlots(man: SyncManager): uint64 =
+  let
+    first = man.getFirstSlot()
+    last = man.getLastSlot()
   if man.direction == SyncQueueKind.Forward:
-    man.getLastSlot() - man.getFirstSlot()
+    if last > first:
+      man.getLastSlot() - man.getFirstSlot()
+    else:
+      0'u64
   else:
-    man.getFirstSlot() - man.getLastSlot()
+    if first > last:
+      man.getFirstSlot() - man.getLastSlot()
+    else:
+      0'u64
 
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
   logScope:


### PR DESCRIPTION
When backfilling, we only need to download blocks that are newer than MIN_EPOCHS_FOR_BLOCK_REQUESTS - the rest cannot reliably be fetched from the network and does not have to be provided to others.

This change affects only trusted-node-synced clients - genesis sync continues to work as before (because it needs to construct a state by building it from genesis).

Those wishing to complete a backfill should do so with era files instead.