### PR TITLE
ncli_db: use fork from runtimeconfig when verifying era file (fixes #4668)

### DIFF
--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -220,7 +220,7 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
 
           # Batch-verification more than doubles total verification speed
           sigs.add block_signature_set(
-              getStateField(state[], fork),
+              cfg.forkAtEpoch(slot.epoch),
               getStateField(state[], genesis_validators_root), slot,
               blck[].root, cooked.get(), sig.get())
 


### PR DESCRIPTION
Sepolia in particular goes through two hard forks during era 1, meaning the phase0 fork is no longer part of the state, even though blocks that belong to it still are phase0.