### PR TITLE
exit/validatorchange pool includes BLS to execution messages; REST support for new pool

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -177,14 +177,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Subnet query after ENR update                                                              OK
 ```
 OK: 3/3 Fail: 0/3 Skip: 0/3
-## Exit pool testing suite
-```diff
-+ addExitMessage/getAttesterSlashingMessage                                                  OK
-+ addExitMessage/getProposerSlashingMessage                                                  OK
-+ addExitMessage/getVoluntaryExitMessage                                                     OK
-+ pre-pre-fork voluntary exit                                                                OK
-```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Fee recipient management [Beacon Node] [Preset: mainnet]
 ```diff
 + Configuring the fee recpient [Beacon Node] [Preset: mainnet]                               OK
@@ -516,6 +508,16 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SyncQueue] hasEndGap() test                                                               OK
 ```
 OK: 23/23 Fail: 0/23 Skip: 0/23
+## Validator change pool testing suite
+```diff
++ addValidatorChangeMessage/getAttesterSlashingMessage                                       OK
++ addValidatorChangeMessage/getBlsToExecutionChange (post-capella)                           OK
++ addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)                            OK
++ addValidatorChangeMessage/getProposerSlashingMessage                                       OK
++ addValidatorChangeMessage/getVoluntaryExitMessage                                          OK
++ pre-pre-fork voluntary exit                                                                OK
+```
+OK: 6/6 Fail: 0/6 Skip: 0/6
 ## Validator pool
 ```diff
 + Activation after check                                                                     OK
@@ -621,4 +623,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 346/351 Fail: 0/351 Skip: 5/351
+OK: 348/353 Fail: 0/353 Skip: 5/353

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -67,7 +67,7 @@ type
     attestationPool*: ref AttestationPool
     syncCommitteeMsgPool*: ref SyncCommitteeMsgPool
     lightClientPool*: ref LightClientPool
-    exitPool*: ref ExitPool
+    validatorChangePool*: ref ValidatorChangePool
     eth1Monitor*: Eth1Monitor
     payloadBuilderRestClient*: RestClientRef
     restServer*: RestServerRef

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -30,7 +30,7 @@ const
   VOLUNTARY_EXITS_BOUND = MAX_VOLUNTARY_EXITS * 4
 
   # For Capella launch; scale back later
-  BLS_TO_EXECUTION_CHANGES_BOUND = 20000'u64
+  BLS_TO_EXECUTION_CHANGES_BOUND = 32768'u64
 
 type
   OnVoluntaryExitCallback =
