### PR TITLE
don't clear validator change subpools after creating each block

### DIFF
--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -228,8 +228,6 @@ proc getValidatorChangeMessagesForBlock(
     if not output.add validator_change_message:
       break
 
-  subpool.clear()
-
 proc getBeaconBlockValidatorChanges*(
     pool: var ValidatorChangePool, cfg: RuntimeConfig, state: ForkyBeaconState):
     BeaconBlockValidatorChanges =

--- a/tests/test_exit_pool.nim
+++ b/tests/test_exit_pool.nim
@@ -91,8 +91,6 @@ suite "Validator change pool testing suite":
           pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).proposer_slashings.lenu64 ==
             min(i + 1, MAX_PROPOSER_SLASHINGS)
-          pool[].getBeaconBlockValidatorChanges(
-            cfg, forkyState.data).proposer_slashings.len == 0
 
   test "addValidatorChangeMessage/getAttesterSlashingMessage":
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS + 5:
@@ -114,8 +112,6 @@ suite "Validator change pool testing suite":
           pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).attester_slashings.lenu64 ==
             min(i + 1, MAX_ATTESTER_SLASHINGS)
-          pool[].getBeaconBlockValidatorChanges(
-            cfg, forkyState.data).attester_slashings.len == 0
 
   test "addValidatorChangeMessage/getVoluntaryExitMessage":
     # Need to advance state or it will not accept voluntary exits
@@ -144,8 +140,6 @@ suite "Validator change pool testing suite":
           pool[].getBeaconBlockValidatorChanges(
               cfg, forkyState.data).voluntary_exits.lenu64 ==
             min(i + 1, MAX_VOLUNTARY_EXITS)
-          pool[].getBeaconBlockValidatorChanges(
-            cfg, forkyState.data).voluntary_exits.len == 0
 
   test "addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)":
     # Need to advance state or it will not accept voluntary exits
@@ -216,9 +210,6 @@ suite "Validator change pool testing suite":
 
           # Ensure priority of API to gossip messages is observed
           allIt(priorityMessages, pool[].isSeen(it))
-
-          pool[].getBeaconBlockValidatorChanges(
-            cfg, forkyState.data).bls_to_execution_changes.len == 0
 
   test "pre-pre-fork voluntary exit":
     var


### PR DESCRIPTION
This dates back to https://github.com/status-im/nimbus-eth2/pull/1812 and in particular https://github.com/status-im/nimbus-eth2/pull/1812/commits/b9e21affff8dd8fc9c2ee26e92d00337ec9353c6#diff-ffb23580affe54832d84c29a7759fd7252bedf4d5843f6388e3153829b32a044

However, it's not clear why it should do so -- it checks validity anyway. Either there will be new messages next block, or there won't be, and either way it'll keep going through its basically LIFO stack discipline view of the subpools.

Meanwhile, when running Hive, e.g.,
```
./hive --client go-ethereum,teku-bn,teku-vc,nimbus-bn,nimbus-vc --sim eth2/withdrawals --sim.limit "/test-bls-to-execution-changes-reorg" --sim.loglevel 5 --docker.nocache nimbus
```
it sends out (there are some nuances here, but basically) one block per node worth of BLS to execution changes, because it then clears the rest.

When each node is a tiny fraction of a network, this probably doesn't matter -- it will typically be hours, days, or weeks before the next block for that node, and as a heuristic, it's not bad. But when a node is large enough to get blocks constantly, such as in small test networks, this shows up.