### PR TITLE
prepare LC update ranking test runner for Capella

### DIFF
--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -525,8 +525,6 @@ ConsensusSpecPreset-minimal
 + Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/supply_sync_committee OK
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
 + Light client - Update ranking - minimal/bellatrix/light_client/update_ranking/pyspec_tests OK
-+ Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u OK
-+ Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u OK
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + Sync - minimal/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
@@ -918,7 +916,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 ```
-OK: 906/915 Fail: 0/915 Skip: 9/915
+OK: 904/913 Fail: 0/913 Skip: 9/913
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2195,6 +2193,12 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
+## EF - Light client - Update ranking [Preset: minimal]
+```diff
+  Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u Skip
+  Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u Skip
+```
+OK: 0/2 Fail: 0/2 Skip: 2/2
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -2763,4 +2767,4 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 OK: 102/102 Fail: 0/102 Skip: 0/102
 
 ---TOTAL---
-OK: 2444/2453 Fail: 0/2453 Skip: 9/2453
+OK: 2442/2453 Fail: 0/2453 Skip: 11/2453

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -525,6 +525,8 @@ ConsensusSpecPreset-minimal
 + Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/supply_sync_committee OK
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
 + Light client - Update ranking - minimal/bellatrix/light_client/update_ranking/pyspec_tests OK
+  Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u Skip
+  Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u Skip
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + Sync - minimal/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
@@ -916,7 +918,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 ```
-OK: 904/913 Fail: 0/913 Skip: 9/913
+OK: 904/915 Fail: 0/915 Skip: 11/915
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2193,12 +2195,6 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
-## EF - Light client - Update ranking [Preset: minimal]
-```diff
-  Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u Skip
-  Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u Skip
-```
-OK: 0/2 Fail: 0/2 Skip: 2/2
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -57,7 +57,9 @@ suite "EF - Light client - Single merkle proof" & preset():
     if kind != pcDir or not dirExists(testsPath):
       continue
     let fork = forkForPathComponent(path).valueOr:
-      raiseAssert "Unknown test fork: " & testsPath
+      test "Light client - Single merkle proof - " & path
+        skip()
+      continue
     for kind, path in walkDir(testsPath, relative = true, checkDir = true):
       let suitePath = testsPath/path
       if kind != pcDir or not dirExists(suitePath):

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -57,7 +57,7 @@ suite "EF - Light client - Single merkle proof" & preset():
     if kind != pcDir or not dirExists(testsPath):
       continue
     let fork = forkForPathComponent(path).valueOr:
-      test "Light client - Single merkle proof - " & path
+      test "Light client - Single merkle proof - " & path:
         skip()
       continue
     for kind, path in walkDir(testsPath, relative = true, checkDir = true):

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -63,6 +63,10 @@ suite "EF - Light client - Update ranking" & preset():
     for kind, path in walkDir(testsPath, relative = true, checkDir = true):
       withStateFork(fork):
         const lcDataFork = lcDataForkAtStateFork(stateFork)
-        when lcDataFork > LightClientDataFork.None:
+        when lcDataFork >= LightClientDataFork.Capella:
+          test "Light client - Update ranking - " &
+              (testsPath/path).relativePath(SszTestsDir):
+            skip()
+        elif lcDataFork > LightClientDataFork.None:
           runTest(testsPath/path, lcDataFork)
         else: raiseAssert "Unreachable"

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -26,6 +26,10 @@ type
 
 proc runTest(path: string, lcDataFork: static LightClientDataFork) =
   test "Light client - Update ranking - " & path.relativePath(SszTestsDir):
+    when lcDataFork >= LightClientDataFork.Capella:
+      skip()
+      return
+
     let meta = block:
       var s = openFileStream(path/"meta.yaml")
       defer: close(s)
@@ -63,10 +67,6 @@ suite "EF - Light client - Update ranking" & preset():
     for kind, path in walkDir(testsPath, relative = true, checkDir = true):
       withStateFork(fork):
         const lcDataFork = lcDataForkAtStateFork(stateFork)
-        when lcDataFork >= LightClientDataFork.Capella:
-          test "Light client - Update ranking - " &
-              (testsPath/path).relativePath(SszTestsDir):
-            skip()
-        elif lcDataFork > LightClientDataFork.None:
+        when lcDataFork > LightClientDataFork.None:
           runTest(testsPath/path, lcDataFork)
         else: raiseAssert "Unreachable"


### PR DESCRIPTION
Adds missing Capella/EIP4844 support to LC update ranking runner.