@@ -85,7 +85,7 @@ func init*(T: type ValidatorChangePool, dag: ChainDAGRef,
       # TODO scale-back to BLS_TO_EXECUTION_CHANGES_BOUND post-capella, but
       # given large bound, allow to grow dynamically rather than statically
       # allocate all at once
-      initDeque[SignedBLSToExecutionChange](initialSize = 1000),
+      initDeque[SignedBLSToExecutionChange](initialSize = 1024),
     dag: dag,
     attestationPool: attestationPool,
     onVoluntaryExitReceived: onVoluntaryExit

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -22,7 +22,7 @@ from ../consensus_object_pools/consensus_manager import
   runProposalForkchoiceUpdated, shouldSyncOptimistically, updateHead,
   updateHeadWithExecution
 from ../beacon_clock import GetBeaconTimeFn, toFloatSeconds
-from ../consensus_object_pools/block_dag import BlockRef, root, slot
+from ../consensus_object_pools/block_dag import BlockRef, root, shortLog, slot
 from ../consensus_object_pools/block_pools_types import
   EpochRef, VerifierError
 from ../consensus_object_pools/block_quarantine import
@@ -248,11 +248,9 @@ from ../consensus_object_pools/attestation_pool import
   addForkChoice, selectOptimisticHead, BeaconHead
 from ../consensus_object_pools/blockchain_dag import
   is_optimistic, loadExecutionBlockRoot, markBlockVerified
-from ../consensus_object_pools/block_dag import shortLog
 from ../consensus_object_pools/spec_cache import get_attesting_indices
 from ../spec/datatypes/phase0 import TrustedSignedBeaconBlock
 from ../spec/datatypes/altair import SignedBeaconBlock
-from ../spec/datatypes/bellatrix import SignedBeaconBlock
 
 from eth/async_utils import awaitWithTimeout
 from ../spec/datatypes/bellatrix import ExecutionPayload, SignedBeaconBlock

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2623,6 +2623,13 @@ proc broadcastProposerSlashing*(
     node.forkDigestAtEpoch(node.getWallEpoch))
   node.broadcast(topic, slashing)
 
+proc broadcastBlsToExecutionChange*(
+    node: Eth2Node, bls_to_execution_change: SignedBLSToExecutionChange):
+    Future[SendResult] =
+  let topic = getBlsToExecutionChangeTopic(
+    node.forkDigestAtEpoch(node.getWallEpoch))
+  node.broadcast(topic, bls_to_execution_change)
+
 proc broadcastAggregateAndProof*(
     node: Eth2Node, proof: SignedAggregateAndProof): Future[SendResult] =
   let topic = getAggregateAndProofsTopic(

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -1065,7 +1065,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttesterSlashings
   router.api(MethodGet, "/eth/v1/beacon/pool/attester_slashings") do (
     ) -> RestApiResponse:
-    return RestApiResponse.jsonResponse(toSeq(node.exitPool.attester_slashings))
+    return RestApiResponse.jsonResponse(
+      toSeq(node.validatorChangePool.attester_slashings))
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolAttesterSlashings
   router.api(MethodPost, "/eth/v1/beacon/pool/attester_slashings") do (
@@ -1090,7 +1091,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolProposerSlashings
   router.api(MethodGet, "/eth/v1/beacon/pool/proposer_slashings") do (
     ) -> RestApiResponse:
-    return RestApiResponse.jsonResponse(toSeq(node.exitPool.proposer_slashings))
+    return RestApiResponse.jsonResponse(
+      toSeq(node.validatorChangePool.proposer_slashings))
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolProposerSlashings
   router.api(MethodPost, "/eth/v1/beacon/pool/proposer_slashings") do (
@@ -1111,6 +1113,38 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                        ProposerSlashingValidationError,
                                        $res.error())
     return RestApiResponse.jsonMsgResponse(ProposerSlashingValidationSuccess)
+
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolBLSToExecutionChanges
+  # https://github.com/ethereum/beacon-APIs/blob/86850001845df9163da5ae9605dbf15cd318d5d0/apis/beacon/pool/bls_to_execution_changes.yaml
+  router.api(MethodGet, "/eth/v1/beacon/pool/bls_to_execution_changes") do (
+    ) -> RestApiResponse:
+    return RestApiResponse.jsonResponse(
+      toSeq(node.validatorChangePool.bls_to_execution_changes))
+
+  # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolBLSToExecutionChange
+  # https://github.com/ethereum/beacon-APIs/blob/86850001845df9163da5ae9605dbf15cd318d5d0/apis/beacon/pool/bls_to_execution_changes.yaml
+  router.api(MethodPost, "/eth/v1/beacon/pool/bls_to_execution_changes") do (
+    contentBody: Option[ContentBody]) -> RestApiResponse:
+    let bls_to_execution_changes =
+      block:
+        if contentBody.isNone():
+          return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
+        let dres = decodeBody(seq[SignedBLSToExecutionChange], contentBody.get())
+        if dres.isErr():
+          return RestApiResponse.jsonError(Http400,
+                                           InvalidBlsToExecutionChangeObjectError,
+                                           $dres.error())
+        dres.get()
+    let res = await allFinished(mapIt(
+      bls_to_execution_changes, node.router.routeBlsToExecutionChange(it)))
+    for individual_res in res:
+      doAssert individual_res.finished()
+      let fut_result = individual_res.read()
+      if fut_result.isErr():
+        return RestApiResponse.jsonError(Http400,
+                                         BlsToExecutionChangeValidationError,
+                                         $fut_result.error())
+    return RestApiResponse.jsonMsgResponse(BlsToExecutionChangeValidationSuccess)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures
   router.api(MethodPost, "/eth/v1/beacon/pool/sync_committees") do (
@@ -1146,7 +1180,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolVoluntaryExits
   router.api(MethodGet, "/eth/v1/beacon/pool/voluntary_exits") do (
     ) -> RestApiResponse:
-    return RestApiResponse.jsonResponse(toSeq(node.exitPool.voluntary_exits))
+    return RestApiResponse.jsonResponse(
+      toSeq(node.validatorChangePool.voluntary_exits))
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolVoluntaryExit
   router.api(MethodPost, "/eth/v1/beacon/pool/voluntary_exits") do (

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1139,6 +1139,10 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       bls_to_execution_changes, node.router.routeBlsToExecutionChange(it)))
     for individual_res in res:
       doAssert individual_res.finished()
+      if individual_res.failed():
+        return RestApiResponse.jsonError(Http400,
+                                         BlsToExecutionChangeValidationError,
+                                         $individual_res.error[].msg)
       let fut_result = individual_res.read()
       if fut_result.isErr():
         return RestApiResponse.jsonError(Http400,

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -36,19 +36,19 @@ const
   AttestationValidationError* =
     "Some errors happened while validating attestation(s)"
   AttestationValidationSuccess* =
-    "Attestation object(s) was broadcasted"
+    "Attestation object(s) was broadcast"
   InvalidAttesterSlashingObjectError* =
     "Unable to decode attester slashing object(s)"
   AttesterSlashingValidationError* =
     "Invalid attester slashing, it will never pass validation so it's rejected"
   AttesterSlashingValidationSuccess* =
-    "Attester slashing object was broadcasted"
+    "Attester slashing object was broadcast"
   InvalidProposerSlashingObjectError* =
     "Unable to decode proposer slashing object(s)"
   ProposerSlashingValidationError* =
     "Invalid proposer slashing, it will never pass validation so it's rejected"
   ProposerSlashingValidationSuccess* =
-    "Proposer slashing object was broadcasted"
+    "Proposer slashing object was broadcast"
   InvalidVoluntaryExitObjectError* =
     "Unable to decode voluntary exit object(s)"
   InvalidFeeRecipientRequestError* =
@@ -56,14 +56,14 @@ const
   VoluntaryExitValidationError* =
     "Invalid voluntary exit, it will never pass validation so it's rejected"
   VoluntaryExitValidationSuccess* =
-    "Voluntary exit object(s) was broadcasted"
+    "Voluntary exit object(s) was broadcast"
   InvalidAggregateAndProofObjectError* =
     "Unable to decode aggregate and proof object(s)"
   AggregateAndProofValidationError* =
     "Invalid aggregate and proof, it will never pass validation so it's " &
     "rejected"
   AggregateAndProofValidationSuccess* =
-    "Aggregate and proof object(s) was broadcasted"
+    "Aggregate and proof object(s) was broadcast"
   BeaconCommitteeSubscriptionSuccess* =
     "Beacon node processed committee subscription request(s)"
   SyncCommitteeSubscriptionSuccess* =
@@ -169,11 +169,11 @@ const
   SyncCommitteeMessageValidationError* =
     "Some errors happened while validating sync committee message(s)"
   SyncCommitteeMessageValidationSuccess* =
-    "Sync committee message(s) was broadcasted"
+    "Sync committee message(s) was broadcast"
   ContributionAndProofValidationError* =
     "Some errors happened while validating contribution and proof(s)"
   ContributionAndProofValidationSuccess* =
-    "Contribution and proof(s) was broadcasted"
+    "Contribution and proof(s) was broadcast"
   ProduceContributionError* =
     "Unable to produce contribution using the passed parameters"
   InternalServerError* =
@@ -221,3 +221,9 @@ const
     "Validator inactive"
   BlobsOutOfRange* =
     "Requested slot is outside of blobs window"
+  InvalidBlsToExecutionChangeObjectError* =
+    "Unable to decode BLS to execution change object(s)"
+  BlsToExecutionChangeValidationError* =
+    "Invalid BLS to execution change; it won't validate, so it's rejected"
+  BlsToExecutionChangeValidationSuccess* =
+    "BLS to execution change was broadcast"

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -475,12 +475,6 @@ type
     next_fork_version*: Version
     next_fork_epoch*: Epoch
 
-  BeaconBlockExits* = object
-    # Collection of exits that are suitable for block production
-    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
-    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
-
   AttnetBits* = BitArray[int ATTESTATION_SUBNET_COUNT]
 
 type

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -39,7 +39,7 @@ const
 
 type
   SignedBLSToExecutionChangeList* =
-    List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]
+    List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.0/specs/capella/beacon-chain.md#withdrawal
   Withdrawal* = object
@@ -483,6 +483,14 @@ type
     parentHash*: string
     timestamp*: string
 
+  BeaconBlockValidatorChanges* = object
+    # Collection of exits that are suitable for block production
+    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+    bls_to_execution_changes*:
+      List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]
+
 func shortLog*(v: SomeBeaconBlock): auto =
   (
     slot: shortLog(v.slot),
@@ -505,6 +513,19 @@ func shortLog*(v: SomeBeaconBlock): auto =
 func shortLog*(v: SomeSignedBeaconBlock): auto =
   (
     blck: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )
+
+func shortLog*(v: BLSToExecutionChange): auto =
+  (
+    validator_index: v.validator_index,
+    from_bls_pubkey: shortLog(v.from_bls_pubkey),
+    to_execution_address: v.to_execution_address
+  )
+
+func shortLog*(v: SignedBLSToExecutionChange): auto =
+  (
+    bls_to_execution_change: shortLog(v.message),
     signature: shortLog(v.signature)
   )
 

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -344,7 +344,7 @@ template partialBeaconBlock*(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList):
@@ -357,11 +357,11 @@ template partialBeaconBlock*(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,
-      proposer_slashings: exits.proposer_slashings,
-      attester_slashings: exits.attester_slashings,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings,
       attestations: List[Attestation, Limit MAX_ATTESTATIONS](attestations),
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: exits.voluntary_exits))
+      voluntary_exits: validator_changes.voluntary_exits))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.1/specs/altair/validator.md#preparing-a-beaconblock
 template partialBeaconBlock*(
@@ -373,10 +373,10 @@ template partialBeaconBlock*(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList):
+    bls_to_execution_changes: SignedBLSToExecutionChangeList):  # TODO remove
     altair.BeaconBlock =
   altair.BeaconBlock(
     slot: state.data.slot,
@@ -386,11 +386,11 @@ template partialBeaconBlock*(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,
-      proposer_slashings: exits.proposer_slashings,
-      attester_slashings: exits.attester_slashings,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings,
       attestations: List[Attestation, Limit MAX_ATTESTATIONS](attestations),
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: exits.voluntary_exits,
+      voluntary_exits: validator_changes.voluntary_exits,
       sync_aggregate: sync_aggregate))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/merge/validator.md#block-proposal
