### PR TITLE
feat: binaries config in build entrypoint

### DIFF
--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -17,7 +17,7 @@ if [[ -z "${1}" ]]; then
   exit 1
 fi
 PLATFORM="${1}"
-BINARIES="nimbus_beacon_node nimbus_validator_client"
+BINARIES="${BINARIES:-nimbus_beacon_node nimbus_validator_client}"
 
 echo "==================STARTING BUILD=================="
 echo "Build Tools = ${BUILD_TOOLS}"


### PR DESCRIPTION
This would make it possible to re-use the script to build other binaries, like `gnosis-chain-build` for example, by simply setting an environment variable.

Alternatively, it could be added as a second argument to the script (similar to how it works with `PLATFORM`).

Once the best way to proceed is defined, I can also add the configuration option to the `Dockerfiles`.