### PR TITLE
rm unused `lowParticipation` flag

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -922,7 +922,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   cfg.checkForkConsistency()
 
   doAssert updateFlags - {
-      strictVerification, experimental, enableTestFeatures, lowParticipation
+      strictVerification, experimental, enableTestFeatures
     } == {}, "Other flags not supported in ChainDAG"
 
   # TODO we require that the db contains both a head and a tail block -
@@ -952,7 +952,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       # The only allowed flag right now is strictVerification, as the others all
       # allow skipping some validation.
       updateFlags: updateFlags * {
-        strictVerification, experimental, enableTestFeatures, lowParticipation
+        strictVerification, experimental, enableTestFeatures
       },
       cfg: cfg,
 

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -40,7 +40,5 @@ type
     ## Whether to enable extra features in development.
     enableTestFeatures ##\
     ## Whether to enable extra features for testing.
-    lowParticipation ##\
-    ## Whether the network is prone to low participation.
 
   UpdateFlags* = set[UpdateFlag]

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -177,11 +177,6 @@ func applyScoreChanges*(self: var ProtoArray,
   self.currentEpoch = currentEpoch
   self.checkpoints = checkpoints
 
-  # If previous epoch is justified, pull up all current tips to previous epoch
-  if self.experimental and self.isPreviousEpochJustified:
-    for realized in self.realizePendingCheckpoints(resetTipTracking = false):
-      discard
-
   ## Alias
   # This cannot raise the IndexError exception, how to tell compiler?
   template node: untyped {.dirty.} =
@@ -545,16 +540,6 @@ func nodeIsViableForHead(
 
   if node.invalid:
     return false
-
-  if self.hasLowParticipation:
-    return
-      if node.checkpoints.justified.epoch < self.checkpoints.justified.epoch:
-        false
-      elif self.isPreviousEpochJustified:
-        node.checkpoints.finalized.epoch >= self.checkpoints.finalized.epoch
-      else:
-        node.checkpoints.finalized == self.checkpoints.finalized or
-        self.checkpoints.finalized.epoch == GENESIS_EPOCH
 
   if self.experimental:
     var correctJustified =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -172,8 +172,6 @@ proc loadChainDag(
   var extraFlags = {enableTestFeatures}
   if config.deploymentPhase <= DeploymentPhase.Testnet:
     extraFlags.incl experimental
-  if config.deploymentPhase <= DeploymentPhase.Devnet:
-    extraFlags.incl lowParticipation
   let
     chainDagFlags =
       if config.strictVerification: {strictVerification}


### PR DESCRIPTION
Remove an unused flag and associated (unreachable) logic, as the flag wasn't even passed to that module.