### PR TITLE
Revert "try not requiring brew install gnu-getopt"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,12 @@ jobs:
           # for miniupnp that runs "wingenminiupnpcstrings.exe" from the current dir
           echo "." >> $GITHUB_PATH
 
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install gnu-getopt
+          brew link --force gnu-getopt
+
       - name: Derive environment variables
         run: |
           if [[ '${{ matrix.target.cpu }}' == 'amd64' ]]; then


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#4569

https://ci.status.im/blue/organizations/jenkins/nimbus-eth2%2Fplatforms%2Fmacos%2Fx86_64/detail/PR-4795/1/pipeline/45/

https://ci.status.im/blue/organizations/jenkins/nimbus-eth2%2Fplatforms%2Fmacos%2Fx86_64/detail/PR-4795/2/pipeline/45/

https://ci.status.im/blue/organizations/jenkins/nimbus-eth2%2Fplatforms%2Fmacos%2Fx86_64/detail/PR-4795/3/pipeline/45

```
[2023-04-07T14:36:22.784Z] + make restapi-test
[2023-04-07T14:36:23.126Z] GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting.
[2023-04-07T14:36:23.126Z] make: *** [restapi-test] Error 1
```