### PR TITLE
ignore systemctl failure in after_install scripts

### DIFF
--- a/scripts/package_src/nimbus_beacon_node/after_install
+++ b/scripts/package_src/nimbus_beacon_node/after_install
@@ -19,4 +19,5 @@ fi
 mkdir -p /var/lib/nimbus
 chown nimbus:nimbus /var/lib/nimbus
 
-systemctl daemon-reload
+# Systems like docker containers do not have systemd.
+systemctl daemon-reload || echo "notice: systemd daemon not reloaded" >&2

--- a/scripts/package_src/nimbus_validator_client/after_install
+++ b/scripts/package_src/nimbus_validator_client/after_install
@@ -19,4 +19,5 @@ fi
 mkdir -p /var/lib/nimbus
 chown nimbus:nimbus /var/lib/nimbus
 
-systemctl daemon-reload
+# Systems like docker containers do not have systemd.
+systemctl daemon-reload || echo "notice: systemd daemon not reloaded" >&2


### PR DESCRIPTION
Otherwise installation in Docker containers fails with:
```
...
Adding new user `nimbus' (UID 101) with group `nimbus' ...
Not creating home directory `/home/nimbus'.
/var/lib/dpkg/info/nimbus-beacon-node.postinst: 39: systemctl: not found
dpkg: error processing package nimbus-beacon-node (--configure):
 installed nimbus-beacon-node package post-installation script subprocess returned error exit status 127
Errors were encountered while processing:
 nimbus-beacon-node
E: Sub-process /usr/bin/dpkg returned an error code (1)
```