@@ -403,10 +403,10 @@ template partialBeaconBlock*(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList):
+    bls_to_execution_changes: SignedBLSToExecutionChangeList):  # TODO remove
     bellatrix.BeaconBlock =
   bellatrix.BeaconBlock(
     slot: state.data.slot,
@@ -416,11 +416,11 @@ template partialBeaconBlock*(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,
-      proposer_slashings: exits.proposer_slashings,
-      attester_slashings: exits.attester_slashings,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings,
       attestations: List[Attestation, Limit MAX_ATTESTATIONS](attestations),
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: exits.voluntary_exits,
+      voluntary_exits: validator_changes.voluntary_exits,
       sync_aggregate: sync_aggregate,
       execution_payload: execution_payload))
 
@@ -434,10 +434,10 @@ template partialBeaconBlock*(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: capella.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList
+    bls_to_execution_changes: SignedBLSToExecutionChangeList   # TODO remove
     ):
     capella.BeaconBlock =
   capella.BeaconBlock(
@@ -448,14 +448,14 @@ template partialBeaconBlock*(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,
-      proposer_slashings: exits.proposer_slashings,
-      attester_slashings: exits.attester_slashings,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings,
       attestations: List[Attestation, Limit MAX_ATTESTATIONS](attestations),
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: exits.voluntary_exits,
+      voluntary_exits: validator_changes.voluntary_exits,
       sync_aggregate: sync_aggregate,
       execution_payload: execution_payload,
-      bls_to_execution_changes: bls_to_execution_changes
+      bls_to_execution_changes: validator_changes.bls_to_execution_changes
       ))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/merge/validator.md#block-proposal
