### PR TITLE
Remove SignedBeaconBlockAndBlobsSidecar

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -23,7 +23,7 @@ import
 
 from ../spec/datatypes/capella import SignedBeaconBlock
 from ../spec/datatypes/eip4844 import
-  SignedBeaconBlock, SignedBeaconBlockAndBlobsSidecar, BLS_MODULUS
+  SignedBeaconBlock, BLS_MODULUS
 
 from libp2p/protocols/pubsub/pubsub import ValidationResult
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -801,7 +801,7 @@ func chunkMaxSize[T](): uint32 =
     MAX_CHUNK_SIZE_BELLATRIX
 
 from ../spec/datatypes/capella import SignedBeaconBlock
-from ../spec/datatypes/eip4844 import SignedBeaconBlockAndBlobsSidecar
+from ../spec/datatypes/eip4844 import SignedBeaconBlock
 
 template gossipMaxSize(T: untyped): uint32 =
   const maxSize = static:

--- a/beacon_chain/spec/datatypes/eip4844.nim
+++ b/beacon_chain/spec/datatypes/eip4844.nim
@@ -55,17 +55,12 @@ type
 
   Blob* = array[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB, byte]
 
-  # TODO remove BlobsSidecar and SignedBeaconBlockAndBlobsSidecar; they're not
-  # in rc.3 anymore
+  # TODO remove BlobsSidecar; it's not in rc.3 anymore
   BlobsSidecar* = object
     beacon_block_root*: Eth2Digest
     beacon_block_slot*: Slot
     blobs*: List[Blob, Limit MAX_BLOBS_PER_BLOCK]
     kzg_aggregated_proof*: KZGProof
-
-  SignedBeaconBlockAndBlobsSidecar* = object
-    beacon_block*: SignedBeaconBlock
-    blobs_sidecar*: BlobsSidecar
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#blobsidecar
   BlobSidecar* = object

--- a/beacon_chain/spec/eth2_ssz_serialization.nim
+++ b/beacon_chain/spec/eth2_ssz_serialization.nim
@@ -59,10 +59,6 @@ template readSszBytes*(
 template readSszBytes*(
     data: openArray[byte], val: var deneb.TrustedSignedBeaconBlock, updateRoot = true) =
   readAndUpdateRoot(data, val, updateRoot)
-template readSszBytes*(
-    data: openArray[byte], val: var deneb.SignedBeaconBlockAndBlobsSidecar, updateRoot = true) =
-  readSszValue(data, val)
-  val.beacon_block.root = hash_tree_root(val.beacon_block.message)
 
 template readSszBytes*(
     data: openArray[byte], val: var auto, updateRoot: bool) =

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -510,7 +510,6 @@ template toFork*[T:
     deneb.ExecutionPayloadHeader |
     deneb.BeaconBlock |
     deneb.SignedBeaconBlock |
-    deneb.SignedBeaconBlockAndBlobsSidecar |
     deneb.TrustedBeaconBlock |
     deneb.SigVerifiedSignedBeaconBlock |
     deneb.MsgTrustedSignedBeaconBlock |

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -121,24 +121,6 @@ proc readChunkPayload*(
     return neterr InvalidContextBytes
 
 proc readChunkPayload*(
-    conn: Connection, peer: Peer, MsgType: type (ref SignedBeaconBlockAndBlobsSidecar)):
-    Future[NetRes[MsgType]] {.async.} =
-  var contextBytes: ForkDigest
-  try:
-    await conn.readExactly(addr contextBytes, sizeof contextBytes)
-  except CatchableError:
-    return neterr UnexpectedEOF
-
-  if contextBytes == peer.network.forkDigests.eip4844:
-    let res = await readChunkPayload(conn, peer, SignedBeaconBlockAndBlobsSidecar)
-    if res.isOk:
-      return ok newClone(res.get)
-    else:
-      return err(res.error)
-  else:
-    return neterr InvalidContextBytes
-
-proc readChunkPayload*(
     conn: Connection, peer: Peer, MsgType: type (ref BlobsSidecar)):
     Future[NetRes[MsgType]] {.async.} =
   var contextBytes: ForkDigest

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -141,8 +141,6 @@ suite "EF - Deneb - SSZ consensus objects " & preset():
             checkSSZ(SignedAggregateAndProof, path, hash)
           of "SignedBeaconBlock":
             checkSSZ(deneb.SignedBeaconBlock, path, hash)
-          of "SignedBeaconBlockAndBlobsSidecar":
-            checkSSZ(deneb.SignedBeaconBlockAndBlobsSidecar, path, hash)
           of "SignedBeaconBlockHeader":
             checkSSZ(SignedBeaconBlockHeader, path, hash)
           of "SignedBlobSidecar": checkSSZ(SignedBlobSidecar, path, hash)


### PR DESCRIPTION
This commit removes SignedBeaconBlockAndBlobsSidecar and all remaining
references.

Only the last commit is net-new; the first three are from #4682. I will rebase  after that PR goes in.