### PR TITLE
https://github.com/ethereum/consensus-specs/pull/3359

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -51,7 +51,8 @@ proc initLightClient*(
 
             if not blckPayload.block_hash.isZero:
               # engine_newPayloadV1
-              discard await node.elManager.newExecutionPayload(blckPayload)
+              discard await node.elManager.newExecutionPayload(
+                blck.message.body)
 
               # Retain optimistic head for other `forkchoiceUpdated` callers.
               # May temporarily block `forkchoiceUpdatedV1` calls, e.g., Geth:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -245,8 +245,8 @@ from web3/engine_api_types import
   PayloadAttributesV1, PayloadAttributesV2, PayloadExecutionStatus,
   PayloadStatusV1
 from ../el/el_manager import
-  ELManager, asEngineExecutionPayload, forkchoiceUpdated, hasConnection,
-  hasProperlyConfiguredConnection, sendNewPayload
+  ELManager, forkchoiceUpdated, hasConnection, hasProperlyConfiguredConnection,
+  sendNewPayload
 
 proc expectValidForkchoiceUpdated(
     elManager: ELManager, headBlockPayloadAttributesType: typedesc,
@@ -304,8 +304,10 @@ from ../spec/datatypes/deneb import SignedBeaconBlock, asTrusted, shortLog
 
 proc newExecutionPayload*(
     elManager: ELManager,
-    executionPayload: ForkyExecutionPayload):
+    blockBody: SomeForkyBeaconBlockBody):
     Future[Opt[PayloadExecutionStatus]] {.async.} =
+
+  template executionPayload: untyped = blockBody.execution_payload
 
   if not elManager.hasProperlyConfiguredConnection:
     if elManager.hasConnection:
@@ -320,8 +322,7 @@ proc newExecutionPayload*(
     executionPayload = shortLog(executionPayload)
 
   try:
-    let payloadStatus = await elManager.sendNewPayload(
-      executionPayload.asEngineExecutionPayload)
+    let payloadStatus = await elManager.sendNewPayload(blockBody)
 
     debug "newPayload: succeeded",
       parentHash = executionPayload.parent_hash,
@@ -348,7 +349,7 @@ proc getExecutionValidity(
 
   try:
     let executionPayloadStatus = await elManager.newExecutionPayload(
-      blck.message.body.execution_payload)
+      blck.message.body)
     if executionPayloadStatus.isNone:
       return NewPayloadStatus.noResponse
 
@@ -442,6 +443,10 @@ proc storeBlock*(
     # When the execution layer is not available to verify the payload, we do the
     # required check on the CL side instead and proceed as if the EL was syncing
 
+    # TODO run https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#blob-kzg-commitments
+    # https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#specification
+    # "This validation MUST be instantly run in all cases even during active sync process."
+    #
     # Client software MUST validate `blockHash` value as being equivalent to
     # `Keccak256(RLP(ExecutionBlockHeader))`
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#specification
@@ -462,6 +467,7 @@ proc storeBlock*(
   # be re-added later
   self.consensusManager.quarantine[].removeOrphan(signedBlock)
 
+  # TODO with v1.4.0, not sure this is still relevant
   # Establish blob viability before calling addHeadBlock to avoid
   # writing the block in case of blob error.
   when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -113,7 +113,7 @@ programMain:
             template payload(): auto = blck.message.body.execution_payload
 
             if elManager != nil and not payload.block_hash.isZero:
-              discard await elManager.newExecutionPayload(payload)
+              discard await elManager.newExecutionPayload(blck.message.body)
               discard await elManager.forkchoiceUpdated(
                 headBlockHash = payload.block_hash,
                 safeBlockHash = payload.block_hash,  # stub value
@@ -124,7 +124,7 @@ programMain:
             template payload(): auto = blck.message.body.execution_payload
 
             if elManager != nil and not payload.block_hash.isZero:
-              discard await elManager.newExecutionPayload(payload)
+              discard await elManager.newExecutionPayload(blck.message.body)
               discard await elManager.forkchoiceUpdated(
                 headBlockHash = payload.block_hash,
                 safeBlockHash = payload.block_hash,  # stub value


### PR DESCRIPTION
Required for `devnet-6`: https://github.com/status-im/nimbus-eth2/issues/5041 / https://notes.ethereum.org/@bbusa/dencun-devnet-6

Bumps `nim-web3` primarily for https://github.com/status-im/nim-web3/pull/87 but this version also contains some CI fixes for Nim `devel`.