### PR TITLE
ignore submodules in copyright check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
           base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
           git fetch origin "$base_branch" 2>/dev/null
-          modified_files=$(git diff --name-only --diff-filter=d "origin/$base_branch" HEAD | grep -vE '\.('$excluded_extensions')$')
+          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "origin/$base_branch" HEAD | grep -vE '\.('$excluded_extensions')$')
 
           current_year=$(date +"%Y")
           outdated_files=()


### PR DESCRIPTION
Otherwise, they get reported as missing copyright header whenever selecting a new commit for a submodule.