### PR TITLE
WIP: eth1: Fix earliest block of interest for eth1 voting

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1251,7 +1251,8 @@ func latestEth1BlockNumber(m: Eth1Monitor): Eth1BlockNumber =
     Eth1BlockNumber 0
 
 func earliestBlockOfInterest(m: Eth1Monitor): Eth1BlockNumber =
-  m.latestEth1BlockNumber - (2 * m.cfg.ETH1_FOLLOW_DISTANCE) - votedBlocksSafetyMargin
+  m.latestEth1BlockNumber - SLOTS_PER_ETH1_VOTING_PERIOD - (2 *
+      m.cfg.ETH1_FOLLOW_DISTANCE) - votedBlocksSafetyMargin
 
 proc syncBlockRange(m: Eth1Monitor,
                     fromBlock, toBlock,


### PR DESCRIPTION
This bug popped up on Zhejiang, where (and when) the follow distance was very small at 12 compared to the voting period length of 2048.

From what I can tell what was going on is that the `earliestBlockOfInterest` was way too high (not even before the voting period start). When it was time for Nimbus to propose, `latestCandidateBlock` then didn't have any valid candidates to choose from.

This commit fixes it, but does make it such that on mainnet 2048 more blocks will be cached in the worst cast. At least, I assume that's what `syncBlockRange` does, build a cache. Although I do wonder if blocks outside this range are indeed evicted, and when (restart? every N minutes?). 

- [ ] Check with devs if above understanding is correct
- [ ] Update / amend commit message