### PR TITLE
LC data fork cleanup

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -303,7 +303,7 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + LVH searching                                                                              OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Light client [Preset: mainnet]
+## Light client - Altair [Preset: mainnet]
 ```diff
 + Init from checkpoint                                                                       OK
 + Light client sync                                                                          OK

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -12,10 +12,11 @@ else:
 
 import
   chronicles,
-  ./spec/datatypes/altair,
   ./beacon_node
 
 logScope: topics = "beacnde"
+
+const storeDataFork = LightClient.storeDataFork
 
 func shouldSyncOptimistically*(node: BeaconNode, wallSlot: Slot): bool =
   if node.eth1Monitor == nil:
@@ -87,7 +88,7 @@ proc initLightClient*(
   if config.syncLightClient:
     proc onOptimisticHeader(
         lightClient: LightClient,
-        optimisticHeader: altair.LightClientHeader) =
+        optimisticHeader: storeDataFork.LightClientHeader) =
       optimisticProcessor.setOptimisticHeader(optimisticHeader.beacon)
 
     lightClient.onOptimisticHeader = onOptimisticHeader
@@ -154,7 +155,7 @@ proc updateLightClientFromDag*(node: BeaconNode) =
     bdata = node.dag.getForkedBlock(dagHead.blck.bid).valueOr:
       return
     header = withBlck(bdata):
-      blck.toLightClientHeader(LightClientStore.kind)
+      blck.toLightClientHeader(storeDataFork)
     current_sync_committee = block:
       let tmpState = assignClone(node.dag.headState)
       node.dag.currentSyncCommitteeForPeriod(tmpState[], dagPeriod).valueOr:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1097,7 +1097,7 @@ proc validateLightClientFinalityUpdate*(
     finality_update: ForkedLightClientFinalityUpdate,
     wallTime: BeaconTime): Result[void, ValidationError] =
   let finalized_slot = withForkyFinalityUpdate(finality_update):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       forkyFinalityUpdate.finalized_header.beacon.slot
     else:
       GENESIS_SLOT
@@ -1108,7 +1108,7 @@ proc validateLightClientFinalityUpdate*(
 
   let
     signature_slot = withForkyFinalityUpdate(finality_update):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         forkyFinalityUpdate.signature_slot
       else:
         GENESIS_SLOT
@@ -1133,7 +1133,7 @@ proc validateLightClientOptimisticUpdate*(
     optimistic_update: ForkedLightClientOptimisticUpdate,
     wallTime: BeaconTime): Result[void, ValidationError] =
   let attested_slot = withForkyOptimisticUpdate(optimistic_update):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       forkyOptimisticUpdate.attested_header.beacon.slot
     else:
       GENESIS_SLOT
@@ -1144,7 +1144,7 @@ proc validateLightClientOptimisticUpdate*(
 
   let
     signature_slot = withForkyOptimisticUpdate(optimistic_update):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         forkyOptimisticUpdate.signature_slot
       else:
         GENESIS_SLOT

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -13,7 +13,6 @@ else:
 import
   stew/objects,
   chronos, metrics,
-  ../spec/datatypes/altair,
   ../spec/light_client_sync,
   ../consensus_object_pools/block_pools_types,
   ".."/[beacon_clock, sszdump],
@@ -29,6 +28,8 @@ logScope: topics = "gossip_lc"
 
 declareHistogram light_client_store_object_duration_seconds,
   "storeObject() duration", buckets = [0.25, 0.5, 1, 2, 4, 8, Inf]
+
+template storeDataFork: LightClientDataFork = LightClientDataFork.high
 
 type
   Nothing = object
@@ -100,7 +101,7 @@ type
 
     # Consumer
     # ----------------------------------------------------------------
-    store: ref Option[LightClientStore]
+    store: ref Option[storeDataFork.LightClientStore]
     getBeaconTime: GetBeaconTimeFn
     getTrustedBlockRoot: GetTrustedBlockRootCallback
     onStoreInitialized, onFinalizedHeader, onOptimisticHeader: VoidCallback
@@ -129,6 +130,9 @@ const
   minForceUpdateDelay = chronos.minutes(30) # Minimum delay until forced-update
   minForceUpdateDuplicates = 100 # Minimum duplicates until forced-update
 
+func storeDataFork*(x: typedesc[LightClientProcessor]): LightClientDataFork =
+  storeDataFork
+
 # Initialization
 # ------------------------------------------------------------------------------
 
@@ -139,7 +143,7 @@ proc new*(
     cfg: RuntimeConfig,
     genesis_validators_root: Eth2Digest,
     finalizationMode: LightClientFinalizationMode,
-    store: ref Option[LightClientStore],
+    store: ref Option[storeDataFork.LightClientStore],
     getBeaconTime: GetBeaconTimeFn,
     getTrustedBlockRoot: GetTrustedBlockRootCallback,
     onStoreInitialized: VoidCallback = nil,
@@ -219,39 +223,45 @@ proc processObject(
   let
     wallSlot = wallTime.slotOrZero()
     store = self.store
-    res = withForkyObject(obj):
-      when lcDataFork >= LightClientDataFork.Altair:
-        when forkyObject is ForkyLightClientBootstrap:
-          if store[].isSome:
-            err(VerifierError.Duplicate)
-          else:
-            let trustedBlockRoot = self.getTrustedBlockRoot()
-            if trustedBlockRoot.isNone:
-              err(VerifierError.MissingParent)
-            else:
-              let initRes =
-                initialize_light_client_store(trustedBlockRoot.get, forkyObject)
-              if initRes.isErr:
-                err(initRes.error)
+    res =
+      if obj.kind > storeDataFork:
+        err(VerifierError.MissingParent)
+      elif obj.kind > LightClientDataFork.None:
+        let upgradedObj = obj.migratingToDataFork(storeDataFork)
+        withForkyObject(upgradedObj):
+          when lcDataFork == storeDataFork:
+            when forkyObject is ForkyLightClientBootstrap:
+              if store[].isSome:
+                err(VerifierError.Duplicate)
               else:
-                store[] = some(initRes.get)
-                ok()
-        elif forkyObject is SomeForkyLightClientUpdate:
-          if store[].isNone:
-            err(VerifierError.MissingParent)
-          else:
-            store[].get.process_light_client_update(
-              forkyObject, wallSlot, self.cfg, self.genesis_validators_root)
+                let trustedBlockRoot = self.getTrustedBlockRoot()
+                if trustedBlockRoot.isNone:
+                  err(VerifierError.MissingParent)
+                else:
+                  let initRes = initialize_light_client_store(
+                    trustedBlockRoot.get, forkyObject, self.cfg)
+                  if initRes.isErr:
+                    err(initRes.error)
+                  else:
+                    store[] = some(initRes.get)
+                    ok()
+            elif forkyObject is SomeForkyLightClientUpdate:
+              if store[].isNone:
+                err(VerifierError.MissingParent)
+              else:
+                store[].get.process_light_client_update(
+                  forkyObject, wallSlot,
+                  self.cfg, self.genesis_validators_root)
+          else: raiseAssert "Unreachable"
       else:
         err(VerifierError.Invalid)
 
   withForkyObject(obj):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       self.dumpObject(forkyObject, res)
 
   if res.isErr:
     when obj is ForkedLightClientUpdate:
-      const storeDataFork = typeof(store[].get).kind
       if self.finalizationMode == LightClientFinalizationMode.Optimistic and
           store[].isSome and store[].get.best_valid_update.isSome and
           obj.kind > LightClientDataFork.None and obj.kind <= storeDataFork:
@@ -300,12 +310,12 @@ template withReportedProgress(
         if store[].isSome:
           store[].get.finalized_header
         else:
-          altair.LightClientHeader()
+          default(typeof(store[].get.finalized_header))
       previousOptimistic =
         if store[].isSome:
           store[].get.optimistic_header
         else:
-          altair.LightClientHeader()
+          default(typeof(store[].get.optimistic_header))
 
     body
 
@@ -323,7 +333,7 @@ template withReportedProgress(
     if store[].isSome:
       if store[].get.optimistic_header != previousOptimistic:
         didProgress = true
-        when obj isnot SomeLightClientUpdateWithFinality:
+        when obj isnot SomeForkedLightClientUpdateWithFinality:
           didSignificantProgress = true
         if self.onOptimisticHeader != nil:
           self.onOptimisticHeader()
@@ -382,7 +392,7 @@ proc storeObject*(
           storeObjectDur.toFloatSeconds())
 
         let objSlot = withForkyObject(obj):
-          when lcDataFork >= LightClientDataFork.Altair:
+          when lcDataFork > LightClientDataFork.None:
             when forkyObject is ForkyLightClientBootstrap:
               forkyObject.header.beacon.slot
             elif forkyObject is SomeForkyLightClientUpdateWithFinality:
@@ -401,12 +411,12 @@ proc storeObject*(
 
 proc resetToFinalizedHeader*(
     self: var LightClientProcessor,
-    header: altair.LightClientHeader,
+    header: storeDataFork.LightClientHeader,
     current_sync_committee: SyncCommittee) =
   let store = self.store
 
   discard withReportedProgress:
-    store[] = some LightClientStore(
+    store[] = some storeDataFork.LightClientStore(
       finalized_header: header,
       current_sync_committee: current_sync_committee,
       optimistic_header: header)
@@ -466,7 +476,7 @@ func toValidationError(
     if didSignificantProgress:
       let
         signature_slot = withForkyObject(obj):
-          when lcDataFork >= LightClientDataFork.Altair:
+          when lcDataFork > LightClientDataFork.None:
             forkyObject.signature_slot
           else:
             GENESIS_SLOT
@@ -531,12 +541,12 @@ proc processLightClientOptimisticUpdate*(
   if v.isOk:
     let
       latestFinalitySlot = withForkyOptimisticUpdate(self.latestFinalityUpdate):
-        when lcDataFork >= LightClientDataFork.Altair:
+        when lcDataFork > LightClientDataFork.None:
           forkyOptimisticUpdate.attested_header.beacon.slot
         else:
           GENESIS_SLOT
       attestedSlot = withForkyOptimisticUpdate(optimistic_update):
-        when lcDataFork >= LightClientDataFork.Altair:
+        when lcDataFork > LightClientDataFork.None:
           forkyOptimisticUpdate.attested_header.beacon.slot
         else:
           GENESIS_SLOT

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -26,7 +26,7 @@ logScope: topics = "lcdb"
 # `altair_sync_committees` holds finalized `SyncCommittee` by period, needed to
 # continue an interrupted sync process without having to obtain bootstrap info.
 
-const dbDataFork = LightClientDataFork.Altair
+template dbDataFork: LightClientDataFork = LightClientDataFork.Altair
 
 type
   LightClientHeaderKind {.pure.} = enum  # Append only, used in DB data!

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -26,8 +26,10 @@ logScope: topics = "lcdb"
 # `altair_sync_committees` holds finalized `SyncCommittee` by period, needed to
 # continue an interrupted sync process without having to obtain bootstrap info.
 
+const dbDataFork = LightClientDataFork.Altair
+
 type
-  LightClientHeaderKind {.pure.} = enum
+  LightClientHeaderKind {.pure.} = enum  # Append only, used in DB data!
     Finalized = 1
 
   LightClientHeadersStore = object
@@ -54,6 +56,7 @@ type
 func initLightClientHeadersStore(
     backend: SqStoreRef,
     name: string): KvResult[LightClientHeadersStore] =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   ? backend.exec("""
     CREATE TABLE IF NOT EXISTS `""" & name & """` (
       `kind` INTEGER PRIMARY KEY,  -- `LightClientHeaderKind`
@@ -82,20 +85,20 @@ func close(store: LightClientHeadersStore) =
   store.putStmt.dispose()
 
 proc getLatestFinalizedHeader*(
-    db: LightClientDB): Opt[altair.LightClientHeader] =
+    db: LightClientDB): Opt[dbDataFork.LightClientHeader] =
   var header: seq[byte]
   for res in db.headers.getStmt.exec(
       LightClientHeaderKind.Finalized.int64, header):
     res.expect("SQL query OK")
     try:
-      return ok SSZ.decode(header, altair.LightClientHeader)
+      return ok SSZ.decode(header, dbDataFork.LightClientHeader)
     except SszError as exc:
       error "LC store corrupted", store = "headers",
         kind = "Finalized", exc = exc.msg
       return err()
 
 func putLatestFinalizedHeader*(
-    db: LightClientDB, header: altair.LightClientHeader) =
+    db: LightClientDB, header: dbDataFork.LightClientHeader) =
   block:
     let res = db.headers.putStmt.exec(
       (LightClientHeaderKind.Finalized.int64, SSZ.encode(header)))

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -832,7 +832,7 @@ template gossipMaxSize(T: untyped): uint32 =
     # having max sizes significantly smaller than GOSSIP_MAX_SIZE.
     elif T is Attestation or T is AttesterSlashing or
          T is SignedAggregateAndProof or T is phase0.SignedBeaconBlock or
-         T is altair.SignedBeaconBlock:
+         T is altair.SignedBeaconBlock or T is SomeForkyLightClientObject:
       GOSSIP_MAX_SIZE
     else:
       {.fatal: "unknown type " & name(T).}

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -153,7 +153,7 @@ proc loadChainDag(
   proc onLightClientFinalityUpdate(data: ForkedLightClientFinalityUpdate) =
     if dag == nil: return
     withForkyFinalityUpdate(data):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         let contextFork =
           dag.cfg.stateForkAtEpoch(forkyFinalityUpdate.contextEpoch)
         eventBus.finUpdateQueue.emit(
@@ -164,7 +164,7 @@ proc loadChainDag(
   proc onLightClientOptimisticUpdate(data: ForkedLightClientOptimisticUpdate) =
     if dag == nil: return
     withForkyOptimisticUpdate(data):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         let contextFork =
           dag.cfg.stateForkAtEpoch(forkyOptimisticUpdate.contextEpoch)
         eventBus.optUpdateQueue.emit(

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -52,6 +52,7 @@ programMain:
     quit 1
   let backend = SqStoreRef.init(dbDir, "nlc").expect("Database OK")
   defer: backend.close()
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   let db = backend.initLightClientDB(LightClientDBNames(
     altairHeaders: "altair_lc_headers",
     altairSyncCommittees: "altair_sync_committees")).expect("Database OK")
@@ -246,10 +247,16 @@ programMain:
       oldGossipForks = currentGossipState - targetGossipState
 
     for gossipFork in oldGossipForks:
+      if gossipFork >= BeaconStateFork.Capella:
+        # Format is still in development, do not use Gossip at this time.
+        continue
       let forkDigest = forkDigests[].atStateFork(gossipFork)
       network.unsubscribe(getBeaconBlocksTopic(forkDigest))
 
     for gossipFork in newGossipForks:
+      if gossipFork >= BeaconStateFork.Capella:
+        # Format is still in development, do not use Gossip at this time.
+        continue
       let forkDigest = forkDigests[].atStateFork(gossipFork)
       network.subscribe(
         getBeaconBlocksTopic(forkDigest), blocksTopicParams,

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -38,7 +38,7 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     let bootstrap = node.dag.getLightClientBootstrap(vroot)
     withForkyBootstrap(bootstrap):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyBootstrap.contextEpoch
           contextFork = node.dag.cfg.stateForkAtEpoch(contextEpoch)
@@ -100,7 +100,7 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
       let
         update = node.dag.getLightClientUpdateForPeriod(period)
         contextEpoch = withForkyUpdate(update):
-          when lcDataFork >= LightClientDataFork.Altair:
+          when lcDataFork > LightClientDataFork.None:
             forkyUpdate.contextEpoch
           else:
             continue
@@ -133,7 +133,7 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     let finality_update = node.dag.getLightClientFinalityUpdate()
     withForkyFinalityUpdate(finality_update):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyFinalityUpdate.contextEpoch
           contextFork = node.dag.cfg.stateForkAtEpoch(contextEpoch)
@@ -164,7 +164,7 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     let optimistic_update = node.dag.getLightClientOptimisticUpdate()
     withForkyOptimisticUpdate(optimistic_update):
-      when lcDataFork >= LightClientDataFork.Altair:
+      when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyOptimisticUpdate.contextEpoch
           contextFork = node.dag.cfg.stateForkAtEpoch(contextEpoch)

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -701,7 +701,9 @@ chronicles.formatIt SyncCommitteeContribution: shortLog(it)
 chronicles.formatIt ContributionAndProof: shortLog(it)
 chronicles.formatIt SignedContributionAndProof: shortLog(it)
 
-func is_valid_light_client_header*(v: LightClientHeader): bool =
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.1/specs/altair/light-client/sync-protocol.md#is_valid_light_client_header
+func is_valid_light_client_header*(
+    header: LightClientHeader, cfg: RuntimeConfig): bool =
   true
 
 func shortLog*(v: LightClientHeader): auto =
@@ -717,7 +719,8 @@ func shortLog*(v: LightClientBootstrap): auto =
 func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
-    has_next_sync_committee: not v.next_sync_committee.isZeroMemory,
+    has_next_sync_committee:
+      v.next_sync_committee != default(typeof(v.next_sync_committee)),
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -19,6 +19,7 @@ else:
   {.push raises: [].}
 
 import
+  stew/byteutils,
   json_serialization,
   ssz_serialization/types as sszTypes,
   ../digest,
@@ -387,8 +388,9 @@ func shortLog*(v: SomeBeaconBlock): auto =
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
-    block_number: 0'u64, # Bellatrix compat
-    fee_recipient: "",
+    block_number: v.body.execution_payload.block_number,
+    # TODO checksum hex? shortlog?
+    fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
   )
 
 func shortLog*(v: SomeSignedBeaconBlock): auto =

--- a/beacon_chain/spec/datatypes/eip4844.nim
+++ b/beacon_chain/spec/datatypes/eip4844.nim
@@ -19,6 +19,7 @@ else:
   {.push raises: [].}
 
 import
+  stew/byteutils,
   json_serialization,
   ssz_serialization/types as sszTypes,
   ../digest,
@@ -392,8 +393,9 @@ func shortLog*(v: SomeBeaconBlock): auto =
     deposits_len: v.body.deposits.len(),
     voluntary_exits_len: v.body.voluntary_exits.len(),
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
-    block_number: 0'u64, # Bellatrix compat
-    fee_recipient: "",
+    block_number: v.body.execution_payload.block_number,
+    # TODO checksum hex? shortlog?
+    fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
   )
 
 func shortLog*(v: SomeSignedBeaconBlock): auto =

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -173,7 +173,7 @@ proc prepareJsonStringResponse*[T: SomeForkedLightClientObject](
         var stream = memoryOutput()
         var writer = JsonWriter[RestJson].init(stream)
         withForkyObject(d.data):
-          when lcDataFork >= LightClientDataFork.Altair:
+          when lcDataFork > LightClientDataFork.None:
             writer.beginRecord()
             writer.writeField("version", d.jsonVersion.toString())
             writer.writeField("data", forkyObject)
@@ -341,7 +341,7 @@ proc jsonResponseVersioned*[T: SomeForkedLightClientObject](
         var writer = JsonWriter[RestJson].init(stream)
         for e in writer.stepwiseArrayCreation(entries):
           withForkyObject(e.data):
-            when lcDataFork >= LightClientDataFork.Altair:
+            when lcDataFork > LightClientDataFork.None:
               writer.beginRecord()
               writer.writeField("version", e.jsonVersion.toString())
               writer.writeField("data", forkyObject)
@@ -499,7 +499,7 @@ proc sszResponseVersioned*[T: SomeForkedLightClientObject](
         var stream = memoryOutput()
         for e in entries:
           withForkyUpdate(e.data):
-            when lcDataFork >= LightClientDataFork.Altair:
+            when lcDataFork > LightClientDataFork.None:
               var cursor = stream.delayFixedSizeWrite(sizeof(uint64))
               let initPos = stream.pos
               stream.write e.sszContext.data

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -20,11 +20,10 @@ import
   ./datatypes/[phase0, altair, bellatrix, capella, eip4844],
   ./mev/bellatrix_mev
 
-# TODO re-export capella, but for now it could cause knock-on effects, so stage
-# it sequentially
 export
-  extras, block_id, phase0, altair, bellatrix, eth2_merkleization,
-  eth2_ssz_serialization, forks_light_client, presets, bellatrix_mev
+  extras, block_id, phase0, altair, bellatrix, capella, eip4844,
+  eth2_merkleization, eth2_ssz_serialization, forks_light_client,
+  presets, bellatrix_mev
 
 # This file contains helpers for dealing with forks - we have two ways we can
 # deal with forks:
@@ -859,6 +858,13 @@ func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   of BeaconStateFork.Bellatrix: cfg.CAPELLA_FORK_EPOCH
   of BeaconStateFork.Altair:    cfg.BELLATRIX_FORK_EPOCH
   of BeaconStateFork.Phase0:    cfg.ALTAIR_FORK_EPOCH
+
+func lcDataForkAtStateFork*(stateFork: BeaconStateFork): LightClientDataFork =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  if stateFork >= BeaconStateFork.Altair:
+    LightClientDataFork.Altair
+  else:
+    LightClientDataFork.None
 
 func getForkSchedule*(cfg: RuntimeConfig): array[5, Fork] =
   ## This procedure returns list of known and/or scheduled forks.

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -272,6 +272,39 @@ template toFork*[T: eip4844.BeaconState | eip4844.HashedBeaconState](
     t: type T): BeaconStateFork =
   BeaconStateFork.EIP4844
 
+template BeaconState*(kind: static BeaconStateFork): auto =
+  static:
+    case kind
+    of BeaconStateFork.EIP4844:
+      typedesc[eip4844.BeaconState]
+    of BeaconStateFork.Capella:
+      typedesc[capella.BeaconState]
+    of BeaconStateFork.Bellatrix:
+      typedesc[bellatrix.BeaconState]
+    of BeaconStateFork.Altair:
+      typedesc[altair.BeaconState]
+    of BeaconStateFork.Phase0:
+      typedesc[phase0.BeaconState]
+
+template withStateFork*(
+    x: BeaconStateFork, body: untyped): untyped =
+  case x
+  of BeaconStateFork.EIP4844:
+    const stateFork {.inject, used.} = BeaconStateFork.Eip4844
+    body
+  of BeaconStateFork.Capella:
+    const stateFork {.inject, used.} = BeaconStateFork.Capella
+    body
+  of BeaconStateFork.Bellatrix:
+    const stateFork {.inject, used.} = BeaconStateFork.Bellatrix
+    body
+  of BeaconStateFork.Altair:
+    const stateFork {.inject, used.} = BeaconStateFork.Altair
+    body
+  of BeaconStateFork.Phase0:
+    const stateFork {.inject, used.} = BeaconStateFork.Phase0
+    body
+
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
 # `ref T`
 func new*(T: type ForkedHashedBeaconState, data: phase0.BeaconState):

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -273,18 +273,18 @@ template toFork*[T: eip4844.BeaconState | eip4844.HashedBeaconState](
   BeaconStateFork.EIP4844
 
 template BeaconState*(kind: static BeaconStateFork): auto =
-  static:
-    case kind
-    of BeaconStateFork.EIP4844:
-      typedesc[eip4844.BeaconState]
-    of BeaconStateFork.Capella:
-      typedesc[capella.BeaconState]
-    of BeaconStateFork.Bellatrix:
-      typedesc[bellatrix.BeaconState]
-    of BeaconStateFork.Altair:
-      typedesc[altair.BeaconState]
-    of BeaconStateFork.Phase0:
-      typedesc[phase0.BeaconState]
+  when kind == BeaconStateFork.EIP4844:
+    typedesc[eip4844.BeaconState]
+  elif kind == BeaconStateFork.Capella:
+    typedesc[capella.BeaconState]
+  elif kind == BeaconStateFork.Bellatrix:
+    typedesc[bellatrix.BeaconState]
+  elif kind == BeaconStateFork.Altair:
+    typedesc[altair.BeaconState]
+  elif kind == BeaconStateFork.Phase0:
+    typedesc[phase0.BeaconState]
+  else:
+    static: raiseAssert "Unreachable"
 
 template withStateFork*(
     x: BeaconStateFork, body: untyped): untyped =

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -335,7 +335,8 @@ func matches*[A, B: SomeForkedLightClientUpdate](a: A, b: B): bool =
       true
 
 template forky*(
-    x: SomeForkedLightClientObject, kind: static LightClientDataFork): untyped =
+    x: SomeForkedLightClientObject | ForkedLightClientStore,
+    kind: static LightClientDataFork): untyped =
   when kind == LightClientDataFork.Altair:
     x.altairData
   else:

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -115,43 +115,37 @@ template kind*(
   LightClientDataFork.Altair
 
 template LightClientHeader*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientHeader]
   else:
     static: raiseAssert "Unreachable"
 
 template LightClientBootstrap*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientBootstrap]
   else:
     static: raiseAssert "Unreachable"
 
 template LightClientUpdate*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientUpdate]
   else:
     static: raiseAssert "Unreachable"
 
 template LightClientFinalityUpdate*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientFinalityUpdate]
   else:
     static: raiseAssert "Unreachable"
 
 template LightClientOptimisticUpdate*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientOptimisticUpdate]
   else:
     static: raiseAssert "Unreachable"
 
 template LightClientStore*(kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     typedesc[altair.LightClientStore]
   else:
     static: raiseAssert "Unreachable"
@@ -159,38 +153,22 @@ template LightClientStore*(kind: static LightClientDataFork): auto =
 template Forky*(
     x: typedesc[ForkedLightClientBootstrap],
     kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
-    typedesc[altair.LightClientBootstrap]
-  else:
-    static: raiseAssert "Unreachable"
+  kind.LightClientBootstrap
 
 template Forky*(
     x: typedesc[ForkedLightClientUpdate],
     kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
-    typedesc[altair.LightClientUpdate]
-  else:
-    static: raiseAssert "Unreachable"
+  kind.LightClientUpdate
 
 template Forky*(
     x: typedesc[ForkedLightClientFinalityUpdate],
     kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
-    typedesc[altair.LightClientFinalityUpdate]
-  else:
-    static: raiseAssert "Unreachable"
+  kind.LightClientFinalityUpdate
 
 template Forky*(
     x: typedesc[ForkedLightClientOptimisticUpdate],
     kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
-    typedesc[altair.LightClientOptimisticUpdate]
-  else:
-    static: raiseAssert "Unreachable"
+  kind.LightClientOptimisticUpdate
 
 template Forked*(x: typedesc[ForkyLightClientBootstrap]): auto =
   typedesc[ForkedLightClientBootstrap]
@@ -439,8 +417,7 @@ func toLightClientHeader*(
       capella.SignedBeaconBlock | capella.TrustedSignedBeaconBlock |
       eip4844.SignedBeaconBlock | eip4844.TrustedSignedBeaconBlock,
     kind: static LightClientDataFork): auto =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
-  when kind >= LightClientDataFork.Altair:
+  when kind == LightClientDataFork.Altair:
     blck.toAltairLightClientHeader()
   else:
     static: raiseAssert "Unreachable"

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -49,6 +49,9 @@ type
     ForkyLightClientBootstrap |
     SomeForkyLightClientUpdate
 
+  ForkyLightClientStore* =
+    altair.LightClientStore
+
   ForkedLightClientBootstrap* = object
     case kind*: LightClientDataFork
     of LightClientDataFork.None:
@@ -77,6 +80,13 @@ type
     of LightClientDataFork.Altair:
       altairData*: altair.LightClientOptimisticUpdate
 
+  SomeForkedLightClientUpdateWithSyncCommittee* =
+    ForkedLightClientUpdate
+
+  SomeForkedLightClientUpdateWithFinality* =
+    ForkedLightClientUpdate |
+    ForkedLightClientFinalityUpdate
+
   SomeForkedLightClientUpdate* =
     ForkedLightClientUpdate |
     ForkedLightClientFinalityUpdate |
@@ -88,118 +98,214 @@ type
 
 func lcDataForkAtEpoch*(
     cfg: RuntimeConfig, epoch: Epoch): LightClientDataFork =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   if epoch >= cfg.ALTAIR_FORK_EPOCH:
     LightClientDataFork.Altair
   else:
     LightClientDataFork.None
 
-template kind*(x: typedesc[altair.LightClientStore]): LightClientDataFork =
+template kind*(
+    x: typedesc[ # `SomeLightClientObject` doesn't work here (Nim 1.6)
+      altair.LightClientHeader |
+      altair.LightClientBootstrap |
+      altair.LightClientUpdate |
+      altair.LightClientFinalityUpdate |
+      altair.LightClientOptimisticUpdate |
+      altair.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Altair
 
-template header*(kind: static LightClientDataFork): auto =
+template LightClientHeader*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
     typedesc[altair.LightClientHeader]
   else:
     static: raiseAssert "Unreachable"
 
-template forky*(
-    x: typedesc[ForkedLightClientBootstrap],
-    kind: static LightClientDataFork): auto =
+template LightClientBootstrap*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
     typedesc[altair.LightClientBootstrap]
   else:
     static: raiseAssert "Unreachable"
 
-template forky*(
-    x: typedesc[ForkedLightClientUpdate],
-    kind: static LightClientDataFork): auto =
+template LightClientUpdate*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
     typedesc[altair.LightClientUpdate]
   else:
     static: raiseAssert "Unreachable"
 
-template forky*(
-    x: typedesc[ForkedLightClientFinalityUpdate],
-    kind: static LightClientDataFork): auto =
+template LightClientFinalityUpdate*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
     typedesc[altair.LightClientFinalityUpdate]
   else:
     static: raiseAssert "Unreachable"
 
-template forky*(
-    x: typedesc[ForkedLightClientOptimisticUpdate],
-    kind: static LightClientDataFork): auto =
+template LightClientOptimisticUpdate*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
     typedesc[altair.LightClientOptimisticUpdate]
   else:
     static: raiseAssert "Unreachable"
 
-template forked*(x: typedesc[ForkyLightClientBootstrap]): auto =
+template LightClientStore*(kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  when kind >= LightClientDataFork.Altair:
+    typedesc[altair.LightClientStore]
+  else:
+    static: raiseAssert "Unreachable"
+
+template Forky*(
+    x: typedesc[ForkedLightClientBootstrap],
+    kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  when kind >= LightClientDataFork.Altair:
+    typedesc[altair.LightClientBootstrap]
+  else:
+    static: raiseAssert "Unreachable"
+
+template Forky*(
+    x: typedesc[ForkedLightClientUpdate],
+    kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  when kind >= LightClientDataFork.Altair:
+    typedesc[altair.LightClientUpdate]
+  else:
+    static: raiseAssert "Unreachable"
+
+template Forky*(
+    x: typedesc[ForkedLightClientFinalityUpdate],
+    kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  when kind >= LightClientDataFork.Altair:
+    typedesc[altair.LightClientFinalityUpdate]
+  else:
+    static: raiseAssert "Unreachable"
+
+template Forky*(
+    x: typedesc[ForkedLightClientOptimisticUpdate],
+    kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  when kind >= LightClientDataFork.Altair:
+    typedesc[altair.LightClientOptimisticUpdate]
+  else:
+    static: raiseAssert "Unreachable"
+
+template Forked*(x: typedesc[ForkyLightClientBootstrap]): auto =
   typedesc[ForkedLightClientBootstrap]
 
-template forked*(x: typedesc[ForkyLightClientUpdate]): auto =
+template Forked*(x: typedesc[ForkyLightClientUpdate]): auto =
   typedesc[ForkedLightClientUpdate]
 
-template forked*(x: typedesc[ForkyLightClientFinalityUpdate]): auto =
+template Forked*(x: typedesc[ForkyLightClientFinalityUpdate]): auto =
   typedesc[ForkedLightClientFinalityUpdate]
 
-template forked*(x: typedesc[ForkyLightClientOptimisticUpdate]): auto =
+template Forked*(x: typedesc[ForkyLightClientOptimisticUpdate]): auto =
   typedesc[ForkedLightClientOptimisticUpdate]
+
+template withAll*(
+    x: typedesc[LightClientDataFork], body: untyped): untyped =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
+  block:
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    body
+  block:
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
+    body
+
+template withLcDataFork*(
+    x: LightClientDataFork, body: untyped): untyped =
+  case x
+  of LightClientDataFork.Altair:
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    body
+  of LightClientDataFork.None:
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
+    body
 
 template withForkyBootstrap*(
     x: ForkedLightClientBootstrap, body: untyped): untyped =
   case x.kind
   of LightClientDataFork.Altair:
-    const lcDataFork {.inject.} = LightClientDataFork.Altair
-    template forkyBootstrap: untyped {.inject.} = x.altairData
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    template forkyBootstrap: untyped {.inject, used.} = x.altairData
     body
   of LightClientDataFork.None:
-    const lcDataFork {.inject.} = LightClientDataFork.None
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
     body
 
 template withForkyUpdate*(
     x: ForkedLightClientUpdate, body: untyped): untyped =
   case x.kind
   of LightClientDataFork.Altair:
-    const lcDataFork {.inject.} = LightClientDataFork.Altair
-    template forkyUpdate: untyped {.inject.} = x.altairData
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    template forkyUpdate: untyped {.inject, used.} = x.altairData
     body
   of LightClientDataFork.None:
-    const lcDataFork {.inject.} = LightClientDataFork.None
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
     body
 
 template withForkyFinalityUpdate*(
     x: ForkedLightClientFinalityUpdate, body: untyped): untyped =
   case x.kind
   of LightClientDataFork.Altair:
-    const lcDataFork {.inject.} = LightClientDataFork.Altair
-    template forkyFinalityUpdate: untyped {.inject.} = x.altairData
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    template forkyFinalityUpdate: untyped {.inject, used.} = x.altairData
     body
   of LightClientDataFork.None:
-    const lcDataFork {.inject.} = LightClientDataFork.None
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
     body
 
 template withForkyOptimisticUpdate*(
     x: ForkedLightClientOptimisticUpdate, body: untyped): untyped =
   case x.kind
   of LightClientDataFork.Altair:
-    const lcDataFork {.inject.} = LightClientDataFork.Altair
-    template forkyOptimisticUpdate: untyped {.inject.} = x.altairData
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    template forkyOptimisticUpdate: untyped {.inject, used.} = x.altairData
     body
   of LightClientDataFork.None:
-    const lcDataFork {.inject.} = LightClientDataFork.None
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
     body
 
 template withForkyObject*(
     x: SomeForkedLightClientObject, body: untyped): untyped =
   case x.kind
   of LightClientDataFork.Altair:
-    const lcDataFork {.inject.} = LightClientDataFork.Altair
-    template forkyObject: untyped {.inject.} = x.altairData
+    const lcDataFork {.inject, used.} = LightClientDataFork.Altair
+    template forkyObject: untyped {.inject, used.} = x.altairData
     body
   of LightClientDataFork.None:
-    const lcDataFork {.inject.} = LightClientDataFork.None
+    const lcDataFork {.inject, used.} = LightClientDataFork.None
     body
+
+template toFull*(
+    update: SomeForkedLightClientUpdate): ForkedLightClientUpdate =
+  when update is ForkyLightClientUpdate:
+    update
+  else:
+    withForkyObject(update):
+      when lcDataFork > LightClientDataFork.None:
+        var res = ForkedLightClientUpdate(kind: lcDataFork)
+        template forkyRes: untyped = res.forky(lcDataFork)
+        forkyRes = forkyObject.toFull()
+        res
+      else:
+        default(ForkedLightClientUpdate)
+
+template toFinality*(
+    update: SomeForkedLightClientUpdate): ForkedLightClientFinalityUpdate =
+  when update is ForkyLightClientFinalityUpdate:
+    update
+  else:
+    withForkyObject(update):
+      when lcDataFork > LightClientDataFork.None:
+        var res = ForkedLightClientFinalityUpdate(kind: lcDataFork)
+        template forkyRes: untyped = res.forky(lcDataFork)
+        forkyRes = forkyObject.toFinality()
+        res
+      else:
+        default(ForkedLightClientFinalityUpdate)
 
 template toOptimistic*(
     update: SomeForkedLightClientUpdate): ForkedLightClientOptimisticUpdate =
@@ -207,10 +313,11 @@ template toOptimistic*(
     update
   else:
     withForkyObject(update):
-      when lcDataFork >= LightClientDataFork.Altair:
-        ForkedLightClientOptimisticUpdate(
-          kind: lcDataFork,
-          altairData: forkyObject.toOptimistic())
+      when lcDataFork > LightClientDataFork.None:
+        var res = ForkedLightClientOptimisticUpdate(kind: lcDataFork)
+        template forkyRes: untyped = res.forky(lcDataFork)
+        forkyRes = forkyObject.toOptimistic()
+        res
       else:
         default(ForkedLightClientOptimisticUpdate)
 
@@ -218,7 +325,7 @@ func matches*[A, B: SomeForkedLightClientUpdate](a: A, b: B): bool =
   if a.kind != b.kind:
     return false
   withForkyObject(a):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       forkyObject.matches(b.forky(lcDataFork))
     else:
       true
@@ -228,7 +335,7 @@ template forky*(
   when kind == LightClientDataFork.Altair:
     x.altairData
   else:
-    discard
+    static: doAssert kind == LightClientDataFork.None
 
 func migrateToDataFork*(
     x: var ForkedLightClientBootstrap,
@@ -242,10 +349,11 @@ func migrateToDataFork*(
   else:
     # Upgrade to Altair
     when newKind >= LightClientDataFork.Altair:
-      if x.kind < LightClientDataFork.Altair:
+      if x.kind == LightClientDataFork.None:
         x = ForkedLightClientBootstrap(
           kind: LightClientDataFork.Altair)
 
+    static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
     doAssert x.kind == newKind
 
 func migrateToDataFork*(
@@ -260,10 +368,11 @@ func migrateToDataFork*(
   else:
     # Upgrade to Altair
     when newKind >= LightClientDataFork.Altair:
-      if x.kind < LightClientDataFork.Altair:
+      if x.kind == LightClientDataFork.None:
         x = ForkedLightClientUpdate(
           kind: LightClientDataFork.Altair)
 
+    static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
     doAssert x.kind == newKind
 
 func migrateToDataFork*(
@@ -278,10 +387,11 @@ func migrateToDataFork*(
   else:
     # Upgrade to Altair
     when newKind >= LightClientDataFork.Altair:
-      if x.kind < LightClientDataFork.Altair:
+      if x.kind == LightClientDataFork.None:
         x = ForkedLightClientFinalityUpdate(
           kind: LightClientDataFork.Altair)
 
+    static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
     doAssert x.kind == newKind
 
 func migrateToDataFork*(
@@ -296,10 +406,11 @@ func migrateToDataFork*(
   else:
     # Upgrade to Altair
     when newKind >= LightClientDataFork.Altair:
-      if x.kind < LightClientDataFork.Altair:
+      if x.kind == LightClientDataFork.None:
         x = ForkedLightClientOptimisticUpdate(
           kind: LightClientDataFork.Altair)
 
+    static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
     doAssert x.kind == newKind
 
 func migratingToDataFork*[T: SomeForkedLightClientObject](
@@ -307,6 +418,18 @@ func migratingToDataFork*[T: SomeForkedLightClientObject](
   var upgradedObject = x
   upgradedObject.migrateToDataFork(newKind)
   upgradedObject
+
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.1/specs/altair/light-client/full-node.md#block_to_light_client_header
+func toAltairLightClientHeader(
+    blck:  # `SomeSignedBeaconBlock` doesn't work here (Nim 1.6)
+      phase0.SignedBeaconBlock | phase0.TrustedSignedBeaconBlock |
+      altair.SignedBeaconBlock | altair.TrustedSignedBeaconBlock |
+      bellatrix.SignedBeaconBlock | bellatrix.TrustedSignedBeaconBlock |
+      capella.SignedBeaconBlock | capella.TrustedSignedBeaconBlock |
+      eip4844.SignedBeaconBlock | eip4844.TrustedSignedBeaconBlock
+): altair.LightClientHeader =
+  altair.LightClientHeader(
+    beacon: blck.message.toBeaconBlockHeader())
 
 func toLightClientHeader*(
     blck:  # `SomeSignedBeaconBlock` doesn't work here (Nim 1.6)
@@ -316,5 +439,8 @@ func toLightClientHeader*(
       capella.SignedBeaconBlock | capella.TrustedSignedBeaconBlock |
       eip4844.SignedBeaconBlock | eip4844.TrustedSignedBeaconBlock,
     kind: static LightClientDataFork): auto =
+  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   when kind >= LightClientDataFork.Altair:
-    kind.header(beacon: blck.message.toBeaconBlockHeader())
+    blck.toAltairLightClientHeader()
+  else:
+    static: raiseAssert "Unreachable"

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -313,7 +313,7 @@ template forky*(
   when kind == LightClientDataFork.Altair:
     x.altairData
   else:
-    static: doAssert kind == LightClientDataFork.None
+    static: raiseAssert "Unreachable"
 
 func migrateToDataFork*(
     x: var ForkedLightClientBootstrap,

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -207,25 +207,26 @@ func has_flag*(flags: ParticipationFlags, flag_index: int): bool =
   (flags and flag) == flag
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/sync-protocol.md#is_sync_committee_update
-template is_sync_committee_update*(update: SomeLightClientUpdate): bool =
-  when update is SomeLightClientUpdateWithSyncCommittee:
-    not isZeroMemory(update.next_sync_committee_branch)
+template is_sync_committee_update*(update: SomeForkyLightClientUpdate): bool =
+  when update is SomeForkyLightClientUpdateWithSyncCommittee:
+    update.next_sync_committee_branch !=
+      default(typeof(update.next_sync_committee_branch))
   else:
     false
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/sync-protocol.md#is_finality_update
-template is_finality_update*(update: SomeLightClientUpdate): bool =
-  when update is SomeLightClientUpdateWithFinality:
-    not isZeroMemory(update.finality_branch)
+template is_finality_update*(update: SomeForkyLightClientUpdate): bool =
+  when update is SomeForkyLightClientUpdateWithFinality:
+    update.finality_branch != default(typeof(update.finality_branch))
   else:
     false
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/sync-protocol.md#is_next_sync_committee_known
-template is_next_sync_committee_known*(store: LightClientStore): bool =
-  not isZeroMemory(store.next_sync_committee)
+template is_next_sync_committee_known*(store: ForkyLightClientStore): bool =
+  store.next_sync_committee != default(typeof(store.next_sync_committee))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/sync-protocol.md#get_safety_threshold
-func get_safety_threshold*(store: LightClientStore): uint64 =
+func get_safety_threshold*(store: ForkyLightClientStore): uint64 =
   max(
     store.previous_max_active_participants,
     store.current_max_active_participants
@@ -237,25 +238,25 @@ type LightClientUpdateMetadata* = object
   has_sync_committee*, has_finality*: bool
   num_active_participants*: uint64
 
-func toMeta*(update: SomeLightClientUpdate): LightClientUpdateMetadata =
+func toMeta*(update: SomeForkyLightClientUpdate): LightClientUpdateMetadata =
   var meta {.noinit.}: LightClientUpdateMetadata
   meta.attested_slot =
     update.attested_header.beacon.slot
   meta.finalized_slot =
-    when update is SomeLightClientUpdateWithFinality:
+    when update is SomeForkyLightClientUpdateWithFinality:
       update.finalized_header.beacon.slot
     else:
       GENESIS_SLOT
   meta.signature_slot =
     update.signature_slot
   meta.has_sync_committee =
-    when update is SomeLightClientUpdateWithSyncCommittee:
-      not update.next_sync_committee_branch.isZeroMemory
+    when update is SomeForkyLightClientUpdateWithSyncCommittee:
+      update.is_sync_committee_update
     else:
       false
   meta.has_finality =
-    when update is SomeLightClientUpdateWithFinality:
-      not update.finality_branch.isZeroMemory
+    when update is SomeForkyLightClientUpdateWithFinality:
+      update.is_finality_update
     else:
       false
   meta.num_active_participants =
@@ -264,7 +265,7 @@ func toMeta*(update: SomeLightClientUpdate): LightClientUpdateMetadata =
 
 template toMeta*(update: ForkedLightClientUpdate): LightClientUpdateMetadata =
   withForkyUpdate(update):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       forkyUpdate.toMeta()
     else:
       default(LightClientUpdateMetadata)
@@ -318,18 +319,18 @@ func is_better_data*(new_meta, old_meta: LightClientUpdateMetadata): bool =
   new_meta.attested_slot < old_meta.attested_slot
 
 template is_better_update*[
-    A, B: SomeLightClientUpdate | ForkedLightClientUpdate](
+    A, B: SomeForkyLightClientUpdate | ForkedLightClientUpdate](
     new_update: A, old_update: B): bool =
   is_better_data(toMeta(new_update), toMeta(old_update))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.1/specs/altair/light-client/p2p-interface.md#getlightclientbootstrap
-func contextEpoch*(bootstrap: altair.LightClientBootstrap): Epoch =
+func contextEpoch*(bootstrap: ForkyLightClientBootstrap): Epoch =
   bootstrap.header.beacon.slot.epoch
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/p2p-interface.md#lightclientupdatesbyrange
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/p2p-interface.md#getlightclientfinalityupdate
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/p2p-interface.md#getlightclientoptimisticupdate
-func contextEpoch*(update: SomeLightClientUpdate): Epoch =
+func contextEpoch*(update: SomeForkyLightClientUpdate): Epoch =
   update.attested_header.beacon.slot.epoch
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/bellatrix/beacon-chain.md#is_merge_transition_complete

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -21,12 +21,16 @@ export block_pools_types.VerifierError
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/altair/light-client/sync-protocol.md#initialize_light_client_store
 func initialize_light_client_store*(
     trusted_block_root: Eth2Digest,
-    bootstrap: altair.LightClientBootstrap
-): Result[LightClientStore, VerifierError] =
-  if not is_valid_light_client_header(bootstrap.header):
-    return err(VerifierError.Invalid)
+    bootstrap: ForkyLightClientBootstrap,
+    cfg: RuntimeConfig
+): auto =
+  type ResultType =
+    Result[typeof(bootstrap).kind.LightClientStore, VerifierError]
+
+  if not is_valid_light_client_header(bootstrap.header, cfg):
+    return ResultType.err(VerifierError.Invalid)
   if hash_tree_root(bootstrap.header) != trusted_block_root:
-    return err(VerifierError.Invalid)
+    return ResultType.err(VerifierError.Invalid)
 
   if not is_valid_merkle_branch(
       hash_tree_root(bootstrap.current_sync_committee),
@@ -34,17 +38,17 @@ func initialize_light_client_store*(
       log2trunc(altair.CURRENT_SYNC_COMMITTEE_INDEX),
       get_subtree_index(altair.CURRENT_SYNC_COMMITTEE_INDEX),
       bootstrap.header.beacon.state_root):
-    return err(VerifierError.Invalid)
+    return ResultType.err(VerifierError.Invalid)
 
-  return ok(LightClientStore(
+  return ResultType.ok(typeof(bootstrap).kind.LightClientStore(
     finalized_header: bootstrap.header,
     current_sync_committee: bootstrap.current_sync_committee,
     optimistic_header: bootstrap.header))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/specs/altair/light-client/sync-protocol.md#validate_light_client_update
 proc validate_light_client_update*(
-    store: LightClientStore,
-    update: SomeLightClientUpdate,
+    store: ForkyLightClientStore,
+    update: SomeForkyLightClientUpdate,
     current_slot: Slot,
     cfg: RuntimeConfig,
     genesis_validators_root: Eth2Digest): Result[void, VerifierError] =
@@ -56,9 +60,9 @@ proc validate_light_client_update*(
     return err(VerifierError.Invalid)
 
   # Verify update does not skip a sync committee period
-  if not is_valid_light_client_header(update.attested_header):
+  if not is_valid_light_client_header(update.attested_header, cfg):
     return err(VerifierError.Invalid)
-  when update is SomeLightClientUpdateWithFinality:
+  when update is SomeForkyLightClientUpdateWithFinality:
     if update.attested_header.beacon.slot < update.finalized_header.beacon.slot:
       return err(VerifierError.Invalid)
   if update.signature_slot <= update.attested_header.beacon.slot:
@@ -78,10 +82,10 @@ proc validate_light_client_update*(
 
   # Verify update is relevant
   let attested_period = update.attested_header.beacon.slot.sync_committee_period
-  when update is SomeLightClientUpdateWithSyncCommittee:
+  when update is SomeForkyLightClientUpdateWithSyncCommittee:
     let is_sync_committee_update = update.is_sync_committee_update
   if update.attested_header.beacon.slot <= store.finalized_header.beacon.slot:
-    when update is SomeLightClientUpdateWithSyncCommittee:
+    when update is SomeForkyLightClientUpdateWithSyncCommittee:
       if is_next_sync_committee_known:
         return err(VerifierError.Duplicate)
       if attested_period != store_period or not is_sync_committee_update:
@@ -91,17 +95,17 @@ proc validate_light_client_update*(
 
   # Verify that the `finalized_header`, if present, actually is the
   # finalized header saved in the state of the `attested_header`
-  when update is SomeLightClientUpdateWithFinality:
+  when update is SomeForkyLightClientUpdateWithFinality:
     if not update.is_finality_update:
-      if update.finalized_header != altair.LightClientHeader():
+      if update.finalized_header != default(typeof(update.finalized_header)):
         return err(VerifierError.Invalid)
     else:
       var finalized_root {.noinit.}: Eth2Digest
       if update.finalized_header.beacon.slot != GENESIS_SLOT:
-        if not is_valid_light_client_header(update.finalized_header):
+        if not is_valid_light_client_header(update.finalized_header, cfg):
           return err(VerifierError.Invalid)
         finalized_root = hash_tree_root(update.finalized_header.beacon)
-      elif update.finalized_header == altair.LightClientHeader():
+      elif update.finalized_header == default(typeof(update.finalized_header)):
         finalized_root.reset()
       else:
         return err(VerifierError.Invalid)
@@ -115,9 +119,10 @@ proc validate_light_client_update*(
 
   # Verify that the `next_sync_committee`, if present, actually is the
   # next sync committee saved in the state of the `attested_header`
-  when update is SomeLightClientUpdateWithSyncCommittee:
+  when update is SomeForkyLightClientUpdateWithSyncCommittee:
     if not is_sync_committee_update:
-      if update.next_sync_committee != altair.SyncCommittee():
+      if update.next_sync_committee !=
+          default(typeof(update.next_sync_committee)):
         return err(VerifierError.Invalid)
     else:
       if attested_period == store_period and is_next_sync_committee_known:
@@ -156,21 +161,21 @@ proc validate_light_client_update*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/specs/altair/light-client/sync-protocol.md#apply_light_client_update
 func apply_light_client_update(
-    store: var LightClientStore,
-    update: SomeLightClientUpdate): bool =
+    store: var ForkyLightClientStore,
+    update: SomeForkyLightClientUpdate): bool =
   var didProgress = false
   let
     store_period = store.finalized_header.beacon.slot.sync_committee_period
     finalized_period = update.finalized_header.beacon.slot.sync_committee_period
   if not store.is_next_sync_committee_known:
     assert finalized_period == store_period
-    when update is SomeLightClientUpdateWithSyncCommittee:
+    when update is SomeForkyLightClientUpdateWithSyncCommittee:
       store.next_sync_committee = update.next_sync_committee
       if store.is_next_sync_committee_known:
         didProgress = true
   elif finalized_period == store_period + 1:
     store.current_sync_committee = store.next_sync_committee
-    when update is SomeLightClientUpdateWithSyncCommittee:
+    when update is SomeForkyLightClientUpdateWithSyncCommittee:
       store.next_sync_committee = update.next_sync_committee
     else:
       store.next_sync_committee.reset()
@@ -193,7 +198,7 @@ type
     DidUpdateWithoutFinality
 
 func process_light_client_store_force_update*(
-    store: var LightClientStore,
+    store: var ForkyLightClientStore,
     current_slot: Slot): ForceUpdateResult {.discardable.} =
   var res = NoUpdate
   if store.best_valid_update.isSome and
@@ -220,8 +225,8 @@ func process_light_client_store_force_update*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.2.0-rc.3/specs/altair/light-client/sync-protocol.md#process_light_client_update
 proc process_light_client_update*(
-    store: var LightClientStore,
-    update: SomeLightClientUpdate,
+    store: var ForkyLightClientStore,
+    update: SomeForkyLightClientUpdate,
     current_slot: Slot,
     cfg: RuntimeConfig,
     genesis_validators_root: Eth2Digest): Result[void, VerifierError] =
@@ -251,11 +256,11 @@ proc process_light_client_update*(
     didProgress = true
 
   # Update finalized header
-  when update is SomeLightClientUpdateWithFinality:
+  when update is SomeForkyLightClientUpdateWithFinality:
     if num_active_participants * 3 >= static(sync_committee_bits.len * 2):
       var improvesFinality =
         update.finalized_header.beacon.slot > store.finalized_header.beacon.slot
-      when update is SomeLightClientUpdateWithSyncCommittee:
+      when update is SomeForkyLightClientUpdateWithSyncCommittee:
         if not improvesFinality and not store.is_next_sync_committee_known:
           improvesFinality =
             update.is_sync_committee_update and update.is_finality_update and

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -29,7 +29,7 @@ func initialize_light_client_store*(
 
   if not is_valid_light_client_header(bootstrap.header, cfg):
     return ResultType.err(VerifierError.Invalid)
-  if hash_tree_root(bootstrap.header) != trusted_block_root:
+  if hash_tree_root(bootstrap.header.beacon) != trusted_block_root:
     return ResultType.err(VerifierError.Invalid)
 
   if not is_valid_merkle_branch(

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -863,7 +863,7 @@ proc process_block*(
   if is_execution_enabled(state, blck.body):
     ? process_execution_payload(
         state, blck.body.execution_payload,
-        func(_: ExecutionPayload): bool = true)
+        func(_: bellatrix.ExecutionPayload): bool = true)
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
 

--- a/beacon_chain/sszdump.nim
+++ b/beacon_chain/sszdump.nim
@@ -60,7 +60,7 @@ proc dump*(dir: string, v: ForkyLightClientBootstrap) =
     SSZ.saveFile(
       dir / &"{prefix}-{slot}-{blck}-{root}.ssz", v)
 
-proc dump*(dir: string, v: SomeLightClientUpdate) =
+proc dump*(dir: string, v: SomeForkyLightClientUpdate) =
   logErrors:
     let
       prefix =

--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -146,7 +146,7 @@ proc doRequest(
     var expectedPeriod = startPeriod
     for update in response.get:
       withForkyUpdate(update):
-        when lcDataFork >= LightClientDataFork.Altair:
+        when lcDataFork > LightClientDataFork.None:
           let
             attPeriod =
               forkyUpdate.attested_header.beacon.slot.sync_committee_period
@@ -245,7 +245,7 @@ proc workerTask[E](
           of VerifierError.UnviableFork:
             # Descore, peer is on an incompatible fork version
             withForkyObject(val):
-              when lcDataFork >= LightClientDataFork.Altair:
+              when lcDataFork > LightClientDataFork.None:
                 notice "Received value from an unviable fork",
                   value = forkyObject,
                   endpoint = E.name, peer, peer_score = peer.getScore()
@@ -257,7 +257,7 @@ proc workerTask[E](
           of VerifierError.Invalid:
             # Descore, received data is malformed
             withForkyObject(val):
-              when lcDataFork >= LightClientDataFork.Altair:
+              when lcDataFork > LightClientDataFork.None:
                 warn "Received invalid value", value = forkyObject.shortLog,
                   endpoint = E.name, peer, peer_score = peer.getScore()
               else:

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -181,7 +181,7 @@ proc handleLightClientUpdates*(node: BeaconNode, slot: Slot) {.async.} =
     await sleepAsync(sendTime.offset)
 
   withForkyFinalityUpdate(node.dag.lcDataStore.cache.latest):
-    when lcDataFork >= LightClientDataFork.Altair:
+    when lcDataFork > LightClientDataFork.None:
       let signature_slot = forkyFinalityUpdate.signature_slot
       if slot != signature_slot:
         return

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,6 +8,7 @@
 import
   std/tables,
   metrics, chronicles,
+  ../spec/datatypes/phase0,
   ../spec/[beaconstate, forks, helpers],
   ../beacon_clock
 

--- a/tests/consensus_spec/altair/test_fixture_light_client_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_light_client_sync_protocol.nim
@@ -138,243 +138,247 @@ let full_sync_committee_bits = block:
   res
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.2/tests/core/pyspec/eth2spec/test/helpers/light_client.py#L20-L29
-func initialize_light_client_store(state: auto): LightClientStore =
-  LightClientStore(
-    finalized_header: altair.LightClientHeader(),
+func initialize_light_client_store(
+    state: auto, storeDataFork: static LightClientDataFork): auto =
+  storeDataFork.LightClientStore(
+    finalized_header: default(storeDataFork.LightClientHeader),
     current_sync_committee: state.current_sync_committee,
     next_sync_committee: state.next_sync_committee,
-    best_valid_update: Opt.none(altair.LightClientUpdate),
-    optimistic_header: altair.LightClientHeader(),
+    best_valid_update: Opt.none(storeDataFork.LightClientUpdate),
+    optimistic_header: default(storeDataFork.LightClientHeader),
     previous_max_active_participants: 0,
     current_max_active_participants: 0,
   )
 
-suite "EF - Altair - Unittests - Light client - Sync protocol" & preset():
-  let
-    cfg = block:
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
-      res
-    genesisState = newClone(initGenesisState(cfg = cfg))
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L23-L60
-  test "test_process_light_client_update_not_timeout":
-    let forked = assignClone(genesisState[])
-    template state(): auto = forked[].altairData.data
-    var store = initialize_light_client_store(state)
-    const lcDataFork = typeof(store).kind
-
-    # Block at slot 1 doesn't increase sync committee period,
-    # so it won't update snapshot
-    var cache: StateCache
+proc runTest(storeDataFork: static LightClientDataFork) =
+  suite "EF - " & $storeDataFork &
+      " - Unittests - Light client - Sync protocol" & preset():
     let
-      attested_block = block_for_next_slot(cfg, forked[], cache).altairData
-      attested_header = attested_block.toLightClientHeader(lcDataFork)
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+        res
+      genesisState = newClone(initGenesisState(cfg = cfg))
 
-    # Sync committee signing the attested_header
-      (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
-      next_sync_committee = SyncCommittee()
-      next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
+    # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L23-L60
+    test "test_process_light_client_update_not_timeout":
+      let forked = assignClone(genesisState[])
+      template state(): auto = forked[].altairData.data
+      var store = initialize_light_client_store(state, storeDataFork)
 
-    # Ensure that finality checkpoint is genesis
-    check state.finalized_checkpoint.epoch == 0
-    # Finality is unchanged
-    let
-      finality_header = altair.LightClientHeader()
-      finality_branch = default(altair.FinalityBranch)
+      # Block at slot 1 doesn't increase sync committee period,
+      # so it won't update snapshot
+      var cache: StateCache
+      let
+        attested_block = block_for_next_slot(cfg, forked[], cache).altairData
+        attested_header = attested_block.toLightClientHeader(storeDataFork)
 
-      update = altair.LightClientUpdate(
-        attested_header: attested_header,
-        next_sync_committee: next_sync_committee,
-        next_sync_committee_branch: next_sync_committee_branch,
-        finalized_header: finality_header,
-        finality_branch: finality_branch,
-        sync_aggregate: sync_aggregate,
-        signature_slot: signature_slot)
+      # Sync committee signing the attested_header
+        (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
+        next_sync_committee = SyncCommittee()
+        next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
 
-      pre_store_finalized_header = store.finalized_header
+      # Ensure that finality checkpoint is genesis
+      check state.finalized_checkpoint.epoch == 0
+      # Finality is unchanged
+      let
+        finality_header = default(storeDataFork.LightClientHeader)
+        finality_branch = default(altair.FinalityBranch)
 
-      res = process_light_client_update(
-        store, update, signature_slot, cfg, state.genesis_validators_root)
+        update = storeDataFork.LightClientUpdate(
+          attested_header: attested_header,
+          next_sync_committee: next_sync_committee,
+          next_sync_committee_branch: next_sync_committee_branch,
+          finalized_header: finality_header,
+          finality_branch: finality_branch,
+          sync_aggregate: sync_aggregate,
+          signature_slot: signature_slot)
 
-    check:
-      res.isOk
-      store.finalized_header == pre_store_finalized_header
-      store.best_valid_update.get == update
-      store.optimistic_header == update.attested_header
-      store.current_max_active_participants > 0
+        pre_store_finalized_header = store.finalized_header
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L63-L104
-  test "test_process_light_client_update_at_period_boundary":
-    var forked = assignClone(genesisState[])
-    template state(): auto = forked[].altairData.data
-    var store = initialize_light_client_store(state)
-    const lcDataFork = typeof(store).kind
+        res = process_light_client_update(
+          store, update, signature_slot, cfg, state.genesis_validators_root)
 
-    # Forward to slot before next sync committee period so that next block is
-    # final one in period
-    var
-      cache: StateCache
-      info: ForkedEpochInfo
-    process_slots(
-      cfg, forked[], Slot(UPDATE_TIMEOUT - 2), cache, info, flags = {}
-    ).expect("no failure")
-    let
-      store_period = sync_committee_period(store.optimistic_header.beacon.slot)
-      update_period = sync_committee_period(state.slot)
-    check: store_period == update_period
+      check:
+        res.isOk
+        store.finalized_header == pre_store_finalized_header
+        store.best_valid_update.get == update
+        store.optimistic_header == update.attested_header
+        store.current_max_active_participants > 0
 
-    let
-      attested_block = block_for_next_slot(cfg, forked[], cache).altairData
-      attested_header = attested_block.toLightClientHeader(lcDataFork)
+    # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L63-L104
+    test "test_process_light_client_update_at_period_boundary":
+      var forked = assignClone(genesisState[])
+      template state(): auto = forked[].altairData.data
+      var store = initialize_light_client_store(state, storeDataFork)
 
-    # Sync committee signing the attested_header
-      (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
-      next_sync_committee = SyncCommittee()
-      next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
+      # Forward to slot before next sync committee period so that next block is
+      # final one in period
+      var
+        cache: StateCache
+        info: ForkedEpochInfo
+      process_slots(
+        cfg, forked[], Slot(UPDATE_TIMEOUT - 2), cache, info, flags = {}
+      ).expect("no failure")
+      let
+        store_period = sync_committee_period(store.optimistic_header.beacon.slot)
+        update_period = sync_committee_period(state.slot)
+      check: store_period == update_period
 
-    # Finality is unchanged
-      finality_header = altair.LightClientHeader()
-      finality_branch = default(altair.FinalityBranch)
+      let
+        attested_block = block_for_next_slot(cfg, forked[], cache).altairData
+        attested_header = attested_block.toLightClientHeader(storeDataFork)
 
-      update = altair.LightClientUpdate(
-        attested_header: attested_header,
-        next_sync_committee: next_sync_committee,
-        next_sync_committee_branch: next_sync_committee_branch,
-        finalized_header: finality_header,
-        finality_branch: finality_branch,
-        sync_aggregate: sync_aggregate,
-        signature_slot: signature_slot)
+      # Sync committee signing the attested_header
+        (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
+        next_sync_committee = SyncCommittee()
+        next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
 
-      pre_store_finalized_header = store.finalized_header
+      # Finality is unchanged
+        finality_header = default(storeDataFork.LightClientHeader)
+        finality_branch = default(altair.FinalityBranch)
 
-      res = process_light_client_update(
-        store, update, signature_slot, cfg, state.genesis_validators_root)
+        update = storeDataFork.LightClientUpdate(
+          attested_header: attested_header,
+          next_sync_committee: next_sync_committee,
+          next_sync_committee_branch: next_sync_committee_branch,
+          finalized_header: finality_header,
+          finality_branch: finality_branch,
+          sync_aggregate: sync_aggregate,
+          signature_slot: signature_slot)
 
-    check:
-      res.isOk
-      store.finalized_header == pre_store_finalized_header
-      store.best_valid_update.get == update
-      store.optimistic_header == update.attested_header
-      store.current_max_active_participants > 0
+        pre_store_finalized_header = store.finalized_header
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L107-L149
-  test "process_light_client_update_timeout":
-    let forked = assignClone(genesisState[])
-    template state(): auto = forked[].altairData.data
-    var store = initialize_light_client_store(state)
-    const lcDataFork = typeof(store).kind
+        res = process_light_client_update(
+          store, update, signature_slot, cfg, state.genesis_validators_root)
 
-    # Forward to next sync committee period
-    var
-      cache: StateCache
-      info: ForkedEpochInfo
-    process_slots(
-      cfg, forked[], Slot(UPDATE_TIMEOUT), cache, info, flags = {}
-    ).expect("no failure")
-    let
-      store_period = sync_committee_period(store.optimistic_header.beacon.slot)
-      update_period = sync_committee_period(state.slot)
-    check: store_period + 1 == update_period
+      check:
+        res.isOk
+        store.finalized_header == pre_store_finalized_header
+        store.best_valid_update.get == update
+        store.optimistic_header == update.attested_header
+        store.current_max_active_participants > 0
 
-    let
-      attested_block = block_for_next_slot(cfg, forked[], cache).altairData
-      attested_header = attested_block.toLightClientHeader(lcDataFork)
+    # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L107-L149
+    test "process_light_client_update_timeout":
+      let forked = assignClone(genesisState[])
+      template state(): auto = forked[].altairData.data
+      var store = initialize_light_client_store(state, storeDataFork)
 
-    # Sync committee signing the attested_header
-      (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
+      # Forward to next sync committee period
+      var
+        cache: StateCache
+        info: ForkedEpochInfo
+      process_slots(
+        cfg, forked[], Slot(UPDATE_TIMEOUT), cache, info, flags = {}
+      ).expect("no failure")
+      let
+        store_period = sync_committee_period(store.optimistic_header.beacon.slot)
+        update_period = sync_committee_period(state.slot)
+      check: store_period + 1 == update_period
 
-    # Sync committee is updated
-    template next_sync_committee(): auto = state.next_sync_committee
-    let
-      next_sync_committee_branch =
-        state.build_proof(altair.NEXT_SYNC_COMMITTEE_INDEX).get
+      let
+        attested_block = block_for_next_slot(cfg, forked[], cache).altairData
+        attested_header = attested_block.toLightClientHeader(storeDataFork)
 
-    # Finality is unchanged
-      finality_header = altair.LightClientHeader()
-      finality_branch = default(altair.FinalityBranch)
+      # Sync committee signing the attested_header
+        (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
 
-      update = altair.LightClientUpdate(
-        attested_header: attested_header,
-        next_sync_committee: next_sync_committee,
-        next_sync_committee_branch: next_sync_committee_branch,
-        finalized_header: finality_header,
-        finality_branch: finality_branch,
-        sync_aggregate: sync_aggregate,
-        signature_slot: signature_slot)
+      # Sync committee is updated
+      template next_sync_committee(): auto = state.next_sync_committee
+      let
+        next_sync_committee_branch =
+          state.build_proof(altair.NEXT_SYNC_COMMITTEE_INDEX).get
 
-      pre_store_finalized_header = store.finalized_header
+      # Finality is unchanged
+        finality_header = default(storeDataFork.LightClientHeader)
+        finality_branch = default(altair.FinalityBranch)
 
-      res = process_light_client_update(
-        store, update, signature_slot, cfg, state.genesis_validators_root)
+        update = storeDataFork.LightClientUpdate(
+          attested_header: attested_header,
+          next_sync_committee: next_sync_committee,
+          next_sync_committee_branch: next_sync_committee_branch,
+          finalized_header: finality_header,
+          finality_branch: finality_branch,
+          sync_aggregate: sync_aggregate,
+          signature_slot: signature_slot)
 
-    check:
-      res.isOk
-      store.finalized_header == pre_store_finalized_header
-      store.best_valid_update.get == update
-      store.optimistic_header == update.attested_header
-      store.current_max_active_participants > 0
+        pre_store_finalized_header = store.finalized_header
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L152-L201
-  test "process_light_client_update_finality_updated":
-    let forked = assignClone(genesisState[])
-    template state(): auto = forked[].altairData.data
-    var store = initialize_light_client_store(state)
-    const lcDataFork = typeof(store).kind
+        res = process_light_client_update(
+          store, update, signature_slot, cfg, state.genesis_validators_root)
 
-    # Change finality
-    var
-      cache: StateCache
-      info: ForkedEpochInfo
-      blocks = newSeq[ForkedSignedBeaconBlock]()
-    process_slots(
-      cfg, forked[], Slot(SLOTS_PER_EPOCH * 2), cache, info, flags = {}).expect("no failure")
-    for slot in 0 ..< 3 * SLOTS_PER_EPOCH:
-      blocks.add block_for_next_slot(cfg, forked[], cache,
-                                     withAttestations = true)
-    # Ensure that finality checkpoint has changed
-    check: state.finalized_checkpoint.epoch == 3
-    # Ensure that it's same period
-    let
-      store_period = sync_committee_period(store.optimistic_header.beacon.slot)
-      update_period = sync_committee_period(state.slot)
-    check: store_period == update_period
+      check:
+        res.isOk
+        store.finalized_header == pre_store_finalized_header
+        store.best_valid_update.get == update
+        store.optimistic_header == update.attested_header
+        store.current_max_active_participants > 0
 
-    let
-      attested_block = blocks[^1].altairData
-      attested_header = attested_block.toLightClientHeader(lcDataFork)
+    # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.0/tests/core/pyspec/eth2spec/test/altair/unittests/light_client/test_sync_protocol.py#L152-L201
+    test "process_light_client_update_finality_updated":
+      let forked = assignClone(genesisState[])
+      template state(): auto = forked[].altairData.data
+      var store = initialize_light_client_store(state, storeDataFork)
 
-    # Sync committee signing the attested_header
-      (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
+      # Change finality
+      var
+        cache: StateCache
+        info: ForkedEpochInfo
+        blocks = newSeq[ForkedSignedBeaconBlock]()
+      process_slots(
+        cfg, forked[], Slot(SLOTS_PER_EPOCH * 2), cache, info, flags = {})
+          .expect("no failure")
+      for slot in 0 ..< 3 * SLOTS_PER_EPOCH:
+        blocks.add block_for_next_slot(cfg, forked[], cache,
+                                      withAttestations = true)
+      # Ensure that finality checkpoint has changed
+      check: state.finalized_checkpoint.epoch == 3
+      # Ensure that it's same period
+      let
+        store_period = sync_committee_period(store.optimistic_header.beacon.slot)
+        update_period = sync_committee_period(state.slot)
+      check: store_period == update_period
 
-    # Updated sync_committee and finality
-      next_sync_committee = SyncCommittee()
-      next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
-      finalized_block = blocks[SLOTS_PER_EPOCH - 1].altairData
-      finalized_header = finalized_block.toLightClientHeader(lcDataFork)
-    check:
-      finalized_header.beacon.slot ==
-        start_slot(state.finalized_checkpoint.epoch)
-      finalized_header.beacon.hash_tree_root() ==
-        state.finalized_checkpoint.root
-    let
-      finality_branch = state.build_proof(altair.FINALIZED_ROOT_INDEX).get
+      let
+        attested_block = blocks[^1].altairData
+        attested_header = attested_block.toLightClientHeader(storeDataFork)
 
-      update = altair.LightClientUpdate(
-        attested_header: attested_header,
-        next_sync_committee: next_sync_committee,
-        next_sync_committee_branch: next_sync_committee_branch,
-        finalized_header: finalized_header,
-        finality_branch: finality_branch,
-        sync_aggregate: sync_aggregate,
-        signature_slot: signature_slot)
+      # Sync committee signing the attested_header
+        (sync_aggregate, signature_slot) = get_sync_aggregate(cfg, forked[])
 
-      res = process_light_client_update(
-        store, update, signature_slot, cfg, state.genesis_validators_root)
+      # Updated sync_committee and finality
+        next_sync_committee = SyncCommittee()
+        next_sync_committee_branch = default(altair.NextSyncCommitteeBranch)
+        finalized_block = blocks[SLOTS_PER_EPOCH - 1].altairData
+        finalized_header = finalized_block.toLightClientHeader(storeDataFork)
+      check:
+        finalized_header.beacon.slot ==
+          start_slot(state.finalized_checkpoint.epoch)
+        finalized_header.beacon.hash_tree_root() ==
+          state.finalized_checkpoint.root
+      let
+        finality_branch = state.build_proof(altair.FINALIZED_ROOT_INDEX).get
 
-    check:
-      res.isOk
-      store.finalized_header == update.finalized_header
-      store.best_valid_update.isNone
-      store.optimistic_header == update.attested_header
-      store.current_max_active_participants > 0
+        update = storeDataFork.LightClientUpdate(
+          attested_header: attested_header,
+          next_sync_committee: next_sync_committee,
+          next_sync_committee_branch: next_sync_committee_branch,
+          finalized_header: finalized_header,
+          finality_branch: finality_branch,
+          sync_aggregate: sync_aggregate,
+          signature_slot: signature_slot)
+
+        res = process_light_client_update(
+          store, update, signature_slot, cfg, state.genesis_validators_root)
+
+      check:
+        res.isOk
+        store.finalized_header == update.finalized_header
+        store.best_valid_update.isNone
+        store.optimistic_header == update.attested_header
+        store.current_max_active_participants > 0
+
+withAll(LightClientDataFork):
+  when lcDataFork > LightClientDataFork.None:
+    runTest(lcDataFork)

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -115,13 +115,13 @@ suite "EF - Altair - SSZ consensus objects " & preset():
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            checkSSZ(LightClientBootstrap, path, hash)
+            checkSSZ(altair.LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(altair.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            checkSSZ(LightClientFinalityUpdate, path, hash)
+            checkSSZ(altair.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            checkSSZ(LightClientOptimisticUpdate, path, hash)
+            checkSSZ(altair.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
           of "SignedAggregateAndProof":

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -129,16 +129,16 @@ suite baseDescription & "Execution Payload " & preset():
   for path in walkTests(OpExecutionPayloadDir):
     proc applyExecutionPayload(
         preState: var bellatrix.BeaconState,
-        executionPayload: ExecutionPayload):
+        executionPayload: bellatrix.ExecutionPayload):
         Result[void, cstring] =
       let payloadValid =
         readFile(OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml").
           contains("execution_valid: true")
-      func executePayload(_: ExecutionPayload): bool = payloadValid
+      func executePayload(_: bellatrix.ExecutionPayload): bool = payloadValid
       process_execution_payload(
             preState, executionPayload, executePayload)
 
-    runTest[ExecutionPayload, typeof applyExecutionPayload](
+    runTest[bellatrix.ExecutionPayload, typeof applyExecutionPayload](
       OpExecutionPayloadDir, "Execution Payload", "execution_payload",
       applyExecutionPayload, path)
 

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -11,7 +11,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/bellatrix,
+  ../../beacon_chain/spec/datatypes/[altair, bellatrix],
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -120,13 +120,13 @@ suite "EF - Bellatrix - SSZ consensus objects " & preset():
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            checkSSZ(LightClientBootstrap, path, hash)
+            checkSSZ(altair.LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(altair.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            checkSSZ(LightClientFinalityUpdate, path, hash)
+            checkSSZ(altair.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            checkSSZ(LightClientOptimisticUpdate, path, hash)
+            checkSSZ(altair.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -14,7 +14,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/capella,
+  ../../beacon_chain/spec/datatypes/[altair, capella],
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -122,13 +122,13 @@ suite "EF - Capella - SSZ consensus objects " & preset():
           of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            checkSSZ(LightClientBootstrap, path, hash)
+            checkSSZ(altair.LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(altair.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            checkSSZ(LightClientFinalityUpdate, path, hash)
+            checkSSZ(altair.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            checkSSZ(LightClientOptimisticUpdate, path, hash)
+            checkSSZ(altair.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
@@ -14,7 +14,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/eip4844,
+  ../../beacon_chain/spec/datatypes/[altair, eip4844],
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
@@ -126,13 +126,13 @@ suite "EF - EIP4844 - SSZ consensus objects " & preset():
           of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            checkSSZ(LightClientBootstrap, path, hash)
+            checkSSZ(altair.LightClientBootstrap, path, hash)
           of "LightClientUpdate":
-            checkSSZ(LightClientUpdate, path, hash)
+            checkSSZ(altair.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            checkSSZ(LightClientFinalityUpdate, path, hash)
+            checkSSZ(altair.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            checkSSZ(LightClientOptimisticUpdate, path, hash)
+            checkSSZ(altair.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -10,11 +10,12 @@
 import
   # Standard library
   std/[json, os, streams],
+  # Status libraries
+  stew/byteutils,
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../../beacon_chain/spec/light_client_sync,
-  ../../../beacon_chain/spec/datatypes/altair,
+  ../../../beacon_chain/spec/[forks, light_client_sync],
   # Test utilities
   ../testutil,
   ./fixtures_utils
@@ -26,9 +27,9 @@ type
 
   TestChecks = object
     finalized_slot: Slot
-    finalized_root: Eth2Digest
+    finalized_beacon_root: Eth2Digest
     optimistic_slot: Slot
-    optimistic_root: Eth2Digest
+    optimistic_beacon_root: Eth2Digest
 
   TestStepKind {.pure.} = enum
     ForceUpdate
@@ -39,11 +40,11 @@ type
     of TestStepKind.ForceUpdate:
       discard
     of TestStepKind.ProcessUpdate:
-      update: altair.LightClientUpdate
+      update: ForkedLightClientUpdate
     current_slot: Slot
     checks: TestChecks
 
-proc loadSteps(path: string): seq[TestStep] =
+proc loadSteps(path: string, fork_digests: ForkDigests): seq[TestStep] =
   let stepsYAML = readFile(path/"steps.yaml")
   let steps = yaml.loadToJson(stepsYAML)
 
@@ -53,28 +54,43 @@ proc loadSteps(path: string): seq[TestStep] =
       TestChecks(
         finalized_slot:
           c["finalized_header"]["slot"].getInt().Slot,
-        finalized_root:
+        finalized_beacon_root:
           Eth2Digest.fromHex(c["finalized_header"]["beacon_root"].getStr()),
         optimistic_slot:
           c["optimistic_header"]["slot"].getInt().Slot,
-        optimistic_root:
+        optimistic_beacon_root:
           Eth2Digest.fromHex(c["optimistic_header"]["beacon_root"].getStr()))
 
     if step.hasKey"force_update":
       let s = step["force_update"]
-      result.add TestStep(kind: TestStepKind.ForceUpdate,
-                          current_slot: s["current_slot"].getInt().Slot,
-                          checks: s["checks"].getChecks())
+
+      result.add TestStep(
+        kind: TestStepKind.ForceUpdate,
+        current_slot: s["current_slot"].getInt().Slot,
+        checks: s["checks"].getChecks())
     elif step.hasKey"process_update":
       let
         s = step["process_update"]
-        filename = s["update"].getStr()
-        update = parseTest(path/filename & ".ssz_snappy", SSZ,
-                           altair.LightClientUpdate)
-      result.add TestStep(kind: TestStepKind.ProcessUpdate,
-                          update: update,
-                          current_slot: s["current_slot"].getInt().Slot,
-                          checks: s["checks"].getChecks())
+        update_fork_digest = fork_digests.altair
+        update_state_fork =
+          fork_digests.stateForkForDigest(update_fork_digest)
+            .expect("Unknown update fork " & $update_fork_digest)
+        update_filename = s["update"].getStr()
+
+      var update {.noinit.}: ForkedLightClientUpdate
+      withLcDataFork(lcDataForkAtStateFork(update_state_fork)):
+        when lcDataFork > LightClientDataFork.None:
+          update = ForkedLightClientUpdate(kind: lcDataFork)
+          update.forky(lcDataFork) = parseTest(
+            path/update_filename & ".ssz_snappy", SSZ,
+            lcDataFork.LightClientUpdate)
+        else: raiseAssert "Unreachable update fork " & $update_fork_digest
+
+      result.add TestStep(
+        kind: TestStepKind.ProcessUpdate,
+        update: update,
+        current_slot: s["current_slot"].getInt().Slot,
+        checks: s["checks"].getChecks())
     else:
       doAssert false, "Unknown test step: " & $step
 
@@ -92,32 +108,73 @@ proc runTest(path: string) =
         Eth2Digest.fromHex(meta.genesis_validators_root)
       trusted_block_root =
         Eth2Digest.fromHex(meta.trusted_block_root)
+      fork_digests =
+        ForkDigests.init(cfg, genesis_validators_root)
+      bootstrap_fork_digest = fork_digests.altair
+      store_fork_digest = fork_digests.altair
+      bootstrap_state_fork =
+        fork_digests.stateForkForDigest(bootstrap_fork_digest)
+          .expect("Unknown bootstrap fork " & $bootstrap_fork_digest)
+      store_state_fork =
+        fork_digests.stateForkForDigest(store_fork_digest)
+          .expect("Unknown store fork " & $store_fork_digest)
+      steps = loadSteps(path, fork_digests)
 
-      bootstrap = parseTest(path/"bootstrap.ssz_snappy", SSZ,
-                            altair.LightClientBootstrap)
-      steps = loadSteps(path)
     doAssert unknowns.len == 0, "Unknown config constants: " & $unknowns
 
-    var store =
-      initialize_light_client_store(trusted_block_root, bootstrap, cfg).get
+    var bootstrap {.noinit.}: ForkedLightClientBootstrap
+    withLcDataFork(lcDataForkAtStateFork(bootstrap_state_fork)):
+      when lcDataFork > LightClientDataFork.None:
+        bootstrap = ForkedLightClientBootstrap(kind: lcDataFork)
+        bootstrap.forky(lcDataFork) = parseTest(
+          path/"bootstrap.ssz_snappy", SSZ,
+          lcDataFork.LightClientBootstrap)
+      else: raiseAssert "Unsupported bootstrap fork " & $bootstrap_fork_digest
+
+    var store {.noinit.}: ForkedLightClientStore
+    withLcDataFork(lcDataForkAtStateFork(store_state_fork)):
+      when lcDataFork > LightClientDataFork.None:
+        store = ForkedLightClientStore(kind: lcDataFork)
+        check bootstrap.kind <= lcDataFork
+        let upgradedBootstrap = bootstrap.migratingToDataFork(lcDataFork)
+        store.forky(lcDataFork) = initialize_light_client_store(
+          trusted_block_root, bootstrap.forky(lcDataFork), cfg).get
+      else: raiseAssert "Unreachable store fork " & $store_fork_digest
+
     for step in steps:
-      case step.kind
-      of TestStepKind.ForceUpdate:
-        process_light_client_store_force_update(
-          store, step.current_slot)
-      of TestStepKind.ProcessUpdate:
-        let res = process_light_client_update(
-          store, step.update, step.current_slot,
-          cfg, genesis_validators_root)
-        check res.isOk
-      let
-        finalized_root = hash_tree_root(store.finalized_header.beacon)
-        optimistic_root = hash_tree_root(store.optimistic_header.beacon)
-      check:
-        store.finalized_header.beacon.slot == step.checks.finalized_slot
-        finalized_root == step.checks.finalized_root
-        store.optimistic_header.beacon.slot == step.checks.optimistic_slot
-        optimistic_root == step.checks.optimistic_root
+      withForkyStore(store):
+        when lcDataFork > LightClientDataFork.None:
+          case step.kind
+          of TestStepKind.ForceUpdate:
+            process_light_client_store_force_update(
+              forkyStore, step.current_slot)
+          of TestStepKind.ProcessUpdate:
+            check step.update.kind <= lcDataFork
+            let
+              upgradedUpdate = step.update.migratingToDataFork(lcDataFork)
+              res = process_light_client_update(
+                forkyStore, upgradedUpdate.forky(lcDataFork), step.current_slot,
+                cfg, genesis_validators_root)
+            check res.isOk
+        else: raiseAssert "Unreachable"
+
+      withForkyStore(store):
+        when lcDataFork > LightClientDataFork.None:
+          let
+            finalized_slot =
+              forkyStore.finalized_header.beacon.slot
+            finalized_beacon_root =
+              hash_tree_root(forkyStore.finalized_header.beacon)
+            optimistic_slot =
+              forkyStore.optimistic_header.beacon.slot
+            optimistic_beacon_root =
+              hash_tree_root(forkyStore.optimistic_header.beacon)
+          check:
+            finalized_slot == step.checks.finalized_slot
+            finalized_beacon_root == step.checks.finalized_beacon_root
+            optimistic_slot == step.checks.optimistic_slot
+            optimistic_beacon_root == step.checks.optimistic_beacon_root
+        else: raiseAssert "Unreachable"
 
 suite "EF - Light client - Sync" & preset():
   const presetPath = SszTestsDir/const_preset

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -99,7 +99,7 @@ proc runTest(path: string) =
     doAssert unknowns.len == 0, "Unknown config constants: " & $unknowns
 
     var store =
-      initialize_light_client_store(trusted_block_root, bootstrap).get
+      initialize_light_client_store(trusted_block_root, bootstrap, cfg).get
     for step in steps:
       case step.kind
       of TestStepKind.ForceUpdate:

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -138,7 +138,7 @@ proc runTest(path: string) =
         check bootstrap.kind <= lcDataFork
         let upgradedBootstrap = bootstrap.migratingToDataFork(lcDataFork)
         store.forky(lcDataFork) = initialize_light_client_store(
-          trusted_block_root, bootstrap.forky(lcDataFork), cfg).get
+          trusted_block_root, upgradedBootstrap.forky(lcDataFork), cfg).get
       else: raiseAssert "Unreachable store fork " & $store_fork_digest
 
     for step in steps:

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -17,206 +17,222 @@ import
   # Test utilities
   ./testutil, ./testdbutil
 
-suite "Light client" & preset():
-  let
-    cfg = block:
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH + 1
-      res
-    altairStartSlot = cfg.ALTAIR_FORK_EPOCH.start_slot
-
-  proc advanceToSlot(
-      dag: ChainDAGRef,
-      targetSlot: Slot,
-      verifier: var BatchVerifier,
-      quarantine: var Quarantine,
-      attested = true,
-      syncCommitteeRatio = 0.82) =
-    var cache: StateCache
-    const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
-    while true:
-      var slot = getStateField(dag.headState, slot)
-      doAssert targetSlot >= slot
-      if targetSlot == slot: break
-
-      # When there is a large jump, skip to the end of the current period,
-      # create blocks for a few epochs to finalize it, then proceed
-      let
-        nextPeriod = slot.sync_committee_period + 1
-        periodEpoch = nextPeriod.start_epoch
-        periodSlot = periodEpoch.start_slot
-        checkpointSlot = periodSlot - maxAttestedSlotsPerPeriod
-      if targetSlot > checkpointSlot and checkpointSlot > dag.head.slot:
-        var info: ForkedEpochInfo
-        doAssert process_slots(cfg, dag.headState, checkpointSlot,
-                               cache, info, flags = {}).isOk()
-        slot = checkpointSlot
-
-      # Create blocks for final few epochs
-      let blocks = min(targetSlot - slot, maxAttestedSlotsPerPeriod)
-      for blck in makeTestBlocks(dag.headState, cache, blocks.int,
-                                 attested, syncCommitteeRatio, cfg):
-        let added =
-          case blck.kind
-          of BeaconBlockFork.Phase0:
-            const nilCallback = OnPhase0BlockAdded(nil)
-            dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
-          of BeaconBlockFork.Altair:
-            const nilCallback = OnAltairBlockAdded(nil)
-            dag.addHeadBlock(verifier, blck.altairData, nilCallback)
-          of BeaconBlockFork.Bellatrix:
-            const nilCallback = OnBellatrixBlockAdded(nil)
-            dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
-          of BeaconBlockFork.Capella:
-            const nilCallback = OnCapellaBlockAdded(nil)
-            dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
-          of BeaconBlockFork.EIP4844:
-            const nilCallback = OnEIP4844BlockAdded(nil)
-            dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
-
-        check: added.isOk()
-        dag.updateHead(added[], quarantine)
-
-  setup:
-    const num_validators = SLOTS_PER_EPOCH
+proc runTest(storeDataFork: static LightClientDataFork) =
+  suite "Light client - " & $storeDataFork & preset():
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = ChainDAGRef.init(
-        cfg, makeTestDB(num_validators), validatorMonitor, {},
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH + 1
+        res
+      altairStartSlot = cfg.ALTAIR_FORK_EPOCH.start_slot
+
+    proc advanceToSlot(
+        dag: ChainDAGRef,
+        targetSlot: Slot,
+        verifier: var BatchVerifier,
+        quarantine: var Quarantine,
+        attested = true,
+        syncCommitteeRatio = 0.82) =
+      var cache: StateCache
+      const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
+      while true:
+        var slot = getStateField(dag.headState, slot)
+        doAssert targetSlot >= slot
+        if targetSlot == slot: break
+
+        # When there is a large jump, skip to the end of the current period,
+        # create blocks for a few epochs to finalize it, then proceed
+        let
+          nextPeriod = slot.sync_committee_period + 1
+          periodEpoch = nextPeriod.start_epoch
+          periodSlot = periodEpoch.start_slot
+          checkpointSlot = periodSlot - maxAttestedSlotsPerPeriod
+        if targetSlot > checkpointSlot and checkpointSlot > dag.head.slot:
+          var info: ForkedEpochInfo
+          doAssert process_slots(cfg, dag.headState, checkpointSlot,
+                                cache, info, flags = {}).isOk()
+          slot = checkpointSlot
+
+        # Create blocks for final few epochs
+        let blocks = min(targetSlot - slot, maxAttestedSlotsPerPeriod)
+        for blck in makeTestBlocks(dag.headState, cache, blocks.int,
+                                  attested, syncCommitteeRatio, cfg):
+          let added =
+            case blck.kind
+            of BeaconBlockFork.Phase0:
+              const nilCallback = OnPhase0BlockAdded(nil)
+              dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
+            of BeaconBlockFork.Altair:
+              const nilCallback = OnAltairBlockAdded(nil)
+              dag.addHeadBlock(verifier, blck.altairData, nilCallback)
+            of BeaconBlockFork.Bellatrix:
+              const nilCallback = OnBellatrixBlockAdded(nil)
+              dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+            of BeaconBlockFork.Capella:
+              const nilCallback = OnCapellaBlockAdded(nil)
+              dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
+            of BeaconBlockFork.EIP4844:
+              const nilCallback = OnEIP4844BlockAdded(nil)
+              dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
+
+          check: added.isOk()
+          dag.updateHead(added[], quarantine)
+
+    setup:
+      const num_validators = SLOTS_PER_EPOCH
+      let
+        validatorMonitor = newClone(ValidatorMonitor.init())
+        dag = ChainDAGRef.init(
+          cfg, makeTestDB(num_validators), validatorMonitor, {},
+          lcDataConfig = LightClientDataConfig(
+            serve: true,
+            importMode: LightClientDataImportMode.OnlyNew))
+        quarantine = newClone(Quarantine.init())
+        taskpool = Taskpool.new()
+      var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+
+    test "Pre-Altair":
+      # Genesis
+      block:
+        let
+          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+          finalityUpdate = dag.getLightClientFinalityUpdate
+          optimisticUpdate = dag.getLightClientOptimisticUpdate
+        check:
+          dag.headState.kind == BeaconStateFork.Phase0
+          update.kind == LightClientDataFork.None
+          finalityUpdate.kind == LightClientDataFork.None
+          optimisticUpdate.kind == LightClientDataFork.None
+
+      # Advance to last slot before Altair
+      dag.advanceToSlot(altairStartSlot - 1, verifier, quarantine[])
+      block:
+        let
+          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+          finalityUpdate = dag.getLightClientFinalityUpdate
+          optimisticUpdate = dag.getLightClientOptimisticUpdate
+        check:
+          dag.headState.kind == BeaconStateFork.Phase0
+          update.kind == LightClientDataFork.None
+          finalityUpdate.kind == LightClientDataFork.None
+          optimisticUpdate.kind == LightClientDataFork.None
+
+      # Advance to Altair
+      dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+      block:
+        let
+          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+          finalityUpdate = dag.getLightClientFinalityUpdate
+          optimisticUpdate = dag.getLightClientOptimisticUpdate
+        check:
+          dag.headState.kind == BeaconStateFork.Altair
+          update.kind == LightClientDataFork.None
+          finalityUpdate.kind == LightClientDataFork.None
+          optimisticUpdate.kind == LightClientDataFork.None
+
+    test "Light client sync":
+      # Advance to Altair
+      dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+
+      # Track trusted checkpoint for light client
+      let
+        genesis_validators_root = dag.genesis_validators_root
+        trusted_block_root = dag.head.root
+
+      # Advance to target slot
+      const
+        headPeriod = 2.SyncCommitteePeriod
+        periodEpoch = headPeriod.start_epoch
+        headSlot = (periodEpoch + 2).start_slot + 5
+      dag.advanceToSlot(headSlot, verifier, quarantine[])
+      let currentSlot = getStateField(dag.headState, slot)
+
+      # Initialize light client store
+      let bootstrap = dag.getLightClientBootstrap(trusted_block_root)
+      check:
+        bootstrap.kind > LightClientDataFork.None
+        bootstrap.kind <= storeDataFork
+      let upgradedBootstrap = bootstrap.migratingToDataFork(storeDataFork)
+      template forkyBootstrap: untyped = upgradedBootstrap.forky(storeDataFork)
+      var storeRes = initialize_light_client_store(
+        trusted_block_root, forkyBootstrap, cfg)
+      check storeRes.isOk
+      template store(): auto = storeRes.get
+
+      # Sync to latest sync committee period
+      var numIterations = 0
+      template storePeriod: SyncCommitteePeriod =
+        store.finalized_header.beacon.slot.sync_committee_period
+      while storePeriod + 1 < headPeriod:
+        let
+          period =
+            if store.is_next_sync_committee_known:
+              storePeriod + 1
+            else:
+              storePeriod
+          update = dag.getLightClientUpdateForPeriod(period)
+        check:
+          update.kind > LightClientDataFork.None
+          update.kind <= storeDataFork
+        let upgradedUpdate = update.migratingToDataFork(storeDataFork)
+        template forkyUpdate: untyped = upgradedUpdate.forky(storeDataFork)
+        let res = process_light_client_update(
+          store, forkyUpdate, currentSlot, cfg, genesis_validators_root)
+        check:
+          forkyUpdate.finalized_header.beacon.slot.sync_committee_period ==
+            period
+          res.isOk
+          if forkyUpdate.finalized_header.beacon.slot >
+              forkyBootstrap.header.beacon.slot:
+            store.finalized_header == forkyUpdate.finalized_header
+          else:
+            store.finalized_header == forkyBootstrap.header
+        inc numIterations
+        if numIterations > 20: doAssert false # Avoid endless loop on test failure
+
+      # Sync to latest update
+      let finalityUpdate = dag.getLightClientFinalityUpdate
+      check:
+        finalityUpdate.kind > LightClientDataFork.None
+        finalityUpdate.kind <= storeDataFork
+      let upgradedFinalityUpdate =
+        finalityUpdate.migratingToDataFork(storeDataFork)
+      template forkyFinalityUpdate: untyped =
+        upgradedFinalityUpdate.forky(storeDataFork)
+      let res = process_light_client_update(
+        store, forkyFinalityUpdate, currentSlot, cfg, genesis_validators_root)
+      check:
+        forkyFinalityUpdate.attested_header.beacon.slot == dag.head.parent.slot
+        res.isOk
+        store.finalized_header == forkyFinalityUpdate.finalized_header
+        store.optimistic_header == forkyFinalityUpdate.attested_header
+
+    test "Init from checkpoint":
+      # Fetch genesis state
+      let genesisState = assignClone dag.headState
+
+      # Advance to target slot for checkpoint
+      let finalizedSlot =
+        ((altairStartSlot.sync_committee_period + 1).start_epoch + 2).start_slot
+      dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
+
+      # Initialize new DAG from checkpoint
+      let cpDb = BeaconChainDB.new("", inMemory = true)
+      ChainDAGRef.preInit(cpDb, genesisState[])
+      ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
+      let cpDag = ChainDAGRef.init(
+        cfg, cpDb, validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(
           serve: true,
-          importMode: LightClientDataImportMode.OnlyNew))
-      quarantine = newClone(Quarantine.init())
-      taskpool = Taskpool.new()
-    var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+          importMode: LightClientDataImportMode.Full))
 
-  test "Pre-Altair":
-    # Genesis
-    block:
-      let
-        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-        finalityUpdate = dag.getLightClientFinalityUpdate
-        optimisticUpdate = dag.getLightClientOptimisticUpdate
-      check:
-        dag.headState.kind == BeaconStateFork.Phase0
-        update.kind == LightClientDataFork.None
-        finalityUpdate.kind == LightClientDataFork.None
-        optimisticUpdate.kind == LightClientDataFork.None
+      # Advance by a couple epochs
+      for i in 1'u64 .. 10:
+        let headSlot = (finalizedSlot.epoch + i).start_slot
+        cpDag.advanceToSlot(headSlot, verifier, quarantine[])
 
-    # Advance to last slot before Altair
-    dag.advanceToSlot(altairStartSlot - 1, verifier, quarantine[])
-    block:
-      let
-        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-        finalityUpdate = dag.getLightClientFinalityUpdate
-        optimisticUpdate = dag.getLightClientOptimisticUpdate
-      check:
-        dag.headState.kind == BeaconStateFork.Phase0
-        update.kind == LightClientDataFork.None
-        finalityUpdate.kind == LightClientDataFork.None
-        optimisticUpdate.kind == LightClientDataFork.None
+      check true
 
-    # Advance to Altair
-    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
-    block:
-      let
-        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-        finalityUpdate = dag.getLightClientFinalityUpdate
-        optimisticUpdate = dag.getLightClientOptimisticUpdate
-      check:
-        dag.headState.kind == BeaconStateFork.Altair
-        update.kind == LightClientDataFork.None
-        finalityUpdate.kind == LightClientDataFork.None
-        optimisticUpdate.kind == LightClientDataFork.None
-
-  test "Light client sync":
-    # Advance to Altair
-    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
-
-    # Track trusted checkpoint for light client
-    let
-      genesis_validators_root = dag.genesis_validators_root
-      trusted_block_root = dag.head.root
-
-    # Advance to target slot
-    const
-      headPeriod = 2.SyncCommitteePeriod
-      periodEpoch = headPeriod.start_epoch
-      headSlot = (periodEpoch + 2).start_slot + 5
-    dag.advanceToSlot(headSlot, verifier, quarantine[])
-    let currentSlot = getStateField(dag.headState, slot)
-
-    # Initialize light client store
-    const storeDataFork = LightClientStore.kind
-    let bootstrap = dag.getLightClientBootstrap(trusted_block_root)
-    check bootstrap.kind == storeDataFork
-    template forkyBootstrap: untyped = bootstrap.forky(storeDataFork)
-    var storeRes = initialize_light_client_store(
-      trusted_block_root, forkyBootstrap)
-    check storeRes.isOk
-    template store(): auto = storeRes.get
-
-    # Sync to latest sync committee period
-    var numIterations = 0
-    template storePeriod: SyncCommitteePeriod =
-      store.finalized_header.beacon.slot.sync_committee_period
-    while storePeriod + 1 < headPeriod:
-      let
-        period =
-          if store.is_next_sync_committee_known:
-            storePeriod + 1
-          else:
-            storePeriod
-        update = dag.getLightClientUpdateForPeriod(period)
-      check update.kind == storeDataFork
-      template forkyUpdate: untyped = update.forky(storeDataFork)
-      let res = process_light_client_update(
-          store, forkyUpdate, currentSlot, cfg, genesis_validators_root)
-      check:
-        forkyUpdate.finalized_header.beacon.slot.sync_committee_period == period
-        res.isOk
-        if forkyUpdate.finalized_header.beacon.slot >
-            forkyBootstrap.header.beacon.slot:
-          store.finalized_header == forkyUpdate.finalized_header
-        else:
-          store.finalized_header == forkyBootstrap.header
-      inc numIterations
-      if numIterations > 20: doAssert false # Avoid endless loop on test failure
-
-    # Sync to latest update
-    let finalityUpdate = dag.getLightClientFinalityUpdate
-    check finalityUpdate.kind == storeDataFork
-    template forkyFinalityUpdate: untyped = finalityUpdate.forky(storeDataFork)
-    let res = process_light_client_update(
-        store, forkyFinalityUpdate, currentSlot, cfg, genesis_validators_root)
-    check:
-      forkyFinalityUpdate.attested_header.beacon.slot == dag.head.parent.slot
-      res.isOk
-      store.finalized_header == forkyFinalityUpdate.finalized_header
-      store.optimistic_header == forkyFinalityUpdate.attested_header
-
-  test "Init from checkpoint":
-    # Fetch genesis state
-    let genesisState = assignClone dag.headState
-
-    # Advance to target slot for checkpoint
-    let finalizedSlot =
-      ((altairStartSlot.sync_committee_period + 1).start_epoch + 2).start_slot
-    dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
-
-    # Initialize new DAG from checkpoint
-    let cpDb = BeaconChainDB.new("", inMemory = true)
-    ChainDAGRef.preInit(cpDb, genesisState[])
-    ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
-    let cpDag = ChainDAGRef.init(
-      cfg, cpDb, validatorMonitor, {},
-      lcDataConfig = LightClientDataConfig(
-        serve: true,
-        importMode: LightClientDataImportMode.Full))
-
-    # Advance by a couple epochs
-    for i in 1'u64 .. 10:
-      let headSlot = (finalizedSlot.epoch + i).start_slot
-      cpDag.advanceToSlot(headSlot, verifier, quarantine[])
-
-    check true
+withAll(LightClientDataFork):
+  when lcDataFork > LightClientDataFork.None:
+    runTest(lcDataFork)

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -98,8 +98,8 @@ suite "Light client processor" & preset():
       var numOnStoreInitializedCalls = 0
       func onStoreInitialized() = inc numOnStoreInitializedCalls
 
-      let store = (ref Option[LightClientStore])()
-      const storeDataFork = typeof(store[].get).kind
+      const storeDataFork = LightClientProcessor.storeDataFork
+      let store = (ref Option[storeDataFork.LightClientStore])()
       var
         processor = LightClientProcessor.new(
           false, "", "", cfg, genesis_validators_root, finalizationMode,
@@ -274,7 +274,7 @@ suite "Light client processor" & preset():
         bootstrap.kind > LightClientDataFork.None
         bootstrap.kind <= storeDataFork
       withForkyBootstrap(bootstrap):
-        when lcDataFork >= LightClientDataFork.Altair:
+        when lcDataFork > LightClientDataFork.None:
           forkyBootstrap.header.beacon.slot.inc()
       let upgradedBootstrap = bootstrap.migratingToDataFork(storeDataFork)
       template forkyBootstrap: untyped = upgradedBootstrap.forky(storeDataFork)


### PR DESCRIPTION
Distinguish between those code locations that need to be updated on each light client data format change, and those others that should generally be fine, as long as a valid light client object is processed.

The former are tagged with static assert for `LightClientDataFork.high`.

The latter are changed to `lcDataFork > LightClientDataFork.None` to indicate that they depend only on presence of any valid object. Also bundled a few minor cleanups and fixes.

Also add `Forky` type for `LightClientStore` and minor fixes / cleanups.