### PR TITLE
final portion of non-trivial v1.3.0 bumps

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -266,16 +266,17 @@ type
     withdrawal_credentials*: Eth2Digest
     amount*: Gwei
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#depositdata
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#depositdata
   DepositData* = object
     pubkey*: ValidatorPubKey
     withdrawal_credentials*: Eth2Digest
     amount*: Gwei
     # Cannot use TrustedSig here as invalid signatures are possible and determine
     # if the deposit should be added or not during processing
-    signature*: ValidatorSig  # Signing over DepositMessage
+    signature*: ValidatorSig
+      ## Signing over DepositMessage
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#voluntaryexit
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#voluntaryexit
   VoluntaryExit* = object
     epoch*: Epoch
       ## Earliest epoch when voluntary exit can be processed
@@ -323,9 +324,9 @@ type
     exit_epoch*: Epoch
 
     withdrawable_epoch*: Epoch
-      ## When validator can withdraw or transfer funds
+      ## When validator can withdraw funds
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#pendingattestation
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#pendingattestation
   PendingAttestation* = object
     aggregation_bits*: CommitteeValidatorsBits
     data*: AttestationData
@@ -415,7 +416,7 @@ type
     branch*: array[DEPOSIT_CONTRACT_TREE_DEPTH, Eth2Digest]
     deposit_count*: array[32, byte] # Uint256
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#validator
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#validator
   ValidatorStatus* = object
     # This is a validator without the expensive, immutable, append-only parts
     # serialized. They're represented in memory to allow in-place SSZ reading
@@ -424,7 +425,7 @@ type
     pubkey* {.dontSerialize.}: ValidatorPubKey
 
     withdrawal_credentials* {.dontSerialize.}: Eth2Digest
-      ## Commitment to pubkey for withdrawals and transfers
+      ## Commitment to pubkey for withdrawals
 
     effective_balance*: Gwei
       ## Balance at stake
@@ -439,9 +440,9 @@ type
     exit_epoch*: Epoch
 
     withdrawable_epoch*: Epoch
-      ## When validator can withdraw or transfer funds
+      ## When validator can withdraw funds
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#validator
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#validator
   ValidatorStatusCapella* = object
     # This is a validator without the expensive, immutable, append-only parts
     # serialized. They're represented in memory to allow in-place SSZ reading
@@ -450,7 +451,7 @@ type
     pubkey* {.dontSerialize.}: ValidatorPubKey
 
     withdrawal_credentials*: Eth2Digest
-      ## Commitment to pubkey for withdrawals and transfers
+      ## Commitment to pubkey for withdrawals
 
     effective_balance*: Gwei
       ## Balance at stake
@@ -465,7 +466,7 @@ type
     exit_epoch*: Epoch
 
     withdrawable_epoch*: Epoch
-      ## When validator can withdraw or transfer funds
+      ## When validator can withdraw funds
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#eth2-field
   ENRForkID* = object

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -47,13 +47,17 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayload
   ExecutionPayload* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
-    fee_recipient*: ExecutionAddress  # 'beneficiary' in the yellow paper
+    fee_recipient*: ExecutionAddress
+      ## 'beneficiary' in the yellow paper
     state_root*: Eth2Digest
-    receipts_root*: Eth2Digest # 'receipts root' in the yellow paper
+    receipts_root*: Eth2Digest
     logs_bloom*: BloomLogs
-    prev_randao*: Eth2Digest  # 'difficulty' in the yellow paper
-    block_number*: uint64  # 'number' in the yellow paper
+    prev_randao*: Eth2Digest
+      ## 'difficulty' in the yellow paper
+    block_number*: uint64
+      ## 'number' in the yellow paper
     gas_limit*: uint64
     gas_used*: uint64
     timestamp*: uint64
@@ -61,7 +65,8 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Eth2Digest # Hash of execution block
+    block_hash*: Eth2Digest
+      ## Hash of execution block
     transactions*: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
 
   ExecutionPayloadForSigning* = object
@@ -70,6 +75,7 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#executionpayloadheader
   ExecutionPayloadHeader* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
     fee_recipient*: ExecutionAddress
     state_root*: Eth2Digest
