### PR TITLE
ensure sync duties for next epoch are registered in time

### DIFF
--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -306,7 +306,8 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef,
         res
 
     nextEpoch = epoch + 1
-    nextEpochHasSameDuties = not nextEpoch.is_sync_committee_period
+    nextEpochHasSameDuties = 
+      epoch.sync_committee_period == nextEpoch.sync_committee_period
 
   let addOrReplaceItems =
     block:

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -305,7 +305,8 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef,
               validator_sync_committee_index: validatorSyncCommitteeIndex))
         res
 
-    fork = vc.forkAtEpoch(epoch)
+    nextEpoch = epoch + 1
+    nextEpochHasSameDuties = not nextEpoch.is_sync_committee_period
 
   let addOrReplaceItems =
     block:
@@ -318,6 +319,10 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef,
           map.duties.withValue(epoch, epochDuty):
             if epochDuty[] != duty:
               dutyFound = true
+          if nextEpochHasSameDuties:
+            map.duties.withValue(nextEpoch, epochDuty):
+              if epochDuty[] != duty:
+                dutyFound = true
 
         if dutyFound and not alreadyWarned:
           info "Sync committee duties re-organization", duty, epoch
@@ -331,6 +336,8 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef,
       var validatorDuties =
         vc.syncCommitteeDuties.getOrDefault(duty.pubkey)
       validatorDuties.duties[epoch] = duty
+      if nextEpochHasSameDuties:
+        validatorDuties.duties[nextEpoch] = duty
       vc.syncCommitteeDuties[duty.pubkey] = validatorDuties
 
   return len(addOrReplaceItems)


### PR DESCRIPTION
For attestations, VC queries duties for current and next epoch. For sync messages, VC queries for current and next period (if soon). This means that for sync messages we don't actually have the duties for next epoch in all situations, leading to situation where VC may miss sync duties in the final slot of an epoch when using. As duties remain same within a sync committee period, simply copy them over to next epoch to avoid this situation without adding network latency.