### PR TITLE
track slot as part of fork choice debug API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,8 +261,8 @@ local-testnet-mainnet:
 
 # test binaries that can output an XML report
 XML_TEST_BINARIES_CORE := \
-	consensus_spec_tests_mainnet \
-	consensus_spec_tests_minimal
+	consensus_spec_tests_minimal \
+	consensus_spec_tests_mainnet
 
 XML_TEST_BINARIES := \
 	$(XML_TEST_BINARIES_CORE) \

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -134,7 +134,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
           # and then to make sure the fork choice data structure doesn't grow
           # too big - getting an EpochRef can be expensive.
           forkChoice.backend.process_block(
-            blckRef.root, blckRef.parent.root, epochRef.checkpoints)
+            blckRef.bid, blckRef.parent.root, epochRef.checkpoints)
         else:
           epochRef = dag.getEpochRef(blckRef, blckRef.slot.epoch, false).expect(
             "Getting an EpochRef should always work for non-finalized blocks")

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -36,6 +36,8 @@ type
     ## When process_slots() is being called as part of a state_transition(),
     ## the hash_tree_root() from the block will fill in the state.root so it
     ## should skip calculating that last state root.
+    experimental ##\
+    ## Whether to enable extra features in development.
     enableTestFeatures ##\
     ## Whether to enable extra features for testing.
     lowParticipation ##\

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -88,6 +88,7 @@ type
     ## Subtracted from logical index to get the physical index
 
   ProtoArray* = object
+    experimental*: bool
     hasLowParticipation*: bool
     currentEpoch*: Epoch
     checkpoints*: FinalityCheckpoints
@@ -98,7 +99,7 @@ type
     previousProposerBoostScore*: uint64
 
   ProtoNode* = object
-    root*: Eth2Digest
+    bid*: BlockId
     parent*: Option[Index]
     checkpoints*: FinalityCheckpoints
     weight*: int64
@@ -111,6 +112,7 @@ type
     balances*: seq[Gwei]
 
   Checkpoints* = object
+    experimental*: bool
     time*: BeaconTime
     justified*: BalanceCheckpoint
     finalized*: Checkpoint

--- a/tests/fork_choice/scenarios/ffg_01.nim
+++ b/tests/fork_choice/scenarios/ffg_01.nim
@@ -41,7 +41,9 @@ func setup_finality_01(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #   3 <- just: 2, fin: 1
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(1),
+    bid: BlockId(
+      slot: Epoch(1).start_slot,
+      root: fakeHash(1)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
@@ -49,7 +51,9 @@ func setup_finality_01(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(2),
+    bid: BlockId(
+      slot: Epoch(2).start_slot,
+      root: fakeHash(2)),
     parent_root: fakeHash(1),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
@@ -57,7 +61,9 @@ func setup_finality_01(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(3),
+    bid: BlockId(
+      slot: Epoch(3).start_slot,
+      root: fakeHash(3)),
     parent_root: fakeHash(2),
     blk_Checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(2), epoch: Epoch(2)),

--- a/tests/fork_choice/scenarios/ffg_02.nim
+++ b/tests/fork_choice/scenarios/ffg_02.nim
@@ -47,7 +47,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #  Left branch
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(1),
+    bid: BlockId(
+      slot: Slot(1),
+      root: fakeHash(1)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
@@ -55,7 +57,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(3),
+    bid: BlockId(
+      slot: Epoch(2).start_slot,
+      root: fakeHash(3)),
     parent_root: fakeHash(1),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
@@ -63,7 +67,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(5),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 2,
+      root: fakeHash(5)),
     parent_root: fakeHash(3),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
@@ -71,7 +77,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(7),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 4,
+      root: fakeHash(7)),
     parent_root: fakeHash(5),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(1), epoch: Epoch(1)),
@@ -79,7 +87,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(9),
+    bid: BlockId(
+      slot: Epoch(3).start_slot,
+      root: fakeHash(9)),
     parent_root: fakeHash(7),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(3), epoch: Epoch(2)),
@@ -102,7 +112,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
   #  Right branch
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(2),
+    bid: BlockId(
+      slot: Slot(2),
+      root: fakeHash(2)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
@@ -110,7 +122,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(4),
+    bid: BlockId(
+      slot: Epoch(1).start_slot + 1,
+      root: fakeHash(4)),
     parent_root: fakeHash(2),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
@@ -118,7 +132,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(6),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 3,
+      root: fakeHash(6)),
     parent_root: fakeHash(4),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(0)),
@@ -126,7 +142,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(8),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 1,
+      root: fakeHash(8)),
     parent_root: fakeHash(6),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(2), epoch: Epoch(1)),
