### PR TITLE
refactor payload builder REST client usage

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -70,7 +70,6 @@ type
     lightClientPool*: ref LightClientPool
     validatorChangePool*: ref ValidatorChangePool
     elManager*: ELManager
-    payloadBuilderRestClient*: RestClientRef
     restServer*: RestServerRef
     keymanagerHost*: ref KeymanagerHost
     keymanagerServer*: RestServerRef
@@ -115,3 +114,14 @@ template rng*(node: BeaconNode): ref HmacDrbgContext =
 
 proc currentSlot*(node: BeaconNode): Slot =
   node.beaconClock.now.slotOrZero
+
+proc getPayloadBuilderClient*(node: BeaconNode): RestResult[RestClientRef] =
+  if node.config.payloadBuilderEnable:
+    # Logging done in caller
+    let res = RestClientRef.new(node.config.payloadBuilderUrl)
+    if res.isOk and res.get.isNil:
+      err "Got nil payload builder REST client reference"
+    else:
+      res
+  else:
+    err "Payload builder globally disabled"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -691,16 +691,7 @@ proc init*(T: type BeaconNode,
       else:
         nil
 
-  let payloadBuilderRestClient =
-    if config.payloadBuilderEnable:
-      RestClientRef.new(config.payloadBuilderUrl).valueOr:
-        warn "Payload builder REST client setup failed",
-          payloadBuilderUrl = config.payloadBuilderUrl
-        nil
-    else:
-      nil
-
-  if config.payloadBuilderEnable and payloadBuilderRestClient != nil:
+  if config.payloadBuilderEnable:
     info "Using external payload builder",
       payloadBuilderUrl = config.payloadBuilderUrl
 
@@ -714,7 +705,6 @@ proc init*(T: type BeaconNode,
     config: config,
     attachedValidators: validatorPool,
     elManager: elManager,
-    payloadBuilderRestClient: payloadBuilderRestClient,
     restServer: restServer,
     keymanagerHost: keymanagerHost,
     keymanagerServer: keymanagerInitResult.server,

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -888,7 +888,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     let payloadBuilderClient = node.getPayloadBuilderClient().valueOr:
       return RestApiResponse.jsonError(
-        Http500, "Unable to initialize payload builder client: " & $error)
+        Http400, "Unable to initialize payload builder client: " & $error)
 
     case currentEpochFork
     of ConsensusFork.Deneb:

--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -45,17 +45,15 @@ macro copyFields*(
 # https://github.com/nim-lang/Nim/issues/21347 fixed, combine and make generic
 # these two very similar versions of unblindAndRouteBlockMEV
 proc unblindAndRouteBlockMEV*(
-    node: BeaconNode, blindedBlock: bellatrix_mev.SignedBlindedBeaconBlock):
+    node: BeaconNode, payloadBuilderRestClient: RestClientRef,
+    blindedBlock: bellatrix_mev.SignedBlindedBeaconBlock):
     Future[Result[Opt[BlockRef], string]] {.async.} =
   # By time submitBlindedBlock is called, must already have done slashing
   # protection check
-  if node.payloadBuilderRestClient.isNil:
-    return err "unblindAndRouteBlockMEV: nil REST client"
-
   let unblindedPayload =
     try:
       awaitWithTimeout(
-          node.payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
+          payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
           BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE):
         return err("Submitting blinded block timed out")
       # From here on, including error paths, disallow local EL production by
@@ -122,17 +120,15 @@ proc unblindAndRouteBlockMEV*(
 # Only difference is `var signedBlock = capella.SignedBeaconBlock` instead of
 # `var signedBlock = bellatrix.SignedBeaconBlock`
 proc unblindAndRouteBlockMEV*(
-    node: BeaconNode, blindedBlock: capella_mev.SignedBlindedBeaconBlock):
+    node: BeaconNode, payloadBuilderRestClient: RestClientRef,
+    blindedBlock: capella_mev.SignedBlindedBeaconBlock):
     Future[Result[Opt[BlockRef], string]] {.async.} =
   # By time submitBlindedBlock is called, must already have done slashing
   # protection check
-  if node.payloadBuilderRestClient.isNil:
-    return err "unblindAndRouteBlockMEV: nil REST client"
-
   let unblindedPayload =
     try:
       awaitWithTimeout(
-          node.payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
+          payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
           BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE):
         return err("Submitting blinded block timed out")
       # From here on, including error paths, disallow local EL production by


### PR DESCRIPTION
Adds the ability to use a different payload builder URL for every payload builder call, enabling dynamically changing the payload builder URL.