### PR TITLE
align `MockPrivKeys` with EF keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ build/
 /local_testnet*_data*/
 
 test_keymanager_api
+test_sim
 
 /libnfuzz_linkerArgs.txt
 

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -30,9 +30,7 @@ const
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/tests/core/pyspec/eth2spec/test/helpers/keys.py
 func `[]`*(_: MockPrivKeysT, index: ValidatorIndex|uint64): ValidatorPrivKey =
-  # 0 is not a valid BLS private key - 1000 helps interop with rust BLS library,
-  # lighthouse. EF tests use 1 instead of 1000.
-  var bytes = (index.uint64 + 1000'u64).toBytesLE()
+  var bytes = (index.uint64 + 1'u64).toBytesLE()  # Consistent with EF tests
   static: doAssert sizeof(bytes) <= sizeof(result)
   copyMem(addr result, addr bytes, sizeof(bytes))
 


### PR DESCRIPTION
Back then, Milagro interop used offset 1000 for mock BLS keys. Meanwhile, interop code was removed and multi client testnets are there. EF tests use an offset of 1 for mock BLS keys. This patch aligns our implementation to also use offset of 1, potentially making debugging of state differences a bit easier (but, ultimately, low impact).

Furthermore, simulation files are now emitted into a subdirectory to have less chunk in the repo root directory, and to avoid conflicts where a cached file with offset 1000 runs against tests expecting 1.

See https://github.com/status-im/nimbus-eth2/pull/2928/files#r719266863