### PR TITLE
fix pruned backfill summary (fixes #4552)

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1094,7 +1094,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   dag.backfill = block:
     let backfillSlot = db.finalizedBlocks.low.expect("tail at least")
-    if backfillSlot < dag.tail.slot:
+    if backfillSlot <= dag.horizon:
+      # Backfill done, no need to load anything
+      BeaconBlockSummary()
+    elif backfillSlot < dag.tail.slot:
       let backfillRoot = db.finalizedBlocks.get(backfillSlot).expect(
         "low to be loadable")
 


### PR DESCRIPTION
When enabling pruned history mode, the backfill summary as it was computed with full backfilling may be pruned - don't try to load it on init