### PR TITLE
double `getBlindedBlock` timeout to 1 second

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -705,7 +705,7 @@ proc proposeBlockMEV[
       getBlindedBeaconBlock[SBBB](
         node, slot, validator, validator_index, forkedBlck,
         executionPayloadHeader),
-      500.milliseconds):
+      1.seconds):
     Result[SBBB, string].err("getBlindedBlock timed out")
 
   if blindedBlock.isErr:


### PR DESCRIPTION
Only merge one of https://github.com/status-im/nimbus-eth2/pull/4751 and this

This is from
https://github.com/status-im/nimbus-eth2/blob/17c0eeeede45126c697a3d8737420517e626b69c/beacon_chain/validators/validator_duties.nim#L691-L717

But `getBlindedBlock` doesn't directly interact with MEV relays, and is only truly asynchronous at all if someone's using a remote keysigner. `getBlindedBlockParts`, rather, is the call which gets the header bid from the MEV relay.

The issue is that if the timeout hits after the slashing has been checked in
https://github.com/status-im/nimbus-eth2/blob/17c0eeeede45126c697a3d8737420517e626b69c/beacon_chain/validators/validator_duties.nim#L584-L608

it can effectively disable the local EL fallback, because the slashing protection already thinks it's produced a block.

500 milliseconds was somewhat arbitrary, and there hadn't been any timeout in non-remote keysigning setups, so reduce likelihood of this case.