### PR TITLE
don't use non-engine-API-whitelisted web3 methods

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1747,9 +1747,6 @@ proc testWeb3Provider*(web3Url: Uri,
     res
 
   let
-    clientVersion = request "Client version":
-      web3.provider.web3_clientVersion()
-
     chainId = request "Chain ID":
       web3.provider.eth_chainId()
 
@@ -1758,12 +1755,6 @@ proc testWeb3Provider*(web3Url: Uri,
 
     syncStatus = request "Sync status":
       web3.provider.eth_syncing()
-
-    peers = request "Peers":
-      web3.provider.net_peerCount()
-
-    miningStatus = request "Mining status":
-      web3.provider.eth_mining()
 
     ns = web3.contractSender(DepositContract, depositContractAddress)
 


### PR DESCRIPTION
Otherwise attempts to interact with Geth on `withdrawals-testnet-2` stall with:
```
WARN [01-10|15:15:32.431] Served web3_clientVersion     ....   err="the method web3_clientVersion does not exist/is not available"
```
And https://github.com/ethereum/execution-apis/blob/main/src/engine/common.md#underlying-protocol does not require it to be:
> To facilitate an Engine API consumer to access state and logs (e.g. proof-of-stake deposits) through the same connection,
the client **MUST** also expose the following subset of `eth` methods:
> * `eth_blockNumber`
> * `eth_call`
> * `eth_chainId`
> * `eth_getCode`
> * `eth_getBlockByHash`
> * `eth_getBlockByNumber`
> * `eth_getLogs`
> * `eth_sendRawTransaction`
> * `eth_syncing`

This PR therefore removes from `testWeb3Provider` anything not a subset of those RPCs.