### PR TITLE
VC: Use not-synced/opt-synced BNs.

### DIFF
--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -645,6 +645,7 @@ proc getProposerDuties*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve proposer duties"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -656,6 +657,7 @@ proc getProposerDuties*(
       if apiResponse.isErr():
         trace ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -667,26 +669,30 @@ proc getProposerDuties*(
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -698,6 +704,7 @@ proc getProposerDuties*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node,  error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -709,25 +716,29 @@ proc getProposerDuties*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getAttesterDuties*(
        vc: ValidatorClientRef,
@@ -740,6 +751,7 @@ proc getAttesterDuties*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve attester duties"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -751,6 +763,7 @@ proc getAttesterDuties*(
       if apiResponse.isErr():
         trace ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -762,26 +775,30 @@ proc getAttesterDuties*(
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -793,6 +810,7 @@ proc getAttesterDuties*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -804,25 +822,29 @@ proc getAttesterDuties*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getSyncCommitteeDuties*(
        vc: ValidatorClientRef,
@@ -835,6 +857,7 @@ proc getSyncCommitteeDuties*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve sync committee duties"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -847,6 +870,7 @@ proc getSyncCommitteeDuties*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -858,26 +882,30 @@ proc getSyncCommitteeDuties*(
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -889,6 +917,7 @@ proc getSyncCommitteeDuties*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -900,25 +929,29 @@ proc getSyncCommitteeDuties*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getForkSchedule*(
        vc: ValidatorClientRef,
@@ -929,6 +962,7 @@ proc getForkSchedule*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve fork schedule"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -940,6 +974,7 @@ proc getForkSchedule*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -951,15 +986,17 @@ proc getForkSchedule*(
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data.data
 
   of ApiStrategyKind.Priority:
@@ -971,6 +1008,7 @@ proc getForkSchedule*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -982,13 +1020,16 @@ proc getForkSchedule*(
           debug ResponseInternalError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
-    raise newException(ValidatorApiError, ErrorMessage)
+
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getHeadBlockRoot*(
        vc: ValidatorClientRef,
@@ -1001,6 +1042,7 @@ proc getHeadBlockRoot*(
   let blockIdent = BlockIdent.init(BlockIdentType.Head)
 
   const ErrorMessage = "Unable to retrieve head block's root"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1012,6 +1054,7 @@ proc getHeadBlockRoot*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1023,25 +1066,29 @@ proc getHeadBlockRoot*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 404:
           debug ResponseNotFoundError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotFound))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -1053,6 +1100,7 @@ proc getHeadBlockRoot*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1064,24 +1112,28 @@ proc getHeadBlockRoot*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 404:
           debug ResponseNotFoundError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotFound))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getValidators*(
        vc: ValidatorClientRef,
@@ -1095,6 +1147,7 @@ proc getValidators*(
   let stateIdent = StateIdent.init(StateIdentType.Head)
 
   const ErrorMessage = "Unable to retrieve head state's validator information"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1106,6 +1159,7 @@ proc getValidators*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1117,25 +1171,29 @@ proc getValidators*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 404:
           debug ResponseNotFoundError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotFound))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data.data
 
   of ApiStrategyKind.Priority:
@@ -1147,6 +1205,7 @@ proc getValidators*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1158,24 +1217,28 @@ proc getValidators*(
           debug ResponseInvalidError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 404:
           debug ResponseNotFoundError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotFound))
           false
         of 500:
           debug ResponseInternalError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError,
                 response_code = response.status, endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc produceAttestationData*(
        vc: ValidatorClientRef,
@@ -1188,6 +1251,7 @@ proc produceAttestationData*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve attestation data"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1200,6 +1264,7 @@ proc produceAttestationData*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1211,26 +1276,30 @@ proc produceAttestationData*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data.data
 
   of ApiStrategyKind.Priority:
@@ -1244,6 +1313,7 @@ proc produceAttestationData*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1255,25 +1325,29 @@ proc produceAttestationData*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc submitPoolAttestations*(
        vc: ValidatorClientRef,
@@ -1287,6 +1361,7 @@ proc submitPoolAttestations*(
   const
     ErrorMessage = "Unable to submit attestation"
     NoErrorMessage = "Attestation was sucessfully published"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1298,6 +1373,7 @@ proc submitPoolAttestations*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1310,22 +1386,25 @@ proc submitPoolAttestations*(
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -1337,6 +1416,7 @@ proc submitPoolAttestations*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1349,21 +1429,24 @@ proc submitPoolAttestations*(
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc submitPoolSyncCommitteeSignature*(
        vc: ValidatorClientRef,
@@ -1384,6 +1467,7 @@ proc submitPoolSyncCommitteeSignature*(
   const
     ErrorMessage = "Unable to submit sync committee message"
     NoErrorMessage = "Sync committee message was successfully published"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1396,6 +1480,7 @@ proc submitPoolSyncCommitteeSignature*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1408,22 +1493,25 @@ proc submitPoolSyncCommitteeSignature*(
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -1436,6 +1524,7 @@ proc submitPoolSyncCommitteeSignature*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1448,21 +1537,24 @@ proc submitPoolSyncCommitteeSignature*(
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getIndexedErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc getAggregatedAttestation*(
        vc: ValidatorClientRef,
@@ -1475,6 +1567,7 @@ proc getAggregatedAttestation*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve aggregated attestation data"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1487,6 +1580,7 @@ proc getAggregatedAttestation*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1498,20 +1592,23 @@ proc getAggregatedAttestation*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data.data
 
   of ApiStrategyKind.Priority:
@@ -1524,6 +1621,7 @@ proc getAggregatedAttestation*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1535,19 +1633,22 @@ proc getAggregatedAttestation*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc produceSyncCommitteeContribution*(
        vc: ValidatorClientRef,
@@ -1561,6 +1662,7 @@ proc produceSyncCommitteeContribution*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve sync committee contribution data"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1573,6 +1675,7 @@ proc produceSyncCommitteeContribution*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1584,20 +1687,23 @@ proc produceSyncCommitteeContribution*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data.data
 
   of ApiStrategyKind.Priority:
@@ -1610,6 +1716,7 @@ proc produceSyncCommitteeContribution*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1621,19 +1728,22 @@ proc produceSyncCommitteeContribution*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc publishAggregateAndProofs*(
        vc: ValidatorClientRef,
@@ -1647,6 +1757,7 @@ proc publishAggregateAndProofs*(
   const
     ErrorMessage = "Unable to publish aggregate and proofs"
     NoErrorMessage = "Aggregate and proofs was sucessfully published"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1658,6 +1769,7 @@ proc publishAggregateAndProofs*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1670,22 +1782,25 @@ proc publishAggregateAndProofs*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -1697,6 +1812,7 @@ proc publishAggregateAndProofs*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1709,21 +1825,24 @@ proc publishAggregateAndProofs*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc publishContributionAndProofs*(
        vc: ValidatorClientRef,
@@ -1737,6 +1856,7 @@ proc publishContributionAndProofs*(
   const
     ErrorMessage = "Unable to publish contribution and proofs"
     NoErrorMessage = "Contribution and proofs were successfully published"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1748,6 +1868,7 @@ proc publishContributionAndProofs*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1760,22 +1881,25 @@ proc publishContributionAndProofs*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -1787,6 +1911,7 @@ proc publishContributionAndProofs*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1799,21 +1924,24 @@ proc publishContributionAndProofs*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc produceBlockV2*(
        vc: ValidatorClientRef,
@@ -1827,6 +1955,7 @@ proc produceBlockV2*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve block data"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1839,6 +1968,7 @@ proc produceBlockV2*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1850,26 +1980,30 @@ proc produceBlockV2*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -1882,6 +2016,7 @@ proc produceBlockV2*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -1893,25 +2028,29 @@ proc produceBlockV2*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc publishBlock*(
        vc: ValidatorClientRef,
@@ -1926,6 +2065,7 @@ proc publishBlock*(
     BlockPublished = "Block was successfully published"
     BlockBroadcasted = "Block not passed validation, but still published"
     ErrorMessage = "Unable to publish block"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -1954,6 +2094,7 @@ proc publishBlock*(
         if apiResponse.isErr():
           debug ErrorMessage, endpoint = node, error = apiResponse.error()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
           false
         else:
           let response = apiResponse.get()
@@ -1969,12 +2110,14 @@ proc publishBlock*(
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Incompatible
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
             false
           of 500:
             debug ResponseInternalError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Offline
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
             false
           of 503:
             debug ResponseNoSyncError, response_code = response.status,
@@ -1982,16 +2125,18 @@ proc publishBlock*(
                   response_error = response.getErrorMessage()
             if node.status notin NotSyncedStatus:
               node.status = RestBeaconNodeStatus.NotSynced
+            failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
             false
           else:
             debug ResponseUnexpectedError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Offline
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
             false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -2018,6 +2163,7 @@ proc publishBlock*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -2033,12 +2179,14 @@ proc publishBlock*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
@@ -2046,15 +2194,17 @@ proc publishBlock*(
                 response_error = response.getErrorMessage()
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc produceBlindedBlock*(
        vc: ValidatorClientRef,
@@ -2068,6 +2218,7 @@ proc produceBlindedBlock*(
     strategy = $strategy
 
   const ErrorMessage = "Unable to retrieve block data"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -2080,6 +2231,7 @@ proc produceBlindedBlock*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -2091,26 +2243,30 @@ proc produceBlindedBlock*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data
 
   of ApiStrategyKind.Priority:
@@ -2123,6 +2279,7 @@ proc produceBlindedBlock*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -2134,25 +2291,29 @@ proc produceBlindedBlock*(
           debug ResponseInvalidError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc publishBlindedBlock*(
        vc: ValidatorClientRef,
@@ -2167,6 +2328,7 @@ proc publishBlindedBlock*(
     BlockPublished = "Block was successfully published"
     BlockBroadcasted = "Block not passed validation, but still published"
     ErrorMessage = "Unable to publish block"
+  var failures: seq[ApiNodeFailure]
 
   case strategy
   of ApiStrategyKind.First, ApiStrategyKind.Best:
@@ -2194,6 +2356,7 @@ proc publishBlindedBlock*(
         if apiResponse.isErr():
           debug ErrorMessage, endpoint = node, error = apiResponse.error()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
           false
         else:
           let response = apiResponse.get()
@@ -2209,12 +2372,14 @@ proc publishBlindedBlock*(
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Incompatible
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
             false
           of 500:
             debug ResponseInternalError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Offline
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
             false
           of 503:
             debug ResponseNoSyncError, response_code = response.status,
@@ -2222,16 +2387,18 @@ proc publishBlindedBlock*(
                   response_error = response.getErrorMessage()
             if node.status notin NotSyncedStatus:
               node.status = RestBeaconNodeStatus.NotSynced
+            failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
             false
           else:
             debug ResponseUnexpectedError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
             node.status = RestBeaconNodeStatus.Offline
+            failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
             false
 
     if res.isErr():
-      raise newException(ValidatorApiError, res.error())
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return true
 
   of ApiStrategyKind.Priority:
@@ -2258,6 +2425,7 @@ proc publishBlindedBlock*(
       if apiResponse.isErr():
         debug ErrorMessage, endpoint = node, error = apiResponse.error()
         node.status = RestBeaconNodeStatus.Offline
+        failures.add(ApiNodeFailure.init(node, ApiFailure.Communication))
         false
       else:
         let response = apiResponse.get()
@@ -2273,12 +2441,14 @@ proc publishBlindedBlock*(
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Incompatible
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Invalid))
           false
         of 500:
           debug ResponseInternalError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Internal))
           false
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
@@ -2286,15 +2456,17 @@ proc publishBlindedBlock*(
                 response_error = response.getErrorMessage()
           if node.status notin NotSyncedStatus:
             node.status = RestBeaconNodeStatus.NotSynced
+          failures.add(ApiNodeFailure.init(node, ApiFailure.NotSynced))
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
           node.status = RestBeaconNodeStatus.Offline
+          failures.add(ApiNodeFailure.init(node, ApiFailure.Unexpected))
           false
 
-    raise newException(ValidatorApiError, ErrorMessage)
+    raise (ref ValidatorApiError)(msg: ErrorMessage, data: failures)
 
 proc prepareBeaconCommitteeSubnet*(
        vc: ValidatorClientRef,

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -41,6 +41,8 @@ const
                       RestBeaconNodeStatus.NotSynced,
                       RestBeaconNodeStatus.OptSynced,
                       RestBeaconNodeStatus.Synced}
+  NotSyncedStatus = {RestBeaconNodeStatus.NotSynced,
+                     RestBeaconNodeStatus.OptSynced}
 
 proc `$`*(strategy: ApiStrategyKind): string =
   case strategy
@@ -674,7 +676,8 @@ proc getProposerDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -715,7 +718,8 @@ proc getProposerDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -767,7 +771,8 @@ proc getAttesterDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -808,7 +813,8 @@ proc getAttesterDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -861,7 +867,8 @@ proc getSyncCommitteeDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -902,7 +909,8 @@ proc getSyncCommitteeDuties*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -1212,7 +1220,8 @@ proc produceAttestationData*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -1255,7 +1264,8 @@ proc produceAttestationData*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -1849,7 +1859,8 @@ proc produceBlockV2*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -1891,7 +1902,8 @@ proc produceBlockV2*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -1968,7 +1980,8 @@ proc publishBlock*(
             debug ResponseNoSyncError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
-            node.status = RestBeaconNodeStatus.NotSynced
+            if node.status notin NotSyncedStatus:
+              node.status = RestBeaconNodeStatus.NotSynced
             false
           else:
             debug ResponseUnexpectedError, response_code = response.status,
@@ -2031,7 +2044,8 @@ proc publishBlock*(
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -2086,7 +2100,8 @@ proc produceBlindedBlock*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -2128,7 +2143,8 @@ proc produceBlindedBlock*(
         of 503:
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -2204,7 +2220,8 @@ proc publishBlindedBlock*(
             debug ResponseNoSyncError, response_code = response.status,
                   endpoint = node,
                   response_error = response.getErrorMessage()
-            node.status = RestBeaconNodeStatus.NotSynced
+            if node.status notin NotSyncedStatus:
+              node.status = RestBeaconNodeStatus.NotSynced
             false
           else:
             debug ResponseUnexpectedError, response_code = response.status,
@@ -2267,7 +2284,8 @@ proc publishBlindedBlock*(
           debug ResponseNoSyncError, response_code = response.status,
                 endpoint = node,
                 response_error = response.getErrorMessage()
-          node.status = RestBeaconNodeStatus.NotSynced
+          if node.status notin NotSyncedStatus:
+            node.status = RestBeaconNodeStatus.NotSynced
           false
         else:
           debug ResponseUnexpectedError, response_code = response.status,
@@ -2636,7 +2654,8 @@ proc getValidatorsLiveness*(
                 response_code = response.status,
                 endpoint = apiResponse.node,
                 response_error = response.getErrorMessage()
-          apiResponse.node.status = RestBeaconNodeStatus.NotSynced
+          if apiResponse.node.status notin NotSyncedStatus:
+            apiResponse.node.status = RestBeaconNodeStatus.NotSynced
           continue
         else:
           debug "Server reports unexpected error code",

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -81,12 +81,12 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
   let res =
     try:
       await vc.submitPoolAttestations(@[attestation], ApiStrategyKind.First)
-    except ValidatorApiError:
+    except ValidatorApiError as exc:
       error "Unable to publish attestation",
             attestation = shortLog(attestation),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason()
+            reason = vc.getFailureReason(exc)
       return false
     except CancelledError as exc:
       debug "Attestation publishing process was interrupted"
@@ -161,12 +161,12 @@ proc serveAggregateAndProof*(service: AttestationServiceRef,
   let res =
     try:
       await vc.publishAggregateAndProofs(@[signedProof], ApiStrategyKind.First)
-    except ValidatorApiError:
+    except ValidatorApiError as exc:
       error "Unable to publish aggregated attestation",
             attestation = shortLog(signedProof.message.aggregate),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason()
+            reason = vc.getFailureReason(exc)
       return false
     except CancelledError as exc:
       debug "Publish aggregate and proofs request was interrupted"
@@ -289,10 +289,10 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
       try:
         await vc.getAggregatedAttestation(slot, attestationRoot,
                                           ApiStrategyKind.Best)
-      except ValidatorApiError:
+      except ValidatorApiError as exc:
         error "Unable to get aggregated attestation data", slot = slot,
               attestation_root = shortLog(attestationRoot),
-              reason = vc.getFailureReason()
+              reason = vc.getFailureReason(exc)
         return
       except CancelledError as exc:
         debug "Aggregated attestation request was interrupted"
@@ -363,10 +363,10 @@ proc publishAttestationsAndAggregates(service: AttestationServiceRef,
   let ad =
     try:
       await service.produceAndPublishAttestations(slot, committee_index, duties)
-    except ValidatorApiError:
+    except ValidatorApiError as exc:
       error "Unable to proceed attestations", slot = slot,
             committee_index = committee_index, duties_count = len(duties),
-            reason = vc.getFailureReason()
+            reason = vc.getFailureReason(exc)
       return
     except CancelledError as exc:
       debug "Publish attestation request was interrupted"

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -85,7 +85,8 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
       error "Unable to publish attestation",
             attestation = shortLog(attestation),
             validator = shortLog(validator),
-            validator_index = vindex
+            validator_index = vindex,
+            reason = vc.getFailureReason()
       return false
     except CancelledError as exc:
       debug "Attestation publishing process was interrupted"
@@ -164,7 +165,8 @@ proc serveAggregateAndProof*(service: AttestationServiceRef,
       error "Unable to publish aggregated attestation",
             attestation = shortLog(signedProof.message.aggregate),
             validator = shortLog(validator),
-            validator_index = vindex
+            validator_index = vindex,
+            reason = vc.getFailureReason()
       return false
     except CancelledError as exc:
       debug "Publish aggregate and proofs request was interrupted"
@@ -289,7 +291,8 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
                                           ApiStrategyKind.Best)
       except ValidatorApiError:
         error "Unable to get aggregated attestation data", slot = slot,
-              attestation_root = shortLog(attestationRoot)
+              attestation_root = shortLog(attestationRoot),
+              reason = vc.getFailureReason()
         return
       except CancelledError as exc:
         debug "Aggregated attestation request was interrupted"
@@ -362,7 +365,8 @@ proc publishAttestationsAndAggregates(service: AttestationServiceRef,
       await service.produceAndPublishAttestations(slot, committee_index, duties)
     except ValidatorApiError:
       error "Unable to proceed attestations", slot = slot,
-            committee_index = committee_index, duties_count = len(duties)
+            committee_index = committee_index, duties_count = len(duties),
+            reason = vc.getFailureReason()
       return
     except CancelledError as exc:
       debug "Publish attestation request was interrupted"

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -86,7 +86,7 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
             attestation = shortLog(attestation),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason(exc)
+            reason = exc.getFailureReason()
       return false
     except CancelledError as exc:
       debug "Attestation publishing process was interrupted"
@@ -166,7 +166,7 @@ proc serveAggregateAndProof*(service: AttestationServiceRef,
             attestation = shortLog(signedProof.message.aggregate),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason(exc)
+            reason = exc.getFailureReason()
       return false
     except CancelledError as exc:
       debug "Publish aggregate and proofs request was interrupted"
@@ -292,7 +292,7 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
       except ValidatorApiError as exc:
         error "Unable to get aggregated attestation data", slot = slot,
               attestation_root = shortLog(attestationRoot),
-              reason = vc.getFailureReason(exc)
+              reason = exc.getFailureReason()
         return
       except CancelledError as exc:
         debug "Aggregated attestation request was interrupted"
@@ -366,7 +366,7 @@ proc publishAttestationsAndAggregates(service: AttestationServiceRef,
     except ValidatorApiError as exc:
       error "Unable to proceed attestations", slot = slot,
             committee_index = committee_index, duties_count = len(duties),
-            reason = vc.getFailureReason(exc)
+            reason = exc.getFailureReason()
       return
     except CancelledError as exc:
       debug "Publish attestation request was interrupted"

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -39,7 +39,7 @@ proc produceBlock(
         await vc.produceBlockV2(slot, randao_reveal, graffiti,
                                 ApiStrategyKind.Best)
       except ValidatorApiError:
-        error "Unable to retrieve block data"
+        error "Unable to retrieve block data", reason = vc.getFailureReason()
         return Opt.none(PreparedBeaconBlock)
       except CancelledError as exc:
         error "Block data production has been interrupted"
@@ -69,7 +69,8 @@ proc produceBlindedBlock(
         await vc.produceBlindedBlock(slot, randao_reveal, graffiti,
                                      ApiStrategyKind.Best)
       except ValidatorApiError as exc:
-        error "Unable to retrieve blinded block data", error_msg = exc.msg
+        error "Unable to retrieve blinded block data", error_msg = exc.msg,
+              reason = vc.getFailureReason()
         return Opt.none(PreparedBlindedBeaconBlock)
       except CancelledError as exc:
         error "Blinded block data production has been interrupted"
@@ -215,7 +216,8 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
             debug "Sending blinded block"
             await vc.publishBlindedBlock(signedBlock, ApiStrategyKind.First)
           except ValidatorApiError:
-            error "Unable to publish blinded block"
+            error "Unable to publish blinded block",
+                  reason = vc.getFailureReason()
             return
           except CancelledError as exc:
             debug "Blinded block publication has been interrupted"
@@ -276,7 +278,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
             debug "Sending block"
             await vc.publishBlock(signedBlock, ApiStrategyKind.First)
           except ValidatorApiError:
-            error "Unable to publish block"
+            error "Unable to publish block", reason = vc.getFailureReason()
             return
           except CancelledError as exc:
             debug "Block publication has been interrupted"

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -38,8 +38,8 @@ proc produceBlock(
       try:
         await vc.produceBlockV2(slot, randao_reveal, graffiti,
                                 ApiStrategyKind.Best)
-      except ValidatorApiError:
-        error "Unable to retrieve block data", reason = vc.getFailureReason()
+      except ValidatorApiError as exc:
+        error "Unable to retrieve block data", reason = vc.getFailureReason(exc)
         return Opt.none(PreparedBeaconBlock)
       except CancelledError as exc:
         error "Block data production has been interrupted"
@@ -70,7 +70,7 @@ proc produceBlindedBlock(
                                      ApiStrategyKind.Best)
       except ValidatorApiError as exc:
         error "Unable to retrieve blinded block data", error_msg = exc.msg,
-              reason = vc.getFailureReason()
+              reason = vc.getFailureReason(exc)
         return Opt.none(PreparedBlindedBeaconBlock)
       except CancelledError as exc:
         error "Blinded block data production has been interrupted"
@@ -215,9 +215,9 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
           try:
             debug "Sending blinded block"
             await vc.publishBlindedBlock(signedBlock, ApiStrategyKind.First)
-          except ValidatorApiError:
+          except ValidatorApiError as exc:
             error "Unable to publish blinded block",
-                  reason = vc.getFailureReason()
+                  reason = vc.getFailureReason(exc)
             return
           except CancelledError as exc:
             debug "Blinded block publication has been interrupted"
@@ -277,8 +277,8 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
           try:
             debug "Sending block"
             await vc.publishBlock(signedBlock, ApiStrategyKind.First)
-          except ValidatorApiError:
-            error "Unable to publish block", reason = vc.getFailureReason()
+          except ValidatorApiError as exc:
+            error "Unable to publish block", reason = vc.getFailureReason(exc)
             return
           except CancelledError as exc:
             debug "Block publication has been interrupted"

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -39,7 +39,7 @@ proc produceBlock(
         await vc.produceBlockV2(slot, randao_reveal, graffiti,
                                 ApiStrategyKind.Best)
       except ValidatorApiError as exc:
-        error "Unable to retrieve block data", reason = vc.getFailureReason(exc)
+        error "Unable to retrieve block data", reason = exc.getFailureReason()
         return Opt.none(PreparedBeaconBlock)
       except CancelledError as exc:
         error "Block data production has been interrupted"
@@ -70,7 +70,7 @@ proc produceBlindedBlock(
                                      ApiStrategyKind.Best)
       except ValidatorApiError as exc:
         error "Unable to retrieve blinded block data", error_msg = exc.msg,
-              reason = vc.getFailureReason(exc)
+              reason = exc.getFailureReason()
         return Opt.none(PreparedBlindedBeaconBlock)
       except CancelledError as exc:
         error "Blinded block data production has been interrupted"
@@ -217,7 +217,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
             await vc.publishBlindedBlock(signedBlock, ApiStrategyKind.First)
           except ValidatorApiError as exc:
             error "Unable to publish blinded block",
-                  reason = vc.getFailureReason(exc)
+                  reason = exc.getFailureReason()
             return
           except CancelledError as exc:
             debug "Blinded block publication has been interrupted"
@@ -278,7 +278,7 @@ proc publishBlock(vc: ValidatorClientRef, currentSlot, slot: Slot,
             debug "Sending block"
             await vc.publishBlock(signedBlock, ApiStrategyKind.First)
           except ValidatorApiError as exc:
-            error "Unable to publish block", reason = vc.getFailureReason(exc)
+            error "Unable to publish block", reason = exc.getFailureReason()
             return
           except CancelledError as exc:
             debug "Block publication has been interrupted"

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -266,8 +266,7 @@ proc getNodeCounts*(vc: ValidatorClientRef): BeaconNodesCounters =
   for node in vc.beaconNodes: inc(res.data[int(node.status)])
   res
 
-proc getFailureReason*(vc: ValidatorClientRef,
-                       exc: ref ValidatorApiError): string =
+proc getFailureReason*(exc: ref ValidatorApiError): string =
   var counts: array[int(high(ApiFailure)) + 1, int]
   let errors = exc[].data
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -64,7 +64,7 @@ type
   DutiesServiceRef* = ref object of ClientServiceRef
 
   FallbackServiceRef* = ref object of ClientServiceRef
-    onlineEvent*: AsyncEvent
+    changesEvent*: AsyncEvent
 
   ForkServiceRef* = ref object of ClientServiceRef
 
@@ -127,7 +127,7 @@ type
     duties*: Table[Epoch, SyncCommitteeDuty]
 
   RestBeaconNodeStatus* {.pure.} = enum
-    Uninitalized, Offline, Incompatible, NotSynced, Online
+    Uninitalized, Offline, Incompatible, NotSynced, OptSynced, Online
 
   BeaconNodeServerRef* = ref BeaconNodeServer
 

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -139,7 +139,7 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
       try:
         await vc.getAttesterDuties(epoch, indices, ApiStrategyKind.First)
       except ValidatorApiError:
-        error "Unable to get attester duties", epoch = epoch
+        notice "Unable to get attester duties", epoch = epoch
         return 0
       except CancelledError as exc:
         debug "Attester duties processing was interrupted"
@@ -272,7 +272,7 @@ proc pollForSyncCommitteeDuties*(vc: ValidatorClientRef,
         try:
           await vc.getSyncCommitteeDuties(epoch, indices, ApiStrategyKind.First)
         except ValidatorApiError:
-          error "Unable to get sync committee duties", epoch = epoch
+          notice "Unable to get sync committee duties", epoch = epoch
           return 0
         except CancelledError as exc:
           debug "Sync committee duties processing was interrupted"
@@ -503,8 +503,8 @@ proc pollForBeaconProposers*(vc: ValidatorClientRef) {.async.} =
           debug "No relevant proposer duties received", slot = currentSlot,
                 duties_count = len(duties)
       except ValidatorApiError:
-        debug "Unable to get proposer duties", slot = currentSlot,
-              epoch = currentEpoch
+        notice "Unable to get proposer duties", slot = currentSlot,
+               epoch = currentEpoch
       except CancelledError as exc:
         debug "Proposer duties processing was interrupted"
         raise exc

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -139,7 +139,8 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
       try:
         await vc.getAttesterDuties(epoch, indices, ApiStrategyKind.First)
       except ValidatorApiError:
-        notice "Unable to get attester duties", epoch = epoch
+        notice "Unable to get attester duties", epoch = epoch,
+               reason = vc.getFailureReason()
         return 0
       except CancelledError as exc:
         debug "Attester duties processing was interrupted"
@@ -272,7 +273,8 @@ proc pollForSyncCommitteeDuties*(vc: ValidatorClientRef,
         try:
           await vc.getSyncCommitteeDuties(epoch, indices, ApiStrategyKind.First)
         except ValidatorApiError:
-          notice "Unable to get sync committee duties", epoch = epoch
+          notice "Unable to get sync committee duties", epoch = epoch,
+                 reason = vc.getFailureReason()
           return 0
         except CancelledError as exc:
           debug "Sync committee duties processing was interrupted"
@@ -504,7 +506,7 @@ proc pollForBeaconProposers*(vc: ValidatorClientRef) {.async.} =
                 duties_count = len(duties)
       except ValidatorApiError:
         notice "Unable to get proposer duties", slot = currentSlot,
-               epoch = currentEpoch
+               epoch = currentEpoch, reason = vc.getFailureReason()
       except CancelledError as exc:
         debug "Proposer duties processing was interrupted"
         raise exc

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -65,9 +65,9 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
     let res =
       try:
         await vc.getValidators(idents, ApiStrategyKind.First)
-      except ValidatorApiError:
+      except ValidatorApiError as exc:
         error "Unable to get head state's validator information",
-              reason = vc.getFailureReason()
+              reason = vc.getFailureReason(exc)
         return
       except CancelledError as exc:
         debug "Validator's indices processing was interrupted"
@@ -139,9 +139,9 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
     let res =
       try:
         await vc.getAttesterDuties(epoch, indices, ApiStrategyKind.First)
-      except ValidatorApiError:
+      except ValidatorApiError as exc:
         notice "Unable to get attester duties", epoch = epoch,
-               reason = vc.getFailureReason()
+               reason = vc.getFailureReason(exc)
         return 0
       except CancelledError as exc:
         debug "Attester duties processing was interrupted"
@@ -273,9 +273,9 @@ proc pollForSyncCommitteeDuties*(vc: ValidatorClientRef,
       res =
         try:
           await vc.getSyncCommitteeDuties(epoch, indices, ApiStrategyKind.First)
-        except ValidatorApiError:
+        except ValidatorApiError as exc:
           notice "Unable to get sync committee duties", epoch = epoch,
-                 reason = vc.getFailureReason()
+                 reason = vc.getFailureReason(exc)
           return 0
         except CancelledError as exc:
           debug "Sync committee duties processing was interrupted"
@@ -505,9 +505,9 @@ proc pollForBeaconProposers*(vc: ValidatorClientRef) {.async.} =
         else:
           debug "No relevant proposer duties received", slot = currentSlot,
                 duties_count = len(duties)
-      except ValidatorApiError:
+      except ValidatorApiError as exc:
         notice "Unable to get proposer duties", slot = currentSlot,
-               epoch = currentEpoch, reason = vc.getFailureReason()
+               epoch = currentEpoch, reason = vc.getFailureReason(exc)
       except CancelledError as exc:
         debug "Proposer duties processing was interrupted"
         raise exc
@@ -534,7 +534,7 @@ proc prepareBeaconProposers*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to prepare beacon proposers", slot = currentSlot,
                 epoch = currentEpoch, err_name = exc.name,
-                err_msg = exc.msg, reason = vc.getFailureReason()
+                err_msg = exc.msg, reason = vc.getFailureReason(exc)
           0
         except CancelledError as exc:
           debug "Beacon proposer preparation processing was interrupted"
@@ -578,7 +578,7 @@ proc registerValidators*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to register validators", slot = currentSlot,
                 fork = genesisFork, err_name = exc.name,
-                err_msg = exc.msg, reason = vc.getFailureReason()
+                err_msg = exc.msg, reason = vc.getFailureReason(exc)
           0
         except CancelledError as exc:
           debug "Validator registration was interrupted", slot = currentSlot,

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -66,7 +66,8 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
       try:
         await vc.getValidators(idents, ApiStrategyKind.First)
       except ValidatorApiError:
-        error "Unable to get head state's validator information"
+        error "Unable to get head state's validator information",
+              reason = vc.getFailureReason()
         return
       except CancelledError as exc:
         debug "Validator's indices processing was interrupted"
@@ -533,7 +534,7 @@ proc prepareBeaconProposers*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to prepare beacon proposers", slot = currentSlot,
                 epoch = currentEpoch, err_name = exc.name,
-                err_msg = exc.msg
+                err_msg = exc.msg, reason = vc.getFailureReason()
           0
         except CancelledError as exc:
           debug "Beacon proposer preparation processing was interrupted"
@@ -577,7 +578,7 @@ proc registerValidators*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to register validators", slot = currentSlot,
                 fork = genesisFork, err_name = exc.name,
-                err_msg = exc.msg
+                err_msg = exc.msg, reason = vc.getFailureReason()
           0
         except CancelledError as exc:
           debug "Validator registration was interrupted", slot = currentSlot,

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -67,7 +67,7 @@ proc pollForValidatorIndices*(vc: ValidatorClientRef) {.async.} =
         await vc.getValidators(idents, ApiStrategyKind.First)
       except ValidatorApiError as exc:
         error "Unable to get head state's validator information",
-              reason = vc.getFailureReason(exc)
+              reason = exc.getFailureReason()
         return
       except CancelledError as exc:
         debug "Validator's indices processing was interrupted"
@@ -141,7 +141,7 @@ proc pollForAttesterDuties*(vc: ValidatorClientRef,
         await vc.getAttesterDuties(epoch, indices, ApiStrategyKind.First)
       except ValidatorApiError as exc:
         notice "Unable to get attester duties", epoch = epoch,
-               reason = vc.getFailureReason(exc)
+               reason = exc.getFailureReason()
         return 0
       except CancelledError as exc:
         debug "Attester duties processing was interrupted"
@@ -275,7 +275,7 @@ proc pollForSyncCommitteeDuties*(vc: ValidatorClientRef,
           await vc.getSyncCommitteeDuties(epoch, indices, ApiStrategyKind.First)
         except ValidatorApiError as exc:
           notice "Unable to get sync committee duties", epoch = epoch,
-                 reason = vc.getFailureReason(exc)
+                 reason = exc.getFailureReason()
           return 0
         except CancelledError as exc:
           debug "Sync committee duties processing was interrupted"
@@ -507,7 +507,7 @@ proc pollForBeaconProposers*(vc: ValidatorClientRef) {.async.} =
                 duties_count = len(duties)
       except ValidatorApiError as exc:
         notice "Unable to get proposer duties", slot = currentSlot,
-               epoch = currentEpoch, reason = vc.getFailureReason(exc)
+               epoch = currentEpoch, reason = exc.getFailureReason()
       except CancelledError as exc:
         debug "Proposer duties processing was interrupted"
         raise exc
@@ -534,7 +534,7 @@ proc prepareBeaconProposers*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to prepare beacon proposers", slot = currentSlot,
                 epoch = currentEpoch, err_name = exc.name,
-                err_msg = exc.msg, reason = vc.getFailureReason(exc)
+                err_msg = exc.msg, reason = exc.getFailureReason()
           0
         except CancelledError as exc:
           debug "Beacon proposer preparation processing was interrupted"
@@ -578,7 +578,7 @@ proc registerValidators*(service: DutiesServiceRef) {.async.} =
         except ValidatorApiError as exc:
           warn "Unable to register validators", slot = currentSlot,
                 fork = genesisFork, err_name = exc.name,
-                err_msg = exc.msg, reason = vc.getFailureReason(exc)
+                err_msg = exc.msg, reason = exc.getFailureReason()
           0
         except CancelledError as exc:
           debug "Validator registration was interrupted", slot = currentSlot,

--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -54,7 +54,7 @@ proc pollForFork(vc: ValidatorClientRef) {.async.} =
         await vc.getForkSchedule(ApiStrategyKind.Best)
       except ValidatorApiError as exc:
         error "Unable to retrieve fork schedule",
-              reason = vc.getFailureReason(), err_msg = exc.msg
+              reason = vc.getFailureReason(exc), err_msg = exc.msg
         return
       except CancelledError as exc:
         debug "Fork retrieval process was interrupted"

--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -54,7 +54,7 @@ proc pollForFork(vc: ValidatorClientRef) {.async.} =
         await vc.getForkSchedule(ApiStrategyKind.Best)
       except ValidatorApiError as exc:
         error "Unable to retrieve fork schedule",
-              reason = vc.getFailureReason(exc), err_msg = exc.msg
+              reason = exc.getFailureReason(), err_msg = exc.msg
         return
       except CancelledError as exc:
         debug "Fork retrieval process was interrupted"

--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -53,7 +53,8 @@ proc pollForFork(vc: ValidatorClientRef) {.async.} =
       try:
         await vc.getForkSchedule(ApiStrategyKind.Best)
       except ValidatorApiError as exc:
-        error "Unable to retrieve fork schedule", reason = exc.msg
+        error "Unable to retrieve fork schedule",
+              reason = vc.getFailureReason(), err_msg = exc.msg
         return
       except CancelledError as exc:
         debug "Fork retrieval process was interrupted"

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -61,7 +61,8 @@ proc serveSyncCommitteeMessage*(service: SyncCommitteeServiceRef,
       error "Unable to publish sync committee message",
             message = shortLog(message),
             validator = shortLog(validator),
-            validator_index = vindex
+            validator_index = vindex,
+            reason = vc.getFailureReason()
       return false
     except CancelledError:
       debug "Publish sync committee message request was interrupted"
@@ -176,7 +177,8 @@ proc serveContributionAndProof*(service: SyncCommitteeServiceRef,
             contribution = shortLog(proof.contribution),
             validator = shortLog(validator),
             validator_index = validatorIdx,
-            err_msg = err.msg
+            err_msg = err.msg,
+            reason = vc.getFailureReason()
       false
     except CancelledError:
       debug "Publish sync contribution request was interrupted"
@@ -280,7 +282,8 @@ proc produceAndPublishContributions(service: SyncCommitteeServiceRef,
               await contributionsFuts[item.subcommitteeIdx]
             except ValidatorApiError:
               error "Unable to get sync message contribution data", slot = slot,
-                    beaconBlockRoot = shortLog(beaconBlockRoot)
+                    beaconBlockRoot = shortLog(beaconBlockRoot),
+                    reason = vc.getFailureReason()
               return
             except CancelledError:
               debug "Request for sync message contribution was interrupted"
@@ -362,7 +365,8 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
             return
           res.data.root
       except ValidatorApiError as exc:
-        error "Unable to retrieve head block's root to sign", reason = exc.msg
+        error "Unable to retrieve head block's root to sign", reason = exc.msg,
+              reason = vc.getFailureReason()
         return
       except CancelledError:
         debug "Block root request was interrupted"
@@ -378,7 +382,7 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
                                                          duties)
   except ValidatorApiError:
     error "Unable to proceed sync committee messages", slot = slot,
-           duties_count = len(duties)
+           duties_count = len(duties), reason = vc.getFailureReason()
     return
   except CancelledError:
     debug "Sync committee producing process was interrupted"

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -357,8 +357,8 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
           res.data.root
         else:
           if res.execution_optimistic.get():
-            error "Could not obtain head block's root because beacon node " &
-                  "only optimistically synced", slot = slot
+            notice "Execution client not in sync; skipping validator duties " &
+                   "for now", slot = slot
             return
           res.data.root
       except ValidatorApiError as exc:

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -57,12 +57,12 @@ proc serveSyncCommitteeMessage*(service: SyncCommitteeServiceRef,
   let res =
     try:
       await vc.submitPoolSyncCommitteeSignature(message, ApiStrategyKind.First)
-    except ValidatorApiError:
+    except ValidatorApiError as exc:
       error "Unable to publish sync committee message",
             message = shortLog(message),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason()
+            reason = vc.getFailureReason(exc)
       return false
     except CancelledError:
       debug "Publish sync committee message request was interrupted"
@@ -172,13 +172,13 @@ proc serveContributionAndProof*(service: SyncCommitteeServiceRef,
     try:
       await vc.publishContributionAndProofs(@[restSignedProof],
                                             ApiStrategyKind.First)
-    except ValidatorApiError as err:
+    except ValidatorApiError as exc:
       error "Unable to publish sync contribution",
             contribution = shortLog(proof.contribution),
             validator = shortLog(validator),
             validator_index = validatorIdx,
-            err_msg = err.msg,
-            reason = vc.getFailureReason()
+            err_msg = exc.msg,
+            reason = vc.getFailureReason(exc)
       false
     except CancelledError:
       debug "Publish sync contribution request was interrupted"
@@ -280,10 +280,10 @@ proc produceAndPublishContributions(service: SyncCommitteeServiceRef,
           let aggContribution =
             try:
               await contributionsFuts[item.subcommitteeIdx]
-            except ValidatorApiError:
+            except ValidatorApiError as exc:
               error "Unable to get sync message contribution data", slot = slot,
                     beaconBlockRoot = shortLog(beaconBlockRoot),
-                    reason = vc.getFailureReason()
+                    reason = vc.getFailureReason(exc)
               return
             except CancelledError:
               debug "Request for sync message contribution was interrupted"
@@ -366,7 +366,7 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
           res.data.root
       except ValidatorApiError as exc:
         error "Unable to retrieve head block's root to sign", reason = exc.msg,
-              reason = vc.getFailureReason()
+              reason = vc.getFailureReason(exc)
         return
       except CancelledError:
         debug "Block root request was interrupted"
@@ -380,9 +380,9 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
     await service.produceAndPublishSyncCommitteeMessages(slot,
                                                          beaconBlockRoot,
                                                          duties)
-  except ValidatorApiError:
+  except ValidatorApiError as exc:
     error "Unable to proceed sync committee messages", slot = slot,
-           duties_count = len(duties), reason = vc.getFailureReason()
+           duties_count = len(duties), reason = vc.getFailureReason(exc)
     return
   except CancelledError:
     debug "Sync committee producing process was interrupted"

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -62,7 +62,7 @@ proc serveSyncCommitteeMessage*(service: SyncCommitteeServiceRef,
             message = shortLog(message),
             validator = shortLog(validator),
             validator_index = vindex,
-            reason = vc.getFailureReason(exc)
+            reason = exc.getFailureReason()
       return false
     except CancelledError:
       debug "Publish sync committee message request was interrupted"
@@ -178,7 +178,7 @@ proc serveContributionAndProof*(service: SyncCommitteeServiceRef,
             validator = shortLog(validator),
             validator_index = validatorIdx,
             err_msg = exc.msg,
-            reason = vc.getFailureReason(exc)
+            reason = exc.getFailureReason()
       false
     except CancelledError:
       debug "Publish sync contribution request was interrupted"
@@ -283,7 +283,7 @@ proc produceAndPublishContributions(service: SyncCommitteeServiceRef,
             except ValidatorApiError as exc:
               error "Unable to get sync message contribution data", slot = slot,
                     beaconBlockRoot = shortLog(beaconBlockRoot),
-                    reason = vc.getFailureReason(exc)
+                    reason = exc.getFailureReason()
               return
             except CancelledError:
               debug "Request for sync message contribution was interrupted"
@@ -366,7 +366,7 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
           res.data.root
       except ValidatorApiError as exc:
         error "Unable to retrieve head block's root to sign", reason = exc.msg,
-              reason = vc.getFailureReason(exc)
+              reason = exc.getFailureReason()
         return
       except CancelledError:
         debug "Block root request was interrupted"
@@ -382,7 +382,7 @@ proc publishSyncMessagesAndContributions(service: SyncCommitteeServiceRef,
                                                          duties)
   except ValidatorApiError as exc:
     error "Unable to proceed sync committee messages", slot = slot,
-           duties_count = len(duties), reason = vc.getFailureReason(exc)
+           duties_count = len(duties), reason = exc.getFailureReason()
     return
   except CancelledError:
     debug "Sync committee producing process was interrupted"


### PR DESCRIPTION
* Optimize checkNode to check only specific BN statuses.
* Add ability to use specific BN status nodes for specific API calls.
* Allow usage of opt-synced and not-synced nodes for all API calls.