### PR TITLE
add ability to load KZG trusted setup via hidden, potentially temporary runtime flag

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -7,7 +7,6 @@
 
 {.push raises: [].}
 
-
 import
   std/[strutils, os, options, unicode, uri],
   metrics,
@@ -604,6 +603,14 @@ type
         desc: "Retention strategy for historical data (archive/prune)"
         defaultValue: HistoryMode.Archive
         name: "history".}: HistoryMode
+
+      # https://notes.ethereum.org/@bbusa/dencun-devnet-6
+      # "Please ensure that there is a way for us to specify the file through a
+      # runtime flag such as --trusted-setup-file (or similar)."
+      trustedSetupFile* {.
+        hidden
+        desc: "Experimental, debug option; could disappear at any time without warning"
+        name: "temporary-debug-trusted-setup-file" .}: Option[string]
 
     of BNStartUpCmd.wallets:
       case walletsCmd* {.command.}: WalletsCmd
@@ -1374,3 +1381,9 @@ proc loadKzgTrustedSetup*(): Result[void, string] =
     Kzg.loadTrustedSetupFromString(trustedSetup)
   else:
     ok()
+
+proc loadKzgTrustedSetup*(trustedSetupPath: string): Result[void, string] =
+  try:
+    Kzg.loadTrustedSetupFromString(readFile(trustedSetupPath))
+  except IOError as err:
+    err(err.msg)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1885,7 +1885,11 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   let node = BeaconNode.init(rng, config, metadata)
 
   if node.dag.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
-    let res = conf.loadKzgTrustedSetup()
+    let res =
+      if config.trustedSetupFile.isNone:
+        conf.loadKzgTrustedSetup()
+      else:
+        conf.loadKzgTrustedSetup(config.trustedSetupFile.get)
     if res.isErr():
       raiseAssert res.error()
 


### PR DESCRIPTION
Required for https://notes.ethereum.org/@bbusa/dencun-devnet-6
> Please ensure that there is a way for us to specify the file through a runtime flag such as `--trusted-setup-file` (or similar). If the file is baked in during compile, please ensure that the flag would indeed override the file. This is a **MUST** requirement for devnet 6. If your client does not support the override, we can’t include it in the devnet.