### PR TITLE
only trigger liveness failsafe for mainnet

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -37,7 +37,7 @@ type
 
     # Transition
     TERMINAL_TOTAL_DIFFICULTY*: UInt256
-    TERMINAL_BLOCK_HASH*: BlockHash # TODO use in eht1monitor
+    TERMINAL_BLOCK_HASH*: BlockHash
 
     # Genesis
     MIN_GENESIS_ACTIVE_VALIDATOR_COUNT*: uint64

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -619,7 +619,7 @@ proc getBlindedBlockParts[EPH: ForkyExecutionPayloadHeader](
           "getBlindedExecutionPayload error: " & exc.msg)
 
   if executionPayloadHeader.isErr:
-    warn "getBlindedBlockParts: getBlindedExecutionPayload failed",
+    warn "Could not obtain blinded execution payload header",
       error = executionPayloadHeader.error, slot, validator_index,
       head = shortLog(head)
     # Haven't committed to the MEV block, so allow EL fallback.

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -619,7 +619,7 @@ proc getBlindedBlockParts[EPH: ForkyExecutionPayloadHeader](
           "getBlindedExecutionPayload error: " & exc.msg)
 
   if executionPayloadHeader.isErr:
-    debug "getBlindedBlockParts: getBlindedExecutionPayload failed",
+    warn "getBlindedBlockParts: getBlindedExecutionPayload failed",
       error = executionPayloadHeader.error, slot, validator_index,
       head = shortLog(head)
     # Haven't committed to the MEV block, so allow EL fallback.
@@ -759,6 +759,9 @@ proc proposeBlockMEV(node: BeaconNode, blindedBlock: auto):
         "Unblinded block not returned to proposer"
     err errMsg
 
+func isEFMainnet(cfg: RuntimeConfig): bool =
+  cfg.DEPOSIT_CHAIN_ID == 1 and cfg.DEPOSIT_NETWORK_ID == 1
+
 proc makeBlindedBeaconBlockForHeadAndSlot*[
     BBB: bellatrix_mev.BlindedBeaconBlock | capella_mev.BlindedBeaconBlock](
     node: BeaconNode, randao_reveal: ValidatorSig,
@@ -781,7 +784,7 @@ proc makeBlindedBeaconBlockForHeadAndSlot*[
     pubkey =
       # Relevant state for knowledge of validators
       withState(node.dag.headState):
-        if livenessFailsafeInEffect(
+        if node.dag.cfg.isEFMainnet and livenessFailsafeInEffect(
             forkyState.data.block_roots.data, forkyState.data.slot):
           # It's head block's slot which matters here, not proposal slot
           return err("Builder API liveness failsafe in effect")
@@ -832,8 +835,8 @@ proc proposeBlockAux(
         # EL fails -- i.e. it would change priorities, so any block from the
         # execution layer client would override builder API. But it seems an
         # odd requirement to produce no block at all in those conditions.
-        not livenessFailsafeInEffect(
-          forkyState.data.block_roots.data, forkyState.data.slot)
+        (not node.dag.cfg.isEFMainnet) or (not livenessFailsafeInEffect(
+          forkyState.data.block_roots.data, forkyState.data.slot))
     else:
       false
 


### PR DESCRIPTION
Sepolia has a closed validator set and Prater/Goerli have too many missed blocks, leading to the liveness failsafe typically being in effect, and preventing testing MEV before mainnet deployment.