### PR TITLE
Revert "switch back to 20.04 build image"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-22.04
             shell: bash
           - target:
               os: macos


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#4976

nope

It was green, so worth a try.