### PR TITLE
avoid `ProveField` warning in `keyGen`

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -490,6 +490,7 @@ func infinity*(T: type ValidatorSig): T =
 func burnMem*(key: var ValidatorPrivKey) =
   burnMem(addr key, sizeof(ValidatorPrivKey))
 
+{.push warning[ProveField]:off.}  # https://github.com/nim-lang/Nim/issues/22060
 proc keyGen(rng: var HmacDrbgContext): BlsResult[blscurve.SecretKey] =
   var
     pubkey: blscurve.PublicKey
@@ -497,6 +498,7 @@ proc keyGen(rng: var HmacDrbgContext): BlsResult[blscurve.SecretKey] =
   result.ok default(blscurve.SecretKey)
   if not keyGen(bytes, pubkey, result.value):
     return err "key generation failed"
+{.pop.}
 
 proc secretShareId(x: uint32) : blscurve.ID =
   let bytes: array[8, uint32] = [uint32 x, 0, 0, 0, 0, 0, 0, 0]


### PR DESCRIPTION
Assigning to fields of `var` case objects emits `ProveField` warnings. We disable them in `make` based builds but they may pop up when building manually with `nim c`. Suppress them for the `keyGen` function, as we assign to `result.value` separately from `result.ok` to avoid copying.