### PR TITLE
fix gossip validation for duplicate blob sidecars

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -289,7 +289,8 @@ proc validateBlobSidecar*(
   # [IGNORE] The sidecar is the only sidecar with valid signature
   # received for the tuple (sidecar.block_root, sidecar.index).
   if blobQuarantine[].hasBlob(sbs.message):
-    return errReject("SignedBlobSidecar: already have blob with valid signature")
+    return errIgnore(
+      "SignedBlobSidecar: already have blob with valid signature")
 
   ok()
 


### PR DESCRIPTION
`SignedBlobSidecar: already have blob with valid signature` is IGNORE in spec, but was implemented as REJECT. Align with spec.