### PR TITLE
capella validator withdrawal credentials aren't immutable

### DIFF
--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -214,7 +214,8 @@ type
     eth1_deposit_index*: uint64
 
     # Registry
-    validators*: HashList[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
+    validators*:
+      HashList[ValidatorStatusCapella, Limit VALIDATOR_REGISTRY_LIMIT]
     balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness
@@ -279,7 +280,8 @@ type
     eth1_deposit_index*: uint64
 
     # Registry
-    validators*: HashList[ValidatorStatus, Limit VALIDATOR_REGISTRY_LIMIT]
+    validators*:
+      HashList[ValidatorStatusCapella, Limit VALIDATOR_REGISTRY_LIMIT]
     balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
 
     # Randomness

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -443,6 +443,32 @@ type
     withdrawable_epoch*: Epoch
       ## When validator can withdraw or transfer funds
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.2/specs/phase0/beacon-chain.md#validator
+  ValidatorStatusCapella* = object
+    # This is a validator without the expensive, immutable, append-only parts
+    # serialized. They're represented in memory to allow in-place SSZ reading
+    # and writing compatibly with the full Validator object.
+
+    pubkey* {.dontSerialize.}: ValidatorPubKey
+
+    withdrawal_credentials*: Eth2Digest
+      ## Commitment to pubkey for withdrawals and transfers
+
+    effective_balance*: Gwei
+      ## Balance at stake
+
+    slashed*: bool
+
+    # Status epochs
+    activation_eligibility_epoch*: Epoch
+      ## When criteria for activation were met
+
+    activation_epoch*: Epoch
+    exit_epoch*: Epoch
+
+    withdrawable_epoch*: Epoch
+      ## When validator can withdraw or transfer funds
+
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.2/specs/phase0/p2p-interface.md#eth2-field
   ENRForkID* = object
     fork_digest*: ForkDigest


### PR DESCRIPTION
Was resulting in
```
nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(489) main
nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(482) NimMain
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2125) main
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1988) handleStartUpCmd
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1812) doRunBeaconNode
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(562) init
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(168) loadChainDag
nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(1005) init
nimbus-eth2/vendor/nim-stew/stew/results.nim(791) expect
nimbus-eth2/vendor/nim-stew/stew/results.nim(368) raiseResultDefect
Error: unhandled exception: head blocks should apply: process_withdrawals: different numbers of payload and expected withdrawals [ResultDefect]
```
when restarting a client reaching capella