### PR TITLE
lower log level of LC optimistic sync

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -40,7 +40,7 @@ proc initLightClient*(
   let
     optimisticHandler = proc(signedBlock: ForkedMsgTrustedSignedBeaconBlock):
                              Future[void] {.async.} =
-      info "New LC optimistic block",
+      debug "New LC optimistic block",
         opt = signedBlock.toBlockId(),
         dag = node.dag.head.bid,
         wallSlot = node.currentSlot


### PR DESCRIPTION
When using light client sync while main forward sync is behind, use DEBUG log level instead of INFO log level to reduce log verbosity.