### PR TITLE
Updated BN/VC docker images and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           cd ../docker/dist/binaries
           REFNAME="${{ github.ref }}"
           TAG="${REFNAME#refs/tags/}"
-          DOCKER_BUILDKIT=1 docker build -f Dockerfile.amd64 -t statusim/nimbus-eth2:amd64-${TAG} -t statusim/nimbus-eth2:amd64-latest .
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile.bn.amd64 -t statusim/nimbus-eth2:amd64-${TAG} -t statusim/nimbus-eth2:amd64-latest .
           docker push statusim/nimbus-eth2:amd64-${TAG}
           docker push statusim/nimbus-eth2:amd64-latest
 
@@ -132,7 +132,7 @@ jobs:
           TAG="${REFNAME#refs/tags/}"
           cp -a /usr/bin/qemu-aarch64-static .
 
-          DOCKER_BUILDKIT=1 docker build -f Dockerfile.arm64 -t statusim/nimbus-eth2:arm64-${TAG} -t statusim/nimbus-eth2:arm64-latest .
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile.bn.arm64 -t statusim/nimbus-eth2:arm64-${TAG} -t statusim/nimbus-eth2:arm64-latest .
           docker push statusim/nimbus-eth2:arm64-${TAG}
           docker push statusim/nimbus-eth2:arm64-latest
 
@@ -210,7 +210,7 @@ jobs:
           REFNAME="${{ github.ref }}"
           TAG="${REFNAME#refs/tags/}"
           cp -a /usr/bin/qemu-arm-static .
-          DOCKER_BUILDKIT=1 docker build -f Dockerfile.arm -t statusim/nimbus-eth2:arm-${TAG} -t statusim/nimbus-eth2:arm-latest .
+          DOCKER_BUILDKIT=1 docker build -f Dockerfile.bn.arm -t statusim/nimbus-eth2:arm-${TAG} -t statusim/nimbus-eth2:arm-latest .
           docker push statusim/nimbus-eth2:arm-${TAG}
           docker push statusim/nimbus-eth2:arm-latest
 

--- a/docker/dist/binaries/Dockerfile.bn.amd64
+++ b/docker/dist/binaries/Dockerfile.bn.amd64
@@ -10,8 +10,6 @@ USER user
 
 STOPSIGNAL SIGINT
 
-# Docker refuses to copy the source directory here, so read it as "nimbus-eth2/*"
-COPY "nimbus-eth2" "/home/user/nimbus-eth2/"
-WORKDIR "/home/user/nimbus-eth2/"
-ENTRYPOINT ["/home/user/nimbus-eth2/build/nimbus_beacon_node"]
-
+COPY "nimbus-eth2/build/nimbus_beacon_node" "/home/user/nimbus_beacon_node"
+WORKDIR "/home/user/"
+ENTRYPOINT ["/home/user/nimbus_beacon_node"]

--- a/docker/dist/binaries/Dockerfile.bn.arm
+++ b/docker/dist/binaries/Dockerfile.bn.arm
@@ -14,8 +14,6 @@ USER user
 
 STOPSIGNAL SIGINT
 
-# Docker refuses to copy the source directory here, so read it as "nimbus-eth2/*"
-COPY "nimbus-eth2" "/home/user/nimbus-eth2/"
-WORKDIR "/home/user/nimbus-eth2/"
-ENTRYPOINT ["/home/user/nimbus-eth2/build/nimbus_beacon_node"]
-
+COPY "nimbus-eth2/build/nimbus_beacon_node" "/home/user/nimbus_beacon_node"
+WORKDIR "/home/user/"
+ENTRYPOINT ["/home/user/nimbus_beacon_node"]

--- a/docker/dist/binaries/Dockerfile.bn.arm64
+++ b/docker/dist/binaries/Dockerfile.bn.arm64
@@ -14,8 +14,6 @@ USER user
 
 STOPSIGNAL SIGINT
 
