### PR TITLE
rename `stateFork` > `consensusFork`

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -45,7 +45,7 @@ proc initLightClient*(
         dag = node.dag.head.bid,
         wallSlot = node.currentSlot
       withBlck(signedBlock):
-        when stateFork >= ConsensusFork.Bellatrix:
+        when consensusFork >= ConsensusFork.Bellatrix:
           if blck.message.is_execution_block:
             template payload(): auto = blck.message.body.execution_payload
 
@@ -151,7 +151,7 @@ proc updateLightClientFromDag*(node: BeaconNode) =
     return
   var header {.noinit.}: ForkedLightClientHeader
   withBlck(bdata):
-    const lcDataFork = lcDataForkAtStateFork(stateFork)
+    const lcDataFork = lcDataForkAtStateFork(consensusFork)
     when lcDataFork > LightClientDataFork.None:
       header = ForkedLightClientHeader(kind: lcDataFork)
       header.forky(lcDataFork) = blck.toLightClientHeader(lcDataFork)

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -143,7 +143,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
           var unrealized: FinalityCheckpoints
           if enableTestFeatures in dag.updateFlags and blckRef == dag.head:
             unrealized = withState(dag.headState):
-              when stateFork >= ConsensusFork.Altair:
+              when consensusFork >= ConsensusFork.Altair:
                 forkyState.data.compute_unrealized_finality()
               else:
                 var cache: StateCache

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -105,7 +105,7 @@ proc addResolvedHeadBlock(
     if enableTestFeatures in dag.updateFlags:
       unrealized = withState(state):
         static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           forkyState.data.compute_unrealized_finality()
         else:
           forkyState.data.compute_unrealized_finality(cache)

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -145,7 +145,7 @@ func validatorKey*(
 template is_merge_transition_complete*(
     stateParam: ForkedHashedBeaconState): bool =
   withState(stateParam):
-    when stateFork >= ConsensusFork.Bellatrix:
+    when consensusFork >= ConsensusFork.Bellatrix:
       is_merge_transition_complete(forkyState.data)
     else:
       false
@@ -757,7 +757,7 @@ proc currentSyncCommitteeForPeriod*(
     bsi = ? dag.getBlockIdAtSlot(syncCommitteeSlot)
   dag.withUpdatedState(tmpState, bsi) do:
     withState(updatedState):
-      when stateFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Altair:
         ok forkyState.data.current_sync_committee
       else: err()
   do: err()
@@ -1037,7 +1037,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       quit 1
 
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       dag.headSyncCommittees = forkyState.data.get_sync_committee_cache(cache)
 
   block:
@@ -1218,7 +1218,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   # If these aren't actually optimistic, the first fcU will resolve that
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Bellatrix:
+    when consensusFork >= ConsensusFork.Bellatrix:
       template executionPayloadHeader(): auto =
         forkyState().data.latest_execution_payload_header
       const emptyExecutionPayloadHeader =
@@ -1735,7 +1735,7 @@ iterator syncSubcommitteePairs*(
 func syncCommitteeParticipants*(dag: ChainDAGRef,
                                 slot: Slot): seq[ValidatorIndex] =
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       let
         period = sync_committee_period(slot)
         curPeriod = sync_committee_period(forkyState.data.slot)
@@ -1765,7 +1765,7 @@ func getSubcommitteePositions*(
     subcommitteeIdx: SyncSubcommitteeIndex,
     validatorIdx: uint64): seq[uint64] =
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       let
         period = sync_committee_period(slot)
         curPeriod = sync_committee_period(forkyState.data.slot)
@@ -1954,9 +1954,9 @@ proc pruneHistory*(dag: ChainDAGRef, startup = false) =
       # so as to "mostly" clean up the phase0 tables as well (which cannot be
       # pruned easily by fork)
 
-      let stateFork = dag.cfg.consensusForkAtEpoch(tailSlot.epoch)
-      if stateFork > ConsensusFork.Phase0:
-        for fork in ConsensusFork.Phase0..<stateFork:
+      let consensusFork = dag.cfg.consensusForkAtEpoch(tailSlot.epoch)
+      if consensusFork > ConsensusFork.Phase0:
+        for fork in ConsensusFork.Phase0..<consensusFork:
           dag.db.clearStates(fork)
 
       let blockFork = dag.cfg.consensusForkAtEpoch(blockHorizon.epoch)
@@ -1973,7 +1973,7 @@ proc loadExecutionBlockRoot*(dag: ChainDAGRef, bid: BlockId): Eth2Digest =
     return ZERO_HASH
 
   withBlck(blockData):
-    when stateFork >= ConsensusFork.Bellatrix:
+    when consensusFork >= ConsensusFork.Bellatrix:
       blck.message.body.execution_payload.block_hash
     else:
       ZERO_HASH
@@ -2099,7 +2099,7 @@ proc updateHead*(
   updateBeaconMetrics(dag.headState, dag.head.bid, cache)
 
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       dag.headSyncCommittees = forkyState.data.get_sync_committee_cache(cache)
 
   let

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -119,7 +119,7 @@ proc syncCommitteeRootForPeriod(
     bsi = ? dag.getExistingBlockIdAtSlot(syncCommitteeSlot)
   dag.withUpdatedExistingState(tmpState, bsi) do:
     withState(updatedState):
-      when stateFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Altair:
         ok forkyState.syncCommitteeRoot
       else: raiseAssert "Unreachable"
   do: err()
@@ -213,8 +213,8 @@ proc initLightClientBootstrapForPeriod(
         res.err()
         continue
       withStateAndBlck(tmpState[], bdata):
-        when stateFork >= ConsensusFork.Altair:
-          const lcDataFork = lcDataForkAtStateFork(stateFork)
+        when consensusFork >= ConsensusFork.Altair:
+          const lcDataFork = lcDataForkAtStateFork(consensusFork)
           if not dag.lcDataStore.db.hasSyncCommittee(period):
             dag.lcDataStore.db.putSyncCommittee(
               period, forkyState.data.current_sync_committee)
@@ -274,7 +274,7 @@ proc initLightClientUpdateForPeriod(
           break
         numParticipants =
           withBlck(bdata):
-            when stateFork >= ConsensusFork.Altair:
+            when consensusFork >= ConsensusFork.Altair:
               blck.message.body.sync_aggregate.num_active_participants
             else: raiseAssert "Unreachable"
       if numParticipants >= maxParticipants:
@@ -332,7 +332,7 @@ proc initLightClientUpdateForPeriod(
       finalizedEpoch = block:
         dag.withUpdatedExistingState(tmpState[], attestedBid.atSlot) do:
           withState(updatedState):
-            when stateFork >= ConsensusFork.Altair:
+            when consensusFork >= ConsensusFork.Altair:
               forkyState.data.finalized_checkpoint.epoch
             else: raiseAssert "Unreachable"
         do:
@@ -364,8 +364,8 @@ proc initLightClientUpdateForPeriod(
       dag.handleUnexpectedLightClientError(bid.slot)
       return err()
     withStateAndBlck(updatedState, bdata):
-      when stateFork >= ConsensusFork.Altair:
-        const lcDataFork = lcDataForkAtStateFork(stateFork)
+      when consensusFork >= ConsensusFork.Altair:
+        const lcDataFork = lcDataForkAtStateFork(consensusFork)
         update = ForkedLightClientUpdate(kind: lcDataFork)
         template forkyUpdate: untyped = update.forky(lcDataFork)
         forkyUpdate.attested_header = blck.toLightClientHeader(lcDataFork)
@@ -386,14 +386,14 @@ proc initLightClientUpdateForPeriod(
     withBlck(bdata):
       withForkyUpdate(update):
         when lcDataFork > LightClientDataFork.None:
-          when lcDataFork >= lcDataForkAtStateFork(stateFork):
+          when lcDataFork >= lcDataForkAtStateFork(consensusFork):
             forkyUpdate.finalized_header = blck.toLightClientHeader(lcDataFork)
           else: raiseAssert "Unreachable"
   let bdata = dag.getExistingForkedBlock(signatureBid).valueOr:
     dag.handleUnexpectedLightClientError(signatureBid.slot)
     return err()
   withBlck(bdata):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       withForkyUpdate(update):
         when lcDataFork > LightClientDataFork.None:
           forkyUpdate.sync_aggregate =
@@ -477,7 +477,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
         `name _ ok` = false
       else:
         withBlck(bdata.get):
-          when data_fork >= lcDataForkAtStateFork(stateFork):
+          when data_fork >= lcDataForkAtStateFork(consensusFork):
             obj.name = blck.toLightClientHeader(data_fork)
           else: raiseAssert "Unreachable"
         `name _ ptr` = addr obj.name
@@ -495,7 +495,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
       else:
         obj.migrateToDataFork(data_fork)
         withBlck(bdata.get):
-          when data_fork >= lcDataForkAtStateFork(stateFork):
+          when data_fork >= lcDataForkAtStateFork(consensusFork):
             obj.forky(data_fork).name = blck.toLightClientHeader(data_fork)
           else: raiseAssert "Unreachable"
         `name _ ptr` = addr obj.forky(data_fork).name
@@ -686,7 +686,7 @@ proc initLightClientDataCache*(dag: ChainDAGRef) =
   if dag.head.slot < dag.lcDataStore.cache.tailSlot:
     return
   withState(dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       dag.cacheLightClientData(forkyState, dag.head.bid)
     else: raiseAssert "Unreachable" # `tailSlot` cannot be before Altair
   if dag.lcDataStore.importMode == LightClientDataImportMode.OnlyNew:
@@ -737,7 +737,7 @@ proc initLightClientDataCache*(dag: ChainDAGRef) =
       res.err()
       continue
     withStateAndBlck(dag.headState, bdata):
-      when stateFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Altair:
         # Cache light client data (non-finalized blocks may refer to this)
         if i != blocks.low:
           dag.cacheLightClientData(forkyState, bid)  # `dag.head` already cached
@@ -826,7 +826,7 @@ proc processHeadChangeForLightClient*(dag: ChainDAGRef) =
         dag.lcDataStore.db.putBestUpdate(
           period, dag.lcDataStore.cache.pendingBest.getOrDefault(key))
     withState(dag.headState): # Common case separate to avoid `tmpState` copy
-      when stateFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Altair:
         let key = (headPeriod, forkyState.syncCommitteeRoot)
         dag.lcDataStore.db.putBestUpdate(
           headPeriod, dag.lcDataStore.cache.pendingBest.getOrDefault(key))
@@ -862,7 +862,7 @@ proc processFinalizationForLightClient*(
         period = bid.slot.sync_committee_period
       if not dag.lcDataStore.db.hasSyncCommittee(period):
         let didPutSyncCommittee = withState(dag.headState):
-          when stateFork >= ConsensusFork.Altair:
+          when consensusFork >= ConsensusFork.Altair:
             if period == forkyState.data.slot.sync_committee_period:
               dag.lcDataStore.db.putSyncCommittee(
                 period, forkyState.data.current_sync_committee)
@@ -880,8 +880,8 @@ proc processFinalizationForLightClient*(
                 break
           dag.lcDataStore.db.putSyncCommittee(period, syncCommittee)
       withBlck(bdata):
-        when stateFork >= ConsensusFork.Altair:
-          const lcDataFork = lcDataForkAtStateFork(stateFork)
+        when consensusFork >= ConsensusFork.Altair:
+          const lcDataFork = lcDataForkAtStateFork(consensusFork)
           dag.lcDataStore.db.putHeader(blck.toLightClientHeader(lcDataFork))
         else: raiseAssert "Unreachable"
       dag.lcDataStore.db.putCurrentSyncCommitteeBranch(
@@ -949,7 +949,7 @@ proc getLightClientBootstrap(
       tmpState = assignClone(dag.headState)
     dag.withUpdatedExistingState(tmpState[], bsi) do:
       withState(updatedState):
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           if not dag.lcDataStore.db.hasSyncCommittee(period):
             dag.lcDataStore.db.putSyncCommittee(
               period, forkyState.data.current_sync_committee)
@@ -1003,8 +1003,8 @@ proc getLightClientBootstrap*(
     debug "LC bootstrap unavailable: Block not found", blockRoot
     return default(ForkedLightClientBootstrap)
   withBlck(bdata):
-    when stateFork >= ConsensusFork.Altair:
-      const lcDataFork = lcDataForkAtStateFork(stateFork)
+    when consensusFork >= ConsensusFork.Altair:
+      const lcDataFork = lcDataForkAtStateFork(consensusFork)
       let
         header = blck.toLightClientHeader(lcDataFork)
         bootstrap = dag.getLightClientBootstrap(header)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -330,7 +330,7 @@ proc runProposalForkchoiceUpdated*(
     feeRecipient = self[].getFeeRecipient(
       nextProposer, Opt.some(validatorIndex), nextWallSlot.epoch)
     withdrawals = withState(self.dag.headState):
-      when stateFork >= ConsensusFork.Capella:
+      when consensusFork >= ConsensusFork.Capella:
         Opt.some get_expected_withdrawals(forkyState.data)
       else:
         Opt.none(seq[Withdrawal])
@@ -352,7 +352,7 @@ proc runProposalForkchoiceUpdated*(
         debug "Fork-choice updated for proposal", status
 
       static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
-      when stateFork >= ConsensusFork.Capella:
+      when consensusFork >= ConsensusFork.Capella:
         callForkchoiceUpdated(PayloadAttributesV2(
           timestamp: Quantity timestamp,
           prevRandao: FixedBytes[32] randomData,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -420,7 +420,7 @@ proc storeBlock*(
           trustedBlock.message.slot)
 
     withState(dag[].clearanceState):
-      when stateFork >= ConsensusFork.Altair and
+      when consensusFork >= ConsensusFork.Altair and
           Trusted isnot phase0.TrustedSignedBeaconBlock: # altair+
         for i in trustedBlock.message.body.sync_aggregate.sync_committee_bits.oneIndices():
           vm[].registerSyncAggregateInBlock(

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -765,7 +765,7 @@ proc validateBlsToExecutionChange*(
   # [REJECT] All of the conditions within `process_bls_to_execution_change`
   # pass validation.
   withState(pool.dag.headState):
-    when stateFork < ConsensusFork.Capella:
+    when consensusFork < ConsensusFork.Capella:
       return errIgnore("validateBlsToExecutionChange: can't validate against pre-Capella state")
     else:
       let res = check_bls_to_execution_change(

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -343,11 +343,11 @@ proc installMessageValidators*(
     ValidationResult.Ignore
 
   let forkDigests = lightClient.forkDigests
-  for stateFork in ConsensusFork:
-    withLcDataFork(lcDataForkAtStateFork(stateFork)):
+  for consensusFork in ConsensusFork:
+    withLcDataFork(lcDataForkAtStateFork(consensusFork)):
       when lcDataFork > LightClientDataFork.None:
         let
-          contextFork = stateFork  # Copy to avoid capturing `Deneb` (Nim 1.6)
+          contextFork = consensusFork  # Avoid capturing `Deneb` (Nim 1.6)
           digest = forkDigests[].atStateFork(contextFork)
 
         lightClient.network.addValidator(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -862,7 +862,7 @@ func hasSyncPubKey(node: BeaconNode, epoch: Epoch): auto =
 
 func getCurrentSyncCommiteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   let syncCommittee = withState(node.dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       forkyState.data.current_sync_committee
     else:
       return static(default(SyncnetBits))
@@ -871,7 +871,7 @@ func getCurrentSyncCommiteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits 
 
 func getNextSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   let syncCommittee = withState(node.dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       forkyState.data.next_sync_committee
     else:
       return static(default(SyncnetBits))

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -105,7 +105,7 @@ programMain:
         opt = signedBlock.toBlockId(),
         wallSlot = getBeaconTime().slotOrZero
       withBlck(signedBlock):
-        when stateFork >= ConsensusFork.Bellatrix:
+        when consensusFork >= ConsensusFork.Bellatrix:
           if blck.message.is_execution_block:
             template payload(): auto = blck.message.body.execution_payload
 

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -233,7 +233,7 @@ func syncCommitteeParticipants*(forkedState: ForkedHashedBeaconState,
                                 epoch: Epoch
                                ): Result[seq[ValidatorPubKey], cstring] =
   withState(forkedState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       let
         epochPeriod = sync_committee_period(epoch)
         curPeriod = sync_committee_period(forkyState.data.slot)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -247,7 +247,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     if qSyncPeriod == headSyncPeriod:
       let optimistic = node.getStateOptimistic(node.dag.headState)
       let res = withState(node.dag.headState):
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           produceResponse(indexList,
                           forkyState.data.current_sync_committee.pubkeys.data,
                           forkyState.data.validators.asSeq)
@@ -257,7 +257,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     elif qSyncPeriod == (headSyncPeriod + 1):
       let optimistic = node.getStateOptimistic(node.dag.headState)
       let res = withState(node.dag.headState):
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           produceResponse(indexList,
                           forkyState.data.next_sync_committee.pubkeys.data,
                           forkyState.data.validators.asSeq)
@@ -288,7 +288,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       node.withStateForBlockSlotId(bsi):
         let optimistic = node.getStateOptimistic(state)
         let res = withState(state):
-          when stateFork >= ConsensusFork.Altair:
+          when consensusFork >= ConsensusFork.Altair:
             produceResponse(indexList,
                             forkyState.data.current_sync_committee.pubkeys.data,
                             forkyState.data.validators.asSeq)

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -282,19 +282,19 @@ template withStateFork*(
     x: ConsensusFork, body: untyped): untyped =
   case x
   of ConsensusFork.Deneb:
-    const stateFork {.inject, used.} = ConsensusFork.Deneb
+    const consensusFork {.inject, used.} = ConsensusFork.Deneb
     body
   of ConsensusFork.Capella:
-    const stateFork {.inject, used.} = ConsensusFork.Capella
+    const consensusFork {.inject, used.} = ConsensusFork.Capella
     body
   of ConsensusFork.Bellatrix:
-    const stateFork {.inject, used.} = ConsensusFork.Bellatrix
+    const consensusFork {.inject, used.} = ConsensusFork.Bellatrix
     body
   of ConsensusFork.Altair:
-    const stateFork {.inject, used.} = ConsensusFork.Altair
+    const consensusFork {.inject, used.} = ConsensusFork.Altair
     body
   of ConsensusFork.Phase0:
-    const stateFork {.inject, used.} = ConsensusFork.Phase0
+    const consensusFork {.inject, used.} = ConsensusFork.Phase0
     body
 
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
@@ -533,23 +533,23 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
   of ConsensusFork.Deneb:
-    const stateFork {.inject, used.} = ConsensusFork.Deneb
+    const consensusFork {.inject, used.} = ConsensusFork.Deneb
     template forkyState: untyped {.inject, used.} = x.denebData
     body
   of ConsensusFork.Capella:
-    const stateFork {.inject, used.} = ConsensusFork.Capella
+    const consensusFork {.inject, used.} = ConsensusFork.Capella
     template forkyState: untyped {.inject, used.} = x.capellaData
     body
   of ConsensusFork.Bellatrix:
-    const stateFork {.inject, used.} = ConsensusFork.Bellatrix
+    const consensusFork {.inject, used.} = ConsensusFork.Bellatrix
     template forkyState: untyped {.inject, used.} = x.bellatrixData
     body
   of ConsensusFork.Altair:
-    const stateFork {.inject, used.} = ConsensusFork.Altair
+    const consensusFork {.inject, used.} = ConsensusFork.Altair
     template forkyState: untyped {.inject, used.} = x.altairData
     body
   of ConsensusFork.Phase0:
-    const stateFork {.inject, used.} = ConsensusFork.Phase0
+    const consensusFork {.inject, used.} = ConsensusFork.Phase0
     template forkyState: untyped {.inject, used.} = x.phase0Data
     body
 
@@ -652,8 +652,8 @@ func stateForkForDigest*(
     err()
 
 func atStateFork*(
-    forkDigests: ForkDigests, stateFork: ConsensusFork): ForkDigest =
-  case stateFork
+    forkDigests: ForkDigests, consensusFork: ConsensusFork): ForkDigest =
+  case consensusFork
   of ConsensusFork.Deneb:
     forkDigests.deneb
   of ConsensusFork.Capella:
@@ -713,23 +713,23 @@ template withBlck*(
     body: untyped): untyped =
   case x.kind
   of ConsensusFork.Phase0:
-    const stateFork {.inject, used.} = ConsensusFork.Phase0
+    const consensusFork {.inject, used.} = ConsensusFork.Phase0
     template blck: untyped {.inject.} = x.phase0Data
     body
   of ConsensusFork.Altair:
-    const stateFork {.inject, used.} = ConsensusFork.Altair
+    const consensusFork {.inject, used.} = ConsensusFork.Altair
     template blck: untyped {.inject.} = x.altairData
     body
   of ConsensusFork.Bellatrix:
-    const stateFork {.inject, used.} = ConsensusFork.Bellatrix
+    const consensusFork {.inject, used.} = ConsensusFork.Bellatrix
     template blck: untyped {.inject.} = x.bellatrixData
     body
   of ConsensusFork.Capella:
-    const stateFork {.inject, used.} = ConsensusFork.Capella
+    const consensusFork {.inject, used.} = ConsensusFork.Capella
     template blck: untyped {.inject.} = x.capellaData
     body
   of ConsensusFork.Deneb:
-    const stateFork {.inject, used.} = ConsensusFork.Deneb
+    const consensusFork {.inject, used.} = ConsensusFork.Deneb
     template blck: untyped {.inject.} = x.denebData
     body
 
@@ -793,27 +793,27 @@ template withStateAndBlck*(
     body: untyped): untyped =
   case s.kind
   of ConsensusFork.Deneb:
-    const stateFork {.inject.} = ConsensusFork.Deneb
+    const consensusFork {.inject.} = ConsensusFork.Deneb
     template forkyState: untyped {.inject.} = s.denebData
     template blck: untyped {.inject.} = b.denebData
     body
   of ConsensusFork.Capella:
-    const stateFork {.inject.} = ConsensusFork.Capella
+    const consensusFork {.inject.} = ConsensusFork.Capella
     template forkyState: untyped {.inject.} = s.capellaData
     template blck: untyped {.inject.} = b.capellaData
     body
   of ConsensusFork.Bellatrix:
-    const stateFork {.inject.} = ConsensusFork.Bellatrix
+    const consensusFork {.inject.} = ConsensusFork.Bellatrix
     template forkyState: untyped {.inject.} = s.bellatrixData
     template blck: untyped {.inject.} = b.bellatrixData
     body
   of ConsensusFork.Altair:
-    const stateFork {.inject.} = ConsensusFork.Altair
+    const consensusFork {.inject.} = ConsensusFork.Altair
     template forkyState: untyped {.inject.} = s.altairData
     template blck: untyped {.inject.} = b.altairData
     body
   of ConsensusFork.Phase0:
-    const stateFork {.inject.} = ConsensusFork.Phase0
+    const consensusFork {.inject.} = ConsensusFork.Phase0
     template forkyState: untyped {.inject.} = s.phase0Data
     template blck: untyped {.inject.} = b.phase0Data
     body
@@ -903,13 +903,13 @@ func forkVersion*(cfg: RuntimeConfig, consensusFork: ConsensusFork): Version =
   of ConsensusFork.Capella:     cfg.CAPELLA_FORK_VERSION
   of ConsensusFork.Deneb:       cfg.DENEB_FORK_VERSION
 
-func lcDataForkAtStateFork*(stateFork: ConsensusFork): LightClientDataFork =
+func lcDataForkAtStateFork*(consensusFork: ConsensusFork): LightClientDataFork =
   static: doAssert LightClientDataFork.high == LightClientDataFork.Deneb
-  if stateFork >= ConsensusFork.Deneb:
+  if consensusFork >= ConsensusFork.Deneb:
     LightClientDataFork.Deneb
-  elif stateFork >= ConsensusFork.Capella:
+  elif consensusFork >= ConsensusFork.Capella:
     LightClientDataFork.Capella
-  elif stateFork >= ConsensusFork.Altair:
+  elif consensusFork >= ConsensusFork.Altair:
     LightClientDataFork.Altair
   else:
     LightClientDataFork.None

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -387,7 +387,7 @@ proc collectSignatureSets*(
       # 7. SyncAggregate
       # ----------------------------------------------------
       withState(state):
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           if signed_block.message.body.sync_aggregate.sync_committee_bits.countOnes() == 0:
             if signed_block.message.body.sync_aggregate.sync_committee_signature != ValidatorSig.infinity():
               return err("collectSignatureSets: empty sync aggregates need signature of point at infinity")
@@ -412,7 +412,7 @@ proc collectSignatureSets*(
     # 8. BLS to execution changes
     when typeof(signed_block).toFork() >= ConsensusFork.Capella:
       withState(state):
-        when stateFork >= ConsensusFork.Capella:
+        when consensusFork >= ConsensusFork.Capella:
           for bls_change in signed_block.message.body.bls_to_execution_changes:
             let sig = bls_change.signature.load.valueOr:
               return err("collectSignatureSets: cannot load BLS to execution change signature")

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -293,7 +293,7 @@ proc state_transition_block*(
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
 
   let res = withState(state):
-    when stateFork == type(signedBlock).toFork:
+    when consensusFork == type(signedBlock).toFork:
       state_transition_block_aux(cfg, forkyState, signedBlock, cache, flags)
     else:
       err("State/block fork mismatch")
@@ -530,10 +530,10 @@ proc makeBeaconBlock*(
     # Override for MEV
     if transactions_root.isSome and execution_payload_root.isSome:
       withState(state):
-        when stateFork < ConsensusFork.Bellatrix:
+        when consensusFork < ConsensusFork.Bellatrix:
           # Vacuously
           discard
-        elif stateFork == ConsensusFork.Bellatrix:
+        elif consensusFork == ConsensusFork.Bellatrix:
           forkyState.data.latest_execution_payload_header.transactions_root =
             transactions_root.get
 
@@ -552,7 +552,7 @@ proc makeBeaconBlock*(
              hash_tree_root(validator_changes.voluntary_exits),
              hash_tree_root(sync_aggregate),
              execution_payload_root.get])
-        elif stateFork == ConsensusFork.Capella:
+        elif consensusFork == ConsensusFork.Capella:
           forkyState.data.latest_execution_payload_header.transactions_root =
             transactions_root.get
 
@@ -572,7 +572,7 @@ proc makeBeaconBlock*(
              hash_tree_root(sync_aggregate),
              execution_payload_root.get,
              hash_tree_root(validator_changes.bls_to_execution_changes)])
-        elif stateFork > ConsensusFork.Capella:
+        elif consensusFork > ConsensusFork.Capella:
           discard denebImplementationMissing
 
     state.`kind Data`.root = hash_tree_root(state.`kind Data`.data)

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -83,10 +83,10 @@ proc doTrustedNodeSync*(
             genesisRoot = genesisRoot.get()
           quit 1
         genesisStateRoot = getForkedBlockField(genesisBlock, state_root)
-        stateFork = cfg.consensusForkAtEpoch(GENESIS_EPOCH)
+        consensusFork = cfg.consensusForkAtEpoch(GENESIS_EPOCH)
 
-        tmp = (ref ForkedHashedBeaconState)(kind: stateFork)
-      if not db.getState(stateFork, genesisStateRoot, tmp[], noRollback):
+        tmp = (ref ForkedHashedBeaconState)(kind: consensusFork)
+      if not db.getState(consensusFork, genesisStateRoot, tmp[], noRollback):
         error "Cannot load genesis state from database",
           genesisStateRoot
         quit 1

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -271,7 +271,7 @@ proc routeSyncCommitteeMessages*(
     router: ref MessageRouter, msgs: seq[SyncCommitteeMessage]):
     Future[seq[SendResult]] {.async.} =
   return withState(router[].dag.headState):
-    when stateFork >= ConsensusFork.Altair:
+    when consensusFork >= ConsensusFork.Altair:
       var statuses = newSeq[Option[SendResult]](len(msgs))
 
       let

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -56,7 +56,7 @@ const
 func copyParticipationFlags*(auxiliaryState: var AuxiliaryState,
                              forkedState: ForkedHashedBeaconState) =
   withState(forkedState):
-    when stateFork > ConsensusFork.Phase0:
+    when consensusFork > ConsensusFork.Phase0:
       template flags: untyped = auxiliaryState.epochParticipationFlags
       flags.currentEpochParticipation =
         forkyState.data.current_epoch_participation
@@ -368,7 +368,7 @@ func collectFromAttestations(
     epochParticipationFlags: var ParticipationFlags,
     cache: var StateCache) =
   withStateAndBlck(forkedState, forkedBlock):
-    when stateFork > ConsensusFork.Phase0:
+    when consensusFork > ConsensusFork.Phase0:
       let base_reward_per_increment = get_base_reward_per_increment(
         get_total_active_balance(forkyState.data, cache))
       doAssert base_reward_per_increment > 0
@@ -419,7 +419,7 @@ func collectFromSyncAggregate(
     forkedBlock: ForkedTrustedSignedBeaconBlock,
     cache: var StateCache) =
   withStateAndBlck(forkedState, forkedBlock):
-    when stateFork > ConsensusFork.Phase0:
+    when consensusFork > ConsensusFork.Phase0:
       let
         total_active_balance = get_total_active_balance(forkyState.data, cache)
         participant_reward = get_participant_reward(total_active_balance)

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -320,7 +320,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
               dbBenchmark.checkpoint()
 
             withTimer(timers[tDbLoad]):
-              case stateFork
+              case consensusFork
               of ConsensusFork.Phase0:
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[0][].data, noRollback)
@@ -337,7 +337,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 raiseAssert $denebImplementationMissing & ": ncli_db.nim: cmdBench (1)"
 
             if forkyState.data.slot.epoch mod 16 == 0:
-              let loadedRoot = case stateFork
+              let loadedRoot = case consensusFork
                 of ConsensusFork.Phase0:    hash_tree_root(loadedState[0][].data)
                 of ConsensusFork.Altair:    hash_tree_root(loadedState[1][].data)
                 of ConsensusFork.Bellatrix: hash_tree_root(loadedState[2][].data)

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -254,7 +254,7 @@ cli do(validatorsDir: string, secretsDir: string,
 
           aggregates.add(attestation)
 
-      when stateFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Altair:
         let
           nextSlot = slot + 1
           pubkeys =

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -42,9 +42,9 @@ func readValue*(r: var JsonReader, a: var seq[byte]) =
 # #######################
 # Mock RuntimeConfig
 
-func genesisTestRuntimeConfig*(stateFork: ConsensusFork): RuntimeConfig =
+func genesisTestRuntimeConfig*(consensusFork: ConsensusFork): RuntimeConfig =
   var res = defaultRuntimeConfig
-  case stateFork
+  case consensusFork
   of ConsensusFork.Deneb:
     res.DENEB_FORK_EPOCH = GENESIS_EPOCH
     res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -69,8 +69,8 @@ suite "EF - Light client - Single merkle proof" & preset():
         for kind, path in walkDir(suitePath, relative = true, checkDir = true):
           case objName
           of "BeaconBlockBody":
-            runTest(suitePath/path, BeaconBlockBodyType(stateFork))
+            runTest(suitePath/path, BeaconBlockBodyType(consensusFork))
           of "BeaconState":
-            runTest(suitePath/path, BeaconStateType(stateFork))
+            runTest(suitePath/path, BeaconStateType(consensusFork))
           else:
             raiseAssert "Unknown test object: " & suitePath/path

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -62,7 +62,7 @@ suite "EF - Light client - Update ranking" & preset():
       continue
     for kind, path in walkDir(testsPath, relative = true, checkDir = true):
       withStateFork(fork):
-        const lcDataFork = lcDataForkAtStateFork(stateFork)
+        const lcDataFork = lcDataForkAtStateFork(consensusFork)
         when lcDataFork > LightClientDataFork.None:
           runTest(testsPath/path, lcDataFork)
         else: raiseAssert "Unreachable"

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -99,12 +99,12 @@ func withDigest(blck: deneb.TrustedBeaconBlock):
     root: hash_tree_root(blck)
   )
 
-proc getTestStates(stateFork: ConsensusFork): auto =
+proc getTestStates(consensusFork: ConsensusFork): auto =
   let
     db = makeTestDB(SLOTS_PER_EPOCH)
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
-  var testStates = getTestStates(dag.headState, stateFork)
+  var testStates = getTestStates(dag.headState, consensusFork)
 
   # Ensure transitions beyond just adding validators and increasing slots
   sort(testStates) do (x, y: ref ForkedHashedBeaconState) -> int:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -144,7 +144,7 @@ proc addTestBlock*(
       default(bellatrix.ExecutionPayloadForSigning)
     else:
       withState(state):
-        when stateFork == ConsensusFork.Bellatrix:
+        when consensusFork == ConsensusFork.Bellatrix:
           # Merge shortly after Bellatrix
           if  forkyState.data.slot >
               cfg.BELLATRIX_FORK_EPOCH * SLOTS_PER_EPOCH + 10:
@@ -363,7 +363,7 @@ proc makeSyncAggregate(
   let
     syncCommittee =
       withState(state):
-        when stateFork >= ConsensusFork.Altair:
+        when consensusFork >= ConsensusFork.Altair:
           if (forkyState.data.slot + 1).is_sync_committee_period():
             forkyState.data.next_sync_committee
           else:

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -42,7 +42,7 @@ proc valid_deposit(state: var ForkyHashedBeaconState) =
   state.root = hash_tree_root(state.data)
 
 proc getTestStates*(
-    initialState: ForkedHashedBeaconState, stateFork: ConsensusFork):
+    initialState: ForkedHashedBeaconState, consensusFork: ConsensusFork):
     seq[ref ForkedHashedBeaconState] =
   # Randomly generated slot numbers, with a jump to around
   # SLOTS_PER_HISTORICAL_ROOT to force wraparound of those
@@ -66,13 +66,13 @@ proc getTestStates*(
     cfg = defaultRuntimeConfig
 
   static: doAssert high(ConsensusFork) == ConsensusFork.Deneb
-  if stateFork >= ConsensusFork.Altair:
+  if consensusFork >= ConsensusFork.Altair:
     cfg.ALTAIR_FORK_EPOCH = 1.Epoch
-  if stateFork >= ConsensusFork.Bellatrix:
+  if consensusFork >= ConsensusFork.Bellatrix:
     cfg.BELLATRIX_FORK_EPOCH = 2.Epoch
-  if stateFork >= ConsensusFork.Capella:
+  if consensusFork >= ConsensusFork.Capella:
     cfg.CAPELLA_FORK_EPOCH = 3.Epoch
-  if stateFork >= ConsensusFork.Deneb:
+  if consensusFork >= ConsensusFork.Deneb:
     cfg.DENEB_FORK_EPOCH = 4.Epoch
 
   for i, epoch in stateEpochs:
@@ -86,5 +86,5 @@ proc getTestStates*(
         valid_deposit(forkyState)
     doAssert getStateField(tmpState[], slot) == slot
 
-    if tmpState[].kind == stateFork:
+    if tmpState[].kind == consensusFork:
       result.add assignClone(tmpState[])


### PR DESCRIPTION
Just the variable, not yet `lcDataForkAtStateFork` / `atStateFork`.

- Shorten comment in `light_client.nim` to keep line width
- Do not rename `stateFork` mention in `runProposalForkchoiceUpdated`.
- Do not rename `stateFork` in `getStateField(dag.headState, fork)`

Rest is just a mechanical mass replace