### PR TITLE
use consensus spec v1.3.0-rc.3 test vectors

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -223,12 +223,12 @@ ConsensusSpecPreset-mainnet
 + EF - Capella - Transition - transition_with_proposer_slashing_right_before_fork [Preset: m OK
 + EF - Capella - Transition - transition_with_random_half_participation [Preset: mainnet]    OK
 + EF - Capella - Transition - transition_with_random_three_quarters_participation [Preset: m OK
-+ EF - Deneb - Fork - eip4844_fork_random_0 [Preset: mainnet]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_1 [Preset: mainnet]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_2 [Preset: mainnet]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_3 [Preset: mainnet]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_low_balances [Preset: mainnet]                     OK
-+ EF - Deneb - Fork - eip4844_fork_random_misc_balances [Preset: mainnet]                    OK
++ EF - Deneb - Fork - deneb_fork_random_0 [Preset: mainnet]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_1 [Preset: mainnet]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_2 [Preset: mainnet]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_3 [Preset: mainnet]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_low_balances [Preset: mainnet]                       OK
++ EF - Deneb - Fork - deneb_fork_random_misc_balances [Preset: mainnet]                      OK
 + EF - Deneb - Fork - fork_base_state [Preset: mainnet]                                      OK
 + EF - Deneb - Fork - fork_many_next_epoch [Preset: mainnet]                                 OK
 + EF - Deneb - Fork - fork_next_epoch [Preset: mainnet]                                      OK
@@ -405,22 +405,22 @@ ConsensusSpecPreset-mainnet
   ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
 + ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost              OK
 + ForkChoice - mainnet/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
-+ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_grea OK
-+ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_ OK
-+ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest OK
-+ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att OK
-+ ForkChoice - mainnet/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/chain_no_attestations       OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/discard_equivocations       OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/genesis                     OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w OK
-+ ForkChoice - mainnet/eip4844/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest OK
-+ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/basic                       OK
-+ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    OK
-  ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
-+ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost              OK
-+ ForkChoice - mainnet/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
++ ForkChoice - mainnet/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_greate OK
++ ForkChoice - mainnet/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_no OK
++ ForkChoice - mainnet/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_a OK
++ ForkChoice - mainnet/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_attes OK
++ ForkChoice - mainnet/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla                OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/chain_no_attestations         OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/discard_equivocations         OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/genesis                       OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head   OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_wei OK
++ ForkChoice - mainnet/deneb/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attestat OK
++ ForkChoice - mainnet/deneb/fork_choice/on_block/pyspec_tests/basic                         OK
++ ForkChoice - mainnet/deneb/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root      OK
+  ForkChoice - mainnet/deneb/fork_choice/on_block/pyspec_tests/on_block_future_block         Skip
++ ForkChoice - mainnet/deneb/fork_choice/on_block/pyspec_tests/proposer_boost                OK
++ ForkChoice - mainnet/deneb/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slot OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_boost_n OK
 + ForkChoice - mainnet/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
@@ -447,13 +447,13 @@ ConsensusSpecPreset-mainnet
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/capella/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - mainnet/eip4844/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - mainnet/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - mainnet/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - mainnet/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - mainnet/deneb/light_client/single_merkle_proof/Beacon OK
 + Sync - mainnet/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - mainnet/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
-+ Sync - mainnet/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
++ Sync - mainnet/deneb/sync/optimistic/pyspec_tests/from_syncing_to_invalid                  OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]         OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: ma OK
@@ -669,6 +669,8 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Capella - Sanity - Blocks - attestation [Preset: mainnet]                   OK
 + [Valid]   EF - Capella - Sanity - Blocks - attester_slashing [Preset: mainnet]             OK
 + [Valid]   EF - Capella - Sanity - Blocks - balance_driven_status_transitions [Preset: main OK
++ [Valid]   EF - Capella - Sanity - Blocks - bls_change [Preset: mainnet]                    OK
++ [Valid]   EF - Capella - Sanity - Blocks - deposit_and_bls_change [Preset: mainnet]        OK
 + [Valid]   EF - Capella - Sanity - Blocks - deposit_in_block [Preset: mainnet]              OK
 + [Valid]   EF - Capella - Sanity - Blocks - deposit_top_up [Preset: mainnet]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - duplicate_attestation_same_block [Preset: mainn OK
@@ -676,6 +678,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Capella - Sanity - Blocks - empty_block_transition_no_tx [Preset: mainnet]  OK
 + [Valid]   EF - Capella - Sanity - Blocks - empty_block_transition_randomized_payload [Pres OK
 + [Valid]   EF - Capella - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]        OK
++ [Valid]   EF - Capella - Sanity - Blocks - exit_and_bls_change [Preset: mainnet]           OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]      OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]      OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]      OK
@@ -697,8 +700,6 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Capella - Sanity - Blocks - proposer_slashing [Preset: mainnet]             OK
 + [Valid]   EF - Capella - Sanity - Blocks - skipped_slots [Preset: mainnet]                 OK
 + [Valid]   EF - Capella - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