@@ -84,7 +90,8 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Eth2Digest  # Hash of execution block
+    block_hash*: Eth2Digest
+      ## Hash of execution block
     transactions_root*: Eth2Digest
 
   ExecutePayload* = proc(

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -65,13 +65,17 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayload
   ExecutionPayload* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
-    fee_recipient*: ExecutionAddress  # 'beneficiary' in the yellow paper
+    fee_recipient*: ExecutionAddress
+      ## 'beneficiary' in the yellow paper
     state_root*: Eth2Digest
-    receipts_root*: Eth2Digest # 'receipts root' in the yellow paper
+    receipts_root*: Eth2Digest
     logs_bloom*: BloomLogs
-    prev_randao*: Eth2Digest  # 'difficulty' in the yellow paper
-    block_number*: uint64  # 'number' in the yellow paper
+    prev_randao*: Eth2Digest
+      ## 'difficulty' in the yellow paper
+    block_number*: uint64
+      ## 'number' in the yellow paper
     gas_limit*: uint64
     gas_used*: uint64
     timestamp*: uint64
@@ -79,9 +83,11 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Eth2Digest # Hash of execution block
+    block_hash*: Eth2Digest
+      ## Hash of execution block
     transactions*: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
-    withdrawals*: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]  # [New in Capella]
+    withdrawals*: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+      ## [New in Capella]
 
   ExecutionPayloadForSigning* = object
     executionPayload*: ExecutionPayload
@@ -89,6 +95,7 @@ type
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayloadheader
   ExecutionPayloadHeader* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
     fee_recipient*: ExecutionAddress
     state_root*: Eth2Digest
@@ -103,9 +110,11 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Eth2Digest  # Hash of execution block
+    block_hash*: Eth2Digest
+      ## Hash of execution block
     transactions_root*: Eth2Digest
-    withdrawals_root*: Eth2Digest  # [New in Capella]
+    withdrawals_root*: Eth2Digest
+      ## [New in Capella]
 
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
@@ -369,7 +378,8 @@ type
     execution_payload*: ExecutionPayload
 
     # Capella operations
-    bls_to_execution_changes*: SignedBLSToExecutionChangeList  # [New in Capella]
+    bls_to_execution_changes*: SignedBLSToExecutionChangeList
+      ## [New in Capella]
 
   SigVerifiedBeaconBlockBody* = object
     ## A BeaconBlock body with signatures verified

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -30,15 +30,15 @@ from  ../../vendor/nim-kzg4844/kzg4844 import KzgCommitment, KzgProof
 export json_serialization, base, kzg4844
 
 const
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/polynomial-commitments.md#constants
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/polynomial-commitments.md#constants
   BYTES_PER_FIELD_ELEMENT = 32
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#blob
   BLOB_TX_TYPE* = 0x03'u8
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/polynomial-commitments.md#constants
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/polynomial-commitments.md#constants
   BLS_MODULUS* = "52435875175126190479447740508185965837690552500527637822603658699938581184513".u256
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#configuration
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#configuration
   MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS* = 4096'u64
 
 type
@@ -49,7 +49,7 @@ type
   # current spec doesn't ever SSZ-serialize it or hash_tree_root it
   VersionedHash* = array[32, byte]
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#custom-types
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#custom-types
   BlobIndex* = uint64
 
   Blob* = array[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB, byte]
@@ -61,36 +61,43 @@ type
     blobs*: Blobs
     kzg_aggregated_proof*: KzgProof
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#blobsidecar
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#blobsidecar
   BlobSidecar* = object
     block_root*: Eth2Digest
-    index*: BlobIndex  # Index of blob in block
+    index*: BlobIndex
+      ## Index of blob in block
     slot*: Slot
-    block_parent_root*: Eth2Digest  # Proposer shuffling determinant
+    block_parent_root*: Eth2Digest
+      ## Proposer shuffling determinant
     proposer_index*: uint64
     blob*: Blob
     kzg_commitment*: KzgCommitment
-    kzg_proof*: KzgProof  # Allows for quick verification of kzg_commitment
+    kzg_proof*: KzgProof
+      ## Allows for quick verification of kzg_commitment
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#signedblobsidecar
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#signedblobsidecar
   SignedBlobSidecar* = object
     message*: BlobSidecar
     signature*: ValidatorSig
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/p2p-interface.md#blobidentifier
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#blobidentifier
   BlobIdentifier* = object
     block_root*: Eth2Digest
     index*: BlobIndex
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#executionpayload
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#executionpayload
   ExecutionPayload* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
-    fee_recipient*: ExecutionAddress  # 'beneficiary' in the yellow paper
+    fee_recipient*: ExecutionAddress
+      ## 'beneficiary' in the yellow paper
     state_root*: Eth2Digest
-    receipts_root*: Eth2Digest # 'receipts root' in the yellow paper
+    receipts_root*: Eth2Digest
     logs_bloom*: BloomLogs
