### PR TITLE
rename `eip4844ImplementationMissing` to `denebImplementationMissing`

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -850,7 +850,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     case currentEpochFork
     of ConsensusFork.EIP4844:
-      return RestApiResponse.jsonError(Http500, $eip4844ImplementationMissing)
+      return RestApiResponse.jsonError(Http500, $denebImplementationMissing)
     of ConsensusFork.Capella:
       let res =
         block:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -473,7 +473,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
     let currentEpoch = node.currentSlot().epoch()
     if currentEpoch >= node.dag.cfg.DENEB_FORK_EPOCH:
-      debugRaiseAssert $eip4844ImplementationMissing & ": GET /eth/v1/validator/blinded_blocks/{slot}"
+      debugRaiseAssert $denebImplementationMissing & ": GET /eth/v1/validator/blinded_blocks/{slot}"
     elif currentEpoch >= node.dag.cfg.CAPELLA_FORK_EPOCH:
       let res = await makeBlindedBeaconBlockForHeadAndSlot[
           capella_mev.BlindedBeaconBlock](

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -1011,7 +1011,7 @@ func checkForkConsistency*(cfg: RuntimeConfig) =
 # due to a Deneb implementation missing. checkForkConsistency() checks that
 # Nimbus does not run any non-FAR_FUTURE_EPOCH Deneb network, so such cases
 # won't be hit.
-const eip4844ImplementationMissing* = false
+const denebImplementationMissing* = false
 
 #template debugRaiseAssert*(x: string) = raiseAssert x
 template debugRaiseAssert*(x: string) = discard

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1002,7 +1002,7 @@ proc readValue*[BlockType: ForkedBeaconBlock](
       reader.raiseUnexpectedValue("Incorrect capella block format")
     value = ForkedBeaconBlock.init(res.get()).BlockType
   of ConsensusFork.EIP4844:
-    reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+    reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc readValue*[BlockType: ForkedBlindedBeaconBlock](
        reader: var JsonReader[RestJson],
@@ -1065,7 +1065,7 @@ proc readValue*[BlockType: ForkedBlindedBeaconBlock](
     value = ForkedBlindedBeaconBlock(kind: ConsensusFork.Capella,
                                      capellaData: res)
   of ConsensusFork.EIP4844:
-    reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+    reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
     reader: var JsonReader[RestJson],
@@ -1135,7 +1135,7 @@ proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
       kind: ConsensusFork.Capella,
       capellaData: res.get())
   of ConsensusFork.EIP4844:
-    reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+    reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc writeValue*[
     BlockType: Web3SignerForkedBeaconBlock](
@@ -1394,7 +1394,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       value.capellaBody.execution_payload.withdrawals,
       ep_src.withdrawals.get())
   of ConsensusFork.EIP4844:
-    reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+    reader.raiseUnexpectedValue($denebImplementationMissing)
 
 ## RestPublishedBeaconBlock
 proc readValue*(reader: var JsonReader[RestJson],
@@ -1492,7 +1492,7 @@ proc readValue*(reader: var JsonReader[RestJson],
         )
       )
     of ConsensusFork.EIP4844:
-      reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+      reader.raiseUnexpectedValue($denebImplementationMissing)
   )
 
 ## RestPublishedSignedBeaconBlock
@@ -1553,7 +1553,7 @@ proc readValue*(reader: var JsonReader[RestJson],
         )
       )
     of ConsensusFork.EIP4844:
-      reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+      reader.raiseUnexpectedValue($denebImplementationMissing)
   )
 
 ## ForkedSignedBeaconBlock
@@ -1647,7 +1647,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       reader.raiseUnexpectedValue("Incorrect capella block format")
     value = ForkedSignedBeaconBlock.init(res.get())
   of ConsensusFork.EIP4844:
-    reader.raiseUnexpectedValue($eip4844ImplementationMissing)
+    reader.raiseUnexpectedValue($denebImplementationMissing)
   withBlck(value):
     blck.root = hash_tree_root(blck.message)
 
@@ -2730,7 +2730,7 @@ proc decodeBody*(
           return err("Unexpected deserialization error")
       ok(RestPublishedSignedBeaconBlock(ForkedSignedBeaconBlock.init(blck)))
     of ConsensusFork.EIP4844:
-      return err($eip4844ImplementationMissing)
+      return err($denebImplementationMissing)
   else:
     return err("Unsupported or invalid content media type")
 

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -425,7 +425,7 @@ func init*(T: type ForkedSignedBlindedBeaconBlock,
       capellaData: capella_mev.SignedBlindedBeaconBlock(message: forked.capellaData,
                                                         signature: signature))
   of ConsensusFork.EIP4844:
-    discard $eip4844ImplementationMissing & "forks.nim:init(T: type ForkedSignedBlindedBeaconBlock)"
+    discard $denebImplementationMissing & "forks.nim:init(T: type ForkedSignedBlindedBeaconBlock)"
     T(kind: ConsensusFork.EIP4844,
       eip4844Data: capella_mev.SignedBlindedBeaconBlock(message: forked.eip4844Data,
                                                         signature: signature))

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -582,7 +582,7 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload |
              execution_payload_root.get,
              hash_tree_root(validator_changes.bls_to_execution_changes)])
         elif stateFork > ConsensusFork.Capella:
