### PR TITLE
Request manager: Handle blobless blocks

### DIFF
--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -32,8 +32,7 @@ const
 
 type
   BlockVerifier* =
-    proc(signedBlock: ForkedSignedBeaconBlock, blobs: BlobSidecars,
-         maybeFinalized: bool):
+    proc(signedBlock: ForkedSignedBeaconBlock, maybeFinalized: bool):
       Future[Result[void, VerifierError]] {.gcsafe, raises: [Defect].}
   RequestManager* = object
     network*: Eth2Node
@@ -91,9 +90,7 @@ proc fetchAncestorBlocksFromNetwork(rman: RequestManager,
           gotUnviableBlock = false
 
         for b in ublocks:
-          let ver = await rman.blockVerifier(b[], BlobSidecars @[], false)
-          # TODO:
-          # blob handling for Deneb blocks
+          let ver = await rman.blockVerifier(b[], false)
           if ver.isErr():
             case ver.error()
             of VerifierError.MissingParent:


### PR DESCRIPTION
Post-Deneb, when the request manager receives a missing block from a peer, it needs to check if the corresponding blobs are available, and if so pass them along. If they aren't available, the newly-fetched block must be put in blobless quarantine (while the blobs are retrieved, coming in next commit).