### PR TITLE
ci: add VERBOSITY parameter to Jenkinsfile

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -8,6 +8,11 @@ pipeline {
       description: 'Label for targetted CI slave host: linux/macos',
       defaultValue: params.AGENT_LABEL ?: getAgentLabel(),
     )
+    choice(
+      name: 'VERBOSITY',
+      description: 'Value for the V make flag to increase log verbosity',
+      choices: [0, 1, 2]
+    )
   }
 
   options {
@@ -37,7 +42,7 @@ pipeline {
 
   environment {
     NPROC = Runtime.getRuntime().availableProcessors()
-    MAKEFLAGS = "-j${env.NPROC}"
+    MAKEFLAGS = "V=${params.VERBOSITY} -j${env.NPROC}"
   }
 
   stages {


### PR DESCRIPTION
It will default to `V=0` since it's the first choice in the list.

![image](https://user-images.githubusercontent.com/2212681/221581907-11919b85-a151-483d-89f6-c3396e89a193.png)

Ran this build again manually to test if it works:
https://ci.status.im/job/nimbus-eth2/job/platforms/job/macos/job/aarch64/job/PR-4676/2/

And based on the log size I'd say it's working:

![image](https://user-images.githubusercontent.com/2212681/221596584-8a123eea-12b0-4d72-b160-9e6c1be0ee04.png)