### PR TITLE
remove `SAFE_SLOTS_TO_UPDATE_JUSTIFIED`

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -91,7 +91,6 @@ const
   ignoredValues = [
     "TRANSITION_TOTAL_DIFFICULTY", # Name that appears in some altair alphas, obsolete, remove when no more testnets
     "MIN_ANCHOR_POW_BLOCK_DIFFICULTY", # Name that appears in some altair alphas, obsolete, remove when no more testnets
-    "SAFE_SLOTS_TO_UPDATE_JUSTIFIED",  # Removed in consensus-specs v1.3.0
   ]
 
 when const_preset == "mainnet":


### PR DESCRIPTION
The `SAFE_SLOTS_TO_UPDATE_JUSTIFIED` constant is no longer used in any EF or Gnosis network metadata definitions. We can remove it.

Upstream changes:

- https://github.com/eth-clients/eth2-networks/pull/87
- https://github.com/gnosischain/configs/pull/10

Which we updated here:

- https://github.com/status-im/nimbus-eth2/pull/5071
- https://github.com/status-im/nimbus-eth2/pull/5077