### PR TITLE
more `eip4844` -> `deneb` changes

### DIFF
--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -13,7 +13,7 @@ import
 
 from ./spec/datatypes/capella import
   ExecutionPayloadHeader, HistoricalSummary, Withdrawal
-from ./spec/datatypes/eip4844 import ExecutionPayloadHeader
+from ./spec/datatypes/deneb import ExecutionPayloadHeader
 
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#beaconstate
@@ -315,7 +315,7 @@ type
     next_sync_committee*: SyncCommittee
 
     # Execution
-    latest_execution_payload_header*: eip4844.ExecutionPayloadHeader
+    latest_execution_payload_header*: deneb.ExecutionPayloadHeader
 
     # Withdrawals
     next_withdrawal_index*: WithdrawalIndex

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -13,7 +13,7 @@ import
   ../spec/forks
 
 from ../spec/datatypes/capella import SomeBeaconBlock, TrustedBeaconBlock
-from ../spec/datatypes/eip4844 import SomeBeaconBlock, TrustedBeaconBlock
+from ../spec/datatypes/deneb import SomeBeaconBlock, TrustedBeaconBlock
 
 export chronicles, forks
 
@@ -69,7 +69,7 @@ func init*(
     T: type BlockRef, root: Eth2Digest,
     blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock |
           capella.SomeBeaconBlock | capella.TrustedBeaconBlock |
-          eip4844.SomeBeaconBlock | eip4844.TrustedBeaconBlock): BlockRef =
+          deneb.SomeBeaconBlock | deneb.TrustedBeaconBlock): BlockRef =
   BlockRef.init(
     root, Opt.some Eth2Digest(blck.body.execution_payload.block_hash),
     blck.slot)

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -20,7 +20,7 @@ import
   ./block_dag, block_pools_types_light_client
 
 from ../spec/datatypes/capella import TrustedSignedBeaconBlock
-from ../spec/datatypes/eip4844 import TrustedSignedBeaconBlock
+from ../spec/datatypes/deneb import TrustedSignedBeaconBlock
 
 from "."/vanity_logs/vanity_logs import VanityLogs
 
@@ -310,7 +310,7 @@ type
 
   OnEIP4844BlockAdded* = proc(
     blckRef: BlockRef,
-    blck: eip4844.TrustedSignedBeaconBlock,
+    blck: deneb.TrustedSignedBeaconBlock,
     epochRef: EpochRef,
     unrealized: FinalityCheckpoints) {.gcsafe, raises: [Defect].}
 

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -11,7 +11,7 @@ import
   std/[tables],
   stew/bitops2,
   ../spec/forks,
-  ../spec/datatypes/eip4844
+  ../spec/datatypes/deneb
 
 export tables, forks
 
@@ -40,7 +40,7 @@ type
     ## Trivially invalid blocks may be dropped before reaching this stage.
 
     orphans*: Table[(Eth2Digest, ValidatorSig),
-                    (ForkedSignedBeaconBlock, Opt[eip4844.BlobsSidecar])]
+                    (ForkedSignedBeaconBlock, Opt[deneb.BlobsSidecar])]
       ## Blocks that we don't have a parent for - when we resolve the parent, we
       ## can proceed to resolving the block as well - we index this by root and
       ## signature such that a block with invalid signature won't cause a block
@@ -193,7 +193,7 @@ func clearAfterReorg*(quarantine: var Quarantine) =
 func addOrphan*(
     quarantine: var Quarantine, finalizedSlot: Slot,
     signedBlock: ForkedSignedBeaconBlock,
-    blobs: Opt[eip4844.BlobsSidecar]): bool =
+    blobs: Opt[deneb.BlobsSidecar]): bool =
   ## Adds block to quarantine's `orphans` and `missing` lists.
   if not isViableOrphan(finalizedSlot, signedBlock):
     quarantine.addUnviable(signedBlock.root)
