### PR TITLE
add success logging for being configured to use payload builder

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -661,6 +661,10 @@ proc init*(T: type BeaconNode,
     else:
       nil
 
+  if config.payloadBuilderEnable and payloadBuilderRestClient != nil:
+    info "Using external payload builder",
+      payloadBuilderUrl = config.payloadBuilderUrl
+
   let node = BeaconNode(
     nickname: nickname,
     graffitiBytes: if config.graffiti.isSome: config.graffiti.get


### PR DESCRIPTION
There have been repeated support questions for how to determine whether this is the case, and hitherto people have been directed to `mev-boost` logs if they're using that, or other indirect sources.

The failure modes are logged, but there's otherwise no confirmation Nimbus is set up to use external payload building until it actually proposes blocks.