### PR TITLE
use `ForkedLightClientStore` internally

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -303,7 +303,7 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + LVH searching                                                                              OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Light client  [Preset: mainnet]
+## Light client [Preset: mainnet]
 ```diff
 + Init from checkpoint                                                                       OK
 + Light client sync                                                                          OK

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -303,7 +303,7 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + LVH searching                                                                              OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## Light client - Altair [Preset: mainnet]
+## Light client  [Preset: mainnet]
 ```diff
 + Init from checkpoint                                                                       OK
 + Light client sync                                                                          OK

--- a/beacon_chain/beacon_chain_db_light_client.nim
+++ b/beacon_chain/beacon_chain_db_light_client.nim
@@ -316,7 +316,7 @@ func putBestUpdate*(
           let res = db.bestUpdates.putStmt.exec(
             (period.int64, lcDataFork.int64, SSZ.encode(forkyUpdate)))
           res.expect("SQL query OK")
-        if update.kind == LightClientDataFork.Altair:
+        when lcDataFork == LightClientDataFork.Altair:
           let res = db.legacyBestUpdates.putStmt.exec(
             (period.int64, SSZ.encode(forkyUpdate)))
           res.expect("SQL query OK")

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -298,7 +298,8 @@ template withReportedProgress(
     obj: SomeForkedLightClientObject | Nothing, body: untyped): bool =
   block:
     let
-      oldKind = self.store[].kind
+      oldIsInitialized =
+        self.store[].kind != LightClientDataFork.None
       oldNextCommitteeKnown = withForkyStore(self.store[]):
         when lcDataFork > LightClientDataFork.None:
           forkyStore.is_next_sync_committee_known
@@ -326,13 +327,13 @@ template withReportedProgress(
       didProgress = false
       didSignificantProgress = false
 
-    if self.store[].kind > oldKind:
+    let newIsInitialized = self.store[].kind != LightClientDataFork.None
+    if newIsInitialized > oldIsInitialized:
       didProgress = true
-      if oldKind == LightClientDataFork.None:
-        didSignificantProgress = true
-        if self.onStoreInitialized != nil:
-          self.onStoreInitialized()
-          self.onStoreInitialized = nil
+      didSignificantProgress = true
+      if self.onStoreInitialized != nil:
+        self.onStoreInitialized()
+        self.onStoreInitialized = nil
 
     withForkyStore(self.store[]):
       when lcDataFork > LightClientDataFork.None:

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -291,9 +291,6 @@ proc installMessageValidators*(
     msg.logReceived()
 
     if contextFork != lightClient.cfg.stateForkAtEpoch(msg.contextEpoch):
-      info "Received obj on wrong fork",
-        contextFork, expectedFork = lightClient.cfg.stateForkAtEpoch(msg.contextEpoch),
-        msg
       msg.logDropped(
         (ValidationResult.Reject, cstring "Invalid context fork"))
       return ValidationResult.Reject

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -12,6 +12,7 @@ else:
 
 import
   # Status libraries
+  stew/base10,
   chronicles,
   eth/db/kvstore_sqlite3,
   # Beacon chain internals
@@ -21,7 +22,7 @@ import
 
 logScope: topics = "lcdb"
 
-# `altair_lc_headers` holds the latest `LightClientStore.finalized_header`.
+# `lc_headers` holds the latest `LightClientStore.finalized_header`.
 #
 # `altair_sync_committees` holds finalized `SyncCommittee` by period, needed to
 # continue an interrupted sync process without having to obtain bootstrap info.
@@ -29,12 +30,12 @@ logScope: topics = "lcdb"
 template dbDataFork: LightClientDataFork = LightClientDataFork.Altair
 
 type
-  LightClientHeaderKind {.pure.} = enum  # Append only, used in DB data!
-    Finalized = 1
+  LightClientHeaderKey {.pure.} = enum  # Append only, used in DB data!
+    Finalized = 1  # Latest finalized header
 
   LightClientHeadersStore = object
-    getStmt: SqliteStmt[int64, seq[byte]]
-    putStmt: SqliteStmt[(int64, seq[byte]), void]
+    getStmt: SqliteStmt[int64, (int64, seq[byte])]
+    putStmt: SqliteStmt[(int64, int64, seq[byte]), void]
 
   SyncCommitteeStore = object
     getStmt: SqliteStmt[int64, seq[byte]]
@@ -46,35 +47,51 @@ type
       ## SQLite backend
 
     headers: LightClientHeadersStore
-      ## LightClientHeaderKind -> altair.LightClientHeader
+      ## LightClientHeaderKey -> (LightClientDataFork, LightClientHeader)
       ## Stores the latest light client headers.
 
     syncCommittees: SyncCommitteeStore
       ## SyncCommitteePeriod -> altair.SyncCommittee
       ## Stores finalized `SyncCommittee` by sync committee period.
 
-func initLightClientHeadersStore(
+proc initLightClientHeadersStore(
     backend: SqStoreRef,
-    name: string): KvResult[LightClientHeadersStore] =
+    name, legacyAltairName: string): KvResult[LightClientHeadersStore] =
   static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   ? backend.exec("""
     CREATE TABLE IF NOT EXISTS `""" & name & """` (
-      `kind` INTEGER PRIMARY KEY,  -- `LightClientHeaderKind`
-      `header` BLOB                -- `altair.LightClientHeader` (SSZ)
+      `key` INTEGER PRIMARY KEY,   -- `LightClientHeaderKey`
+      `kind` INTEGER,              -- `LightClientDataFork`
+      `header` BLOB                -- `LightClientHeader` (SSZ)
     );
   """)
+  if backend.hasTable(legacyAltairName).expect("SQL query OK"):
+    info "Importing Altair light client data"
+    # LightClientHeaderKey -> altair.LightClientHeader
+    const legacyKind = Base10.toString(ord(LightClientDataFork.Altair).uint)
+    ? backend.exec("""
+      INSERT OR IGNORE INTO `""" & name & """` (
+        `key`, `kind`, `header`
+      )
+      SELECT `kind` AS `key`, """ & legacyKind & """ AS `kind`, `header`
+      FROM `""" & legacyAltairName & """`;
+    """)
+    ? backend.exec("""
+      DROP TABLE `""" & legacyAltairName & """`;
+    """)
 
   let
     getStmt = backend.prepareStmt("""
-      SELECT `header`
+      SELECT `kind`, `header`
       FROM `""" & name & """`
-      WHERE `kind` = ?;
-    """, int64, seq[byte], managed = false).expect("SQL query OK")
+      WHERE `key` = ?;
+    """, int64, (int64, seq[byte]), managed = false).expect("SQL query OK")
     putStmt = backend.prepareStmt("""
       REPLACE INTO `""" & name & """` (
-        `kind`, `header`
-      ) VALUES (?, ?);
-    """, (int64, seq[byte]), void, managed = false).expect("SQL query OK")
+        `key`, `kind`, `header`
+      ) VALUES (?, ?, ?);
+    """, (int64, int64, seq[byte]), void, managed = false)
+      .expect("SQL query OK")
 
   ok LightClientHeadersStore(
     getStmt: getStmt,
@@ -85,29 +102,41 @@ func close(store: LightClientHeadersStore) =
   store.putStmt.dispose()
 
 proc getLatestFinalizedHeader*(
-    db: LightClientDB): Opt[dbDataFork.LightClientHeader] =
-  var header: seq[byte]
-  for res in db.headers.getStmt.exec(
-      LightClientHeaderKind.Finalized.int64, header):
+    db: LightClientDB): ForkedLightClientHeader =
+  const key = LightClientHeaderKey.Finalized
+  var header: (int64, seq[byte])
+  for res in db.headers.getStmt.exec(key.int64, header):
     res.expect("SQL query OK")
     try:
-      return ok SSZ.decode(header, dbDataFork.LightClientHeader)
+      withAll(LightClientDataFork):
+        when lcDataFork > LightClientDataFork.None:
+          if header[0] == ord(lcDataFork).int64:
+            var obj = ForkedLightClientHeader(kind: lcDataFork)
+            obj.forky(lcDataFork) = SSZ.decode(
+              header[1], lcDataFork.LightClientHeader)
+            return obj
+      warn "Unsupported LC store kind", store = "headers",
+        key, kind = header[0]
+      return default(ForkedLightClientHeader)
     except SszError as exc:
       error "LC store corrupted", store = "headers",
-        kind = "Finalized", exc = exc.msg
-      return err()
+        key, kind = header[0], exc = exc.msg
+      return default(ForkedLightClientHeader)
 
 func putLatestFinalizedHeader*(
-    db: LightClientDB, header: dbDataFork.LightClientHeader) =
-  block:
-    let res = db.headers.putStmt.exec(
-      (LightClientHeaderKind.Finalized.int64, SSZ.encode(header)))
-    res.expect("SQL query OK")
-  block:
-    let period = header.beacon.slot.sync_committee_period
-    doAssert period.isSupportedBySQLite
-    let res = db.syncCommittees.keepFromStmt.exec(period.int64)
-    res.expect("SQL query OK")
+    db: LightClientDB, header: ForkedLightClientHeader) =
+  withForkyHeader(header):
+    when lcDataFork > LightClientDataFork.None:
+      block:
+        const key = LightClientHeaderKey.Finalized
+        let res = db.headers.putStmt.exec(
+          (key.int64, lcDataFork.int64, SSZ.encode(forkyHeader)))
+        res.expect("SQL query OK")
+      block:
+        let period = forkyHeader.beacon.slot.sync_committee_period
+        doAssert period.isSupportedBySQLite
+        let res = db.syncCommittees.keepFromStmt.exec(period.int64)
+        res.expect("SQL query OK")
 
 func initSyncCommitteesStore(
     backend: SqStoreRef,
@@ -156,7 +185,7 @@ proc getSyncCommittee*(
     except SszError as exc:
       error "LC store corrupted", store = "syncCommittees",
         period, exc = exc.msg
-      return err()
+      return Opt.none(altair.SyncCommittee)
 
 func putSyncCommittee*(
     db: LightClientDB, period: SyncCommitteePeriod,
@@ -167,15 +196,17 @@ func putSyncCommittee*(
   res.expect("SQL query OK")
 
 type LightClientDBNames* = object
-  altairHeaders*: string
+  legacyAltairHeaders*: string
+  headers*: string
   altairSyncCommittees*: string
 
-func initLightClientDB*(
+proc initLightClientDB*(
     backend: SqStoreRef,
     names: LightClientDBNames): KvResult[LightClientDB] =
   let
     headers =
-      ? backend.initLightClientHeadersStore(names.altairHeaders)
+      ? backend.initLightClientHeadersStore(
+        names.headers, names.legacyAltairHeaders)
     syncCommittees =
       ? backend.initSyncCommitteesStore(names.altairSyncCommittees)
 

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -137,6 +137,7 @@ func putLatestFinalizedHeader*(
         doAssert period.isSupportedBySQLite
         let res = db.syncCommittees.keepFromStmt.exec(period.int64)
         res.expect("SQL query OK")
+    else: raiseAssert "Cannot store empty `LightClientHeader`"
 
 func initSyncCommitteesStore(
     backend: SqStoreRef,

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -57,7 +57,6 @@ type
 proc initLightClientHeadersStore(
     backend: SqStoreRef,
     name, legacyAltairName: string): KvResult[LightClientHeadersStore] =
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   ? backend.exec("""
     CREATE TABLE IF NOT EXISTS `""" & name & """` (
       `key` INTEGER PRIMARY KEY,   -- `LightClientHeaderKey`

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -27,8 +27,6 @@ logScope: topics = "lcdb"
 # `altair_sync_committees` holds finalized `SyncCommittee` by period, needed to
 # continue an interrupted sync process without having to obtain bootstrap info.
 
-template dbDataFork: LightClientDataFork = LightClientDataFork.Altair
-
 type
   LightClientHeaderKey {.pure.} = enum  # Append only, used in DB data!
     Finalized = 1  # Latest finalized header

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -157,7 +157,7 @@ func putLatestFinalizedHeader*(
           let res = db.headers.putStmt.exec(
             (key.int64, lcDataFork.int64, SSZ.encode(forkyHeader)))
           res.expect("SQL query OK")
-        if header.kind == LightClientDataFork.Altair:
+        when lcDataFork == LightClientDataFork.Altair:
           let res = db.legacyHeaders.putStmt.exec(
             (key.int64, SSZ.encode(forkyHeader)))
           res.expect("SQL query OK")

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -64,7 +64,7 @@ proc initLegacyLightClientHeadersStore(
     name: string): KvResult[LegacyLightClientHeadersStore] =
   ? backend.exec("""
     CREATE TABLE IF NOT EXISTS `""" & name & """` (
-      `key` INTEGER PRIMARY KEY,   -- `LightClientHeaderKey`
+      `kind` INTEGER PRIMARY KEY,  -- `LightClientHeaderKey`
       `header` BLOB                -- `altair.LightClientHeader` (SSZ)
     );
   """)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -54,7 +54,7 @@ programMain:
   defer: backend.close()
   let db = backend.initLightClientDB(LightClientDBNames(
     legacyAltairHeaders: "altair_lc_headers",
-    headers: "headers",
+    headers: "lc_headers",
     altairSyncCommittees: "altair_sync_committees")).expect("Database OK")
   defer: db.close()
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -52,9 +52,9 @@ programMain:
     quit 1
   let backend = SqStoreRef.init(dbDir, "nlc").expect("Database OK")
   defer: backend.close()
-  static: doAssert LightClientDataFork.high == LightClientDataFork.Altair
   let db = backend.initLightClientDB(LightClientDBNames(
-    altairHeaders: "altair_lc_headers",
+    legacyAltairHeaders: "altair_lc_headers",
+    headers: "headers",
     altairSyncCommittees: "altair_sync_committees")).expect("Database OK")
   defer: db.close()
 
@@ -159,41 +159,46 @@ programMain:
   waitFor network.start()
 
   proc onFinalizedHeader(
-      lightClient: LightClient, finalizedHeader: altair.LightClientHeader) =
-    info "New LC finalized header",
-      finalized_header = shortLog(finalizedHeader)
+      lightClient: LightClient, finalizedHeader: ForkedLightClientHeader) =
+    withForkyHeader(finalizedHeader):
+      when lcDataFork > LightClientDataFork.None:
+        info "New LC finalized header",
+          finalized_header = shortLog(forkyHeader)
 
-    let
-      period = finalizedHeader.beacon.slot.sync_committee_period
-      syncCommittee = lightClient.finalizedSyncCommittee.expect("Bootstrap OK")
-    db.putSyncCommittee(period, syncCommittee)
-    db.putLatestFinalizedHeader(finalizedHeader)
+        let
+          period = forkyHeader.beacon.slot.sync_committee_period
+          syncCommittee = lightClient.finalizedSyncCommittee.expect("Init OK")
+        db.putSyncCommittee(period, syncCommittee)
+        db.putLatestFinalizedHeader(finalizedHeader)
 
   proc onOptimisticHeader(
-      lightClient: LightClient, optimisticHeader: altair.LightClientHeader) =
-    info "New LC optimistic header",
-      optimistic_header = shortLog(optimisticHeader)
-    optimisticProcessor.setOptimisticHeader(optimisticHeader.beacon)
+      lightClient: LightClient, optimisticHeader: ForkedLightClientHeader) =
+    withForkyHeader(optimisticHeader):
+      when lcDataFork > LightClientDataFork.None:
+        info "New LC optimistic header",
+          optimistic_header = shortLog(forkyHeader)
+        optimisticProcessor.setOptimisticHeader(forkyHeader.beacon)
 
   lightClient.onFinalizedHeader = onFinalizedHeader
   lightClient.onOptimisticHeader = onOptimisticHeader
   lightClient.trustedBlockRoot = some config.trustedBlockRoot
 
   let latestHeader = db.getLatestFinalizedHeader()
-  if latestHeader.isOk:
-    let
-      period = latestHeader.get.beacon.slot.sync_committee_period
-      syncCommittee = db.getSyncCommittee(period)
-    if syncCommittee.isErr:
-      error "LC store lacks sync committee", finalized_header = latestHeader.get
-    else:
-      lightClient.resetToFinalizedHeader(latestHeader.get, syncCommittee.get)
+  withForkyHeader(latestHeader):
+    when lcDataFork > LightClientDataFork.None:
+      let
+        period = forkyHeader.beacon.slot.sync_committee_period
+        syncCommittee = db.getSyncCommittee(period)
+      if syncCommittee.isErr:
+        error "LC store lacks sync committee", finalized_header = forkyHeader
+      else:
+        lightClient.resetToFinalizedHeader(latestHeader, syncCommittee.get)
 
   # Full blocks gossip is required to portably drive an EL client:
   # - EL clients may not sync when only driven with `forkChoiceUpdated`,
   #   e.g., Geth: "Forkchoice requested unknown head"
   # - `newPayload` requires the full `ExecutionPayload` (most of block content)
-  # - `ExecutionPayload` block root is not available in
+  # - `ExecutionPayload` block hash is not available in
   #   `altair.LightClientHeader`, so won't be exchanged via light client gossip
   #
   # Future `ethereum/consensus-specs` versions may remove need for full blocks.
@@ -201,16 +206,14 @@ programMain:
   # optimized for reducing code duplication, e.g., with `nimbus_beacon_node`.
 
   func isSynced(wallSlot: Slot): bool =
-    # Check whether light client is used
-    let optimisticHeader = lightClient.optimisticHeader.valueOr:
-      return false
-
-    # Check whether light client has synced sufficiently close to wall slot
-    const maxAge = 2 * SLOTS_PER_EPOCH
-    if optimisticHeader.beacon.slot < max(wallSlot, maxAge.Slot) - maxAge:
-      return false
-
-    true
+    let optimisticHeader = lightClient.optimisticHeader
+    withForkyHeader(optimisticHeader):
+      when lcDataFork > LightClientDataFork.None:
+        # Check whether light client has synced sufficiently close to wall slot
+        const maxAge = 2 * SLOTS_PER_EPOCH
+        forkyHeader.beacon.slot >= max(wallSlot, maxAge.Slot) - maxAge
+      else:
+        false
 
   func shouldSyncOptimistically(wallSlot: Slot): bool =
     # Check whether an EL is connected
@@ -273,19 +276,19 @@ programMain:
       finalizedHeader = lightClient.finalizedHeader
       optimisticHeader = lightClient.optimisticHeader
 
-      finalizedBid =
-        if finalizedHeader.isSome:
-          finalizedHeader.get.beacon.toBlockId()
+      finalizedBid = withForkyHeader(finalizedHeader):
+        when lcDataFork > LightClientDataFork.None:
+          forkyHeader.beacon.toBlockId()
         else:
           BlockId(root: genesisBlockRoot, slot: GENESIS_SLOT)
-      optimisticBid =
-        if optimisticHeader.isSome:
-          optimisticHeader.get.beacon.toBlockId()
+      optimisticBid = withForkyHeader(optimisticHeader):
+        when lcDataFork > LightClientDataFork.None:
+          forkyHeader.beacon.toBlockId()
         else:
           BlockId(root: genesisBlockRoot, slot: GENESIS_SLOT)
 
       syncStatus =
-        if optimisticHeader.isNone:
+        if optimisticHeader.kind == LightClientDataFork.None:
           "bootstrapping(" & $config.trustedBlockRoot & ")"
         elif not isSynced(wallSlot):
           "syncing"

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -10,8 +10,6 @@
 import
   # Standard library
   std/[json, os, streams],
-  # Status libraries
-  stew/byteutils,
   # Third-party
   yaml,
   # Beacon chain internals

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -17,7 +17,7 @@ import
   # Test utilities
   ./testutil, ./testdbutil
 
-suite "Light client " & preset():
+suite "Light client" & preset():
   const  # Test config, should be long enough to cover interesting transitions
     headPeriod = 3.SyncCommitteePeriod
   let

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -9,7 +9,7 @@
 
 import
   # Status libraries
-  eth/keys, stew/objects, taskpools,
+  eth/keys, taskpools,
   # Beacon chain internals
   ../beacon_chain/consensus_object_pools/
     [block_clearance, block_quarantine, blockchain_dag],
@@ -17,222 +17,238 @@ import
   # Test utilities
   ./testutil, ./testdbutil
 
-proc runTest(storeDataFork: static LightClientDataFork) =
-  suite "Light client - " & $storeDataFork & preset():
+suite "Light client " & preset():
+  const  # Test config, should be long enough to cover interesting transitions
+    headPeriod = 3.SyncCommitteePeriod
+  let
+    cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
+      static: doAssert BeaconStateFork.high == BeaconStateFork.EIP4844
+      var res = defaultRuntimeConfig
+      res.ALTAIR_FORK_EPOCH = 1.Epoch
+      res.BELLATRIX_FORK_EPOCH = 2.Epoch
+      # $capellaImplementationMissing res.CAPELLA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 1).Epoch
+      # $eip4844ImplementationMissing res.EIP4844_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 2).Epoch
+      res
+    altairStartSlot = cfg.ALTAIR_FORK_EPOCH.start_slot
+
+  proc advanceToSlot(
+      dag: ChainDAGRef,
+      targetSlot: Slot,
+      verifier: var BatchVerifier,
+      quarantine: var Quarantine,
+      attested = true,
+      syncCommitteeRatio = 0.82) =
+    var cache: StateCache
+    const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
+    while true:
+      var slot = getStateField(dag.headState, slot)
+      doAssert targetSlot >= slot
+      if targetSlot == slot: break
+
+      # When there is a large jump, skip to the end of the current period,
+      # create blocks for a few epochs to finalize it, then proceed
+      let
+        nextPeriod = slot.sync_committee_period + 1
+        periodEpoch = nextPeriod.start_epoch
+        periodSlot = periodEpoch.start_slot
+        checkpointSlot = periodSlot - maxAttestedSlotsPerPeriod
+      if targetSlot > checkpointSlot and checkpointSlot > dag.head.slot:
+        var info: ForkedEpochInfo
+        doAssert process_slots(cfg, dag.headState, checkpointSlot,
+                              cache, info, flags = {}).isOk()
+        slot = checkpointSlot
+
+      # Create blocks for final few epochs
+      let blocks = min(targetSlot - slot, maxAttestedSlotsPerPeriod)
+      for blck in makeTestBlocks(dag.headState, cache, blocks.int,
+                                attested, syncCommitteeRatio, cfg):
+        let added =
+          case blck.kind
+          of BeaconBlockFork.Phase0:
+            const nilCallback = OnPhase0BlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
+          of BeaconBlockFork.Altair:
+            const nilCallback = OnAltairBlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.altairData, nilCallback)
+          of BeaconBlockFork.Bellatrix:
+            const nilCallback = OnBellatrixBlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
+          of BeaconBlockFork.Capella:
+            const nilCallback = OnCapellaBlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
+          of BeaconBlockFork.EIP4844:
+            const nilCallback = OnEIP4844BlockAdded(nil)
+            dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
+
+        check: added.isOk()
+        dag.updateHead(added[], quarantine)
+
+  setup:
+    const num_validators = SLOTS_PER_EPOCH
     let
-      cfg = block:
-        var res = defaultRuntimeConfig
-        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH + 1
-        res
-      altairStartSlot = cfg.ALTAIR_FORK_EPOCH.start_slot
+      validatorMonitor = newClone(ValidatorMonitor.init())
+      dag = ChainDAGRef.init(
+        cfg, makeTestDB(num_validators), validatorMonitor, {},
+        lcDataConfig = LightClientDataConfig(
+          serve: true,
+          importMode: LightClientDataImportMode.OnlyNew))
+      quarantine = newClone(Quarantine.init())
+      taskpool = Taskpool.new()
+    var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
 
-    proc advanceToSlot(
-        dag: ChainDAGRef,
-        targetSlot: Slot,
-        verifier: var BatchVerifier,
-        quarantine: var Quarantine,
-        attested = true,
-        syncCommitteeRatio = 0.82) =
-      var cache: StateCache
-      const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
-      while true:
-        var slot = getStateField(dag.headState, slot)
-        doAssert targetSlot >= slot
-        if targetSlot == slot: break
-
-        # When there is a large jump, skip to the end of the current period,
-        # create blocks for a few epochs to finalize it, then proceed
-        let
-          nextPeriod = slot.sync_committee_period + 1
-          periodEpoch = nextPeriod.start_epoch
-          periodSlot = periodEpoch.start_slot
-          checkpointSlot = periodSlot - maxAttestedSlotsPerPeriod
-        if targetSlot > checkpointSlot and checkpointSlot > dag.head.slot:
-          var info: ForkedEpochInfo
-          doAssert process_slots(cfg, dag.headState, checkpointSlot,
-                                cache, info, flags = {}).isOk()
-          slot = checkpointSlot
-
-        # Create blocks for final few epochs
-        let blocks = min(targetSlot - slot, maxAttestedSlotsPerPeriod)
-        for blck in makeTestBlocks(dag.headState, cache, blocks.int,
-                                  attested, syncCommitteeRatio, cfg):
-          let added =
-            case blck.kind
-            of BeaconBlockFork.Phase0:
-              const nilCallback = OnPhase0BlockAdded(nil)
-              dag.addHeadBlock(verifier, blck.phase0Data, nilCallback)
-            of BeaconBlockFork.Altair:
-              const nilCallback = OnAltairBlockAdded(nil)
-              dag.addHeadBlock(verifier, blck.altairData, nilCallback)
-            of BeaconBlockFork.Bellatrix:
-              const nilCallback = OnBellatrixBlockAdded(nil)
-              dag.addHeadBlock(verifier, blck.bellatrixData, nilCallback)
-            of BeaconBlockFork.Capella:
-              const nilCallback = OnCapellaBlockAdded(nil)
-              dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
-            of BeaconBlockFork.EIP4844:
-              const nilCallback = OnEIP4844BlockAdded(nil)
-              dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
-
-          check: added.isOk()
-          dag.updateHead(added[], quarantine)
-
-    setup:
-      const num_validators = SLOTS_PER_EPOCH
+  test "Pre-Altair":
+    # Genesis
+    block:
       let
-        validatorMonitor = newClone(ValidatorMonitor.init())
-        dag = ChainDAGRef.init(
-          cfg, makeTestDB(num_validators), validatorMonitor, {},
-          lcDataConfig = LightClientDataConfig(
-            serve: true,
-            importMode: LightClientDataImportMode.OnlyNew))
-        quarantine = newClone(Quarantine.init())
-        taskpool = Taskpool.new()
-      var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
-
-    test "Pre-Altair":
-      # Genesis
-      block:
-        let
-          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-          finalityUpdate = dag.getLightClientFinalityUpdate
-          optimisticUpdate = dag.getLightClientOptimisticUpdate
-        check:
-          dag.headState.kind == BeaconStateFork.Phase0
-          update.kind == LightClientDataFork.None
-          finalityUpdate.kind == LightClientDataFork.None
-          optimisticUpdate.kind == LightClientDataFork.None
-
-      # Advance to last slot before Altair
-      dag.advanceToSlot(altairStartSlot - 1, verifier, quarantine[])
-      block:
-        let
-          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-          finalityUpdate = dag.getLightClientFinalityUpdate
-          optimisticUpdate = dag.getLightClientOptimisticUpdate
-        check:
-          dag.headState.kind == BeaconStateFork.Phase0
-          update.kind == LightClientDataFork.None
-          finalityUpdate.kind == LightClientDataFork.None
-          optimisticUpdate.kind == LightClientDataFork.None
-
-      # Advance to Altair
-      dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
-      block:
-        let
-          update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
-          finalityUpdate = dag.getLightClientFinalityUpdate
-          optimisticUpdate = dag.getLightClientOptimisticUpdate
-        check:
-          dag.headState.kind == BeaconStateFork.Altair
-          update.kind == LightClientDataFork.None
-          finalityUpdate.kind == LightClientDataFork.None
-          optimisticUpdate.kind == LightClientDataFork.None
-
-    test "Light client sync":
-      # Advance to Altair
-      dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
-
-      # Track trusted checkpoint for light client
-      let
-        genesis_validators_root = dag.genesis_validators_root
-        trusted_block_root = dag.head.root
-
-      # Advance to target slot
-      const
-        headPeriod = 2.SyncCommitteePeriod
-        periodEpoch = headPeriod.start_epoch
-        headSlot = (periodEpoch + 2).start_slot + 5
-      dag.advanceToSlot(headSlot, verifier, quarantine[])
-      let currentSlot = getStateField(dag.headState, slot)
-
-      # Initialize light client store
-      let bootstrap = dag.getLightClientBootstrap(trusted_block_root)
+        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+        finalityUpdate = dag.getLightClientFinalityUpdate
+        optimisticUpdate = dag.getLightClientOptimisticUpdate
       check:
-        bootstrap.kind > LightClientDataFork.None
-        bootstrap.kind <= storeDataFork
-      let upgradedBootstrap = bootstrap.migratingToDataFork(storeDataFork)
-      template forkyBootstrap: untyped = upgradedBootstrap.forky(storeDataFork)
-      var storeRes = initialize_light_client_store(
-        trusted_block_root, forkyBootstrap, cfg)
-      check storeRes.isOk
-      template store(): auto = storeRes.get
+        dag.headState.kind == BeaconStateFork.Phase0
+        update.kind == LightClientDataFork.None
+        finalityUpdate.kind == LightClientDataFork.None
+        optimisticUpdate.kind == LightClientDataFork.None
 
-      # Sync to latest sync committee period
-      var numIterations = 0
-      template storePeriod: SyncCommitteePeriod =
-        store.finalized_header.beacon.slot.sync_committee_period
-      while storePeriod + 1 < headPeriod:
-        let
-          period =
-            if store.is_next_sync_committee_known:
+    # Advance to last slot before Altair
+    dag.advanceToSlot(altairStartSlot - 1, verifier, quarantine[])
+    block:
+      let
+        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+        finalityUpdate = dag.getLightClientFinalityUpdate
+        optimisticUpdate = dag.getLightClientOptimisticUpdate
+      check:
+        dag.headState.kind == BeaconStateFork.Phase0
+        update.kind == LightClientDataFork.None
+        finalityUpdate.kind == LightClientDataFork.None
+        optimisticUpdate.kind == LightClientDataFork.None
+
+    # Advance to Altair
+    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+    block:
+      let
+        update = dag.getLightClientUpdateForPeriod(0.SyncCommitteePeriod)
+        finalityUpdate = dag.getLightClientFinalityUpdate
+        optimisticUpdate = dag.getLightClientOptimisticUpdate
+      check:
+        dag.headState.kind == BeaconStateFork.Altair
+        update.kind == LightClientDataFork.None
+        finalityUpdate.kind == LightClientDataFork.None
+        optimisticUpdate.kind == LightClientDataFork.None
+
+  test "Light client sync":
+    # Advance to Altair
+    dag.advanceToSlot(altairStartSlot, verifier, quarantine[])
+
+    # Track trusted checkpoint for light client
+    let
+      genesis_validators_root = dag.genesis_validators_root
+      trusted_block_root = dag.head.root
+
+    # Advance to target slot
+    const
+      periodEpoch = headPeriod.start_epoch
+      headSlot = (periodEpoch + 2).start_slot + 5
+    dag.advanceToSlot(headSlot, verifier, quarantine[])
+    let currentSlot = getStateField(dag.headState, slot)
+
+    # Initialize light client store
+    var bootstrap = dag.getLightClientBootstrap(trusted_block_root)
+    check bootstrap.kind > LightClientDataFork.None
+    var store {.noinit.}: ForkedLightClientStore
+    withForkyBootstrap(bootstrap):
+      when lcDataFork > LightClientDataFork.None:
+        var storeRes = initialize_light_client_store(
+          trusted_block_root, forkyBootstrap, cfg)
+        check storeRes.isOk
+        store = ForkedLightClientStore(kind: lcDataFork)
+        store.forky(lcDataFork) = storeRes.get
+
+    # Sync to latest sync committee period
+    var numIterations = 0
+    while true:
+      let storePeriod = withForkyStore(store):
+        when lcDataFork > LightClientDataFork.None:
+          forkyStore.finalized_header.beacon.slot.sync_committee_period
+        else:
+          GENESIS_SLOT.SyncCommitteePeriod
+      if storePeriod + 1 >= headPeriod:
+        break
+      let
+        period = withForkyStore(store):
+          when lcDataFork > LightClientDataFork.None:
+            if forkyStore.is_next_sync_committee_known:
               storePeriod + 1
             else:
               storePeriod
-          update = dag.getLightClientUpdateForPeriod(period)
-        check:
-          update.kind > LightClientDataFork.None
-          update.kind <= storeDataFork
-        let upgradedUpdate = update.migratingToDataFork(storeDataFork)
-        template forkyUpdate: untyped = upgradedUpdate.forky(storeDataFork)
-        let res = process_light_client_update(
-          store, forkyUpdate, currentSlot, cfg, genesis_validators_root)
-        check:
-          forkyUpdate.finalized_header.beacon.slot.sync_committee_period ==
-            period
-          res.isOk
-          if forkyUpdate.finalized_header.beacon.slot >
-              forkyBootstrap.header.beacon.slot:
-            store.finalized_header == forkyUpdate.finalized_header
           else:
-            store.finalized_header == forkyBootstrap.header
-        inc numIterations
-        if numIterations > 20: doAssert false # Avoid endless loop on test failure
+            storePeriod
+        update = dag.getLightClientUpdateForPeriod(period)
+      check update.kind > LightClientDataFork.None
+      if update.kind > store.kind:
+        withForkyUpdate(update):
+          when lcDataFork > LightClientDataFork.None:
+            store.migrateToDataFork(lcDataFork)
+      withForkyStore(store):
+        when lcDataFork > LightClientDataFork.None:
+          bootstrap.migrateToDataFork(lcDataFork)
+          template forkyBootstrap: untyped = bootstrap.forky(lcDataFork)
+          let upgradedUpdate = update.migratingToDataFork(lcDataFork)
+          template forkyUpdate: untyped = upgradedUpdate.forky(lcDataFork)
+          let res = process_light_client_update(
+            forkyStore, forkyUpdate, currentSlot, cfg, genesis_validators_root)
+          check:
+            forkyUpdate.finalized_header.beacon.slot.sync_committee_period ==
+              period
+            res.isOk
+            if forkyUpdate.finalized_header.beacon.slot >
+                forkyBootstrap.header.beacon.slot:
+              forkyStore.finalized_header == forkyUpdate.finalized_header
+            else:
+              forkyStore.finalized_header == forkyBootstrap.header
+      inc numIterations
+      if numIterations > 20: doAssert false # Avoid endless loop on test failure
 
-      # Sync to latest update
-      let finalityUpdate = dag.getLightClientFinalityUpdate
-      check:
-        finalityUpdate.kind > LightClientDataFork.None
-        finalityUpdate.kind <= storeDataFork
-      let upgradedFinalityUpdate =
-        finalityUpdate.migratingToDataFork(storeDataFork)
-      template forkyFinalityUpdate: untyped =
-        upgradedFinalityUpdate.forky(storeDataFork)
-      let res = process_light_client_update(
-        store, forkyFinalityUpdate, currentSlot, cfg, genesis_validators_root)
-      check:
-        forkyFinalityUpdate.attested_header.beacon.slot == dag.head.parent.slot
-        res.isOk
-        store.finalized_header == forkyFinalityUpdate.finalized_header
-        store.optimistic_header == forkyFinalityUpdate.attested_header
+    # Sync to latest update
+    let finalityUpdate = dag.getLightClientFinalityUpdate
+    check finalityUpdate.kind > LightClientDataFork.None
+    if finalityUpdate.kind > store.kind:
+      withForkyFinalityUpdate(finalityUpdate):
+        when lcDataFork > LightClientDataFork.None:
+          store.migrateToDataFork(lcDataFork)
+    withForkyStore(store):
+      when lcDataFork > LightClientDataFork.None:
+        let upgradedUpdate = finalityUpdate.migratingToDataFork(lcDataFork)
+        template forkyUpdate: untyped = upgradedUpdate.forky(lcDataFork)
+        let res = process_light_client_update(
+          forkyStore, forkyUpdate, currentSlot, cfg, genesis_validators_root)
+        check:
+          forkyUpdate.attested_header.beacon.slot == dag.head.parent.slot
+          res.isOk
+          forkyStore.finalized_header == forkyUpdate.finalized_header
+          forkyStore.optimistic_header == forkyUpdate.attested_header
 
-    test "Init from checkpoint":
-      # Fetch genesis state
-      let genesisState = assignClone dag.headState
+  test "Init from checkpoint":
+    # Fetch genesis state
+    let genesisState = assignClone dag.headState
 
-      # Advance to target slot for checkpoint
-      let finalizedSlot =
-        ((altairStartSlot.sync_committee_period + 1).start_epoch + 2).start_slot
-      dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
+    # Advance to target slot for checkpoint
+    let finalizedSlot =
+      ((altairStartSlot.sync_committee_period + 1).start_epoch + 2).start_slot
+    dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
 
-      # Initialize new DAG from checkpoint
-      let cpDb = BeaconChainDB.new("", inMemory = true)
-      ChainDAGRef.preInit(cpDb, genesisState[])
-      ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
-      let cpDag = ChainDAGRef.init(
-        cfg, cpDb, validatorMonitor, {},
-        lcDataConfig = LightClientDataConfig(
-          serve: true,
-          importMode: LightClientDataImportMode.Full))
+    # Initialize new DAG from checkpoint
+    let cpDb = BeaconChainDB.new("", inMemory = true)
+    ChainDAGRef.preInit(cpDb, genesisState[])
+    ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
+    let cpDag = ChainDAGRef.init(
+      cfg, cpDb, validatorMonitor, {},
+      lcDataConfig = LightClientDataConfig(
+        serve: true,
+        importMode: LightClientDataImportMode.Full))
 
-      # Advance by a couple epochs
-      for i in 1'u64 .. 10:
-        let headSlot = (finalizedSlot.epoch + i).start_slot
-        cpDag.advanceToSlot(headSlot, verifier, quarantine[])
+    # Advance by a couple epochs
+    for i in 1'u64 .. 10:
+      let headSlot = (finalizedSlot.epoch + i).start_slot
+      cpDag.advanceToSlot(headSlot, verifier, quarantine[])
 
-      check true
-
-withAll(LightClientDataFork):
-  when lcDataFork > LightClientDataFork.None:
-    runTest(lcDataFork)
+    check true


### PR DESCRIPTION
When running `nimbus_light_client`, we persist the latest header from `LightClientStore.finalized_header` in a database across restarts. Because the data format is derived from the latest `LightClientStore`, this could lead to data being persisted in pre-release formats.

To enable us to test later `LightClientStore` versions on devnets, transition to a `ForkedLightClientStore` internally that is only migrated to newer forks on-demand (instead of starting at latest).