### PR TITLE
extract helper for validating `UpdatesByRange` consistency

### DIFF
--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -7,13 +7,13 @@
 
 {.push raises: [].}
 
-import chronos, chronicles, stew/base10
+import chronos, chronicles
 import
   eth/p2p/discoveryv5/random2,
   ../spec/network,
   ../networking/eth2_network,
   ../beacon_clock,
-  "."/sync_protocol, "."/sync_manager
+  "."/[light_client_sync_helpers, sync_protocol, sync_manager]
 export sync_manager
 
 logScope:
@@ -137,38 +137,10 @@ proc doRequest(
     reqCount = min(periods.len, MAX_REQUEST_LIGHT_CLIENT_UPDATES).uint64
   let response = await peer.lightClientUpdatesByRange(startPeriod, reqCount)
   if response.isOk:
-    if response.get.lenu64 > reqCount:
-      raise newException(ResponseError, "Too many values in response" &
-        " (" & Base10.toString(response.get.lenu64) &
-        " > " & Base10.toString(reqCount.uint) & ")")
-    var expectedPeriod = startPeriod
-    for update in response.get:
-      withForkyUpdate(update):
-        when lcDataFork > LightClientDataFork.None:
-          let
-            attPeriod =
-              forkyUpdate.attested_header.beacon.slot.sync_committee_period
-            sigPeriod = forkyUpdate.signature_slot.sync_committee_period
-          if attPeriod != sigPeriod:
-            raise newException(
-              ResponseError, "Conflicting sync committee periods" &
-              " (signature: " & Base10.toString(distinctBase(sigPeriod)) &
-              " != " & Base10.toString(distinctBase(attPeriod)) & ")")
-          if attPeriod < expectedPeriod:
-            raise newException(
-              ResponseError, "Unexpected sync committee period" &
-              " (" & Base10.toString(distinctBase(attPeriod)) &
-              " < " & Base10.toString(distinctBase(expectedPeriod)) & ")")
-          if attPeriod > expectedPeriod:
-            if attPeriod > lastPeriod:
-              raise newException(
-                ResponseError, "Sync committee period too high" &
-                " (" & Base10.toString(distinctBase(attPeriod)) &
-                " > " & Base10.toString(distinctBase(lastPeriod)) & ")")
-            expectedPeriod = attPeriod
-          inc expectedPeriod
-        else:
-          raise newException(ResponseError, "Invalid context bytes")
+    let e = distinctBase(response.get)
+      .checkLightClientUpdates(startPeriod, reqCount)
+    if e.isErr:
+      raise newException(ResponseError, e.error)
   return response
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.1/specs/altair/light-client/p2p-interface.md#getlightclientfinalityupdate

--- a/beacon_chain/sync/light_client_sync_helpers.nim
+++ b/beacon_chain/sync/light_client_sync_helpers.nim
@@ -1,0 +1,50 @@
+# beacon_chain
+# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/typetraits,
+  chronos,
+  stew/base10,
+  ../spec/[forks_light_client, network]
+
+func checkLightClientUpdates*(
+    updates: openArray[ForkedLightClientUpdate],
+    startPeriod: SyncCommitteePeriod,
+    count: uint64): Result[void, string] =
+  if updates.lenu64 > count:
+    return err("Too many values in response" &
+      " (" & Base10.toString(updates.lenu64) &
+      " > " & Base10.toString(count.uint) & ")")
+  let lastPeriod = startPeriod + count - 1
+  var expectedPeriod = startPeriod
+  for update in updates:
+    withForkyUpdate(update):
+      when lcDataFork > LightClientDataFork.None:
+        let
+          attPeriod =
+            forkyUpdate.attested_header.beacon.slot.sync_committee_period
+          sigPeriod = forkyUpdate.signature_slot.sync_committee_period
+        if attPeriod != sigPeriod:
+          return err("Conflicting sync committee periods" &
+            " (signature: " & Base10.toString(distinctBase(sigPeriod)) &
+            " != " & Base10.toString(distinctBase(attPeriod)) & ")")
+        if attPeriod < expectedPeriod:
+          return err("Unexpected sync committee period" &
+            " (" & Base10.toString(distinctBase(attPeriod)) &
+            " < " & Base10.toString(distinctBase(expectedPeriod)) & ")")
+        if attPeriod > expectedPeriod:
+          if attPeriod > lastPeriod:
+            return err("Sync committee period too high" &
+              " (" & Base10.toString(distinctBase(attPeriod)) &
+              " > " & Base10.toString(distinctBase(lastPeriod)) & ")")
+          expectedPeriod = attPeriod
+        inc expectedPeriod
+      else:
+        return err("Invalid context bytes")
+  ok()


### PR DESCRIPTION
Reduce code duplication when checking response of `UpdatesByRange`.