### PR TITLE
remove vestigial/unused BLSToExecutionChange parameters

### DIFF
--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -497,7 +497,6 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload](
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
     executionPayload: T,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,
     rollback: RollbackForkedHashedProc,
     cache: var StateCache,
     # TODO:
@@ -587,16 +586,14 @@ proc makeBeaconBlock*[T](
     proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
     eth1_data: Eth1Data, graffiti: GraffitiBytes,
     attestations: seq[Attestation], deposits: seq[Deposit],
-    exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
-    executionPayload: T,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,  # TODO remove
+    validator_changes: BeaconBlockValidatorChanges,
+    sync_aggregate: SyncAggregate, executionPayload: T,
     rollback: RollbackForkedHashedProc, cache: var StateCache):
     Result[ForkedBeaconBlock, cstring] =
   makeBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, executionPayload,
-    bls_to_execution_changes, rollback, cache,
-    verificationFlags = {},
+    attestations, deposits, validator_changes, sync_aggregate,
+    executionPayload, rollback, cache, verificationFlags = {},
     transactions_root = Opt.none Eth2Digest,
     execution_payload_root = Opt.none Eth2Digest)
 
@@ -605,16 +602,14 @@ proc makeBeaconBlock*[T](
     proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
     eth1_data: Eth1Data, graffiti: GraffitiBytes,
     attestations: seq[Attestation], deposits: seq[Deposit],
-    exits: BeaconBlockValidatorChanges, sync_aggregate: SyncAggregate,
-    executionPayload: T,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,  # TODO remove
+    validator_changes: BeaconBlockValidatorChanges,
+    sync_aggregate: SyncAggregate, executionPayload: T,
     rollback: RollbackForkedHashedProc,
     cache: var StateCache, verificationFlags: UpdateFlags):
     Result[ForkedBeaconBlock, cstring] =
   makeBeaconBlock(
     cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, exits, sync_aggregate, executionPayload,
-    bls_to_execution_changes, rollback, cache,
-    verificationFlags = verificationFlags,
+    attestations, deposits, validator_changes, sync_aggregate,
+    executionPayload, rollback, cache, verificationFlags = verificationFlags,
     transactions_root = Opt.none Eth2Digest,
     execution_payload_root = Opt.none Eth2Digest)

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -515,7 +515,6 @@ proc makeBeaconBlockForHeadAndSlot*[EP](
       exits,
       syncAggregate,
       payload,
-      (static(default(SignedBLSToExecutionChangeList))),   # TODO remove
       noRollback, # Temporary state - no need for rollback
       cache,
       verificationFlags = {},

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -163,7 +163,6 @@ cli do(validatorsDir: string, secretsDir: string,
           BeaconBlockValidatorChanges(),
           syncAggregate,
           default(bellatrix.ExecutionPayload),
-          (static(default(SignedBLSToExecutionChangeList))),
           noRollback,
           cache).get()
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -202,7 +202,6 @@ proc addTestBlockAux[EP: bellatrix.ExecutionPayload | capella.ExecutionPayload](
       BeaconBlockValidatorChanges(),
       sync_aggregate,
       execution_payload,
-      default(SignedBLSToExecutionChangeList),
       noRollback,
       cache,
       verificationFlags = {skipBlsValidation})


### PR DESCRIPTION
They're part of `BeaconBlockValidatorChanges` now