### PR TITLE
use 1.3.0-rc.2-hotfix consensus spec test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -706,6 +706,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
++ [Valid]   EF - Capella - Sanity - Blocks - top_up_to_fully_withdrawn_validator [Preset: ma OK
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 + [Valid]   EF - EIP4844 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -771,6 +772,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_to_fully_withdrawn_validator [Preset: ma OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 + [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -819,7 +821,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 ```
-OK: 807/816 Fail: 0/816 Skip: 9/816
+OK: 809/818 Fail: 0/818 Skip: 9/818
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2602,4 +2604,4 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 OK: 100/100 Fail: 0/100 Skip: 0/100
 
 ---TOTAL---
-OK: 2299/2308 Fail: 0/2308 Skip: 9/2308
+OK: 2301/2310 Fail: 0/2310 Skip: 9/2310

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -764,6 +764,8 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Random - randomized_7 [Preset: minimal]                           OK
 + [Valid]   EF - Capella - Random - randomized_8 [Preset: minimal]                           OK
 + [Valid]   EF - Capella - Random - randomized_9 [Preset: minimal]                           OK
++ [Valid]   EF - Capella - Sanity - Blocks - activate_and_partial_withdrawal_max_effective_b OK
++ [Valid]   EF - Capella - Sanity - Blocks - activate_and_partial_withdrawal_overdeposit [Pr OK
 + [Valid]   EF - Capella - Sanity - Blocks - attestation [Preset: minimal]                   OK
 + [Valid]   EF - Capella - Sanity - Blocks - attester_slashing [Preset: minimal]             OK
 + [Valid]   EF - Capella - Sanity - Blocks - balance_driven_status_transitions [Preset: mini OK
@@ -809,6 +811,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
 + [Valid]   EF - Capella - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
++ [Valid]   EF - Capella - Sanity - Blocks - top_up_to_fully_withdrawn_validator [Preset: mi OK
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 + [Valid]   EF - EIP4844 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -832,6 +835,8 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - EIP4844 - Random - randomized_7 [Preset: minimal]                           OK
 + [Valid]   EF - EIP4844 - Random - randomized_8 [Preset: minimal]                           OK
 + [Valid]   EF - EIP4844 - Random - randomized_9 [Preset: minimal]                           OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - activate_and_partial_withdrawal_max_effective_b OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - activate_and_partial_withdrawal_overdeposit [Pr OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - attestation [Preset: minimal]                   OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - attester_slashing [Preset: minimal]             OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - balance_driven_status_transitions [Preset: mini OK
@@ -879,6 +884,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__full [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - sync_committee_committee_genesis__half [Preset: OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_and_partial_withdrawable_validator [Pres OK
++ [Valid]   EF - EIP4844 - Sanity - Blocks - top_up_to_fully_withdrawn_validator [Preset: mi OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + [Valid]   EF - EIP4844 - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 + [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -932,7 +938,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 ```
-OK: 920/929 Fail: 0/929 Skip: 9/929
+OK: 926/935 Fail: 0/935 Skip: 9/935
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2777,4 +2783,4 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 OK: 102/102 Fail: 0/102 Skip: 0/102
 
 ---TOTAL---
-OK: 2458/2467 Fail: 0/2467 Skip: 9/2467
+OK: 2464/2473 Fail: 0/2473 Skip: 9/2473

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-rc.2"
+const SPEC_VERSION* = "1.3.0-rc.2-hotfix"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -63,8 +63,6 @@ proc runTest(
 
   `testImpl _ blck _ testName`()
 
-from std/strutils import contains
-
 template runForkBlockTests(
     forkDirName, forkHumanName: static[string], BeaconStateType,
     BeaconBlockType: untyped) =
@@ -78,13 +76,6 @@ template runForkBlockTests(
 
   suite "EF - " & forkHumanName & " - Sanity - Blocks " & preset():
     for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
-      if  path.contains("top_up_to_fully_withdrawn_validator") or
-          path.contains("activate_and_partial_withdrawal_overdeposit") or
-          path.contains("activate_and_partial_withdrawal_max_effective_balance"):
-        # TODO when GitHub Actions CI returns and can verify the hotfix working
-        # within Windows `MAX_PATH` constraints, not, try updating and enabling
-        # these tests.
-        continue
       runTest(
         BeaconStateType, BeaconBlockType,
         "EF - " & forkHumanName & " - Sanity - Blocks", SanityBlocksDir, path)


### PR DESCRIPTION
Probably should not be merged until Windows GitHub Actions returns, due to likely `MAX_PATH` issues, but does demonstrate that all the excluded tests from rc.2 are a result of things fixed by said hotfix.