### PR TITLE
bump more consensus-specs refs to v1.3.0 (with comments)

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2342,8 +2342,8 @@ proc aggregateAll*(
   if validator_indices.len == 0:
     # Aggregation spec requires non-empty collection
     # - https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04
-    # Eth2 spec requires at least one attesting index in attestation
-    # - https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
+    # Consensus specs require at least one attesting index in attestation
+    # - https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
     return err("aggregate: no attesting keys")
 
   let

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1430,7 +1430,8 @@ proc installRestHandlers(restServer: RestServerRef, node: BeaconNode) =
 from ./spec/datatypes/capella import SignedBeaconBlock
 
 proc installMessageValidators(node: BeaconNode) =
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/p2p-interface.md#attestations-and-aggregation
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#attestations-and-aggregation
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/p2p-interface.md#sync-committees-and-aggregation
   # These validators stay around the whole time, regardless of which specific
   # subnets are subscribed to during any given epoch.
   let forkDigests = node.dag.forkDigests

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -522,11 +522,11 @@ func get_attestation_participation_flag_indices(
 # TODO these duplicate some stuff in state_transition_epoch which uses TotalBalances
 # better to centralize around that if feasible
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#get_total_active_balance
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#get_total_active_balance
 func get_total_active_balance*(state: ForkyBeaconState, cache: var StateCache): Gwei =
   ## Return the combined effective balance of the active validators.
-  # Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei
-  # minimum to avoid divisions by zero.
+  ## Note: ``get_total_balance`` returns ``EFFECTIVE_BALANCE_INCREMENT`` Gwei
+  ## minimum to avoid divisions by zero.
 
   let epoch = state.get_current_epoch()
 
@@ -798,12 +798,12 @@ func get_expected_withdrawals*(
     validator_index = (validator_index + 1) mod num_validators
   withdrawals
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/altair/beacon-chain.md#get_next_sync_committee
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#get_next_sync_committee
 func get_next_sync_committee*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState):
     SyncCommittee =
-  ## Return the *next* sync committee for a given ``state``.
+  ## Return the next sync committee, with possible pubkey duplicates.
   var res: SyncCommittee
   res.pubkeys.data = get_next_sync_committee_keys(state)
 
@@ -837,7 +837,7 @@ proc initialize_beacon_state_from_eth1*(
   # Not in spec: the system doesn't work unless there are at least SLOTS_PER_EPOCH
   # validators - there needs to be at least one member in each committee -
   # good to know for testing, though arguably the system is not that useful at
-  # at that point :)
+  # that point :)
   doAssert deposits.lenu64 >= SLOTS_PER_EPOCH
 
   # TODO https://github.com/nim-lang/Nim/issues/19094

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -5,19 +5,20 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-# Serenity hash function / digest
+# Consensus hash function / digest
 #
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#hash
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#hash
 #
 # In Phase 0 the beacon chain is deployed with SHA256 (SHA2-256).
 # Note that is is different from Keccak256 (often mistakenly called SHA3-256)
 # and SHA3-256.
 #
-# In Eth1.0, the default hash function is Keccak256 and SHA256 is available as a precompiled contract.
+# In execution, the default hash function is Keccak256,
+# and SHA256 is available as a precompiled contract.
 #
 # In our code base, to enable a smooth transition
 # (already did Blake2b --> Keccak256 --> SHA2-256),
-# we call this function `eth2digest`, and it outputs a `Eth2Digest`. Easy to sed :)
+# we call this function `eth2digest` and it outputs `Eth2Digest`. Easy to sed :)
 
 {.push raises: [].}
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -55,13 +55,13 @@ func integer_squareroot*(n: SomeInteger): SomeInteger =
     y = (x + n div x) div 2
   x
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#is_active_validator
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#is_active_validator
 func is_active_validator*(validator: Validator, epoch: Epoch): bool =
-  ## Check if ``validator`` is active
+  ## Check if ``validator`` is active.
   validator.activation_epoch <= epoch and epoch < validator.exit_epoch
 
 func is_exited_validator*(validator: Validator, epoch: Epoch): bool =
-  ## Check if ``validator`` is exited
+  ## Check if ``validator`` is exited.
   validator.exit_epoch <= epoch
 
 func is_withdrawable_validator*(validator: Validator, epoch: Epoch): bool =
@@ -109,9 +109,9 @@ func get_previous_epoch*(
   ## Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
   get_previous_epoch(get_current_epoch(state))
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#get_randao_mix
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#get_randao_mix
 func get_randao_mix*(state: ForkyBeaconState, epoch: Epoch): Eth2Digest =
-  ## Returns the randao mix at a recent ``epoch``.
+  ## Return the randao mix at a recent ``epoch``.
   state.randao_mixes[epoch mod EPOCHS_PER_HISTORICAL_VECTOR]
 
 func bytes_to_uint32*(data: openArray[byte]): uint32 =
@@ -166,10 +166,9 @@ func get_domain*(
   ## of a message.
   get_domain(state.fork, domain_type, epoch, state.genesis_validators_root)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#compute_signing_root
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#compute_signing_root
 func compute_signing_root*(ssz_object: auto, domain: Eth2Domain): Eth2Digest =
-  ## Return the signing root of an object by calculating the root of the
-  ## object-domain tree.
+  ## Return the signing root for the corresponding signing data.
   let domain_wrapped_object = SigningData(
     object_root: hash_tree_root(ssz_object),
     domain: domain


### PR DESCRIPTION
Bump some more consensus-specs links to v1.3.0, and also align comments with latest specs where they differ, and fix typos.