### PR TITLE
fix `Access-Control-Allow-Origin` response

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -636,7 +636,7 @@ proc init*(T: type BeaconNode,
 
   let restServer = if config.restEnabled:
     RestServerRef.init(config.restAddress, config.restPort,
-                       config.keymanagerAllowedOrigin,
+                       config.restAllowedOrigin,
                        validateBeaconApiQueries,
                        config)
   else:

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -356,7 +356,7 @@ proc init*(T: type RestServerRef,
     maxRequestBodySize = config.restMaxRequestBodySize * 1024
 
   let res = try:
-    RestServerRef.new(RestRouter.init(validateFn),
+    RestServerRef.new(RestRouter.init(validateFn, allowedOrigin),
                       address, serverFlags = serverFlags,
                       httpHeadersTimeout = headersTimeout,
                       maxHeadersSize = maxHeadersSize,


### PR DESCRIPTION
Since #3976, CORS functionality is broken. Fix it to work again:

- Use `--rest-allowed-origin` instead of `--keymanager-allowed-origin` to specify CORS `Access-Control-Allow-Origin` header for beacon-APIs.

- Actually pass CORS config to `nim-presto` once more.