### PR TITLE
use merge-base for copyright year check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-          with:
-            fetch-depth: 2
-            # submodules: true  # Fails on nimyaml tests
+        with:
+          fetch-depth: 2
+          # submodules: true  # Fails on nimyaml tests
 
       - name: Check copyright year (Linux)
         if: github.event_name == 'pull_request' && runner.os == 'Linux'
@@ -69,6 +69,7 @@ jobs:
           base_branch="${{ github.event.pull_request.base.ref }}"
           git fetch origin "$base_branch"
           git log --oneline -n 10
+          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^ HEAD
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
 
           current_year=$(date +"%Y")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff-tree --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
+          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
 
           base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
           git fetch origin "$base_branch" 2>/dev/null
-          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "origin/$base_branch" HEAD | grep -vE '\.('$excluded_extensions')$' || true)
+          common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
+          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true)
 
           current_year=$(date +"%Y")
           outdated_files=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,15 @@ jobs:
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
+          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD
+
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | { grep -vE '\.('$excluded_extensions')$' || true; } | while read -r file; do
+          while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi
-          done
+          done < <(git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '\.('$excluded_extensions')$' || true)
 
           if (( ${#outdated_files[@]} )); then
             echo "The following files do not have an up-to-date copyright year:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        # Fails on nimyaml tests:
-        # with:
-        #  submodules: true
+          with:
+            fetch-depth: 2
+            # submodules: true  # Fails on nimyaml tests
 
       - name: Check copyright year (Linux)
         if: github.event_name == 'pull_request' && runner.os == 'Linux'
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
-          base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
-          git fetch origin "$base_branch" 2>/dev/null
+          base_branch="${{ github.event.pull_request.base.ref }}"
+          git fetch origin "$base_branch"
+          git log --oneline -n 10
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
-          echo $common_ancestor
 
           current_year=$(date +"%Y")
           outdated_files=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
           git fetch origin "$base_branch" 2>/dev/null
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
+          echo $common_ancestor
 
           current_year=$(date +"%Y")
           outdated_files=()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,10 @@ jobs:
           base_branch=$(jq -r '.pull_request.base.ref' "$GITHUB_EVENT_PATH")
           git fetch origin "$base_branch" 2>/dev/null
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
-          modified_files=$(git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true)
 
           current_year=$(date +"%Y")
           outdated_files=()
-          for file in $modified_files; do
+          git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
           # submodules: true  # Fails on nimyaml tests
 
       - name: Check copyright year (Linux)
@@ -66,24 +66,9 @@ jobs:
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
-          git log --oneline -n 10 --graph --all
-          echo "#####"
-          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^1 HEAD
-          echo "-----"
-          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^2 HEAD
-          echo "now getting ancestor"
-
-          base_branch="${{ github.event.pull_request.base.ref }}"
-          git fetch origin "$base_branch"
-          git log --oneline -n 10 --graph --all
-          common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
-          echo "$common_ancestor"
-
-          exit 3
-
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff --name-only --diff-filter=AM --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
+          git diff-tree --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' | while read -r file; do
+          git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
+          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | { grep -vE '\.('$excluded_extensions')$' || true; } | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,16 @@ jobs:
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
-          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^ HEAD
+          git log --oneline -n 10 --graph --all
+          echo "#####"
+          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^1 HEAD
+          echo "-----"
+          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^2 HEAD
+          echo "now getting ancestor"
 
           base_branch="${{ github.event.pull_request.base.ref }}"
           git fetch origin "$base_branch"
-          git log --oneline -n 10
+          git log --oneline -n 10 --graph --all
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
           echo "$common_ancestor"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
-          git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD
-
           current_year=$(date +"%Y")
           outdated_files=()
           while read -r file; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,19 @@ jobs:
         run: |
           excluded_extensions="ans|json|md|png|txt"
 
+          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^ HEAD
+
           base_branch="${{ github.event.pull_request.base.ref }}"
           git fetch origin "$base_branch"
           git log --oneline -n 10
-          git diff-tree --no-commit-id --diff-filter=AM -r HEAD^ HEAD
           common_ancestor=$(git merge-base "origin/$base_branch" HEAD)
+          echo "$common_ancestor"
+
+          exit 3
 
           current_year=$(date +"%Y")
           outdated_files=()
-          git diff --name-only --diff-filter=d --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
+          git diff --name-only --diff-filter=AM --ignore-submodules "$common_ancestor" HEAD | grep -vE '\.('$excluded_extensions')$' || true | while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
               outdated_files+=("$file")
             fi
@@ -85,7 +89,7 @@ jobs:
             for file in "${outdated_files[@]}"; do
               echo "- $file"
             done
-            exit 1
+            exit 2
           fi
 
       - name: MSYS2 (Windows amd64)

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Instead of comparing against current base branch head, use the common ancestor of the PR and the base branch to avoid false positives when a year was bumped in the base branch but not yet merged into the PR.