### PR TITLE
log `bls_to_execution_changes_len` in `shortLog`

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -598,6 +598,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: 0'u64, # Bellatrix compat
     fee_recipient: "",
+    bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -399,6 +399,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
+    bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -583,6 +583,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
+    bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -530,6 +530,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
+    bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: v.body.blob_kzg_commitments.len(),
   )
 

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -298,6 +298,7 @@ func shortLog*(v: SomeBeaconBlock): auto =
     sync_committee_participants: -1, # Altair logging compatibility
     block_number: 0'u64, # Bellatrix compat
     fee_recipient: "",
+    bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -85,6 +85,7 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     block_number: v.body.execution_payload_header.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload_header.fee_recipient.data),
+    bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/beacon_chain/spec/mev/capella_mev.nim
+++ b/beacon_chain/spec/mev/capella_mev.nim
@@ -73,7 +73,7 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     block_number: v.body.execution_payload_header.block_number,
     # TODO checksum hex? shortlog?
     fee_recipient: to0xHex(v.body.execution_payload_header.fee_recipient.data),
-    #bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),  # TODO validator_client/block_service.nim seems to want same shape of shortLogs across all block types
+    bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: 0,  # Deneb compat
   )
 

--- a/ncli/logtrace.nim
+++ b/ncli/logtrace.nim
@@ -195,7 +195,9 @@ type
           "voluntary_exits_len": 0,
           "sync_committee_participants": 32,
           "block_number": 0,
-          "fee_recipient": ""
+          "fee_recipient": "",
+          "bls_to_execution_changes_len": 0,
+          "blob_kzg_commitments_len": 0,
         },
         "signature": "b544f144",
         "delay": "32ms3us"

--- a/ncli/logtrace.nim
+++ b/ncli/logtrace.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -17,7 +17,7 @@ const
   LogTracePatch: int = 4
   LogTraceVersion = $LogTraceMajor & "." & $LogTraceMinor & "." &
                       $LogTracePatch
-  LogTraceCopyright = "Copyright(C) 2021" &
+  LogTraceCopyright = "Copyright(C) 2021-2023" &
                        " Status Research & Development GmbH"
   LogTraceHeader = LogTraceName & ", Version " & LogTraceVersion &
                     " [" & hostOS & ": " & hostCPU & "]\r\n" &

--- a/ncli/logtrace.nim
+++ b/ncli/logtrace.nim
@@ -197,7 +197,7 @@ type
           "block_number": 0,
           "fee_recipient": "",
           "bls_to_execution_changes_len": 0,
-          "blob_kzg_commitments_len": 0,
+          "blob_kzg_commitments_len": 0
         },
         "signature": "b544f144",
         "delay": "32ms3us"


### PR DESCRIPTION
When logging blocks to console, include num BLS to Execution changes.