### PR TITLE
use consensus spec v1.3.0-rc.5 test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-rc.4"
+const SPEC_VERSION* = "1.3.0-rc.5"
 ## Spec version we're aiming to be compatible with, right now
 
 const


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.3.0-rc.5
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.3.0-rc.5

Minimal changes: https://github.com/ethereum/consensus-specs/pull/3302/files