### PR TITLE
query EL and builder relay for bids in parallel

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -695,7 +695,7 @@ proc getBuilderBid[
   if blindedBlockParts.isErr:
     # Not signed yet, fine to try to fall back on EL
     beacon_block_builder_missed_with_fallback.inc()
-    return err "getBlindedBlockParts failed"
+    return err blindedBlockParts.error()
 
   # These, together, get combined into the blinded block for signing and
   # proposal through the relay network.
@@ -730,10 +730,7 @@ proc getBuilderBid[
         Result[SBBB, string].err("getBlindedBlock timed out")
 
   if blindedBlock.isErr:
-    info "getBuilderBid: getBlindedBeaconBlock failed",
-      slot, head = shortLog(head), validator_index, blindedBlock,
-      error = blindedBlock.error
-    return err "getBuilderBid: getBlindedBeaconBlock failed"
+    return err blindedBlock.error()
 
   return blindedBlock
 

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -811,15 +811,11 @@ proc makeBlindedBeaconBlockForHeadAndSlot*[
     else:
       return err("Attempt to create pre-Bellatrix blinded block")
 
-proc proposeBlockAux[SBBB, EPS](node: BeaconNode,
-                                validator: AttachedValidator,
-                                validator_index: ValidatorIndex,
-                                head: BlockRef,
-                                slot: Slot,
-                                randao: ValidatorSig,
-                                fork: Fork,
-                                genesis_validators_root: Eth2Digest):
-                                Future[BlockRef] {.async.} =
+proc proposeBlockAux(
+    SBBB: typedesc, EPS: typedesc, node: BeaconNode,
+    validator: AttachedValidator, validator_index: ValidatorIndex,
+    head: BlockRef, slot: Slot, randao: ValidatorSig, fork: Fork,
+    genesis_validators_root: Eth2Digest): Future[BlockRef] {.async.} =
   # Collect bids
   let usePayloadBuilder =
     if node.config.payloadBuilderEnable:
@@ -1015,8 +1011,8 @@ proc proposeBlock(node: BeaconNode,
       res.get()
 
   template proposeBlockContinuation(type1, type2: untyped): auto =
-    await proposeBlockAux[type1, type2](
-      node, validator, validator_index, head, slot, randao, fork,
+    await proposeBlockAux(
+      type1, type2, node, validator, validator_index, head, slot, randao, fork,
         genesis_validators_root)
 
   return

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -881,7 +881,8 @@ proc proposeBlockAux[SBBB, EPS](node: BeaconNode,
         false
     else:
       info "Engine block building failed",
-        slot, head = shortLog(head), validator = shortLog(validator)
+        slot, head = shortLog(head), validator = shortLog(validator),
+        err = engineBlockFut.error.msg
       false
 
   let useBuilderBlock =

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -866,7 +866,8 @@ proc proposeBlockAux[SBBB, EPS](node: BeaconNode,
         false
     else:
       info "Payload builder bid future failed",
-        slot, head = shortLog(head), validator = shortLog(validator)
+        slot, head = shortLog(head), validator = shortLog(validator),
+        err = payloadBuilderBidFut.error.msg
       false
 
   let engineBidAvailable =


### PR DESCRIPTION
The VC implementation has tradeoffs, but among them is that it doesn't have the tight coupling this PR moves towards breaking up a bit.