### PR TITLE
avoid implicit `CaseTransition` in keystore Json parsing

### DIFF
--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -589,7 +589,7 @@ template readValueImpl(r: var JsonReader, value: var Checksum) =
       messageSpecified = true
 
     else:
-      r.raiseUnexpectedField(fieldName, "Kdf")
+      r.raiseUnexpectedField(fieldName, "Checksum")
 
   if not (functionSpecified and paramsSpecified and messageSpecified):
     r.raiseUnexpectedValue(
@@ -630,7 +630,7 @@ template readValueImpl(r: var JsonReader, value: var Cipher) =
       messageSpecified = true
 
     else:
-      r.raiseUnexpectedField(fieldName, "Kdf")
+      r.raiseUnexpectedField(fieldName, "Cipher")
 
   if not (functionSpecified and paramsSpecified and messageSpecified):
     r.raiseUnexpectedValue(


### PR DESCRIPTION
Override default Json parsing for keystore case objects to avoid `CaseTransition` logic to be emitted. When parsing the discriminator, reinitialize the entire object instead of implicitly changing it, to avoid UB and also possible oversights when extending the object. See https://github.com/status-im/nim-serialization/pull/59