### PR TITLE
fix false positive getopt failure with multiple getopt matches in searched path

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -35,7 +35,8 @@ PIDS=""
 
 GETOPT_BINARY="getopt"
 if [[ "${OS}" == "macos" ]]; then
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null || true)
+  # Without the head -n1 constraint, it gets confused by multiple matches
+  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
   [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
 fi
 

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2022 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2023 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license

--- a/scripts/make_prometheus_config.sh
+++ b/scripts/make_prometheus_config.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2023 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -16,7 +16,8 @@ set -e
 GETOPT_BINARY="getopt"
 if uname | grep -qi darwin; then
   # macOS
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null || true)
+  # Without the head -n1 constraint, it gets confused by multiple matches
+  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
 	[[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
 fi
 

--- a/tests/simulation/restapi.sh
+++ b/tests/simulation/restapi.sh
@@ -17,7 +17,8 @@ KILL_OLD_PROCESSES="0"
 GETOPT_BINARY="getopt"
 if uname | grep -qi darwin; then
   # macOS
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null || true)
+  # Without the head -n1 constraint, it gets confused by multiple matches
+  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
   [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
 fi
 


### PR DESCRIPTION
```
admin@maci7-02.ms-eu-dublin.ci.devel:~ % ls -l /usr/local/opt/gnu-getopt/bin/getopt 
-r-xr-xr-x  1 admin  wheel  54704 Aug 16  2021 /usr/local/opt/gnu-getopt/bin/getopt
admin@maci7-02.ms-eu-dublin.ci.devel:~ % ls -l /opt/homebrew/opt/gnu-getopt/bin/getopt
-r-xr-xr-x  1 admin  wheel  54704 Aug 16  2021 /opt/homebrew/opt/gnu-getopt/bin/getopt
```

```
admin@maci7-02.ms-eu-dublin.ci.devel:~ % cat test.sh 
GETOPT_BINARY="getopt"
if uname | grep -qi darwin; then
  # macOS
  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null || true)
  [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
fi
echo %GETOPT_BINARY
admin@maci7-02.ms-eu-dublin.ci.devel:~ % bash test.sh
GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting.
```