### PR TITLE
stricter check for context bytes when recv LC data

### DIFF
--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -135,7 +135,7 @@ proc readChunkPayload*(
       return neterr InvalidContextBytes
   if res.isErr:
     return err(res.error)
-  if stateFork != node.cfg.stateForkAtEpoch(res.contextEpoch):
+  if stateFork != peer.network.cfg.stateForkAtEpoch(res.get.contextEpoch):
     return neterr InvalidContextBytes
   return ok res.get
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -135,6 +135,8 @@ proc readChunkPayload*(
       return neterr InvalidContextBytes
   if res.isErr:
     return err(res.error)
+  if stateFork != node.cfg.stateForkAtEpoch(res.contextEpoch):
+    return neterr InvalidContextBytes
   return ok res.get
 
 func shortLog*(s: StatusMsg): auto =


### PR DESCRIPTION
Bellatrix and Altair light client data share same body, but have other fork digests. Validate that the peer's sent fork digest matches the one that we expect (derived from `attested_header.slot`).