@@ -468,10 +468,10 @@ template partialBeaconBlock*(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: eip4844.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList
+    bls_to_execution_changes: SignedBLSToExecutionChangeList   # TODO remove
     ):
     eip4844.BeaconBlock =
   discard $eip4844ImplementationMissing & ": state_transition.nim: partialBeaconBlock, leaves additional fields default, okay for block_sim"
@@ -483,14 +483,14 @@ template partialBeaconBlock*(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,
-      proposer_slashings: exits.proposer_slashings,
-      attester_slashings: exits.attester_slashings,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings,
       attestations: List[Attestation, Limit MAX_ATTESTATIONS](attestations),
       deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: exits.voluntary_exits,
+      voluntary_exits: validator_changes.voluntary_exits,
       sync_aggregate: sync_aggregate,
       execution_payload: execution_payload,
-      bls_to_execution_changes: bls_to_execution_changes
+      bls_to_execution_changes: validator_changes.bls_to_execution_changes
       ))
 
 proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
@@ -502,7 +502,7 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     executionPayload: T,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -528,7 +528,7 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
       ForkedBeaconBlock.init(
         partialBeaconBlock(
           cfg, state.`kind Data`, proposer_index, randao_reveal, eth1_data,
-          graffiti, attestations, deposits, exits, sync_aggregate,
+          graffiti, attestations, deposits, validator_changes, sync_aggregate,
           executionPayload, bls_to_execution_changes))
 
     let res = process_block(
@@ -549,15 +549,16 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
           # Effectively hash_tree_root(ExecutionPayload) with the beacon block
           # body, with the execution payload replaced by the execution payload
           # header. htr(payload) == htr(payload header), so substitute.
+          discard $capellaImplementationMissing # need different htr to match capella changes
           forkyState.data.latest_block_header.body_root = hash_tree_root(
             [hash_tree_root(randao_reveal),
              hash_tree_root(eth1_data),
              hash_tree_root(graffiti),
-             hash_tree_root(exits.proposer_slashings),
-             hash_tree_root(exits.attester_slashings),
+             hash_tree_root(validator_changes.proposer_slashings),
+             hash_tree_root(validator_changes.attester_slashings),
              hash_tree_root(List[Attestation, Limit MAX_ATTESTATIONS](attestations)),
              hash_tree_root(List[Deposit, Limit MAX_DEPOSITS](deposits)),
-             hash_tree_root(exits.voluntary_exits),
+             hash_tree_root(validator_changes.voluntary_exits),
              hash_tree_root(sync_aggregate),
              execution_payload_root.get])
 
@@ -594,7 +595,7 @@ proc makeBeaconBlock*[T](
     proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
     eth1_data: Eth1Data, graffiti: GraffitiBytes,
     attestations: seq[Attestation], deposits: seq[Deposit],
-    exits: BeaconBlockExits, sync_aggregate: SyncAggregate,
+    exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
     executionPayload: T,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
     rollback: RollbackForkedHashedProc, cache: var StateCache):
@@ -612,7 +613,7 @@ proc makeBeaconBlock*[T](
     proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
     eth1_data: Eth1Data, graffiti: GraffitiBytes,
     attestations: seq[Attestation], deposits: seq[Deposit],
-    exits: BeaconBlockExits, sync_aggregate: SyncAggregate,
+    exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
     executionPayload: T,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
     rollback: RollbackForkedHashedProc,

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -346,8 +346,7 @@ template partialBeaconBlock*(
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    execution_payload: bellatrix.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList):
+    execution_payload: bellatrix.ExecutionPayload):
     phase0.BeaconBlock =
   phase0.BeaconBlock(
     slot: state.data.slot,
@@ -375,8 +374,7 @@ template partialBeaconBlock*(
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    execution_payload: bellatrix.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList):  # TODO remove
+    execution_payload: bellatrix.ExecutionPayload):
     altair.BeaconBlock =
   altair.BeaconBlock(
     slot: state.data.slot,
@@ -405,8 +403,7 @@ template partialBeaconBlock*(
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    execution_payload: bellatrix.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList):  # TODO remove
+    execution_payload: bellatrix.ExecutionPayload):
     bellatrix.BeaconBlock =
   bellatrix.BeaconBlock(
     slot: state.data.slot,
@@ -437,7 +434,6 @@ template partialBeaconBlock*(
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: capella.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList   # TODO remove
     ):
     capella.BeaconBlock =
   capella.BeaconBlock(
@@ -471,7 +467,6 @@ template partialBeaconBlock*(
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: eip4844.ExecutionPayload,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList   # TODO remove
     ):
     eip4844.BeaconBlock =
   discard $eip4844ImplementationMissing & ": state_transition.nim: partialBeaconBlock, leaves additional fields default, okay for block_sim"
@@ -529,7 +524,7 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
         partialBeaconBlock(
           cfg, state.`kind Data`, proposer_index, randao_reveal, eth1_data,
           graffiti, attestations, deposits, validator_changes, sync_aggregate,
-          executionPayload, bls_to_execution_changes))
+          executionPayload))
 
     let res = process_block(
       cfg, state.`kind Data`.data, blck.`kind Data`.asSigVerified(),
@@ -597,7 +592,7 @@ proc makeBeaconBlock*[T](
     attestations: seq[Attestation], deposits: seq[Deposit],
     exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
     executionPayload: T,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,
+    bls_to_execution_changes: SignedBLSToExecutionChangeList,  # TODO remove
     rollback: RollbackForkedHashedProc, cache: var StateCache):
     Result[ForkedBeaconBlock, cstring] =
   makeBeaconBlock(
@@ -615,7 +610,7 @@ proc makeBeaconBlock*[T](
     attestations: seq[Attestation], deposits: seq[Deposit],
     exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
     executionPayload: T,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,
+    bls_to_execution_changes: SignedBLSToExecutionChangeList,  # TODO remove
     rollback: RollbackForkedHashedProc,
     cache: var StateCache, verificationFlags: UpdateFlags):
     Result[ForkedBeaconBlock, cstring] =

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -391,8 +391,8 @@ proc process_voluntary_exit*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-alpha.1/specs/capella/beacon-chain.md#new-process_bls_to_execution_change
-proc process_bls_to_execution_change*(
-    cfg: RuntimeConfig, state: var (capella.BeaconState | eip4844.BeaconState),
+proc check_bls_to_execution_change*(
+    cfg: RuntimeConfig, state: capella.BeaconState | eip4844.BeaconState,
     signed_address_change: SignedBLSToExecutionChange): Result[void, cstring] =
   let address_change = signed_address_change.message
 
@@ -414,6 +414,16 @@ proc process_bls_to_execution_change*(
       signed_address_change, address_change.from_bls_pubkey,
       signed_address_change.signature):
     return err("process_bls_to_execution_change: invalid signature")
+
+  ok()
+
+proc process_bls_to_execution_change*(
+    cfg: RuntimeConfig, state: var (capella.BeaconState | eip4844.BeaconState),
+    signed_address_change: SignedBLSToExecutionChange): Result[void, cstring] =
+  ? check_bls_to_execution_change(cfg, state, signed_address_change)
+  let address_change = signed_address_change.message
+  var withdrawal_credentials =
+    state.validators.item(address_change.validator_index).withdrawal_credentials
 
   withdrawal_credentials.data[0] = ETH1_ADDRESS_WITHDRAWAL_PREFIX
   withdrawal_credentials.data.fill(1, 11, 0)

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -493,7 +493,8 @@ proc makeBeaconBlockForHeadAndSlot*[EP](
     attestations =
       node.attestationPool[].getAttestationsForBlock(state[], cache)
     exits = withState(state[]):
-      node.exitPool[].getBeaconBlockExits(node.dag.cfg, forkyState.data)
+      node.validatorChangePool[].getBeaconBlockValidatorChanges(
+        node.dag.cfg, forkyState.data)
     syncAggregate =
       if slot.epoch < node.dag.cfg.ALTAIR_FORK_EPOCH:
         SyncAggregate.init()
@@ -517,7 +518,7 @@ proc makeBeaconBlockForHeadAndSlot*[EP](
       exits,
       syncAggregate,
       payload,
-      (static(default(SignedBLSToExecutionChangeList))),
+      (static(default(SignedBLSToExecutionChangeList))),   # TODO remove
       noRollback, # Temporary state - no need for rollback
       cache,
       verificationFlags = {},

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -2590,6 +2590,18 @@
     }
   },
   {
+    "topics": ["beacon", "pool_bls_to_execution_changes"],
+    "request": {
+      "url": "/eth/v1/beacon/pool/bls_to_execution_changes",
+      "headers": {"Accept": "application/json"}
+    },
+    "response": {
+      "status": {"operator": "equals", "value": "200"},
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "body": [{"operator": "jstructcmps", "start": ["data"],"value": [{"message": {"validator_index": "", "from_bls_pubkey": "", "to_execution_address": ""}, "signature": ""}]}]
+    }
+  },
+  {
     "topics": ["config"],
     "request": {
       "url": "/eth/v1/config/fork_schedule",

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019-2022 Status Research & Development GmbH
+# Copyright (c) 2019-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -84,7 +84,7 @@ proc makeBeaconBlock(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    exits: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -128,7 +128,7 @@ proc makeBeaconBlock(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    exits: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -173,7 +173,7 @@ proc makeBeaconBlock(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    exits: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: bellatrix.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -217,7 +217,7 @@ proc makeBeaconBlock(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    exits: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: capella.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -261,7 +261,7 @@ proc makeBeaconBlock(
     graffiti: GraffitiBytes,
     attestations: seq[Attestation],
     deposits: seq[Deposit],
-    exits: BeaconBlockExits,
+    exits: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     execution_payload: eip4844.ExecutionPayload,
     bls_to_execution_changes: SignedBLSToExecutionChangeList,
@@ -520,7 +520,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
         default(GraffitiBytes),
         attPool.getAttestationsForBlock(state, cache),
         eth1ProposalData.deposits,
-        BeaconBlockExits(),
+        BeaconBlockValidatorChanges(),
         sync_aggregate,
         when T is eip4844.SignedBeaconBlock:
           default(eip4844.ExecutionPayload)

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -72,9 +72,6 @@ from ../beacon_chain/spec/state_transition_block import process_block
 # when possible, to also use the forked version. It'll be worth keeping some
 # example of the non-forked version because it enables fork bootstrapping.
 
-const defaultSignedBLSToExecutionChangeList =
-  default(SignedBLSToExecutionChangeList)
-
 proc makeBeaconBlock(
     cfg: RuntimeConfig,
     state: var phase0.HashedBeaconState,
@@ -104,8 +101,7 @@ proc makeBeaconBlock(
 
   var blck = partialBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, execution_payload,
-    defaultSignedBLSToExecutionChangeList)
+    attestations, deposits, exits, sync_aggregate, execution_payload)
 
   let res = process_block(
     cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
@@ -148,8 +144,7 @@ proc makeBeaconBlock(
 
   var blck = partialBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, execution_payload,
-    defaultSignedBLSToExecutionChangeList)
+    attestations, deposits, exits, sync_aggregate, execution_payload)
 
   # Signatures are verified elsewhere, so don't duplicate inefficiently here
   let res = process_block(
@@ -193,8 +188,7 @@ proc makeBeaconBlock(
 
   var blck = partialBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, execution_payload,
-    defaultSignedBLSToExecutionChangeList)
+    attestations, deposits, exits, sync_aggregate, execution_payload)
 
   let res = process_block(
     cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
@@ -237,8 +231,7 @@ proc makeBeaconBlock(
 
   var blck = partialBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, execution_payload,
-    bls_to_execution_changes)
+    attestations, deposits, exits, sync_aggregate, execution_payload)
 
   let res = process_block(
     cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
@@ -281,8 +274,7 @@ proc makeBeaconBlock(
 
   var blck = partialBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, execution_payload,
-    bls_to_execution_changes)
+    attestations, deposits, exits, sync_aggregate, execution_payload)
 
   let res = process_block(
     cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
@@ -528,7 +520,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
           default(capella.ExecutionPayload)
         else:
           default(bellatrix.ExecutionPayload),
-        defaultSignedBLSToExecutionChangeList,
+        static(default(SignedBLSToExecutionChangeList)),
         noRollback,
         cache)
 

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -160,7 +160,7 @@ cli do(validatorsDir: string, secretsDir: string,
           GraffitiBytes.init("insecura"),
           blockAggregates,
           @[],
-          BeaconBlockExits(),
+          BeaconBlockValidatorChanges(),
           syncAggregate,
           default(bellatrix.ExecutionPayload),
           (static(default(SignedBLSToExecutionChangeList))),

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -49,13 +49,14 @@ func makeSignedVoluntaryExit(
       fork, genesis_validators_root, tmp,
       MockPrivKeys[validator_index]).toValidatorSig)
 
-suite "Exit pool testing suite":
+suite "Validator change pool testing suite":
   setup:
     let
       cfg = block:
         var tmp = defaultRuntimeConfig
         tmp.ALTAIR_FORK_EPOCH = Epoch(tmp.SHARD_COMMITTEE_PERIOD)
         tmp.BELLATRIX_FORK_EPOCH = Epoch(tmp.SHARD_COMMITTEE_PERIOD) + 1
+        tmp.CAPELLA_FORK_EPOCH = Epoch(tmp.SHARD_COMMITTEE_PERIOD) + 2
         tmp
 
       validatorMonitor = newClone(ValidatorMonitor.init())
@@ -64,9 +65,9 @@ suite "Exit pool testing suite":
         validatorMonitor, {})
       fork = dag.forkAtEpoch(Epoch(0))
       genesis_validators_root = dag.genesis_validators_root
-      pool = newClone(ExitPool.init(dag))
+      pool = newClone(ValidatorChangePool.init(dag))
 
-  test "addExitMessage/getProposerSlashingMessage":
+  test "addValidatorChangeMessage/getProposerSlashingMessage":
     for i in 0'u64 .. MAX_PROPOSER_SLASHINGS + 5:
       for j in 0'u64 .. i:
         let
@@ -85,13 +86,13 @@ suite "Exit pool testing suite":
         check: pool[].isSeen(msg)
       withState(dag.headState):
         check:
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).proposer_slashings.lenu64 ==
             min(i + 1, MAX_PROPOSER_SLASHINGS)
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
             cfg, forkyState.data).proposer_slashings.len == 0
 
-  test "addExitMessage/getAttesterSlashingMessage":
+  test "addValidatorChangeMessage/getAttesterSlashingMessage":
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS + 5:
       for j in 0'u64 .. i:
         let
@@ -108,13 +109,13 @@ suite "Exit pool testing suite":
         check: pool[].isSeen(msg)
       withState(dag.headState):
         check:
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).attester_slashings.lenu64 ==
             min(i + 1, MAX_ATTESTER_SLASHINGS)
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
             cfg, forkyState.data).attester_slashings.len == 0
 
