### PR TITLE
split file loading from parsing in helpers

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -964,16 +964,20 @@ type
     genesis_validators_root: Eth2Digest
     slot: Slot
 
-func readSszForkedHashedBeaconState*(
-    cfg: RuntimeConfig, slot: Slot, data: openArray[byte]):
+func readSszForkedHashedBeaconState(
+    consensusFork: ConsensusFork, data: openArray[byte]):
     ForkedHashedBeaconState {.raises: [Defect, SszError].} =
   # TODO https://github.com/nim-lang/Nim/issues/19357
-  result = ForkedHashedBeaconState(
-    kind: cfg.consensusForkAtEpoch(slot.epoch()))
+  result = ForkedHashedBeaconState(kind: consensusFork)
 
   withState(result):
     readSszBytes(data, forkyState.data)
     forkyState.root = hash_tree_root(forkyState.data)
+
+template readSszForkedHashedBeaconState*(
+    cfg: RuntimeConfig, slot: Slot, data: openArray[byte]):
+    ForkedHashedBeaconState =
+  cfg.consensusForkAtEpoch(slot.epoch()).readSszForkedHashedBeaconState(data)
 
 func readSszForkedHashedBeaconState*(cfg: RuntimeConfig, data: openArray[byte]):
     ForkedHashedBeaconState {.raises: [Defect, SszError].} =

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -964,7 +964,7 @@ type
     genesis_validators_root: Eth2Digest
     slot: Slot
 
-func readSszForkedHashedBeaconState(
+func readSszForkedHashedBeaconState*(
     consensusFork: ConsensusFork, data: openArray[byte]):
     ForkedHashedBeaconState {.raises: [Defect, SszError].} =
   # TODO https://github.com/nim-lang/Nim/issues/19357

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -473,8 +473,8 @@ func parse(T: type DomainType, input: string): T
            {.raises: [ValueError, Defect].} =
   DomainType hexToByteArray(input, 4)
 
-proc readRuntimeConfig*(
-    path: string): (RuntimeConfig, seq[string]) {.
+proc readRuntimeConfig(
+    fileContent: string, path: string): (RuntimeConfig, seq[string]) {.
     raises: [IOError, PresetFileError, PresetIncompatibleError, Defect].} =
   var
     lineNum = 0
@@ -492,7 +492,7 @@ proc readRuntimeConfig*(
     names.add name
 
   var values: Table[string, string]
-  for line in splitLines(readFile(path)):
+  for line in splitLines(fileContent):
     inc lineNum
     if line.len == 0 or line[0] == '#': continue
     # remove any trailing comments
@@ -605,6 +605,11 @@ proc readRuntimeConfig*(
     unknowns.add name
 
   (cfg, unknowns)
+
+proc readRuntimeConfig*(
+    path: string): (RuntimeConfig, seq[string]) {.
+    raises: [IOError, PresetFileError, PresetIncompatibleError, Defect].} =
+  readRuntimeConfig(readFile(path), path)
 
 template name*(cfg: RuntimeConfig): string =
   if cfg.CONFIG_NAME.len() > 0:


### PR DESCRIPTION
In `readSszForkedHashedBeaconState` and `readRuntimeConfig`, split the part that loads the file from the part that parses the file. The parsing portion can be reused with that, e.g., when loading from the network.