### PR TITLE
also pack attestations where LMD vote is orphaned

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -537,26 +537,21 @@ func score(
 
 proc check_attestation_compatible*(
     dag: ChainDAGRef,
-    state: ForkyBeaconState,
+    state: ForkyHashedBeaconState,
     attestation: SomeAttestation): Result[void, cstring] =
-  let targetEpoch = attestation.data.target.epoch
-  if targetEpoch <= MIN_SEED_LOOKAHEAD:
-    return ok()
-
   let
-    attestedBlck =
-      dag.getBlockRef(attestation.data.beacon_block_root).valueOr:
-        return err("Unknown `beacon_block_root`")
+    targetEpoch = attestation.data.target.epoch
+    compatibleRoot = state.dependent_root(targetEpoch.get_previous_epoch)
 
-    dependentSlot = (targetEpoch - MIN_SEED_LOOKAHEAD).start_slot - 1
+    attestedBlck = dag.getBlockRef(attestation.data.target.root).valueOr:
+      return err("Unknown `target.root`")
+    dependentSlot = targetEpoch.attester_dependent_slot
     dependentBid = dag.atSlot(attestedBlck.bid, dependentSlot).valueOr:
       return err("Dependent root not found")
-
     dependentRoot = dependentBid.bid.root
-    compatibleRoot = state.get_block_root_at_slot(dependentSlot)
+
   if dependentRoot != compatibleRoot:
     return err("Incompatible shuffling")
-
   ok()
 
 proc getAttestationsForBlock*(pool: var AttestationPool,
@@ -610,8 +605,7 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
 
         # Filter out attestations that were created with a different shuffling.
         # As we don't re-check signatures, this needs to be done separately
-        if not check_attestation_compatible(
-              pool.dag, state.data, attestation).isOk():
+        if not pool.dag.check_attestation_compatible(state, attestation).isOk():
           continue
 
         # Attestations are checked based on the state that we're adding the

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -164,12 +164,12 @@ suite "Attestation pool processing" & preset():
     # An additional compatibility check catches that (used in block production)
     withState(state[]):
       check:
-        check_attestation_compatible(dag, forkyState.data, att1).isOk
-        check_attestation_compatible(dag, forkyState.data, att2).isErr
+        check_attestation_compatible(dag, forkyState, att1).isOk
+        check_attestation_compatible(dag, forkyState, att2).isErr
     withState(state2[]):
       check:
-        check_attestation_compatible(dag, forkyState.data, att1).isErr
-        check_attestation_compatible(dag, forkyState.data, att2).isOk
+        check_attestation_compatible(dag, forkyState, att1).isErr
+        check_attestation_compatible(dag, forkyState, att2).isOk
 
   test "Can add and retrieve simple attestations" & preset():
     let


### PR DESCRIPTION
When `attestation.data.beacon_block_root` gets orphaned, attestations with a good `attestation.data.target.root` may still be valuable. The LMD GHOST vote is not relevant for attestation rewards.

Switch to use the FFG vote (`attestation.data.target.root`) instead, gossip validation ensures it is an ancestor of `beacon_block_root`.