-+ [Valid]   EF - Capella - Sanity - Blocks - success_bls_change [Preset: mainnet]            OK
-+ [Valid]   EF - Capella - Sanity - Blocks - success_exit_and_bls_change [Preset: mainnet]   OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__empty [Preset: mainne OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__full [Preset: mainnet OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__half [Preset: mainnet OK
@@ -733,6 +734,8 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Deneb - Sanity - Blocks - attestation [Preset: mainnet]                     OK
 + [Valid]   EF - Deneb - Sanity - Blocks - attester_slashing [Preset: mainnet]               OK
 + [Valid]   EF - Deneb - Sanity - Blocks - balance_driven_status_transitions [Preset: mainne OK
++ [Valid]   EF - Deneb - Sanity - Blocks - bls_change [Preset: mainnet]                      OK
++ [Valid]   EF - Deneb - Sanity - Blocks - deposit_and_bls_change [Preset: mainnet]          OK
 + [Valid]   EF - Deneb - Sanity - Blocks - deposit_in_block [Preset: mainnet]                OK
 + [Valid]   EF - Deneb - Sanity - Blocks - deposit_top_up [Preset: mainnet]                  OK
 + [Valid]   EF - Deneb - Sanity - Blocks - duplicate_attestation_same_block [Preset: mainnet OK
@@ -740,6 +743,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Deneb - Sanity - Blocks - empty_block_transition_no_tx [Preset: mainnet]    OK
 + [Valid]   EF - Deneb - Sanity - Blocks - empty_block_transition_randomized_payload [Preset OK
 + [Valid]   EF - Deneb - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]          OK
++ [Valid]   EF - Deneb - Sanity - Blocks - exit_and_bls_change [Preset: mainnet]             OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]        OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]        OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]        OK
@@ -763,8 +767,6 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Deneb - Sanity - Blocks - proposer_slashing [Preset: mainnet]               OK
 + [Valid]   EF - Deneb - Sanity - Blocks - skipped_slots [Preset: mainnet]                   OK
 + [Valid]   EF - Deneb - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]       OK
-+ [Valid]   EF - Deneb - Sanity - Blocks - success_bls_change [Preset: mainnet]              OK
-+ [Valid]   EF - Deneb - Sanity - Blocks - success_exit_and_bls_change [Preset: mainnet]     OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__empty [Preset: mainnet] OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__full [Preset: mainnet]  OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__half [Preset: mainnet]  OK
@@ -821,7 +823,7 @@ ConsensusSpecPreset-mainnet
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 ```
-OK: 809/818 Fail: 0/818 Skip: 9/818
+OK: 811/820 Fail: 0/820 Skip: 9/820
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -1990,7 +1992,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    BeaconBlockBody                                                               OK
 +   Testing    BeaconBlockHeader                                                             OK
 +   Testing    BeaconState                                                                   OK
-+   Testing    BlobsSidecar                                                                  OK
++   Testing    BlobIdentifier                                                                OK
++   Testing    BlobSidecar                                                                   OK
 +   Testing    Checkpoint                                                                    OK
 +   Testing    ContributionAndProof                                                          OK
 +   Testing    Deposit                                                                       OK
@@ -2016,8 +2019,8 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    SignedAggregateAndProof                                                       OK
 +   Testing    SignedBLSToExecutionChange                                                    OK
 +   Testing    SignedBeaconBlock                                                             OK
-+   Testing    SignedBeaconBlockAndBlobsSidecar                                              OK
 +   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedBlobSidecar                                                             OK
 +   Testing    SignedContributionAndProof                                                    OK
 +   Testing    SignedVoluntaryExit                                                           OK
 +   Testing    SigningData                                                                   OK
@@ -2030,7 +2033,7 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
+OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - EIP4844 - Unittests - Light client - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -2604,4 +2607,4 @@ OK: 63/63 Fail: 0/63 Skip: 0/63
 OK: 100/100 Fail: 0/100 Skip: 0/100
 
 ---TOTAL---
-OK: 2301/2310 Fail: 0/2310 Skip: 9/2310
+OK: 2304/2313 Fail: 0/2313 Skip: 9/2313

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -241,13 +241,13 @@ ConsensusSpecPreset-minimal
 + EF - Capella - Transition - transition_with_random_three_quarters_participation [Preset: m OK
 + EF - Capella - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minim OK
 + EF - Capella - Transition - transition_with_voluntary_exit_right_before_fork [Preset: mini OK
-+ EF - Deneb - Fork - eip4844_fork_random_0 [Preset: minimal]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_1 [Preset: minimal]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_2 [Preset: minimal]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_3 [Preset: minimal]                                OK
-+ EF - Deneb - Fork - eip4844_fork_random_large_validator_set [Preset: minimal]              OK
-+ EF - Deneb - Fork - eip4844_fork_random_low_balances [Preset: minimal]                     OK
-+ EF - Deneb - Fork - eip4844_fork_random_misc_balances [Preset: minimal]                    OK
++ EF - Deneb - Fork - deneb_fork_random_0 [Preset: minimal]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_1 [Preset: minimal]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_2 [Preset: minimal]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_3 [Preset: minimal]                                  OK
++ EF - Deneb - Fork - deneb_fork_random_large_validator_set [Preset: minimal]                OK
++ EF - Deneb - Fork - deneb_fork_random_low_balances [Preset: minimal]                       OK
++ EF - Deneb - Fork - deneb_fork_random_misc_balances [Preset: minimal]                      OK
 + EF - Deneb - Fork - fork_base_state [Preset: minimal]                                      OK
 + EF - Deneb - Fork - fork_many_next_epoch [Preset: minimal]                                 OK
 + EF - Deneb - Fork - fork_next_epoch [Preset: minimal]                                      OK
@@ -453,30 +453,30 @@ ConsensusSpecPreset-minimal
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/on_block_update_justified_c OK
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost              OK
 + ForkChoice - minimal/capella/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
-+ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest OK
-+ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_att OK
-+ ForkChoice - minimal/eip4844/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla              OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/chain_no_attestations       OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/discard_equivocations       OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/filtered_block_tree         OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/genesis                     OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_w OK
-+ ForkChoice - minimal/eip4844/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attest OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/basic                       OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justi OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_j OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/new_justified_is_later_than OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root    OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_before_finalized   OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_checkpoints        OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slo OK
-  ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_future_block       Skip
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/on_block_update_justified_c OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost              OK
-+ ForkChoice - minimal/eip4844/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_sl OK
++ ForkChoice - minimal/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_a OK
++ ForkChoice - minimal/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_attes OK
++ ForkChoice - minimal/deneb/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla                OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/chain_no_attestations         OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/discard_equivocations         OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/filtered_block_tree           OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/genesis                       OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/proposer_boost_correct_head   OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/shorter_chain_but_heavier_wei OK
++ ForkChoice - minimal/deneb/fork_choice/get_head/pyspec_tests/split_tie_breaker_no_attestat OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/basic                         OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_justifi OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/new_finalized_slot_is_not_jus OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/new_justified_is_later_than_s OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_bad_parent_root      OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_before_finalized     OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_checkpoints          OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slots OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_finalized_skip_slots OK
+  ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_future_block         Skip
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_outside_safe_slots_b OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/on_block_update_justified_che OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/proposer_boost                OK
++ ForkChoice - minimal/deneb/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slot OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_without_atte OK
 + ForkChoice - minimal/phase0/fork_choice/ex_ante/pyspec_tests/ex_ante_vanilla               OK
@@ -511,37 +511,37 @@ ConsensusSpecPreset-minimal
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/capella/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
-+ Light client - Single merkle proof - minimal/eip4844/light_client/single_merkle_proof/Beac OK
++ Light client - Single merkle proof - minimal/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - minimal/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - minimal/deneb/light_client/single_merkle_proof/Beacon OK
++ Light client - Single merkle proof - minimal/deneb/light_client/single_merkle_proof/Beacon OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/advance_finality_witho OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/capella_store_with_leg OK
-+ Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/eip4844_store_with_leg OK
++ Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/deneb_store_with_legac OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/light_client_sync      OK
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/supply_sync_committee_ OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/advance_finality_wi OK
-+ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_eip4844_for OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_deneb_fork  OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_fork        OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/capella_store_with_ OK
-+ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/eip4844_store_with_ OK
++ Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/deneb_store_with_le OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/light_client_sync   OK
 + Light client - Sync - minimal/bellatrix/light_client/sync/pyspec_tests/supply_sync_committ OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/advance_finality_with OK
-+ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/eip4844_fork          OK
-+ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/eip4844_store_with_le OK
++ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/deneb_fork            OK
++ Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/deneb_store_with_lega OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/light_client_sync     OK
 + Light client - Sync - minimal/capella/light_client/sync/pyspec_tests/supply_sync_committee OK
-+ Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/advance_finality_with OK
-+ Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/light_client_sync     OK
-+ Light client - Sync - minimal/eip4844/light_client/sync/pyspec_tests/supply_sync_committee OK
++ Light client - Sync - minimal/deneb/light_client/sync/pyspec_tests/advance_finality_withou OK
++ Light client - Sync - minimal/deneb/light_client/sync/pyspec_tests/light_client_sync       OK
++ Light client - Sync - minimal/deneb/light_client/sync/pyspec_tests/supply_sync_committee_f OK
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
 + Light client - Update ranking - minimal/bellatrix/light_client/update_ranking/pyspec_tests OK
 + Light client - Update ranking - minimal/capella/light_client/update_ranking/pyspec_tests/u OK
-+ Light client - Update ranking - minimal/eip4844/light_client/update_ranking/pyspec_tests/u OK
++ Light client - Update ranking - minimal/deneb/light_client/update_ranking/pyspec_tests/upd OK
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
 + Sync - minimal/capella/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
-+ Sync - minimal/eip4844/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
++ Sync - minimal/deneb/sync/optimistic/pyspec_tests/from_syncing_to_invalid                  OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]         OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: mi OK
@@ -769,6 +769,8 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Sanity - Blocks - attestation [Preset: minimal]                   OK
 + [Valid]   EF - Capella - Sanity - Blocks - attester_slashing [Preset: minimal]             OK
 + [Valid]   EF - Capella - Sanity - Blocks - balance_driven_status_transitions [Preset: mini OK
++ [Valid]   EF - Capella - Sanity - Blocks - bls_change [Preset: minimal]                    OK
++ [Valid]   EF - Capella - Sanity - Blocks - deposit_and_bls_change [Preset: minimal]        OK
 + [Valid]   EF - Capella - Sanity - Blocks - deposit_in_block [Preset: minimal]              OK
 + [Valid]   EF - Capella - Sanity - Blocks - deposit_top_up [Preset: minimal]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - duplicate_attestation_same_block [Preset: minim OK
@@ -781,6 +783,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset:  OK
 + [Valid]   EF - Capella - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]     OK
 + [Valid]   EF - Capella - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]  OK
++ [Valid]   EF - Capella - Sanity - Blocks - exit_and_bls_change [Preset: minimal]           OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_0 [Preset: minimal]      OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_1 [Preset: minimal]      OK
 + [Valid]   EF - Capella - Sanity - Blocks - full_random_operations_2 [Preset: minimal]      OK
@@ -802,8 +805,6 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Capella - Sanity - Blocks - proposer_slashing [Preset: minimal]             OK
 + [Valid]   EF - Capella - Sanity - Blocks - skipped_slots [Preset: minimal]                 OK
 + [Valid]   EF - Capella - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
-+ [Valid]   EF - Capella - Sanity - Blocks - success_bls_change [Preset: minimal]            OK
-+ [Valid]   EF - Capella - Sanity - Blocks - success_exit_and_bls_change [Preset: minimal]   OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__empty [Preset: minima OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__full [Preset: minimal OK
 + [Valid]   EF - Capella - Sanity - Blocks - sync_committee_committee__half [Preset: minimal OK
@@ -840,6 +841,8 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Deneb - Sanity - Blocks - attestation [Preset: minimal]                     OK
 + [Valid]   EF - Deneb - Sanity - Blocks - attester_slashing [Preset: minimal]               OK
 + [Valid]   EF - Deneb - Sanity - Blocks - balance_driven_status_transitions [Preset: minima OK
++ [Valid]   EF - Deneb - Sanity - Blocks - bls_change [Preset: minimal]                      OK
++ [Valid]   EF - Deneb - Sanity - Blocks - deposit_and_bls_change [Preset: minimal]          OK
 + [Valid]   EF - Deneb - Sanity - Blocks - deposit_in_block [Preset: minimal]                OK
 + [Valid]   EF - Deneb - Sanity - Blocks - deposit_top_up [Preset: minimal]                  OK
 + [Valid]   EF - Deneb - Sanity - Blocks - duplicate_attestation_same_block [Preset: minimal OK
@@ -852,6 +855,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Deneb - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset: mi OK
 + [Valid]   EF - Deneb - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]       OK
 + [Valid]   EF - Deneb - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]    OK
++ [Valid]   EF - Deneb - Sanity - Blocks - exit_and_bls_change [Preset: minimal]             OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_0 [Preset: minimal]        OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_1 [Preset: minimal]        OK
 + [Valid]   EF - Deneb - Sanity - Blocks - full_random_operations_2 [Preset: minimal]        OK
@@ -875,8 +879,6 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Deneb - Sanity - Blocks - proposer_slashing [Preset: minimal]               OK
 + [Valid]   EF - Deneb - Sanity - Blocks - skipped_slots [Preset: minimal]                   OK
 + [Valid]   EF - Deneb - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]       OK
-+ [Valid]   EF - Deneb - Sanity - Blocks - success_bls_change [Preset: minimal]              OK
-+ [Valid]   EF - Deneb - Sanity - Blocks - success_exit_and_bls_change [Preset: minimal]     OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__empty [Preset: minimal] OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__full [Preset: minimal]  OK
 + [Valid]   EF - Deneb - Sanity - Blocks - sync_committee_committee__half [Preset: minimal]  OK
@@ -938,7 +940,7 @@ ConsensusSpecPreset-minimal
 + [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
 + [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 ```
-OK: 926/935 Fail: 0/935 Skip: 9/935
+OK: 928/937 Fail: 0/937 Skip: 9/937
 ## Attestation
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_epoch_slots               OK
@@ -2166,7 +2168,8 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    BeaconBlockBody                                                               OK
 +   Testing    BeaconBlockHeader                                                             OK
 +   Testing    BeaconState                                                                   OK
-+   Testing    BlobsSidecar                                                                  OK
++   Testing    BlobIdentifier                                                                OK
++   Testing    BlobSidecar                                                                   OK
 +   Testing    Checkpoint                                                                    OK
 +   Testing    ContributionAndProof                                                          OK
 +   Testing    Deposit                                                                       OK
@@ -2192,8 +2195,8 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    SignedAggregateAndProof                                                       OK
 +   Testing    SignedBLSToExecutionChange                                                    OK
 +   Testing    SignedBeaconBlock                                                             OK
-+   Testing    SignedBeaconBlockAndBlobsSidecar                                              OK
 +   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedBlobSidecar                                                             OK
 +   Testing    SignedContributionAndProof                                                    OK
 +   Testing    SignedVoluntaryExit                                                           OK
 +   Testing    SigningData                                                                   OK
@@ -2206,7 +2209,7 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
+OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - EIP4844 - Unittests - Light client - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -2783,4 +2786,4 @@ OK: 68/68 Fail: 0/68 Skip: 0/68
 OK: 102/102 Fail: 0/102 Skip: 0/102
 
 ---TOTAL---
-OK: 2464/2473 Fail: 0/2473 Skip: 9/2473
+OK: 2467/2476 Fail: 0/2476 Skip: 9/2476

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-rc.2-hotfix"
+const SPEC_VERSION* = "1.3.0-rc.3"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/beacon_chain/spec/datatypes/eip4844.nim
+++ b/beacon_chain/spec/datatypes/eip4844.nim
@@ -50,8 +50,13 @@ type
   # current spec doesn't ever SSZ-serialize it or hash_tree_root it
   VersionedHash* = array[32, byte]
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/beacon-chain.md#custom-types
+  BlobIndex* = uint64
+
   Blob* = array[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB, byte]
 
+  # TODO remove BlobsSidecar and SignedBeaconBlockAndBlobsSidecar; they'e not
+  # in rc.3 anymore
   BlobsSidecar* = object
     beacon_block_root*: Eth2Digest
     beacon_block_slot*: Slot
@@ -61,6 +66,27 @@ type
   SignedBeaconBlockAndBlobsSidecar* = object
     beacon_block*: SignedBeaconBlock
     blobs_sidecar*: BlobsSidecar
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#blobsidecar
+  BlobSidecar* = object
+    block_root*: Eth2Digest
+    index*: BlobIndex  # Index of blob in block
+    slot*: Slot
+    block_parent_root*: Eth2Digest  # Proposer shuffling determinant
+    proposer_index*: uint64
+    blob*: Blob
+    kzg_commitment*: KZGCommitment
+    kzg_proof*: KZGProof  # Allows for quick verification of kzg_commitment
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#signedblobsidecar
+  SignedBlobSidecar* = object
+    message*: BlobSidecar
+    signature*: ValidatorSig
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#blobidentifier
+  BlobIdentifier* = object
+    block_root*: Eth2Digest
+    index*: BlobIndex
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/eip4844/beacon-chain.md#executionpayload
   ExecutionPayload* = object
@@ -76,12 +102,12 @@ type
     timestamp*: uint64
     extra_data*: List[byte, MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas*: UInt256
-    excess_data_gas*: UInt256  # [New in EIP-4844]
 
     # Extra payload fields
     block_hash*: Eth2Digest # Hash of execution block
     transactions*: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
     withdrawals*: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    excess_data_gas*: UInt256  # [New in EIP-4844]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/eip4844/beacon-chain.md#executionpayloadheader
   ExecutionPayloadHeader* = object
@@ -97,12 +123,12 @@ type
     timestamp*: uint64
     extra_data*: List[byte, MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas*: UInt256
-    excess_data_gas*: UInt256  # [New in EIP-4844]
 
     # Extra payload fields
     block_hash*: Eth2Digest  # Hash of execution block
     transactions_root*: Eth2Digest
     withdrawals_root*: Eth2Digest
+    excess_data_gas*: UInt256  # [New in EIP-4844]
 
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -16,14 +16,14 @@ import
   stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, state_transition_block],
-  ../../../beacon_chain/spec/datatypes/eip4844,
+  ../../../beacon_chain/spec/datatypes/deneb,
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops,
   ../../helpers/debug_state
 
 const
-  OpDir                     = SszTestsDir/const_preset/"eip4844"/"operations"
+  OpDir                     = SszTestsDir/const_preset/"deneb"/"operations"
   OpAttestationsDir         = OpDir/"attestation"
   OpAttSlashingDir          = OpDir/"attester_slashing"
   OpBlockHeaderDir          = OpDir/"block_header"
@@ -58,14 +58,14 @@ proc runTest[T, U](
 
     test prefix & baseDescription & testSuiteName & " - " & identifier:
       let preState = newClone(
-        parseTest(testDir/"pre.ssz_snappy", SSZ, eip4844.BeaconState))
+        parseTest(testDir/"pre.ssz_snappy", SSZ, deneb.BeaconState))
       let done = applyProc(
         preState[], parseTest(testDir/(applyFile & ".ssz_snappy"), SSZ, T))
 
       if fileExists(testDir/"post.ssz_snappy"):
         let postState =
           newClone(parseTest(
-            testDir/"post.ssz_snappy", SSZ, eip4844.BeaconState))
+            testDir/"post.ssz_snappy", SSZ, deneb.BeaconState))
 
         reportDiff(preState, postState)
         check:
