### PR TITLE
Eip4844 sync fixes

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -201,6 +201,7 @@ proc processSignedBeaconBlock*(
     blockRoot = shortLog(signedBlock.root)
     blck = shortLog(signedBlock.message)
     signature = shortLog(signedBlock.signature)
+    hasBlobs = optBlobs(signedBlockAndBlobs).isSome
     wallSlot
 
   if not afterGenesis:
@@ -227,7 +228,7 @@ proc processSignedBeaconBlock*(
 
     self.blockProcessor[].addBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),
-      Opt.none(eip4844.BlobsSidecar),
+      optBlobs(signedBlockAndBlobs),
       validationDur = nanoseconds(
         (self.getCurrentBeaconTime() - wallTime).nanoseconds))
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -196,12 +196,13 @@ proc processSignedBeaconBlock*(
     wallTime = self.getCurrentBeaconTime()
     (afterGenesis, wallSlot) = wallTime.toSlot()
     signedBlock = toSignedBeaconBlock(signedBlockAndBlobs)
+    blobs = optBlobs(signedBlockAndBlobs)
 
   logScope:
     blockRoot = shortLog(signedBlock.root)
     blck = shortLog(signedBlock.message)
     signature = shortLog(signedBlock.signature)
-    hasBlobs = optBlobs(signedBlockAndBlobs).isSome
+    hasBlobs = blobs.isSome
     wallSlot
 
   if not afterGenesis:
@@ -228,7 +229,7 @@ proc processSignedBeaconBlock*(
 
     self.blockProcessor[].addBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),
-      optBlobs(signedBlockAndBlobs),
+      blobs,
       validationDur = nanoseconds(
         (self.getCurrentBeaconTime() - wallTime).nanoseconds))
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -374,11 +374,8 @@ proc validateBeaconBlock*(
         # validation.
         return errReject("BeaconBlock: rejected, parent from unviable fork")
 
-    let blobs =
-      when signed_beacon_block is eip4844.SignedBeaconBlockAndBlobsSidecar:
-        Opt.some(signed_beacon_block.blobs_sidecar)
-      else:
-        Opt.none(eip4844.BlobsSidecar)
+    let blobs = optBlobs(signed_beacon_block_and_blobs)
+
     # When the parent is missing, we can't validate the block - we'll queue it
     # in the quarantine for later processing
     if not quarantine[].addOrphan(

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -170,8 +170,8 @@ proc fetchAncestorBlocksAndBlobsFromNetwork(rman: RequestManager,
   var peer: Peer
   try:
     peer = await rman.network.peerPool.acquire()
-    debug "Requesting blocks by root", peer = peer, blocks = shortLog(items),
-                                       peer_score = peer.getScore()
+    debug "Requesting blocks and sidecars by root",
+      peer = peer, blocks = shortLog(items), peer_score = peer.getScore()
 
     let blocks = (await beaconBlockAndBlobsSidecarByRoot_v1(peer, BlockRootsList items))
 
@@ -203,7 +203,7 @@ proc fetchAncestorBlocksAndBlobsFromNetwork(rman: RequestManager,
             of VerifierError.Invalid:
               # We stop processing blocks because peer is either sending us
               # junk or working a different fork
-              notice "Received invalid block",
+              notice "Received invalid block and blobs",
                 peer = peer, blocks = shortLog(items),
                 peer_score = peer.getScore()
               peer.updateScore(PeerScoreBadValues)
@@ -213,7 +213,7 @@ proc fetchAncestorBlocksAndBlobsFromNetwork(rman: RequestManager,
             gotGoodBlock = true
 
         if gotUnviableBlock:
-          notice "Received blocks from an unviable fork",
+          notice "Received blocks and blobs from an unviable fork",
             peer = peer, blocks = shortLog(items),
             peer_score = peer.getScore()
           peer.updateScore(PeerScoreUnviableFork)
@@ -240,7 +240,7 @@ proc fetchAncestorBlocksAndBlobsFromNetwork(rman: RequestManager,
     raise exc
   except CatchableError as exc:
     peer.updateScore(PeerScoreNoValues)
-    debug "Error while fetching ancestor blocks", exc = exc.msg,
+    debug "Error while fetching ancestor blocks and blobs", exc = exc.msg,
           items = shortLog(items), peer = peer, peer_score = peer.getScore()
     raise exc
   finally:

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -877,7 +877,6 @@ proc proposeBlock(node: BeaconNode,
 
   withBlck(forkedBlck):
     var blobs_sidecar = eip4844.BlobsSidecar(
-      beacon_block_root: hash_tree_root(blck),
       beacon_block_slot: slot,
     )
     when blck is eip4844.BeaconBlock and const_preset != "minimal":
@@ -912,6 +911,7 @@ proc proposeBlock(node: BeaconNode,
         .slashingProtection
         .registerBlock(validator_index, validator.pubkey, slot, signingRoot)
 
+    blobs_sidecar.beacon_block_root = blockRoot
     if notSlashable.isErr:
       warn "Slashing protection activated for block proposal",
         blockRoot = shortLog(blockRoot), blck = shortLog(blck),


### PR DESCRIPTION
With these fixes, local testnet finalizes when run as 
`./scripts/launch_local_testnet.sh --verbose --disable-vc --nodes 4 --disable-htop --stop-at-epoch 6 --light-clients 0 -- --verify-finalization --discv5:no`

with 
```
+CAPELLA_FORK_EPOCH: 3
+EIP4844_FORK_EPOCH: 4
``` 
added to the config.