### PR TITLE
use Bourne shell as the actual postinst script does

### DIFF
--- a/scripts/package_src/nimbus_beacon_node/after_install
+++ b/scripts/package_src/nimbus_beacon_node/after_install
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 DISTRO="UNKNOWN"
-if [[ -r /etc/os-release ]]; then
+if [ -r /etc/os-release ]; then
     source /etc/os-release
     DISTRO="${ID}"
 fi

--- a/scripts/package_src/nimbus_validator_client/after_install
+++ b/scripts/package_src/nimbus_validator_client/after_install
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 DISTRO="UNKNOWN"
-if [[ -r /etc/os-release ]]; then
+if [ -r /etc/os-release ]; then
     . /etc/os-release
     DISTRO="${ID}"
 fi


### PR DESCRIPTION
The `postinst` wrapper script into which these scripts are embedded as `after_upgrade` and `after_install` functions are executed using Bourne shell(`sh`), so we cannot use the Bash specific `[[ ]]` test or it fails:
```
/var/lib/dpkg/info/nimbus-beacon-node.postinst: 22: [[: not found
```