### PR TITLE
use v1.3.0-rc.2 consensus spec test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -284,6 +284,8 @@ ConsensusSpecPreset-mainnet
 + EF - EIP4844 - Transition - transition_with_activation_at_fork_epoch [Preset: mainnet]     OK
 + EF - EIP4844 - Transition - transition_with_attester_slashing_right_after_fork [Preset: ma OK
 + EF - EIP4844 - Transition - transition_with_attester_slashing_right_before_fork [Preset: m OK
++ EF - EIP4844 - Transition - transition_with_btec_right_after_fork [Preset: mainnet]        OK
++ EF - EIP4844 - Transition - transition_with_btec_right_before_fork [Preset: mainnet]       OK
 + EF - EIP4844 - Transition - transition_with_deposit_right_after_fork [Preset: mainnet]     OK
 + EF - EIP4844 - Transition - transition_with_deposit_right_before_fork [Preset: mainnet]    OK
 + EF - EIP4844 - Transition - transition_with_finality [Preset: mainnet]                     OK
@@ -444,6 +446,8 @@ ConsensusSpecPreset-mainnet
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
@@ -701,6 +705,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__empty [Preset OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
++ [Valid]   EF - Capella - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 + [Valid]   EF - EIP4844 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -765,6 +770,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__empty [Preset OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 + [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -813,7 +819,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 ```
-OK: 801/810 Fail: 0/810 Skip: 9/810
+OK: 807/816 Fail: 0/816 Skip: 9/816
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2546,7 +2552,7 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 + [Valid]   EF - Capella - Operations - Withdrawals - success_all_partially_withdrawable_in_ OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_excess_balance_but_no_max_effe OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_max_partial_withdrawable       OK
-+ [Valid]   EF - Capella - Operations - Withdrawals - success_max_per_slot                   OK
++ [Valid]   EF - Capella - Operations - Withdrawals - success_mixed_fully_and_partial_withdr OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_no_excess_balance              OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_no_max_effective_balance       OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_one_full_withdrawal            OK
@@ -2577,7 +2583,7 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_all_partially_withdrawable_in_ OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_excess_balance_but_no_max_effe OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_max_partial_withdrawable       OK
-+ [Valid]   EF - EIP4844 - Operations - Withdrawals - success_max_per_slot                   OK
++ [Valid]   EF - EIP4844 - Operations - Withdrawals - success_mixed_fully_and_partial_withdr OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_no_excess_balance              OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_no_max_effective_balance       OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_one_full_withdrawal            OK
@@ -2596,4 +2602,4 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 OK: 100/100 Fail: 0/100 Skip: 0/100
 
 ---TOTAL---
-OK: 2293/2302 Fail: 0/2302 Skip: 9/2302
+OK: 2299/2308 Fail: 0/2308 Skip: 9/2308

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -304,6 +304,8 @@ ConsensusSpecPreset-minimal
 + EF - EIP4844 - Transition - transition_with_activation_at_fork_epoch [Preset: minimal]     OK
 + EF - EIP4844 - Transition - transition_with_attester_slashing_right_after_fork [Preset: mi OK
 + EF - EIP4844 - Transition - transition_with_attester_slashing_right_before_fork [Preset: m OK
++ EF - EIP4844 - Transition - transition_with_btec_right_after_fork [Preset: minimal]        OK
++ EF - EIP4844 - Transition - transition_with_btec_right_before_fork [Preset: minimal]       OK
 + EF - EIP4844 - Transition - transition_with_deposit_right_after_fork [Preset: minimal]     OK
 + EF - EIP4844 - Transition - transition_with_deposit_right_before_fork [Preset: minimal]    OK
 + EF - EIP4844 - Transition - transition_with_finality [Preset: minimal]                     OK
@@ -508,16 +510,26 @@ ConsensusSpecPreset-minimal
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/advance_finality_witho OK
++ Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/capella_store_with_leg OK
++ Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/eip4844_store_with_leg OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/light_client_sync      OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/supply_sync_committee_ OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/advance_finality_wi OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_eip4844_for OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_fork        OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_store_with_ OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/eip4844_store_with_ OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/light_client_sync   OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/supply_sync_committ OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/advance_finality_with OK
++ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/eip4844_fork          OK
++ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/eip4844_store_with_le OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/light_client_sync     OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/supply_sync_committee OK
 + Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/advance_finality_with OK
@@ -525,8 +537,8 @@ ConsensusSpecPreset-minimal
 + Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/supply_sync_committee OK
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
 + Light client - Update ranking - minimal/bellatrix/light_client/update_ranking/pyspec_tests OK
-  Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u Skip
-  Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u Skip
++ Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u OK
++ Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u OK
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + Sync - minimal/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
@@ -796,6 +808,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__empty [Preset OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
++ [Valid]   EF - Capella - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 + [Valid]   EF - EIP4844 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -865,6 +878,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__empty [Preset OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 + [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -918,7 +932,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 ```
-OK: 904/915 Fail: 0/915 Skip: 11/915
+OK: 920/929 Fail: 0/929 Skip: 9/929
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2711,8 +2725,8 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 + [Valid]   EF - Capella - Operations - Withdrawals - success_all_partially_withdrawable     OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_excess_balance_but_no_max_effe OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_max_partial_withdrawable       OK
-+ [Valid]   EF - Capella - Operations - Withdrawals - success_max_per_slot                   OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_max_plus_one_withdrawable      OK
++ [Valid]   EF - Capella - Operations - Withdrawals - success_mixed_fully_and_partial_withdr OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_no_excess_balance              OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_no_max_effective_balance       OK
 + [Valid]   EF - Capella - Operations - Withdrawals - success_one_full_withdrawal            OK
@@ -2743,8 +2757,8 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_all_partially_withdrawable     OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_excess_balance_but_no_max_effe OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_max_partial_withdrawable       OK
-+ [Valid]   EF - EIP4844 - Operations - Withdrawals - success_max_per_slot                   OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_max_plus_one_withdrawable      OK
++ [Valid]   EF - EIP4844 - Operations - Withdrawals - success_mixed_fully_and_partial_withdr OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_no_excess_balance              OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_no_max_effective_balance       OK
 + [Valid]   EF - EIP4844 - Operations - Withdrawals - success_one_full_withdrawal            OK
@@ -2763,4 +2777,4 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 OK: 102/102 Fail: 0/102 Skip: 0/102
 
 ---TOTAL---
-OK: 2442/2453 Fail: 0/2453 Skip: 11/2453
+OK: 2458/2467 Fail: 0/2467 Skip: 9/2467

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-rc.1"
+const SPEC_VERSION* = "1.3.0-rc.2"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -122,15 +122,15 @@ suite "EF - Capella - SSZ consensus objects " & preset():
           of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            discard  # checkSSZ(capella.LightClientBootstrap, path, hash)
+            checkSSZ(capella.LightClientBootstrap, path, hash)
           of "LightClientHeader":
-            discard  # checkSSZ(capella.LightClientHeader, path, hash)
+            checkSSZ(capella.LightClientHeader, path, hash)
           of "LightClientUpdate":
-            discard  # checkSSZ(capella.LightClientUpdate, path, hash)
+            checkSSZ(capella.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            discard  # checkSSZ(capella.LightClientFinalityUpdate, path, hash)
+            checkSSZ(capella.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            discard  # checkSSZ(capella.LightClientOptimisticUpdate, path, hash)
+            checkSSZ(capella.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/eip4844/test_fixture_ssz_consensus_objects.nim
@@ -126,15 +126,15 @@ suite "EF - EIP4844 - SSZ consensus objects " & preset():
           of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            discard  # checkSSZ(eip4844.LightClientBootstrap, path, hash)
+            checkSSZ(eip4844.LightClientBootstrap, path, hash)
           of "LightClientHeader":
-            discard  # checkSSZ(eip4844.LightClientHeader, path, hash)
+            checkSSZ(eip4844.LightClientHeader, path, hash)
           of "LightClientUpdate":
-            discard  # checkSSZ(eip4844.LightClientUpdate, path, hash)
+            checkSSZ(eip4844.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            discard  # checkSSZ(eip4844.LightClientFinalityUpdate, path, hash)
+            checkSSZ(eip4844.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            discard  # checkSSZ(eip4844.LightClientOptimisticUpdate, path, hash)
+            checkSSZ(eip4844.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -26,10 +26,6 @@ type
 
 proc runTest(path: string, lcDataFork: static LightClientDataFork) =
   test "Light client - Update ranking - " & path.relativePath(SszTestsDir):
-    when lcDataFork >= LightClientDataFork.Capella:
-      skip()
-      return
-
     let meta = block:
       var s = openFileStream(path/"meta.yaml")
       defer: close(s)

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -63,6 +63,8 @@ proc runTest(
 
   `testImpl _ blck _ testName`()
 
+from std/strutils import contains
+
 template runForkBlockTests(
     forkDirName, forkHumanName: static[string], BeaconStateType,
     BeaconBlockType: untyped) =
@@ -76,6 +78,13 @@ template runForkBlockTests(
 
   suite "EF - " & forkHumanName & " - Sanity - Blocks " & preset():
     for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
+      if  path.contains("top_up_to_fully_withdrawn_validator") or
+          path.contains("activate_and_partial_withdrawal_overdeposit") or
+          path.contains("activate_and_partial_withdrawal_max_effective_balance"):
+        # TODO when GitHub Actions CI returns and can verify the hotfix working
+        # within Windows `MAX_PATH` constraints, not, try updating and enabling
+        # these tests.
+        continue
       runTest(
         BeaconStateType, BeaconBlockType,
         "EF - " & forkHumanName & " - Sanity - Blocks", SanityBlocksDir, path)


### PR DESCRIPTION
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.3.0-rc.2-hotfix are already out, but because there have been `MAX_PATH` issues on the Windows GitHub Actions CI runner before with those, and GitHub Actions was at last check refusing to run on this repository, only update to the non-hotfixed `rc.2` and exclude the hotfixed tests, to keep this reliably testable by just Linux and macOS Jenkins.