### PR TITLE
rename `ConsensusFork.EIP4844` to `ConsensusFork.Deneb`

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1075,7 +1075,7 @@ proc getBlockSSZ*(
     getBlockSSZ(db, key, data, bellatrix.TrustedSignedBeaconBlock)
   of ConsensusFork.Capella:
     getBlockSSZ(db, key, data, capella.TrustedSignedBeaconBlock)
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     getBlockSSZ(db, key, data, deneb.TrustedSignedBeaconBlock)
 
 proc getBlobsSidecarSZ*(db: BeaconChainDB, key: Eth2Digest, data: var seq[byte]):
@@ -1137,7 +1137,7 @@ proc getBlockSZ*(
     getBlockSZ(db, key, data, bellatrix.TrustedSignedBeaconBlock)
   of ConsensusFork.Capella:
     getBlockSZ(db, key, data, capella.TrustedSignedBeaconBlock)
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     getBlockSZ(db, key, data, deneb.TrustedSignedBeaconBlock)
 
 proc getStateOnlyMutableValidators(
@@ -1520,7 +1520,7 @@ iterator getAncestorSummaries*(db: BeaconChainDB, root: Eth2Digest):
 
   # Backwards compat for reading old databases, or those that for whatever
   # reason lost a summary along the way..
-  static: doAssert ConsensusFork.high == ConsensusFork.EIP4844
+  static: doAssert ConsensusFork.high == ConsensusFork.Deneb
   while true:
     if db.v0.backend.getSnappySSZ(
         subkey(BeaconBlockSummary, res.root), res.summary) == GetResult.found:

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -104,7 +104,7 @@ proc addResolvedHeadBlock(
     var unrealized: FinalityCheckpoints
     if enableTestFeatures in dag.updateFlags:
       unrealized = withState(state):
-        static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+        static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
         when stateFork >= ConsensusFork.Altair:
           forkyState.data.compute_unrealized_finality()
         else:

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -212,7 +212,7 @@ proc getForkedBlock*(db: BeaconChainDB, root: Eth2Digest):
     Opt[ForkedTrustedSignedBeaconBlock] =
   # When we only have a digest, we don't know which fork it's from so we try
   # them one by one - this should be used sparingly
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+  static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
   if (let blck = db.getBlock(root, deneb.TrustedSignedBeaconBlock);
       blck.isSome()):
     ok(ForkedTrustedSignedBeaconBlock.init(blck.get()))
@@ -908,7 +908,7 @@ proc applyBlock(
     state_transition(
       dag.cfg, state, data, cache, info,
       dag.updateFlags + {slotProcessed}, noRollback)
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     let data = getBlock(dag, bid, deneb.TrustedSignedBeaconBlock).valueOr:
       return err("Block load failed")
     state_transition(
@@ -1070,7 +1070,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of ConsensusFork.Altair: altairFork(cfg)
       of ConsensusFork.Bellatrix: bellatrixFork(cfg)
       of ConsensusFork.Capella: capellaFork(cfg)
-      of ConsensusFork.EIP4844: denebFork(cfg)
+      of ConsensusFork.Deneb:   denebFork(cfg)
     stateFork = getStateField(dag.headState, fork)
 
   # Here, we check only the `current_version` field because the spec
@@ -2086,7 +2086,7 @@ proc updateHead*(
     of ConsensusFork.Capella:
       if dag.vanityLogs.onUpgradeToCapella != nil:
         dag.vanityLogs.onUpgradeToCapella()
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       discard
 
   if  dag.vanityLogs.onKnownBlsToExecutionChange != nil and

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -392,7 +392,7 @@ iterator getBlockIds*(
     # `case` ensures we're on a fork for which the `PartialBeaconState`
     # definition is consistent
     case db.cfg.consensusForkAtEpoch(slot.epoch)
-    of ConsensusFork.Phase0 .. ConsensusFork.EIP4844:
+    of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
       let stateSlot = (slot.era() + 1).start_slot()
       if not getPartialState(db, historical_roots, stateSlot, state[]):
         state = nil # No `return` in iterators

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -179,7 +179,7 @@ proc storeBackfillBlock(
   # Establish blob viability before calling addbackfillBlock to avoid
   # writing the block in case of blob error.
   let blobsOk =
-      when typeof(signedBlock).toFork() >= ConsensusFork.EIP4844:
+      when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
           blobs.len > 0 or true
         # TODO: validate blobs
       else:
@@ -416,7 +416,7 @@ proc storeBlock*(
 
   # Establish blob viability before calling addHeadBlock to avoid
   # writing the block in case of blob error.
-  when typeof(signedBlock).toFork() >= ConsensusFork.EIP4844:
+  when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
     if blobs.len > 0:
       discard
       # TODO: validate blobs

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -840,7 +840,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http400, BlockIncorrectFork)
 
     case currentEpochFork
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       return RestApiResponse.jsonError(Http500, $denebImplementationMissing)
     of ConsensusFork.Capella:
       let res =

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -279,7 +279,7 @@ proc getStateOptimistic*(node: BeaconNode,
     of ConsensusFork.Phase0, ConsensusFork.Altair:
       some[bool](false)
     of  ConsensusFork.Bellatrix, ConsensusFork.Capella,
-        ConsensusFork.EIP4844:
+        ConsensusFork.Deneb:
       # A state is optimistic iff the block which created it is
       withState(state):
         # The block root which created the state at slot `n` is at slot `n-1`
@@ -299,7 +299,7 @@ proc getBlockOptimistic*(node: BeaconNode,
     case blck.kind
     of ConsensusFork.Phase0, ConsensusFork.Altair:
       some[bool](false)
-    of ConsensusFork.Bellatrix, ConsensusFork.Capella, ConsensusFork.EIP4844:
+    of ConsensusFork.Bellatrix, ConsensusFork.Capella, ConsensusFork.Deneb:
       some[bool](node.dag.is_optimistic(blck.root))
   else:
     none[bool]()
@@ -309,7 +309,7 @@ proc getBlockRefOptimistic*(node: BeaconNode, blck: BlockRef): bool =
   case blck.kind
   of ConsensusFork.Phase0, ConsensusFork.Altair:
     false
-  of ConsensusFork.Bellatrix, ConsensusFork.Capella, ConsensusFork.EIP4844:
+  of ConsensusFork.Bellatrix, ConsensusFork.Capella, ConsensusFork.Deneb:
     node.dag.is_optimistic(blck.root)
 
 const

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -474,7 +474,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
-    static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+    static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
     let currentEpoch = node.currentSlot().epoch()
     if currentEpoch >= node.dag.cfg.DENEB_FORK_EPOCH:
       debugRaiseAssert $denebImplementationMissing & ": GET /eth/v1/validator/blinded_blocks/{slot}"

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -927,8 +927,8 @@ template prepareForkedBlockReading(
         version = some(ConsensusFork.Bellatrix)
       of "capella":
         version = some(ConsensusFork.Capella)
-      of "eip4844":
-        version = some(ConsensusFork.EIP4844)
+      of "deneb":
+        version = some(ConsensusFork.Deneb)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "block", "block_header", "data":
@@ -1002,7 +1002,7 @@ proc readValue*[BlockType: ForkedBeaconBlock](
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect capella block format")
     value = ForkedBeaconBlock.init(res.get()).BlockType
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc readValue*[BlockType: ForkedBlindedBeaconBlock](
@@ -1065,7 +1065,7 @@ proc readValue*[BlockType: ForkedBlindedBeaconBlock](
                                     exc.formatMsg("BlindedBlock") & "]")
     value = ForkedBlindedBeaconBlock(kind: ConsensusFork.Capella,
                                      capellaData: res)
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
@@ -1135,7 +1135,7 @@ proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
     value = Web3SignerForkedBeaconBlock(
       kind: ConsensusFork.Capella,
       capellaData: res.get())
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     reader.raiseUnexpectedValue($denebImplementationMissing)
 
 proc writeValue*[
@@ -1160,8 +1160,8 @@ proc writeValue*[
   of ConsensusFork.Capella:
     writer.writeField("version", forkIdentifier "capella")
     writer.writeField("block_header", value.capellaData)
-  of ConsensusFork.EIP4844:
-    writer.writeField("version", forkIdentifier "eip4844")
+  of ConsensusFork.Deneb:
+    writer.writeField("version", forkIdentifier "deneb")
     writer.writeField("block_header", value.eip4844Data)
   writer.endRecord()
 
@@ -1190,8 +1190,8 @@ proc writeValue*[
   of ConsensusFork.Capella:
     writer.writeField("version", forkIdentifier "capella")
     writer.writeField("data", value.capellaData)
-  of ConsensusFork.EIP4844:
-    writer.writeField("version", forkIdentifier "eip4844")
+  of ConsensusFork.Deneb:
+    writer.writeField("version", forkIdentifier "deneb")
     writer.writeField("data", value.eip4844Data)
   writer.endRecord()
 
@@ -1394,7 +1394,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     assign(
       value.capellaBody.execution_payload.withdrawals,
       ep_src.withdrawals.get())
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     reader.raiseUnexpectedValue($denebImplementationMissing)
 
 ## RestPublishedBeaconBlock
@@ -1492,7 +1492,7 @@ proc readValue*(reader: var JsonReader[RestJson],
           body: body.capellaBody
         )
       )
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       reader.raiseUnexpectedValue($denebImplementationMissing)
   )
 
@@ -1553,7 +1553,7 @@ proc readValue*(reader: var JsonReader[RestJson],
           signature: signature.get()
         )
       )
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       reader.raiseUnexpectedValue($denebImplementationMissing)
   )
 
@@ -1581,8 +1581,8 @@ proc readValue*(reader: var JsonReader[RestJson],
         version = some(ConsensusFork.Bellatrix)
       of "capella":
         version = some(ConsensusFork.Capella)
-      of "eip4844":
-        version = some(ConsensusFork.EIP4844)
+      of "deneb":
+        version = some(ConsensusFork.Deneb)
       else:
         reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
@@ -1647,7 +1647,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     if res.isNone():
       reader.raiseUnexpectedValue("Incorrect capella block format")
     value = ForkedSignedBeaconBlock.init(res.get())
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     reader.raiseUnexpectedValue($denebImplementationMissing)
   withBlck(value):
     blck.root = hash_tree_root(blck.message)
@@ -1669,8 +1669,8 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   of ConsensusFork.Capella:
     writer.writeField("version", "capella")
     writer.writeField("data", value.capellaData)
-  of ConsensusFork.EIP4844:
-    writer.writeField("version", "eip4844")
+  of ConsensusFork.Deneb:
+    writer.writeField("version", "deneb")
     writer.writeField("data", value.eip4844Data)
   writer.endRecord()
 
@@ -1695,7 +1695,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       of "altair": some(ConsensusFork.Altair)
       of "bellatrix": some(ConsensusFork.Bellatrix)
       of "capella": some(ConsensusFork.Capella)
-      of "eip4844": some(ConsensusFork.EIP4844)
+      of "deneb": some(ConsensusFork.Deneb)
       else: reader.raiseUnexpectedValue("Incorrect version field value")
     of "data":
       if data.isSome():
@@ -1765,7 +1765,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     except SerializationError:
       reader.raiseUnexpectedValue("Incorrect capella beacon state format")
     toValue(capellaData)
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     try:
       tmp[].eip4844Data.data = RestJson.decode(
         string(data.get()),
@@ -1792,8 +1792,8 @@ proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconStat
   of ConsensusFork.Capella:
     writer.writeField("version", "capella")
     writer.writeField("data", value.capellaData.data)
-  of ConsensusFork.EIP4844:
-    writer.writeField("version", "eip4844")
+  of ConsensusFork.Deneb:
+    writer.writeField("version", "deneb")
     writer.writeField("data", value.eip4844Data.data)
   writer.endRecord()
 
@@ -2730,7 +2730,7 @@ proc decodeBody*(
         except CatchableError:
           return err("Unexpected deserialization error")
       ok(RestPublishedSignedBeaconBlock(ForkedSignedBeaconBlock.init(blck)))
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       return err($denebImplementationMissing)
   else:
     return err("Unsupported or invalid content media type")
@@ -3200,5 +3200,5 @@ proc decodeString*(t: typedesc[ConsensusFork],
   of "altair": ok(ConsensusFork.Altair)
   of "bellatrix": ok(ConsensusFork.Bellatrix)
   of "capella": ok(ConsensusFork.Capella)
-  of "eip4844": ok(ConsensusFork.EIP4844)
+  of "deneb": ok(ConsensusFork.Deneb)
   else: err("Unsupported or invalid beacon block fork version")

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -311,7 +311,7 @@ type
     of ConsensusFork.Altair:    altairBody*:    altair.BeaconBlockBody
     of ConsensusFork.Bellatrix: bellatrixBody*: bellatrix.BeaconBlockBody
     of ConsensusFork.Capella:   capellaBody*:   capella.BeaconBlockBody
-    of ConsensusFork.EIP4844:   eip4844Body*:   deneb.BeaconBlockBody
+    of ConsensusFork.Deneb:     eip4844Body*:   deneb.BeaconBlockBody
 
   RestSpec* = object
     # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/presets/mainnet/phase0.yaml

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -46,7 +46,7 @@ type
     Altair,
     Bellatrix,
     Capella,
-    EIP4844
+    Deneb
 
   ForkyBeaconState* =
     phase0.BeaconState |
@@ -68,7 +68,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.HashedBeaconState
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix.HashedBeaconState
     of ConsensusFork.Capella:   capellaData*:   capella.HashedBeaconState
-    of ConsensusFork.EIP4844:   eip4844Data*:   deneb.HashedBeaconState
+    of ConsensusFork.Deneb:     eip4844Data*:   deneb.HashedBeaconState
 
   ForkyExecutionPayload* =
     bellatrix.ExecutionPayload |
@@ -138,7 +138,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.BeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix.BeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella.BeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   deneb.BeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   deneb.BeaconBlock
 
   Web3SignerForkedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -146,7 +146,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.BeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: BeaconBlockHeader
     of ConsensusFork.Capella:   capellaData*:   BeaconBlockHeader
-    of ConsensusFork.EIP4844:   eip4844Data*:   BeaconBlockHeader
+    of ConsensusFork.Deneb:     eip4844Data*:   BeaconBlockHeader
 
   ForkedBlindedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -154,7 +154,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.BeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix_mev.BlindedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella_mev.BlindedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   capella_mev.BlindedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   capella_mev.BlindedBeaconBlock
 
   ForkedTrustedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -162,7 +162,7 @@ type
     of ConsensusFork.Altair:    altairData*:     altair.TrustedBeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*:  bellatrix.TrustedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:    capella.TrustedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:    deneb.TrustedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:    deneb.TrustedBeaconBlock
 
   ForkySignedBeaconBlock* =
     phase0.SignedBeaconBlock |
@@ -177,7 +177,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.SignedBeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix.SignedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella.SignedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   deneb.SignedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   deneb.SignedBeaconBlock
 
   ForkySignedBlindedBeaconBlock* =
     phase0.SignedBeaconBlock |
@@ -191,7 +191,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.SignedBeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix_mev.SignedBlindedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella_mev.SignedBlindedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   capella_mev.SignedBlindedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   capella_mev.SignedBlindedBeaconBlock
 
   ForkySigVerifiedSignedBeaconBlock* =
     phase0.SigVerifiedSignedBeaconBlock |
@@ -220,7 +220,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.MsgTrustedSignedBeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix.MsgTrustedSignedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella.MsgTrustedSignedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   deneb.MsgTrustedSignedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   deneb.MsgTrustedSignedBeaconBlock
 
   ForkedTrustedSignedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -228,7 +228,7 @@ type
     of ConsensusFork.Altair:    altairData*:    altair.TrustedSignedBeaconBlock
     of ConsensusFork.Bellatrix: bellatrixData*: bellatrix.TrustedSignedBeaconBlock
     of ConsensusFork.Capella:   capellaData*:   capella.TrustedSignedBeaconBlock
-    of ConsensusFork.EIP4844:   eip4844Data*:   deneb.TrustedSignedBeaconBlock
+    of ConsensusFork.Deneb:     eip4844Data*:   deneb.TrustedSignedBeaconBlock
 
   SomeForkySignedBeaconBlock* =
     ForkySignedBeaconBlock |
@@ -261,7 +261,7 @@ macro getSymbolFromForkModule(fork: static ConsensusFork,
     of ConsensusFork.Altair: "altair"
     of ConsensusFork.Bellatrix: "bellatrix"
     of ConsensusFork.Capella: "capella"
-    of ConsensusFork.EIP4844: "deneb"
+    of ConsensusFork.Deneb:   "deneb"
   newDotExpr(ident moduleName, ident symbolName)
 
 template BeaconStateType*(fork: static ConsensusFork): auto =
@@ -276,8 +276,8 @@ template BeaconBlockBodyType*(fork: static ConsensusFork): auto =
 template withStateFork*(
     x: ConsensusFork, body: untyped): untyped =
   case x
-  of ConsensusFork.EIP4844:
-    const stateFork {.inject, used.} = ConsensusFork.Eip4844
+  of ConsensusFork.Deneb:
+    const stateFork {.inject, used.} = ConsensusFork.Deneb
     body
   of ConsensusFork.Capella:
     const stateFork {.inject, used.} = ConsensusFork.Capella
@@ -312,7 +312,7 @@ func new*(T: type ForkedHashedBeaconState, data: capella.BeaconState):
     data: data, root: hash_tree_root(data)))
 func new*(T: type ForkedHashedBeaconState, data: deneb.BeaconState):
     ref ForkedHashedBeaconState =
-  (ref T)(kind: ConsensusFork.EIP4844, eip4844Data: deneb.HashedBeaconState(
+  (ref T)(kind: ConsensusFork.Deneb, eip4844Data: deneb.HashedBeaconState(
     data: data, root: hash_tree_root(data)))
 
 template init*(T: type ForkedBeaconBlock, blck: phase0.BeaconBlock): T =
@@ -324,7 +324,7 @@ template init*(T: type ForkedBeaconBlock, blck: bellatrix.BeaconBlock): T =
 template init*(T: type ForkedBeaconBlock, blck: capella.BeaconBlock): T =
   T(kind: ConsensusFork.Capella, capellaData: blck)
 template init*(T: type ForkedBeaconBlock, blck: deneb.BeaconBlock): T =
-  T(kind: ConsensusFork.EIP4844, eip4844Data: blck)
+  T(kind: ConsensusFork.Deneb, eip4844Data: blck)
 
 template init*(T: type ForkedTrustedBeaconBlock, blck: phase0.TrustedBeaconBlock): T =
   T(kind: ConsensusFork.Phase0, phase0Data: blck)
@@ -344,7 +344,7 @@ template init*(T: type ForkedSignedBeaconBlock, blck: bellatrix.SignedBeaconBloc
 template init*(T: type ForkedSignedBeaconBlock, blck: capella.SignedBeaconBlock): T =
   T(kind: ConsensusFork.Capella, capellaData: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: deneb.SignedBeaconBlock): T =
-  T(kind: ConsensusFork.EIP4844, eip4844Data: blck)
+  T(kind: ConsensusFork.Deneb, eip4844Data: blck)
 
 func init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
            blockRoot: Eth2Digest, signature: ValidatorSig): T =
@@ -369,8 +369,8 @@ func init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
       capellaData: capella.SignedBeaconBlock(message: forked.capellaData,
                                              root: blockRoot,
                                              signature: signature))
-  of ConsensusFork.EIP4844:
-    T(kind: ConsensusFork.EIP4844,
+  of ConsensusFork.Deneb:
+    T(kind: ConsensusFork.Deneb,
       eip4844Data: deneb.SignedBeaconBlock(message: forked.eip4844Data,
                                            root: blockRoot,
                                            signature: signature))
@@ -397,9 +397,9 @@ func init*(T: type ForkedSignedBlindedBeaconBlock,
     T(kind: ConsensusFork.Capella,
       capellaData: capella_mev.SignedBlindedBeaconBlock(message: forked.capellaData,
                                                         signature: signature))
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     discard $denebImplementationMissing & "forks.nim:init(T: type ForkedSignedBlindedBeaconBlock)"
-    T(kind: ConsensusFork.EIP4844,
+    T(kind: ConsensusFork.Deneb,
       eip4844Data: capella_mev.SignedBlindedBeaconBlock(message: forked.eip4844Data,
                                                         signature: signature))
 
@@ -412,7 +412,7 @@ template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: bellatrix.MsgTru
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: capella.MsgTrustedSignedBeaconBlock): T =
   T(kind: ConsensusFork.Capella,   capellaData: blck)
 template init*(T: type ForkedMsgTrustedSignedBeaconBlock, blck: deneb.MsgTrustedSignedBeaconBlock): T =
-  T(kind: ConsensusFork.EIP4844,   eip4844Data: blck)
+  T(kind: ConsensusFork.Deneb,   eip4844Data: blck)
 
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: phase0.TrustedSignedBeaconBlock): T =
   T(kind: ConsensusFork.Phase0, phase0Data: blck)
@@ -423,7 +423,7 @@ template init*(T: type ForkedTrustedSignedBeaconBlock, blck: bellatrix.TrustedSi
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: capella.TrustedSignedBeaconBlock): T =
   T(kind: ConsensusFork.Capella, capellaData: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: deneb.TrustedSignedBeaconBlock): T =
-  T(kind: ConsensusFork.EIP4844, eip4844Data: blck)
+  T(kind: ConsensusFork.Deneb, eip4844Data: blck)
 
 template toString*(kind: ConsensusFork): string =
   case kind
@@ -435,8 +435,8 @@ template toString*(kind: ConsensusFork): string =
     "bellatrix"
   of ConsensusFork.Capella:
     "capella"
-  of ConsensusFork.EIP4844:
-    "eip4844"
+  of ConsensusFork.Deneb:
+    "deneb"
 
 template toString*(kind: ConsensusFork): string =
   case kind
@@ -448,8 +448,8 @@ template toString*(kind: ConsensusFork): string =
     "bellatrix"
   of ConsensusFork.Capella:
     "capella"
-  of ConsensusFork.EIP4844:
-    "eip4844"
+  of ConsensusFork.Deneb:
+    "deneb"
 
 template toFork*[T:
     phase0.BeaconState |
@@ -515,7 +515,7 @@ template toFork*[T:
     deneb.MsgTrustedSignedBeaconBlock |
     deneb.TrustedSignedBeaconBlock](
     t: type T): ConsensusFork =
-  ConsensusFork.EIP4844
+  ConsensusFork.Deneb
 
 template init*(T: type ForkedEpochInfo, info: phase0.EpochInfo): T =
   T(kind: EpochInfoFork.Phase0, phase0Data: info)
@@ -524,8 +524,8 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
-  of ConsensusFork.EIP4844:
-    const stateFork {.inject, used.} = ConsensusFork.EIP4844
+  of ConsensusFork.Deneb:
+    const stateFork {.inject, used.} = ConsensusFork.Deneb
     template forkyState: untyped {.inject, used.} = x.eip4844Data
     body
   of ConsensusFork.Capella:
@@ -577,10 +577,10 @@ template withEpochInfo*(
 func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
   if tgt.kind == src.kind:
     case tgt.kind
-    of ConsensusFork.EIP4844:
-      assign(tgt.eip4844Data, src.eip4844Data):
+    of ConsensusFork.Deneb:
+      assign(tgt.eip4844Data,   src.eip4844Data):
     of ConsensusFork.Capella:
-      assign(tgt.capellaData, src.capellaData):
+      assign(tgt.capellaData,   src.capellaData):
     of ConsensusFork.Bellatrix:
       assign(tgt.bellatrixData, src.bellatrixData):
     of ConsensusFork.Altair:
@@ -599,7 +599,7 @@ template getStateField*(x: ForkedHashedBeaconState, y: untyped): untyped =
   # ```
   # Without `unsafeAddr`, the `validators` list would be copied to a temporary variable.
   (case x.kind
-  of ConsensusFork.EIP4844:   unsafeAddr x.eip4844Data.data.y
+  of ConsensusFork.Deneb:     unsafeAddr x.eip4844Data.data.y
   of ConsensusFork.Capella:   unsafeAddr x.capellaData.data.y
   of ConsensusFork.Bellatrix: unsafeAddr x.bellatrixData.data.y
   of ConsensusFork.Altair:    unsafeAddr x.altairData.data.y
@@ -614,14 +614,14 @@ func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
 func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
   ## Return the current fork for the given epoch.
   static:
-    doAssert high(ConsensusFork) == ConsensusFork.EIP4844
-    doAssert ConsensusFork.EIP4844   > ConsensusFork.Capella
+    doAssert high(ConsensusFork) == ConsensusFork.Deneb
+    doAssert ConsensusFork.Deneb     > ConsensusFork.Capella
     doAssert ConsensusFork.Capella   > ConsensusFork.Bellatrix
     doAssert ConsensusFork.Bellatrix > ConsensusFork.Altair
     doAssert ConsensusFork.Altair    > ConsensusFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.DENEB_FORK_EPOCH:     ConsensusFork.EIP4844
+  if   epoch >= cfg.DENEB_FORK_EPOCH:     ConsensusFork.Deneb
   elif epoch >= cfg.CAPELLA_FORK_EPOCH:   ConsensusFork.Capella
   elif epoch >= cfg.BELLATRIX_FORK_EPOCH: ConsensusFork.Bellatrix
   elif epoch >= cfg.ALTAIR_FORK_EPOCH:    ConsensusFork.Altair
@@ -629,9 +629,9 @@ func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
 
 func stateForkForDigest*(
     forkDigests: ForkDigests, forkDigest: ForkDigest): Opt[ConsensusFork] =
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+  static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
   if   forkDigest == forkDigests.eip4844:
-    ok ConsensusFork.EIP4844
+    ok ConsensusFork.Deneb
   elif forkDigest == forkDigests.capella:
     ok ConsensusFork.Capella
   elif forkDigest == forkDigests.bellatrix:
@@ -646,7 +646,7 @@ func stateForkForDigest*(
 func atStateFork*(
     forkDigests: ForkDigests, stateFork: ConsensusFork): ForkDigest =
   case stateFork
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     forkDigests.eip4844
   of ConsensusFork.Capella:
     forkDigests.capella
@@ -720,8 +720,8 @@ template withBlck*(
     const stateFork {.inject, used.} = ConsensusFork.Capella
     template blck: untyped {.inject.} = x.capellaData
     body
-  of ConsensusFork.EIP4844:
-    const stateFork {.inject, used.} = ConsensusFork.EIP4844
+  of ConsensusFork.Deneb:
+    const stateFork {.inject, used.} = ConsensusFork.Deneb
     template blck: untyped {.inject.} = x.eip4844Data
     body
 
@@ -743,7 +743,7 @@ template getForkedBlockField*(
   of ConsensusFork.Altair:    unsafeAddr x.altairData.message.y
   of ConsensusFork.Bellatrix: unsafeAddr x.bellatrixData.message.y
   of ConsensusFork.Capella:   unsafeAddr x.capellaData.message.y
-  of ConsensusFork.EIP4844:   unsafeAddr x.eip4844Data.message.y)[]
+  of ConsensusFork.Deneb:     unsafeAddr x.eip4844Data.message.y)[]
 
 template signature*(x: ForkedSignedBeaconBlock |
                        ForkedMsgTrustedSignedBeaconBlock |
@@ -784,8 +784,8 @@ template withStateAndBlck*(
        ForkedTrustedSignedBeaconBlock,
     body: untyped): untyped =
   case s.kind
-  of ConsensusFork.EIP4844:
-    const stateFork {.inject.} = ConsensusFork.EIP4844
+  of ConsensusFork.Deneb:
+    const stateFork {.inject.} = ConsensusFork.Deneb
     template forkyState: untyped {.inject.} = s.eip4844Data
     template blck: untyped {.inject.} = b.eip4844Data
     body
@@ -864,7 +864,7 @@ func denebFork*(cfg: RuntimeConfig): Fork =
 
 func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
   case cfg.consensusForkAtEpoch(epoch)
-  of ConsensusFork.EIP4844:   cfg.denebFork
+  of ConsensusFork.Deneb:     cfg.denebFork
   of ConsensusFork.Capella:   cfg.capellaFork
   of ConsensusFork.Bellatrix: cfg.bellatrixFork
   of ConsensusFork.Altair:    cfg.altairFork
@@ -872,16 +872,16 @@ func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
 
 func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   case cfg.consensusForkAtEpoch(epoch)
-  of ConsensusFork.EIP4844:   cfg.DENEB_FORK_VERSION
+  of ConsensusFork.Deneb:     cfg.DENEB_FORK_VERSION
   of ConsensusFork.Capella:   cfg.CAPELLA_FORK_VERSION
   of ConsensusFork.Bellatrix: cfg.BELLATRIX_FORK_VERSION
   of ConsensusFork.Altair:    cfg.ALTAIR_FORK_VERSION
   of ConsensusFork.Phase0:    cfg.GENESIS_FORK_VERSION
 
 func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+  static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
   case cfg.consensusForkAtEpoch(epoch)
-  of ConsensusFork.EIP4844:   FAR_FUTURE_EPOCH
+  of ConsensusFork.Deneb:     FAR_FUTURE_EPOCH
   of ConsensusFork.Capella:   cfg.DENEB_FORK_EPOCH
   of ConsensusFork.Bellatrix: cfg.CAPELLA_FORK_EPOCH
   of ConsensusFork.Altair:    cfg.BELLATRIX_FORK_EPOCH
@@ -893,11 +893,11 @@ func forkVersion*(cfg: RuntimeConfig, consensusFork: ConsensusFork): Version =
   of ConsensusFork.Altair:      cfg.ALTAIR_FORK_VERSION
   of ConsensusFork.Bellatrix:   cfg.BELLATRIX_FORK_VERSION
   of ConsensusFork.Capella:     cfg.CAPELLA_FORK_VERSION
-  of ConsensusFork.EIP4844:     cfg.DENEB_FORK_VERSION
+  of ConsensusFork.Deneb:       cfg.DENEB_FORK_VERSION
 
 func lcDataForkAtStateFork*(stateFork: ConsensusFork): LightClientDataFork =
   static: doAssert LightClientDataFork.high == LightClientDataFork.EIP4844
-  if stateFork >= ConsensusFork.EIP4844:
+  if stateFork >= ConsensusFork.Deneb:
     LightClientDataFork.EIP4844
   elif stateFork >= ConsensusFork.Capella:
     LightClientDataFork.Capella
@@ -996,7 +996,7 @@ func compute_fork_digest*(current_version: Version,
 func init*(T: type ForkDigests,
            cfg: RuntimeConfig,
            genesis_validators_root: Eth2Digest): T =
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+  static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
   T(
     phase0:
       compute_fork_digest(cfg.GENESIS_FORK_VERSION, genesis_validators_root),

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -426,7 +426,7 @@ proc payloadToBlockHeader*(
       else:
         none(Hash256)
     excessDataGas =
-      when typeof(payload).toFork >= ConsensusFork.EIP4844:
+      when typeof(payload).toFork >= ConsensusFork.Deneb:
         some payload.excess_data_gas
       else:
         none(UInt256)

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -175,7 +175,7 @@ func getTargetGossipState*(
   maybeIncludeFork(
     ConsensusFork.Capella,   CAPELLA_FORK_EPOCH,   DENEB_FORK_EPOCH)
   maybeIncludeFork(
-    ConsensusFork.EIP4844,   DENEB_FORK_EPOCH,     FAR_FUTURE_EPOCH)
+    ConsensusFork.Deneb,     DENEB_FORK_EPOCH,     FAR_FUTURE_EPOCH)
 
   doAssert len(targetForks) <= 2
   targetForks

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -211,7 +211,7 @@ func maybeUpgradeStateToEIP4844(
       state.kind == ConsensusFork.Capella:
     let newState = upgrade_to_eip4844(cfg, state.capellaData.data)
     state = (ref ForkedHashedBeaconState)(
-      kind: ConsensusFork.EIP4844,
+      kind: ConsensusFork.Deneb,
       eip4844Data: deneb.HashedBeaconState(
         root: hash_tree_root(newState[]), data: newState[]))[]
 
@@ -594,12 +594,12 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload |
     of ConsensusFork.Phase0:    makeBeaconBlock(phase0)
     of ConsensusFork.Altair:    makeBeaconBlock(altair)
     of ConsensusFork.Bellatrix: makeBeaconBlock(bellatrix)
-    of ConsensusFork.Capella, ConsensusFork.EIP4844:
+    of ConsensusFork.Capella, ConsensusFork.Deneb:
       raiseAssert "Attempt to use Bellatrix payload with post-Bellatrix state"
   elif T is capella.ExecutionPayload:
     case state.kind
     of  ConsensusFork.Phase0, ConsensusFork.Altair,
-        ConsensusFork.Bellatrix, ConsensusFork.EIP4844:
+        ConsensusFork.Bellatrix, ConsensusFork.Deneb:
       raiseAssert "Attempt to use Capella payload with non-Capella state"
     of ConsensusFork.Capella:   makeBeaconBlock(capella)
   elif T is deneb.ExecutionPayload:
@@ -607,8 +607,7 @@ proc makeBeaconBlock*[T: bellatrix.ExecutionPayload | capella.ExecutionPayload |
     of  ConsensusFork.Phase0, ConsensusFork.Altair,
         ConsensusFork.Bellatrix, ConsensusFork.Capella:
       raiseAssert "Attempt to use EIP4844 payload with non-EIP4844 state"
-    of ConsensusFork.EIP4844: makeBeaconBlock(eip4844)
-
+    of ConsensusFork.Deneb: makeBeaconBlock(eip4844)
 
 # workaround for https://github.com/nim-lang/Nim/issues/20900 rather than have
 # these be default arguments

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -2224,7 +2224,7 @@ proc publishBlock*(
           publishBlock(it, data.bellatrixData)
         of ConsensusFork.Capella:
           publishBlock(it, data.capellaData)
-        of ConsensusFork.EIP4844:
+        of ConsensusFork.Deneb:
           debugRaiseAssert $denebImplementationMissing &
                            ": validator_client/api.nim:publishBlock (1)"
           let f = newFuture[RestPlainResponse]("")
@@ -2288,7 +2288,7 @@ proc publishBlock*(
         publishBlock(it, data.bellatrixData)
       of ConsensusFork.Capella:
         publishBlock(it, data.capellaData)
-      of ConsensusFork.EIP4844:
+      of ConsensusFork.Deneb:
         debugRaiseAssert $denebImplementationMissing &
                          ": validator_client/api.nim:publishBlock (2)"
         let f = newFuture[RestPlainResponse]("")
@@ -2487,7 +2487,7 @@ proc publishBlindedBlock*(
           publishBlindedBlock(it, data.bellatrixData)
         of ConsensusFork.Capella:
           publishBlindedBlock(it, data.capellaData)
-        of ConsensusFork.EIP4844:
+        of ConsensusFork.Deneb:
           debugRaiseAssert $denebImplementationMissing &
                            ": validator_client/api.nim:publishBlindedBlock (1)"
           let f = newFuture[RestPlainResponse]("")
@@ -2550,7 +2550,7 @@ proc publishBlindedBlock*(
         publishBlindedBlock(it, data.bellatrixData)
       of ConsensusFork.Capella:
         publishBlindedBlock(it, data.capellaData)
-      of ConsensusFork.EIP4844:
+      of ConsensusFork.Deneb:
         debugRaiseAssert $denebImplementationMissing &
                          ": validator_client/api.nim:publishBlindedBlock (2)"
         let f = newFuture[RestPlainResponse]("")

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -724,7 +724,7 @@ proc getBlindedBeaconBlock[
                             capella.ExecutionPayloadHeader):
     Future[Result[T, string]] {.async.} =
   withBlck(forkedBlock):
-    when stateFork >= ConsensusFork.EIP4844:
+    when stateFork >= ConsensusFork.Deneb:
       debugRaiseAssert $denebImplementationMissing & ": getBlindedBeaconBlock"
       return err("getBlindedBeaconBlock: Deneb blinded block creation not implemented")
     elif stateFork >= ConsensusFork.Bellatrix:
@@ -909,7 +909,7 @@ proc makeBlindedBeaconBlockForHeadAndSlot*[
 
   let (executionPayloadHeader, forkedBlck) = blindedBlockParts.get
   withBlck(forkedBlck):
-    when stateFork >= ConsensusFork.EIP4844:
+    when stateFork >= ConsensusFork.Deneb:
       debugRaiseAssert $denebImplementationMissing & ": makeBlindedBeaconBlockForHeadAndSlot"
     elif stateFork >= ConsensusFork.Bellatrix:
       when ((stateFork == ConsensusFork.Bellatrix and

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -461,9 +461,9 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
               Web3SignerForkedBeaconBlock(
                 kind: ConsensusFork.Capella,
                 capellaData: blck.capellaData.toBeaconBlockHeader)
-            of ConsensusFork.EIP4844:
+            of ConsensusFork.Deneb:
               Web3SignerForkedBeaconBlock(
-                kind: ConsensusFork.EIP4844,
+                kind: ConsensusFork.Deneb,
                 eip4844Data: blck.eip4844Data.toBeaconBlockHeader)
 
           request = Web3SignerRequest.init(
@@ -503,9 +503,9 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
               Web3SignerForkedBeaconBlock(
                 kind: ConsensusFork.Capella,
                 capellaData: blck.capellaData.toBeaconBlockHeader)
-            of ConsensusFork.EIP4844:
+            of ConsensusFork.Deneb:
               Web3SignerForkedBeaconBlock(
-                kind: ConsensusFork.EIP4844,
+                kind: ConsensusFork.Deneb,
                 eip4844Data: blck.eip4844Data.toBeaconBlockHeader)
 
           request = Web3SignerRequest.init(

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -85,7 +85,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
   of ConsensusFork.Altair:    SSZ.saveFile(filename, value.altairData.data)
   of ConsensusFork.Bellatrix: SSZ.saveFile(filename, value.bellatrixData.data)
   of ConsensusFork.Capella:   SSZ.saveFile(filename, value.capellaData.data)
-  of ConsensusFork.EIP4844:   SSZ.saveFile(filename, value.eip4844Data.data)
+  of ConsensusFork.Deneb:     SSZ.saveFile(filename, value.eip4844Data.data)
 
 proc loadFile(filename: string, T: type): T =
   let

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -263,7 +263,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       of ConsensusFork.Capella:
         blocks[3].add dag.db.getBlock(
           blck.root, capella.TrustedSignedBeaconBlock).get()
-      of ConsensusFork.EIP4844:
+      of ConsensusFork.Deneb:
         raiseAssert $denebImplementationMissing
 
   let stateData = newClone(dag.headState)
@@ -333,7 +333,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
               of ConsensusFork.Capella:
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[3][].data, noRollback)
-              of ConsensusFork.EIP4844:
+              of ConsensusFork.Deneb:
                 raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (1)"
 
             if forkyState.data.slot.epoch mod 16 == 0:
@@ -342,7 +342,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 of ConsensusFork.Altair:    hash_tree_root(loadedState[1][].data)
                 of ConsensusFork.Bellatrix: hash_tree_root(loadedState[2][].data)
                 of ConsensusFork.Capella:   hash_tree_root(loadedState[3][].data)
-                of ConsensusFork.EIP4844:   raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (2)"
+                of ConsensusFork.Deneb:     raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (2)"
               doAssert hash_tree_root(forkyState.data) == loadedRoot
 
   processBlocks(blocks[0])

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -700,7 +700,7 @@ cli do(slots = SLOTS_PER_EPOCH * 6,
     if blockRatio > 0.0:
       withTimer(timers[t]):
         case dag.cfg.consensusForkAtEpoch(slot.epoch)
-        of ConsensusFork.EIP4844:   proposeEIP4844Block(slot)
+        of ConsensusFork.Deneb:     proposeEIP4844Block(slot)
         of ConsensusFork.Capella:   proposeCapellaBlock(slot)
         of ConsensusFork.Bellatrix: proposeBellatrixBlock(slot)
         of ConsensusFork.Altair:    proposeAltairBlock(slot)

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -204,7 +204,7 @@ cli do(validatorsDir: string, secretsDir: string,
             fork, genesis_validators_root, slot, blockRoot,
             validators[proposer]).toValidatorSig())
         dump(".", signedBlock)
-      of ConsensusFork.EIP4844:
+      of ConsensusFork.Deneb:
         blockRoot = hash_tree_root(message.eip4844Data)
         let signedBlock = eip4844.SignedBeaconBlock(
           message: message.eip4844Data,

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -27,10 +27,6 @@ export
 # Path parsing
 
 func forkForPathComponent*(forkPath: string): Opt[ConsensusFork] =
-  # TODO remove after EIP4844 gets renamed to Deneb in ConsensusFork
-  if forkPath == "deneb":
-    return ok ConsensusFork.EIP4844
-
   for fork in ConsensusFork:
     if ($fork).toLowerAscii() == forkPath:
       return ok fork
@@ -49,7 +45,7 @@ func readValue*(r: var JsonReader, a: var seq[byte]) =
 func genesisTestRuntimeConfig*(stateFork: ConsensusFork): RuntimeConfig =
   var res = defaultRuntimeConfig
   case stateFork
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     res.DENEB_FORK_EPOCH = GENESIS_EPOCH
     res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
     res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
@@ -132,9 +128,9 @@ proc loadForkedState*(
     path: string, fork: ConsensusFork): ref ForkedHashedBeaconState =
   var forkedState: ref ForkedHashedBeaconState
   case fork
-  of ConsensusFork.EIP4844:
+  of ConsensusFork.Deneb:
     let state = newClone(parseTest(path, SSZ, deneb.BeaconState))
-    forkedState = (ref ForkedHashedBeaconState)(kind: ConsensusFork.EIP4844)
+    forkedState = (ref ForkedHashedBeaconState)(kind: ConsensusFork.Deneb)
     forkedState.eip4844Data.data = state[]
     forkedState.eip4844Data.root = hash_tree_root(state[])
   of ConsensusFork.Capella:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -174,7 +174,7 @@ proc loadOps(path: string, fork: ConsensusFork): seq[Operation] =
         )
         result.add Operation(kind: opOnBlock,
           blck: ForkedSignedBeaconBlock.init(blck))
-      of ConsensusFork.EIP4844:
+      of ConsensusFork.Deneb:
         let blck = parseTest(
           path/filename & ".ssz_snappy",
           SSZ, deneb.SignedBeaconBlock
@@ -228,7 +228,6 @@ proc stepOnBlock(
   )
 
   # 2. Add block to DAG
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
   when signedBlock is phase0.SignedBeaconBlock:
     type TrustedBlock = phase0.TrustedSignedBeaconBlock
   elif signedBlock is altair.SignedBeaconBlock:
@@ -337,7 +336,7 @@ proc doRunTest(path: string, fork: ConsensusFork) =
 
   let stores =
     case fork
-    of ConsensusFork.EIP4844:
+    of ConsensusFork.Deneb:
       initialLoad(path, db, deneb.BeaconState, deneb.BeaconBlock)
     of ConsensusFork.Capella:
       initialLoad(path, db, capella.BeaconState, capella.BeaconBlock)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -118,7 +118,7 @@ let
   testStatesAltair    = getTestStates(ConsensusFork.Altair)
   testStatesBellatrix = getTestStates(ConsensusFork.Bellatrix)
   testStatesCapella   = getTestStates(ConsensusFork.Capella)
-  testStatesEIP4844   = getTestStates(ConsensusFork.EIP4844)
+  testStatesEIP4844   = getTestStates(ConsensusFork.Deneb)
 doAssert len(testStatesPhase0) > 8
 doAssert len(testStatesAltair) > 8
 doAssert len(testStatesBellatrix) > 8
@@ -346,7 +346,7 @@ suite "Beacon chain DB" & preset():
       uncompressedLenFramed(tmp2).isSome
 
     check:
-      db.delBlock(ConsensusFork.EIP4844, root)
+      db.delBlock(ConsensusFork.Deneb, root)
       not db.containsBlock(root)
       not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
       not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
@@ -451,7 +451,7 @@ suite "Beacon chain DB" & preset():
         db.containsState(root)
         hash_tree_root(db.getEIP4844StateRef(root)[]) == root
 
-      db.delState(ConsensusFork.EIP4844, root)
+      db.delState(ConsensusFork.Deneb, root)
       check:
         not db.containsState(root)
         db.getEIP4844StateRef(root).isNil
@@ -551,7 +551,7 @@ suite "Beacon chain DB" & preset():
         db.containsState(root)
         hash_tree_root(stateBuffer[]) == root
 
-      db.delState(ConsensusFork.EIP4844, root)
+      db.delState(ConsensusFork.Deneb, root)
       check:
         not db.containsState(root)
         not db.getState(root, stateBuffer[], noRollback)
@@ -665,12 +665,12 @@ suite "Beacon chain DB" & preset():
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
       state = (ref ForkedHashedBeaconState)(
-        kind: ConsensusFork.EIP4844,
+        kind: ConsensusFork.Deneb,
         eip4844Data: eip4844.HashedBeaconState(data: eip4844.BeaconState(
           slot: 10.Slot)))
       root = Eth2Digest()
 
-    db.putCorruptState(ConsensusFork.EIP4844, root)
+    db.putCorruptState(ConsensusFork.Deneb, root)
 
     let restoreAddr = addr dag.headState
 

--- a/tests/test_gossip_transition.nim
+++ b/tests/test_gossip_transition.nim
@@ -21,36 +21,36 @@ suite "Gossip fork transition":
       getTargetGossipState( 5,  0,  1,  8, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  4,  7,  9, 11,  true) == {}
       getTargetGossipState( 3,  0,  5,  6, 10, false) == {ConsensusFork.Altair}
-      getTargetGossipState(11,  2,  6, 10, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  2,  6, 10, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 8,  4,  6, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 9,  2,  4,  9, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 7,  2,  3,  5, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 9,  0,  4,  8,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  4,  8,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 7,  1,  2,  3, 10, false) == {ConsensusFork.Capella}
-      getTargetGossipState(11,  3,  4,  5, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  3,  4,  5, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  0,  1,  2,  3,  true) == {}
-      getTargetGossipState(10,  0,  6,  7,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  6,  7,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  1,  3,  4,  7, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  3,  7, 10, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(10,  0,  5,  8, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  5,  8, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 8,  1,  3,  6, 10, false) == {ConsensusFork.Capella}
       getTargetGossipState( 6,  1,  4, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 3,  0,  5,  7,  8, false) == {ConsensusFork.Altair}
       getTargetGossipState( 3,  2,  3,  4,  7, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 4,  3,  6,  7,  8, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 8,  2,  6,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState(11,  1,  5,  7,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  2,  6,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState(11,  1,  5,  7,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  1,  2,  7, 10,  true) == {}
       getTargetGossipState( 2,  1,  2,  3,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 4,  0,  4,  8, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  4,  5,  7,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
-      getTargetGossipState( 8,  0,  0,  4,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  0,  0,  4,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  5,  7,  8, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 6,  0,  2, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  1,  2, 10, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState( 5,  0,  2,  3,  6, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 5,  0,  2,  3,  6, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 2,  2,  6,  8, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  0,  6,  8, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  6,  8, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 8,  0,  0,  2,  3,  true) == {}
       getTargetGossipState( 4,  3,  7,  8,  9,  true) == {}
       getTargetGossipState( 0,  0,  2,  5, 10, false) == {ConsensusFork.Altair}
@@ -59,31 +59,31 @@ suite "Gossip fork transition":
       getTargetGossipState( 7,  0,  1,  4, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 3,  2,  3,  9, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 8,  3,  5,  9, 11,  true) == {}
-      getTargetGossipState( 9,  3,  6,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  3,  6,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  1,  2,  8,  9, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 6,  2,  7,  8, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  3,  4,  6,  7, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 1,  3,  5,  8, 10, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 1,  2,  5,  8, 10,  true) == {}
-      getTargetGossipState( 9,  4,  5,  7,  9, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  5,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  4,  5,  7,  9, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  5,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  1,  5,  7,  9, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 0,  2,  6,  8, 10,  true) == {}
       getTargetGossipState( 8,  0,  5,  8, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 7,  4,  7, 10, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState( 6,  2,  3,  5,  7, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  1,  3,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 6,  2,  3,  5,  7, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  1,  3,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  5,  6,  8,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  2,  5,  8, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(11,  1,  5,  9, 11, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  3,  6,  7,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  5,  9, 11, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  3,  6,  7,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 3,  0,  1,  6,  8, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  1,  6,  8, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  2,  3,  8, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  2,  8,  9, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 3,  1,  3,  4,  5, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState(11,  2,  7, 10, 11, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  3,  5, 10, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(11,  2,  7, 10, 11, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  3,  5, 10, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 5,  2,  6,  8, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  2,  6,  8, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 2,  0,  1,  4, 11, false) == {ConsensusFork.Bellatrix}
@@ -92,7 +92,7 @@ suite "Gossip fork transition":
       getTargetGossipState( 7,  3,  4,  7,  8,  true) == {}
       getTargetGossipState( 1,  0,  0,  6,  8, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  1,  3,  6, 10,  true) == {}
-      getTargetGossipState( 7,  2,  3,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  2,  3,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 3,  2,  4,  5, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  4,  5,  7,  8, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 1,  3,  7,  8, 10, false) == {ConsensusFork.Phase0}
@@ -100,7 +100,7 @@ suite "Gossip fork transition":
       getTargetGossipState( 7,  1,  5,  7, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 1,  6,  8, 10, 11, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 0,  1,  2,  3,  7, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(11,  2,  4,  5,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  2,  4,  5,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  1,  5,  7,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 7,  0,  3,  5, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 6,  0,  3,  9, 10, false) == {ConsensusFork.Bellatrix}
@@ -109,106 +109,106 @@ suite "Gossip fork transition":
       getTargetGossipState( 8,  0,  4,  7, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 8,  0,  3,  8, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 4,  1,  2,  4,  6, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  0,  2,  4, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  2,  4, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 1,  0,  2,  7, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
-      getTargetGossipState( 6,  1,  2,  5,  7, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState(10,  0,  1,  8,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 6,  1,  2,  5,  7, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState(10,  0,  1,  8,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  1,  3,  4,  5,  true) == {}
-      getTargetGossipState(11,  0,  2,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  2,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 7,  2,  7,  8,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 0,  0,  5,  6,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 4,  2,  6,  8,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 2,  2,  6,  7,  8, false) == {ConsensusFork.Altair}
       getTargetGossipState(11,  2,  8,  9, 10,  true) == {}
       getTargetGossipState( 8,  1,  2,  8, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 7,  0,  1,  2,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  0,  1,  2,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 7,  0,  1,  8,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 3,  1,  7,  9, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 6,  2,  6,  7, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 2,  3,  5,  7, 10, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(10,  4,  5,  7,  9, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 8,  1,  4,  5,  8, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  0,  2,  7, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState( 8,  1,  5,  7,  8, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 8,  1,  3,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  4,  5,  7,  9, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 8,  1,  4,  5,  8, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  0,  2,  7, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState( 8,  1,  5,  7,  8, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 8,  1,  3,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  3,  4, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  1,  5,  9, 10, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 3,  4,  6,  7,  8, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(11,  4,  5,  6, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  4,  5,  6, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  2,  4,  9, 10, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(11,  0,  3,  5,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  3,  5,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  0,  3,  7, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState(11,  1,  7,  8, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  7,  8, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  0,  1,  3,  4, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 3,  4,  5,  7,  9, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState(10,  3,  6,  8,  9,  true) == {}
       getTargetGossipState( 6,  7,  9, 10, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState( 7,  2,  4,  5,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  2,  4,  5,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  0,  0,  6, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 4,  2,  3,  7, 10,  true) == {}
       getTargetGossipState( 3,  0,  2,  3,  5, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  4,  6,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  4,  6,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  2,  6,  9, 11,  true) == {}
-      getTargetGossipState( 7,  0,  1,  3,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  0,  1,  3,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  0,  6,  8, 11,  true) == {}
       getTargetGossipState( 6,  2,  4, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 8,  1,  3,  7, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  0,  5,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  5,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  0,  4,  7,  true) == {}
       getTargetGossipState( 0,  1,  2,  5,  9,  true) == {}
       getTargetGossipState( 6,  2,  3, 10, 11,  true) == {}
       getTargetGossipState( 5,  1,  5,  9, 10, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(10,  3,  5,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  3,  5,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 3,  0,  1,  2,  5, false) == {ConsensusFork.Capella}
       getTargetGossipState( 8,  0,  1,  7, 10, false) == {ConsensusFork.Capella}
       getTargetGossipState( 2,  0,  5,  7, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(11,  0,  1,  3, 11, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 8,  5,  7,  8,  9, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  1,  3, 11, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 8,  5,  7,  8,  9, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 0,  0,  0,  1, 11,  true) == {}
       getTargetGossipState( 6,  1,  4,  5,  9, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 8,  2,  4,  5,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  2,  4,  5,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  5,  8,  9, 10, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(10,  2,  5,  6,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  2,  5,  6,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  1,  2,  5,  9, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  1,  5,  6, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState( 5,  0,  0,  1,  4, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 8,  0,  2,  5,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  1,  5,  6, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState( 5,  0,  0,  1,  4, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 8,  0,  2,  5,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 7,  3,  4,  8, 10, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 9,  1,  6,  9, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  1,  6,  9, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 5,  4,  5,  7, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  2,  8,  9, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 0,  2,  4,  7, 10, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(11,  1,  4,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  4,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  6,  8, 10, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  0,  1,  6, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  1,  6, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  0,  1,  3, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 2,  2,  5,  6, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 1,  0,  4,  5,  8, false) == {ConsensusFork.Altair}
       getTargetGossipState( 5,  0,  2,  3,  8, false) == {ConsensusFork.Capella}
       getTargetGossipState( 2,  6,  7,  8,  9, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 2,  2,  4,  6,  7, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 8,  2,  5,  6,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  2,  5,  6,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  5,  8,  9, 10,  true) == {}
       getTargetGossipState( 0,  0,  3,  5, 10, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 8,  0,  1,  2,  4, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  0,  1,  2,  4, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  5,  7,  9, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 8,  1,  3,  6,  9, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  1,  3,  6,  9, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 1,  5,  6,  7,  8, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 5,  0,  5,  8, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 0,  0,  2,  9, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  4,  6,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  4,  6,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  5,  9, 10, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(10,  3,  5,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  3,  5,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  0,  1,  2, 10, false) == {ConsensusFork.Capella}
       getTargetGossipState( 2,  0,  5,  8,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 1,  1,  2,  8,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 6,  4,  7,  9, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
-      getTargetGossipState(10,  0,  1,  6,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  1,  6,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 3,  5,  6,  9, 10, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 4,  0,  1,  6,  7, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  1,  2,  5,  6, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 9,  0,  6,  9, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  2,  5, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  6,  9, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  2,  5, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  0,  2,  6,  9,  true) == {}
       getTargetGossipState( 5,  1,  5, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 0,  0,  1,  5,  7, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
@@ -220,23 +220,23 @@ suite "Gossip fork transition":
       getTargetGossipState( 2,  1,  2,  5,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  1,  3,  8, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  0,  3,  4,  7, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
-      getTargetGossipState(11,  4,  7,  8,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  4,  7,  8,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  2,  3,  9, false) == {ConsensusFork.Capella}
       getTargetGossipState( 4,  1,  2,  8, 10,  true) == {}
       getTargetGossipState( 6,  3,  5,  6, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 1,  3,  4,  9, 10,  true) == {}
       getTargetGossipState( 7,  0,  4,  7, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 1,  0,  5,  7, 10, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 7,  3,  4,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  3,  4,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState(10,  5,  7,  8,  9,  true) == {}
-      getTargetGossipState( 9,  1,  3,  4,  6, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  0,  1,  8, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  1,  3,  4,  6, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  0,  1,  8, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  4,  7, 11,  true) == {}
       getTargetGossipState( 3,  0,  2,  5, 11,  true) == {}
       getTargetGossipState( 5,  1,  3,  7,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  2,  3,  8, 10, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 6,  0,  4,  5, 10,  true) == {}
-      getTargetGossipState( 9,  0,  0,  4,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  0,  4,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 7,  2,  3,  9, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  2,  4,  7,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 4,  1,  6,  9, 11, false) == {ConsensusFork.Altair}
@@ -244,64 +244,64 @@ suite "Gossip fork transition":
       getTargetGossipState( 6,  1,  6,  7,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 2,  2,  6,  9, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 6,  0,  1,  6, 10, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 9,  1,  2,  5, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  1,  2,  5, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 6,  1,  2,  5, 11,  true) == {}
       getTargetGossipState( 5,  3,  4,  8,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  0,  2,  5,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 7,  1,  4,  9, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  0,  4,  7, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  4,  6,  8, 10, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(11,  1,  2,  4,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  2,  4,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  6,  8,  9, 11, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 1,  0,  9, 10, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 9,  1,  2,  6,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  1,  2,  6,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  1,  6,  8, 11,  true) == {}
       getTargetGossipState( 6,  1,  4,  8, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  2,  3,  5,  8, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  1,  2,  3, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 4,  3,  6,  8,  9, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 8,  0,  2,  4,  6, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  0,  2,  4,  6, false) == {ConsensusFork.Deneb}
       getTargetGossipState(10,  0,  1,  6, 10,  true) == {}
       getTargetGossipState( 3,  1,  9, 10, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 7,  2,  6,  8, 10, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 7,  2,  3,  7, 10, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  5,  8,  9, 10, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  3,  6,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  5,  8,  9, 10, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  3,  6,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 8,  0,  0,  5, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  2,  6,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  2,  6,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 2,  2,  3,  5,  7, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState(10,  2,  7,  8, 10,  true) == {}
       getTargetGossipState( 5,  0,  4,  5,  9,  true) == {}
-      getTargetGossipState( 5,  0,  1,  2,  3, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  1,  2,  3,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 5,  0,  1,  2,  3, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  1,  2,  3,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  1,  3,  4, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 5,  0,  1,  3,  9, false) == {ConsensusFork.Capella}
       getTargetGossipState( 9,  0,  4, 10, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 4,  1,  5,  7, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  0,  1,  4,  7, false) == {ConsensusFork.Capella}
       getTargetGossipState( 8,  5,  8, 10, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(11,  2,  3,  5,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  2,  3,  5,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  6,  7,  9, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 8,  3,  4,  7, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  1,  2,  3,  6, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 0,  3,  4,  5,  9, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 5,  3,  6,  7,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  5,  7,  8, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  1,  3,  7,  9, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  3,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  1,  3,  7,  9, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  3,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  0,  2,  3,  4,  true) == {}
       getTargetGossipState( 1,  0,  1,  8,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 6,  0,  6,  7,  8,  true) == {}
       getTargetGossipState( 4,  0,  1,  4, 10, false) == {ConsensusFork.Capella}
-      getTargetGossipState(11,  4,  5,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  4,  5,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  1,  4,  5,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 6,  0,  2,  4,  7,  true) == {}
       getTargetGossipState( 6,  3,  8, 10, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 3,  0,  1,  7, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  0,  6,  9, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 7,  2,  4,  6, 10, false) == {ConsensusFork.Capella}
-      getTargetGossipState(10,  0,  3,  5,  8, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  0,  5,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  3,  5,  8, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  0,  5,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  2,  8,  9, 11, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 3,  0,  1,  5,  8, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  0,  0,  3,  4, false) == {ConsensusFork.Bellatrix}
@@ -310,50 +310,50 @@ suite "Gossip fork transition":
       getTargetGossipState( 4,  0,  2,  5,  6,  true) == {}
       getTargetGossipState( 2,  0,  2,  3,  5, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 8,  0,  5,  6, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 7,  0,  2,  5,  7, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  1,  2,  5,  8, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  0,  3,  6, 10, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  0,  0,  2,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  0,  2,  5,  7, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  1,  2,  5,  8, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  0,  3,  6, 10, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  0,  0,  2,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  1,  2,  7,  8, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 5,  0,  1,  2,  8, false) == {ConsensusFork.Capella}
       getTargetGossipState( 5,  3,  6,  9, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  4,  5,  9, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  1,  5,  6,  7, false) == {ConsensusFork.Altair}
       getTargetGossipState( 3,  0,  0,  4,  8, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 3,  0,  0,  1,  4, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 3,  0,  0,  1,  4, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 2,  0,  2,  5,  8, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  4,  7,  8, 10, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 6,  0,  3,  8,  9, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState( 9,  2,  3,  5,  6, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  1,  6, 10, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  2,  3,  5,  6, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  1,  6, 10, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  1,  4,  7, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 8,  4,  5,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  4,  5,  7,  9, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 9,  1,  8, 10, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 5,  0,  1,  4,  5, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 5,  0,  1,  4,  5, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  2,  7,  8, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 7,  3,  6,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState(10,  3,  4,  7, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  3,  6,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState(10,  3,  4,  7, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  2,  3,  5,  8, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState(11,  1,  2,  3,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  2,  3,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  2,  8,  9, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 1,  1,  5, 10, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 2,  2,  9, 10, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(11,  0,  0,  1, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  0,  1, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 8,  2,  4,  6, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 1,  0,  3,  5, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 2,  3,  4,  9, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState( 8,  1,  2,  4,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  1,  2,  4,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  4,  5,  6,  7, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 5,  3,  7,  9, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 3,  0,  5,  6,  9, false) == {ConsensusFork.Altair}
-      getTargetGossipState(11,  4,  6,  9, 11, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  4,  6,  9, 11, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  5,  8, 10, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(11,  2,  3,  4,  5, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  2,  3,  4,  5, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  3,  5,  6, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState(11,  5,  6,  7, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  5,  6,  7, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  2,  6,  8,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  1,  3,  6, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState( 6,  0,  0,  1,  3, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 6,  0,  0,  1,  3, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  2,  6,  8,  9, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 1,  3,  5,  6,  7, false) == {ConsensusFork.Phase0}
       getTargetGossipState(10,  3,  4,  5,  8,  true) == {}
@@ -364,7 +364,7 @@ suite "Gossip fork transition":
       getTargetGossipState( 9,  2,  4,  5,  8,  true) == {}
       getTargetGossipState( 1,  0,  0,  2, 10, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 3,  0,  3,  7,  8, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(10,  2,  3,  5,  6, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  2,  3,  5,  6, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  3,  6,  9, 10,  true) == {}
       getTargetGossipState( 4,  2,  3,  8, 10, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 2,  1,  3, 10, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
@@ -378,40 +378,40 @@ suite "Gossip fork transition":
       getTargetGossipState( 8,  0,  4,  5, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 2,  0,  6,  8,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 0,  1,  4,  8, 10, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(10,  0,  0,  0,  4, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  1,  3,  5,  9, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  0,  0,  4, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 9,  1,  3,  5,  9, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  1,  4, 10, 11,  true) == {}
-      getTargetGossipState(11,  1,  8,  9, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  1,  8,  9, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  0,  1,  4,  5, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 3,  4,  8, 10, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 5,  7,  8,  9, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 6,  0,  1,  3,  6, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  0,  2,  6,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 6,  0,  1,  3,  6, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  0,  2,  6,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 3,  0,  5,  9, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 5,  0,  6,  7,  9, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 8,  6,  7,  8, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 2,  3,  4,  8, 11, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
-      getTargetGossipState(10,  6,  7,  9, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  6,  7,  9, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 5,  1,  2,  8, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(10,  4,  7,  9, 10, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 2,  0,  0,  2,  3, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  4,  7,  9, 10, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 2,  0,  0,  2,  3, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 6,  0,  5,  7,  8,  true) == {}
-      getTargetGossipState(10,  1,  2,  3,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  1,  2,  3,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 3,  3,  5,  7,  8,  true) == {}
-      getTargetGossipState( 7,  1,  2,  3,  6, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  1,  2,  3,  6, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 6,  3,  4,  7,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 4,  0,  3, 10, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState( 9,  0,  0,  0,  2, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  0,  0,  2, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  3,  6,  7, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
-      getTargetGossipState( 9,  0,  2,  4,  6, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  2,  4,  6, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  1,  4,  9, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 6,  3,  5,  6, 10, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  4,  7,  9, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 9,  0,  5,  8, 10, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  5,  8, 10, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 5,  4,  5,  7,  9,  true) == {}
-      getTargetGossipState( 4,  0,  1,  2,  3, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 4,  0,  1,  2,  3, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  2,  8, 10, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(10,  0,  1,  4,  5, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  1,  4,  5, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  4,  5,  8,  9, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 7,  1,  3,  7, 11,  true) == {}
       getTargetGossipState(11,  0,  1,  2, 10,  true) == {}
@@ -419,7 +419,7 @@ suite "Gossip fork transition":
       getTargetGossipState( 2,  2,  3,  9, 11, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 3,  2,  6,  8,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 7,  0,  7,  8,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 7,  0,  5,  6,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState( 7,  0,  5,  6,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 9,  1,  9, 10, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 9,  4,  5,  6, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 9,  1,  4,  6,  8,  true) == {}
@@ -437,12 +437,12 @@ suite "Gossip fork transition":
       getTargetGossipState( 2,  0,  4,  6,  7, false) == {ConsensusFork.Altair}
       getTargetGossipState( 8,  2,  4, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 4,  6,  7,  8, 10,  true) == {}
-      getTargetGossipState(11,  0,  1,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  1,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 0,  1,  2,  3,  4, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 3,  5,  6,  7,  9, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 8,  0,  2,  3,  5, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  6,  7,  8, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  1,  2,  3, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 8,  0,  2,  3,  5, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  6,  7,  8, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  1,  2,  3, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 9,  1,  3,  6, 10,  true) == {}
       getTargetGossipState( 0,  2,  7,  8,  9, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 2,  1,  2,  4, 11, false) == {ConsensusFork.Bellatrix}
@@ -453,8 +453,8 @@ suite "Gossip fork transition":
       getTargetGossipState( 9,  2,  6,  8, 11,  true) == {}
       getTargetGossipState( 3,  0,  4,  8, 10, false) == {ConsensusFork.Altair,    ConsensusFork.Bellatrix}
       getTargetGossipState( 9,  2,  3,  9, 11, false) == {ConsensusFork.Capella}
-      getTargetGossipState( 6,  0,  1,  2,  6, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(11,  0,  3,  8, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 6,  0,  1,  2,  6, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(11,  0,  3,  8, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  2,  4,  5,  6, false) == {ConsensusFork.Altair}
       getTargetGossipState( 1,  1,  3,  6,  8, false) == {ConsensusFork.Altair}
       getTargetGossipState( 5,  1,  3,  6,  9, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
@@ -467,13 +467,13 @@ suite "Gossip fork transition":
       getTargetGossipState( 2,  0,  4,  6,  9, false) == {ConsensusFork.Altair}
       getTargetGossipState( 8,  0,  8,  9, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 0,  0,  4,  6,  9, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  1,  2,  3,  4, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  1,  2,  3,  4, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 4,  0,  3,  4,  7, false) == {ConsensusFork.Capella}
       getTargetGossipState( 0,  2,  3,  8, 11, false) == {ConsensusFork.Phase0}
       getTargetGossipState( 0,  3,  5,  7, 10,  true) == {}
-      getTargetGossipState( 9,  0,  0,  3,  7, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  0,  0,  3,  7, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 2,  1,  5,  6, 11, false) == {ConsensusFork.Altair}
-      getTargetGossipState(10,  2,  3,  6, 10, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(10,  2,  3,  6, 10, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 5,  0,  4,  6, 11,  true) == {}
       getTargetGossipState( 1,  1,  3,  4,  5, false) == {ConsensusFork.Altair}
       getTargetGossipState(11,  1,  7,  8, 11,  true) == {}
@@ -481,27 +481,27 @@ suite "Gossip fork transition":
       getTargetGossipState( 6,  0,  2,  5,  9, false) == {ConsensusFork.Capella}
       getTargetGossipState( 4,  0,  1,  4,  9, false) == {ConsensusFork.Capella}
       getTargetGossipState( 6,  4,  8,  9, 11,  true) == {}
-      getTargetGossipState(10,  0,  1,  2,  6, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState(10,  1,  3,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(10,  0,  1,  2,  6, false) == {ConsensusFork.Deneb}
+      getTargetGossipState(10,  1,  3,  7, 11, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 3,  2,  5,  6,  7, false) == {ConsensusFork.Altair}
       getTargetGossipState( 9,  4,  9, 10, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
       getTargetGossipState( 2,  2,  4,  9, 10, false) == {ConsensusFork.Altair}
       getTargetGossipState( 8,  2,  4, 10, 11,  true) == {}
-      getTargetGossipState(11,  0,  8, 10, 11, false) == {ConsensusFork.EIP4844}
-      getTargetGossipState( 7,  0,  1,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
+      getTargetGossipState(11,  0,  8, 10, 11, false) == {ConsensusFork.Deneb}
+      getTargetGossipState( 7,  0,  1,  7,  8, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
       getTargetGossipState( 4,  2,  8, 10, 11, false) == {ConsensusFork.Altair}
       getTargetGossipState( 8,  5,  6,  8, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 8,  1,  5,  8, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 6,  1,  6,  7, 11, false) == {ConsensusFork.Bellatrix, ConsensusFork.Capella}
-      getTargetGossipState( 9,  3,  4,  5,  6, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 9,  3,  4,  5,  6, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 1,  0,  3,  4,  7, false) == {ConsensusFork.Altair}
       getTargetGossipState( 6,  1,  2,  3, 11, false) == {ConsensusFork.Capella}
       getTargetGossipState( 1,  2,  5,  9, 10, false) == {ConsensusFork.Phase0,    ConsensusFork.Altair}
       getTargetGossipState( 5,  0,  5,  7,  8, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 8,  0,  3, 10, 11, false) == {ConsensusFork.Bellatrix}
-      getTargetGossipState(11,  3,  6,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState(11,  3,  6,  7,  8, false) == {ConsensusFork.Deneb}
       getTargetGossipState( 3,  6,  7,  9, 10,  true) == {}
       getTargetGossipState( 7,  1,  6, 10, 11, false) == {ConsensusFork.Bellatrix}
       getTargetGossipState( 0,  6,  9, 10, 11, false) == {ConsensusFork.Phase0}
-      getTargetGossipState( 4,  1,  2,  3,  5, false) == {ConsensusFork.Capella,   ConsensusFork.EIP4844}
-      getTargetGossipState( 9,  1,  2,  7,  8, false) == {ConsensusFork.EIP4844}
+      getTargetGossipState( 4,  1,  2,  3,  5, false) == {ConsensusFork.Capella,   ConsensusFork.Deneb}
+      getTargetGossipState( 9,  1,  2,  7,  8, false) == {ConsensusFork.Deneb}

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -211,7 +211,7 @@ suite "Gossip validation - Extra": # Not based on preset config
             of ConsensusFork.Capella:
               const nilCallback = OnCapellaBlockAdded(nil)
               dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
-            of ConsensusFork.EIP4844:
+            of ConsensusFork.Deneb:
               const nilCallback = OnEIP4844BlockAdded(nil)
               dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
           check: added.isOk()

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -22,7 +22,7 @@ suite "Light client" & preset():
     headPeriod = 3.SyncCommitteePeriod
   let
     cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
-      static: doAssert ConsensusFork.high == ConsensusFork.EIP4844
+      static: doAssert ConsensusFork.high == ConsensusFork.Deneb
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch
       res.BELLATRIX_FORK_EPOCH = 2.Epoch
@@ -76,7 +76,7 @@ suite "Light client" & preset():
           of ConsensusFork.Capella:
             const nilCallback = OnCapellaBlockAdded(nil)
             dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
-          of ConsensusFork.EIP4844:
+          of ConsensusFork.Deneb:
             const nilCallback = OnEIP4844BlockAdded(nil)
             dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
 

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -25,7 +25,7 @@ suite "Light client processor" & preset():
     highPeriod = 5.SyncCommitteePeriod
   let
     cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
-      static: doAssert ConsensusFork.high == ConsensusFork.EIP4844
+      static: doAssert ConsensusFork.high == ConsensusFork.Deneb
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch
       res.BELLATRIX_FORK_EPOCH = 2.Epoch
@@ -63,7 +63,7 @@ suite "Light client processor" & preset():
         of ConsensusFork.Capella:
           const nilCallback = OnCapellaBlockAdded(nil)
           dag.addHeadBlock(verifier, blck.capellaData, nilCallback)
-        of ConsensusFork.EIP4844:
+        of ConsensusFork.Deneb:
           const nilCallback = OnEIP4844BlockAdded(nil)
           dag.addHeadBlock(verifier, blck.eip4844Data, nilCallback)
       doAssert added.isOk()

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -65,14 +65,14 @@ proc getTestStates*(
     info = ForkedEpochInfo()
     cfg = defaultRuntimeConfig
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.EIP4844
+  static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
   if stateFork >= ConsensusFork.Altair:
     cfg.ALTAIR_FORK_EPOCH = 1.Epoch
   if stateFork >= ConsensusFork.Bellatrix:
     cfg.BELLATRIX_FORK_EPOCH = 2.Epoch
   if stateFork >= ConsensusFork.Capella:
     cfg.CAPELLA_FORK_EPOCH = 3.Epoch
-  if stateFork >= ConsensusFork.EIP4844:
+  if stateFork >= ConsensusFork.Deneb:
     cfg.DENEB_FORK_EPOCH = 4.Epoch
 
   for i, epoch in stateEpochs:


### PR DESCRIPTION
Almost minimal. Some copyright year changes, and in REST serialization, since they tend to be on the same lines of code, some instances of looking for/producing the literal string `eip4844` as a fork identifier in the protocol are replaced with `deneb`. The tests don't need a workaround anymore, either, of seeing a `deneb` directory and interpreting that as `eip4844`.