### PR TITLE
switch back to 20.04 build image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-22.04
+            builder: ubuntu-20.04
             shell: bash
           - target:
               os: macos


### PR DESCRIPTION
Because https://github.com/status-im/nimbus-eth2/commit/8b7ec932cb59fc41a24a6f1ab1cf51a2106f7a74 isn't ideal

But https://github.com/status-im/nimbus-eth2/pull/4975 suggests that it resolves the immediate issue, so attempted to unbreak `unstable`.