### PR TITLE
after_install: use . not source in bourne shell

### DIFF
--- a/scripts/package_src/nimbus_beacon_node/after_install
+++ b/scripts/package_src/nimbus_beacon_node/after_install
@@ -3,7 +3,7 @@ set -e
 
 DISTRO="UNKNOWN"
 if [ -r /etc/os-release ]; then
-    source /etc/os-release
+    . /etc/os-release
     DISTRO="${ID}"
 fi
 


### PR DESCRIPTION
Another dumb mistake when using bourne shell:
```
/var/lib/dpkg/info/nimbus-beacon-node.postinst: 23: source: not found
```
I might add that the other file is fine:
https://github.com/status-im/nimbus-eth2/blob/7d599185e0560434eb7d486b92a6d00817920809/scripts/package_src/nimbus_validator_client/after_install#L7