### PR TITLE
make `--trusted-block-root` option visible for CP sync

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -782,7 +782,6 @@ type
       .}: Option[string]
 
       lcTrustedBlockRoot* {.
-        hidden
         desc: "Recent trusted finalized block root to initialize light client from"
         name: "trusted-block-root" .}: Option[Eth2Digest]
 


### PR DESCRIPTION
Add `--trusted-block-root` to `--help` for `trustedNodeSync`.