### PR TITLE
`KZG(Commitment(s)?|Proof)` > `Kzg$1`

### DIFF
--- a/beacon_chain/eth1/eth1_monitor.nim
+++ b/beacon_chain/eth1/eth1_monitor.nim
@@ -529,7 +529,7 @@ func asConsensusType*(payload: engine_api.GetPayloadV3Response):
     # The `mapIt` calls below are necessary only because we use different distinct
     # types for KZG commitments and Blobs in the `web3` and the `deneb` spec types.
     # Both are defined as `array[N, byte]` under the hood.
-    kzgs: KZGCommitments payload.blobsBundle.commitments.mapIt(it.bytes),
+    kzgs: KzgCommitments payload.blobsBundle.commitments.mapIt(it.bytes),
     blobs: Blobs payload.blobsBundle.blobs.mapIt(it.bytes)
   )
 

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -25,7 +25,7 @@ import
   ../digest,
   "."/[base, phase0, altair, bellatrix, capella]
 
-from  ../../vendor/nim-kzg4844/kzg4844 import KZGCommitment, KZGProof
+from  ../../vendor/nim-kzg4844/kzg4844 import KzgCommitment, KzgProof
 
 export json_serialization, base, kzg4844
 
@@ -42,7 +42,7 @@ const
   MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS* = 4096'u64
 
 type
-  KZGCommitments* = List[KZGCommitment, Limit MAX_BLOBS_PER_BLOCK]
+  KzgCommitments* = List[KzgCommitment, Limit MAX_BLOBS_PER_BLOCK]
   Blobs* = List[Blob, Limit MAX_BLOBS_PER_BLOCK]
 
   # TODO this apparently is suppposed to be SSZ-equivalent to Bytes32, but
@@ -59,7 +59,7 @@ type
     beacon_block_root*: Eth2Digest
     beacon_block_slot*: Slot
     blobs*: Blobs
-    kzg_aggregated_proof*: KZGProof
+    kzg_aggregated_proof*: KzgProof
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#blobsidecar
   BlobSidecar* = object
@@ -69,8 +69,8 @@ type
     block_parent_root*: Eth2Digest  # Proposer shuffling determinant
     proposer_index*: uint64
     blob*: Blob
-    kzg_commitment*: KZGCommitment
-    kzg_proof*: KZGProof  # Allows for quick verification of kzg_commitment
+    kzg_commitment*: KzgCommitment
+    kzg_proof*: KzgProof  # Allows for quick verification of kzg_commitment
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#signedblobsidecar
   SignedBlobSidecar* = object
@@ -106,7 +106,7 @@ type
   ExecutionPayloadForSigning* = object
     executionPayload*: ExecutionPayload
     blockValue*: Wei
-    kzgs*: KZGCommitments
+    kzgs*: KzgCommitments
     blobs*: Blobs
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#executionpayloadheader
@@ -387,7 +387,7 @@ type
     # Execution
     execution_payload*: ExecutionPayload  # [Modified in Deneb]
     bls_to_execution_changes*: SignedBLSToExecutionChangeList
-    blob_kzg_commitments*: KZGCommitments  # [New in Deneb]
+    blob_kzg_commitments*: KzgCommitments  # [New in Deneb]
 
   SigVerifiedBeaconBlockBody* = object
     ## A BeaconBlock body with signatures verified
@@ -422,7 +422,7 @@ type
     # Execution
     execution_payload*: ExecutionPayload  # [Modified in Deneb]
     bls_to_execution_changes*: SignedBLSToExecutionChangeList
-    blob_kzg_commitments*: List[KZGCommitment, Limit MAX_BLOBS_PER_BLOCK]  # [New in Deneb]
+    blob_kzg_commitments*: KzgCommitments  # [New in Deneb]
 
   TrustedBeaconBlockBody* = object
     ## A full verified block