-          discard eip4844ImplementationMissing
+          discard denebImplementationMissing
 
     state.`kind Data`.root = hash_tree_root(state.`kind Data`.data)
     blck.`kind Data`.state_root = state.`kind Data`.root

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -775,7 +775,7 @@ proc validate_blobs_sidecar*(slot: Slot, root: Eth2Digest,
 func is_data_available(
     slot: Slot, beacon_block_root: Eth2Digest,
     blob_kzg_commitments: seq[deneb.KZGCommitment]): bool =
-  discard $eip4844ImplementationMissing & ": state_transition_block.nim:is_data_available"
+  discard $denebImplementationMissing & ": state_transition_block.nim:is_data_available"
 
   true
 

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -2084,7 +2084,7 @@ proc publishBlock*(
         of ConsensusFork.Capella:
           publishBlock(it, data.capellaData)
         of ConsensusFork.EIP4844:
-          debugRaiseAssert $eip4844ImplementationMissing &
+          debugRaiseAssert $denebImplementationMissing &
                            ": validator_client/api.nim:publishBlock (1)"
           let f = newFuture[RestPlainResponse]("")
           f.fail(new RestError)
@@ -2154,7 +2154,7 @@ proc publishBlock*(
       of ConsensusFork.Capella:
         publishBlock(it, data.capellaData)
       of ConsensusFork.EIP4844:
-        debugRaiseAssert $eip4844ImplementationMissing &
+        debugRaiseAssert $denebImplementationMissing &
                          ": validator_client/api.nim:publishBlock (2)"
         let f = newFuture[RestPlainResponse]("")
         f.fail(new RestError)
@@ -2347,7 +2347,7 @@ proc publishBlindedBlock*(
         of ConsensusFork.Capella:
           publishBlindedBlock(it, data.capellaData)
         of ConsensusFork.EIP4844:
-          debugRaiseAssert $eip4844ImplementationMissing &
+          debugRaiseAssert $denebImplementationMissing &
                            ": validator_client/api.nim:publishBlindedBlock (1)"
           let f = newFuture[RestPlainResponse]("")
           f.fail(new RestError)
@@ -2416,7 +2416,7 @@ proc publishBlindedBlock*(
       of ConsensusFork.Capella:
         publishBlindedBlock(it, data.capellaData)
       of ConsensusFork.EIP4844:
-        debugRaiseAssert $eip4844ImplementationMissing &
+        debugRaiseAssert $denebImplementationMissing &
                          ": validator_client/api.nim:publishBlindedBlock (2)"
         let f = newFuture[RestPlainResponse]("")
         f.fail(new RestError)

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -724,7 +724,7 @@ proc getBlindedBeaconBlock[
     Future[Result[T, string]] {.async.} =
   withBlck(forkedBlock):
     when stateFork >= ConsensusFork.EIP4844:
-      debugRaiseAssert $eip4844ImplementationMissing & ": getBlindedBeaconBlock"
+      debugRaiseAssert $denebImplementationMissing & ": getBlindedBeaconBlock"
       return err("getBlindedBeaconBlock: Deneb blinded block creation not implemented")
     elif stateFork >= ConsensusFork.Bellatrix:
       when not (
@@ -909,7 +909,7 @@ proc makeBlindedBeaconBlockForHeadAndSlot*[
   let (executionPayloadHeader, forkedBlck) = blindedBlockParts.get
   withBlck(forkedBlck):
     when stateFork >= ConsensusFork.EIP4844:
-      debugRaiseAssert $eip4844ImplementationMissing & ": makeBlindedBeaconBlockForHeadAndSlot"
+      debugRaiseAssert $denebImplementationMissing & ": makeBlindedBeaconBlockForHeadAndSlot"
     elif stateFork >= ConsensusFork.Bellatrix:
       when ((stateFork == ConsensusFork.Bellatrix and
              EPH is bellatrix.ExecutionPayloadHeader) or
@@ -952,7 +952,7 @@ proc proposeBlock(node: BeaconNode,
   if node.config.payloadBuilderEnable:
     let newBlockMEV =
       if slot.epoch >= node.dag.cfg.DENEB_FORK_EPOCH:
-        debugRaiseAssert $eip4844ImplementationMissing & ": proposeBlock"
+        debugRaiseAssert $denebImplementationMissing & ": proposeBlock"
         await proposeBlockMEV[
             capella_mev.SignedBlindedBeaconBlock](
           node, head, validator, slot, randao, validator_index)

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -264,7 +264,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
         blocks[3].add dag.db.getBlock(
           blck.root, capella.TrustedSignedBeaconBlock).get()
       of ConsensusFork.EIP4844:
-        raiseAssert $eip4844ImplementationMissing
+        raiseAssert $denebImplementationMissing
 
   let stateData = newClone(dag.headState)
 
@@ -334,7 +334,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[3][].data, noRollback)
               of ConsensusFork.EIP4844:
-                raiseAssert $eip4844ImplementationMissing & ": ncli_db.nim: cmdBench (1)"
+                raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (1)"
 
             if forkyState.data.slot.epoch mod 16 == 0:
               let loadedRoot = case stateFork
@@ -342,7 +342,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 of ConsensusFork.Altair:    hash_tree_root(loadedState[1][].data)
                 of ConsensusFork.Bellatrix: hash_tree_root(loadedState[2][].data)
                 of ConsensusFork.Capella:   hash_tree_root(loadedState[3][].data)
-                of ConsensusFork.EIP4844:   raiseAssert $eip4844ImplementationMissing & ": ncli_db.nim: cmdBench (2)"
+                of ConsensusFork.EIP4844:   raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (2)"
               doAssert hash_tree_root(forkyState.data) == loadedRoot
 
   processBlocks(blocks[0])


### PR DESCRIPTION
Precisely. Nothing more, nothing less.