### PR TITLE
vc: fix missing attestations due to doppelganger in epoch 1

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -332,7 +332,7 @@ proc asyncRun*(vc: ValidatorClientRef) {.async.} =
     vc.keymanagerServer.router.installKeymanagerHandlers(vc.keymanagerHost[])
     vc.keymanagerServer.start()
 
-  var doppelEventFut = vc.doppelExit.wait()
+  let doppelEventFut = vc.doppelExit.wait()
   try:
     vc.runSlotLoopFut = runSlotLoop(vc, vc.beaconClock.now(), onSlotStart)
     vc.runKeystoreCachePruningLoopFut =
@@ -349,7 +349,7 @@ proc asyncRun*(vc: ValidatorClientRef) {.async.} =
   await vc.shutdownMetrics()
   vc.shutdownSlashingProtection()
 
-  if doppelEventFut.finished:
+  if doppelEventFut.completed():
     # Critically, database has been shut down - the rest doesn't matter, we need
     # to stop as soon as possible
     # TODO we need to actually quit _before_ any other async tasks have had the

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -26,7 +26,7 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
                       duty: DutyAndProof): Future[bool] {.async.} =
   let vc = service.client
   let validator = vc.getValidatorForDuties(
-      duty.data.pubkey, adata.slot, true).valueOr:
+      duty.data.pubkey, adata.slot).valueOr:
     return false
   let fork = vc.forkAtEpoch(adata.slot.epoch)
 
@@ -77,6 +77,8 @@ proc serveAttestation(service: AttestationServiceRef, adata: AttestationData,
   debug "Sending attestation", attestation = shortLog(attestation),
         validator = shortLog(validator), validator_index = vindex,
         delay = vc.getDelay(adata.slot.attestation_deadline())
+
+  validator.doppelgangerActivity(attestation.data.slot.epoch)
 
   let res =
     try:
@@ -157,6 +159,8 @@ proc serveAggregateAndProof*(service: AttestationServiceRef,
         attestation = shortLog(signedProof.message.aggregate),
         validator = shortLog(validator), validator_index = vindex,
         delay = vc.getDelay(slot.aggregate_deadline())
+
+  validator.doppelgangerActivity(proof.aggregate.data.slot.epoch)
 
   let res =
     try:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -550,10 +550,8 @@ proc getDelay*(vc: ValidatorClientRef, deadline: BeaconTime): TimeDiff =
 
 proc getValidatorForDuties*(vc: ValidatorClientRef,
                             key: ValidatorPubKey, slot: Slot,
-                            doppelActivity = false,
                             slashingSafe = false): Opt[AttachedValidator] =
-  vc.attachedValidators[].getValidatorForDuties(
-    key, slot, doppelActivity, slashingSafe)
+  vc.attachedValidators[].getValidatorForDuties(key, slot, slashingSafe)
 
 proc forkAtEpoch*(vc: ValidatorClientRef, epoch: Epoch): Fork =
   # If schedule is present, it MUST not be empty.

--- a/beacon_chain/validator_client/doppelganger_service.nim
+++ b/beacon_chain/validator_client/doppelganger_service.nim
@@ -40,6 +40,9 @@ proc processActivities(service: DoppelgangerServiceRef, epoch: Epoch,
           validator.doppelgangerChecked(epoch)
 
           if item.is_live and validator.triggersDoppelganger(epoch):
+            warn "Doppelganger detection triggered",
+              validator = shortLog(validator), epoch
+
             vc.doppelExit.fire()
             return
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1347,7 +1347,7 @@ proc signAndSendAggregate(
         return
       res.get()
 
-    validator.doppelgangerActivity(msg.message.aggregate.data.slot)
+    validator.doppelgangerActivity(msg.message.aggregate.data.slot.epoch)
 
     # Logged in the router
     discard await node.router.routeSignedAggregateAndProof(

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -326,7 +326,7 @@ proc doppelgangerReady*(validator: AttachedValidator, slot: Slot): bool =
 
 proc getValidatorForDuties*(
     pool: ValidatorPool, key: ValidatorPubKey, slot: Slot,
-    doppelActivity: bool, slashingSafe: bool):
+    slashingSafe: bool):
     Opt[AttachedValidator] =
   ## Return validator only if it is ready for duties (has index and has passed
   ## doppelganger check where applicable)
@@ -347,11 +347,6 @@ proc getValidatorForDuties*(
             activationEpoch = shortLog(validator.activationEpoch)
 
     return Opt.none(AttachedValidator)
-
-  if doppelActivity:
-    # Record the activity
-    # TODO consider moving to the the "registration point"
-    validator.doppelgangerActivity(slot.epoch)
 
   return Opt.some(validator)
 


### PR DESCRIPTION
* log which validator triggers doppelganger
* move activity detection closer to where it's performed, record
aggregation as activity (since it's part of the liveness endpoint)
* vc: check for doppelgangers in epoch 0 also (so that activity in epoch
1 can happen)
* avoid some looping when processing activities