### PR TITLE
Replace validator_client's normalizeUri with a function that validates some requirements are met instead

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -501,44 +501,22 @@ proc parseRoles*(data: string): Result[set[BeaconNodeRole], cstring] =
       return err("Invalid beacon node role string found")
   ok(res)
 
-proc normalizeUri*(remoteUri: Uri): Uri =
-  var r = remoteUri
-  if (len(r.scheme) == 0) and (len(r.username) == 0) and
-     (len(r.password) == 0) and (len(r.hostname) == 0) and
-     (len(r.port) == 0) and (len(r.path) > 0):
-    # When `scheme` is not specified and `port` is not specified - whole
-    # hostname is stored in `path`.`query` and `anchor` could still be present.
-    # test.com
-    # test.com?q=query
-    # test.com?q=query#anchor=anchor
-    parseUri("http://" & $remoteUri & ":" & $defaultEth2RestPort)
-  elif (len(r.scheme) > 0) and (len(r.username) == 0) and
-       (len(r.password) == 0) and (len(r.hostname) == 0) and
-       (len(r.port) == 0) and (len(r.path) > 0):
-    # When `scheme` is not specified but `port` is specified - whole
-    # hostname is stored in `scheme` and `port` is in `path`.
-    # 192.168.0.1:5052
-    # test.com:5052
-    # test.com:5052?q=query
-    # test.com:5052?q=query#anchor=anchor
-    parseUri("http://" & $remoteUri)
-  elif (len(r.scheme) > 0) and (len(r.hostname) > 0):
-    # When `scheme` is specified, but `port` is not we use default.
-    # http://192.168.0.1
-    # http://test.com
-    # http://test.com?q=query
-    # http://test.com?q=query#anchor=anchor
-    if len(r.port) == 0: r.port = $defaultEth2RestPort
-    r
-  else:
-    remoteUri
+proc validateUri*(remoteUri: Uri): Result[void, string] =
+  if ((len(remoteUri.scheme) == 0) or
+    (len(remoteUri.hostname) == 0)):
+    return err("Invalid URI, must contain scheme and hostname: " & $remoteUri)
+  ok()
 
 proc init*(t: typedesc[BeaconNodeServerRef], remote: Uri,
            index: int): Result[BeaconNodeServerRef, string] =
   doAssert(index >= 0)
   let
     flags = {RestClientFlag.CommaSeparatedArray}
-    remoteUri = normalizeUri(remote)
+    remoteUri =
+      block:
+        let res = validateUri(remote)
+        if res.isErr(): return err($res.error())
+        remote
     client =
       block:
         let res = RestClientRef.new($remoteUri, flags = flags)


### PR DESCRIPTION
A curmudgeonly fix.

Resolves https://github.com/status-im/nimbus-eth2/issues/4920

This is the least 'astonishing' way to handle this. If a user omits `--beacon-node` it defaults to `http://localhost:5052` which is fine.

However, if a user sets `--beacon-node`, we ought not twist the uri parser into submission. At a minimum we need a hostname and a scheme over which to dial it, so make sure we have those.

Supercedes https://github.com/status-im/nimbus-eth2/pull/4921 I guess

```
jacob@Joshua:~/eth/nimbus-eth2 (stable)$ ./build/nimbus_validator_client --beacon-node=192.168.1.1
WRN 2023-05-09 17:46:55.754-04:00 Unable to initialize remote beacon node    url=192.168.1.1 error="Invalid URI, must contain scheme and hostname: 192.168.1.1"
FAT 2023-05-09 17:46:55.754-04:00 Not enough beacon nodes available          nodes_count=0
```
```
jacob@Joshua:~/eth/nimbus-eth2 (stable)$ ./build/nimbus_validator_client --beacon-node=192.168.1.1:8080
WRN 2023-05-09 17:47:38.094-04:00 Unable to initialize remote beacon node    url=192.168.1.1:8080 error="Invalid URI, must contain scheme and hostname: 192.168.1.1:8080"
FAT 2023-05-09 17:47:38.094-04:00 Not enough beacon nodes available          nodes_count=0
```

whereas `http://192.168.1.1` and `http://192.168.1.1:8080` work as one would expect them to.