### PR TITLE
Fix incorrect handling of blobless blocks

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -249,6 +249,7 @@ proc processSignedBeaconBlock*(
            blockRoot = shortLog(signedBlock.root),
            blck = shortLog(signedBlock.message),
            signature = shortLog(signedBlock.signature)
+        return v
 
     self.blockProcessor[].addBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),


### PR DESCRIPTION
We were passing all blocks to local processing, including those for which we were missing blobs. This commit fixes that.