### PR TITLE
no timeout for purely local async slashing protection and signing

### DIFF
--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -701,12 +701,19 @@ proc proposeBlockMEV[
   let (executionPayloadHeader, forkedBlck) = blindedBlockParts.get
 
   # This is only substantively asynchronous with a remote key signer
-  let blindedBlock = awaitWithTimeout(
-      getBlindedBeaconBlock[SBBB](
+  let blindedBlock =
+    case validator.kind
+    of ValidatorKind.Local:
+      await getBlindedBeaconBlock[SBBB](
         node, slot, validator, validator_index, forkedBlck,
-        executionPayloadHeader),
-      500.milliseconds):
-    Result[SBBB, string].err("getBlindedBlock timed out")
+        executionPayloadHeader)
+    of ValidatorKind.Remote:
+      awaitWithTimeout(
+          getBlindedBeaconBlock[SBBB](
+            node, slot, validator, validator_index, forkedBlck,
+            executionPayloadHeader),
+          1.seconds):
+        Result[SBBB, string].err("getBlindedBlock timed out")
 
   if blindedBlock.isErr:
     info "proposeBlockMEV: getBlindedBeaconBlock failed",


### PR DESCRIPTION
alternative to https://github.com/status-im/nimbus-eth2/pull/4750

Removes, for locally held keys, the race entirely