### PR TITLE
ensure that submodule bumps are reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,42 +82,6 @@ jobs:
             exit 2
           fi
 
-      - name: Check submodules (Linux)
-        if: github.event_name == 'pull_request' && runner.os == 'Linux'
-        run: |
-          while IFS='' read -r line; do
-            # Format:
-            # - +/-/U/space to indicate changes
-            # - 40 characters commit
-            # - space
-            # - path to submodule
-            # - space
-            # - (
-            # - ref
-            # - )
-
-            if [[ "${line:0:1}" == ' ' ]]; then
-              # No changes, skip
-              continue
-            fi
-
-            commit="${line:1:40}"
-            path="$(cut -f 1 -d ' ' <<<${line:42})"
-
-            if ! branch="$(git config -f .gitmodules --get "submodule.$path.branch")"; then
-              echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
-              exit 2
-            fi
-            if ! error="$(git -C "$path" fetch -q origin "$branch")"; then
-              echo "Submodule '$path': Failed to fetch '$branch': $error"
-              exit 2
-            fi
-            if ! git -C "$path" merge-base --is-ancestor "$commit" "origin/$branch"; then
-              echo "Submodule '$path': '$commit' is not on '$branch'"
-              exit 2
-            fi
-          done < <(git submodule status)
-
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
         uses: msys2/setup-msys2@v2
@@ -198,6 +162,42 @@ jobs:
         run: |
           ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
           ./env.sh nim --version
+
+      - name: Check submodules (Linux)
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
+        run: |
+          while IFS='' read -r line; do
+            # Format:
+            # - +/-/U/space to indicate changes
+            # - 40 characters commit
+            # - space
+            # - path to submodule
+            # - space
+            # - (
+            # - ref
+            # - )
+
+            if [[ "${line:0:1}" == ' ' ]]; then
+              # No changes, skip
+              continue
+            fi
+
+            commit="${line:1:40}"
+            path="$(cut -f 1 -d ' ' <<<${line:42})"
+
+            if ! branch="$(git config -f .gitmodules --get "submodule.$path.branch")"; then
+              echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
+              exit 2
+            fi
+            if ! error="$(git -C "$path" fetch -q origin "$branch")"; then
+              echo "Submodule '$path': Failed to fetch '$branch': $error"
+              exit 2
+            fi
+            if ! git -C "$path" merge-base --is-ancestor "$commit" "origin/$branch"; then
+              echo "Submodule '$path': '$commit' is not on '$branch'"
+              exit 2
+            fi
+          done < <(git submodule status)
 
       - name: Get latest fixtures commit hash
         id: fixtures_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
         if: github.event_name == 'pull_request' && runner.os == 'Linux'
         run: |
           while IFS='' read -r line; do
+            # Format:
+            # - +/-/U/space to indicate changes
+            # - 40 characters commit
+            # - space
+            # - path to submodule
+            # - space
+            # - (
+            # - ref
+            # - )
+
             if [[ "${line:0:1}" == ' ' ]]; then
               # No changes, skip
               continue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
               echo "Submodule '$file': '$commit' is not on '$branch'"
               exit 2
             fi
