### PR TITLE
Fix incorrect naming and use of Quarantine.peekBlobless

### DIFF
--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -307,7 +307,7 @@ proc addBlobless*(
   quarantine.missing.del(signedBlock.root)
   true
 
-func peekBlobless*(quarantine: var Quarantine, root: Eth2Digest):
+func popBlobless*(quarantine: var Quarantine, root: Eth2Digest):
          Option[deneb.SignedBeaconBlock] =
   var blck: deneb.SignedBeaconBlock
   if quarantine.blobless.pop(root, blck):

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -306,7 +306,7 @@ proc processSignedBlobSidecar*(
 
   var skippedBlocks = false
 
-  if (let o = self.quarantine[].peekBlobless(
+  if (let o = self.quarantine[].popBlobless(
     signedBlobSidecar.message.block_root); o.isSome):
     let blobless = o.unsafeGet()
 
@@ -317,6 +317,9 @@ proc processSignedBlobSidecar*(
         self.blobQuarantine[].popBlobs(
           signedBlobSidecar.message.block_root)
       )
+    else:
+      discard self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
+                                            blobless)
 
   blob_sidecars_received.inc()
   blob_sidecar_delay.observe(delay.toFloatSeconds())


### PR DESCRIPTION
The 'peek' name was incorrect as it was actually removing from the table. It was consequently used incorrectly in block processing: the blobless block wasn't returned to the table when it should be.