### PR TITLE
try not requiring brew install gnu-getopt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,6 @@ jobs:
           # for miniupnp that runs "wingenminiupnpcstrings.exe" from the current dir
           echo "." >> $GITHUB_PATH
 
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install gnu-getopt
-          brew link --force gnu-getopt
-
       - name: Derive environment variables
         run: |
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then


### PR DESCRIPTION
It failed in https://github.com/status-im/nimbus-eth2/actions/runs/4047898159/jobs/6962479210
```
Run brew install gnu-getopt
==> Fetching gnu-getopt
==> Downloading https://ghcr.io/v2/homebrew/core/gnu-getopt/manifests/2.38.1
curl: (22) The requested URL returned error: [5](https://github.com/status-im/nimbus-eth2/actions/runs/4047898159/jobs/6962479210#step:7:6)00 
Error: gnu-getopt: Failed to download resource "gnu-getopt_bottle_manifest"
Download failed: https://ghcr.io/v2/homebrew/core/gnu-getopt/manifests/2.38.1
Error: Process completed with exit code 1.Run brew install gnu-getopt
==> Fetching gnu-getopt
==> Downloading https://ghcr.io/v2/homebrew/core/gnu-getopt/manifests/2.38.1
curl: (22) The requested URL returned error: [5](https://github.com/status-im/nimbus-eth2/actions/runs/4047898159/jobs/6962479210#step:7:6)00 
Error: gnu-getopt: Failed to download resource "gnu-getopt_bottle_manifest"
Download failed: https://ghcr.io/v2/homebrew/core/gnu-getopt/manifests/2.38.1
Error: Process completed with exit code 1.
```

A few places reference it:
- https://github.com/status-im/nimbus-eth2/blob/unstable/scripts/launch_local_testnet.sh
- https://github.com/status-im/nimbus-eth2/blob/unstable/scripts/make_packages.sh
- https://github.com/status-im/nimbus-eth2/blob/unstable/scripts/make_prometheus_config.sh
- https://github.com/status-im/nimbus-benchmarking/tree/dff3634b5d843f9b63425086f1b13245e26b6177

But none of these look necessary for an ordinary GitHub Actions CI build.