-  test "addExitMessage/getVoluntaryExitMessage":
+  test "addValidatorChangeMessage/getVoluntaryExitMessage":
     # Need to advance state or it will not accept voluntary exits
     var
       cache: StateCache
@@ -139,11 +140,66 @@ suite "Exit pool testing suite":
 
       withState(dag.headState):
         check:
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).voluntary_exits.lenu64 ==
             min(i + 1, MAX_VOLUNTARY_EXITS)
-          pool[].getBeaconBlockExits(
+          pool[].getBeaconBlockValidatorChanges(
             cfg, forkyState.data).voluntary_exits.len == 0
+
+  test "addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)":
+    # Need to advance state or it will not accept voluntary exits
+    var
+      cache: StateCache
+      info: ForkedEpochInfo
+    process_slots(
+      dag.cfg, dag.headState,
+      Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 1,
+      cache, info, {}).expect("ok")
+    let fork = dag.forkAtEpoch(dag.headState.get_current_epoch())
+
+    for i in 0'u64 .. MAX_BLS_TO_EXECUTION_CHANGES + 5:
+      for j in 0'u64 .. i:
+        let msg = SignedBLSToExecutionChange(
+          message: BLSToExecutionChange(validator_index: j))
+        if i == 0:
+          check not pool[].isSeen(msg)
+
+        pool[].addMessage(msg)
+        check: pool[].isSeen(msg)
+
+      withState(dag.headState):
+        # Too early to get BLS to execution changes for blocks
+        check pool[].getBeaconBlockValidatorChanges(
+          cfg, forkyState.data).bls_to_execution_changes.len == 0
+
+  test "addValidatorChangeMessage/getBlsToExecutionChange (post-capella)":
+    # Need to advance state or it will not accept voluntary exits
+    var
+      cache: StateCache
+      info: ForkedEpochInfo
+    process_slots(
+      dag.cfg, dag.headState,
+      Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 2,
+      cache, info, {}).expect("ok")
+    let fork = dag.forkAtEpoch(dag.headState.get_current_epoch())
+
+    for i in 0'u64 .. MAX_BLS_TO_EXECUTION_CHANGES + 5:
+      for j in 0'u64 .. i:
+        let msg = SignedBLSToExecutionChange(
+          message: BLSToExecutionChange(validator_index: j))
+        if i == 0:
+          check not pool[].isSeen(msg)
+
+        pool[].addMessage(msg)
+        check: pool[].isSeen(msg)
+
+      withState(dag.headState):
+        check:
+          pool[].getBeaconBlockValidatorChanges(
+              cfg, forkyState.data).bls_to_execution_changes.lenu64 ==
+            min(i + 1, MAX_BLS_TO_EXECUTION_CHANGES)
+          pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).bls_to_execution_changes.len == 0
 
   test "pre-pre-fork voluntary exit":
     var
