### PR TITLE
revert to Geth stable commits for testnet

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -455,12 +455,12 @@ fi
 
 
 download_geth() {
-  GETH_VERSION="1.11.0-unstable-b818e73e"
+  GETH_VERSION="1.10.26-e5eb32ac"
 
 # https://geth.ethereum.org/downloads/
-#  "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.11.0-unstable-b818e73e.tar.gz"
-#  "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.11.0-unstable-b818e73e.tar.gz"
-#  "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.11.0-unstable-b818e73e.zip"
+#  "https://gethstore.blob.core.windows.net/builds/geth-linux-amd64-1.10.26-e5eb32ac.tar.gz"
+#  "https://gethstore.blob.core.windows.net/builds/geth-darwin-amd64-1.10.26-e5eb32ac.tar.gz"
+#  "https://gethstore.blob.core.windows.net/builds/geth-windows-amd64-1.10.26-e5eb32ac.zip"
 
   GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 


### PR DESCRIPTION
The unstable versions seem to have disappeared. Intent was to be able to potentially run capella local testnets, but:
![20230109_13h21m51s_grim](https://user-images.githubusercontent.com/11422416/211308680-db872825-1317-4fbb-947c-8a4acbc46b8a.png)
