### PR TITLE
make DEB package descriptions long

### DIFF
--- a/scripts/package_src/nimbus_beacon_node/description
+++ b/scripts/package_src/nimbus_beacon_node/description
@@ -1,1 +1,12 @@
 Nimbus Beacon Node / Ethereum Consensus client
+Nimbus is a client for the Ethereum network that is lightweight,
+secure and easy to use.
+.
+Its efficiency and low resource consumption allows it to perform well
+on all kinds of systems, ranging from Raspberry Pi's and mobile devices
+where it contributes to low power consumption and security
+-- to powerful servers where it leaves resources free to perform other tasks,
+such as running an execution node.
+.
+The beacon node connects to the beacon chain network, syncs historical data
+and provides API's to monitor and interact with the beacon chain.

--- a/scripts/package_src/nimbus_validator_client/description
+++ b/scripts/package_src/nimbus_validator_client/description
@@ -1,1 +1,12 @@
-Nimbus Validator Client
+Nimbus Validator Client for Ethereum
+Nimbus is a client for the Ethereum network that is lightweight,
+secure and easy to use.
+.
+Its efficiency and low resource consumption allows it to perform well
+on all kinds of systems, ranging from Raspberry Pi's and mobile devices
+where it contributes to low power consumption and security
+-- to powerful servers where it leaves resources free to perform other tasks,
+such as running an execution node.
+.
+The validator client allows advanced users to run validators in a separate
+process from the beacon node, allowing more flexible deployment strategies.


### PR DESCRIPTION
Apparently it's a good practice:
https://www.debian.org/doc/manuals/developers-reference/best-pkging-practices.html#the-long-description

Text mostly taken from https://nimbus.guide/.
