### PR TITLE
revert Makefile and local testnet script to before changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,12 @@ restapi-test:
 		--resttest-delay 30 \
 		--kill-old-processes
 
+ifneq ($(shell uname -p), arm)
+TESTNET_EXTRA_FLAGS := --run-geth --dl-geth
+else
+TESTNET_EXTRA_FLAGS :=
+endif
+
 local-testnet-minimal:
 	./scripts/launch_local_testnet.sh \
 		--data-dir $@ \
@@ -225,7 +231,7 @@ local-testnet-minimal:
 		--el-port-offset 5 \
 		--timeout 648 \
 		--kill-old-processes \
-		--run-geth --dl-geth \
+		$(TESTNET_EXTRA_FLAGS) \
 		-- \
 		--verify-finalization \
 		--discv5:no
@@ -250,7 +256,7 @@ local-testnet-mainnet:
 		--el-port-offset 5 \
 		--timeout 2784 \
 		--kill-old-processes \
-		--run-geth --dl-geth \
+		$(TESTNET_EXTRA_FLAGS) \
 		-- \
 		--verify-finalization \
 		--discv5:no

--- a/Makefile
+++ b/Makefile
@@ -209,11 +209,8 @@ local-testnet-minimal:
 		--data-dir $@ \
 		--preset minimal \
 		--nodes 2 \
-		--capella-fork-epoch 3 \
-		--deneb-fork-epoch 20 \
 		--stop-at-epoch 6 \
 		--disable-htop \
-		--enable-payload-builder \
 		--enable-logtrace \
 		--base-port $$(( 6001 + EXECUTOR_NUMBER * 500 )) \
 		--base-rest-port $$(( 6031 + EXECUTOR_NUMBER * 500 )) \
@@ -221,9 +218,8 @@ local-testnet-minimal:
 		--base-vc-keymanager-port $$(( 6131 + EXECUTOR_NUMBER * 500 )) \
 		--base-vc-metrics-port $$(( 6161 + EXECUTOR_NUMBER * 500 )) \
 		--base-remote-signer-port $$(( 6201 + EXECUTOR_NUMBER * 500 )) \
