### PR TITLE
use v1.4.0-alpha.2 consensus spec test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.4.0-alpha.1"
+const SPEC_VERSION* = "1.4.0-alpha.2"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/beacon_chain/spec/presets/mainnet/deneb_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/deneb_preset.nim
@@ -6,11 +6,11 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Mainnet preset - Deneb
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.1/presets/mainnet/deneb.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.2/presets/mainnet/deneb.yaml
 const
   # `uint64(4096)`
   FIELD_ELEMENTS_PER_BLOB*: uint64 = 4096
   # `uint64(2**12)` (= 4096)
   MAX_BLOB_COMMITMENTS_PER_BLOCK*: uint64 = 4096
   # `uint64(2**2)` (= 4)
-  MAX_BLOBS_PER_BLOCK*: uint64 = 4
+  MAX_BLOBS_PER_BLOCK*: uint64 = 6

--- a/beacon_chain/spec/presets/minimal/deneb_preset.nim
+++ b/beacon_chain/spec/presets/minimal/deneb_preset.nim
@@ -6,11 +6,11 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Minimal preset - Deneb
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.1/presets/minimal/deneb.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.2/presets/minimal/deneb.yaml
 const
   # [customized]
   FIELD_ELEMENTS_PER_BLOB*: uint64 = 4
   # [customized]
   MAX_BLOB_COMMITMENTS_PER_BLOCK*: uint64 = 16
-  # `uint64(2**2)` (= 4)
-  MAX_BLOBS_PER_BLOCK*: uint64 = 4
+  # `uint64(6)`
+  MAX_BLOBS_PER_BLOCK*: uint64 = 6


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0-alpha.2
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.4.0-alpha.2

Required for the next devnet:
> It increases `MAX_BLOBS_PER_BLOCK` to `6` for the next Dencun devnet.