### PR TITLE
beacon_chain: fix history flag help message

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -603,7 +603,7 @@ type
         name: "payload-builder-url" .}: string
 
       historyMode* {.
-        desc: "Retention strategy for historical data (archive/pruned)"
+        desc: "Retention strategy for historical data (archive/prune)"
         defaultValue: HistoryMode.Archive
         name: "history".}: HistoryMode
 


### PR DESCRIPTION
Or you just get:
```
Error while processing the history=pruned parameter: Invalid enum value: pruned
```