### PR TITLE
compile-time flag to test SSZ `txs_root` / `withdrawals_root`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,10 @@ ifeq ($(USE_LIBBACKTRACE), 0)
 NIM_PARAMS += -d:disable_libbacktrace
 endif
 
+ifeq ($(DEBUG_CAPELLA_USE_SSZ), 1)
+NIM_PARAMS += -d:DEBUG_CAPELLA_USE_SSZ
+endif
+
 deps: | deps-common nat-libs build/generate_makefile
 ifneq ($(USE_LIBBACKTRACE), 0)
 deps: | libbacktrace

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -321,7 +321,12 @@ func asEth2Digest*(x: BlockHash): Eth2Digest =
 template asBlockHash*(x: Eth2Digest): BlockHash =
   BlockHash(x.data)
 
-const weiInGwei = 1_000_000_000.u256
+const
+  weiInGwei =
+    when DEBUG_CAPELLA_USE_SSZ:
+      1.u256
+    else:
+      1_000_000_000.u256
 
 from ../spec/datatypes/capella import ExecutionPayload, Withdrawal
 


### PR DESCRIPTION
There is a current discussion to transition certain EL block header parts to match their CL counterparts.

This includes:
1. Transitioning EL `Withdrawal` object to match CL `Withdrawal` object, i.e., use SSZ and Gwei amounts.
2. Transitioning EL `withdrawals_root` from hexary root to SSZ root.
3. Transitioning EL `txs_root` from hexary root to SSZ root. EL `Transaction` object is still exchanged in RLP format.

To support such tests, the engine API is updated for compatibility.

Use this command to build a compatible Nimbus beacon node:
```sh
make -j nimbus_beacon_node DEBUG_CAPELLA_USE_SSZ=1
```