### PR TITLE
fix `/eth/v1/debug/fork_choice` output

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2667,6 +2667,12 @@ proc writeValue*(writer: var JsonWriter[RestJson],
     writer.writeField("execution_optimistic", value.optimistic.get())
   writer.endRecord()
 
+## RestNodeValidity
+proc writeValue*(writer: var JsonWriter[RestJson],
+                 value: RestNodeValidity) {.
+     raises: [IOError, Defect].} =
+  writer.writeValue($value)
+
 ## RestSyncInfo
 proc writeValue*(writer: var JsonWriter[RestJson],
                  value: RestSyncInfo) {.

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -671,6 +671,39 @@ type
   GetValidatorsActivityResponse* = DataEnclosedObject[seq[RestActivityItem]]
   GetValidatorsLivenessResponse* = DataEnclosedObject[seq[RestLivenessItem]]
 
+  RestNodeValidity* {.pure.} = enum
+    valid = "VALID",
+    invalid = "INVALID",
+    optimistic = "OPTIMISTIC"
+
+  RestNodeExtraData* = object
+    justified_root*: Eth2Digest
+    finalized_root*: Eth2Digest
+    u_justified_checkpoint*: Option[Checkpoint]
+    u_finalized_checkpoint*: Option[Checkpoint]
+    best_child*: Eth2Digest
+    best_descendant*: Eth2Digest
+
+  RestNode* = object
+    slot*: Slot
+    block_root*: Eth2Digest
+    parent_root*: Eth2Digest
+    justified_epoch*: Epoch
+    finalized_epoch*: Epoch
+    weight*: uint64
+    validity*: RestNodeValidity
+    execution_block_hash*: Eth2Digest
+    extra_data*: Option[RestNodeExtraData]
+
+  RestExtraData* = object
+    discard
+
+  GetForkChoiceResponse* = object
+    justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+    fork_choice_nodes*: seq[RestNode]
+    extra_data*: RestExtraData
+
 func `==`*(a, b: RestValidatorIndex): bool =
   uint64(a) == uint64(b)
 


### PR DESCRIPTION
Two fixes to `/eth/v1/debug/fork_choice`:

- `validity` enum is expected to be serialized as string instead of int
- `data` wrapper is not expected for this endpoint