### PR TITLE
use consensus specs v1.3.0 test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.3.0-rc.5"
+const SPEC_VERSION* = "1.3.0"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -32,8 +32,8 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/polynomial-commitments.md#constants
   BYTES_PER_FIELD_ELEMENT = 32
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#blob
-  BLOB_TX_TYPE* = 0x05'u8
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#blob
+  BLOB_TX_TYPE* = 0x03'u8
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/polynomial-commitments.md#constants
   BLS_MODULUS* = "52435875175126190479447740508185965837690552500527637822603658699938581184513".u256


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.3.0
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.3.0

Minimal changes, almost exclusively ratifying `v1.3.0-rc.5`.