### PR TITLE
fix copyright year check if only submodules bumped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,12 @@ jobs:
 
           base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
           git fetch origin "$base_branch" 2>/dev/null
-          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "origin/$base_branch" HEAD | grep -vE '\.('$excluded_extensions')$')
+          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "origin/$base_branch" HEAD | grep -vE '\.('$excluded_extensions')$' || true)
 
           current_year=$(date +"%Y")
           outdated_files=()
           for file in $modified_files; do
-            if ! grep -qE "Copyright \(c\) .*$current_year Status Research & Development GmbH" "$file"; then
+            if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi
           done


### PR DESCRIPTION
When only submodules were bumped but no other changes are committed, `git diff` returns empty list, and `grep` returns 1. Suppress `grep` error to prevent CI fail in that case.