### PR TITLE
show number of cores and total physical memory on Windows GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
           'Windows')
             ncpu=${NUMBER_OF_PROCESSORS}
             make_cmd="mingw32-make"
+            echo "Number of cores: ${NUMBER_OF_PROCESSORS}"
+            echo "Physical memory: $(wmic ComputerSystem get TotalPhysicalMemory)"
             ;;
           esac
           [[ -z "$ncpu" || $ncpu -le 0 ]] && ncpu=1


### PR DESCRIPTION
Followup to https://github.com/status-im/nimbus-eth2/pull/4495 and https://github.com/status-im/nimbus-eth2/pull/4502

4495 was too aggressive, but it remains possible that GitHub Actions is supplying varyingly configured CI VMs, some of which are identifiable/predictably more likely to result in OOMs and can be detected as such, while others might have fewer cores or more RAM. This PR aims to allow discovery of such.