### PR TITLE
reduce `nim-eth` dependencies just for RNG

### DIFF
--- a/beacon_chain/el/deposit_contract.nim
+++ b/beacon_chain/el/deposit_contract.nim
@@ -202,7 +202,7 @@ proc main() {.async.} =
   except Exception as exc: # TODO fix confutils
     raiseAssert exc.msg
 
-  let rng = keys.newRng()
+  let rng = HmacDrbgContext.new()
 
   if conf.cmd == StartUpCommand.generateSimulationDeposits:
     let

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -8,7 +8,7 @@ import
   std/os,
   chronicles,
   stew/results, snappy, taskpools,
-  ../ncli/e2store, eth/keys,
+  ../ncli/e2store,
   ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/[beaconstate, forks, signatures_batch],
   ./consensus_object_pools/block_dag # TODO move to somewhere else to avoid circular deps
@@ -167,9 +167,9 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
     startSlot = f.stateIdx.startSlot
     era = startSlot.era
 
-  var
+    rng = HmacDrbgContext.new()
     taskpool = Taskpool.new()
-    verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+  var verifier = BatchVerifier(rng: rng, taskpool: taskpool)
 
   var tmp: seq[byte]
   ? f.getStateSSZ(startSlot, tmp)

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -9,7 +9,6 @@
 
 import
   chronicles,
-  eth/keys,
   ./gossip_processing/light_client_processor,
   ./networking/[eth2_network, topic_params],
   ./spec/datatypes/altair,

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -10,10 +10,10 @@
 import
   std/[os, strutils],
   chronicles, stew/shims/net, stew/results,
-  eth/keys, eth/p2p/discoveryv5/[enr, protocol, node],
+  eth/p2p/discoveryv5/[enr, protocol, node],
   ".."/[conf, conf_light_client]
 
-export protocol, keys
+export protocol
 
 type
   Eth2DiscoveryProtocol* = protocol.Protocol

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -13,7 +13,6 @@ import
   metrics, metrics/chronos_httpserver,
   stew/[byteutils, io2],
   eth/p2p/discoveryv5/[enr, random2],
-  eth/keys,
   ./consensus_object_pools/blob_quarantine,
   ./consensus_object_pools/vanity_logs/vanity_logs,
   ./networking/topic_params,
