### PR TITLE
annotate `secondarySources` with `{.raises.}`

### DIFF
--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -200,7 +200,9 @@ template makeBannerAndConfig*(clientId: string, ConfType: type): untyped =
     ConfType.load(
       version = version, # but a short version string makes more sense...
       copyrightBanner = clientId,
-      secondarySources = proc (config: ConfType, sources: auto) =
+      secondarySources = proc (
+          config: ConfType, sources: auto
+      ) {.raises: [ConfigurationError].} =
         if config.configFile.isSome:
           sources.addConfigFile(Toml, config.configFile.get)
     )


### PR DESCRIPTION
`sources.addConfigFile` may raise `ConfigurationError`, annotate caller to propagate that error explicitly.