### PR TITLE
Add Yamux experimental support

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -305,6 +305,11 @@ type
         defaultValue: false
         name: "enr-auto-update" .}: bool
 
+      enableYamux* {.
+        desc: "Enable the Yamux multiplexer"
+        defaultValue: false
+        name: "enable-yamux" .}: bool
+
       weakSubjectivityCheckpoint* {.
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -306,6 +306,7 @@ type
         name: "enr-auto-update" .}: bool
 
       enableYamux* {.
+        hidden
         desc: "Enable the Yamux multiplexer"
         defaultValue: false
         name: "enable-yamux" .}: bool

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -103,6 +103,7 @@ type LightClientConf* = object
     name: "enr-auto-update" .}: bool
 
   enableYamux* {.
+    hidden
     desc: "Enable the Yamux multiplexer"
     defaultValue: false
     name: "enable-yamux" .}: bool

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -102,6 +102,11 @@ type LightClientConf* = object
     defaultValue: false
     name: "enr-auto-update" .}: bool
 
+  enableYamux* {.
+    desc: "Enable the Yamux multiplexer"
+    defaultValue: false
+    name: "enable-yamux" .}: bool
+
   agentString* {.
     defaultValue: "nimbus",
     desc: "Node agent string which is used as identifier in network"

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2271,8 +2271,14 @@ func gossipId(
 proc newBeaconSwitch(config: BeaconNodeConf | LightClientConf,
                      seckey: PrivateKey, address: MultiAddress,
                      rng: ref HmacDrbgContext): Switch {.raises: [Defect, CatchableError].} =
-  SwitchBuilder
-    .new()
+  var sb =
+    if config.enableYamux:
+      SwitchBuilder.new().withYamux()
+    else:
+      SwitchBuilder.new()
+  # Order of multiplexers matters, the first will be default
+
+  sb
     .withPrivateKey(seckey)
     .withAddress(address)
     .withRng(rng)

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -60,7 +60,6 @@ The following options are available:
      --enr-auto-update         Discovery can automatically update its ENR with the IP address and UDP port as
                                seen by other nodes it communicates with. This option allows to enable/disable
                                this functionality [=false].
-     --enable-yamux            Enable the Yamux multiplexer [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
      --sync-light-client       Accelerate execution layer sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -60,6 +60,7 @@ The following options are available:
      --enr-auto-update         Discovery can automatically update its ENR with the IP address and UDP port as
                                seen by other nodes it communicates with. This option allows to enable/disable
                                this functionality [=false].
+     --enable-yamux            Enable the Yamux multiplexer [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
      --sync-light-client       Accelerate execution layer sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.


### PR DESCRIPTION
Mplex is starting to get slowly kicked out of libp2p, and it's probably for the best

We've had experimental yamux in nim-libp2p for a while, but it had limited testing on actual networks
Adding this flag, so that we can test on a few fleet nodes, and in some future, make it default to true

Also see https://github.com/libp2p/specs/issues/553