@@ -2008,7 +2007,7 @@ proc doSlashingInterchange(conf: BeaconNodeConf) {.raises: [Defect, CatchableErr
 proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [Defect, CatchableError].} =
   # Single RNG instance for the application - will be seeded on construction
   # and avoid using system resources (such as urandom) after that
-  let rng = keys.newRng()
+  let rng = HmacDrbgContext.new()
 
   case config.cmd
   of BNStartUpCmd.noCommand: doRunBeaconNode(config, rng)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -8,7 +8,7 @@
 import
   std/os,
   chronicles, chronos, stew/io2,
-  eth/db/kvstore_sqlite3, eth/keys,
+  eth/db/kvstore_sqlite3,
   ./el/el_manager,
   ./gossip_processing/optimistic_processor,
   ./networking/[topic_params, network_metadata],
@@ -79,7 +79,7 @@ programMain:
 
     genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
 
-    rng = keys.newRng()
+    rng = HmacDrbgContext.new()
     netKeys = getRandomNetKeys(rng[])
     network = createEth2Node(
       rng, config, netKeys, cfg,

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 import
   stew/io2, presto, metrics, metrics/chronos_httpserver,
-  libp2p/crypto/crypto,
   ./rpc/rest_key_management_api,
   ./validator_client/[
     common, fallback_service, duties_service, fork_service, block_service,
@@ -512,7 +511,7 @@ programMain:
 
     # Single RNG instance for the application - will be seeded on construction
     # and avoid using system resources (such as urandom) after that
-    rng = crypto.newRng()
+    rng = HmacDrbgContext.new()
 
   setupLogging(config.logLevel, config.logStdout, config.logFile)
   waitFor runValidatorClient(config, rng)

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -11,7 +11,7 @@ import
   std/[os, strutils, terminal, wordwrap, unicode],
   chronicles, chronos, json_serialization, zxcvbn,
   bearssl/rand,
-  serialization, blscurve, eth/common/eth_types, eth/keys, confutils,
+  serialization, blscurve, eth/common/eth_types, confutils,
   nimbus_security_resources,
   ".."/spec/[eth2_merkleization, keystore, crypto],
   ".."/spec/datatypes/base,

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -21,7 +21,7 @@ import
   chronicles, chronicles/timings,
   json_serialization/std/[options, sets, net],
   eth/db/kvstore,
-  eth/keys, eth/p2p/discoveryv5/[protocol, enr],
+  eth/p2p/discoveryv5/[protocol, enr],
   web3/ethtypes,
 
   # Local modules

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -1,6 +1,6 @@
 import
   std/os,
-  confutils, eth/keys,
+  confutils, 
   ../beacon_chain/validators/keystore_management,
   ../beacon_chain/spec/[keystore, crypto],
   ../beacon_chain/conf
@@ -58,9 +58,8 @@ proc main =
     error "The specified treshold must be lower or equal to the number of signers"
     quit 1
 
-  var
-    rng = keys.newRng()
-    rngCtx = rng[]
+  let rng = HmacDrbgContext.new()
+  template rngCtx: untyped = rng[]
 
   let
     validatorsDir = conf.validatorsDir

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -1,6 +1,13 @@
+# beacon_chain
+# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/os,
-  confutils, 
+  confutils,
   ../beacon_chain/validators/keystore_management,
   ../beacon_chain/spec/[keystore, crypto],
   ../beacon_chain/conf

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -523,7 +523,7 @@ proc main() {.async.} =
   except Exception as exc: # TODO fix confutils
     raiseAssert exc.msg
 
-  let rng = keys.newRng()
+  let rng = HmacDrbgContext.new()
 
   if conf.cmd == StartUpCommand.generateDeposits:
     let
@@ -589,7 +589,7 @@ proc main() {.async.} =
 
   case conf.cmd
   of StartUpCommand.createTestnet:
-    let rng = keys.newRng()
+    let rng = HmacDrbgContext.new()
     doCreateTestnet(conf, rng[])
 
   of StartUpCommand.deployDepositContract:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -10,7 +10,7 @@
 import
   # Status libraries
   stew/results, chronicles,
-  eth/keys, taskpools,
+  taskpools,
   # Internals
   ../../beacon_chain/spec/[helpers, forks, state_transition_block],
   ../../beacon_chain/spec/datatypes/[
@@ -348,9 +348,10 @@ proc doRunTest(path: string, fork: ConsensusFork) =
     of ConsensusFork.Phase0:
       initialLoad(path, db, phase0.BeaconState, phase0.BeaconBlock)
 
-  var
+  let
+    rng = HmacDrbgContext.new()
     taskpool = Taskpool.new()
-    verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+  var verifier = BatchVerifier(rng: rng, taskpool: taskpool)
 
   let steps = loadOps(path, fork)
   var time = stores.fkChoice.checkpoints.time

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -2,12 +2,11 @@
 
 import
   unittest2,
-  eth/keys,
   ../beacon_chain/validators/action_tracker
 
 suite "subnet tracker":
   setup:
-    let rng = keys.newRng()
+    let rng = HmacDrbgContext.new()
 
   test "should register stability subnets on attester duties":
     var tracker = ActionTracker.init(rng, false)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -13,7 +13,7 @@ import
   unittest2,
   chronicles, chronos,
   stew/byteutils,
-  eth/keys, taskpools,
+  taskpools,
   # Internal
   ../beacon_chain/gossip_processing/[gossip_validation],
   ../beacon_chain/fork_choice/[fork_choice_types, fork_choice],
@@ -58,13 +58,14 @@ suite "Attestation pool processing" & preset():
 
   setup:
     # Genesis state that results in 6 members per committee
+    let rng = HmacDrbgContext.new()
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(
         ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 6),
         validatorMonitor, {})
       taskpool = Taskpool.new()
-      verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+      verifier = BatchVerifier(rng: rng, taskpool: taskpool)
       quarantine = newClone(Quarantine.init())
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -36,7 +36,7 @@ const noSyncnetsPreference = SyncnetBits()
 
 procSuite "Eth2 specific discovery tests":
   let
-    rng = keys.newRng()
+    rng = HmacDrbgContext.new()
     enrForkId = ENRForkID(
       fork_digest: ForkDigest([byte 0, 1, 2, 3]),
       next_fork_version: Version([byte 0, 0, 0, 0]),

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -13,7 +13,7 @@ import
   # Status lib
   unittest2,
   chronos,
-  eth/keys, taskpools,
+  taskpools,
   # Internal
   ../beacon_chain/[beacon_clock],
   ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
@@ -36,20 +36,21 @@ proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
 suite "Gossip validation " & preset():
   setup:
     # Genesis state that results in 3 members per committee
+    let rng = HmacDrbgContext.new()
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(
         ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3),
         validatorMonitor, {})
       taskpool = Taskpool.new()
-      verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+      verifier = BatchVerifier(rng: rng, taskpool: taskpool)
       quarantine = newClone(Quarantine.init())
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()
       info = ForkedEpochInfo()
       batchCrypto = BatchCrypto.new(
-        keys.newRng(), eager = proc(): bool = false,
+        rng, eager = proc(): bool = false,
         genesis_validators_root = dag.genesis_validators_root, taskpool)
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check:
@@ -187,8 +188,9 @@ suite "Gossip validation - Extra": # Not based on preset config
         cfg
       taskpool = Taskpool.new()
       quarantine = newClone(Quarantine.init())
+      rng = HmacDrbgContext.new()
     var
-      verifier = BatchVerifier(rng: keys.newRng(), taskpool: Taskpool.new())
+      verifier = BatchVerifier(rng: rng, taskpool: Taskpool.new())
       dag = block:
         let
           validatorMonitor = newClone(ValidatorMonitor.init())
@@ -220,7 +222,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         dag
 
     let batchCrypto = BatchCrypto.new(
-      keys.newRng(), eager = proc(): bool = false,
+      rng, eager = proc(): bool = false,
       genesis_validators_root = dag.genesis_validators_root, taskpool)
 
     var
@@ -243,8 +245,7 @@ suite "Gossip validation - Extra": # Not based on preset config
         slot, state[].latest_block_root)
       msg = resMsg.get()
 
-      syncCommitteePool = newClone(
-        SyncCommitteeMsgPool.init(keys.newRng(), cfg))
+      syncCommitteePool = newClone(SyncCommitteeMsgPool.init(rng, cfg))
       res = waitFor validateSyncCommitteeMessage(
         dag, quarantine, batchCrypto, syncCommitteePool,
         msg, subcommitteeIdx, slot.start_beacon_time(), true)

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -9,7 +9,7 @@
 
 import
   std/[typetraits, sequtils],
-  unittest2, eth/keys, stew/byteutils,
+  unittest2, stew/byteutils,
   ../beacon_chain/spec/[crypto, keystore],
   ./testutil
 
@@ -24,7 +24,7 @@ suite "Key spliting":
     password = string.fromBytes hexToSeqByte("7465737470617373776f7264f09f9491")
     salt = hexToSeqByte "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
     iv = hexToSeqByte "264daa3f303d7259501c93d997d84fe6"
-    rng = keys.newRng()
+    rng = HmacDrbgContext.new()
     msg = rng[].generateBytes(32)
 
   test "single share":

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -10,7 +10,7 @@
 import
   std/[typetraits, os, options, json, sequtils, uri, algorithm],
   testutils/unittests, chronicles, stint, json_serialization, confutils,
-  chronos, eth/keys, blscurve, libp2p/crypto/crypto as lcrypto,
+  chronos, blscurve, libp2p/crypto/crypto as lcrypto,
   stew/[byteutils, io2], stew/shims/net,
 
   ../beacon_chain/spec/[crypto, keystore, eth2_merkleization],
@@ -121,7 +121,7 @@ func contains*(keylist: openArray[KeystoreInfo], key: string): bool =
 
 proc prepareNetwork =
   let
-    rng = keys.newRng()
+    rng = HmacDrbgContext.new()
     mnemonic = generateMnemonic(rng[])
     seed = getSeed(mnemonic, KeystorePass.init "")
     cfg = defaultRuntimeConfig
@@ -271,7 +271,7 @@ proc addPreTestRemoteKeystores(validatorsDir: string) =
       quit 1
 
 proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
-  let rng = keys.newRng()
+  let rng = HmacDrbgContext.new()
 
   copyHalfValidators(nodeDataDir, true)
   addPreTestRemoteKeystores(nodeValidatorsDir)
@@ -309,7 +309,7 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   # os.removeDir dataDir
 
 proc startValidatorClient(basePort: int) {.async, thread.} =
-  let rng = keys.newRng()
+  let rng = HmacDrbgContext.new()
 
   copyHalfValidators(vcDataDir, false)
   addPreTestRemoteKeystores(vcValidatorsDir)
@@ -390,7 +390,7 @@ func `==`(a: seq[ValidatorPubKey],
 proc runTests(keymanager: KeymanagerToTest) {.async.} =
   let
     client = RestClientRef.new(initTAddress("127.0.0.1", keymanager.port))
-    rng = keys.newRng()
+    rng = HmacDrbgContext.new()
     privateKey = ValidatorPrivKey.fromRaw(secretBytes).get
 
     allValidators = listLocalValidators(

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -10,7 +10,7 @@
 import
   std/[json, typetraits],
   unittest2,
-  stew/byteutils, blscurve, eth/keys, json_serialization,
+  stew/byteutils, blscurve, json_serialization,
   libp2p/crypto/crypto as lcrypto,
   ../beacon_chain/spec/[crypto, keystore],
   ./testutil
@@ -268,7 +268,7 @@ const
   iv = hexToSeqByte "264daa3f303d7259501c93d997d84fe6"
 
 let
-  rng = keys.newRng()
+  rng = HmacDrbgContext.new()
 
 suite "KeyStorage testing suite":
   setup:
@@ -472,4 +472,3 @@ suite "eth2.0-deposits-cli compatibility":
 
       v3SK.toHex == "1445cec3861d7cbf80e409d79aeee131622dcb0c815ff97ceab2515e14c41a1a"
       v3WK.toHex == "1ccd5dce4c842bd3f65bbd59a382662e689fcf01ddc39aaaf2dcc7d073f11a93"
-

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -10,7 +10,7 @@
 import
   std/[os, options, json, typetraits, uri, algorithm],
   unittest2, chronos, chronicles, stint, json_serialization,
-  blscurve, eth/keys,
+  blscurve,
   libp2p/crypto/crypto as lcrypto,
   stew/[io2, byteutils],
   ../beacon_chain/filepath,
@@ -44,7 +44,7 @@ proc contentEquals(filePath, expectedContent: string): bool =
   expectedContent == readAll(file)
 
 let
-  rng = keys.newRng()
+  rng = HmacDrbgContext.new()
   mnemonic = generateMnemonic(rng[])
   seed = getSeed(mnemonic, KeystorePass.init "")
   cfg = defaultRuntimeConfig

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -9,7 +9,7 @@
 
 import
   # Status libraries
-  eth/keys, taskpools,
+  taskpools,
   # Beacon chain internals
   ../beacon_chain/consensus_object_pools/
     [block_clearance, block_quarantine, blockchain_dag],
@@ -94,8 +94,9 @@ suite "Light client" & preset():
           serve: true,
           importMode: LightClientDataImportMode.OnlyNew))
       quarantine = newClone(Quarantine.init())
+      rng = HmacDrbgContext.new()
       taskpool = Taskpool.new()
-    var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+    var verifier = BatchVerifier(rng: rng, taskpool: taskpool)
 
   test "Pre-Altair":
     # Genesis

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -9,7 +9,7 @@
 
 import
   # Status libraries
-  chronos, eth/keys,
+  chronos,
   # Beacon chain internals
   ../beacon_chain/consensus_object_pools/
     [block_clearance, block_quarantine, blockchain_dag],
@@ -42,8 +42,9 @@ suite "Light client processor" & preset():
         serve: true,
         importMode: LightClientDataImportMode.OnlyNew))
     quarantine = newClone(Quarantine.init())
