### PR TITLE
only run copyright year check in pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         #  submodules: true
 
       - name: Check copyright year (Linux)
-        if: runner.os == 'Linux'
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
         run: |
           excluded_extensions="md|png"
 


### PR DESCRIPTION
On `unstable`, the `git diff` doesn't work, so only check during PR.