### PR TITLE
drop subset sync contributions in gossip

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -599,7 +599,7 @@ proc processSignedContributionAndProof*(
 
   return if v.isOk():
     trace "Contribution validated"
-    let addStatus = self.syncCommitteeMsgPool[].addContribution(
+    self.syncCommitteeMsgPool[].addContribution(
       contributionAndProof, v.get()[0])
 
     self.validatorMonitor[].registerSyncContribution(
@@ -607,18 +607,7 @@ proc processSignedContributionAndProof*(
 
     beacon_sync_committee_contributions_received.inc()
 
-    case addStatus
-    of newBest, notBestButNotSubsetOfBest: ok()
-    of strictSubsetOfTheBest:
-      # This implements the spec directive:
-      #
-      # _[IGNORE]_ A valid sync committee contribution with equal `slot`, `beacon_block_root`
-      # and `subcommittee_index` whose `aggregation_bits` is non-strict superset has _not_
-      # already been seen.
-      #
-      # We are implementing this here, because this may be an unique contribution, so we would
-      # like for it to be counted and registered by the validator monitor above.
-      errIgnore("strict superset already seen")
+    ok()
   else:
     debug "Dropping contribution", error = v.error
     beacon_sync_committee_contributions_dropped.inc(1, [$v.error[0]])

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1008,11 +1008,9 @@ proc validateContribution*(
 
   # [REJECT] The subcommittee index is in the allowed range
   # i.e. contribution.subcommittee_index < SYNC_COMMITTEE_SUBNET_COUNT.
-  let subcommitteeIdx = block:
-    let v = SyncSubcommitteeIndex.init(msg.message.contribution.subcommittee_index)
-    if v.isErr():
-      return errReject("SignedContributionAndProof: subcommittee index too high")
-    v.get()
+  let subcommitteeIdx = SyncSubcommitteeIndex.init(
+      msg.message.contribution.subcommittee_index).valueOr:
+    return errReject("SignedContributionAndProof: subcommittee index too high")
 
   # [REJECT] contribution_and_proof.selection_proof selects the validator as an aggregator for the slot
   # i.e. is_sync_committee_aggregator(contribution_and_proof.selection_proof) returns True.
@@ -1041,19 +1039,17 @@ proc validateContribution*(
     # that is, any(contribution.aggregation_bits).
     return errReject("SignedContributionAndProof: aggregation bits empty")
 
+  # _[IGNORE]_ A valid sync committee contribution with equal `slot`, `beacon_block_root`
+  # and `subcommittee_index` whose `aggregation_bits` is non-strict superset has _not_
+  # already been seen.
+  if syncCommitteeMsgPool[].covers(msg.message.contribution):
+    return errIgnore("SignedContributionAndProof: duplicate contribution")
+
   # TODO we take a copy of the participants to avoid the data going stale
   #      between validation and use - nonetheless, a design that avoids it and
   #      stays safe would be nice
   let participants = dag.syncCommitteeParticipants(
     msg.message.contribution.slot, subcommitteeIdx)
-
-  # The following spec rule:
-  #
-  # _[IGNORE]_ A valid sync committee contribution with equal `slot`, `beacon_block_root`
-  # and `subcommittee_index` whose `aggregation_bits` is non-strict superset has _not_
-  # already been seen.
-  #
-  # is implemented in eth2_processor.nim
 
   let sig = if checkSignature:
     let deferredCrypto = batchCrypto.scheduleContributionChecks(

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -468,11 +468,13 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             signedContributionAndProof,
             contributionsTime,
             false)
+        if res.isOk():
+          syncCommitteePool[].addContribution(
+            signedContributionAndProof, res.get()[0])
+        else:
+          # We ignore duplicates / already-covered contributions
+          doAssert res.error()[0] == ValidationResult.Ignore
 
-        doAssert res.isOk or (res.error()[0] == ValidationResult.Ignore)
-
-        syncCommitteePool[].addContribution(
-          signedContributionAndProof, res.get()[0])
 
   proc getNewBlock[T](
       state: var ForkedHashedBeaconState, slot: Slot, cache: var StateCache): T =

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -469,9 +469,9 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
             contributionsTime,
             false)
 
-        doAssert res.isOk
+        doAssert res.isOk or (res.error()[0] == ValidationResult.Ignore)
 
-        discard syncCommitteePool[].addContribution(
+        syncCommitteePool[].addContribution(
           signedContributionAndProof, res.get()[0])
 
   proc getNewBlock[T](

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -256,9 +256,8 @@ suite "Gossip validation - Extra": # Not based on preset config
           syncCommitteeMsgPool[].produceContribution(
             slot, state[].root, subcommitteeIdx,
             contribution.message.contribution)
-        let addContributionRes = syncCommitteeMsgPool[].addContribution(
+        syncCommitteeMsgPool[].addContribution(
           contribution[], contribution.message.contribution.signature.load.get)
-        check addContributionRes == newBest
         let signRes = waitFor validator.getContributionAndProofSignature(
           state[].data.fork, state[].data.genesis_validators_root,
           contribution[].message)

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -118,10 +118,13 @@ suite "Sync committee pool":
         contribution.aggregation_bits[10] == true
         contribution.signature == expectedSig.toValidatorSig
 
-      let addContributionRes = pool.addContribution(outContribution, expectedSig)
       check:
-        addContributionRes == newBest
+        not pool.covers(contribution)
+
+      pool.addContribution(outContribution, expectedSig)
+      check:
         pool.isSeen(outContribution.message)
+        pool.covers(contribution)
 
     block:
       # Checking a committee with a signle participant:
@@ -142,10 +145,12 @@ suite "Sync committee pool":
         contribution.aggregation_bits[7] == true
         contribution.signature == sig3.toValidatorSig
 
-      let addContributionRes = pool.addContribution(outContribution, sig3)
       check:
-        addContributionRes == newBest
+        not pool.covers(contribution)
+      pool.addContribution(outContribution, sig3)
+      check:
         pool.isSeen(outContribution.message)
+        pool.covers(contribution)
 
     block:
       # Checking another committee with a signle participant
@@ -167,10 +172,13 @@ suite "Sync committee pool":
         contribution.aggregation_bits[3] == true
         contribution.signature == sig4.toValidatorSig
 
-      let addContributionRes = pool.addContribution(outContribution, sig4)
       check:
-        addContributionRes == newBest
+        not pool.covers(contribution)
+      pool.addContribution(outContribution, sig4)
+
+      check:
         pool.isSeen(outContribution.message)
+        pool.covers(contribution)
 
     block:
       # Checking a block root nobody voted for

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -511,7 +511,7 @@ proc makeSyncAggregate(
         signedContributionAndProof = SignedContributionAndProof(
           message: contributionAndProof,
           signature: contributionSig.toValidatorSig)
-      discard syncCommitteePool[].addContribution(
+      syncCommitteePool[].addContribution(
         signedContributionAndProof, contribution.signature.load.get)
 
   syncCommitteePool[].produceSyncAggregate(latest_block_root)


### PR DESCRIPTION
* correctly report ignored contributions in metrics
* avoid counting subset contributions in vmon (bring in line with attestation aggregates)
* avoid signature checks for subset attestations

Being a non-strict subset is a sufficient condition to ignore.