### PR TITLE
use v1.4.0-alpha.3 consensus spec test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, json_serialization, timer, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.4.0-alpha.2"
+const SPEC_VERSION* = "1.4.0-alpha.3"
 ## Spec version we're aiming to be compatible with, right now
 
 const


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0-alpha.3
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.4.0-alpha.3