@@ -134,7 +152,9 @@ func setup_finality_02(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operati
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(10),
+    bid: BlockId(
+      slot: Epoch(5).start_slot + 1,
+      root: fakeHash(10)),
     parent_root: fakeHash(8),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(4), epoch: Epoch(2)),

--- a/tests/fork_choice/scenarios/no_votes.nim
+++ b/tests/fork_choice/scenarios/no_votes.nim
@@ -38,7 +38,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #       2
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(2),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 2,
+      root: fakeHash(2)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -64,7 +66,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #       2  1
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(1),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 1,
+      root: fakeHash(1)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -92,7 +96,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #          3
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(3),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 3,
+      root: fakeHash(3)),
     parent_root: fakeHash(1),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -122,7 +128,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #       4  3
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(4),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 4,
+      root: fakeHash(4)),
     parent_root: fakeHash(2),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -154,7 +162,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #       5 <- justified epoch = 2
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(5),
+    bid: BlockId(
+      slot: Epoch(4).start_slot,
+      root: fakeHash(5)),
     parent_root: fakeHash(4),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -221,7 +231,9 @@ func setup_no_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]
   #     6
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(6),
+    bid: BlockId(
+      slot: Epoch(4).start_slot + 1,
+      root: fakeHash(6)),
     parent_root: fakeHash(5),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),

--- a/tests/fork_choice/scenarios/votes.nim
+++ b/tests/fork_choice/scenarios/votes.nim
@@ -38,7 +38,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #       2
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(2),
+    bid: BlockId(
+      slot: Epoch(1).start_slot + 2,
+      root: fakeHash(2)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -64,7 +66,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #       2  1
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(1),
+    bid: BlockId(
+      slot: Epoch(1).start_slot + 1,
+      root: fakeHash(1)),
     parent_root: GenesisRoot,
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -140,7 +144,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #          3
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(3),
+    bid: BlockId(
+      slot: Epoch(1).start_slot + 3,
+      root: fakeHash(3)),
     parent_root: fakeHash(1),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -226,7 +232,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #          4
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(4),
+    bid: BlockId(
+      slot: Epoch(1).start_slot + 4,
+      root: fakeHash(4)),
     parent_root: fakeHash(3),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -262,7 +270,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #          5 <- justified epoch = 2
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(5),
+    bid: BlockId(
+      slot: Epoch(2).start_slot,
+      root: fakeHash(5)),
     parent_root: fakeHash(4),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -300,7 +310,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #          5   6 <- justified epoch = 0
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(6),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 1,
+      root: fakeHash(6)),
     parent_root: fakeHash(4),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: GenesisRoot, epoch: Epoch(1)),
@@ -349,7 +361,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #        9
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(7),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 2,
+      root: fakeHash(7)),
     parent_root: fakeHash(5),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -357,7 +371,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
 
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(8),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 3,
+      root: fakeHash(8)),
     parent_root: fakeHash(7),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -366,7 +382,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # Finalizes 5
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(9),
+    bid: BlockId(
+      slot: Epoch(2).start_slot + 4,
+      root: fakeHash(9)),
     parent_root: fakeHash(8),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -481,7 +499,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #        9  10
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(10),
+    bid: BlockId(
+      slot: Epoch(3).start_slot,
+      root: fakeHash(10)),
     parent_root: fakeHash(8),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
@@ -626,7 +646,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   # - 6 is a discarded chain
   result.ops.add Operation(
     kind: Prune,
-    finalized_root: fakeHash(5),
+    prune_checkpoints: FinalityCheckpoints(
+      justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),
+      finalized: Checkpoint(root: fakeHash(5), epoch: Epoch(2))),
     expected_len: 6)
 
   # Prune shouldn't have changed the head
@@ -651,7 +673,9 @@ func setup_votes(): tuple[fork_choice: ForkChoiceBackend, ops: seq[Operation]] =
   #        11
   result.ops.add Operation(
     kind: ProcessBlock,
-    root: fakeHash(11),
+    bid: BlockId(
+      slot: Epoch(3).start_slot + 1,
+      root: fakeHash(11)),
     parent_root: fakeHash(9),
     blk_checkpoints: FinalityCheckpoints(
       justified: Checkpoint(root: fakeHash(5), epoch: Epoch(2)),


### PR DESCRIPTION
Extends fork choice state to also track slot numbers to improve accuracy of `/eth/v1/debug/fork_choice` endpoint. Autoenable this API on devnet, and disable some extra checks on devnet to aid focused testing efforts. Align fork choice pruning logic with API based on checkpoints vs root.