### PR TITLE
don't require optional fields importing slashing protection information

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1957,7 +1957,7 @@ proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOErr
   var spdir: SPDIR
   try:
     spdir = Json.loadFile(interchange, SPDIR,
-                          requireAllFields = false)
+                          requireAllFields = true)
   except SerializationError as err:
     writeStackTrace()
     stderr.write $Json & " load issue for file \"", interchange, "\"\n"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1957,7 +1957,7 @@ proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOErr
   var spdir: SPDIR
   try:
     spdir = Json.loadFile(interchange, SPDIR,
-                          requireAllFields = true)
+                          requireAllFields = false)
   except SerializationError as err:
     writeStackTrace()
     stderr.write $Json & " load issue for file \"", interchange, "\"\n"

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -13,12 +13,12 @@ import
   # Status
   stew/[byteutils, results],
   serialization,
-  json_serialization,
+  json_serialization, json_serialization/std/options,
   chronicles,
   # Internal
   ../spec/datatypes/base
 
-export serialization, json_serialization # Generic sandwich https://github.com/nim-lang/Nim/issues/11225
+export options, serialization, json_serialization # Generic sandwich https://github.com/nim-lang/Nim/issues/11225
 
 # Slashing Protection Interop
 # --------------------------------------------
@@ -29,7 +29,7 @@ export serialization, json_serialization # Generic sandwich https://github.com/n
 # References: https://eips.ethereum.org/EIPS/eip-3076
 #
 # SPDIR: Nimbus-specific, Slashing Protection Database Intermediate Representation
-# SPDIF: Cross-client, json, Slashing Protection Database Interchange Format
+# SPDIF: Cross-client, JSON, Slashing Protection Database Interchange Format
 
 type
   SPDIR* = object
@@ -70,12 +70,12 @@ type
 
   SPDIR_SignedBlock* = object
     slot*: SlotString
-    signing_root*: Eth2Digest0x # compute_signing_root(block, domain)
+    signing_root*: Option[Eth2Digest0x] # compute_signing_root(block, domain)
 
   SPDIR_SignedAttestation* = object
     source_epoch*: EpochString
     target_epoch*: EpochString
-    signing_root*: Eth2Digest0x # compute_signing_root(attestation, domain)
+    signing_root*: Option[Eth2Digest0x] # compute_signing_root(attestation, domain)
 
 # Slashing Protection types
 # --------------------------------------------
