### PR TITLE
ignore attestations that miss shuffling cache

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -516,7 +516,7 @@ proc validateAttestation*(
   # store.finalized_checkpoint.root
   let
     shufflingRef =
-      pool.dag.findShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+      pool.dag.findShufflingRef(target.blck, target.slot.epoch).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           attestation = shortLog(attestation), target = shortLog(target)
@@ -700,7 +700,7 @@ proc validateAggregate*(
 
   let
     shufflingRef =
-      pool.dag.findShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+      pool.dag.findShufflingRef(target.blck, target.slot.epoch).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           aggregate = shortLog(aggregate), target = shortLog(target)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -516,7 +516,7 @@ proc validateAttestation*(
   # store.finalized_checkpoint.root
   let
     shufflingRef =
-      pool.dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+      pool.dag.findShufflingRef(target.blck, target.slot.epoch, false).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           attestation = shortLog(attestation), target = shortLog(target)
@@ -700,7 +700,7 @@ proc validateAggregate*(
 
   let
     shufflingRef =
-      pool.dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+      pool.dag.findShufflingRef(target.blck, target.slot.epoch, false).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           aggregate = shortLog(aggregate), target = shortLog(target)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -516,7 +516,7 @@ proc validateAttestation*(
   # store.finalized_checkpoint.root
   let
     shufflingRef =
-      pool.dag.findShufflingRef(target.blck, target.slot.epoch).valueOr:
+      pool.dag.findShufflingRef(target.blck.bid, target.slot.epoch).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           attestation = shortLog(attestation), target = shortLog(target)
@@ -700,7 +700,7 @@ proc validateAggregate*(
 
   let
     shufflingRef =
-      pool.dag.findShufflingRef(target.blck, target.slot.epoch).valueOr:
+      pool.dag.findShufflingRef(target.blck.bid, target.slot.epoch).valueOr:
         # Target is verified - shouldn't happen
         warn "No shuffling for attestation - report bug",
           aggregate = shortLog(aggregate), target = shortLog(target)


### PR DESCRIPTION
Replace `getShufflingRef` with `findShufflingRef`.