### PR TITLE
broaden `SszError` catches to `SerializationError`

### DIFF
--- a/beacon_chain/beacon_chain_db_light_client.nim
+++ b/beacon_chain/beacon_chain_db_light_client.nim
@@ -194,7 +194,7 @@ proc getHeader*[T: ForkyLightClientHeader](
     res.expect("SQL query OK")
     try:
       return ok SSZ.decode(header, T)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC data store corrupted", store = "headers", kind = T.kind,
         blockRoot, exc = exc.msg
       return Opt.none(T)
@@ -278,7 +278,7 @@ proc getCurrentSyncCommitteeBranch*(
     res.expect("SQL query OK")
     try:
       return ok SSZ.decode(branch, altair.CurrentSyncCommitteeBranch)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC data store corrupted", store = "currentBranches",
         slot, exc = exc.msg
       return Opt.none(altair.CurrentSyncCommitteeBranch)
@@ -361,7 +361,7 @@ proc getSyncCommittee*(
     res.expect("SQL query OK")
     try:
       return ok SSZ.decode(branch, altair.SyncCommittee)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC data store corrupted", store = "syncCommittees",
         period, exc = exc.msg
       return Opt.none(altair.SyncCommittee)
@@ -511,7 +511,7 @@ proc getBestUpdate*(
       warn "Unsupported LC data store kind", store = "bestUpdates",
         period, kind = update[0]
       return default(ForkedLightClientUpdate)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC data store corrupted", store = "bestUpdates",
         period, kind = update[0], exc = exc.msg
       return default(ForkedLightClientUpdate)

--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -159,7 +159,7 @@ proc getLatestFinalizedHeader*(
       warn "Unsupported LC store kind", store = "headers",
         key, kind = header[0]
       return default(ForkedLightClientHeader)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC store corrupted", store = "headers",
         key, kind = header[0], exc = exc.msg
       return default(ForkedLightClientHeader)
@@ -248,7 +248,7 @@ proc getSyncCommittee*(
     res.expect("SQL query OK")
     try:
       return ok SSZ.decode(syncCommittee, altair.SyncCommittee)
-    except SszError as exc:
+    except SerializationError as exc:
       error "LC store corrupted", store = "syncCommittees",
         period, exc = exc.msg
       return Opt.none(altair.SyncCommittee)

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2441,7 +2441,7 @@ proc addValidator*[MsgType](node: Eth2Node,
         let decoded = SSZ.decode(decompressed, MsgType)
         decompressed = newSeq[byte](0) # release memory before validating
         msgValidator(decoded) # doesn't raise!
-      except SszError as e:
+      except SerializationError as e:
         inc nbc_gossip_failed_ssz
         debug "Error decoding gossip",
           topic, len = message.data.len, decompressed = decompressed.len,
@@ -2472,7 +2472,7 @@ proc addAsyncValidator*[MsgType](node: Eth2Node,
         let decoded = SSZ.decode(decompressed, MsgType)
         decompressed = newSeq[byte](0) # release memory before validating
         msgValidator(decoded) # doesn't raise!
-      except SszError as e:
+      except SerializationError as e:
         inc nbc_gossip_failed_ssz
         debug "Error decoding gossip",
           topic, len = message.data.len, decompressed = decompressed.len,

--- a/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
@@ -53,7 +53,7 @@ func decodeSszLightClientObject[T: SomeForkedLightClientObject](
       else:
         raiseRestDecodingBytesError(
           cstring("Unsupported fork: " & $consensusFork))
-  except SszError as exc:
+  except SerializationError as exc:
     raiseRestDecodingBytesError(cstring("Malformed data: " & $exc.msg))
 
 proc decodeJsonLightClientObject[T: SomeForkedLightClientObject](
@@ -145,7 +145,7 @@ proc decodeSszLightClientObjects[S: seq[SomeForkedLightClientObject]](
         else:
           raiseRestDecodingBytesError(
             cstring("Unsupported fork: " & $consensusFork))
-    except SszError as exc:
+    except SerializationError as exc:
       raiseRestDecodingBytesError(cstring("Malformed data: " & $exc.msg))
   res
 

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -980,7 +980,7 @@ template readSszForkedHashedBeaconState*(
   cfg.consensusForkAtEpoch(slot.epoch()).readSszForkedHashedBeaconState(data)
 
 func readSszForkedHashedBeaconState*(cfg: RuntimeConfig, data: openArray[byte]):
-    ForkedHashedBeaconState {.raises: [Defect, SszError].} =
+    ForkedHashedBeaconState {.raises: [SerializationError].} =
   ## Read a state picking the right fork by first reading the slot from the byte
   ## source
   if data.len() < sizeof(BeaconStateHeader):
@@ -1000,7 +1000,7 @@ type
 
 func readSszForkedSignedBeaconBlock*(
     cfg: RuntimeConfig, data: openArray[byte]):
-    ForkedSignedBeaconBlock {.raises: [Defect, SszError].} =
+    ForkedSignedBeaconBlock {.raises: [SerializationError].} =
   ## Helper to read a header from bytes when it's not certain what kind of block
   ## it is
   if data.len() < sizeof(ForkedBeaconBlockHeader):

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -72,14 +72,10 @@ template decodeAndProcess(typ, process: untyped): bool =
     data {.inject.} = newClone(
       try:
         SSZ.decode(input, typ)
-      except MalformedSszError as e:
+      except SerializationError as e:
         raise newException(
           FuzzCrashError,
           "Malformed SSZ, likely bug in preprocessing.", e)
-      except SszSizeMismatchError as e:
-        raise newException(
-          FuzzCrashError,
-          "SSZ size mismatch, likely bug in preprocessing.", e)
     )
   let processOk =
     try:


### PR DESCRIPTION
`nim-serialization` is tagged with `{.raises:[SerializationError].}` so it is no longer sufficient to catch `SszError` in some situations. `SszError` inherits from `SerializationError`, so broadening the caught exception types can be done now, to enable bumping `nim-serialization`.

https://github.com/status-im/nimbus-eth2/pull/5043#issuecomment-1584227993

#5061 is also needed to bump `nim-serialization`.