-# Docker refuses to copy the source directory here, so read it as "nimbus-eth2/*"
-COPY "nimbus-eth2" "/home/user/nimbus-eth2/"
-WORKDIR "/home/user/nimbus-eth2/"
-ENTRYPOINT ["/home/user/nimbus-eth2/build/nimbus_beacon_node"]
-
+COPY "nimbus-eth2/build/nimbus_beacon_node" "/home/user/nimbus_beacon_node"
+WORKDIR "/home/user/"
+ENTRYPOINT ["/home/user/nimbus_beacon_node"]

--- a/docs/the_nimbus_book/src/docker.md
+++ b/docs/the_nimbus_book/src/docker.md
@@ -1,41 +1,42 @@
 # Docker images
 
-Docker images are available from [Docker Hub](https://hub.docker.com/r/statusim/nimbus-eth2)  .
+Docker images for the [Nimbus beacon node](https://hub.docker.com/r/statusim/nimbus-eth2) and the [Nimbus validator client](https://hub.docker.com/r/statusim/nimbus-validator-client) are available at docker hub.
 
-We have version-specific Docker tags (`statusim/nimbus-eth2:amd64-v1.2.3`) and a tag for the latest image (`statusim/nimbus-eth2:amd64-latest`).
+We have version-specific Docker tags (e.g. `statusim/nimbus-eth2:amd64-v1.2.3`) and a tag for the latest image (e.g. `statusim/nimbus-eth2:amd64-latest`).
 
-These images are simply the contents of [release tarballs](./binaries.md) inside a `debian:bullseye-slim` image, running under a user imaginatively named `user`, with UID:GID of 1000:1000.
+These images contain the same binaries as the [release tarballs](./binaries.md) inside a `debian:bullseye-slim` image, running under a user imaginatively named `user`, with UID:GID of 1000:1000.
 
-The unpacked archive is in `/home/user/nimbus-eth2` which is also the default *WORKDIR*. The default *ENTRYPOINT* is the binary itself: `/home/user/nimbus-eth2/build/nimbus_beacon_node`
+The binaries are placed under the `/home/user/` directory which is also the default *WORKDIR*. The *ENTRYPOINT* of the image is configured to directly launch the respective binary without any extra arguments.
 
 ## Usage
 
 Before running Nimbus via docker, you need to prepare a data directory and mount it in docker.
 
-It is recommended that you mount the directory at `/home/user/nimbus-eth2/build/data` and pass `--data-dir=build/data/shared_mainnet_0` to all `nimbus_beacon_node` commands.
-
-The wrapper script outlined below will set the data directory automatically.
+It is recommended that you mount the directory at `/home/user/data` and pass `--data-dir=data/beacon_node/mainnet_0` to all `nimbus_beacon_node` commands.
 
 ```sh
 mkdir data
 docker run -it --rm \
-  -v ${PWD}/data:/home/user/nimbus-eth2/build/data \
+  -v ${PWD}/data:/home/user/data \
   statusim/nimbus-eth2:amd64-latest \
-  --data-dir=build/data/shared_mainnet_0
-  --network=mainnet [other options]
+  --data-dir=data/beacon_node/mainnet_0
+  --network=mainnet \
+  [other options]
 ```
 
-### Wrapper script
-
-If you wish, you can choose to use a wrapper script instead:
+Similarly, to launch a Nimbus validator client you can use the following command:
 
 ```sh
 mkdir data
 docker run -it --rm \
-  -v ${PWD}/data:/home/user/nimbus-eth2/build/data \
-  --entrypoint /home/user/nimbus-eth2/run-mainnet-beacon-node.sh \
-  statusim/nimbus-eth2:amd64-latest [other options]
+  -v ${PWD}/data:/home/user/data \
+  statusim/nimbus-validator_client:amd64-latest \
+  --data-dir=data/validator_client/mainnet_0 \
+  [other options]
 ```
+
+!!! warning
+    Do not use the same data directory for beacon node and validator client - they will both try to load the same keys which may result in slashing!
 
 ### Docker compose
 


### PR DESCRIPTION
Changes: 

* Don't package the nimbus_validator_client binary in the nimbus-eth2 docker images
* Document the new dedicated image for the VC