### PR TITLE
build make all targets in debug mode on GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Build binaries (with trace logging enabled)
         run: |
-          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE
+          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="-u:release --opt:none"
           # The Windows image runs out of disk space, so make some room
           rm -rf build nimcache
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ DEPOSITS_DELAY := 0
 #- "--define:release" cannot be added to "config.nims"
 #- disable Nim's default parallelisation because it starts too many processes for too little gain
 #- https://github.com/status-im/nim-libp2p#use-identify-metrics
-NIM_PARAMS += -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,lodestar,prysm,teku
+NIM_PARAMS := -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,lodestar,prysm,teku $(NIM_PARAMS)
 
 ifeq ($(USE_LIBBACKTRACE), 0)
 NIM_PARAMS += -d:disable_libbacktrace


### PR DESCRIPTION
This reduces the time for an equivalent, starting sans `nimcache`s, build locally for `make -j2 LOG_LEVEL=TRACE` from 25 to 15 minutes. A recent `unstable` commit required 1h40m for Windows; if this is similarly faster, that's worth the tradeoff in building slightly different binaries which are never used.

Jenkins still builds release `make LOG_LEVEL=TRACE`, and while it's important not to run Nim in `--compileOnly` mode because it does sometimes generate invalid C code which it's useful to run `gcc` against, and for build artifacts which are run/released/tested in CI or otherwise, `-O3` with LTO has definitely triggered issues, those would not be visible in this context regardless.

`make all_tests` regardless effectively builds a copy of `nimbus_beacon_node`.

This additional release mode build time doesn't much help catch bugs.