### PR TITLE
launch_local_testnet.sh: show which killed processes

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -738,26 +738,27 @@ cleanup() {
   # Avoid the trap enterring an infinite loop
   trap - SIGINT SIGTERM EXIT
 
-  for proc in "${PROCS_TO_KILL[@]}"
-  do
-    # TODO Previously, the code here used the '-P $$' option to limit
-    #      the kill command only to children of this shell process.
-    #      Unfortunately, this doesn't seem to work at the moment.
-    #      Perhaps the child processes are not direct children of
-    #      the current shell process?
-    pkill -f "$(basename "$proc")" || true
+  PKILL_ECHO_FLAG='-e'
+  if [[ "${OS}" == "macos" ]]; then
+    PKILL_ECHO_FLAG='-l'
+  fi
+
+  echo "Terminating:"
+  for proc in "${PROCS_TO_KILL[@]}"; do
+    # FIXME We should be using '-P $$' here but it doesn't always work.
+    PROC_NAME=$(basename "$proc")
+    pkill -SIGTERM "${PKILL_ECHO_FLAG}" -f "${PROC_NAME}" \
+        || echo "Nothing to terminate: ${PROC_NAME}"
   done
 
   sleep 2
 
-  for proc in "${PROCS_TO_KILL[@]}"
-  do
-    # TODO Previously, the code here used the '-P $$' option to limit
-    #      the kill command only to children of this shell process.
-    #      Unfortunately, this doesn't seem to work at the moment.
-    #      Perhaps the child processes are not direct children of
-    #      the current shell process?
-    pkill -SIGKILL -f "$(basename "$proc")" || true
+  echo "Killing:"
+  for proc in "${PROCS_TO_KILL[@]}"; do
+    # FIXME We should be using '-P $$' here but it doesn't always work.
+    PROC_NAME=$(basename "$proc")
+    pkill -SIGKILL "${PKILL_ECHO_FLAG}" -f "${PROC_NAME}" \
+        || echo "Nothing to kill: ${PROC_NAME}"
   done
 
   # Delete all binaries we just built, because these are unusable outside this

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -743,6 +743,12 @@ cleanup() {
     PKILL_ECHO_FLAG='-l'
   fi
 
+  echo "Existing processes:"
+  for proc in "${PROCS_TO_KILL[@]}"; do
+    PROC_NAME=$(basename "$proc")
+    pgrep -alf "${PROC_NAME}" || true
+  done
+
   echo "Terminating:"
   for proc in "${PROCS_TO_KILL[@]}"; do
     # FIXME We should be using '-P $$' here but it doesn't always work.


### PR DESCRIPTION
First step in debugging issue most probably re-introduced by:

* https://github.com/status-im/nimbus-eth2/pull/4551

Which causes the finalization tests script to kill other processes unrelated to the given CI job.

Result:
```
[jakubgs@caspair:~]$ cleanup 
Cleaning up
Existing processes:
744091 bash ./sleep.sh nimbus_beacon_node
Terminating:
bash killed (pid 744091)
Nothing to terminate: nimbus_validator_client
Nothing to terminate: nimbus_signing_node
Nothing to terminate: nimbus_light_client
Killing:
Nothing to kill: nimbus_beacon_node
Nothing to kill: nimbus_validator_client
Nothing to kill: nimbus_signing_node
Nothing to kill: nimbus_light_client
```