### PR TITLE
remove TTD monitoring

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -94,6 +94,7 @@ type
     dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
     externalBuilderRegistrations*:
       Table[ValidatorPubKey, SignedValidatorRegistrationV1]
+    mergeAtEpoch*: Epoch
 
 const
   MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -224,6 +224,12 @@ type
       desc: "The slashing DB flavour to use"
       name: "slashing-db-kind" .}: SlashingDbKind
 
+    mergeAtEpoch* {.
+      hidden
+      desc: "Debugging argument not for external use; may be removed at any time"
+      defaultValue: FAR_FUTURE_EPOCH
+      name: "merge-at-epoch-debug-internal" .}: uint64
+
     numThreads* {.
       defaultValue: 0,
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -324,12 +324,6 @@ proc getExecutionValidity(
     blck: bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
     eip4844.SignedBeaconBlock):
     Future[NewPayloadStatus] {.async.} =
-  # Eth1 syncing is asynchronous from this
-  # TODO self.consensusManager.eth1Monitor.ttdReached
-  # should gate this when it works more reliably
-  # TODO detect have-TTD-but-not-is_execution_block case, and where
-  # execution payload was non-zero when TTD detection more reliable
-
   if not blck.message.is_execution_block:
     return NewPayloadStatus.valid  # vacuously
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -571,8 +571,7 @@ proc init*(T: type BeaconNode,
       config.web3Urls,
       eth1Network,
       config.web3ForcePolling,
-      optJwtSecret,
-      ttdReached = not dag.loadExecutionBlockRoot(dag.finalizedHead.blck).isZero)
+      optJwtSecret)
 
   if config.rpcEnabled.isSome:
     warn "Nimbus's JSON-RPC server has been removed. This includes the --rpc, --rpc-port, and --rpc-address configuration options. https://nimbus.guide/rest-api.html shows how to enable and configure the REST Beacon API server which replaces it."
@@ -674,7 +673,8 @@ proc init*(T: type BeaconNode,
       # Delay first call by that time to allow for EL syncing to begin; it can
       # otherwise generate an EL warning by claiming a zero merge block.
       Moment.now + chronos.seconds(60),
-    dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()))
+    dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()),
+    mergeAtEpoch: config.mergeAtEpoch.Epoch)
 
   node.initLightClient(
     rng, cfg, dag.forkDigests, getBeaconTime, dag.genesis_validators_root)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -99,10 +99,7 @@ programMain:
           config.web3Urls,
           metadata.eth1Network,
           forcePolling = false,
-          rng[].loadJwtSecret(config, allowCreate = false),
-          # TTD is not relevant for the light client, so it's safe
-          # to assume that the TTD has been reached.
-          ttdReached = true)
+          rng[].loadJwtSecret(config, allowCreate = false))
         waitFor res.ensureDataProvider()
         res
       else:

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -387,10 +387,8 @@ proc getExecutionPayload[T](
       latestHead =
         if not executionBlockRoot.isZero:
           executionBlockRoot
-        elif node.eth1Monitor.terminalBlockHash.isSome:
-          node.eth1Monitor.terminalBlockHash.get.asEth2Digest
         else:
-          default(Eth2Digest)
+          (static(default(Eth2Digest)))
       latestSafe = beaconHead.safeExecutionPayloadHash
       latestFinalized = beaconHead.finalizedExecutionPayloadHash
       lastFcU = node.consensusManager.forkchoiceUpdatedInfo
@@ -472,10 +470,9 @@ proc makeBeaconBlockForHeadAndSlot*[EP](
         let fut = newFuture[Opt[EP]]("given-payload")
         fut.complete(execution_payload)
         fut
-      elif slot.epoch < node.dag.cfg.BELLATRIX_FORK_EPOCH or
-            not (
-              is_merge_transition_complete(state[]) or
-              ((not node.eth1Monitor.isNil) and node.eth1Monitor.ttdReached)):
+      elif slot.epoch < node.dag.cfg.BELLATRIX_FORK_EPOCH or not (
+          state[].is_merge_transition_complete or
+          slot.epoch >= node.mergeAtEpoch):
         let fut = newFuture[Opt[EP]]("empty-payload")
         # https://github.com/nim-lang/Nim/issues/19802
         fut.complete(Opt.some(default(EP)))


### PR DESCRIPTION
Supercedes https://github.com/status-im/nimbus-eth2/pull/4249

Only part of that not carried over is
```
diff --git a/scripts/launch_local_testnet.sh b/scripts/launch_local_testnet.sh
index a5a66da7..8678d726 100755
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -994,6 +994,7 @@ for NUM_NODE in $(seq 0 $(( NUM_NODES - 1 ))); do
     --keymanager-token-file="${DATA_DIR}/keymanager-token" \
     --rest-port="$(( BASE_REST_PORT + NUM_NODE ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE ))" \
+    --merge-at-epoch-debug-internal=2 \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &
```
because it didn't work unless there's a real EL present