-    prev_randao*: Eth2Digest  # 'difficulty' in the yellow paper
-    block_number*: uint64  # 'number' in the yellow paper
+    prev_randao*: Eth2Digest
+      ## 'difficulty' in the yellow paper
+    block_number*: uint64
+      ## 'number' in the yellow paper
     gas_limit*: uint64
     gas_used*: uint64
     timestamp*: uint64
@@ -109,8 +116,9 @@ type
     kzgs*: KzgCommitments
     blobs*: Blobs
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/deneb/beacon-chain.md#executionpayloadheader
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#executionpayloadheader
   ExecutionPayloadHeader* = object
+    # Execution block header fields
     parent_hash*: Eth2Digest
     fee_recipient*: ExecutionAddress
     state_root*: Eth2Digest
@@ -125,15 +133,17 @@ type
     base_fee_per_gas*: UInt256
 
     # Extra payload fields
-    block_hash*: Eth2Digest  # Hash of execution block
+    block_hash*: Eth2Digest
+      ## Hash of execution block
     transactions_root*: Eth2Digest
     withdrawals_root*: Eth2Digest
-    excess_data_gas*: UInt256  # [New in Deneb]
+    excess_data_gas*: UInt256
+      ## [New in Deneb]
 
   ExecutePayload* = proc(
     execution_payload: ExecutionPayload): bool {.gcsafe, raises: [Defect].}
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/capella/light-client/sync-protocol.md#modified-lightclientheader
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/light-client/sync-protocol.md#modified-lightclientheader
   LightClientHeader* = object
     beacon*: BeaconBlockHeader
       ## Beacon block header

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -167,11 +167,14 @@ type
     state_root*: Eth2Digest
     body*: TrustedBeaconBlockBody
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/beacon-chain.md#beaconblockbody
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beaconblockbody
   BeaconBlockBody* = object
     randao_reveal*: ValidatorSig
     eth1_data*: Eth1Data
+      ## Eth1 data vote
+
     graffiti*: GraffitiBytes
+      ## Arbitrary data
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]

--- a/beacon_chain/spec/presets/gnosis/capella_preset.nim
+++ b/beacon_chain/spec/presets/gnosis/capella_preset.nim
@@ -6,12 +6,10 @@ const
   # 2**4 (= 16)
   MAX_BLS_TO_EXECUTION_CHANGES* = 16
 
-
   # Execution
   # ---------------------------------------------------------------
   # 2**4 (= 16) withdrawals
   MAX_WITHDRAWALS_PER_PAYLOAD* = 16
-
 
   # Withdrawals processing
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/presets/gnosis/capella_preset.nim
+++ b/beacon_chain/spec/presets/gnosis/capella_preset.nim
@@ -6,10 +6,12 @@ const
   # 2**4 (= 16)
   MAX_BLS_TO_EXECUTION_CHANGES* = 16
 
+
   # Execution
   # ---------------------------------------------------------------
   # 2**4 (= 16) withdrawals
   MAX_WITHDRAWALS_PER_PAYLOAD* = 16
+
 
   # Withdrawals processing
   # ---------------------------------------------------------------

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -68,9 +68,10 @@ proc verify_block_signature(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#beacon-chain-state-transition-function
 func verifyStateRoot(
-    state: ForkyBeaconState, blck: ForkyBeaconBlock | ForkySigVerifiedBeaconBlock):
+    state: ForkyBeaconState,
+    blck: ForkyBeaconBlock | ForkySigVerifiedBeaconBlock):
     Result[void, cstring] =
   # This is inlined in state_transition(...) in spec.
   let state_root = hash_tree_root(state)
@@ -136,6 +137,7 @@ proc advance_slot(
 
   info.clear()
 
+  # Process epoch on the start slot of the next epoch
   let is_epoch_transition = (state.slot + 1).is_epoch
   if is_epoch_transition:
     # Note: Genesis epoch = 0, no need to test if before Genesis
@@ -447,10 +449,9 @@ template partialBeaconBlock*(
       voluntary_exits: validator_changes.voluntary_exits,
       sync_aggregate: sync_aggregate,
       execution_payload: execution_payload.executionPayload,
-      bls_to_execution_changes: validator_changes.bls_to_execution_changes
-      ))
+      bls_to_execution_changes: validator_changes.bls_to_execution_changes))
 
