### PR TITLE
Bugfix: historic blocks violate the latest specs for the extraData field

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -884,6 +884,11 @@ proc getPayload*(m: ELManager,
             withdrawals_from_cl = engineApiWithdrawals,
             withdrawals_from_el = req.read.executionPayload.withdrawals
 
+      if req.read.executionPayload.extraData.len > MAX_EXTRA_DATA_BYTES:
+        warn "Execution client provided a block with invalid extraData (size exceeds limit)",
+             size = req.read.executionPayload.extraData.len, limit = MAX_EXTRA_DATA_BYTES
+        continue
+
       if bestPayloadIdx.isNone:
         bestPayloadIdx = some idx
       else:


### PR DESCRIPTION
Fixes #4695