### PR TITLE
cache computed mock pubkeys in tests

### DIFF
--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -89,7 +89,7 @@ template mockGenesisDepositsImpl(
       depositsData.add result[valIdx]
       depositsDataHash.add hash_tree_root(result[valIdx])
 
-func mockGenesisBalancedDeposits*(
+proc mockGenesisBalancedDeposits*(
         validatorCount: uint64,
         amountInEth: Positive,
         flags: UpdateFlags = {}
@@ -106,7 +106,7 @@ func mockGenesisBalancedDeposits*(
   mockGenesisDepositsImpl(result, validatorCount,amount,flags):
     discard
 
-func mockUpdateStateForNewDeposit*(
+proc mockUpdateStateForNewDeposit*(
        state: var ForkyBeaconState,
        validator_index: uint64,
        amount: uint64,

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -36,15 +36,24 @@ func `[]`*(_: MockPrivKeysT, index: ValidatorIndex|uint64): ValidatorPrivKey =
   static: doAssert sizeof(bytes) <= sizeof(result)
   copyMem(addr result, addr bytes, sizeof(bytes))
 
-func `[]`*(_: MockPubKeysT, index: ValidatorIndex|uint64): ValidatorPubKey =
-  MockPrivKeys[index].toPubKey().toPubKey()
+proc `[]`*(_: MockPubKeysT, index: uint64): ValidatorPubKey =
+  var cache {.threadvar.}: Table[uint64, ValidatorPubKey]
+  cache.withValue(index, key) do:
+    return key[]
+  do:
+    let key = MockPrivKeys[index].toPubKey().toPubKey()
+    cache[index] = key
+    return key
+
+proc `[]`*(_: MockPubKeysT, index: ValidatorIndex): ValidatorPubKey =
+  _[index.uint64]
 
 func makeFakeHash*(i: int): Eth2Digest =
   var bytes = uint64(i).toBytesLE()
   static: doAssert sizeof(bytes) <= sizeof(result.data)
   copyMem(addr result.data[0], addr bytes[0], sizeof(bytes))
 
-func makeDeposit*(
+proc makeDeposit*(
     i: int,
     flags: UpdateFlags = {},
     cfg = defaultRuntimeConfig): DepositData =
@@ -61,7 +70,7 @@ func makeDeposit*(
   if skipBlsValidation notin flags:
     result.signature = get_deposit_signature(cfg, result, privkey).toValidatorSig()
 
-func makeInitialDeposits*(
+proc makeInitialDeposits*(
     n = SLOTS_PER_EPOCH, flags: UpdateFlags = {}, cfg = defaultRuntimeConfig): seq[DepositData] =
   for i in 0..<n.int:
     result.add makeDeposit(i, flags, cfg = cfg)


### PR DESCRIPTION
We have a few tests that access `MockPubKeys`. Adding a cache provides a minor speedup, as repeated pubkey computations are avoided.

64 cache hits: EF - Capella - Unittests - Light client - Sync protocol
64 cache hits: EF - Altair - Unittests - Light client - Sync protocol
256 cache hits: EF - Capella - Unittests - Light client - Sync protocol
256 cache hits: EF - Altair - Unittests - Light client - Sync protocol
2297 cache hits: Attestation pool processing [Preset: mainnet]
512 cache hits: Beacon chain DB [Preset: mainnet]
32 cache hits: Block processor [Preset: mainnet]
1082 cache hits: Validator change pool testing suite
192 cache hits: Gossip validation  [Preset: mainnet]
32 cache hits: Gossip validation - Extra
192 cache hits: Spec helpers
32 cache hits: Light client processor [Preset: mainnet]
96 cache hits: Light client [Preset: mainnet]
192 cache hits: Beacon state [Preset: mainnet]
37 cache hits: state diff tests [Preset: mainnet]
160 cache hits: Block pool processing [Preset: mainnet]
32 cache hits: Block pool altair processing [Preset: mainnet]
96 cache hits: chain DAG finalization tests [Preset: mainnet]
32 cache hits: Old database versions [Preset: mainnet]
64 cache hits: Diverging hardforks
96 cache hits: Backfill
32 cache hits: Starting states
32 cache hits: Latest valid hash [Preset: mainnet]
32 cache hits: Pruning

5912 cache hits total per `make -j test`.