@@ -169,5 +225,5 @@ suite "Exit pool testing suite":
       check:
         # Message signed with a (fork-2) domain can no longer be added as that
         # fork is not present in the BeaconState and thus fails transition
-        pool[].getBeaconBlockExits(
+        pool[].getBeaconBlockValidatorChanges(
           cfg, forkyState.data).voluntary_exits.lenu64 == 0

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -199,7 +199,7 @@ proc addTestBlockAux[EP: bellatrix.ExecutionPayload | capella.ExecutionPayload](
       graffiti,
       attestations,
       deposits,
-      BeaconBlockExits(),
+      BeaconBlockValidatorChanges(),
       sync_aggregate,
       execution_payload,
       default(SignedBLSToExecutionChangeList),


### PR DESCRIPTION
- `ExitPool` -> `ValidatorChangePool`
- Add BLS to execution changes to this validator change pool
- in `block_processor`, clean up some Nim warnings about duplicate imports because it doesn't like `from a import b` and `from a import c` as two separate statements and wants them combined into `from a import b, c`
- rename most variables and function paramaters of type `ValidatorChangePool` from `exitPool` to `validatorChangePool` and `exits` to `validatorChanges`
- implement gossip broadcast and validation of BLS to execution changes
- implement BLS to execution change-related Beacon API calls in REST server
- include BLS to execution changes in proposed blocks
- REST error message grammar tweaks
- remove some vestigial passing of the BLS changes as a separate parameter during block construction, since it's now part of the `ValidatorChangePool`

The exits and BLS changes are structurally near-isomorphic:
- they happen either 0 or 1 times per validator lifetime
- they aren't functions of blocks or forks, unlike, e.g, the attestation pool, which needs to care about the DAG
- they're surfaced in exactly two ways: being packed into blocks and via a pair of `GET`/`POST` REST Beacon APIs to introspect the pool
- they're initiated by either by the `POST` Beacon API or a gossip message on a dedicated gossip topic