### PR TITLE
track `el_offline` status in VC

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -184,8 +184,11 @@ proc runVCSlotLoop(vc: ValidatorClientRef) {.async.} =
         # Good nodes are nodes which can be used for ALL the requests.
         goodNodes = counts.data[int(RestBeaconNodeStatus.Synced)]
         # Viable nodes are nodes which can be used only SOME of the requests.
-        viableNodes = counts.data[int(RestBeaconNodeStatus.OptSynced)] +
+        viableNodes = counts.data[int(RestBeaconNodeStatus.SyncedELOff)] +
+                      counts.data[int(RestBeaconNodeStatus.OptSynced)] +
+                      counts.data[int(RestBeaconNodeStatus.OptSyncedELOff)] +
                       counts.data[int(RestBeaconNodeStatus.NotSynced)] +
+                      counts.data[int(RestBeaconNodeStatus.NotSyncedELOff)] +
                       counts.data[int(RestBeaconNodeStatus.Compatible)]
         # Bad nodes are nodes which can't be used at all.
         badNodes = counts.data[int(RestBeaconNodeStatus.Offline)] +

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -39,8 +39,11 @@ type
 
 const
   ViableNodeStatus = {RestBeaconNodeStatus.Compatible,
+                      RestBeaconNodeStatus.NotSyncedELOff,
                       RestBeaconNodeStatus.NotSynced,
+                      RestBeaconNodeStatus.OptSyncedELOff,
                       RestBeaconNodeStatus.OptSynced,
+                      RestBeaconNodeStatus.SyncedELOff,
                       RestBeaconNodeStatus.Synced}
 
 proc `$`*(strategy: ApiStrategyKind): string =


### PR DESCRIPTION
Updates the validator client to track the new `el_offline` field in the `/eth/v1/node/syncing` response.
https://github.com/ethereum/beacon-APIs/pull/290

If `el_offline` is present, the BN will be treated same as if it was optimistically synced. Note that a BN could report that it is in sync, but may still have intermittent connection issues to the EL, making it impossible to `getPayload` from them since Capella.