### PR TITLE
add optimized Linux amd64 flavor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -802,6 +802,10 @@ dist-amd64:
 	+ MAKE="$(MAKE)" \
 		scripts/make_dist.sh amd64
 
+dist-amd64-opt:
+	+ MAKE="$(MAKE)" \
+		scripts/make_dist.sh amd64-opt
+
 dist-arm64:
 	+ MAKE="$(MAKE)" \
 		scripts/make_dist.sh arm64
@@ -824,6 +828,7 @@ dist-macos-arm64:
 
 dist:
 	+ $(MAKE) dist-amd64
+	+ $(MAKE) dist-amd64-opt
 	+ $(MAKE) dist-arm64
 	+ $(MAKE) dist-arm
 	+ $(MAKE) dist-win64

--- a/config.nims
+++ b/config.nims
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import strutils
 
 --noNimblePath
@@ -79,12 +86,6 @@ if defined(windows):
   # toolchain: https://github.com/status-im/nimbus-eth2/issues/3121
   switch("define", "nimRawSetjmp")
 
-# This helps especially for 32-bit x86, which sans SSE2 and newer instructions
-# requires quite roundabout code generation for cryptography, and other 64-bit
-# and larger arithmetic use cases, along with register starvation issues. When
-# engineering a more portable binary release, this should be tweaked but still
-# use at least -msse2 or -msse3.
-#
 # https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#ssse3-supplemental-sse3
 # suggests that SHA256 hashing with SSSE3 is 20% faster than without SSSE3, so
 # given its near-ubiquity in the x86 installed base, it renders a distribution
@@ -93,8 +94,7 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # https://support.apple.com/kb/sp803
-      # "macOS Catalina - Technical Specifications": EOL as of 2022-09
+      # macOS Catalina is EOL as of 2022-09
       # https://support.apple.com/kb/sp833
       # "macOS Big Sur - Technical Specifications" lists current oldest
       # supported models: MacBook (2015 or later), MacBook Air (2013 or later),
@@ -107,8 +107,13 @@ if defined(disableMarchNative):
       switch("passC", "-march=haswell -mtune=generic")
       switch("passL", "-march=haswell -mtune=generic")
     else:
-      switch("passC", "-mssse3")
-      switch("passL", "-mssse3")
+      if defined(marchOptimized):
+        # https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#bmi2--adx
+        switch("passC", "-march=broadwell -mtune=generic")
+        switch("passL", "-march=broadwell -mtune=generic")
+      else:
+        switch("passC", "-mssse3")
+        switch("passL", "-mssse3")
 elif defined(macosx) and defined(arm64):
   # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
   switch("passC", "-mcpu=apple-m1")

--- a/docker/dist/Dockerfile.amd64-opt
+++ b/docker/dist/Dockerfile.amd64-opt
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # The build is reproducible only if this base image stays the same.
 FROM statusteam/nimbus_beacon_node:dist_base_20201103201341@sha256:25510b42e7573450bd0a2bbfa4c331e3345b80bee8b96a7e60621949b6154f7f
 

--- a/docker/dist/Dockerfile.amd64-opt
+++ b/docker/dist/Dockerfile.amd64-opt
@@ -1,0 +1,22 @@
+# The build is reproducible only if this base image stays the same.
+FROM statusteam/nimbus_beacon_node:dist_base_20201103201341@sha256:25510b42e7573450bd0a2bbfa4c331e3345b80bee8b96a7e60621949b6154f7f
+
+SHELL ["/bin/bash", "-c"]
+
+ARG USER_ID
+ARG GROUP_ID
+
+ENV BUILD_TOOLS=${BUILD_TOOLS}
+
+RUN echo "BUILD_TOOLS=${BUILD_TOOLS}"
+RUN addgroup --gid ${GROUP_ID} user; \
+	adduser --disabled-password --gecos '' --uid ${USER_ID} --gid ${GROUP_ID} user;
+
+USER user
+
+STOPSIGNAL SIGINT
+
+COPY "entry_point.sh" "/home/user/"
+ENTRYPOINT ["/home/user/entry_point.sh", "Linux_amd64_opt"]
+
+

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2022 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2023 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -29,7 +29,6 @@ fi
 
 echo -e "\nPLATFORM=${PLATFORM}"
 
-# we need to build everything against libraries available inside this container, including the Nim compiler
 # we need to build everything against libraries available inside this container, including the Nim compiler
 # the nimbus-build-system.paths file needs to be re-created because it may include absolute paths that are
 # valid only on the host system (and not in the docker container where the build is executing)
@@ -183,6 +182,17 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
     FORCE_DSYMUTIL=1 \
     USE_VENDORED_LIBUNWIND=1 \
     NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --passC:'-mcpu=apple-a13' --passL:'-mcpu=apple-a13' --clang.exe=${CC} --clang.linkerexe=${CC}" \
+    ${BINARIES}
+elif [[ "${PLATFORM}" == "Linux_amd64_opt" ]]; then
+  gcc --version
+  echo
+
+  make \
+    -j$(nproc) \
+    LOG_LEVEL="TRACE" \
+    NIMFLAGS="${NIMFLAGS_COMMON} -d:marchOptimized" \
+    PARTIAL_STATIC_LINKING=1 \
+    QUICK_AND_DIRTY_COMPILER=1 \
     ${BINARIES}
 else
   # Linux AMD64


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/3198

This does not do dynamic runtime selection, but does demonstrate another approach.

Have confirmed that per https://github.com/status-im/nimbus-eth2/blob/stable/docs/cpu_features.md#bmi2--adx the target it adds statically includes all of the `mulx`, `adox`, and `adcx` instructions.