### PR TITLE
handle one of the `ProveField` warnings

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -578,7 +578,7 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
     template forkyState: untyped {.inject, used.} = x.phase0Data
     body
 
-template forky*(
+template forky(
     x: ForkedHashedBeaconState, kind: static ConsensusFork): untyped =
   when kind == ConsensusFork.Deneb:
     x.denebData

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -627,6 +627,7 @@ func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
     withState(tgt):
       {.push warning[ProveField]: off.}
       assign(forkyState, src.forky(consensusFork))
+      {.pop.}
   else:
     # Ensure case object and discriminator get updated simultaneously, even
     # with nimOldCaseObjects. This is infrequent.

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -578,6 +578,21 @@ template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
     template forkyState: untyped {.inject, used.} = x.phase0Data
     body
 
+template forky*(
+    x: ForkedHashedBeaconState, kind: static ConsensusFork): untyped =
+  when kind == ConsensusFork.Deneb:
+    x.denebData
+  elif kind == ConsensusFork.Capella:
+    x.capellaData
+  elif kind == ConsensusFork.Bellatrix:
+    x.bellatrixData
+  elif kind == ConsensusFork.Altair:
+    x.altairData
+  elif kind == ConsensusFork.Phase0:
+    x.phase0Data
+  else:
+    static: raiseAssert "Unreachable"
+
 template withEpochInfo*(x: ForkedEpochInfo, body: untyped): untyped =
   case x.kind
   of EpochInfoFork.Phase0:
@@ -609,17 +624,9 @@ template withEpochInfo*(
 
 func assign*(tgt: var ForkedHashedBeaconState, src: ForkedHashedBeaconState) =
   if tgt.kind == src.kind:
-    case tgt.kind
-    of ConsensusFork.Deneb:
-      assign(tgt.denebData,     src.denebData):
-    of ConsensusFork.Capella:
-      assign(tgt.capellaData,   src.capellaData):
-    of ConsensusFork.Bellatrix:
-      assign(tgt.bellatrixData, src.bellatrixData):
-    of ConsensusFork.Altair:
-      assign(tgt.altairData,    src.altairData):
-    of ConsensusFork.Phase0:
-      assign(tgt.phase0Data,    src.phase0Data):
+    withState(tgt):
+      {.push warning[ProveField]: off.}
+      assign(forkyState, src.forky(consensusFork))
   else:
     # Ensure case object and discriminator get updated simultaneously, even
     # with nimOldCaseObjects. This is infrequent.


### PR DESCRIPTION
When assigning between `ForkyHashedBeaconState`, suppress `ProveField` warning, as `tgt.kind == src.kind` was already checked, but compiler doesn't understand that (as we only `case tgt.kind`).