### PR TITLE
Revert "reduce intermittent Windows GitHub Actions CI build failures"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,7 @@ jobs:
             ncpu=$(sysctl -n hw.ncpu)
             ;;
           'Windows')
-            # otherwise, intermittent CI build failures
-            # e.g., cc1.exe: out of memory allocating 215528 bytes
-            # underflow corrected later
-            ncpu=$((${NUMBER_OF_PROCESSORS} - 1))
+            ncpu=${NUMBER_OF_PROCESSORS}
             make_cmd="mingw32-make"
             ;;
           esac


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#4495

Windows CI jobs are slowing too much, some timing out at 4+ hours when they never used to.

The OOMs are still a problem, but that PR was too big a change.

It's possible that the OOMs are hitting on some build servers with more cores available, or other more specific conditions which need to be checked, and others are only presenting 2 or 4 cores, where not using all of them hurts build time disproportionately compared to 8 or 12 or 16.