### PR TITLE
avoid noisy deprecation warning on build

### DIFF
--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -404,7 +404,12 @@ func shortLog*(v: ExecutionPayload): auto =
     gas_used: v.gas_used,
     timestamp: v.timestamp,
     extra_data_len: len(v.extra_data),
-    base_fee_per_gas: $(v.base_fee_per_gas),
+
+    # TODO re-enable when this doesn't trigger multiple
+    # nimbus-eth2/vendor/nim-stint/stint/private/uint_div.nim(240, 24) Warning:
+    # See corresponding Defect; DivByZeroError is deprecated [Deprecated]
+    # base_fee_per_gas: $(v.base_fee_per_gas),
+
     block_hash: shortLog(v.block_hash),
     num_transactions: len(v.transactions)
   )


### PR DESCRIPTION
it'd be nice to have, but it's not useful enough as part of the `shortLog` to warrant the build noise, e.g.
```
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/spec/datatypes/bellatrix.nim(407, 23) template/generic instantiation of `$` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(384, 13) template/generic instantiation of `toString` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(332, 22) template/generic instantiation of `divmod` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/intops.nim(74, 47) template/generic instantiation of `divmod` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/private/uint_div.nim(240, 24) Warning: See corresponding Defect; DivByZeroError is deprecated [Deprecated]
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/spec/datatypes/bellatrix.nim(407, 23) template/generic instantiation of `$` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(384, 13) template/generic instantiation of `toString` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(332, 22) template/generic instantiation of `divmod` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/intops.nim(74, 47) template/generic instantiation of `divmod` from here
[2023-02-03T10:33:03.091Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/private/uint_div.nim(240, 24) Warning: See corresponding Defect; DivByZeroError is deprecated [Deprecated]
[2023-02-03T10:33:44.049Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/tests/testdbutil.nim(30, 25) template/generic instantiation of `new` from here
[2023-02-03T10:33:44.049Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/beacon_chain_db.nim(596, 17) template/generic instantiation of `init` from here
[2023-02-03T10:33:44.049Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-eth/eth/db/kvstore_sqlite3.nim(569, 25) Warning: unsafe conversion to 'cstring' from 'ptr cuchar'; this will become a compile time error in the future [PtrToCstringConv]
[2023-02-03T10:33:55.401Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/tests/testdbutil.nim(30, 25) template/generic instantiation of `new` from here
[2023-02-03T10:33:55.401Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/beacon_chain_db.nim(596, 17) template/generic instantiation of `init` from here
[2023-02-03T10:33:55.401Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-eth/eth/db/kvstore_sqlite3.nim(569, 25) Warning: unsafe conversion to 'cstring' from 'ptr cuchar'; this will become a compile time error in the future [PtrToCstringConv]
[2023-02-03T10:35:49.734Z] ld: warning: could not create compact unwind for _blst_sha256_block_data_order: does not use RBP or RSP based frame
[2023-02-03T10:36:01.099Z] ld: warning: could not create compact unwind for _blst_sha256_block_data_order: does not use RBP or RSP based frame
[2023-02-03T10:37:11.456Z] Build completed successfully: build/consensus_spec_tests_minimal
[2023-02-03T10:37:11.456Z] Building: build/state_sim
[2023-02-03T10:37:11.456Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/spec/datatypes/bellatrix.nim(407, 23) template/generic instantiation of `$` from here
[2023-02-03T10:37:11.457Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(384, 13) template/generic instantiation of `toString` from here
[2023-02-03T10:37:11.457Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(332, 22) template/generic instantiation of `divmod` from here
[2023-02-03T10:37:11.457Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/intops.nim(74, 47) template/generic instantiation of `divmod` from here
[2023-02-03T10:37:11.457Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/private/uint_div.nim(240, 24) Warning: See corresponding Defect; DivByZeroError is deprecated [Deprecated]
[2023-02-03T10:37:16.632Z] Build completed successfully: build/consensus_spec_tests_mainnet
[2023-02-03T10:37:16.632Z] Building: build/block_sim
[2023-02-03T10:37:19.141Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/beacon_chain/spec/datatypes/bellatrix.nim(407, 23) template/generic instantiation of `$` from here
[2023-02-03T10:37:19.141Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(384, 13) template/generic instantiation of `toString` from here
[2023-02-03T10:37:19.141Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/io.nim(332, 22) template/generic instantiation of `divmod` from here
[2023-02-03T10:37:19.141Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/intops.nim(74, 47) template/generic instantiation of `divmod` from here
[2023-02-03T10:37:19.142Z] /Users/jenkins/workspace/2_platforms_macos_x86_64_PR-4586/vendor/nim-stint/stint/private/uint_div.nim(240, 24) Warning: See corresponding Defect; DivByZeroError is deprecated [Deprecated]
```