@@ -78,7 +78,7 @@ proc runTest[T, U](
 
 suite baseDescription & "Attestation " & preset():
   proc applyAttestation(
-      preState: var eip4844.BeaconState, attestation: Attestation):
+      preState: var deneb.BeaconState, attestation: Attestation):
       Result[void, cstring] =
     var cache = StateCache()
     let
@@ -95,7 +95,7 @@ suite baseDescription & "Attestation " & preset():
 
 suite baseDescription & "Attester Slashing " & preset():
   proc applyAttesterSlashing(
-      preState: var eip4844.BeaconState, attesterSlashing: AttesterSlashing):
+      preState: var deneb.BeaconState, attesterSlashing: AttesterSlashing):
       Result[void, cstring] =
     var cache = StateCache()
     process_attester_slashing(
@@ -108,13 +108,13 @@ suite baseDescription & "Attester Slashing " & preset():
 
 suite baseDescription & "Block Header " & preset():
   func applyBlockHeader(
-      preState: var eip4844.BeaconState, blck: eip4844.BeaconBlock):
+      preState: var deneb.BeaconState, blck: deneb.BeaconBlock):
       Result[void, cstring] =
     var cache = StateCache()
     process_block_header(preState, blck, {}, cache)
 
   for path in walkTests(OpBlockHeaderDir):