+    rng = HmacDrbgContext.new()
     taskpool = Taskpool.new()
-  var verifier = BatchVerifier(rng: keys.newRng(), taskpool: taskpool)
+  var verifier = BatchVerifier(rng: rng, taskpool: taskpool)
 
   var cache: StateCache
   proc addBlocks(blocks: uint64, syncCommitteeRatio: float) =

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -9,7 +9,6 @@
 
 import
   unittest2,
-  eth/keys,
   ../beacon_chain/spec/[beaconstate, helpers, signatures],
   ../beacon_chain/consensus_object_pools/sync_committee_msg_pool,
   ./testblockutil
@@ -23,12 +22,14 @@ func aggregate(sigs: openArray[CookedSig]): CookedSig =
 
 suite "Sync committee pool":
   setup:
-    let cfg = block:
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = 0.Epoch
-      res.BELLATRIX_FORK_EPOCH = 20.Epoch
-      res
-    var pool = SyncCommitteeMsgPool.init(keys.newRng(), cfg)
+    let
+      rng = HmacDrbgContext.new()
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = 0.Epoch
+        res.BELLATRIX_FORK_EPOCH = 20.Epoch
+        res
+    var pool = SyncCommitteeMsgPool.init(rng, cfg)
 
   test "An empty pool is safe to use":
     let headBid =

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -7,7 +7,6 @@
 
 import
   chronicles,
-  eth/keys,
   stew/endians2,
   ../beacon_chain/consensus_object_pools/sync_committee_msg_pool,
   ../beacon_chain/spec/datatypes/bellatrix,
@@ -423,7 +422,8 @@ proc makeSyncAggregate(
       getStateField(state, slot)
     latest_block_id =
       withState(state): forkyState.latest_block_id
-    syncCommitteePool = newClone(SyncCommitteeMsgPool.init(keys.newRng(), cfg))
+    rng = HmacDrbgContext.new()
+    syncCommitteePool = newClone(SyncCommitteeMsgPool.init(rng, cfg))
 
   type
     Aggregator = object


### PR DESCRIPTION
We have several modules that import `nim-eth` for the sole purpose of its `keys.newRng` function. This function is meanwhile a simple wrapper around `nim-bearssl`'s `HmacDrbgContext.new()`, so the import doesn't really serve a use anymore. Replace `keys.newRng` with the direct call to reduce `nim-eth` imports.