### PR TITLE
fix `produceBlockV2` call for Capella

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -374,8 +374,12 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http400, InvalidRandaoRevealValue)
 
         let res =
-          await makeBeaconBlockForHeadAndSlot[bellatrix.ExecutionPayload](
-            node, qrandao, proposer.get(), qgraffiti, qhead, qslot)
+          if qslot.epoch >= node.dag.cfg.CAPELLA_FORK_EPOCH:
+            await makeBeaconBlockForHeadAndSlot[capella.ExecutionPayload](
+              node, qrandao, proposer.get(), qgraffiti, qhead, qslot)
+          else:
+            await makeBeaconBlockForHeadAndSlot[bellatrix.ExecutionPayload](
+              node, qrandao, proposer.get(), qgraffiti, qhead, qslot)
         if res.isErr():
           return RestApiResponse.jsonError(Http400, res.error())
         res.get()

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -16,6 +16,7 @@ import ".."/[beacon_chain_db, beacon_node],
        "."/[rest_utils, state_ttl_cache]
 
 from ".."/spec/datatypes/bellatrix import ExecutionPayload
+from ".."/spec/datatypes/capella import ExecutionPayload
 
 export rest_utils
 


### PR DESCRIPTION
Avoid issue when calling `/eth/v2/validator/blocks/{slot}` for a Capella slot via VC, same logic as in `validator_duties`.