### PR TITLE
update `/eth/v1/debug/fork_choice` format to latest

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -519,7 +519,7 @@ type
 
       debugForkChoice* {.
         hidden
-        desc: "Enable debug API for fork choice (https://github.com/ethereum/beacon-APIs/pull/232)"
+        desc: "Enable debug API for fork choice (https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Debug/getDebugForkChoice)"
         defaultValue: false
         name: "debug-fork-choice" .}: bool
 


### PR DESCRIPTION
Syncs the `/eth/v1/debug/fork_choice` REST endpoint with latest specs.

- Validity is now reported as tri-state `enum` instead of two `bool`s
- Response includes store's justified and finalized checkpoints
- Additional `ExtraData` field on outer layer (empty for now)

https://github.com/ethereum/beacon-APIs/pull/232