### PR TITLE
add `el_offline` to `/eth/v1/node/syncing`

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -1965,6 +1965,9 @@ func isNewLastBlock(m: ELManager, blk: Eth1BlockHeader|BlockObject): bool =
 func hasConnection*(m: ELManager): bool =
   m.elConnections.len > 0
 
+func hasAnyWorkingConnection*(m: ELManager): bool =
+  m.elConnections.anyIt(it.state == Working)
+
 func hasProperlyConfiguredConnection*(m: ELManager): bool =
   for connection in m.elConnections:
     if connection.etcStatus == EtcStatus.match:

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -268,12 +268,10 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
         else:
           none[bool]()
       elOffline =
-        if node.currentSlot().epoch() < node.dag.cfg.CAPELLA_FORK_EPOCH:
-          none[bool]()  # Added with ethereum/beacon-APIs v2.4.0
-        elif isNil(node.elManager):
-          some(true)
-        else:
+        if node.currentSlot().epoch() >= node.dag.cfg.CAPELLA_FORK_EPOCH:
           some(not node.elManager.hasAnyWorkingConnection)
+        else:
+          none[bool]()  # Added with ethereum/beacon-APIs v2.4.0
 
       info = RestSyncInfo(
         head_slot: headSlot, sync_distance: distance,

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -267,10 +267,18 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
           some(node.dag.is_optimistic(node.dag.head.root))
         else:
           none[bool]()
+      elOffline =
+        if node.currentSlot().epoch() < node.dag.cfg.CAPELLA_FORK_EPOCH:
+          none[bool]()  # Added with ethereum/beacon-APIs v2.4.0
+        elif isNil(node.elManager):
+          some(true)
+        else:
+          some(not node.elManager.hasAnyWorkingConnection)
 
       info = RestSyncInfo(
         head_slot: headSlot, sync_distance: distance,
-        is_syncing: isSyncing, is_optimistic: isOptimistic
+        is_syncing: isSyncing, is_optimistic: isOptimistic,
+        el_offline: elOffline
       )
     return RestApiResponse.jsonResponse(info)
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2742,6 +2742,8 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   writer.writeField("is_syncing", value.is_syncing)
   if value.is_optimistic.isSome():
     writer.writeField("is_optimistic", value.is_optimistic.get())
+  if value.el_offline.isSome():
+    writer.writeField("el_offline", value.el_offline.get())
   writer.endRecord()
 
 ## RestErrorMessage

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -245,6 +245,7 @@ type
     sync_distance*: uint64
     is_syncing*: bool
     is_optimistic*: Option[bool]
+    el_offline*: Option[bool]
 
   RestPeerCount* = object
     disconnected*: uint64


### PR DESCRIPTION
Add compatibility with https://github.com/ethereum/beacon-APIs/pull/290 to the beacon node. Behaviour when configured with multiple ELs is not specified; intention suggests to indicate whether all ELs are offline.