### PR TITLE
pass correct CI test flag to initializer

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -98,7 +98,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
 
   var forkChoice = ForkChoice.init(
     finalizedEpochRef, dag.finalizedHead.blck,
-    lowParticipation in dag.updateFlags)
+    experimental in dag.updateFlags)
 
   # Feed fork choice with unfinalized history - during startup, block pool only
   # keeps track of a single history so we just need to follow it


### PR DESCRIPTION
Use correct `experimental` flag for running tests.