### PR TITLE
add deployment phase for Capella-ready networks

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -116,6 +116,7 @@ type
 
   DeploymentPhase* {.pure.} = enum
     Devnet = "devnet"
+    CapellaReady = "capella"
     Testnet = "testnet"
     Mainnet = "mainnet"
     None = "none"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1870,8 +1870,8 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
-  if not (metadata.cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH
-      or config.deploymentPhase == DeploymentPhase.None):
+  if not (metadata.cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH or
+      config.deploymentPhase == DeploymentPhase.None):
     config.deploymentPhase = DeploymentPhase.CapellaReady
 
   let node = BeaconNode.init(rng, config, metadata)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1870,6 +1870,9 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
+  if not (metadata.cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH
+      or config.deploymentPhase == DeploymentPhase.None):
+    config.deploymentPhase = DeploymentPhase.CapellaReady
 
   let node = BeaconNode.init(rng, config, metadata)
 


### PR DESCRIPTION
Allow distinguishing Capella-ready networks from non-upgraded networks based on `CAPELLA_FORK_EPOCH` being set (Zhejiang public testnet).