### PR TITLE
update engine API URLs to v1.0.0-beta.2

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -232,7 +232,7 @@ type
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
       name: "num-threads" .}: int
 
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#key-distribution
     jwtSecret* {.
       desc: "A file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens"
       name: "jwt-secret" .}: Option[string]

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -661,7 +661,7 @@ proc exchangeTransitionConfiguration*(p: Eth1Monitor): Future[EtcStatus] {.async
   if dataProvider.isNil:
     return EtcStatus.exchangeError
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#engine_exchangetransitionconfigurationv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#engine_exchangetransitionconfigurationv1
   let consensusCfg = TransitionConfigurationV1(
     terminalTotalDifficulty: p.depositsChain.cfg.TERMINAL_TOTAL_DIFFICULTY,
     terminalBlockHash: p.depositsChain.cfg.TERMINAL_BLOCK_HASH,
@@ -1194,7 +1194,7 @@ proc detectPrimaryProviderComingOnline(m: Eth1Monitor) {.async.} =
     var tempProvider = tempProviderRes.get
 
     # Use one of the get/request-type methods from
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#underlying-protocol
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/common.md#underlying-protocol
     # which doesn't take parameters and returns a small structure, to ensure
     # this works with engine API endpoints.
     let testRequest = tempProvider.web3.provider.eth_syncing()

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -276,7 +276,8 @@ proc newExecutionPayload*(
     baseFeePerGas = $executionPayload.base_fee_per_gas,
     numTransactions = executionPayload.transactions.len
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#request
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/shanghai.md#request
   const NEWPAYLOAD_TIMEOUT = 8.seconds
 
   try:
@@ -383,7 +384,7 @@ proc storeBlock*(
 
     # Client software MUST validate blockHash value as being equivalent to
     # Keccak256(RLP(ExecutionBlockHeader))
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#specification
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#specification
     when typeof(signedBlock).toFork() >= ConsensusFork.Bellatrix:
       template payload(): auto = signedBlock.message.body.execution_payload
       if payload.block_hash != payload.compute_execution_block_hash():
@@ -503,7 +504,7 @@ proc storeBlock*(
       # > Client software MAY skip an update of the forkchoice state and MUST
       #   NOT begin a payload build process if `forkchoiceState.headBlockHash`
       #   references an ancestor of the head of canonical chain.
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#engine_forkchoiceupdatedv1
+      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#specification-1
       #
       # However, in practice, an EL client may not have completed importing all
       # block headers, so may be unaware of a block's ancestor status.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -675,7 +675,7 @@ proc init*(T: type BeaconNode,
     validatorMonitor: validatorMonitor,
     stateTtlCache: stateTtlCache,
     nextExchangeTransitionConfTime:
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#specification-3
+      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#specification-3
       # Consensus Layer client software **SHOULD** poll this endpoint every
       # 60 seconds.
       # Delay first call by that time to allow for EL syncing to begin; it can
@@ -1328,11 +1328,11 @@ proc onSecond(node: BeaconNode, time: Moment) =
   updateThreadMetrics()
 
   if time >= node.nextExchangeTransitionConfTime and not node.eth1Monitor.isNil:
-    # The EL client SHOULD log a warning when not receiving an exchange message
-    # at least once every 120 seconds. If we only attempt to exchange every 60
-    # seconds, the warning would be triggered if a single message is missed.
+    # Execution Layer client software **SHOULD** surface an error to the user
+    # if it does not receive a request on this endpoint at least once every 120
+    # seconds.
     # To accommodate for that, exchange slightly more frequently.
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#engine_exchangetransitionconfigurationv1
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#specification-3
     node.nextExchangeTransitionConfTime = time + chronos.seconds(45)
 
     if node.currentSlot.epoch >= node.dag.cfg.BELLATRIX_FORK_EPOCH:

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -25,7 +25,8 @@ import
 export json_serialization, base
 
 const
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#request-1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/shanghai.md#request-1
   FORKCHOICEUPDATED_TIMEOUT* = 8.seconds
 
 type

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -27,9 +27,10 @@ proc base64urlEncode(x: auto): string =
   base64.encode(x, safe = true).replace("=", "")
 
 func getIatToken*(time: int64): JsonNode =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#jwt-claims
-  # "Required: iat (issued-at) claim. The EL SHOULD only accept iat timestamps
-  # which are within +-60 seconds from the current time."
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#jwt-claims
+  # "Required: `iat` (issued-at) claim. The execution layer client **SHOULD**
+  # only accept `iat` timestamps which are within +-60 seconds from the current
+  # time."
   #
   # https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6 describes iat
   # claims.
@@ -39,8 +40,9 @@ func getIatToken*(time: int64): JsonNode =
   %* {"iat": time}
 
 proc getSignedToken*(key: openArray[byte], payload: string): string =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#jwt-specifications
-  # "The EL MUST support at least the following alg: HMAC + SHA256 (HS256)"
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#jwt-specifications
+  # "The execution layer client **MUST** support at least the following `alg`
+  # `HMAC + SHA256` (`HS256`)"
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
   const jwsProtectedHeader =
@@ -67,11 +69,11 @@ proc checkJwtSecret*(
 
   if jwtSecret.isNone:
     # If such a parameter is not given, the client SHOULD generate such a
-    # token, valid for the duration of the execution, and store it the
+    # token, valid for the duration of the execution, and store the
     # hex-encoded secret as a jwt.hex file on the filesystem. This file can
     # then be used to provision the counterpart client.
     #
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#key-distribution
     const jwtSecretFilename = "jwt.hex"
     let jwtSecretPath = dataDir / jwtSecretFilename
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -377,7 +377,8 @@ proc getExecutionPayload[T](
     # Minimize window for Eth1 monitor to shut down connection
     await node.consensusManager.eth1Monitor.ensureDataProvider()
 
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/specification.md#request-2
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#request-2
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/shanghai.md#request-2
     const GETPAYLOAD_TIMEOUT = 1.seconds
 
     let
@@ -447,7 +448,7 @@ proc getBlobsBundle(
   # Minimize window for Eth1 monitor to shut down connection
   await node.consensusManager.eth1Monitor.ensureDataProvider()
 
-  # https://github.com/ethereum/execution-apis/blob/8058687053598e8fa3cc25a4ca4965fb96cf1e65/src/engine/experimental/blob-extension.md#engine_getblobsbundlev1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/experimental/blob-extension.md#engine_getblobsbundlev1
   const GETBLOBS_TIMEOUT = 1.seconds
 
   let payload = try:

--- a/research/fakeee.nim
+++ b/research/fakeee.nim
@@ -1,7 +1,7 @@
 ## Fake execution engine API implementation useful for testing beacon node without a running execution node
 
 # Nimbus
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -16,7 +16,7 @@ import
   chronicles
 
 proc setupEngineAPI*(server: RpcServer) =
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_newpayloadv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#engine_newpayloadv1
   # cannot use `params` as param name. see https:#github.com/status-im/nim-json-rpc/issues/128
   server.rpc("engine_newPayloadV1") do(payload: ExecutionPayloadV1) -> PayloadStatusV1:
     info "engine_newPayloadV1",
@@ -26,7 +26,7 @@ proc setupEngineAPI*(server: RpcServer) =
       status: PayloadExecutionStatus.syncing,
     )
 
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_getpayloadv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#engine_getpayloadv1
   server.rpc("engine_getPayloadV1") do(payloadId: PayloadID) -> ExecutionPayloadV1:
     info "engine_getPayloadV1",
       id = payloadId.toHex
@@ -36,7 +36,7 @@ proc setupEngineAPI*(server: RpcServer) =
       msg: "Unkown payload"
     )
 
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_exchangetransitionconfigurationv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#engine_exchangetransitionconfigurationv1
   server.rpc("engine_exchangeTransitionConfigurationV1") do(conf: TransitionConfigurationV1) -> TransitionConfigurationV1:
     info "engine_exchangeTransitionConfigurationV1",
       ttd = conf.terminalTotalDifficulty,
@@ -45,7 +45,7 @@ proc setupEngineAPI*(server: RpcServer) =
 
     return conf
 
-  # https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_forkchoiceupdatedv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/paris.md#engine_forkchoiceupdatedv1
   server.rpc("engine_forkchoiceUpdatedV1") do(
       update: ForkchoiceStateV1,
       payloadAttributes: Option[PayloadAttributesV1]) -> ForkchoiceUpdatedResponse:

--- a/scripts/test_merge_node.nim
+++ b/scripts/test_merge_node.nim
@@ -26,7 +26,7 @@ from ../beacon_chain/spec/presets import Eth1Address, defaultRuntimeConfig
 # TODO factor this out and have a version with the result of the JWT secret
 # slurp for testing purposes
 proc readJwtSecret(jwtSecretFile: string): Result[seq[byte], cstring] =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#key-distribution
   # If such a parameter is given, but the file cannot be read, or does not
   # contain a hex-encoded key of 256 bits, the client should treat this as an
   # error: either abort the startup, or show error and continue without

--- a/scripts/test_merge_vectors.nim
+++ b/scripts/test_merge_vectors.nim
@@ -25,7 +25,7 @@ from ../beacon_chain/spec/presets import Eth1Address, defaultRuntimeConfig
 # TODO hm, actually factor this out into a callable function
 # and have a version with the result of the JWT secret slurp for testing purposes
 proc readJwtSecret(jwtSecretFile: string): Result[seq[byte], cstring] =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.1/src/engine/authentication.md#key-distribution
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.2/src/engine/authentication.md#key-distribution
   # If such a parameter is given, but the file cannot be read, or does not
   # contain a hex-encoded key of 256 bits, the client should treat this as an
   # error: either abort the startup, or show error and continue without


### PR DESCRIPTION
All comments, no semantic changes.

In the future, this will likely be more feasible to automate, but the specifications were refactored between `v1.0.0-beta.1` and `v1.0.0-beta.2` to support multiple forks, which hinders that here.