@@ -221,7 +221,7 @@ func addOrphan*(
   true
 
 iterator pop*(quarantine: var Quarantine, root: Eth2Digest):
-    (ForkedSignedBeaconBlock, Opt[eip4844.BlobsSidecar]) =
+    (ForkedSignedBeaconBlock, Opt[deneb.BlobsSidecar]) =
   # Pop orphans whose parent is the block identified by `root`
 
   var toRemove: seq[(Eth2Digest, ValidatorSig)]

--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -17,7 +17,7 @@ import
   eth/async_utils, stew/[byteutils, objects, results, shims/hashes],
   # Local modules:
   ../spec/[deposit_snapshots, eth2_merkleization, forks, helpers],
-  ../spec/datatypes/[base, phase0, bellatrix, eip4844],
+  ../spec/datatypes/[base, phase0, bellatrix, deneb],
   ../networking/network_metadata,
   ../consensus_object_pools/block_pools_types,
   ".."/[beacon_chain_db, beacon_node_status, beacon_clock],
@@ -301,11 +301,11 @@ func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV2):
       mapIt(rpcExecutionPayload.withdrawals, it.asConsensusWithdrawal)))
 
 func asConsensusExecutionPayload*(rpcExecutionPayload: ExecutionPayloadV3):
-    eip4844.ExecutionPayload =
+    deneb.ExecutionPayload =
   template getTransaction(tt: TypedTransaction): bellatrix.Transaction =
     bellatrix.Transaction.init(tt.distinctBase)
 
