### PR TITLE
fix 2 BareExcept warning sources

### DIFF
--- a/beacon_chain/statusbar.nim
+++ b/beacon_chain/statusbar.nim
@@ -89,7 +89,7 @@ var complained = false
 template ignoreException(body: untyped) =
   try:
     body
-  except Exception as exc:
+  except CatchableError as exc:
     if not complained:
       # TODO terminal.nim exception leak
       echo "Unable to update status bar: ", exc.msg

--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -50,7 +50,7 @@ func start_slot*(e: Era): Slot =
 
 proc toString(v: IoErrorCode): string =
   try: ioErrorMsg(v)
-  except Exception as e: raiseAssert e.msg
+  except CatchableError as e: raiseAssert e.msg
 
 func eraRoot*(
     genesis_validators_root: Eth2Digest,

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -85,7 +85,7 @@ template decodeAndProcess(typ, process: untyped): bool =
       raise newException(
         FuzzCrashError,
         "Unexpected  (logging?) IOError in state transition", e)
-    except Exception as e:
+    except CatchableError as e:
       # TODO why an Exception?
       # Lots of vendor code looks like it might raise a bare exception type
       raise newException(FuzzCrashError, "Unexpected Exception in state transition", e)

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -85,7 +85,7 @@ template decodeAndProcess(typ, process: untyped): bool =
       raise newException(
         FuzzCrashError,
         "Unexpected  (logging?) IOError in state transition", e)
-    except CatchableError as e:
+    except Exception as e:
       # TODO why an Exception?
       # Lots of vendor code looks like it might raise a bare exception type
       raise newException(FuzzCrashError, "Unexpected Exception in state transition", e)


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/4661

in particular
```
     17 nimbus-eth2/ncli/e2store.nim(53, 3) Warning: catch a more precise Exception deriving from CatchableError or Defect. [BareExcept]
     14 nimbus-eth2/nfuzz/libnfuzz.nim(88, 5) Warning: catch a more precise Exception deriving from CatchableError or Defect. [BareExcept]
      9 nimbus-eth2/beacon_chain/statusbar.nim(92, 3) Warning: catch a more precise Exception deriving from CatchableError or Defect. [BareExcept]
```

The semantics are slightly different, between `except:` and `except CatchableError`, but for these three, it shouldn't be important.

`nfuzz` isn't currently in active use. No loss there -- if someone tries to use it and discovers that it's inadequate to the purpose, it can be addressed then.

`ncli/e2store.nim`  is used to address what `ioErrorMsg` does, and (a) that's `nim-stew` code under Status control, and fixable even if it throws something where this difference is important; and (b) it doesn't intentionally throw any exceptions. It calls `formatMessageW` and `localFree`. Both of these are just direct calls to Win32 API functions, which don't per se participate in the Nim exception system.

` nimbus-eth2/beacon_chain/statusbar.nim` uses it in some generic way, as part of an `ignoreExceptions` wrapper. This is used for `terminal.nim` functions, which uniformly call [raiseOSError](https://nim-lang.org/docs/os.html#raiseOSError%2COSErrorCode%2Cstring), which raises an [OSError](https://nim-lang.org/docs/system.html#OSError), which:
```nim
  OSError = object of CatchableError
```