-		--base-remote-signer-metrics-port $$(( 6251 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-net-port $$(( 6301 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-rpc-port $$(( 6302 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-http-port $$(( 6302 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-ws-port $$(( 6303 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-auth-rpc-port $$(( 6304 + EXECUTOR_NUMBER * 500 )) \
 		--el-port-offset 5 \
@@ -247,9 +243,8 @@ local-testnet-mainnet:
 		--base-vc-keymanager-port $$(( 7131 + EXECUTOR_NUMBER * 500 )) \
 		--base-vc-metrics-port $$(( 7161 + EXECUTOR_NUMBER * 500 )) \
 		--base-remote-signer-port $$(( 7201 + EXECUTOR_NUMBER * 500 )) \
-		--base-remote-signer-metrics-port $$(( 7251 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-net-port $$(( 7301 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-rpc-port $$(( 7302 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-http-port $$(( 7302 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-ws-port $$(( 7303 + EXECUTOR_NUMBER * 500 )) \
 		--base-el-auth-rpc-port $$(( 7304 + EXECUTOR_NUMBER * 500 )) \
 		--el-port-offset 5 \

--- a/scripts/geth_vars.sh
+++ b/scripts/geth_vars.sh
@@ -5,28 +5,13 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-if [ -z "${GETH_VARS_SOURCED:-}" ]; then
-GETH_VARS_SOURCED=1
-
+GETH_BINARY="${GETH_BINARY:-"${HOME}/go-ethereum/build/bin/geth"}"
 GETH_NUM_NODES="${GETH_NUM_NODES:-4}"
+GETH_BINARY="${GETH_BINARY:-${HOME}/go-ethereum/build/bin/geth}"
 GETH_BASE_NET_PORT="${BASE_EL_NET_PORT:-30303}"
-GETH_BASE_RPC_PORT="${BASE_EL_RPC_PORT:-8545}"
+GETH_BASE_HTTP_PORT="${BASE_EL_HTTP_PORT:-8545}"
 GETH_BASE_WS_PORT="${BASE_EL_WS_PORT:-8546}"
 GETH_BASE_AUTH_RPC_PORT="${BASE_EL_AUTH_RPC_PORT:-8551}"
-GETH_PORT_OFFSET="${EL_PORT_OFFSET:-20}"
+GETH_PORT_OFFSET="${EL_PORT_OFFSET:-10}"
+GENESISJSON="${GENESISJSON:-${BASEDIR}/geth_genesis.json}"
 DISCOVER="--nodiscover"
-
-GETH_NET_PORTS=()
-GETH_AUTH_RPC_PORTS=()
-GETH_DATA_DIRS=()
-
-GETH_LAST_NODE_IDX=$((GETH_NUM_NODES - 1))
-
-for GETH_NODE_IDX in $(seq 0 $GETH_LAST_NODE_IDX); do
-  GETH_NET_PORTS+=($(( GETH_NODE_IDX * GETH_PORT_OFFSET + GETH_BASE_NET_PORT )))
-  GETH_RPC_PORTS+=($(( GETH_NODE_IDX * GETH_PORT_OFFSET + GETH_BASE_RPC_PORT )))
-  GETH_AUTH_RPC_PORTS+=($(( GETH_NODE_IDX * GETH_PORT_OFFSET + GETH_BASE_AUTH_RPC_PORT )))
-  GETH_DATA_DIRS+=("${DATA_DIR}/geth-${GETH_NODE_IDX}")
-done
-
-fi

--- a/scripts/start_geth_nodes.sh
+++ b/scripts/start_geth_nodes.sh
@@ -2,63 +2,58 @@
 
 set -euo pipefail
 
-SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+BASEDIR="$(dirname "${BASH_SOURCE[0]}")"
 
-source "${SCRIPTS_DIR}/geth_binaries.sh"
-source "${SCRIPTS_DIR}/geth_vars.sh"
+. "${BASEDIR}/geth_vars.sh"
 
 #These are used in the caller script
 GETH_ENODES=()
+GETH_HTTP_PORTS=()
+GETH_NET_PORTS=()
+GETH_WS_PORTS=()
+GETH_RPC_PORTS=()
+GETH_DATA_DIRS=()
 
 log "Using ${GETH_BINARY}"
 
-start_geth_node() {
-  GETH_NODE_IDX=$1
-  mkdir -p "${GETH_DATA_DIRS[GETH_NODE_IDX]}"
-  set -x
-
-  ${GETH_BINARY} version
-  ${GETH_BINARY} --datadir "${GETH_DATA_DIRS[GETH_NODE_IDX]}" init "${EXECUTION_GENESIS_JSON}"
-  ${GETH_BINARY} \
-    --syncmode full \
-    --datadir "${GETH_DATA_DIRS[GETH_NODE_IDX]}" \
-    ${DISCOVER} \
-    --http \
-    --http.port ${GETH_RPC_PORTS[GETH_NODE_IDX]} \
-    --port ${GETH_NET_PORTS[GETH_NODE_IDX]} \
-    --authrpc.port ${GETH_AUTH_RPC_PORTS[GETH_NODE_IDX]} \
-    --authrpc.jwtsecret "${JWT_FILE}"
-}
-
-for GETH_NODE_IDX in $(seq 0 $GETH_LAST_NODE_IDX); do
-  start_geth_node $GETH_NODE_IDX \
-    &> "${DATA_DIR}/geth-log${GETH_NODE_IDX}.txt" &
-done
-
-for GETH_NODE_IDX in $(seq 0 $GETH_LAST_NODE_IDX); do
-  GETH_RETRY=0
-  while :; do
-    if [[ -S "${GETH_DATA_DIRS[GETH_NODE_IDX]}/geth.ipc" ]]; then
-        echo "Geth ${GETH_NODE_IDX} started in $(( GETH_RETRY * 100 ))ms"
-        break
-    fi
-    if (( ++GETH_RETRY >= 300 )); then
-        echo "Geth ${GETH_NODE_IDX} failed to start"
-        exit 1
-    fi
-    sleep 0.1
-  done
-  NODE_ID=$(${GETH_BINARY} attach --datadir "${GETH_DATA_DIRS[GETH_NODE_IDX]}" --exec admin.nodeInfo.enode)
-  GETH_ENODES+=("${NODE_ID}")
+for GETH_NUM_NODE in $(seq 0 $(( GETH_NUM_NODES - 1 ))); do
+    GETH_NET_PORT=$(( GETH_NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_NET_PORT ))
+    GETH_HTTP_PORT=$(( GETH_NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_HTTP_PORT ))
+    GETH_WS_PORT=$(( GETH_NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_WS_PORT ))
+    GETH_AUTH_RPC_PORT=$(( GETH_NUM_NODE * GETH_PORT_OFFSET + GETH_BASE_AUTH_RPC_PORT ))
+    log "Starting geth node ${GETH_NUM_NODE} on net port ${GETH_NET_PORT} HTTP port ${GETH_HTTP_PORT} WS port ${GETH_WS_PORT}"
+    GETHDATADIR=$(mktemp -d "${DATA_DIR}"/geth-data-XXX)
+    GETH_DATA_DIRS+=(${GETHDATADIR})
+    openssl rand -hex 32 | tr -d "\n" > "${GETHDATADIR}/jwtsecret"
+    ${GETH_BINARY} --http --ws -http.api "engine" --datadir "${GETHDATADIR}" init "${GENESISJSON}"
+    ${GETH_BINARY} --syncmode full --http --ws --http.corsdomain '*' --http.api "eth,net,engine" -ws.api "eth,net,engine" --datadir "${GETHDATADIR}" ${DISCOVER} --port ${GETH_NET_PORT} --http.port ${GETH_HTTP_PORT} --ws.port ${GETH_WS_PORT} --authrpc.port ${GETH_AUTH_RPC_PORT} --authrpc.jwtsecret "${GETHDATADIR}/jwtsecret" &> "${DATA_DIR}/geth-log${GETH_NUM_NODE}.txt" &
+    GETH_RETRY=0
+    while :; do
+        if [[ -S "${GETHDATADIR}/geth.ipc" ]]; then
+            echo "Geth ${GETH_NUM_NODE} started in $(( GETH_RETRY * 100 ))ms"
+            break
+        fi
+        if (( ++GETH_RETRY >= 300 )); then
+            echo "Geth ${GETH_NUM_NODE} failed to start"
+            exit 1
+        fi
+        sleep 0.1
+    done
+    NODE_ID=$(${GETH_BINARY} attach --datadir "${GETHDATADIR}" --exec admin.nodeInfo.enode)
+    GETH_ENODES+=("${NODE_ID}")
+    GETH_HTTP_PORTS+=("${GETH_HTTP_PORT}")
+    GETH_NET_PORTS+=("${GETH_NET_PORT}")
+    GETH_WS_PORTS+=("${GETH_WS_PORT}")
+    GETH_RPC_PORTS+=("${GETH_AUTH_RPC_PORT}")
 done
 
 #Add all nodes as peers
 for dir in "${GETH_DATA_DIRS[@]}"
 do
-  for enode in "${GETH_ENODES[@]}"
-  do
-    ${GETH_BINARY} attach --datadir "${dir}" --exec "admin.addPeer(${enode})" &
-  done
+    for enode in "${GETH_ENODES[@]}"
+    do
+      ${GETH_BINARY} attach --datadir "${dir}" --exec "admin.addPeer(${enode})"
+    done
 done
 
-log "GETH RPC Ports: ${GETH_AUTH_RPC_PORTS[*]}"
+log "GETH HTTP Ports: ${GETH_HTTP_PORTS[*]}"


### PR DESCRIPTION
Might work

Based on going to https://github.com/status-im/nimbus-eth2/commits/unstable/scripts/launch_local_testnet.sh and finding the last known-passing-CI version before https://github.com/status-im/nimbus-eth2/pull/4551 i.e. reverting to https://github.com/status-im/nimbus-eth2/pull/4586

The `Makefile` then needs a few changes