-# https://github.com/ethereum/consensus-specs/blob/v1.1.3/specs/merge/validator.md#block-proposal
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/validator.md#constructing-the-beaconblockbody
 template partialBeaconBlock*(
     cfg: RuntimeConfig,
     state: var deneb.HashedBeaconState,
@@ -480,8 +481,7 @@ template partialBeaconBlock*(
       sync_aggregate: sync_aggregate,
       execution_payload: execution_payload.executionPayload,
       bls_to_execution_changes: validator_changes.bls_to_execution_changes,
-      blob_kzg_commitments: execution_payload.kzgs
-      ))
+      blob_kzg_commitments: execution_payload.kzgs))
 
 proc makeBeaconBlock*(
     cfg: RuntimeConfig,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -269,11 +269,12 @@ func get_beacon_committee*(
   withState(state):
     get_beacon_committee(forkyState.data, slot, index, cache)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#get_beacon_committee
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#get_beacon_committee
 func get_beacon_committee_len*(
     state: ForkyBeaconState, slot: Slot, index: CommitteeIndex,
     cache: var StateCache): uint64 =
-  # Return the number of members in the beacon committee at ``slot`` for ``index``.
+  ## Return the number of members in the beacon committee at ``slot``
+  ## for ``index``.
   let
     epoch = epoch(slot)
     committees_per_slot = get_committee_count_per_slot(state, epoch, cache)
@@ -392,9 +393,10 @@ func get_beacon_proposer_index*(
 
     return res
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/phase0/beacon-chain.md#get_beacon_proposer_index
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#get_beacon_proposer_index
 func get_beacon_proposer_index*(state: ForkyBeaconState, cache: var StateCache):
     Opt[ValidatorIndex] =
+  ## Return the beacon proposer index at the current slot.
   get_beacon_proposer_index(state, cache, state.slot)
 
 func get_beacon_proposer_index*(state: ForkedHashedBeaconState,
@@ -403,10 +405,9 @@ func get_beacon_proposer_index*(state: ForkedHashedBeaconState,
   withState(state):
     get_beacon_proposer_index(forkyState.data, cache, slot)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.5/specs/phase0/validator.md#aggregation-selection
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#aggregation-selection
 func is_aggregator*(committee_len: uint64, slot_signature: ValidatorSig): bool =
-  let
-    modulo = max(1'u64, committee_len div TARGET_AGGREGATORS_PER_COMMITTEE)
+  let modulo = max(1'u64, committee_len div TARGET_AGGREGATORS_PER_COMMITTEE)
   bytes_to_uint64(eth2digest(
     slot_signature.toRaw()).data.toOpenArray(0, 7)) mod modulo == 0
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -465,10 +465,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef), blobindex = index
           continue
 
-        peer.awaitQuota(
-          blockResponseCost, "blob_sidecars_by_root/1")
-        peer.network.awaitQuota(
-          blockResponseCost, "blob_sidecars_by_root/1")
+        peer.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
+        peer.network.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -537,10 +535,8 @@ p2pProtocol BeaconSync(version = 1,
             continue
 
           # TODO extract from libp2pProtocol
-          peer.awaitQuota(
-            blockResponseCost, "blobs_sidecars_by_range/1")
-          peer.network.awaitQuota(
-            blockResponseCost, "blobs_sidecars_by_range/1")
+          peer.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
+          peer.network.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
 
           await response.writeBytesSZ(
             uncompressedLen, bytes,

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -465,8 +465,10 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef), blobindex = index
           continue
 
-        peer.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
-        peer.network.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
+        peer.awaitQuota(
+          blockResponseCost, "blob_sidecars_by_root/1")
+        peer.network.awaitQuota(
+          blockResponseCost, "blob_sidecars_by_root/1")
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -476,12 +478,13 @@ p2pProtocol BeaconSync(version = 1,
     debug "Blob root request done",
       peer, roots = blobIds.len, count, found
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0-rc.3/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1
   proc blobSidecarsByRange(
       peer: Peer,
       startSlot: Slot,
       reqCount: uint64,
-      response: MultipleChunksResponse[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
+      response: MultipleChunksResponse[
+        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
       {.async, libp2pProtocol("blob_sidecars_by_range", 1).} =
     # TODO This code is more complicated than it needs to be, since the type
     #      of the multiple chunks response is not actually used in this server
@@ -534,8 +537,10 @@ p2pProtocol BeaconSync(version = 1,
             continue
 
           # TODO extract from libp2pProtocol
-          peer.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
-          peer.network.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
+          peer.awaitQuota(
+            blockResponseCost, "blobs_sidecars_by_range/1")
+          peer.network.awaitQuota(
+            blockResponseCost, "blobs_sidecars_by_range/1")
 
           await response.writeBytesSZ(
             uncompressedLen, bytes,


### PR DESCRIPTION
Updates unchanged logic to latest v1.3.0 consensus-specs refs, and cleans up surrounding sections / syncs comments, and so on.

```
https://github.com/ethereum/consensus-specs/(blob|tree)/(?!v1\.3\.0/)
```