### PR TITLE
drop dependency on lsb-release script

### DIFF
--- a/scripts/make_packages.sh
+++ b/scripts/make_packages.sh
@@ -142,7 +142,6 @@ fpm -s dir -t deb -n "${PKG_NAME}" \
   -C "${PKG_IMG_DIR}" \
   -p "${PKG_PATH_DEB}" \
   -a "${PKG_ARCH_DEB}" \
-  --depends lsb-release \
   --after-install "${PKG_SRC_DIR}/after_install" \
   --before-remove "${PKG_SRC_DIR}/before_remove" \
   --after-remove "${PKG_SRC_DIR}/after_remove" \
@@ -159,7 +158,6 @@ fpm -s dir -t rpm -n "${PKG_NAME}" \
   -C "${PKG_IMG_DIR}" \
   -p "${PKG_PATH_RPM}" \
   -a "${PKG_ARCH_RPM}" \
-  --depends redhat-lsb-core \
   --after-install "${PKG_SRC_DIR}/after_install" \
   --before-remove "${PKG_SRC_DIR}/before_remove" \
   --after-remove "${PKG_SRC_DIR}/after_remove" \

--- a/scripts/package_src/nimbus_beacon_node/after_install
+++ b/scripts/package_src/nimbus_beacon_node/after_install
@@ -1,11 +1,15 @@
 #!/bin/bash
-
 set -e
 
-DISTRO=$(lsb_release -si)
+DISTRO="UNKNOWN"
+if [[ -r /etc/os-release ]]; then
+    source /etc/os-release
+    DISTRO="${ID}"
+fi
+
 if ! id -u nimbus > /dev/null 2>&1; then
   case $DISTRO in
-    Ubuntu|Debian)
+    Ubuntu|ubuntu|Debian|debian)
       # Debian uses `adduser` to create user...
       adduser --system --no-create-home --group nimbus
       ;;

--- a/scripts/package_src/nimbus_validator_client/after_install
+++ b/scripts/package_src/nimbus_validator_client/after_install
@@ -2,10 +2,15 @@
 
 set -e
 
-DISTRO=$(lsb_release -si)
+DISTRO="UNKNOWN"
+if [[ -r /etc/os-release ]]; then
+    . /etc/os-release
+    DISTRO="${ID}"
+fi
+
 if ! id -u nimbus > /dev/null 2>&1; then
   case $DISTRO in
-    Ubuntu|Debian)
+    Ubuntu|ubuntu|Debian|debian)
       # Debian uses `adduser` to create user...
       adduser --system --no-create-home --group nimbus
       ;;


### PR DESCRIPTION
The `/etc/os-release` file exists in most distributions and can be easily read in Bash by sourcing it:
```sh
 > docker run --rm -it debian:bullseye
root@2f5d6e038738:/# grep '^ID=' /etc/os-release
ID=debian
```
```sh
 > docker run --rm -it ubuntu:22.04
root@316b572b6e4d:/# grep '^ID=' /etc/os-release
ID=ubuntu
```
The dependency on `lsb-release` tool is unnecessary, and pulls in additional big dependencies like `python3`:
```sh
 # apt show lsb-release | grep Depends
Depends: python3:any, distro-info-data
```
Which if used in a Docker container would make it unnecessarily big.