### PR TITLE
fix slow checking of unknown validators

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -95,6 +95,8 @@ type
     externalBuilderRegistrations*:
       Table[ValidatorPubKey, SignedValidatorRegistrationV1]
     mergeAtEpoch*: Epoch
+    dutyValidatorCount*: int
+      ## Number of validators that we've checked for activation
 
 const
   MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -103,7 +103,7 @@ proc initValidators(sn: var SigningNode): bool =
     let feeRecipient = default(Eth1Address)
     case keystore.kind
     of KeystoreKind.Local:
-      discard sn.attachedValidators.addLocalValidator(keystore, feeRecipient)
+      discard sn.attachedValidators.addValidator(keystore, feeRecipient)
       publicKeyIdents.add("\"0x" & keystore.pubkey.toHex() & "\"")
     of KeystoreKind.Remote:
       error "Signing node do not support remote validators",

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -84,16 +84,10 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.async.} =
       return melem
 
 proc initValidators(vc: ValidatorClientRef): Future[bool] {.async.} =
-  info "Initializaing validators", path = vc.config.validatorsDir()
+  info "Loading validators", validatorsDir = vc.config.validatorsDir()
   var duplicates: seq[ValidatorPubKey]
   for keystore in listLoadableKeystores(vc.config):
-    let pubkey = keystore.pubkey
-    if pubkey in duplicates:
-      warn "Duplicate validator key found", validator_pubkey = pubkey
-      continue
-    else:
-      duplicates.add(pubkey)
-      vc.addValidator(keystore)
+    vc.addValidator(keystore)
   return true
 
 proc initClock(vc: ValidatorClientRef): Future[BeaconClock] {.async.} =

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -271,9 +271,6 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
     vc.syncCommitteeService = await SyncCommitteeServiceRef.init(vc)
     vc.keymanagerServer = keymanagerInitResult.server
     if vc.keymanagerServer != nil:
-      func getValidatorData(pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
-        Opt.none(ValidatorAndIndex)
-
       vc.keymanagerHost = newClone KeymanagerHost.init(
         validatorPool,
         vc.rng,
@@ -281,7 +278,7 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
         vc.config.validatorsDir,
         vc.config.secretsDir,
         vc.config.defaultFeeRecipient,
-        getValidatorData,
+        nil,
         vc.beaconClock.getBeaconTimeFn)
 
   except CatchableError as exc:

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -130,7 +130,7 @@ proc handleAddRemoteValidatorReq(host: KeymanagerHost,
       data = host.getValidatorData(keystore.pubkey)
       feeRecipient = host.getSuggestedFeeRecipient(keystore.pubkey).valueOr(
         host.defaultFeeRecipient)
-      v = host.validatorPool[].addRemoteValidator(res.get, feeRecipient)
+      v = host.validatorPool[].addValidator(res.get, feeRecipient)
     if data.isSome():
       v.updateValidator(data.get().index, data.get().validator.activation_epoch)
 

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -126,13 +126,7 @@ proc handleAddRemoteValidatorReq(host: KeymanagerHost,
                                  keystore: RemoteKeystore): RequestItemStatus =
   let res = importKeystore(host.validatorPool[], host.validatorsDir, keystore)
   if res.isOk:
-    let
-      data = host.getValidatorData(keystore.pubkey)
-      feeRecipient = host.getSuggestedFeeRecipient(keystore.pubkey).valueOr(
-        host.defaultFeeRecipient)
-      v = host.validatorPool[].addValidator(res.get, feeRecipient)
-    if data.isSome():
-      v.updateValidator(data.get().index, data.get().validator.activation_epoch)
+    host.addValidator(res.get())
 
     RequestItemStatus(status: $KeystoreStatus.imported)
   else:
@@ -199,7 +193,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
           response.data.add(
             RequestItemStatus(status: $KeystoreStatus.duplicate))
       else:
-        host.addLocalValidator(res.get())
+        host.addValidator(res.get())
         response.data.add(
           RequestItemStatus(status: $KeystoreStatus.imported))
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -173,6 +173,7 @@ type
     dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
     validatorsRegCache*: Table[ValidatorPubKey, SignedValidatorRegistrationV1]
     rng*: ref HmacDrbgContext
+    polledIndices*: bool
 
   ValidatorClientRef* = ref ValidatorClient
 
@@ -508,37 +509,8 @@ proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
     feeRecipient = vc.config.validatorsDir.getSuggestedFeeRecipient(
       keystore.pubkey, vc.config.defaultFeeRecipient).valueOr(
         vc.config.defaultFeeRecipient)
-  case keystore.kind
-  of KeystoreKind.Local:
-    discard vc.attachedValidators[].addLocalValidator(keystore, feeRecipient)
-  of KeystoreKind.Remote:
-    let
-      httpFlags =
-        block:
-          var res: set[HttpClientFlag]
-          if RemoteKeystoreFlag.IgnoreSSLVerification in keystore.flags:
-            res.incl({HttpClientFlag.NoVerifyHost,
-                      HttpClientFlag.NoVerifyServerName})
-          res
-      prestoFlags = {RestClientFlag.CommaSeparatedArray}
-      clients =
-        block:
-          var res: seq[(RestClientRef, RemoteSignerInfo)]
-          for remote in keystore.remotes:
-            let client = RestClientRef.new($remote.url, prestoFlags,
-                                           httpFlags)
-            if client.isErr():
-              warn "Unable to resolve distributed signer address",
-                   remote_url = $remote.url, validator = $remote.pubkey
-            else:
-              res.add((client.get(), remote))
-          res
-    if len(clients) > 0:
-      discard vc.attachedValidators[].addRemoteValidator(keystore, clients,
-                                                         feeRecipient)
-    else:
-      warn "Unable to initialize remote validator",
-           validator = $keystore.pubkey
+
+  discard vc.attachedValidators[].addValidator(keystore, feeRecipient)
 
 proc removeValidator*(vc: ValidatorClientRef,
                       pubkey: ValidatorPubKey) {.async.} =

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -173,7 +173,6 @@ type
     dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
     validatorsRegCache*: Table[ValidatorPubKey, SignedValidatorRegistrationV1]
     rng*: ref HmacDrbgContext
-    polledIndices*: bool
 
   ValidatorClientRef* = ref ValidatorClient
 

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -96,11 +96,20 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
       list.add(validator)
 
   if len(updated) > 0:
-    info "Validator indices updated", missing_validators = len(missing),
-         updated_validators = len(updated)
+    info "Validator indices updated",
+      pending = len(validatorIdents) - len(updated),
+      missing = len(missing),
+      updated = len(updated)
     trace "Validator indices update dump", missing_validators = missing,
           updated_validators = updated
     vc.indicesAvailable.fire()
+
+  if not vc.polledIndices:
+    vc.polledIndices = true
+    for validator in vc.attachedValidators[].items():
+      if validator.needsUpdate():
+        notice "Validator deposit not yet processed, monitoring",
+          pubkey = validator.pubkey
 
 proc pollForAttesterDuties*(vc: ValidatorClientRef,
                             epoch: Epoch): Future[int] {.async.} =

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -1329,8 +1329,7 @@ proc addLocalValidator*(host: KeymanagerHost, keystore: KeystoreData) =
     data = host.getValidatorData(keystore.pubkey)
     feeRecipient = host.getSuggestedFeeRecipient(keystore.pubkey).valueOr(
       host.defaultFeeRecipient)
-
-  let v = host.validatorPool[].addLocalValidator(keystore, feeRecipient)
+    v = host.validatorPool[].addValidator(keystore, feeRecipient)
   if data.isSome():
     v.updateValidator(data.get().index, data.get().validator.activation_epoch)
 

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -64,10 +64,6 @@ type
 
   ImportResult*[T] = Result[T, AddValidatorFailure]
 
-  ValidatorAndIndex* = object
-    index*: ValidatorIndex
-    validator*: Validator
-
   ValidatorPubKeyToDataFn* =
     proc (pubkey: ValidatorPubKey): Opt[ValidatorAndIndex]
          {.raises: [Defect], gcsafe.}
@@ -108,22 +104,6 @@ func init*(T: type KeymanagerHost,
     defaultFeeRecipient: defaultFeeRecipient,
     getValidatorAndIdxFn: getValidatorAndIdxFn,
     getBeaconTimeFn: getBeaconTimeFn)
-
-proc getValidatorIdx*(host: KeymanagerHost,
-                      pubkey: ValidatorPubKey): Opt[ValidatorIndex] =
-  if not(isNil(host.getValidatorAndIdxFn)):
-    let res = host.getValidatorAndIdxFn(pubkey).valueOr:
-      return Opt.none ValidatorIndex
-    Opt.some res.index
-  else:
-    Opt.none ValidatorIndex
-
-proc getValidatorData*(host: KeymanagerHost,
-                       pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
-  if not(isNil(host.getValidatorAndIdxFn)):
-    host.getValidatorAndIdxFn(pubkey)
-  else:
-    Opt.none ValidatorAndIndex
 
 proc echoP*(msg: string) =
   ## Prints a paragraph aligned to 80 columns
@@ -1324,14 +1304,15 @@ proc getSuggestedFeeRecipient*(
     pubkey: ValidatorPubKey): Result[Eth1Address, FeeRecipientStatus] =
   host.validatorsDir.getSuggestedFeeRecipient(pubkey, host.defaultFeeRecipient)
 
-proc addLocalValidator*(host: KeymanagerHost, keystore: KeystoreData) =
+proc addValidator*(host: KeymanagerHost, keystore: KeystoreData) =
   let
-    data = host.getValidatorData(keystore.pubkey)
     feeRecipient = host.getSuggestedFeeRecipient(keystore.pubkey).valueOr(
       host.defaultFeeRecipient)
     v = host.validatorPool[].addValidator(keystore, feeRecipient)
-  if data.isSome():
-    v.updateValidator(data.get().index, data.get().validator.activation_epoch)
+
+  if host.getValidatorAndIdxFn != nil:
+    let data = host.getValidatorAndIdxFn(keystore.pubkey)
+    v.updateValidator(data)
 
 proc generateDeposits*(cfg: RuntimeConfig,
                        rng: var HmacDrbgContext,

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -1310,7 +1310,7 @@ proc addValidator*(host: KeymanagerHost, keystore: KeystoreData) =
       host.defaultFeeRecipient)
     v = host.validatorPool[].addValidator(keystore, feeRecipient)
 
-  if host.getValidatorAndIdxFn != nil:
+  if not isNil(host.getValidatorAndIdxFn):
     let data = host.getValidatorAndIdxFn(keystore.pubkey)
     v.updateValidator(data)
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -121,12 +121,7 @@ proc addValidators*(node: BeaconNode) =
         keystore.pubkey, index, epoch)
 
       v = node.attachedValidators[].addValidator(keystore, feeRecipient)
-
-    if data.isSome:
-      v.updateValidator(data.get().index, data.get().validator.activation_epoch)
-    else:
-      notice "Validator deposit not yet processed, monitoring",
-        pubkey = keystore.pubkey
+    v.updateValidator(data)
 
 proc getValidatorForDuties*(
     node: BeaconNode,
@@ -1472,7 +1467,9 @@ proc updateValidators(
       let index = validator.index.get()
       if index < validators.lenu64:
         validator.updateValidator(
-          index, validators[int index].activation_epoch)
+          Opt.some(ValidatorAndIndex(
+            index: index, validator: validators[int index]
+          )))
 
 proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
   ## Perform validator duties - create blocks, vote and aggregate existing votes

--- a/tests/test_validator_pool.nim
+++ b/tests/test_validator_pool.nim
@@ -11,6 +11,13 @@ import
   unittest2,
   ../beacon_chain/validators/validator_pool
 
+func makeValidatorAndIndex(
+    index: ValidatorIndex, activation_epoch: Epoch): Opt[ValidatorAndIndex] =
+  Opt.some ValidatorAndIndex(
+    index: index,
+    validator: Validator(activation_epoch: activation_epoch)
+  )
+
 suite "Validator pool":
   test "Doppelganger for genesis validator":
     let
@@ -19,7 +26,7 @@ suite "Validator pool":
     check:
       not v.triggersDoppelganger(GENESIS_EPOCH)
 
-    v.updateValidator(ValidatorIndex(1), GENESIS_EPOCH)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(1), GENESIS_EPOCH))
 
     check:
       not v.triggersDoppelganger(GENESIS_EPOCH)
@@ -33,13 +40,13 @@ suite "Validator pool":
       not v.triggersDoppelganger(GENESIS_EPOCH)
       not v.triggersDoppelganger(now.epoch())
 
-    v.updateValidator(ValidatorIndex(5), FAR_FUTURE_EPOCH)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), FAR_FUTURE_EPOCH))
 
     check: # We still don't know when validator activates so we wouldn't trigger
       not v.triggersDoppelganger(GENESIS_EPOCH)
       not v.triggersDoppelganger(now.epoch())
 
