### PR TITLE
rename `execution(Block|Payload)Root` > `executionBlockHash`

### DIFF
--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -34,7 +34,7 @@ type
     bid*: BlockId ##\
       ## Root that can be used to retrieve block data from database
 
-    executionBlockRoot*: Opt[Eth2Digest]
+    executionBlockHash*: Opt[Eth2Digest]
 
     parent*: BlockRef ##\
       ## Not nil, except for the finalized head
@@ -54,10 +54,10 @@ template slot*(blck: BlockRef): Slot = blck.bid.slot
 
 func init*(
     T: type BlockRef, root: Eth2Digest,
-    executionPayloadRoot: Opt[Eth2Digest], slot: Slot): BlockRef =
+    executionBlockHash: Opt[Eth2Digest], slot: Slot): BlockRef =
   BlockRef(
     bid: BlockId(root: root, slot: slot),
-    executionBlockRoot: executionPayloadRoot)
+    executionBlockHash: executionBlockHash)
 
 func init*(
     T: type BlockRef, root: Eth2Digest,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1978,9 +1978,9 @@ proc loadExecutionBlockHash*(dag: ChainDAGRef, bid: BlockId): Eth2Digest =
       ZERO_HASH
 
 proc loadExecutionBlockHash*(dag: ChainDAGRef, blck: BlockRef): Eth2Digest =
-  if blck.executionBlockRoot.isNone:
-    blck.executionBlockRoot = Opt.some dag.loadExecutionBlockHash(blck.bid)
-  blck.executionBlockRoot.unsafeGet
+  if blck.executionBlockHash.isNone:
+    blck.executionBlockHash = Opt.some dag.loadExecutionBlockHash(blck.bid)
+  blck.executionBlockHash.unsafeGet
 
 from std/packedsets import PackedSet, incl, items
 

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -51,19 +51,19 @@ proc getEarliestInvalidBlockRoot*(
 
   # Only allow this special case outside loop; it's when the LVH is the direct
   # parent of the reported invalid block
-  if  curBlck.executionBlockRoot.isSome and
-      curBlck.executionBlockRoot.get == latestValidHash:
+  if  curBlck.executionBlockHash.isSome and
+      curBlck.executionBlockHash.get == latestValidHash:
     return defaultEarliestInvalidBlockRoot
 
   while true:
     # This was supposed to have been either caught by the pre-loop check or the
     # parent check.
-    if  curBlck.executionBlockRoot.isSome and
-        curBlck.executionBlockRoot.get == latestValidHash:
+    if  curBlck.executionBlockHash.isSome and
+        curBlck.executionBlockHash.get == latestValidHash:
       doAssert false, "getEarliestInvalidBlockRoot: unexpected LVH in loop body"
 
     if (curBlck.parent.isNil) or
-       curBlck.parent.executionBlockRoot.get(latestValidHash) ==
+       curBlck.parent.executionBlockHash.get(latestValidHash) ==
          latestValidHash:
       break
     curBlck = curBlck.parent


### PR DESCRIPTION
Note: `execution_payload_root` is _actually_ `htr(payload)`. Only `executionPayloadRoot` was used as `executionBlockHash`.