### PR TITLE
deprecate req/resp GetMetaData v1

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -47,9 +47,7 @@ proc initLightClient*(
         dag = node.dag.head.bid,
         wallSlot = node.currentSlot
       withBlck(signedBlock):
-        when stateFork == ConsensusFork.EIP4844:
-          debugRaiseAssert $eip4844ImplementationMissing & ": beacon_node_light_client.nim:initLightClient"
-        elif stateFork >= ConsensusFork.Bellatrix:
+        when stateFork >= ConsensusFork.Bellatrix:
           if blck.message.is_execution_block:
             template payload(): auto = blck.message.body.execution_payload
 

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -129,11 +129,6 @@ type
 
     body*: BeaconBlockBody
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/phase0/p2p-interface.md#metadata
-  MetaData* = object
-    seq_number*: uint64
-    attnets*: AttnetBits
-
   SigVerifiedBeaconBlock* = object
     ## A BeaconBlock that contains verified signatures
     ## but that has not been verified for state transition

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -281,9 +281,10 @@ p2pProtocol BeaconSync(version = 1,
     {.libp2pProtocol("ping", 1, isRequired = true).} =
     return peer.network.metadata.seq_number
 
-  proc getMetaData(peer: Peer): phase0.MetaData
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/p2p-interface.md#transitioning-from-v1-to-v2
+  proc getMetaData(peer: Peer): uint64
     {.libp2pProtocol("metadata", 1, isRequired = true).} =
-    return peer.network.phase0metadata
+    raise newException(InvalidInputsError, "GetMetaData v1 unsupported")
 
   proc getMetadata_v2(peer: Peer): altair.MetaData
     {.libp2pProtocol("metadata", 2, isRequired = true).} =


### PR DESCRIPTION
Should have been returning `InvalidRequest` already: https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/altair/p2p-interface.md#transitioning-from-v1-to-v2