### PR TITLE
disallow filling BLS to execution change pool pre-capella

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1128,7 +1128,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     if node.currentSlot().epoch() < node.dag.cfg.CAPELLA_FORK_EPOCH:
       return RestApiResponse.jsonError(Http400,
                                        InvalidBlsToExecutionChangeObjectError,
-                                       $dres.error())
+                                       "Attempt to add to BLS to execution change pool pre-Capella")
     let bls_to_execution_changes =
       block:
         if contentBody.isNone():

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1125,6 +1125,10 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://github.com/ethereum/beacon-APIs/blob/86850001845df9163da5ae9605dbf15cd318d5d0/apis/beacon/pool/bls_to_execution_changes.yaml
   router.api(MethodPost, "/eth/v1/beacon/pool/bls_to_execution_changes") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
+    if node.currentSlot().epoch() < node.dag.cfg.CAPELLA_FORK_EPOCH:
+      return RestApiResponse.jsonError(Http400,
+                                       InvalidBlsToExecutionChangeObjectError,
+                                       $dres.error())
     let bls_to_execution_changes =
       block:
         if contentBody.isNone():


### PR DESCRIPTION
This is a correctness fix: unless it's able to broadcast, it can't/shouldn't return 200, and it can't broadcast until Capella.