### PR TITLE
require sync committee supermajority in CI

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -140,7 +140,8 @@ suite baseDescription & "Sync Aggregate " & preset():
       Result[void, cstring] =
     var cache = StateCache()
     process_sync_aggregate(
-      preState, syncAggregate, get_total_active_balance(preState, cache), cache)
+      preState, syncAggregate, get_total_active_balance(preState, cache),
+      {}, cache)
 
   for path in walkTests(OpSyncAggregateDir):
     runTest[SyncAggregate, typeof applySyncAggregate](

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -161,7 +161,8 @@ suite baseDescription & "Sync Aggregate " & preset():
       Result[void, cstring] =
     var cache = StateCache()
     process_sync_aggregate(
-      preState, syncAggregate, get_total_active_balance(preState, cache), cache)
+      preState, syncAggregate, get_total_active_balance(preState, cache),
+      {}, cache)
 
   for path in walkTests(OpSyncAggregateDir):
     runTest[SyncAggregate, typeof applySyncAggregate](

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -178,7 +178,8 @@ suite baseDescription & "Sync Aggregate " & preset():
       Result[void, cstring] =
     var cache = StateCache()
     process_sync_aggregate(
-      preState, syncAggregate, get_total_active_balance(preState, cache), cache)
+      preState, syncAggregate, get_total_active_balance(preState, cache),
+      {}, cache)
 
   for path in walkTests(OpSyncAggregateDir):
     runTest[SyncAggregate, typeof applySyncAggregate](

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -180,7 +180,8 @@ suite baseDescription & "Sync Aggregate " & preset():
       Result[void, cstring] =
     var cache = StateCache()
     process_sync_aggregate(
-      preState, syncAggregate, get_total_active_balance(preState, cache), cache)
+      preState, syncAggregate, get_total_active_balance(preState, cache),
+      {}, cache)
 
   for path in walkTests(OpSyncAggregateDir):
     runTest[SyncAggregate, typeof applySyncAggregate](


### PR DESCRIPTION
To better catch problems with sync committee messages in CI, extend local testnet simulation to also verify that each block is signed by a supermajority of the sync committee.

Requires #5083 and #5084