### PR TITLE
move spec constants to spec

### DIFF
--- a/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
@@ -195,7 +195,7 @@ proc getLightClientBootstrap*(
         contentType: resp.contentType,
         data: data))
 
-from ../../networking/eth2_network import MAX_REQUEST_LIGHT_CLIENT_UPDATES
+from ../../spec/network import MAX_REQUEST_LIGHT_CLIENT_UPDATES
 export MAX_REQUEST_LIGHT_CLIENT_UPDATES
 
 proc getLightClientUpdatesByRangePlain(

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -29,7 +29,7 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS_DENEB* = 128 # TODO Make use of in request code
-  MAX_REQUEST_BLOB_SIDECARS* = int(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
+  MAX_REQUEST_BLOB_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
   # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -28,8 +28,8 @@ const
   MAX_REQUEST_BLOCKS* = 1024
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
-  # TODO MAX_REQUEST_BLOCKS_DENEB
-  MAX_REQUEST_BLOB_SIDECARS* = 128
+  MAX_REQUEST_BLOCKS_DENEB* = 128 # TODO Make use of in request code
+  MAX_REQUEST_BLOB_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
   # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -27,21 +27,20 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS* = 1024
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
-  MAX_REQUEST_BLOCKS_DENEB* = 128 # TODO Make use of in request code
-  MAX_REQUEST_BLOB_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
-  # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
+  RESP_TIMEOUT* = 10.seconds
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration
   MAX_REQUEST_LIGHT_CLIENT_UPDATES* = 128
 
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
-  RESP_TIMEOUT* = 10.seconds
-
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/bellatrix/p2p-interface.md#configuration
   GOSSIP_MAX_SIZE_BELLATRIX* = 10 * 1024 * 1024 # bytes
   MAX_CHUNK_SIZE_BELLATRIX* = 10 * 1024 * 1024 # bytes
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
+  MAX_REQUEST_BLOCKS_DENEB* = 128 # TODO Make use of in request code
+  MAX_REQUEST_BLOB_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
+  # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
 
   defaultEth2TcpPort* = 9000
   defaultEth2TcpPortDesc* = $defaultEth2TcpPort

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -25,6 +25,18 @@ const
   topicBlsToExecutionChangeSuffix* = "bls_to_execution_change/ssz_snappy"
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
+  MAX_REQUEST_BLOCKS* = 1024
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
+  # TODO MAX_REQUEST_BLOCKS_DENEB
+  MAX_REQUEST_BLOB_SIDECARS* = 128
+  # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration
+  MAX_REQUEST_LIGHT_CLIENT_UPDATES* = 128
+
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
   RESP_TIMEOUT* = 10.seconds
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/bellatrix/p2p-interface.md#configuration

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -29,7 +29,7 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS_DENEB* = 128 # TODO Make use of in request code
-  MAX_REQUEST_BLOB_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK
+  MAX_REQUEST_BLOB_SIDECARS* = int(MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK)
   # TODO MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -26,8 +26,6 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS* = 1024
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/p2p-interface.md#configuration
   RESP_TIMEOUT* = 10.seconds
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration

--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -10,6 +10,7 @@
 import chronos, chronicles, stew/base10
 import
   eth/p2p/discoveryv5/random2,
+  ../spec/network,
   ../networking/eth2_network,
   ../beacon_clock,
   "."/sync_protocol, "."/sync_manager

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -78,7 +78,7 @@ type
     slots*: uint64
 
   BeaconBlocksRes = NetRes[List[ref ForkedSignedBeaconBlock, MAX_REQUEST_BLOCKS]]
-  BlobSidecarsRes = NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK)]]
+  BlobSidecarsRes = NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)]]
 
 proc now*(sm: typedesc[SyncMoment], slots: uint64): SyncMoment {.inline.} =
   SyncMoment(stamp: now(chronos.Moment), slots: slots)

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -78,7 +78,7 @@ type
     slots*: uint64
 
   BeaconBlocksRes = NetRes[List[ref ForkedSignedBeaconBlock, MAX_REQUEST_BLOCKS]]
-  BlobSidecarsRes = NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)]]
+  BlobSidecarsRes = NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)]]
 
 proc now*(sm: typedesc[SyncMoment], slots: uint64): SyncMoment {.inline.} =
   SyncMoment(stamp: now(chronos.Moment), slots: slots)

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -66,7 +66,7 @@ type
     slot: Slot
 
   BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS]
-  BlobIdentifierList* = List[BlobIdentifier, Limit (MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)]
+  BlobIdentifierList* = List[BlobIdentifier, Limit (MAX_REQUEST_BLOB_SIDECARS)]
 
 template readChunkPayload*(
     conn: Connection, peer: Peer, MsgType: type ForkySignedBeaconBlock):
