### PR TITLE
avoid polluting Jenkins CI with geth binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
@@ -52,6 +52,10 @@ test_keymanager_api
 test_sim
 
 /libnfuzz_linkerArgs.txt
+
+# scripts/geth_binaries.sh
+geth-*.tar.gz
+geth-*.zip
 
 # Prometheus db
 /data

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,3 +1,11 @@
+/* beacon_chain
+ * Copyright (c) 2019-2023 Status Research & Development GmbH
+ * Licensed and distributed under either of
+ *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+ *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+ * at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
   agent { label params.AGENT_LABEL }
@@ -117,7 +125,11 @@ pipeline {
         }
       }
       post { always { timeout(5) {
-        archiveArtifacts(artifacts: '*.tar.gz', allowEmptyArchive: true)
+        archiveArtifacts(
+          artifacts: '*.tar.gz',
+          excludes: '**/geth-*.tar.gz',  /* `scripts/geth_binaries.sh` */
+          allowEmptyArchive: true
+        )
       } } }
     }
   }


### PR DESCRIPTION
When `scripts/geth_binaries.sh` was updated, as a side effect of dumping downloaded Geth tarballs / zips into the repo root directory, artifacts for Jenkins jobs started preserving those downloads with every job, repeatedly leading to full disks. Exclude those downloads from Jenkins.