### PR TITLE
use correct slot when producing sync aggregate around forks

### DIFF
--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -333,8 +333,9 @@ proc produceSyncAggregateAux(
 proc produceSyncAggregate*(
     pool: SyncCommitteeMsgPool,
     bid: BlockId,
-    slot: Slot): SyncAggregate =
-  let target = pool.cfg.toSyncMsgTarget(bid, slot)
+    signatureSlot: Slot): SyncAggregate =
+  # Sync committee signs previous slot, relative to when new block is produced
+  let target = pool.cfg.toSyncMsgTarget(bid, max(signatureSlot, 1.Slot) - 1)
   if target in pool.bestContributions:
     try:
       produceSyncAggregateAux(pool.bestContributions[target])

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -274,7 +274,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         doAssert(signRes.isOk())
         contrib[].signature = signRes.get()
         contrib
-      aggregate = syncCommitteePool[].produceSyncAggregate(bid, slot)
+      aggregate = syncCommitteePool[].produceSyncAggregate(bid, slot + 1)
 
     check:
       expectedCount > 1 # Cover edge case

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -43,7 +43,7 @@ suite "Sync committee pool":
 
     check(success == false)
 
-    let aggregate = pool.produceSyncAggregate(headBid, headBid.slot)
+    let aggregate = pool.produceSyncAggregate(headBid, headBid.slot + 1)
 
     check:
       aggregate.sync_committee_bits.isZeros
@@ -326,21 +326,21 @@ suite "Sync committee pool":
     #
     block:
       # Checking for a block that got no votes
-      let aggregate = pool.produceSyncAggregate(bid3, bid3.slot)
+      let aggregate = pool.produceSyncAggregate(bid3, bid3.slot + 1)
       check:
         aggregate.sync_committee_bits.isZeros
         aggregate.sync_committee_signature == ValidatorSig.infinity
 
     block:
       # Checking for a block that got votes from 1 committee
-      let aggregate = pool.produceSyncAggregate(bid2, bid2.slot)
+      let aggregate = pool.produceSyncAggregate(bid2, bid2.slot + 1)
       check:
         aggregate.sync_committee_bits.countOnes == 1
         aggregate.sync_committee_signature == sig4.toValidatorSig
 
     block:
       # Checking for a block that got votes from 2 committees
-      let aggregate = pool.produceSyncAggregate(bid1, bid1.slot)
+      let aggregate = pool.produceSyncAggregate(bid1, bid1.slot + 1)
       let sig = aggregate [sig1, sig2, sig3]
       check:
         aggregate.sync_committee_bits.countOnes == 3
@@ -362,7 +362,7 @@ suite "Sync committee pool":
       check:
         not success
 
-      let aggregate = pool.produceSyncAggregate(bid2, bid2.slot)
+      let aggregate = pool.produceSyncAggregate(bid2, bid2.slot + 1)
       check:
         aggregate.sync_committee_bits.isZeros
         aggregate.sync_committee_signature == ValidatorSig.infinity

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -514,7 +514,7 @@ proc makeSyncAggregate(
         signedContributionAndProof,
         latest_block_id, contribution.signature.load.get)
 
-  syncCommitteePool[].produceSyncAggregate(latest_block_id, slot)
+  syncCommitteePool[].produceSyncAggregate(latest_block_id, slot + 1)
 
 iterator makeTestBlocks*(
   state: ForkedHashedBeaconState,


### PR DESCRIPTION
`produceSyncAggregate` is called in new slot when block is produced, while the other functions in `sync_committee_msg_pool` are called in previous slot. So, need to subtract 1 slot when producing sync aggregate to accept the signatures using the old digest during fork transition.