### PR TITLE
accelerate execution layer sync using light client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -507,7 +507,6 @@ define CONNECT_TO_NETWORK_IN_DEV_MODE
 		--network=$(1) $(3) $(GOERLI_TESTNETS_PARAMS) \
 		--log-level="DEBUG; TRACE:discv5,networking; REQUIRED:none; DISABLED:none" \
 		--data-dir=build/data/shared_$(1)_$(NODE_ID) \
-		--sync-light-client=on \
 		--dump $(NODE_PARAMS)
 endef
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -312,9 +312,8 @@ type
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
 
       syncLightClient* {.
-        hidden
-        desc: "Accelerate sync using light client"
-        defaultValue: false
+        desc: "Accelerate execution layer sync using light client"
+        defaultValue: true
         name: "sync-light-client" .}: bool
 
       trustedBlockRoot* {.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -60,6 +60,7 @@ The following options are available:
                                seen by other nodes it communicates with. This option allows to enable/disable
                                this functionality [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
+     --sync-light-client       Accelerate execution layer sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.
      --finalized-deposit-tree-snapshot  SSZ file specifying a recent finalized EIP-4881 deposit tree snapshot.
      --node-name               A name for this node that will appear in the logs. If you set this to 'auto', a

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1202,7 +1202,6 @@ for NUM_NODE in $(seq 1 $NUM_NODES); do
     --finalized-deposit-tree-snapshot="$CONTAINER_DEPOSIT_TREE_SNAPSHOT_FILE" \
     --rest-port="$(( BASE_REST_PORT + NUM_NODE - 1 ))" \
     --metrics-port="$(( BASE_METRICS_PORT + NUM_NODE - 1 ))" \
-    --sync-light-client=on \
     --doppelganger-detection=off \
     ${EXTRA_ARGS} \
     &> "${DATA_DIR}/log${NUM_NODE}.txt" &


### PR DESCRIPTION
Turn on `--sync-light-client` option by default, now that it has shown stability in local testnets.