### PR TITLE
e2store: avoid uint48

### DIFF
--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -20,8 +20,9 @@ const
   SnappyBeaconState* = [byte 0x02, 0x00]
 
   TypeFieldLen = 2
-  LengthFieldLen = 6
-  HeaderFieldLen = TypeFieldLen + LengthFieldLen
+  LengthFieldLen = 4
+  ReservedFieldLen = 2
+  HeaderFieldLen = TypeFieldLen + LengthFieldLen + ReservedFieldLen
 
   FAR_FUTURE_ERA* = Era(not 0'u64)
 
@@ -71,10 +72,14 @@ proc append(f: IoHandle, data: openArray[byte]): Result[void, string] =
   ok()
 
 proc appendHeader(f: IoHandle, typ: Type, dataLen: int): Result[int64, string] =
+  if dataLen.uint64 > uint32.high:
+    return err("entry does not fit 32-bit length")
+
   let start = ? getFilePos(f).mapErr(toString)
 
   ? append(f, typ)
-  ? append(f, toBytesLE(dataLen.uint64).toOpenArray(0, 5))
+  ? append(f, toBytesLE(dataLen.uint32))
+  ? append(f, [0'u8, 0'u8])
 
   ok(start)
 
@@ -137,9 +142,9 @@ proc readHeader(f: IoHandle): Result[Header, string] =
     typ: Type
   discard typ.copyFrom(buf)
 
-  # Cast safe because we had only 6 bytes of length data
+  # Cast safe because we had only 4 bytes of length data
   let
-    len = cast[int64](uint64.fromBytesLE(buf.toOpenArray(2, 9)))
+    len = cast[int64](uint32.fromBytesLE(buf.toOpenArray(2, 5)))
 
   # No point reading these..
   if len > int.high(): return err("header length exceeds int.high")

--- a/ncli/e2store.py
+++ b/ncli/e2store.py
@@ -5,7 +5,7 @@ def read_entry(f):
   if not header: return (None, None)
 
   typ = header[0:2] # 2 bytes of type
-  dlen = struct.unpack("<q", header[2:8] + b"\0\0")[0] # 6 bytes of little-endian length
+  dlen = struct.unpack("<I", header[2:6])[0] # 4 bytes of unsigned little-endian length
 
   data = f.read(dlen)
 


### PR DESCRIPTION
In SSZ, `uint32` is used for offsets, effectively limiting the size of an SSZ entry to 2**32 bytes.

Also, `uint48` isn't a valid SSZ type, so the header was not correctly defined according to the SSZ spec - the extra 2 bytes are left for future expansion instead.