### PR TITLE
add `num_active_participants` helpers for `SyncAggregate`

### DIFF
--- a/beacon_chain/beacon_chain_db_light_client.nim
+++ b/beacon_chain/beacon_chain_db_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -226,7 +226,7 @@ func putBestUpdate*(
     db: LightClientDataDB, period: SyncCommitteePeriod,
     update: altair.LightClientUpdate) =
   doAssert period.isSupportedBySQLite
-  let numParticipants = countOnes(update.sync_aggregate.sync_committee_bits)
+  let numParticipants = update.sync_aggregate.num_active_participants
   if numParticipants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
     let res = db.bestUpdates.delStmt.exec(period.int64)
     res.expect("SQL query OK")

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -642,8 +642,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     attestations_len: v.body.attestations.len(),
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
-    sync_committee_participants:
-      countOnes(v.body.sync_aggregate.sync_committee_bits),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: 0'u64, # Bellatrix compat
     fee_recipient: "",
   )
@@ -672,6 +671,9 @@ func shortLog*(v: SyncCommitteeMessage): auto =
 
 func init*(T: type SyncAggregate): SyncAggregate =
   SyncAggregate(sync_committee_signature: ValidatorSig.infinity)
+
+func num_active_participants*(v: SomeSyncAggregate): int =
+  countOnes(v.sync_committee_bits)
 
 func shortLog*(v: SyncAggregate): auto =
   $(v.sync_committee_bits)
@@ -704,7 +706,7 @@ func shortLog*(v: LightClientUpdate): auto =
     attested: shortLog(v.attested_header),
     has_next_sync_committee: not v.next_sync_committee.isZeroMemory,
     finalized: shortLog(v.finalized_header),
-    num_active_participants: countOnes(v.sync_aggregate.sync_committee_bits),
+    num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot
   )
 
@@ -712,14 +714,14 @@ func shortLog*(v: LightClientFinalityUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     finalized: shortLog(v.finalized_header),
-    num_active_participants: countOnes(v.sync_aggregate.sync_committee_bits),
+    num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot
   )
 
 func shortLog*(v: LightClientOptimisticUpdate): auto =
   (
     attested: shortLog(v.attested_header),
-    num_active_participants: countOnes(v.sync_aggregate.sync_committee_bits),
+    num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot,
   )
 

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -382,8 +382,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     attestations_len: v.body.attestations.len(),
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
-    sync_committee_participants:
-      countOnes(v.body.sync_aggregate.sync_committee_bits),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -373,8 +373,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     attestations_len: v.body.attestations.len(),
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
-    sync_committee_participants:
-      countOnes(v.body.sync_aggregate.sync_committee_bits),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: 0'u64, # Bellatrix compat
     fee_recipient: "",
   )

--- a/beacon_chain/spec/datatypes/eip4844.nim
+++ b/beacon_chain/spec/datatypes/eip4844.nim
@@ -385,8 +385,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     attestations_len: v.body.attestations.len(),
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
-    sync_committee_participants:
-      countOnes(v.body.sync_aggregate.sync_committee_bits),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: 0'u64, # Bellatrix compat
     fee_recipient: "",
   )

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -14,7 +14,7 @@ else:
 
 import
   # Status libraries
-  stew/[bitops2, byteutils, endians2, objects, saturation_arith],
+  stew/[byteutils, endians2, objects, saturation_arith],
   chronicles,
   eth/eip1559, eth/common/[eth_types, eth_types_rlp],
   eth/rlp, eth/trie/[db, hexary],
@@ -259,7 +259,7 @@ func toMeta*(update: SomeLightClientUpdate): LightClientUpdateMetadata =
     else:
       false
   meta.num_active_participants =
-    countOnes(update.sync_aggregate.sync_committee_bits).uint64
+    update.sync_aggregate.num_active_participants.uint64
   meta
 
 func is_better_data*(new_meta, old_meta: LightClientUpdateMetadata): bool =

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -84,8 +84,7 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     attestations_len: v.body.attestations.len(),
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
-    sync_committee_participants:
-      countOnes(v.body.sync_aggregate.sync_committee_bits),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload_header.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload_header.fee_recipient.data),

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -187,9 +187,7 @@ proc handleLightClientUpdates*(node: BeaconNode, slot: Slot) {.async.} =
   if slot != signature_slot:
     return
 
-  template sync_aggregate(): auto = latest.sync_aggregate
-  template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
-  let num_active_participants = countOnes(sync_committee_bits).uint64
+  let num_active_participants = latest.sync_aggregate.num_active_participants
   if num_active_participants < MIN_SYNC_COMMITTEE_PARTICIPANTS:
     return
 


### PR DESCRIPTION
Introduce `num_active_participants` helper function to reduce visibility of low-level `countOnes` function and reduce code duplication.