-    runTest[eip4844.BeaconBlock, typeof applyBlockHeader](
+    runTest[deneb.BeaconBlock, typeof applyBlockHeader](
       OpBlockHeaderDir, "Block Header", "block", applyBlockHeader, path)
 
 from ../../../beacon_chain/spec/datatypes/capella import
@@ -122,7 +122,7 @@ from ../../../beacon_chain/spec/datatypes/capella import
 
 suite baseDescription & "BLS to execution change " & preset():
   proc applyBlsToExecutionChange(
-      preState: var eip4844.BeaconState,
+      preState: var deneb.BeaconState,
       signed_address_change: SignedBLSToExecutionChange):
       Result[void, cstring] =
     process_bls_to_execution_change(
@@ -135,7 +135,7 @@ suite baseDescription & "BLS to execution change " & preset():
 
 suite baseDescription & "Deposit " & preset():
   proc applyDeposit(
-      preState: var eip4844.BeaconState, deposit: Deposit):
+      preState: var deneb.BeaconState, deposit: Deposit):
       Result[void, cstring] =
     process_deposit(defaultRuntimeConfig, preState, deposit, {})
 
@@ -146,23 +146,23 @@ suite baseDescription & "Deposit " & preset():
 suite baseDescription & "Execution Payload " & preset():
   for path in walkTests(OpExecutionPayloadDir):
     proc applyExecutionPayload(
-        preState: var eip4844.BeaconState,
-        executionPayload: eip4844.ExecutionPayload):
+        preState: var deneb.BeaconState,
+        executionPayload: deneb.ExecutionPayload):
         Result[void, cstring] =
       let payloadValid =
         os_ops.readFile(OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml").
           contains("execution_valid: true")
-      func executePayload(_: eip4844.ExecutionPayload): bool = payloadValid
+      func executePayload(_: deneb.ExecutionPayload): bool = payloadValid
       process_execution_payload(
             preState, executionPayload, executePayload)
 
-    runTest[eip4844.ExecutionPayload, typeof applyExecutionPayload](
+    runTest[deneb.ExecutionPayload, typeof applyExecutionPayload](
       OpExecutionPayloadDir, "Execution Payload", "execution_payload",
       applyExecutionPayload, path)
 
 suite baseDescription & "Proposer Slashing " & preset():
   proc applyProposerSlashing(
-      preState: var eip4844.BeaconState, proposerSlashing: ProposerSlashing):
+      preState: var deneb.BeaconState, proposerSlashing: ProposerSlashing):
       Result[void, cstring] =
     var cache = StateCache()
     process_proposer_slashing(
@@ -175,7 +175,7 @@ suite baseDescription & "Proposer Slashing " & preset():
 
 suite baseDescription & "Sync Aggregate " & preset():
   proc applySyncAggregate(
-      preState: var eip4844.BeaconState, syncAggregate: SyncAggregate):
+      preState: var deneb.BeaconState, syncAggregate: SyncAggregate):
       Result[void, cstring] =
     var cache = StateCache()
     process_sync_aggregate(
@@ -188,7 +188,7 @@ suite baseDescription & "Sync Aggregate " & preset():
 
 suite baseDescription & "Voluntary Exit " & preset():
   proc applyVoluntaryExit(
-      preState: var eip4844.BeaconState, voluntaryExit: SignedVoluntaryExit):
+      preState: var deneb.BeaconState, voluntaryExit: SignedVoluntaryExit):
       Result[void, cstring] =
     var cache = StateCache()
     process_voluntary_exit(
@@ -201,11 +201,11 @@ suite baseDescription & "Voluntary Exit " & preset():
 
 suite baseDescription & "Withdrawals " & preset():
   proc applyWithdrawals(
-      preState: var eip4844.BeaconState,
-      executionPayload: eip4844.ExecutionPayload): Result[void, cstring] =
+      preState: var deneb.BeaconState,
+      executionPayload: deneb.ExecutionPayload): Result[void, cstring] =
     process_withdrawals(preState, executionPayload)
 
   for path in walkTests(OpWithdrawalsDir):
-    runTest[eip4844.ExecutionPayload, typeof applyWithdrawals](
+    runTest[deneb.ExecutionPayload, typeof applyWithdrawals](
       OpWithdrawalsDir, "Withdrawals", "execution_payload",
       applyWithdrawals, path)

--- a/tests/consensus_spec/deneb/test_fixture_rewards.nim
+++ b/tests/consensus_spec/deneb/test_fixture_rewards.nim
@@ -16,7 +16,7 @@ import
   ../fixtures_utils, ../os_ops
 
 const
-  RewardsDirBase = SszTestsDir/const_preset/"eip4844"/"rewards"
+  RewardsDirBase = SszTestsDir/const_preset/"deneb"/"rewards"
   RewardsDirBasic = RewardsDirBase/"basic"/"pyspec_tests"
   RewardsDirLeak = RewardsDirBase/"leak"/"pyspec_tests"
   RewardsDirRandom = RewardsDirBase/"random"/"pyspec_tests"
@@ -36,7 +36,7 @@ proc runTest(rewardsDir, identifier: string) =
 
       let
         state = newClone(
-          parseTest(testDir/"pre.ssz_snappy", SSZ, eip4844.BeaconState))
+          parseTest(testDir/"pre.ssz_snappy", SSZ, deneb.BeaconState))
         flagDeltas = [
           parseTest(testDir/"source_deltas.ssz_snappy", SSZ, Deltas),
           parseTest(testDir/"target_deltas.ssz_snappy", SSZ, Deltas),

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -14,7 +14,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/[altair, eip4844],
+  ../../beacon_chain/spec/datatypes/[altair, deneb],
   # Status libraries
   snappy,
   # Test utilities
@@ -31,7 +31,7 @@ from ../../beacon_chain/spec/datatypes/capella import
 # ----------------------------------------------------------------
 
 const
-  SSZDir = SszTestsDir/const_preset/"eip4844"/"ssz_static"
+  SSZDir = SszTestsDir/const_preset/"deneb"/"ssz_static"
 
 type
   SSZHashTreeRoot = object
@@ -44,7 +44,7 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type eip4844.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(T: type deneb.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
    # Deserialize into a ref object to not fill Nim stack
    let encoded = snappy.decode(
      readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -104,11 +104,12 @@ suite "EF - Deneb - SSZ consensus objects " & preset():
           of "Attestation": checkSSZ(Attestation, path, hash)
           of "AttestationData": checkSSZ(AttestationData, path, hash)
           of "AttesterSlashing": checkSSZ(AttesterSlashing, path, hash)
-          of "BeaconBlock": checkSSZ(eip4844.BeaconBlock, path, hash)
-          of "BeaconBlockBody": checkSSZ(eip4844.BeaconBlockBody, path, hash)
+          of "BeaconBlock": checkSSZ(deneb.BeaconBlock, path, hash)
+          of "BeaconBlockBody": checkSSZ(deneb.BeaconBlockBody, path, hash)
           of "BeaconBlockHeader": checkSSZ(BeaconBlockHeader, path, hash)
-          of "BeaconState": checkSSZ(eip4844.BeaconState, path, hash)
-          of "BlobsSidecar": checkSSZ(BlobsSidecar, path, hash)
+          of "BeaconState": checkSSZ(deneb.BeaconState, path, hash)
+          of "BlobIdentifier": checkSSZ(BlobIdentifier, path, hash)
+          of "BlobSidecar": checkSSZ(BlobSidecar, path, hash)
           of "BLSToExecutionChange": checkSSZ(BLSToExecutionChange, path, hash)
           of "Checkpoint": checkSSZ(Checkpoint, path, hash)
           of "ContributionAndProof": checkSSZ(ContributionAndProof, path, hash)
@@ -126,26 +127,25 @@ suite "EF - Deneb - SSZ consensus objects " & preset():
           of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
           of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
           of "LightClientBootstrap":
-            checkSSZ(eip4844.LightClientBootstrap, path, hash)
-          of "LightClientHeader":
-            checkSSZ(eip4844.LightClientHeader, path, hash)
-          of "LightClientUpdate":
-            checkSSZ(eip4844.LightClientUpdate, path, hash)
+            checkSSZ(deneb.LightClientBootstrap, path, hash)
+          of "LightClientHeader": checkSSZ(deneb.LightClientHeader, path, hash)
+          of "LightClientUpdate": checkSSZ(deneb.LightClientUpdate, path, hash)
           of "LightClientFinalityUpdate":
-            checkSSZ(eip4844.LightClientFinalityUpdate, path, hash)
+            checkSSZ(deneb.LightClientFinalityUpdate, path, hash)
           of "LightClientOptimisticUpdate":
-            checkSSZ(eip4844.LightClientOptimisticUpdate, path, hash)
+            checkSSZ(deneb.LightClientOptimisticUpdate, path, hash)
           of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
           of "PowBlock": checkSSZ(PowBlock, path, hash)
           of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
           of "SignedAggregateAndProof":
             checkSSZ(SignedAggregateAndProof, path, hash)
           of "SignedBeaconBlock":
-            checkSSZ(eip4844.SignedBeaconBlock, path, hash)
+            checkSSZ(deneb.SignedBeaconBlock, path, hash)
           of "SignedBeaconBlockAndBlobsSidecar":
-            checkSSZ(eip4844.SignedBeaconBlockAndBlobsSidecar, path, hash)
+            checkSSZ(deneb.SignedBeaconBlockAndBlobsSidecar, path, hash)
           of "SignedBeaconBlockHeader":
             checkSSZ(SignedBeaconBlockHeader, path, hash)
+          of "SignedBlobSidecar": checkSSZ(SignedBlobSidecar, path, hash)
           of "SignedBLSToExecutionChange":
             checkSSZ(SignedBLSToExecutionChange, path, hash)
           of "SignedContributionAndProof":

--- a/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
@@ -23,7 +23,7 @@ from std/sequtils import mapIt, toSeq
 from std/strutils import rsplit
 
 const
-  RootDir = SszTestsDir/const_preset/"eip4844"/"epoch_processing"
+  RootDir = SszTestsDir/const_preset/"deneb"/"epoch_processing"
 
   JustificationFinalizationDir = RootDir/"justification_and_finalization"
   InactivityDir =                RootDir/"inactivity_updates"
@@ -54,7 +54,7 @@ template runSuite(
       let unitTestName = testDir.rsplit(DirSep, 1)[1]
       test testName & " - " & unitTestName & preset():
         # BeaconState objects are stored on the heap to avoid stack overflow
-        type T = eip4844.BeaconState
+        type T = deneb.BeaconState
         let preState {.inject.} = newClone(parseTest(testDir/"pre.ssz_snappy", SSZ, T))
         var cache {.inject, used.} = StateCache()
         template state: untyped {.inject, used.} = preState[]

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -27,6 +27,10 @@ export
 # Path parsing
 
 func forkForPathComponent*(forkPath: string): Opt[ConsensusFork] =
+  # TODO remove after EIP4844 gets renamed to Deneb in ConsensusFork
+  if forkPath == "deneb":
+    return ok ConsensusFork.EIP4844
+
   for fork in ConsensusFork:
     if ($fork).toLowerAscii() == forkPath:
       return ok fork

--- a/tests/consensus_spec/test_fixture_fork.nim
+++ b/tests/consensus_spec/test_fixture_fork.nim
@@ -66,11 +66,11 @@ suite "EF - Capella - Fork " & preset():
     runTest(bellatrix.BeaconState, capella.BeaconState, "Capella", OpForkDir,
             upgrade_to_capella, path)
 
-from ../../beacon_chain/spec/datatypes/eip4844 import BeaconState
+from ../../beacon_chain/spec/datatypes/deneb import BeaconState
 
 suite "EF - Deneb - Fork " & preset():
   const OpForkDir =
-    SszTestsDir/const_preset/"eip4844"/"fork"/"fork"/"pyspec_tests"
+    SszTestsDir/const_preset/"deneb"/"fork"/"fork"/"pyspec_tests"
   for kind, path in walkDir(OpForkDir, relative = true, checkDir = true):
-    runTest(capella.BeaconState, eip4844.BeaconState, "Deneb", OpForkDir,
+    runTest(capella.BeaconState, deneb.BeaconState, "Deneb", OpForkDir,
             upgrade_to_eip4844, path)

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -128,15 +128,7 @@ proc runTest(path: string) =
     proc loadTestMeta(): (RuntimeConfig, TestMeta) =
       let (cfg, unknowns) = readRuntimeConfig(path/"config.yaml")
 
-      # TODO
-      # Uncomment the assertion below and remove the loop below.
-      # The two unknown constants are "EIP4844_FORK_VERSION", "EIP4844_FORK_EPOCH"
-      # This is likely to be fixed in the next release of the test suite where
-      # EIP4844 will be renamed to DENEB (our code is already using the new name).
-      # doAssert unknowns.len == 0, "Unknown config constants: " & $unknowns
-      for name in unknowns:
-        if name notin ["EIP4844_FORK_VERSION", "EIP4844_FORK_EPOCH"]:
-          raiseAssert "Unknown constant: " & name
+      doAssert unknowns.len == 0, "Unknown config constants: " & $unknowns
 
       type TestMetaYaml {.sparse.} = object
         genesis_validators_root: string

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -110,7 +110,7 @@ from ../../../beacon_chain/spec/datatypes/capella import
 runForkBlockTests(
   "capella", "Capella", capella.BeaconState, capella.SignedBeaconBlock)
 
-from ../../../beacon_chain/spec/datatypes/eip4844 import
+from ../../../beacon_chain/spec/datatypes/deneb import
   BeaconState, SignedBeaconBlock
 runForkBlockTests(
-  "eip4844", "Deneb", eip4844.BeaconState, eip4844.SignedBeaconBlock)
+  "deneb", "Deneb", deneb.BeaconState, deneb.SignedBeaconBlock)

--- a/tests/consensus_spec/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/test_fixture_sanity_slots.nim
@@ -81,10 +81,10 @@ suite "EF - Capella - Sanity - Slots " & preset():
       capellaSanitySlotsDir, relative = true, checkDir = true):
     runTest(capella.BeaconState, capellaSanitySlotsDir, "Capella", path)
 
-from ../../../beacon_chain/spec/datatypes/eip4844 import BeaconState
+from ../../../beacon_chain/spec/datatypes/deneb import BeaconState
 
 suite "EF - Deneb - Sanity - Slots " & preset():
-  const eip4844SanitySlotsDir = sanitySlotsDir("eip4844")
+  const denebSanitySlotsDir = sanitySlotsDir("deneb")
   for kind, path in walkDir(
-      eip4844SanitySlotsDir, relative = true, checkDir = true):
-    runTest(eip4844.BeaconState, eip4844SanitySlotsDir, "Deneb", path)
+      denebSanitySlotsDir, relative = true, checkDir = true):
+    runTest(deneb.BeaconState, denebSanitySlotsDir, "Deneb", path)

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -128,18 +128,18 @@ suite "EF - Capella - Transition " & preset():
       capella.SignedBeaconBlock, cfg, "EF - Capella - Transition",
       TransitionDir, path, transitionInfo.fork_block)
 
-from ../../beacon_chain/spec/datatypes/eip4844 import
+from ../../beacon_chain/spec/datatypes/deneb import
   BeaconState, SignedBeaconBlock
 
 suite "EF - Deneb - Transition " & preset():
   const TransitionDir =
-    SszTestsDir/const_preset/"eip4844"/"transition"/"core"/"pyspec_tests"
+    SszTestsDir/const_preset/"deneb"/"transition"/"core"/"pyspec_tests"
 
   for kind, path in walkDir(TransitionDir, relative = true, checkDir = true):
     let transitionInfo = getTransitionInfo(TransitionDir / path)
     var cfg = defaultRuntimeConfig
     cfg.DENEB_FORK_EPOCH = transitionInfo.fork_epoch.Epoch
     runTest(
-      capella.BeaconState, eip4844.BeaconState, capella.SignedBeaconBlock,
-      eip4844.SignedBeaconBlock, cfg, "EF - EIP4844 - Transition",
+      capella.BeaconState, deneb.BeaconState, capella.SignedBeaconBlock,
+      deneb.SignedBeaconBlock, cfg, "EF - EIP4844 - Transition",
       TransitionDir, path, transitionInfo.fork_block)


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.3.0-rc.3
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.3.0-rc.3

Mostly minimal changes included, though it doesn't implement https://github.com/ethereum/consensus-specs/pull/3244 in any meaningful way, just adds the SSZ objects to pass the tests.