### PR TITLE
use correct exception in `parseCmdArg(enr.Record)`

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1147,8 +1147,7 @@ func parseCmdArg*(T: type WalletName, input: string): T
 func completeCmdArg*(T: type WalletName, input: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(
-    T: type enr.Record, p: string): T {.raises: [ValueError].} =
+proc parseCmdArg*(T: type enr.Record, p: string): T {.raises: [ValueError].} =
   if not fromURI(result, p):
     raise newException(ValueError, "Invalid ENR")
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1147,10 +1147,10 @@ func parseCmdArg*(T: type WalletName, input: string): T
 func completeCmdArg*(T: type WalletName, input: string): seq[string] =
   return @[]
 
-proc parseCmdArg*(T: type enr.Record, p: string): T
-    {.raises: [ConfigurationError, Defect].} =
+proc parseCmdArg*(
+    T: type enr.Record, p: string): T {.raises: [ValueError].} =
   if not fromURI(result, p):
-    raise newException(ConfigurationError, "Invalid ENR")
+    raise newException(ValueError, "Invalid ENR")
 
 func completeCmdArg*(T: type enr.Record, val: string): seq[string] =
   return @[]


### PR DESCRIPTION
`parseCmdArg` is expected to raise `ValueError` but for `enr.Record` we currently raise `ConfigurationError`. Change to `ValueError` instead.