### PR TITLE
use compile-time year in `--version` copyright

### DIFF
--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -11,11 +11,11 @@
 
 import std/[strutils, compilesettings]
 
-when not defined(nimscript):
-  import times
-  let copyrights* = "Copyright (c) 2019-" & $(now().utc.year) & " Status Research & Development GmbH"
-
 const
+  compileYear = CompileDate[0 ..< 4]  # YYYY-MM-DD (UTC)
+  copyrights* =
+    "Copyright (c) 2019-" & compileYear & " Status Research & Development GmbH"
+
   versionMajor* = 23
   versionMinor* = 5
   versionBuild* = 0


### PR DESCRIPTION
Instead of using current runtime year, use compile-time year in notice.

```
nimbus_beacon_node --version
```