### PR TITLE
launch_local_testnet.sh: re-add targetting parent PID

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -751,9 +751,9 @@ cleanup() {
 
   echo "Terminating:"
   for proc in "${PROCS_TO_KILL[@]}"; do
-    # FIXME We should be using '-P $$' here but it doesn't always work.
     PROC_NAME=$(basename "$proc")
-    pkill -SIGTERM "${PKILL_ECHO_FLAG}" -f "${PROC_NAME}" \
+    # WARNING: The '-P $$' avoids killing unrelated processes.
+    pkill -SIGTERM "${PKILL_ECHO_FLAG}" -P $$ "${PROC_NAME}" \
         || echo "Nothing to terminate: ${PROC_NAME}"
   done
 
@@ -761,9 +761,9 @@ cleanup() {
 
   echo "Killing:"
   for proc in "${PROCS_TO_KILL[@]}"; do
-    # FIXME We should be using '-P $$' here but it doesn't always work.
     PROC_NAME=$(basename "$proc")
-    pkill -SIGKILL "${PKILL_ECHO_FLAG}" -f "${PROC_NAME}" \
+    # WARNING: The '-P $$' avoids killing unrelated processes.
+    pkill -SIGKILL "${PKILL_ECHO_FLAG}" -P $$ "${PROC_NAME}" \
         || echo "Nothing to kill: ${PROC_NAME}"
   done
 


### PR DESCRIPTION
Otherwise we kill of other unrelated processes.
  
Fix for bug introduced most probably in:
* https://github.com/status-im/nimbus-eth2/pull/4551