-  eip4844.ExecutionPayload(
+  deneb.ExecutionPayload(
     parent_hash: rpcExecutionPayload.parentHash.asEth2Digest,
     feeRecipient:
       ExecutionAddress(data: rpcExecutionPayload.feeRecipient.distinctBase),
@@ -371,7 +371,7 @@ func asEngineExecutionPayload*(executionPayload: capella.ExecutionPayload):
     transactions: mapIt(executionPayload.transactions, it.getTypedTransaction),
     withdrawals: mapIt(executionPayload.withdrawals, it.asEngineWithdrawal))
 
-func asEngineExecutionPayload*(executionPayload: eip4844.ExecutionPayload):
+func asEngineExecutionPayload*(executionPayload: deneb.ExecutionPayload):
     ExecutionPayloadV3 =
   template getTypedTransaction(tt: bellatrix.Transaction): TypedTransaction =
     TypedTransaction(tt.distinctBase)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -19,7 +19,7 @@ import ".."/[eth2_ssz_serialization, forks, keystore],
 import nimcrypto/utils as ncrutils
 
 from ".."/datatypes/capella import SignedBeaconBlock
-from ".."/datatypes/eip4844 import BeaconState
+from ".."/datatypes/deneb import BeaconState
 
 export
   eth2_ssz_serialization, results, peerid, common, serialization, chronicles,
@@ -1768,7 +1768,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     try:
       tmp[].eip4844Data.data = RestJson.decode(
         string(data.get()),
-        eip4844.BeaconState,
+        deneb.BeaconState,
         requireAllFields = true,
         allowUnknownFields = true)
     except SerializationError:

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -17,7 +17,7 @@ import
   std/json,
   stew/base10, web3/ethtypes,
   ".."/forks,
-  ".."/datatypes/[phase0, altair, bellatrix, eip4844],
+  ".."/datatypes/[phase0, altair, bellatrix, deneb],
   ".."/mev/[bellatrix_mev, capella_mev]
 
 from ".."/datatypes/capella import BeaconBlockBody
@@ -311,7 +311,7 @@ type
     of ConsensusFork.Altair:    altairBody*:    altair.BeaconBlockBody
     of ConsensusFork.Bellatrix: bellatrixBody*: bellatrix.BeaconBlockBody
     of ConsensusFork.Capella:   capellaBody*:   capella.BeaconBlockBody
-    of ConsensusFork.EIP4844:   eip4844Body*:   eip4844.BeaconBlockBody
+    of ConsensusFork.EIP4844:   eip4844Body*:   deneb.BeaconBlockBody
 
   RestSpec* = object
     # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/presets/mainnet/phase0.yaml

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -190,7 +190,7 @@ template kind*(
 
 template LightClientHeader*(kind: static LightClientDataFork): auto =
   when kind == LightClientDataFork.EIP4844:
-    typedesc[eip4844.LightClientHeader]
+    typedesc[deneb.LightClientHeader]
   elif kind == LightClientDataFork.Capella:
     typedesc[capella.LightClientHeader]
   elif kind == LightClientDataFork.Altair:
@@ -210,7 +210,7 @@ template LightClientBootstrap*(kind: static LightClientDataFork): auto =
 
 template LightClientUpdate*(kind: static LightClientDataFork): auto =
   when kind == LightClientDataFork.EIP4844:
-    typedesc[eip4844.LightClientUpdate]
+    typedesc[deneb.LightClientUpdate]
   elif kind == LightClientDataFork.Capella:
     typedesc[capella.LightClientUpdate]
   elif kind == LightClientDataFork.Altair:
@@ -240,7 +240,7 @@ template LightClientOptimisticUpdate*(kind: static LightClientDataFork): auto =
 
 template LightClientStore*(kind: static LightClientDataFork): auto =
   when kind == LightClientDataFork.EIP4844:
-    typedesc[eip4844.LightClientStore]
+    typedesc[deneb.LightClientStore]
   elif kind == LightClientDataFork.Capella:
     typedesc[capella.LightClientStore]
   elif kind == LightClientDataFork.Altair:

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -726,7 +726,7 @@ proc registerAttestationInBlock*(
       update_if_lt(
         epochSummary.attestation_min_block_inclusion_distance, inclusion_lag)
 
-from ../spec/datatypes/eip4844 import shortLog
+from ../spec/datatypes/deneb import shortLog
 
 proc registerBeaconBlock*(
     self: var ValidatorMonitor,

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -19,7 +19,7 @@ import
   chronos/timer, eth/keys, taskpools,
   ../tests/testblockutil,
   ../beacon_chain/spec/[forks, state_transition],
-  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, eip4844],
+  ../beacon_chain/spec/datatypes/[phase0, altair, bellatrix, deneb],
   ../beacon_chain/[beacon_chain_db, beacon_clock],
   ../beacon_chain/eth1/eth1_monitor,
   ../beacon_chain/validators/validator_pool,
@@ -34,8 +34,6 @@ from std/random import Rand, initRand, rand
 from std/stats import RunningStat
 from std/strformat import `&`
 from ../beacon_chain/spec/datatypes/capella import SignedBeaconBlock
-from ../beacon_chain/spec/datatypes/eip4844 import
-  HashedBeaconState, asSigVerified
 from ../beacon_chain/spec/beaconstate import
   get_beacon_committee, get_beacon_proposer_index,
   get_committee_count_per_slot, get_committee_indices

--- a/tests/consensus_spec/deneb/test_fixture_rewards.nim
+++ b/tests/consensus_spec/deneb/test_fixture_rewards.nim
@@ -10,7 +10,7 @@
 import
   # Beacon chain internals
   ../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/[altair, eip4844],
+  ../../beacon_chain/spec/datatypes/[altair, deneb],
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
@@ -12,7 +12,7 @@ import
   chronicles,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, presets, state_transition_epoch],
-  ../../../beacon_chain/spec/datatypes/[altair, eip4844],
+  ../../../beacon_chain/spec/datatypes/[altair, deneb],
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops,


### PR DESCRIPTION
As these move out of the lower layers of the BN which more intrinsically have to treat each fork differently, in general, the remaining modules have fewer specific dependencies, so it won't be 30 lines per file mostly, but a few.

At the other end of the abstraction, code exclusively working with `ForkyFoo` and `ForkedFoo` types might not even notice.