-          done < <(git diff --name-only --diff-filter=AM HEAD^2 HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
+          done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
 
       - name: Get latest fixtures commit hash
         id: fixtures_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
               echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi
-
             if ! error="$(git -C "$path" fetch -q origin "$branch")"; then
               echo "Submodule '$path': Failed to fetch '$branch': $error"
               exit 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,33 @@ jobs:
             exit 2
           fi
 
+      - name: Check submouldes (Linux)
+        if: github.event_name == 'pull_request' && runner.os == 'Linux'
+        run: |
+          while IFS='' read -r line; do
+            if [[ "${line:0:1}" == ' ' ]]; then
+              # No changes, skip
+              continue
+            fi
+
+            commit="${line:1:40}"
+            path="$(cut -f 1 -d ' ' <<<${line:42})"
+
+            if ! branch="$(git config -f .gitmodules --get submodule.$path.branch)"; then
+              echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
+              exit 2
+            fi
+
+            if ! error="$(git -C "$path" fetch -q origin "$branch")"; then
+              echo "Submodule '$path': Failed to fetch '$branch': $error"
+              exit 2
+            fi
+            if ! git -C "$path" merge-base --is-ancestor "$commit" "origin/$branch"; then
+              echo "Submodule '$path': '$commit' is not on '$branch'"
+              exit 2
+            fi
+          done < <(git submodule status)
+
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,38 +166,22 @@ jobs:
       - name: Check submodules (Linux)
         if: github.event_name == 'pull_request' && runner.os == 'Linux'
         run: |
-          while IFS='' read -r line; do
-            # Format:
-            # - +/-/U/space to indicate changes
-            # - 40 characters commit
-            # - space
-            # - path to submodule
-            # - space
-            # - (
-            # - ref
-            # - )
-
-            if [[ "${line:0:1}" == ' ' ]]; then
-              # No changes, skip
-              continue
-            fi
-
-            commit="${line:1:40}"
-            path="$(cut -f 1 -d ' ' <<<${line:42})"
-
-            if ! branch="$(git config -f .gitmodules --get "submodule.$path.branch")"; then
-              echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
+          while read -r file; do
+            commit="$(git -C "$file" rev-parse HEAD)"
+            if ! branch="$(git config -f .gitmodules --get "submodule.$file.branch")"; then
+              echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi
-            if ! error="$(git -C "$path" fetch -q origin "$branch")"; then
-              echo "Submodule '$path': Failed to fetch '$branch': $error"
+            echo "git -C $file fetch -q origin $branch"
+            if ! error="$(git -C "$file" fetch -q origin "$branch")"; then
+              echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2
             fi
-            if ! git -C "$path" merge-base --is-ancestor "$commit" "origin/$branch"; then
-              echo "Submodule '$path': '$commit' is not on '$branch'"
+            if ! git -C "$file" merge-base --is-ancestor "$commit" "origin/$branch"; then
+              echo "Submodule '$file': '$commit' is not on '$branch'"
               exit 2
             fi
-          done < <(git submodule status)
+          done < <(git diff --name-only --diff-filter=AM HEAD^2 HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
 
       - name: Get latest fixtures commit hash
         id: fixtures_version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
             commit="${line:1:40}"
             path="$(cut -f 1 -d ' ' <<<${line:42})"
 
-            if ! branch="$(git config -f .gitmodules --get submodule.$path.branch)"; then
+            if ! branch="$(git config -f .gitmodules --get "submodule.$path.branch")"; then
               echo "Submodule '$path': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             exit 2
           fi
 
-      - name: Check submouldes (Linux)
+      - name: Check submodules (Linux)
         if: github.event_name == 'pull_request' && runner.os == 'Linux'
         run: |
           while IFS='' read -r line; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,6 @@ jobs:
               echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi
-            echo "git -C $file fetch -q origin $branch"
             if ! error="$(git -C "$file" fetch -q origin "$branch")"; then
               echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2

--- a/.gitmodules
+++ b/.gitmodules
@@ -203,9 +203,15 @@
 [submodule "vendor/gnosis-chain-configs"]
 	path = vendor/gnosis-chain-configs
 	url = https://github.com/gnosischain/configs.git
+	ignore = untracked
+	branch = main
 [submodule "vendor/sepolia"]
 	path = vendor/sepolia
 	url = https://github.com/eth-clients/sepolia.git
+	ignore = untracked
+	branch = main
 [submodule "vendor/nim-kzg4844"]
 	path = vendor/nim-kzg4844
-	url = https://github.com/status-im/nim-kzg4844/
+	url = https://github.com/status-im/nim-kzg4844.git
+	ignore = untracked
+	branch = master


### PR DESCRIPTION
It occurs sometimes that a submodule is bumped to a PR commit instead of the corresponding canonical branch (as registered in `.gitmodules`). Because we typically use `squash`, that PR commit can subsequently become unreachable, randomly breaking the build of `nimbus-eth2`. Prevent these accidents by only allowing submodule bumps to commits on the branch registered in `.gitmodules`. On private branches, simply update `.gitmodules` to match the personal dev branch.