### PR TITLE
Remove uses of beacon_block_and_blobs_sidecar topic

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -808,7 +808,7 @@ template gossipMaxSize(T: untyped): uint32 =
     when isFixedSize(T):
       fixedPortionSize(T)
     elif T is bellatrix.SignedBeaconBlock or T is capella.SignedBeaconBlock or
-         T is eip4844.SignedBeaconBlockAndBlobsSidecar:
+         T is eip4844.SignedBeaconBlock:
       GOSSIP_MAX_SIZE_BELLATRIX
     # TODO https://github.com/status-im/nim-ssz-serialization/issues/20 for
     # Attestation, AttesterSlashing, and SignedAggregateAndProof, which all

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -157,13 +157,10 @@ programMain:
       toValidationResult(
         optimisticProcessor.processSignedBeaconBlock(signedBlock)))
   network.addValidator(
-    getBeaconBlockAndBlobsSidecarTopic(forkDigests.eip4844),
-    proc (
-        signedBlock: eip4844.SignedBeaconBlockAndBlobsSidecar
-    ): ValidationResult =
+    getBeaconBlocksTopic(forkDigests.eip4844),
+    proc (signedBlock: eip4844.SignedBeaconBlock): ValidationResult =
       toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(
-          signedBlock.beacon_block)))
+        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
   lightClient.installMessageValidators()
   waitFor network.startListening()
   waitFor network.start()

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -23,7 +23,6 @@ const
   topicAttesterSlashingsSuffix* = "attester_slashing/ssz_snappy"
   topicAggregateAndProofsSuffix* = "beacon_aggregate_and_proof/ssz_snappy"
   topicBlsToExecutionChangeSuffix* = "bls_to_execution_change/ssz_snappy"
-  topicBeaconBlockAndBlobsSidecarTopicSuffix* = "beacon_block_and_blobs_sidecar/ssz_snappy"
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/p2p-interface.md#configuration
   RESP_TIMEOUT* = 10.seconds
@@ -64,10 +63,6 @@ func getAggregateAndProofsTopic*(forkDigest: ForkDigest): string =
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/capella/p2p-interface.md#topics-and-messages
 func getBlsToExecutionChangeTopic*(forkDigest: ForkDigest): string =
   eth2Prefix(forkDigest) & topicBlsToExecutionChangeSuffix
-
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.2/specs/eip4844/p2p-interface.md#topics-and-messages
-func getBeaconBlockAndBlobsSidecarTopic*(forkDigest: ForkDigest): string =
-  eth2Prefix(forkDigest) & topicBeaconBlockAndBlobsSidecarTopicSuffix
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/validator.md#broadcast-attestation
 func compute_subnet_for_attestation*(

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -24,7 +24,6 @@ suite "Honest validator":
       getAttesterSlashingsTopic(forkDigest) == "/eth2/00000000/attester_slashing/ssz_snappy"
       getAggregateAndProofsTopic(forkDigest) == "/eth2/00000000/beacon_aggregate_and_proof/ssz_snappy"
       getBlsToExecutionChangeTopic(forkDigest) == "/eth2/00000000/bls_to_execution_change/ssz_snappy"
-      getBeaconBlockAndBlobsSidecarTopic(forkDigest) == "/eth2/00000000/beacon_block_and_blobs_sidecar/ssz_snappy"
       getSyncCommitteeContributionAndProofTopic(forkDigest) == "/eth2/00000000/sync_committee_contribution_and_proof/ssz_snappy"
       getLightClientFinalityUpdateTopic(forkDigest) == "/eth2/00000000/light_client_finality_update/ssz_snappy"
       getLightClientOptimisticUpdateTopic(forkDigest) == "/eth2/00000000/light_client_optimistic_update/ssz_snappy"


### PR DESCRIPTION
The topic goes away with decoupled blocks and blobs.


The first commit of this PR is from #4681; I will rebase after that PR goes in.