### PR TITLE
align sync horizons between VC and BN

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -127,3 +127,5 @@ func fromFloatSeconds*(T: type Duration, f: float): Duration =
   of fcInf: InfiniteDuration
 
 chronicles.formatIt Duration: $it
+
+const defaultSyncHorizon* = 50.uint64

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -252,8 +252,6 @@ func isSynced(dag: ChainDAGRef, wallSlot: Slot): bool =
   # the defaultSyncHorizon, it will start triggering in time so that potential
   # discrepancies between the head here, and the head the DAG has (which might
   # not yet be updated) won't be visible.
-  const defaultSyncHorizon = 50
-
   if dag.head.slot + defaultSyncHorizon < wallSlot:
     false
   else:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -29,7 +29,7 @@ export
   dynamic_fee_recipients, Time, toUnix, fromUnix, getTime
 
 const
-  SYNC_TOLERANCE* = 4'u64
+  SYNC_TOLERANCE* = defaultSyncHorizon
   SLOT_LOOKAHEAD* = 1.seconds
   HISTORICAL_DUTIES_EPOCHS* = 2'u64
   TIME_DELAY_FROM_SLOT* = 79.milliseconds


### PR DESCRIPTION
Sometimes, more than 3 blocks are missed in a row, and VC falls back to `Execution client not in sync (beacon node optimistically synced). Aligning the VC `SYNC_TOLERANCE` with the BN `defaultSyncHorizon` (50) should continue with validator duties at that time.