### PR TITLE
Blob storage

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -771,7 +771,7 @@ proc putBlock*(
     db.blocks[type(value).toFork].putSZSSZ(value.root.data, value)
     db.putBeaconBlockSummary(value.root, value.message.toBeaconBlockSummary())
 
-proc putBlobs*(
+proc putBlobsSidecar*(
     db: BeaconChainDB,
     value: BlobsSidecar) =
   db.blobs.putSZSSZ(value.beacon_block_root.data, value)

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -774,7 +774,7 @@ proc putBlock*(
 proc putBlobs*(
     db: BeaconChainDB,
     value: BlobsSidecar) =
-    db.blobs.putSZSSZ(value.beacon_block_root.data, value)
+  db.blobs.putSZSSZ(value.beacon_block_root.data, value)
 
 proc updateImmutableValidators*(
     db: BeaconChainDB, validators: openArray[Validator]) =

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -480,7 +480,7 @@ proc new*(T: type BeaconChainDBV0,
 
 proc new*(T: type BeaconChainDB,
           db: SqStoreRef,
-          cfg: RuntimeConfig,
+          cfg: RuntimeConfig = defaultRuntimeConfig
     ): BeaconChainDB =
   if not db.readOnly:
     # Remove the deposits table we used before we switched
@@ -574,7 +574,7 @@ proc new*(T: type BeaconChainDB,
 
 proc new*(T: type BeaconChainDB,
           dir: string,
-          cfg: RuntimeConfig,
+          cfg: RuntimeConfig = defaultRuntimeConfig,
           inMemory = false,
           readOnly = false
     ): BeaconChainDB =

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -731,6 +731,8 @@ proc close*(db: BeaconChainDB) =
   if db.db == nil: return
 
   # Close things roughly in reverse order
+  if not isNil(db.blobs):
+    discard db.blobs.close()
   db.lcData.close()
   db.finalizedBlocks.close()
   discard db.summaries.close()

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -960,7 +960,7 @@ proc getBlock*[
   else:
     result.err()
 
-proc getBlobs*(db: BeaconChainDB, key: Eth2Digest): Opt[BlobsSidecar] =
+proc getBlobsSidecar*(db: BeaconChainDB, key: Eth2Digest): Opt[BlobsSidecar] =
   var blobs: BlobsSidecar
   result.ok(blobs)
   if db.blobs.getSZSSZ(key.data, result.get) != GetResult.found:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -30,6 +30,7 @@ from ../consensus_object_pools/block_quarantine import
 from ../validators/validator_monitor import
   MsgSource, ValidatorMonitor, registerAttestationInBlock, registerBeaconBlock,
   registerSyncAggregateInBlock
+from ../spec/datatypes/eip4844 import BlobsSidecar
 
 export sszdump, signatures_batch
 
@@ -43,6 +44,7 @@ declareHistogram beacon_store_block_duration_seconds,
 type
   BlockEntry* = object
     blck*: ForkedSignedBeaconBlock
+    blobs*: Opt[eip4844.BlobsSidecar]
     resfut*: Future[Result[void, VerifierError]]
     queueTick*: Moment # Moment when block was enqueued
     validationDur*: Duration # Time it took to perform gossip validation
@@ -102,6 +104,7 @@ type
 
 proc addBlock*(
     self: var BlockProcessor, src: MsgSource, blck: ForkedSignedBeaconBlock,
+    blobs: Opt[eip4844.BlobsSidecar],
     resfut: Future[Result[void, VerifierError]] = nil,
     validationDur = Duration())
 
@@ -157,10 +160,12 @@ proc dumpBlock[T](
 
 from ../consensus_object_pools/block_clearance import
   addBackfillBlock, addHeadBlock
+from ../beacon_chain_db import putBlobs
 
 proc storeBackfillBlock(
     self: var BlockProcessor,
-    signedBlock: ForkySignedBeaconBlock): Result[void, VerifierError] =
+    signedBlock: ForkySignedBeaconBlock,
+    blobs: Opt[eip4844.BlobsSidecar]): Result[void, VerifierError] =
 
   # The block is certainly not missing any more
   self.consensusManager.quarantine[].missing.del(signedBlock.root)
@@ -181,7 +186,11 @@ proc storeBackfillBlock(
       # Track unviables so that descendants can be discarded properly
       self.consensusManager.quarantine[].addUnviable(signedBlock.root)
     else: discard
+    return res
 
+  if blobs.isSome():
+    # Only store blobs after successfully establishing block viability.
+    self.consensusManager.dag.db.putBlobs(blobs.get())
   res
 
 from web3/engine_api_types import PayloadExecutionStatus, PayloadStatusV1
@@ -353,8 +362,9 @@ proc getExecutionValidity(
 
 proc storeBlock*(
     self: ref BlockProcessor, src: MsgSource, wallTime: BeaconTime,
-    signedBlock: ForkySignedBeaconBlock, queueTick: Moment = Moment.now(),
-    validationDur = Duration()):
+    signedBlock: ForkySignedBeaconBlock,
+    blobs: Opt[eip4844.BlobsSidecar] = none(eip4844.BlobsSidecar),
+    queueTick: Moment = Moment.now(), validationDur = Duration()):
     Future[Result[BlockRef, (VerifierError, ProcessingStatus)]] {.async.} =
   ## storeBlock is the main entry point for unvalidated blocks - all untrusted
   ## blocks, regardless of origin, pass through here. When storing a block,
@@ -447,7 +457,7 @@ proc storeBlock*(
         return err((VerifierError.UnviableFork, ProcessingStatus.completed))
 
       if not self.consensusManager.quarantine[].addOrphan(
-          dag.finalizedHead.slot, ForkedSignedBeaconBlock.init(signedBlock)):
+        dag.finalizedHead.slot, ForkedSignedBeaconBlock.init(signedBlock), blobs):
         debug "Block quarantine full",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),
@@ -458,6 +468,10 @@ proc storeBlock*(
     else: discard
 
     return err((blck.error, ProcessingStatus.completed))
+
+  # write blobs now that block has been written.
+  if blobs.isSome():
+    self.consensusManager.dag.db.putBlobs(blobs.get())
 
   let storeBlockTick = Moment.now()
 
@@ -554,7 +568,7 @@ proc storeBlock*(
 
   for quarantined in self.consensusManager.quarantine[].pop(blck.get().root):
     # Process the blocks that had the newly accepted block as parent
-    self[].addBlock(MsgSource.gossip, quarantined)
+    self[].addBlock(MsgSource.gossip, quarantined[0], quarantined[1])
 
   return Result[BlockRef, (VerifierError, ProcessingStatus)].ok blck.get
 
@@ -563,7 +577,7 @@ proc storeBlock*(
 
 proc addBlock*(
     self: var BlockProcessor, src: MsgSource, blck: ForkedSignedBeaconBlock,
-    resfut: Future[Result[void, VerifierError]] = nil,
+    blobs: Opt[eip4844.BlobsSidecar], resfut: Future[Result[void, VerifierError]] = nil,
     validationDur = Duration()) =
   ## Enqueue a Gossip-validated block for consensus verification
   # Backpressure:
@@ -578,8 +592,7 @@ proc addBlock*(
     if blck.message.slot <= self.consensusManager.dag.finalizedHead.slot:
       # let backfill blocks skip the queue - these are always "fast" to process
       # because there are no state rewinds to deal with
-      let res = self.storeBackfillBlock(blck)
-
+      let res = self.storeBackfillBlock(blck, blobs)
       if resfut != nil:
         resfut.complete(res)
       return
@@ -587,6 +600,7 @@ proc addBlock*(
   try:
     self.blockQueue.addLastNoWait(BlockEntry(
       blck: blck,
+      blobs: blobs,
       resfut: resfut, queueTick: Moment.now(),
       validationDur: validationDur,
       src: src))
@@ -611,7 +625,8 @@ proc processBlock(
 
   let res = withBlck(entry.blck):
     await self.storeBlock(
-      entry.src, wallTime, blck, entry.queueTick, entry.validationDur)
+      entry.src, wallTime, blck, entry.blobs, entry.queueTick,
+      entry.validationDur)
 
   if res.isErr and res.error[1] == ProcessingStatus.notCompleted:
     # When an execution engine returns an error or fails to respond to a
@@ -622,8 +637,7 @@ proc processBlock(
     # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.2/sync/optimistic.md#execution-engine-errors
     await sleepAsync(chronos.seconds(1))
     self[].addBlock(
-      entry.src, entry.blck, entry.resfut, entry.validationDur)
-
+      entry.src, entry.blck, entry.blobs, entry.resfut, entry.validationDur)
     # To ensure backpressure on the sync manager, do not complete these futures.
     return
 

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -430,8 +430,6 @@ proc storeBlock*(
                                 .body.blob_kzg_commitments.asSeq,
                                 blobs.get()).isOk():
        return err((VerifierError.Invalid, ProcessingStatus.completed))
-    else:
-      discard
 
   type Trusted = typeof signedBlock.asTrusted()
   let blck = dag.addHeadBlock(self.verifier, signedBlock, payloadValid) do (

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -160,7 +160,7 @@ proc dumpBlock[T](
 
 from ../consensus_object_pools/block_clearance import
   addBackfillBlock, addHeadBlock
-from ../beacon_chain_db import putBlobs
+from ../beacon_chain_db import putBlobsSidecar
 
 proc storeBackfillBlock(
     self: var BlockProcessor,
@@ -190,7 +190,7 @@ proc storeBackfillBlock(
 
   if blobs.isSome():
     # Only store blobs after successfully establishing block viability.
-    self.consensusManager.dag.db.putBlobs(blobs.get())
+    self.consensusManager.dag.db.putBlobsSidecar(blobs.get())
   res
 
 from web3/engine_api_types import PayloadExecutionStatus, PayloadStatusV1
@@ -471,7 +471,7 @@ proc storeBlock*(
 
   # write blobs now that block has been written.
   if blobs.isSome():
-    self.consensusManager.dag.db.putBlobs(blobs.get())
+    self.consensusManager.dag.db.putBlobsSidecar(blobs.get())
 
   let storeBlockTick = Moment.now()
 

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -457,7 +457,7 @@ proc storeBlock*(
         return err((VerifierError.UnviableFork, ProcessingStatus.completed))
 
       if not self.consensusManager.quarantine[].addOrphan(
-        dag.finalizedHead.slot, ForkedSignedBeaconBlock.init(signedBlock), blobs):
+          dag.finalizedHead.slot, ForkedSignedBeaconBlock.init(signedBlock), blobs):
         debug "Block quarantine full",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -363,7 +363,7 @@ proc getExecutionValidity(
 proc storeBlock*(
     self: ref BlockProcessor, src: MsgSource, wallTime: BeaconTime,
     signedBlock: ForkySignedBeaconBlock,
-    blobs: Opt[eip4844.BlobsSidecar] = none(eip4844.BlobsSidecar),
+    blobs: Opt[eip4844.BlobsSidecar],
     queueTick: Moment = Moment.now(), validationDur = Duration()):
     Future[Result[BlockRef, (VerifierError, ProcessingStatus)]] {.async.} =
   ## storeBlock is the main entry point for unvalidated blocks - all untrusted

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -225,7 +225,7 @@ proc processSignedBeaconBlock*(
 
     self.blockProcessor[].addBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),
-      none(eip4844.BlobsSidecar),
+      Opt.none(eip4844.BlobsSidecar),
       validationDur = nanoseconds(
         (self.getCurrentBeaconTime() - wallTime).nanoseconds))
 
@@ -269,7 +269,7 @@ proc processSignedBeaconBlockAndBlobsSidecar*(
   debug "Block received", delay
 
   let blockRes =
-    self.dag.validateBeaconBlock(self.quarantine, signedBlock, some(blobs),
+    self.dag.validateBeaconBlock(self.quarantine, signedBlock, Opt.some(blobs),
                                  wallTime, {})
   if blockRes.isErr():
     debug "Dropping block", error = blockRes.error()
@@ -292,7 +292,7 @@ proc processSignedBeaconBlockAndBlobsSidecar*(
   trace "Block validated"
   self.blockProcessor[].addBlock(
     src, ForkedSignedBeaconBlock.init(signedBlock),
-    some(blobs),
+    Opt.some(blobs),
     validationDur = nanoseconds(
         (self.getCurrentBeaconTime() - wallTime).nanoseconds))
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -236,6 +236,10 @@ proc validateBeaconBlock*(
   # verification could be quite a bit more expensive than the rest. This is an
   # externally easy-to-invoke function by tossing network packets at the node.
 
+  # We should enforce this statically via the type system... but for now, assert.
+  when typeof(signed_beacon_block).toFork() < BeaconBlockFork.EIP4844:
+    doAssert blobs.isNone(), "Blobs with pre-EIP4844 block"
+
   # [IGNORE] The block is not from a future slot (with a
   # MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. validate that
   # signed_beacon_block.message.slot <= current_slot (a client MAY queue future

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -399,7 +399,7 @@ proc validateBeaconBlock*(
                          eip4844.SignedBeaconBlock,
     wallTime: BeaconTime, flags: UpdateFlags): Result[void, ValidationError] =
     dag.validateBeaconBlock(quarantine, signed_beacon_block,
-                            none(eip4844.BlobsSidecar), wallTime, flags)
+                            Opt.none(eip4844.BlobsSidecar), wallTime, flags)
 
 proc validateBeaconBlockAndBlobsSidecar*(signedBlock: SignedBeaconBlockAndBlobsSidecar):
                          Result[void, ValidationError] =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -309,7 +309,7 @@ proc initFullNode(
       # that should probably be reimagined more holistically in the future.
       let resfut = newFuture[Result[void, VerifierError]]("blockVerifier")
       blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                none(eip4844.BlobsSidecar), resfut)
+                                Opt.none(eip4844.BlobsSidecar), resfut)
       resfut
     processor = Eth2Processor.new(
       config.doppelgangerDetection,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -308,7 +308,8 @@ proc initFullNode(
       # taken in the sync/request managers - this is an architectural compromise
       # that should probably be reimagined more holistically in the future.
       let resfut = newFuture[Result[void, VerifierError]]("blockVerifier")
-      blockProcessor[].addBlock(MsgSource.gossip, signedBlock, resfut)
+      blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+                                none(eip4844.BlobsSidecar), resfut)
       resfut
     processor = Eth2Processor.new(
       config.doppelgangerDetection,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -421,7 +421,7 @@ proc init*(T: type BeaconNode,
       exitQueue: newAsyncEventQueue[SignedVoluntaryExit](),
       finalQueue: newAsyncEventQueue[FinalizationInfoObject]()
     )
-    db = BeaconChainDB.new(config.databaseDir, inMemory = false)
+    db = BeaconChainDB.new(config.databaseDir, cfg, inMemory = false)
 
   if config.finalizedCheckpointBlock.isSome:
     warn "--finalized-checkpoint-block has been deprecated, ignoring"

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -71,7 +71,7 @@ proc doTrustedNodeSync*(
       quit 1
 
   let
-    db = BeaconChainDB.new(databaseDir, inMemory = false)
+    db = BeaconChainDB.new(databaseDir, cfg, inMemory = false)
   defer:
     db.close()
 

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -11,6 +11,7 @@ else:
   {.push raises: [].}
 
 import
+  stew/results,
   std/sequtils,
   chronicles,
   metrics,
@@ -18,7 +19,8 @@ import
   ../consensus_object_pools/spec_cache,
   ../gossip_processing/eth2_processor,
   ../networking/eth2_network,
-  ./activity_metrics
+  ./activity_metrics,
+  ../spec/datatypes/eip4844
 
 export eth2_processor, eth2_network
 
@@ -122,7 +124,7 @@ proc routeSignedBeaconBlock*(
 
   let
     newBlockRef = await router[].blockProcessor.storeBlock(
-      MsgSource.api, sendTime, blck)
+      MsgSource.api, sendTime, blck, Opt.none(eip4844.BlobsSidecar))
 
   # The boolean we return tells the caller whether the block was integrated
   # into the chain

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -855,7 +855,7 @@ proc insertValidators(db: SqStoreRef, state: ForkedHashedBeaconState,
 proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
   # Create a database with performance information for every epoch
   info "Opening database..."
-  let db = BeaconChainDB.new(conf.databaseDir.string, false, true)
+  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
   defer: db.close()
 
   if (let v = ChainDAGRef.isInitialized(db); v.isErr()):

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -14,6 +14,7 @@ import
   eth/keys, taskpools,
   ../beacon_chain/beacon_clock,
   ../beacon_chain/spec/[beaconstate, forks, helpers, state_transition],
+  ../beacon_chain/spec/datatypes/eip4844,
   ../beacon_chain/gossip_processing/block_processor,
   ../beacon_chain/consensus_object_pools/[
     attestation_pool, blockchain_dag, block_quarantine, block_clearance,
@@ -59,7 +60,7 @@ suite "Block processor" & preset():
 
   asyncTest "Reverse order block add & get" & preset():
     let missing = await processor.storeBlock(
-      MsgSource.gossip, b2.message.slot.start_beacon_time(), b2)
+      MsgSource.gossip, b2.message.slot.start_beacon_time(), b2, Opt.none(BlobsSidecar))
     check: missing.error[0] == VerifierError.MissingParent
 
     check:
@@ -69,7 +70,7 @@ suite "Block processor" & preset():
 
     let
       status = await processor.storeBlock(
-        MsgSource.gossip, b2.message.slot.start_beacon_time(), b1)
+        MsgSource.gossip, b2.message.slot.start_beacon_time(), b1, Opt.none(BlobsSidecar))
       b1Get = dag.getBlockRef(b1.root)
 
     check:

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -10,7 +10,7 @@
 import
   unittest2,
   ../beacon_chain/spec/forks,
-  ../beacon_chain/spec/datatypes/phase0,
+  ../beacon_chain/spec/datatypes/[phase0,eip4844],
   ../beacon_chain/consensus_object_pools/block_quarantine
 
 func makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
@@ -35,13 +35,13 @@ suite "Block quarantine":
     check:
       FetchRecord(root: b1.root) in quarantine.checkMissing()
 
-      quarantine.addOrphan(Slot 0, b1)
+      quarantine.addOrphan(Slot 0, b1, Opt.none(BlobsSidecar))
 
       FetchRecord(root: b1.root) notin quarantine.checkMissing()
 
-      quarantine.addOrphan(Slot 0, b2)
-      quarantine.addOrphan(Slot 0, b3)
-      quarantine.addOrphan(Slot 0, b4)
+      quarantine.addOrphan(Slot 0, b2, Opt.none(BlobsSidecar))
+      quarantine.addOrphan(Slot 0, b3, Opt.none(BlobsSidecar))
+      quarantine.addOrphan(Slot 0, b4, Opt.none(BlobsSidecar))
 
       (b4.root, ValidatorSig()) in quarantine.orphans
 


### PR DESCRIPTION
Initial support for storing blobs. 

After a few different false starts, I ended up using `Opt[blob]`s quite extensively as that was the simplest / least invasive change. (Initially, I tried creating separate procs e.g. `AddBlockAndBlobs`, `StoreBlockAndBlobs` that would be used in lieu of the non-blob procs in the presence of blobs, but this was altogether more complex and lead to more repeated code).

Currently blob storage is only wired in for blobs coming from gossip. Sync is not wired in yet but _should_ also slot in relatively easily via passing a blob to `nimbus_beacon_node.blockVerifier()`