### PR TITLE
disable geth in default ci local testnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ local-testnet-minimal:
 		--el-port-offset 5 \
 		--timeout 648 \
 		--kill-old-processes \
-		--run-geth --dl-geth \
 		-- \
 		--verify-finalization \
 		--discv5:no
@@ -255,7 +254,6 @@ local-testnet-mainnet:
 		--el-port-offset 5 \
 		--timeout 2784 \
 		--kill-old-processes \
-		--run-geth --dl-geth \
 		-- \
 		--verify-finalization \
 		--discv5:no

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -892,7 +892,7 @@ if [[ "${RUN_NIMBUS_ETH1}" == "1" ]]; then
   fi
 fi
 
-jq -r '.hash' "$EXECUTION_GENESIS_BLOCK_JSON" > "${DATA_DIR}/deposit_contract_block_hash.txt"
+#jq -r '.hash' "$EXECUTION_GENESIS_BLOCK_JSON" > "${DATA_DIR}/deposit_contract_block_hash.txt"
 
 ./build/ncli_testnet createTestnet \
   --data-dir="$CONTAINER_DATA_DIR" \
@@ -907,8 +907,8 @@ jq -r '.hash' "$EXECUTION_GENESIS_BLOCK_JSON" > "${DATA_DIR}/deposit_contract_bl
   --insecure-netkey-password=true \
   --genesis-time=$GENESIS_TIME \
   --capella-fork-epoch=$CAPELLA_FORK_EPOCH \
-  --deneb-fork-epoch=$DENEB_FORK_EPOCH \
-  --execution-genesis-block="$EXECUTION_GENESIS_BLOCK_JSON"
+  --deneb-fork-epoch=$DENEB_FORK_EPOCH
+  #--execution-genesis-block="$EXECUTION_GENESIS_BLOCK_JSON"
 
 ./scripts/make_prometheus_config.sh \
     --nodes ${NUM_NODES} \


### PR DESCRIPTION
Inspired by https://github.com/status-im/nimbus-eth2/pull/4684 -- this is a stopgap if it works, but if it works, potentially worthwhile