@@ -429,7 +429,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       blobIds: BlobIdentifierList,
       response: MultipleChunksResponse[
-        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)])
+        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
       {.async, libp2pProtocol("blob_sidecars_by_root", 1).} =
     # TODO Semantically, this request should return a non-ref, but doing so
     #      runs into extreme inefficiency due to the compiler introducing
@@ -481,7 +481,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       startSlot: Slot,
       reqCount: uint64,
-      response: MultipleChunksResponse[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)])
+      response: MultipleChunksResponse[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
       {.async, libp2pProtocol("blob_sidecars_by_range", 1).} =
     # TODO This code is more complicated than it needs to be, since the type
     #      of the multiple chunks response is not actually used in this server
@@ -507,7 +507,7 @@ p2pProtocol BeaconSync(version = 1,
     if startSlot.epoch < epochBoundary:
       raise newException(ResourceUnavailableError, BlobsOutOfRange)
 
-    var blockIds: array[MAX_REQUEST_BLOB_SIDECARS, BlockId]
+    var blockIds: array[int(MAX_REQUEST_BLOB_SIDECARS), BlockId]
     let
       count = int min(reqCount, blockIds.lenu64)
       endIndex = count - 1

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -22,13 +22,8 @@ logScope:
   topics = "sync"
 
 const
-  MAX_REQUEST_BLOCKS* = 1024
-  MAX_REQUEST_BLOBS_SIDECARS* = 128
-
   blockResponseCost = allowedOpsPerSecondCost(64) # Allow syncing ~64 blocks/sec (minus request costs)
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/altair/light-client/p2p-interface.md#configuration
-  MAX_REQUEST_LIGHT_CLIENT_UPDATES* = 128
   lightClientBootstrapResponseCost = allowedOpsPerSecondCost(1)
     ## Only one bootstrap per peer should ever be needed - no need to allow more
   lightClientUpdateResponseCost = allowedOpsPerSecondCost(1000)
@@ -71,7 +66,7 @@ type
     slot: Slot
 
   BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS]
-  BlobIdentifierList* = List[BlobIdentifier, Limit (MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK)]
+  BlobIdentifierList* = List[BlobIdentifier, Limit (MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)]
 
 template readChunkPayload*(
     conn: Connection, peer: Peer, MsgType: type ForkySignedBeaconBlock):
@@ -434,7 +429,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       blobIds: BlobIdentifierList,
       response: MultipleChunksResponse[
-        ref BlobSidecar, Limit(MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK)])
+        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)])
       {.async, libp2pProtocol("blob_sidecars_by_root", 1).} =
     # TODO Semantically, this request should return a non-ref, but doing so
     #      runs into extreme inefficiency due to the compiler introducing
@@ -486,7 +481,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       startSlot: Slot,
       reqCount: uint64,
-      response: MultipleChunksResponse[ref BlobSidecar, Limit(MAX_REQUEST_BLOBS_SIDECARS * MAX_BLOBS_PER_BLOCK)])
+      response: MultipleChunksResponse[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS * MAX_BLOBS_PER_BLOCK)])
       {.async, libp2pProtocol("blob_sidecars_by_range", 1).} =
     # TODO This code is more complicated than it needs to be, since the type
     #      of the multiple chunks response is not actually used in this server
@@ -512,7 +507,7 @@ p2pProtocol BeaconSync(version = 1,
     if startSlot.epoch < epochBoundary:
       raise newException(ResourceUnavailableError, BlobsOutOfRange)
 
-    var blockIds: array[MAX_REQUEST_BLOBS_SIDECARS, BlockId]
+    var blockIds: array[MAX_REQUEST_BLOB_SIDECARS, BlockId]
     let
       count = int min(reqCount, blockIds.lenu64)
       endIndex = count - 1

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -12,7 +12,8 @@ import
   ./sync/sync_manager,
   ./consensus_object_pools/[block_clearance, blockchain_dag],
   ./spec/eth2_apis/rest_beacon_client,
-  ./spec/[beaconstate, eth2_merkleization, forks, light_client_sync, presets,
+  ./spec/[beaconstate, eth2_merkleization, forks, light_client_sync,
+          network, presets,
           state_transition, deposit_snapshots],
   "."/[beacon_clock, beacon_chain_db, era_db]
 


### PR DESCRIPTION
quite funny, this removes >_1000_ transitive imports when building `nimbus_validator_client`.

`genDepend`:

```sh
[arnetheduck@praeceps beacon_chain]$ diff -u
nimbus_validator_client.dot.pre nimbus_validator_client.dot | wc
   1167    3507  103822
```