### PR TITLE
weaken overaggressive different-fork-next-slot check

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -354,11 +354,14 @@ proc runProposalForkchoiceUpdated*(
     nextWallSlot, validatorIndex, nextProposer
 
   withState(self.dag.headState):
-    let nextSlotFork = self.dag.cfg.forkAtEpoch(nextWallSlot.epoch)
-    if forkyState.data.fork != nextSlotFork:
-      debug "runProposalForkchoiceUpdated: about to do fork transition; don't have appropriate state to fcU ahead",
+    let
+      nextSlotFork = self.dag.cfg.forkAtEpoch(nextWallSlot.epoch)
+      nextSlotForkVersion = self.dag.cfg.forkVersionAtEpoch(nextWallSlot.epoch)
+    if  nextSlotForkVersion == self.dag.cfg.CAPELLA_FORK_VERSION and
+        forkyState.data.fork.current_version != nextSlotFork.current_version:
+      debug "runProposalForkchoiceUpdated: about to do Capella transition; don't have appropriate state to fcU ahead",
         nextWallSlot, validatorIndex, nextProposer, nextSlotFork,
-        stateFork = forkyState.data.fork
+        nextSlotForkVersion, stateFork = forkyState.data.fork
 
   # Approximately lines up with validator_duties version. Used optimistically/
   # opportunistically, so mismatches are fine if not too frequent.


### PR DESCRIPTION
The condition was too strong: required `previous_version` to match, unnecessarily and applied beyond the Capella fork transition where the v1/v2 engine API transition occurs.

This shows up, e.g., in the local testnets with Bellatrix genesis:
```
{"lvl":"DBG","ts":"2023-02-24 21:16:12.084+00:00","msg":"runProposalForkchoiceUpdated: about to do fork transition; don't have appropriate state to fcU ahead","nextWallSlot":20,"validatorIndex":505,"nextProposer":"a7f63e571422ee642cd220954df8bba7ea507897c3b8e22dcea73e37e0e7021a6fce33a419981cbc7b7faec09a2b68cb","nextSlotFork":{"previous_version":"0x01000000","current_version":"0x02000000","epoch":0},"stateFork":{"previous_version":"0x02000000","current_version":"0x02000000","epoch":0}}
```

The `current_version`s match, which is enough for what this check is getting at, but because of a quirk of how the default previous/current versions are defined, there's a notional previous Altair (0x01000000) fork which never actually exists, so until the first Capella transition, it thinks the next slot fork is perpetually different than the current slot fork.