### PR TITLE
`bls_to_execution_changes` check alternative

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -458,6 +458,9 @@ template toFork*[T:
     phase0.BeaconBlock |
     phase0.SignedBeaconBlock |
     phase0.TrustedBeaconBlock |
+    phase0.BeaconBlockBody |
+    phase0.SigVerifiedBeaconBlockBody |
+    phase0.TrustedBeaconBlockBody |
     phase0.SigVerifiedSignedBeaconBlock |
     phase0.MsgTrustedSignedBeaconBlock |
     phase0.TrustedSignedBeaconBlock](
@@ -470,6 +473,9 @@ template toFork*[T:
     altair.BeaconBlock |
     altair.SignedBeaconBlock |
     altair.TrustedBeaconBlock |
+    altair.BeaconBlockBody |
+    altair.SigVerifiedBeaconBlockBody |
+    altair.TrustedBeaconBlockBody |
     altair.SigVerifiedSignedBeaconBlock |
     altair.MsgTrustedSignedBeaconBlock |
     altair.TrustedSignedBeaconBlock](
@@ -485,6 +491,9 @@ template toFork*[T:
     bellatrix.BeaconBlock |
     bellatrix.SignedBeaconBlock |
     bellatrix.TrustedBeaconBlock |
+    bellatrix.BeaconBlockBody |
+    bellatrix.SigVerifiedBeaconBlockBody |
+    bellatrix.TrustedBeaconBlockBody |
     bellatrix.SigVerifiedSignedBeaconBlock |
     bellatrix.MsgTrustedSignedBeaconBlock |
     bellatrix.TrustedSignedBeaconBlock](
@@ -500,6 +509,9 @@ template toFork*[T:
     capella.BeaconBlock |
     capella.SignedBeaconBlock |
     capella.TrustedBeaconBlock |
+    capella.BeaconBlockBody |
+    capella.SigVerifiedBeaconBlockBody |
+    capella.TrustedBeaconBlockBody |
     capella.SigVerifiedSignedBeaconBlock |
     capella.MsgTrustedSignedBeaconBlock |
     capella.TrustedSignedBeaconBlock](
@@ -515,6 +527,9 @@ template toFork*[T:
     deneb.BeaconBlock |
     deneb.SignedBeaconBlock |
     deneb.TrustedBeaconBlock |
+    deneb.BeaconBlockBody |
+    deneb.SigVerifiedBeaconBlockBody |
+    deneb.TrustedBeaconBlockBody |
     deneb.SigVerifiedSignedBeaconBlock |
     deneb.MsgTrustedSignedBeaconBlock |
     deneb.TrustedSignedBeaconBlock](

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -438,10 +438,9 @@ proc process_operations(cfg: RuntimeConfig,
     ? process_deposit(cfg, state, op, flags)
   for op in body.voluntary_exits:
     ? process_voluntary_exit(cfg, state, op, flags, cache)
-  for fieldName, _ in body.fieldPairs:
-    when fieldName == "bls_to_execution_changes":
-      for op in body.bls_to_execution_changes:
-        ? process_bls_to_execution_change(cfg, state, op)
+  when typeof(body).toFork >= ConsensusFork.Capella:
+    for op in body.bls_to_execution_changes:
+      ? process_bls_to_execution_change(cfg, state, op)
 
   ok()
 


### PR DESCRIPTION
Make intent clearer about when to expect `bls_to_execution_changes`, and replace test-time errors with compile-time errors if the field is renamed or goes away in the future.