@@ -241,16 +241,24 @@ proc importSlashingInterchange*(
 # Logging
 # --------------------------------------------
 
+func shortLog*(v: Option[Eth2Digest0x]): auto =
+  (
+    if v.isSome:
+      v.get.Eth2Digest.shortLog
+    else:
+      "none"
+  )
+
 func shortLog*(v: SPDIR_SignedBlock): auto =
   (
     slot: shortLog(v.slot.Slot),
-    signing_root: shortLog(v.signing_root.Eth2Digest)
+    signing_root: shortLog(v.signing_root)
   )
 func shortLog*(v: SPDIR_SignedAttestation): auto =
   (
     source_epoch: shortLog(v.source_epoch.Epoch),
     target_epoch: shortLog(v.target_epoch.Epoch),
-    signing_root: shortLog(v.signing_root.Eth2Digest)
+    signing_root: shortLog(v.signing_root)
   )
 
 chronicles.formatIt SlotString: it.Slot.shortLog
@@ -319,11 +327,23 @@ proc importInterchangeV5Impl*(
       maxValidSlotSeen = int dbSlot.get()
 
     if spdir.data[v].signed_blocks.len >= 1:
-      # Minification, to limit Sqlite IO we only import the last block after sorting
+      # Minification, to limit SQLite IO we only import the last block after sorting
       template B: untyped = spdir.data[v].signed_blocks[^1]
-      let status = db.registerBlock(
-        parsedKey, B.slot.Slot, B.signing_root.Eth2Digest
-      )
+      let
+        signing_root =
+          if B.signing_root.isSome:
+            B.signing_root.get.Eth2Digest
+          else:
+            # https://eips.ethereum.org/EIPS/eip-3076#advice-for-complete-databases
+            # "If your database records the signing roots of messages in
+            # addition to their slot/epochs, you should ensure that imported
+            # messages without signing roots are assigned a suitable dummy
+            # signing root internally. We suggest using a special "null" value
+            # which is distinct from all other signing roots, although a value
+            # like 0x0 may be used instead (as it is extremely unlikely to
+            # collide with any real signing root)."
+            ZeroDigest
+        status = db.registerBlock(parsedKey, B.slot.Slot, signing_root)
       if status.isErr():
         # We might be importing a duplicate which EIP-3076 allows
         # there is no reason during normal operation to integrate
@@ -333,8 +353,8 @@ proc importInterchangeV5Impl*(
         #       having 2 blocks with the same signing root and different slots
         #       would break the blockchain so we only check for exact slot.
         if status.error.kind == DoubleProposal and
-            B.signing_root.Eth2Digest != ZeroDigest and
-            status.error.existingBlock == B.signing_root.Eth2Digest:
+            signing_root != ZeroDigest and
+            status.error.existingBlock == signing_root:
           warn "Block already exists in the DB",
             pubkey = spdir.data[v].pubkey.PubKeyBytes.toHex(),
             candidateBlock = B

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1422,7 +1422,7 @@ proc toSPDIR*(db: SlashingProtectionDB_v2): SPDIR
         let status = selectBlkStmt.exec(validator.pubkey.PubKeyBytes) do (res: tuple[slot: int64, root: Hash32]):
           validator.signed_blocks.add SPDIR_SignedBlock(
             slot: SlotString res.slot,
-            signing_root: Eth2Digest0x(Eth2Digest(data: res.root))
+            signing_root: some Eth2Digest0x(Eth2Digest(data: res.root))
           )
         doAssert status.isOk()
       block: # Attestations
@@ -1430,7 +1430,7 @@ proc toSPDIR*(db: SlashingProtectionDB_v2): SPDIR
           validator.signed_attestations.add SPDIR_SignedAttestation(
             source_epoch: EpochString res.source,
             target_epoch: EpochString res.target,
-            signing_root: Eth2Digest0x(Eth2Digest(data: res.root))
+            signing_root: some Eth2Digest0x(Eth2Digest(data: res.root))
           )
         doAssert status.isOk()
 


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/pull/4149 changed this, but it's unclear why.

Meanwhile, since then:
```
$ build/nimbus_beacon_node slashingdb import ~/eip3076_example.json
Traceback (most recent call last, using override)
nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(507) main
nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(500) NimMain
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2149) main
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2002) handleStartUpCmd
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1989) doSlashingInterchange
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1962) doSlashingImport
Json load issue for file "eip3076_example.json"
eip3076_example.json(16, -7) Not all required fields were specified when reading 'SPDIR_SignedBlock'
```
using from https://eips.ethereum.org/EIPS/eip-3076#example-json-instance 
```json
{
  "metadata": {
    "interchange_format_version": "5",
    "genesis_validators_root": "0x4b363db94e286120d76eb905340fdd4e54bfe9f06bf33ff6cf5ad27f511bfe95"
  },
  "data": [
    {
      "pubkey": "0xb845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed",
      "signed_blocks": [
        {
          "slot": "81952",
          "signing_root": "0x4ff6f743a43f3b4f95350831aeaf0a122a1a392922c45d804280284a69eb850b"
        },
        {
          "slot": "81951"
        }
      ],
      "signed_attestations": [
        {
          "source_epoch": "2290",
          "target_epoch": "3007",
          "signing_root": "0x587d6a4f59a58fe24f406e0502413e77fe1babddee641fda30034ed37ecc884d"
        },
        {
          "source_epoch": "2290",
          "target_epoch": "3008"
        }
      ]
    }
  ]
}
```
(`genesis_validators_root` modified for mainnet compatibility for easier testing)

With this PR's change:
```
$ build/nimbus_beacon_node slashingdb import ~/eip3076_example.json
INF 2023-05-26 21:30:34.479+00:00 No slashing protection data for validator - initiating topics="antislash" validator=b845089a1457f811bfc000588fbb4e713669be8ce060ea6be3c6ece09afc3794106c91ca73acda5e5457122d58723bed
Import finished: 'eip3076_example.json' into '.cache/nimbus/BeaconNode/validators/slashing_protection.sqlite3'
```

https://eips.ethereum.org/EIPS/eip-3076#json-schema confirms that these `signing_root` fields are, in fact, optional and not required.

https://github.com/status-im/nimbus-eth2/blob/unstable/tests/slashing_protection/test_fixtures.nim and https://github.com/status-im/nimbus-eth2/blob/unstable/tests/slashing_protection/test_slashing_protection_db.nim test that these schema variations work, but in this case, `nimbus_beacon_node` has been preventing the slashing protection database import code from ever seeing the JSON.