### PR TITLE
Quarantine and reassembly of gossiped blobs and blocks

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -1,0 +1,70 @@
+# beacon_chain
+# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/tables,
+  ../spec/datatypes/deneb
+
+
+const
+  MaxBlobs = SLOTS_PER_EPOCH * MAX_BLOBS_PER_BLOCK
+
+
+type
+  BlobQuarantine* = object
+    blobs*: Table[(Eth2Digest, BlobIndex), ref BlobSidecar]
+
+
+func put*(quarantine: var BlobQuarantine, blobSidecar: ref BlobSidecar) =
+  if quarantine.blobs.lenu64 > MaxBlobs:
+    return
+  discard quarantine.blobs.hasKeyOrPut((blobSidecar.block_root,
+                                        blobSidecar.index), blobSidecar)
+
+func blobIndices*(quarantine: BlobQuarantine, digest: Eth2Digest):
+     seq[BlobIndex] =
+  var r: seq[BlobIndex] = @[]
+  for i in 0..MAX_BLOBS_PER_BLOCK-1:
+    if quarantine.blobs.hasKey((digest, i)):
+      r.add(i)
+  r
+
+func hasBlob*(quarantine: BlobQuarantine, blobSidecar: BlobSidecar) : bool =
+  quarantine.blobs.hasKey((blobSidecar.block_root, blobSidecar.index))
+
+func popBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
+     seq[ref BlobSidecar] =
+  var r: seq[ref BlobSidecar] = @[]
+  for i in 0..MAX_BLOBS_PER_BLOCK-1:
+    var b: ref BlobSidecar
+    if quarantine.blobs.pop((digest, i), b):
+      r.add(b)
+  r
+
+func peekBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
+     seq[ref BlobSidecar] =
+  var r: seq[ref BlobSidecar] = @[]
+  for i in 0..MAX_BLOBS_PER_BLOCK-1:
+    quarantine.blobs.withValue((digest, i), value):
+      r.add(value[])
+  r
+
+func removeBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest) =
+  for i in 0..MAX_BLOBS_PER_BLOCK-1:
+    quarantine.blobs.del((digest, i))
+
+func hasBlobs*(quarantine: BlobQuarantine, blck: deneb.SignedBeaconBlock):
+     bool =
+  let idxs = quarantine.blobIndices(blck.root)
+  if len(blck.message.body.blob_kzg_commitments) != len(idxs):
+    return false
+  for i in 0..len(idxs):
+    if idxs[i] != uint64(i):
+      return false
+  true

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -17,8 +17,8 @@ import
   ../beacon_chain/spec/datatypes/deneb,
   ../beacon_chain/gossip_processing/block_processor,
   ../beacon_chain/consensus_object_pools/[
-    attestation_pool, blockchain_dag, block_quarantine, block_clearance,
-    consensus_manager],
+    attestation_pool, blockchain_dag, blob_quarantine, block_quarantine,
+    block_clearance, consensus_manager],
   ../beacon_chain/eth1/eth1_monitor,
   ./testutil, ./testdbutil, ./testblockutil
 
@@ -41,6 +41,7 @@ suite "Block processor" & preset():
       taskpool = Taskpool.new()
       verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
       quarantine = newClone(Quarantine.init())
+      blobQuarantine = newClone(BlobQuarantine())
       attestationPool = newClone(AttestationPool.init(dag, quarantine))
       elManager = new ELManager # TODO: initialise this properly
       actionTracker: ActionTracker
@@ -56,7 +57,7 @@ suite "Block processor" & preset():
       getTimeFn = proc(): BeaconTime = b2.message.slot.start_beacon_time()
       processor = BlockProcessor.new(
         false, "", "", keys.newRng(), taskpool, consensusManager,
-        validatorMonitor, getTimeFn)
+        validatorMonitor, blobQuarantine, getTimeFn)
 
   asyncTest "Reverse order block add & get" & preset():
     let missing = await processor.storeBlock(

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -20,6 +20,13 @@ func makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
   b.root = hash_tree_root(b.message)
   ForkedSignedBeaconBlock.init(b)
 
+func makeBlobbyBlock(slot: Slot, parent: Eth2Digest): deneb.SignedBeaconBlock =
+  var
+    b = deneb.SignedBeaconBlock(
+      message: deneb.BeaconBlock(slot: slot, parent_root: parent))
+  b.root = hash_tree_root(b.message)
+  b
+
 suite "Block quarantine":
   test "Unviable smoke test":
     let
@@ -28,6 +35,8 @@ suite "Block quarantine":
       b2 = makeBlock(Slot 2, b1.root)
       b3 = makeBlock(Slot 3, b2.root)
       b4 = makeBlock(Slot 4, b2.root)
+      b5 = makeBlobbyBlock(Slot 4, b3.root)
+      b6 = makeBlobbyBlock(Slot 4, b4.root)
 
     var quarantine: Quarantine
 
@@ -43,12 +52,20 @@ suite "Block quarantine":
       quarantine.addOrphan(Slot 0, b3)
       quarantine.addOrphan(Slot 0, b4)
 
+      quarantine.addBlobless(Slot 0, b5)
+      quarantine.addBlobless(Slot 0, b6)
+
       (b4.root, ValidatorSig()) in quarantine.orphans
+      (b5.root, ValidatorSig()) in quarantine.blobless
+      (b6.root, ValidatorSig()) in quarantine.blobless
 
     quarantine.addUnviable(b4.root)
 
     check:
       (b4.root, ValidatorSig()) notin quarantine.orphans
+
+      (b5.root, ValidatorSig()) in quarantine.blobless
+      (b6.root, ValidatorSig()) notin quarantine.blobless
 
     quarantine.addUnviable(b1.root)
 
@@ -56,3 +73,6 @@ suite "Block quarantine":
       (b1.root, ValidatorSig()) notin quarantine.orphans
       (b2.root, ValidatorSig()) notin quarantine.orphans
       (b3.root, ValidatorSig()) notin quarantine.orphans
+
+      (b5.root, ValidatorSig()) notin quarantine.blobless
+      (b6.root, ValidatorSig()) notin quarantine.blobless


### PR DESCRIPTION
This PR adds support for reassembly of blobs and blocks received through gossip:

- A new component BlobQuarantine, that is used to store blobs pending
  receiving all blobs for a block.
- The existing block quarantine is augmented to store blocks in a
  "blobless" bucket - these are blocks that have blob transactions,
  and are awaiting blobs before being sent up the stack.

- Upon receiving a new blob from gossip, it is stored in blob
  quarantine. If the corresponding block is already in "blobless"
  block quarantine, and if all blobs for that block are present in
  blob quarnatine, then they are pulled out of quarantine and sent
  along for local processing.

- Upon receiving a new block from gossip, if it has blob transactions
  and all blobs are in blob quarantine, they are pulled out and the
  block+blobs is sent along for local processing. Otherwise, the block
  is added to the "blobless" block quarantine bucket.

- When an orphan becomes unorphaned, rather than immediately sending
  it to local processing, we first check if it has blob
  transactions. If so, and if the blobs are not present in quarantine,
  it is moved to the blobless bucket. If the blobs are present, they
  are pulled out, and the block+blobs can be sent to local processing.


Still remaining:
  - Periodically initiate blob requests for "blobless" blocks (analogous to the existing "handleMissingBlocks")
  - Storing blobs
  - Proposals
  - Sync
