### PR TITLE
display `ExecutionAddress` as hex string

### DIFF
--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -382,6 +382,9 @@ proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.
     raiseUnexpectedValue(reader,
                          "ExecutionAddress value should be a valid hex string")
 
+func `$`*(v: ExecutionAddress): string =
+  v.data.toHex()
+
 func shortLog*(v: SomeBeaconBlock): auto =
   (
     slot: shortLog(v.slot),


### PR DESCRIPTION
When logging `ExecutionAddress`, serialize it as a hex string instead of as a byte array.