@@ -445,7 +445,7 @@ type
     # Execution
     execution_payload*: ExecutionPayload  # [Modified in Deneb]
     bls_to_execution_changes*: SignedBLSToExecutionChangeList
-    blob_kzg_commitments*: List[KZGCommitment, Limit MAX_BLOBS_PER_BLOCK]  # [New in Deneb]
+    blob_kzg_commitments*: KzgCommitments  # [New in Deneb]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#signedbeaconblock
   SignedBeaconBlock* = object

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -775,7 +775,7 @@ proc validate_blobs*(expected_kzg_commitments: seq[KzgCommitment],
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/fork-choice.md#is_data_available
 func is_data_available(
     slot: Slot, beacon_block_root: Eth2Digest,
-    blob_kzg_commitments: seq[KzgCommitment]): bool =
+    blob_kzg_commitments: seq[deneb.KZGCommitment]): bool =
   discard $denebImplementationMissing & ": state_transition_block.nim:is_data_available"
 
   true

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -272,7 +272,7 @@ func findValidatorIndex*(state: ForkyBeaconState, pubkey: ValidatorPubKey):
       return Opt[ValidatorIndex].ok(vidx)
 
 from ./datatypes/deneb import
-  BLOB_TX_TYPE, BeaconState, KZGCommitment, VersionedHash
+  BLOB_TX_TYPE, BeaconState, KzgCommitment, VersionedHash
 
 proc process_deposit*(cfg: RuntimeConfig,
                       state: var ForkyBeaconState,
@@ -715,10 +715,10 @@ func tx_peek_blob_versioned_hashes(opaque_tx: Transaction):
     res.add versionedHash
   ok res
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
 func kzg_commitment_to_versioned_hash(
-    kzg_commitment: deneb.KZGCommitment): VersionedHash =
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#blob
+    kzg_commitment: KzgCommitment): VersionedHash =
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#blob
   const VERSIONED_HASH_VERSION_KZG = 0x01'u8
 
   var res: VersionedHash
@@ -726,10 +726,10 @@ func kzg_commitment_to_versioned_hash(
   res[1 .. 31] = eth2digest(kzg_commitment).data.toOpenArray(1, 31)
   res
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#verify_kzg_commitments_against_transactions
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#verify_kzg_commitments_against_transactions
 func verify_kzg_commitments_against_transactions*(
     transactions: seq[Transaction],
-    kzg_commitments: seq[deneb.KZGCommitment]): bool =
+    kzg_commitments: seq[KzgCommitment]): bool =
   var all_versioned_hashes: seq[VersionedHash]
   for tx in transactions:
     if tx[0] == BLOB_TX_TYPE:
@@ -757,9 +757,9 @@ func process_blob_kzg_commitments(
     return err("process_blob_kzg_commitments: verify_kzg_commitments_against_transactions failed")
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/fork-choice.md#validate_blobs
-proc validate_blobs*(expected_kzg_commitments: seq[KZGCommitment],
+proc validate_blobs*(expected_kzg_commitments: seq[KzgCommitment],
                      blobs: seq[KzgBlob],
-                     proofs: seq[KZGProof]):
+                     proofs: seq[KzgProof]):
                        Result[void, cstring] =
   if expected_kzg_commitments.len != blobs.len:
     return err("validate_blobs: different commitment and blob lengths")
@@ -775,7 +775,7 @@ proc validate_blobs*(expected_kzg_commitments: seq[KZGCommitment],
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/fork-choice.md#is_data_available
 func is_data_available(
     slot: Slot, beacon_block_root: Eth2Digest,
-    blob_kzg_commitments: seq[deneb.KZGCommitment]): bool =
+    blob_kzg_commitments: seq[KzgCommitment]): bool =
   discard $denebImplementationMissing & ": state_transition_block.nim:is_data_available"
 
   true


### PR DESCRIPTION
Fix style-check by using matching capitalization for `nim-kzg` types.