-    v.updateValidator(ValidatorIndex(5), now.epoch())
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch()))
 
     check:
       # Activates in current epoch, shouldn't trigger
@@ -50,7 +57,7 @@ suite "Validator pool":
       v = AttachedValidator(activationEpoch: FAR_FUTURE_EPOCH)
       now = Epoch(10).start_slot()
 
-    v.updateValidator(ValidatorIndex(5), now.epoch() - 1)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch() - 1))
 
     check:
       # Already activated, should trigger
@@ -61,7 +68,7 @@ suite "Validator pool":
       v = AttachedValidator(activationEpoch: FAR_FUTURE_EPOCH)
       now = Epoch(10).start_slot()
 
-    v.updateValidator(ValidatorIndex(5), now.epoch() + 1)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch() + 1))
 
     check:
       # Activates in the future, should not be checked
@@ -72,7 +79,7 @@ suite "Validator pool":
       v = AttachedValidator(activationEpoch: FAR_FUTURE_EPOCH)
       now = Epoch(10).start_slot()
 
-    v.updateValidator(ValidatorIndex(5), now.epoch() - 4)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch() - 4))
 
     check:
       v.triggersDoppelganger(now.epoch)
@@ -92,7 +99,7 @@ suite "Validator pool":
     check:
       not v.triggersDoppelganger(now.epoch)
 
-    v.updateValidator(ValidatorIndex(5), now.epoch())
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch()))
 
     check: # already proven not to validate
       not v.triggersDoppelganger(now.epoch)
@@ -103,7 +110,7 @@ suite "Validator pool":
       now = Epoch(10).start_slot()
 
     v.updateDoppelganger(now.epoch())
-    v.updateValidator(ValidatorIndex(5), now.epoch() + 1)
+    v.updateValidator(makeValidatorAndIndex(ValidatorIndex(5), now.epoch() + 1))
 
     check: # doesn't trigger check just after activation
       not v.triggersDoppelganger(now.epoch() + 1)


### PR DESCRIPTION
We do a linear scan of all pubkeys for each validator and slot - this becomes expensive with large validator counts.

* normalise BN/VC validator startup logging
* fix crash when host cannot be resolved while adding remote validator
* silence repeated log spam for unknown validators
* print pubkey/index/activation mapping on startup/validator identification