### PR TITLE
fix chronos `done` -> `completed` deprecation warnings

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -41,7 +41,7 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.async.} =
         var bres: seq[BeaconNodeServerRef]
         for i in 0 ..< len(pendingRequests):
           let fut = pendingRequests[i]
-          if fut.done():
+          if fut.completed():
             let resp = fut.read()
             if resp.status == 200:
               debug "Received genesis information", endpoint = nodes[i],

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1091,7 +1091,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         var res: seq[RestIndexedErrorMessageItem]
         await allFutures(pending)
         for index, future in pending:
-          if future.done():
+          if future.completed():
             let fres = future.read()
             if fres.isErr():
               let failure = RestIndexedErrorMessageItem(index: index,

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -655,7 +655,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res
     await allFutures(pending)
     for future in pending:
-      if future.done():
+      if future.completed():
         let res = future.read()
         if res.isErr():
           return RestApiResponse.jsonError(Http400,
@@ -878,7 +878,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         var res: seq[RestIndexedErrorMessageItem]
         await allFutures(pending)
         for index, future in pending:
-          if future.done():
+          if future.completed():
             let fres = future.read()
             if fres.isErr():
               let failure = RestIndexedErrorMessageItem(index: index,

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -212,7 +212,7 @@ proc produceAndPublishAttestations*(service: AttestationServiceRef,
         raise exc
 
       for future in pendingAttestations:
-        if future.done():
+        if future.completed():
           if future.read():
             inc(succeed)
           else:
@@ -307,7 +307,7 @@ proc produceAndPublishAggregates(service: AttestationServiceRef,
           raise exc
 
         for future in pendingAggregates:
-          if future.done():
+          if future.completed():
             if future.read():
               inc(succeed)
             else:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -894,7 +894,7 @@ proc getValidatorRegistration(
     let sigfut = validator.getBuilderSignature(fork, registration.message)
     if sigfut.finished():
       # This is short-path if we able to create signature locally.
-      if not(sigfut.done()):
+      if not(sigfut.completed()):
         let exc = sigfut.readError()
         debug "Got unexpected exception while signing validator registration",
               validator = shortLog(validator), error_name = $exc.name,
@@ -962,7 +962,7 @@ proc prepareRegistrationList*(
     await allFutures(futures)
 
   for index, future in futures.pairs():
-    if future.done():
+    if future.completed():
       let sres = future.read()
       if sres.isOk():
         var reg = messages[index]

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -220,7 +220,7 @@ proc pollForAttesterDuties*(service: DutiesServiceRef,
     for index, fut in pendingRequests:
       let item = addOrReplaceItems[index]
       let dap =
-        if fut.done():
+        if fut.completed():
           let sigRes = fut.read()
           if sigRes.isErr():
             warn "Unable to create slot signature using remote signer",

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -122,7 +122,7 @@ proc produceAndPublishSyncCommitteeMessages(service: SyncCommitteeServiceRef,
         raise exc
 
       for future in pendingSyncCommitteeMessages:
-        if future.done():
+        if future.completed():
           if future.read():
             inc(succeed)
           else:
@@ -246,7 +246,7 @@ proc produceAndPublishContributions(service: SyncCommitteeServiceRef,
   let validatorContributions = block:
     var res: seq[ContributionItem]
     for idx, fut in slotSignatureReqs:
-      if fut.done:
+      if fut.completed:
         let
           sigRes = fut.read
           validator = validators[idx][0]
@@ -316,7 +316,7 @@ proc produceAndPublishContributions(service: SyncCommitteeServiceRef,
           raise err
 
         for future in pendingAggregates:
-          if future.done():
+          if future.completed():
             if future.read():
               inc(succeed)
             else:

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -336,7 +336,7 @@ proc routeSyncCommitteeMessages*(
       await allFutures(pending)
 
       for index, future in pending:
-        if future.done():
+        if future.completed():
           let fres = future.read()
           if fres.isErr():
             statuses[indices[index]] = Opt.some(SendResult.err(fres.error()))

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -396,7 +396,7 @@ proc signWithDistributedKey(v: AttachedValidator,
 
   for i, req in signatureReqs:
     template shareInfo: untyped = v.clients[i][1]
-    if req.done and req.read.isOk:
+    if req.completed and req.read.isOk:
       shares.add req.read.get.toSignatureShare(shareInfo.id)
       neededShares = neededShares - 1
     else:

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -963,7 +963,7 @@ suite "Nimbus remote signer/signing test (web3signer)":
         GenesisValidatorsRoot, Epoch(i)))
     await allFutures(futures1)
     for fut in futures1:
-      check fut.done()
+      check fut.completed()
 
     await sleepAsync(seconds(SigningRequestTimeoutSeconds) + 100.milliseconds)
 
@@ -974,7 +974,7 @@ suite "Nimbus remote signer/signing test (web3signer)":
     await allFutures(futures2)
 
     for fut in futures2:
-      check fut.done()
+      check fut.completed()
 
     for i in 0 ..< TestsCount:
       let


### PR DESCRIPTION
https://github.com/status-im/nim-chronos/blob/e436f20b33d2dfd8e341b316f30bd8d11360f8f7/chronos/asyncfutures2.nim#L173-L175 shows it's a drop-in replacement, with the same semantics, so it's safe to replace:
```nim
proc done*(future: FutureBase): bool {.deprecated: "Use `completed` instead".} =
  ## This is an alias for ``completed(future)`` procedure.
  completed(future)
```