### PR TITLE
eliminate fcU/getPayload race condition causing missed proposals

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -211,7 +211,7 @@ proc storeBackfillBlock(
 from web3/engine_api_types import PayloadExecutionStatus, PayloadStatusV1
 from ../eth1/eth1_monitor import
   ELManager, NoPayloadAttributes, asEngineExecutionPayload, sendNewPayload,
-  forkchoiceUpdated, forkchoiceUpdatedNoResult
+  forkchoiceUpdated
 
 proc expectValidForkchoiceUpdated(
     elManager: ELManager,


### PR DESCRIPTION
In this example found by Antithesis, `blockSlot=129` block gets fcU'd during wall slot 131, because the node will propose at slot 132, but then a `blockSlot=131` block arrives late, only slightly before/concurrently with, from the EL perspective, the slot 132 proposal execution payload is being prepared. This results in a confusion where because `nextExpectedPayloadParams` had been set by the time the `getPayload` call began, but the actual fcU hadn't successfully completed yet (e.g., timing of `Stopping work on payload                 id=0x641f6bbe66b789a9 reason=delivery`/`Starting work on payload                 id=0x8a68b1e33ee08f06`), the proposal flow incorrectly treated the `nextExpectedPayloadParams` as reflecting the local CL head, which resulted in the payload and state parent hash mismatch because it was based on payload based on slot 129 from the EL and slot 131 from the CL:
```
[  195555] [   805.505708] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:03.607+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=342
[  195555] [   805.510681] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:03.612+00:00 Block processed                            localHeadSlot=129 blockSlot=129 validationDur=262us678ns queueDur=715us256ns storeBlockDur=772ms995us889ns updateHeadDur=215ms364us635ns
[  195555] [   805.815118] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:03.916+00:00 Block received                             topics="beacnde" delay=12s916ms723us191ns blockRoot=ea81d9ea wallSlot=130 signature=93377fcc blck="(slot: 128, proposer_index: 37, parent_root: \"52da256a\", state_root: \"646e9a92\", eth1data: (deposit_root: 54e51a8dfe18df1b46ba3247fc92d4a65d17f0ed8663f69027ebecb260dec8e6, deposit_count: 17, block_hash: 9a35fa3c039577765ebe67b45794d646434663af9e77ca9dc992f627aa063201), graffiti: \"lodestar-geth-0\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 18, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 12, block_number: 71, fee_recipient: \"0x0000000000000000000000000000000000000000\")"
[  195555] [   805.816218] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:03.917+00:00 newPayload: inserting block into execution engine executionPayload="(parent_hash: \"ad10e8a1\", fee_recipient: \"(data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])\", state_root: \"f2f0c697\", receipts_root: \"556235c6\", prev_randao: \"53e0ade1\", block_number: 71, gas_limit: 4495181, gas_used: 104256, timestamp: 1679950671, extra_data_len: 25, base_fee_per_gas: \"82719\", block_hash: \"173868b8\", num_transactions: 2, num_withdrawals: 1)"
[  195555] [   811.293932] [service_nimbus-geth-0]                   [I] DEBUG[03-27|20:58:09.395] Served engine_newPayloadV2               conn=127.0.0.1:57344   reqid=374 duration=5.47181815s
[  195555] [   811.300582] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.402+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=3583
[  195555] [   811.342228] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.443+00:00 newPayload: succeeded                      parentHash=ad10e8a1 blockHash=173868b8 blockNumber=71 payloadStatus=VALID
[  195555] [   811.345576] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.447+00:00 UpdateStateData cache miss                 topics="chaindag" current=f226dc9e:129@130 target=52da256a:124@128
[  195555] [   811.353762] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.455+00:00 Block resolved                             blockRoot=ea81d9ea blck="(slot: 128, proposer_index: 37, parent_root: \"52da256a\", state_root: \"646e9a92\", eth1data: (deposit_root: 54e51a8dfe18df1b46ba3247fc92d4a65d17f0ed8663f69027ebecb260dec8e6, deposit_count: 17, block_hash: 9a35fa3c039577765ebe67b45794d646434663af9e77ca9dc992f627aa063201), graffiti: \"lodestar-geth-0\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 18, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 12, block_number: 71, fee_recipient: \"0x0000000000000000000000000000000000000000\")" blockVerified=true heads=3 stateDataDur=4ms727us423ns sigVerifyDur=340us819ns stateVerifyDur=882us924ns putBlockDur=284us969ns epochRefDur=2ms263us129ns
[  195555] [   811.356316] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.457+00:00 runProposalForkchoiceUpdated: expected to be proposing next slot nextWallSlot=132 validatorIndex=45 nextProposer=856a9450b07b12d435cee625d9755501d13fc237444db8b7cfbad30d92baf0bc82255f98c662c7f565487de18fc1107d
[  195555] [   811.477110] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:09.578] Starting work on payload                 id=0x641f6bbe66b789a9
[  195555] [   811.499367] [service_nimbus-geth-0]                   [I] DEBUG[03-27|20:58:09.600] Served engine_forkchoiceUpdatedV2        conn=127.0.0.1:57714   reqid=375 duration=136.904418ms
[  195555] [   811.500881] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.602+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=532
[  195555] [   811.504055] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.605+00:00 Fork-choice updated for proposal           status`gensym734=VALID
[  195555] [   811.509626] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:09.611+00:00 Block processed                            localHeadSlot=129 blockSlot=128 validationDur=452us578ns queueDur=72us598ns storeBlockDur=5s539ms745us93ns updateHeadDur=153ms958us797ns
[  195555] [   811.525015] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:09.626] Updated payload                          id=0x641f6bbe66b789a9 number=72 hash=ca9244..c3fe4f txs=0 gas=0       fees=0           root=8299db..0fee5d elapsed=40.842ms
[  195555] [   816.517674] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.619+00:00 Block received                             topics="beacnde" delay=5s619ms329us452ns blockRoot=f97aa7d7 wallSlot=131 signature=b80af46e blck="(slot: 131, proposer_index: 16, parent_root: \"f226dc9e\", state_root: \"b7b0af97\", eth1data: (deposit_root: 54e51a8dfe18df1b46ba3247fc92d4a65d17f0ed8663f69027ebecb260dec8e6, deposit_count: 17, block_hash: 9a35fa3c039577765ebe67b45794d646434663af9e77ca9dc992f627aa063201), graffiti: \"teku-geth-0\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 6, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 3, block_number: 72, fee_recipient: \"0xa18fd83a55a9bedb96d66c24b768259eed183be3\")"
[  195555] [   816.518394] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.620+00:00 newPayload: inserting block into execution engine executionPayload="(parent_hash: \"10e1604f\", fee_recipient: \"(data: [161, 143, 216, 58, 85, 169, 190, 219, 150, 214, 108, 36, 183, 104, 37, 158, 237, 24, 59, 227])\", state_root: \"8299db6f\", receipts_root: \"56e81f17\", prev_randao: \"dd272e09\", block_number: 72, gas_limit: 4499569, gas_used: 0, timestamp: 1679950689, extra_data_len: 25, base_fee_per_gas: \"72380\", block_hash: \"bc87839f\", num_transactions: 0, num_withdrawals: 0)"
[  195555] [   816.700801] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:14.785] Imported new potential chain segment     number=72 hash=bc8783..8eeb76 blocks=1 txs=0 mgas=0.000 elapsed=136.557ms    mgasps=0.000  dirty=0.00B
[  195555] [   816.710072] [service_nimbus-geth-0]                   [I] DEBUG[03-27|20:58:14.809] Served engine_newPayloadV2               conn=127.0.0.1:58492   reqid=376 duration=182.624877ms
[  195555] [   816.712307] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.814+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=1281
[  195555] [   816.713145] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.814+00:00 newPayload: succeeded                      parentHash=10e1604f blockHash=bc87839f blockNumber=72 payloadStatus=VALID
[  195555] [   816.714263] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.815+00:00 UpdateStateData cache miss                 topics="chaindag" current=ea81d9ea:128@129 target=f226dc9e:129@131
[  195555] [   816.715637] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.817+00:00 State replayed                             topics="chaindag" blocks=1 slots=3 current=ea81d9ea:128@129 ancestor=52da256a:124@128 target=f226dc9e:129@131 ancestorStateRoot=bedba5a2 targetStateRoot=dde87102 found=false assignDur=1ms100us838ns replayDur=284us970ns
[  195555] [   816.717934] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.819+00:00 Block resolved                             blockRoot=f97aa7d7 blck="(slot: 131, proposer_index: 16, parent_root: \"f226dc9e\", state_root: \"b7b0af97\", eth1data: (deposit_root: 54e51a8dfe18df1b46ba3247fc92d4a65d17f0ed8663f69027ebecb260dec8e6, deposit_count: 17, block_hash: 9a35fa3c039577765ebe67b45794d646434663af9e77ca9dc992f627aa063201), graffiti: \"teku-geth-0\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 6, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 3, block_number: 72, fee_recipient: \"0xa18fd83a55a9bedb96d66c24b768259eed183be3\")" blockVerified=true heads=3 stateDataDur=3ms414us214ns sigVerifyDur=5us603ns stateVerifyDur=5us602ns putBlockDur=284us970ns epochRefDur=5us603ns
[  195555] [   816.747047] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.848+00:00 Updated head block                         topics="chaindag" stateRoot=b7b0af97 justified=13:2d2c85b7 finalized=11:33f522bc isOptHead=false newHead=f97aa7d7:131 lastHead=f226dc9e:129
[  195555] [   816.747422] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:14.849+00:00 runProposalForkchoiceUpdated: expected to be proposing next slot nextWallSlot=132 validatorIndex=45 nextProposer=856a9450b07b12d435cee625d9755501d13fc237444db8b7cfbad30d92baf0bc82255f98c662c7f565487de18fc1107d
[  195555] [   816.860326] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:14.960] Chain head was updated                   number=72 hash=bc8783..8eeb76 root=8299db..0fee5d elapsed=11.410594ms
[  195555] [   816.905644] [service_nimbus-geth-0]                   [I] INF 2023-03-27 20:58:15.007+00:00 Slot start                                 topics="beacnde" slot=132 epoch=16 sync=synced peers=2 head=f97aa7d7:131 finalized=11:33f522bc delay=7ms199us227ns
[  195555] [   816.907192] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.008+00:00 Voting on eth1 head with majority          topics="elmon" votes=2
[  195555] [   816.912310] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.013+00:00 Packed attestations for block              topics="attpool" newBlockSlot=132 packingDur=3ms559us530ns totalCandidates=3 attestations=3
[  195555] [   817.090867] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:15.172] Stopping work on payload                 id=0x641f6bbe66b789a9 reason=delivery
[  195555] [   817.111520] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:15.212] Starting work on payload                 id=0x8a68b1e33ee08f06
[  195555] [   817.124596] [service_nimbus-geth-0]                   [I] DEBUG[03-27|20:58:15.214] Served engine_forkchoiceUpdatedV2        conn=127.0.0.1:58504   reqid=377 duration=361.802041ms
[  195555] [   817.126703] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.228+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=532
[  195555] [   817.131687] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.233+00:00 syncEth1Chain tick                         topics="elmon" url=http://127.0.0.1:8551
[  195555] [   817.134682] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.236+00:00 Fork-choice updated for proposal           status`gensym734=VALID
[  195555] [   817.142751] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.244+00:00 Block processed                            localHeadSlot=131 blockSlot=131 validationDur=273us824ns queueDur=497us281ns storeBlockDur=222ms170us770ns updateHeadDur=402ms169us288ns
[  195555] [   817.143846] [service_nimbus-geth-0]                   [I] DEBUG[03-27|20:58:15.221] Served engine_getPayloadV2               conn=127.0.0.1:58520   reqid=378 duration=46.340704ms
[  195555] [   817.151915] [service_nimbus-geth-0]                   [I] DBG 2023-03-27 20:58:15.253+00:00 Message sent to RPC server                 topics="JSONRPC-HTTP-CLIENT" address="ok((id: \"127.0.0.1:8551\", scheme: NonSecure, hostname: \"127.0.0.1\", port: 8551, path: \"\", query: \"\", anchor: \"\", username: \"\", password: \"\", addresses: @[127.0.0.1:8551]))" msg_len=89
[  195555] [   817.194792] [service_nimbus-geth-0]                   [I] ERR 2023-03-27 20:58:15.280+00:00 Cannot create block for proposal           topics="beacval" slot=132 head=f97aa7d7:131 error="process_execution_payload: payload and state parent hash mismatch"
[  195555] [   817.196608] [service_nimbus-geth-0]                   [I] INFO [03-27|20:58:15.280] Updated payload                          id=0x8a68b1e33ee08f06 number=73 hash=810933..d22d00 txs=0 gas=0       fees=0           root=8299db..0fee5d elapsed=39.473ms
```