### PR TITLE
VC: Use scoring function to select best attestation data when using multiple BNs.

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -575,9 +575,10 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Validator Client test suite
 ```diff
++ getAttestationDataScore() test vectors                                                     OK
 + normalizeUri() test vectors                                                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Validator change pool testing suite
 ```diff
 + addValidatorChangeMessage/getAttesterSlashingMessage                                       OK
@@ -688,4 +689,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 389/394 Fail: 0/394 Skip: 5/394
+OK: 390/395 Fail: 0/395 Skip: 5/395

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -391,6 +391,12 @@ template bestSuccess*(
                   else:
                     scores.add(ApiScore.init(node))
 
+              if perfectScoreFound:
+                # lazyWait will cancel `pendingRequests` on timeout.
+                asyncSpawn lazyWait(pendingNodes, pendingRequests, timerFut,
+                                    RequestName, strategy)
+                break innerLoop
+
               if not(isNil(timerFut)) and timerFut.finished():
                 # If timeout is exceeded we need to cancel all the tasks which
                 # are still running.
@@ -401,13 +407,8 @@ template bestSuccess*(
                 await allFutures(pendingCancel)
                 break innerLoop
 
-              if perfectScoreFound:
-                asyncSpawn lazyWait(pendingNodes, pendingRequests, timerFut,
-                                    RequestName, strategy)
-                break innerLoop
-              else:
-                pendingRequests.keepItIf(it notin finishedRequests)
-                pendingNodes.keepItIf(it notin finishedNodes)
+              pendingRequests.keepItIf(it notin finishedRequests)
+              pendingNodes.keepItIf(it notin finishedNodes)
 
             except CancelledError as exc:
               var pendingCancel: seq[Future[void]]

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -5,10 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import chronicles
+import std/strutils
+import chronicles, stew/base10
 import ../spec/eth2_apis/eth2_rest_serialization,
        ../spec/datatypes/[phase0, altair]
-import common, fallback_service
+import common, fallback_service, scoring
 
 export eth2_rest_serialization, common
 
@@ -35,11 +36,39 @@ type
     status*: ApiOperation
     data*: seq[ApiNodeResponse[T]]
 
+  ApiScore* = object
+    index*: int
+    score*: Opt[float64]
+
 const
   ViableNodeStatus = {RestBeaconNodeStatus.Compatible,
                       RestBeaconNodeStatus.NotSynced,
                       RestBeaconNodeStatus.OptSynced,
                       RestBeaconNodeStatus.Synced}
+
+proc `$`*(s: ApiScore): string =
+  var res = Base10.toString(uint64(s.index))
+  res.add(": ")
+  if s.score.isSome():
+    res.add(formatFloat(s.score.get(), ffDecimal, 4))
+  else:
+    res.add("<n/a>")
+  res
+
+proc `$`*(ss: openArray[ApiScore]): string =
+  "[" & ss.mapIt($it).join(",") & "]"
+
+chronicles.formatIt(seq[ApiScore]):
+  $it
+
+chronicles.formatIt(Opt[ApiScore]):
+  if it.isSome(): formatFloat(it.get(), ffDecimal, 4) else: "<n/a>"
+
+func init*(t: typedesc[ApiScore], index: int, score: float64): ApiScore =
+  ApiScore(index: index, score: Opt.some(score))
+
+func init*(t: typedesc[ApiScore], index: int): ApiScore =
+  ApiScore(index: index, score: Opt.none(float64))
 
 proc lazyWaiter(node: BeaconNodeServerRef, request: FutureBase,
                 requestName: string, strategy: ApiStrategyKind) {.async.} =
@@ -213,7 +242,7 @@ template firstSuccessParallel*(
             pendingCancel.add(raceFut.cancelAndWait())
           if not(isNil(timerFut)) and not(timerFut.finished()):
             pendingCancel.add(timerFut.cancelAndWait())
-          for index, future in pendingRequests.pairs():
+          for future in pendingRequests.items():
             if not(future.finished()):
               pendingCancel.add(future.cancelAndWait())
           await allFutures(pendingCancel)
@@ -236,13 +265,16 @@ template firstSuccessParallel*(
 template bestSuccess*(
            vc: ValidatorClientRef,
            responseType: typedesc,
+           handlerType: typedesc,
            timeout: Duration,
            statuses: set[RestBeaconNodeStatus],
            roles: set[BeaconNodeRole],
            bodyRequest,
-           bodyScore: untyped): ApiResponse[responseType] =
-  var it {.inject.}: RestClientRef
-  type BodyType = typeof(bodyRequest)
+           bodyScore,
+           bodyHandler: untyped): ApiResponse[handlerType] =
+  var
+    it {.inject.}: RestClientRef
+    iterations = 0
 
   var timerFut =
     if timeout != InfiniteDuration:
@@ -250,114 +282,163 @@ template bestSuccess*(
     else:
       nil
 
-  let onlineNodes =
-    try:
-      await vc.waitNodes(timerFut, statuses, roles, false)
-      vc.filterNodes(statuses, roles)
-    except CancelledError as exc:
-      if not(isNil(timerFut)) and not(timerFut.finished()):
-        await timerFut.cancelAndWait()
-      raise exc
-    except CatchableError as exc:
-      # This case could not be happened.
-      error "Unexpected exception while waiting for beacon nodes",
-            err_name = $exc.name, err_msg = $exc.msg
-      var default: seq[BeaconNodeServerRef]
-      default
+  var
+    retRes: ApiResponse[handlerType]
+    scores: seq[ApiScore]
+    bestScore: Opt[float64]
+    bestNode: Opt[BeaconNodeServerRef]
 
-  if len(onlineNodes) == 0:
-    ApiResponse[responseType].err("No online beacon node(s)")
-  else:
-    let
-      (pendingRequests, pendingNodes) =
-        block:
-          var requests: seq[BodyType]
-          var nodes: seq[BeaconNodeServerRef]
-          for node {.inject.} in onlineNodes:
-            it = node.client
-            let fut = bodyRequest
-            requests.add(fut)
-            nodes.add(node)
-          (requests, nodes)
+  while true:
+    var resultReady = false
+    let onlineNodes =
+      try:
+        if iterations == 0:
+          # We are not going to wait for BNs if there some available.
+          await vc.waitNodes(timerFut, statuses, roles, false)
+        else:
+          # We get here only, if all the requests are failed. To avoid requests
+          # spam we going to wait for changes in BNs statuses.
+          await vc.waitNodes(timerFut, statuses, roles, true)
+        vc.filterNodes(statuses, roles)
+      except CancelledError as exc:
+        if not(isNil(timerFut)) and not(timerFut.finished()):
+          await timerFut.cancelAndWait()
+        raise exc
+      except CatchableError as exc:
+        # This case could not be happened.
+        error "Unexpected exception while waiting for beacon nodes",
+              err_name = $exc.name, err_msg = $exc.msg
+        var default: seq[BeaconNodeServerRef]
+        default
 
-      status =
-        try:
-          if isNil(timerFut):
-            await allFutures(pendingRequests)
-            ApiOperation.Success
-          else:
-            let waitFut = allFutures(pendingRequests)
-            discard await race(waitFut, timerFut)
-            if not(waitFut.finished()):
-              await waitFut.cancelAndWait()
-              ApiOperation.Timeout
-            else:
-              if not(timerFut.finished()):
-                await timerFut.cancelAndWait()
-              ApiOperation.Success
-        except CancelledError as exc:
-          # We should cancel all the pending requests and timer before we return
-          # result.
-          var pendingCancel: seq[Future[void]]
-          for future in pendingRequests:
-            if not(fut.finished()):
-              pendingCancel.add(fut.cancelAndWait())
-          if not(isNil(timerFut)) and not(timerFut.finished()):
-            pendingCancel.add(timerFut.cancelAndWait())
-          await allFutures(pendingCancel)
-          raise exc
-        except CatchableError:
-          # This should not be happened, because allFutures() and race() did not
-          # raise any exceptions.
-          ApiOperation.Failure
-
-      apiResponses {.inject.} =
-        block:
-          var res: seq[ApiNodeResponse[responseType]]
-          for requestFut, pnode in pendingRequests.pairs():
-            let beaconNode = pendingNodes[index]
-            if requestFut.finished():
-              if requestFut.failed():
-                let exc = requestFut.readError()
-                debug "One of operation requests has been failed",
-                      node = beaconNode, err_name = $exc.name,
-                      err_msg = $exc.msg
-                beaconNode.status.updateStatus(RestBeaconNodeStatus.Offline)
-              elif future.cancelled():
-                debug "One of operation requests has been interrupted",
-                      node = beaconNode
-              else:
-                res.add(
-                  ApiNodeResponse(
-                    node: beaconNode,
-                    data: ApiResponse[responseType].ok(future.read())
-                  )
-                )
-            else:
-              case status
-              of ApiOperation.Timeout:
-                debug "One of operation requests has been timed out",
-                      node = beaconNode
-                pendingNodes[index].status = RestBeaconNodeStatus.Offline
-              of ApiOperation.Success, ApiOperation.Failure,
-                 ApiOperation.Interrupt:
-                 # This should not be happened, because all Futures should be
-                 # finished.
-                debug "One of operation requests failed unexpectedly",
-                      node = beaconNode
-                pendingNodes[index].status = RestBeaconNodeStatus.Offline
-          res
-
-    if len(apiResponses) == 0:
-      ApiResponse[responseType].err("No successful responses available")
+    if len(onlineNodes) == 0:
+      retRes = ApiResponse[handlerType].err("No online beacon node(s)")
+      resultReady = true
     else:
-      let index = bestScore
-      if index >= 0:
-        debug "Operation request result was selected",
-              node = apiResponses[index].node
-        apiResponses[index].data
-      else:
-        ApiResponse[responseType].err("Unable to get best response")
+      var
+        (pendingRequests, pendingNodes) =
+          block:
+            var requests: seq[FutureBase]
+            var nodes: seq[BeaconNodeServerRef]
+            for node {.inject.} in onlineNodes:
+              it = node.client
+              let fut = FutureBase(bodyRequest)
+              requests.add(fut)
+              nodes.add(node)
+            (requests, nodes)
+        bestResponse: ApiResponse[handlerType]
+        allFut: Future[void]
+
+      try:
+        if len(pendingRequests) == 0:
+          if not(isNil(timerFut)) and not(timerFut.finished()):
+            await timerFut.cancelAndWait()
+          retRes = ApiResponse[handlerType].err(
+            "Beacon node(s) unable to satisfy request")
+          resultReady = true
+          break
+        else:
+          allFut = allFutures(pendingRequests)
+
+          if isNil(timerFut):
+            await allFut or timerFut
+          else:
+            await allFut
+
+          for index, future in pendingRequests.pairs():
+            let
+              node {.inject.} = pendingNodes[index]
+              apiResponse {.inject.} =
+                if future.finished():
+                  if future.failed():
+                    ApiResponse[responseType].err($future.error.msg)
+                  else:
+                    ApiResponse[responseType].ok(
+                      Future[responseType](future).read())
+                else:
+                  doAssert(timerFut.finished())
+                  ApiResponse[responseType].err(
+                    "Timeout exceeded while awaiting for the response")
+              handlerResponse =
+                try:
+                  bodyHandler
+                except CancelledError as exc:
+                  raise exc
+                except CatchableError:
+                  raiseAssert("Response handler must not raise exceptions")
+
+            if apiResponse.isOk() and handlerResponse.isOk():
+              let
+                itresponse {.inject.} = handlerResponse.get()
+                score =
+                  try:
+                    bodyScore
+                  except CancelledError as exc:
+                    raise exc
+                  except CatchableError:
+                    raiseAssert("Score handler must not raise exceptions")
+
+              scores.add(ApiScore.init(index, score))
+
+              if bestScore.isNone():
+                bestScore = Opt.some(score)
+                bestNode = Opt.some(node)
+                bestResponse = handlerResponse
+              else:
+                if score > bestScore.get():
+                  bestScore = Opt.some(score)
+                  bestNode = Opt.some(node)
+                  bestResponse = handlerResponse
+            else:
+              scores.add(ApiScore.init(index))
+
+          if timerFut.finished():
+            # If timeout is exceeded we need to cancel all the tasks which are
+            # still running.
+            var pendingCancel: seq[Future[void]]
+            for future in pendingRequests.items():
+              if not(future.finished()):
+                pendingCancel.add(future.cancelAndWait())
+            await allFutures(pendingCancel)
+            retRes = ApiResponse[handlerType].err(
+              "Timeout exceeded while awaiting for responses")
+            resultReady = true
+
+          # When all requests failed, bestScore will not be set.
+          if bestScore.isSome():
+            retRes = bestResponse
+            resultReady = true
+
+      except CancelledError as exc:
+        var pendingCancel: seq[Future[void]]
+        if not(isNil(allFut)) and not(allFut.finished()):
+          pendingCancel.add(allFut.cancelAndWait())
+        if not(isNil(timerFut)) and not(timerFut.finished()):
+            pendingCancel.add(timerFut.cancelAndWait())
+        for future in pendingRequests.items():
+          if not(future.finished()):
+            pendingCancel.add(future.cancelAndWait())
+        await allFutures(pendingCancel)
+        raise exc
+      except CatchableError as exc:
+        # This should not be happened, because allFutures() and race() did not
+        # raise any exceptions.
+        error "Unexpected exception while processing request",
+              err_name = $exc.name, err_msg = $exc.msg
+        retRes = ApiResponse[handlerType].err("Unexpected error")
+        resultReady = true
+
+    if resultReady:
+      break
+
+    inc(iterations)
+
+  if retRes.isOk():
+    notice "Best score result selected",
+          request = RequestName, scores = scores, best_score = bestScore,
+          best_node = bestNode.get()
+
+  retRes
 
 template onceToAll*(
            vc: ValidatorClientRef,
@@ -1225,7 +1306,7 @@ proc produceAttestationData*(
   var failures: seq[ApiNodeFailure]
 
   case strategy
-  of ApiStrategyKind.First, ApiStrategyKind.Best:
+  of ApiStrategyKind.First:
     let res = vc.firstSuccessParallel(
       RestPlainResponse,
       ProduceAttestationDataResponse,
@@ -1262,6 +1343,47 @@ proc produceAttestationData*(
           ApiResponse[ProduceAttestationDataResponse].err(
             ResponseUnexpectedError)
 
+    if res.isErr():
+      raise (ref ValidatorApiError)(msg: res.error, data: failures)
+    return res.get().data
+
+  of ApiStrategyKind.Best:
+    let res = vc.bestSuccess(
+      RestPlainResponse,
+      ProduceAttestationDataResponse,
+      OneThirdDuration,
+      ViableNodeStatus,
+      {BeaconNodeRole.AttestationData},
+      produceAttestationDataPlain(it, slot, committee_index),
+      getAttestationDataScore(vc, itresponse)):
+      if apiResponse.isErr():
+        handleCommunicationError()
+        ApiResponse[ProduceAttestationDataResponse].err(apiResponse.error)
+      else:
+        let response = apiResponse.get()
+        case response.status
+        of 200:
+          let res = decodeBytes(ProduceAttestationDataResponse, response.data,
+                                response.contentType)
+          if res.isErr():
+            handleUnexpectedData()
+            ApiResponse[ProduceAttestationDataResponse].err($res.error)
+          else:
+            ApiResponse[ProduceAttestationDataResponse].ok(res.get())
+        of 400:
+          handle400()
+          ApiResponse[ProduceAttestationDataResponse].err(ResponseInvalidError)
+        of 500:
+          handle500()
+          ApiResponse[ProduceAttestationDataResponse].err(ResponseInternalError)
+        of 503:
+          handle503()
+          ApiResponse[ProduceAttestationDataResponse].err(
+            ResponseNoSyncError)
+        else:
+          handleUnexpectedCode()
+          ApiResponse[ProduceAttestationDataResponse].err(
+            ResponseUnexpectedError)
     if res.isErr():
       raise (ref ValidatorApiError)(msg: res.error, data: failures)
     return res.get().data

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -154,8 +154,7 @@ template firstSuccessParallel*(
         # This case could not be happened.
         error "Unexpected exception while waiting for beacon nodes",
               err_name = $exc.name, err_msg = $exc.msg
-        var default: seq[BeaconNodeServerRef]
-        default
+        default(seq[BeaconNodeServerRef])
 
     if len(onlineNodes) == 0:
       retRes = ApiResponse[handlerType].err("No online beacon node(s)")
@@ -236,7 +235,7 @@ template firstSuccessParallel*(
                 except CatchableError:
                   raiseAssert("Response handler must not raise exceptions")
 
-            if apiResponse.isOk() and handlerResponse.isOk():
+            if handlerResponse.isOk():
               retRes = handlerResponse
               resultReady = true
               asyncSpawn lazyWait(pendingNodes, pendingRequests, timerFut,
@@ -314,8 +313,7 @@ template bestSuccess*(
           # This case could not be happened.
           error "Unexpected exception while waiting for beacon nodes",
                 err_name = $exc.name, err_msg = $exc.msg
-          var default: seq[BeaconNodeServerRef]
-          default
+          default(seq[BeaconNodeServerRef])
 
       if len(onlineNodes) == 0:
         retRes = ApiResponse[handlerType].err("No online beacon node(s)")
@@ -377,7 +375,7 @@ template bestSuccess*(
                         raiseAssert(
                           "Response handler must not raise exceptions")
 
-                  if apiResponse.isOk() and handlerResponse.isOk():
+                  if handlerResponse.isOk():
                     let
                       itresponse {.inject.} = handlerResponse.get()
                       score =

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -434,9 +434,9 @@ template bestSuccess*(
     inc(iterations)
 
   if retRes.isOk():
-    notice "Best score result selected",
-          request = RequestName, scores = scores, best_score = bestScore,
-          best_node = bestNode.get()
+    debug "Best score result selected",
+          request = RequestName, available_scores = scores,
+          best_score = bestScore.get(), best_node = bestNode.get()
 
   retRes
 

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -61,8 +61,8 @@ proc `$`*(ss: openArray[ApiScore]): string =
 chronicles.formatIt(seq[ApiScore]):
   $it
 
-chronicles.formatIt(Opt[ApiScore]):
-  if it.isSome(): formatFloat(it.get(), ffDecimal, 4) else: "<n/a>"
+func shortLog(oas: Opt[float64]): string =
+  if oas.isSome(): formatFloat(oas.get(), ffDecimal, 4) else: "<n/a>"
 
 func init*(t: typedesc[ApiScore], index: int, score: float64): ApiScore =
   ApiScore(index: index, score: Opt.some(score))
@@ -436,7 +436,7 @@ template bestSuccess*(
   if retRes.isOk():
     debug "Best score result selected",
           request = RequestName, available_scores = scores,
-          best_score = bestScore.get(), best_node = bestNode.get()
+          best_score = shortLog(bestScore), best_node = bestNode.get()
 
   retRes
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1208,14 +1208,14 @@ proc expectBlock*(vc: ValidatorClientRef, slot: Slot,
   if not(retFuture.finished()): retFuture.cancelCallback = cancellation
   retFuture
 
-proc registerBlock*(vc: ValidatorClientRef, data: EventBeaconBlockObject,
+proc registerBlock*(vc: ValidatorClientRef, eblck: EventBeaconBlockObject,
                     node: BeaconNodeServerRef) =
   let
     wallTime = vc.beaconClock.now()
-    delay = wallTime - edata.slot.start_beacon_time()
+    delay = wallTime - eblck.slot.start_beacon_time()
 
-  debug "Block received", slot = data.slot,
-        block_root = shortLog(data.block_root), optimistic = data.optimistic,
+  debug "Block received", slot = eblck.slot,
+        block_root = shortLog(eblck.block_root), optimistic = eblck.optimistic,
         node = node, delay = delay
 
   proc scheduleCallbacks(data: var BlockDataItem,
@@ -1226,7 +1226,7 @@ proc registerBlock*(vc: ValidatorClientRef, data: EventBeaconBlockObject,
       if mitem.count >= len(data.blocks):
         if not(mitem.future.finished()): mitem.future.complete(data.blocks)
 
-  vc.blocksSeen.mgetOrPut(edata.slot, BlockDataItem()).scheduleCallbacks(edata)
+  vc.blocksSeen.mgetOrPut(eblck.slot, BlockDataItem()).scheduleCallbacks(eblck)
 
 proc pruneBlocksSeen*(vc: ValidatorClientRef, epoch: Epoch) =
   var blocksSeen: Table[Slot, BlockDataItem]

--- a/beacon_chain/validator_client/scoring.nim
+++ b/beacon_chain/validator_client/scoring.nim
@@ -5,17 +5,9 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std/tables
-import metrics
-import ssz_serialization/types as sszTypes
-import ./common
-import ../spec/datatypes/[phase0, altair, bellatrix]
-import ../spec/forks
+import "."/common
 
 {.push raises: [].}
-
-type
-  BitsTable = Table[uint64, BitArray[int(MAX_VALIDATORS_PER_COMMITTEE)]]
 
 proc getAttestationDataScore*(vc: ValidatorClientRef,
                               adata: ProduceAttestationDataResponse): float64 =

--- a/beacon_chain/validator_client/scoring.nim
+++ b/beacon_chain/validator_client/scoring.nim
@@ -11,7 +11,7 @@ import "."/common
 {.push raises: [].}
 
 func perfectScore*(score: float64): bool =
-  if score == Inf: true else: false
+  score == Inf
 
 proc shortScore*(score: float64): string =
   if score == Inf: "<perfect>" else: formatFloat(score, ffDecimal, 4)

--- a/beacon_chain/validator_client/scoring.nim
+++ b/beacon_chain/validator_client/scoring.nim
@@ -22,18 +22,23 @@ proc getAttestationDataScore*(vc: ValidatorClientRef,
     slot = vc.rootsSeen.getOrDefault(
       adata.data.beacon_block_root, FAR_FUTURE_SLOT)
 
-  if (slot == adata.data.slot) and
-     (adata.data.source.epoch + 1 == adata.data.target.epoch):
-    # Perfect score
-    Inf
-  else:
-    let score = float64(adata.data.source.epoch) +
-                float64(adata.data.target.epoch)
-    if slot == FAR_FUTURE_SLOT:
-      score
+  let res =
+    if (slot == adata.data.slot) and
+       (adata.data.source.epoch + 1 == adata.data.target.epoch):
+      # Perfect score
+      Inf
     else:
-      if adata.data.slot + 1 == slot:
-        # To avoid `DivizionByZero` defect.
+      let score = float64(adata.data.source.epoch) +
+                  float64(adata.data.target.epoch)
+      if slot == FAR_FUTURE_SLOT:
         score
       else:
-        score + float64(1) / float64(adata.data.slot + 1 - slot)
+        if adata.data.slot + 1 == slot:
+          # To avoid `DivizionByZero` defect.
+          score
+        else:
+          score + float64(1) / float64(adata.data.slot + 1 - slot)
+
+  debug "Attestation score", attestation_data = shortLog(adata.data),
+        slot_result = slot, score = shortScore(res)
+  res

--- a/beacon_chain/validator_client/scoring.nim
+++ b/beacon_chain/validator_client/scoring.nim
@@ -1,0 +1,34 @@
+# beacon_chain
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import std/tables
+import metrics
+import ssz_serialization/types as sszTypes
+import ./common
+import ../spec/datatypes/[phase0, altair, bellatrix]
+import ../spec/forks
+
+{.push raises: [].}
+
+type
+  BitsTable = Table[uint64, BitArray[int(MAX_VALIDATORS_PER_COMMITTEE)]]
+
+proc getAttestationDataScore*(vc: ValidatorClientRef,
+                              adata: ProduceAttestationDataResponse): float64 =
+  let
+    slot = vc.rootsSeen.getOrDefault(
+      adata.data.beacon_block_root, FAR_FUTURE_SLOT)
+    score = float64(adata.data.source.epoch) + float64(adata.data.target.epoch)
+
+  if slot == FAR_FUTURE_SLOT:
+    score
+  else:
+    if adata.data.slot + 1 == slot:
+      # To avoid `DivizionByZero` defect.
+      score
+    else:
+      score + float64(1) / float64(adata.data.slot + 1 - slot)

--- a/tests/test_validator_client.nim
+++ b/tests/test_validator_client.nim
@@ -10,7 +10,7 @@
 
 import std/strutils
 import unittest2
-import ../beacon_chain/validator_client/common
+import ../beacon_chain/validator_client/[common, scoring]
 
 const
   HostNames = [
@@ -143,9 +143,110 @@ const
     ("", "err(Missing hostname)")
   ]
 
+type
+  AttestationDataTuple* = tuple[
+    slot: uint64,
+    index: uint64,
+    beacon_block_root: string,
+    source: uint64,
+    target: uint64
+  ]
+
+const
+  AttestationDataVectors = [
+    # Attestation score with block monitoring enabled (perfect).
+    ((6002798'u64, 10'u64, "22242212", 187586'u64, 187587'u64),
+     ("22242212", 6002798'u64), "<perfect>"),
+    ((6002811'u64, 24'u64, "26ec78d6", 187586'u64, 187587'u64),
+     ("26ec78d6", 6002811'u64), "<perfect>"),
+    ((6002821'u64, 11'u64, "10c6d1a2", 187587'u64, 187588'u64),
+     ("10c6d1a2", 6002821'u64), "<perfect>"),
+    ((6002836'u64, 15'u64, "42354ded", 187587'u64, 187588'u64),
+     ("42354ded", 6002836'u64), "<perfect>"),
+    ((6002859'u64, 10'u64, "97d8ac69", 187588'u64, 187589'u64),
+     ("97d8ac69", 6002859'u64), "<perfect>"),
+    # Attestation score with block monitoring enabled #1 (not perfect).
+    ((6002871'u64, 25'u64, "524a9e2b", 187588'u64, 187589'u64),
+     ("524a9e2b", 6002870'u64), "375177.5000"),
+    ((6002871'u64, 25'u64, "524a9e2b", 187588'u64, 187589'u64),
+     ("524a9e2b", 6002869'u64), "375177.3333"),
+    ((6002871'u64, 25'u64, "524a9e2b", 187588'u64, 187589'u64),
+     ("524a9e2b", 6002868'u64), "375177.2500"),
+    ((6002871'u64, 25'u64, "524a9e2b", 187588'u64, 187589'u64),
+     ("524a9e2b", 6002867'u64), "375177.2000"),
+    ((6002871'u64, 25'u64, "524a9e2b", 187588'u64, 187589'u64),
+     ("524a9e2b", 6002866'u64), "375177.1667"),
+    # Attestation score with block monitoring enabled #2 (not perfect).
+    ((6002962'u64, 14'u64, "22a19d87", 187591'u64, 187592'u64),
+     ("22a19d87", 6002961'u64), "375183.5000"),
+    ((6002962'u64, 14'u64, "22a19d87", 187591'u64, 187592'u64),
+     ("22a19d87", 6002960'u64), "375183.3333"),
+    ((6002962'u64, 14'u64, "22a19d87", 187591'u64, 187592'u64),
+     ("22a19d87", 6002959'u64), "375183.2500"),
+    ((6002962'u64, 14'u64, "22a19d87", 187591'u64, 187592'u64),
+     ("22a19d87", 6002958'u64), "375183.2000"),
+    ((6002962'u64, 14'u64, "22a19d87", 187591'u64, 187592'u64),
+     ("22a19d87", 6002957'u64), "375183.1667"),
+    # Attestation score with block monitoring disabled #1.
+    ((6003217'u64, 52'u64, "5e945218", 187599'u64, 187600'u64),
+     ("00000000", 0'u64), "375199.0000"),
+    ((6003217'u64, 52'u64, "5e945218", 187598'u64, 187600'u64),
+     ("00000000", 0'u64), "375198.0000"),
+    ((6003217'u64, 52'u64, "5e945218", 187597'u64, 187600'u64),
+     ("00000000", 0'u64), "375197.0000"),
+    ((6003217'u64, 52'u64, "5e945218", 187596'u64, 187600'u64),
+     ("00000000", 0'u64), "375196.0000"),
+    ((6003217'u64, 52'u64, "5e945218", 187595'u64, 187600'u64),
+     ("00000000", 0'u64), "375195.0000"),
+    # Attestation score with block monitoring disabled #2.
+    ((6003257'u64, 9'u64, "7bfa464e", 187600'u64, 187601'u64),
+     ("00000000", 0'u64), "375201.0000"),
+    ((6003257'u64, 9'u64, "7bfa464e", 187599'u64, 187601'u64),
+     ("00000000", 0'u64), "375200.0000"),
+    ((6003257'u64, 9'u64, "7bfa464e", 187598'u64, 187601'u64),
+     ("00000000", 0'u64), "375199.0000"),
+    ((6003257'u64, 9'u64, "7bfa464e", 187597'u64, 187601'u64),
+     ("00000000", 0'u64), "375198.0000"),
+    ((6003257'u64, 9'u64, "7bfa464e", 187596'u64, 187601'u64),
+     ("00000000", 0'u64), "375197.0000"),
+  ]
+
+proc init(t: typedesc[Eth2Digest], data: string): Eth2Digest =
+  let length = len(data)
+  var dst = Eth2Digest()
+  try:
+    hexToByteArray(data.toOpenArray(0, len(data) - 1),
+                   dst.data.toOpenArray(0, (length div 2) - 1))
+  except ValueError:
+    discard
+  dst
+
+proc init*(t: typedesc[ProduceAttestationDataResponse],
+           ad: AttestationDataTuple): ProduceAttestationDataResponse =
+  ProduceAttestationDataResponse(data: AttestationData(
+    slot: Slot(ad.slot), index: ad.index,
+    beacon_block_root: Eth2Digest.init(ad.beacon_block_root),
+    source: Checkpoint(epoch: Epoch(ad.source)),
+    target: Checkpoint(epoch: Epoch(ad.target))
+  ))
+
+proc createRootsSeen(
+       root: tuple[root: string, slot: uint64]): Table[Eth2Digest, Slot] =
+  var res: Table[Eth2Digest, Slot]
+  res[Eth2Digest.init(root.root)] = Slot(root.slot)
+  res
+
 suite "Validator Client test suite":
   test "normalizeUri() test vectors":
     for hostname in HostNames:
       for vector in GoodTestVectors:
         let expect = vector[1] % (hostname)
         check $normalizeUri(parseUri(vector[0] % (hostname))) == expect
+
+  test "getAttestationDataScore() test vectors":
+    for vector in AttestationDataVectors:
+      let
+        adata = ProduceAttestationDataResponse.init(vector[0])
+        roots = createRootsSeen(vector[1])
+        score = shortScore(roots.getAttestationDataScore(adata))
+      check score == vector[2]


### PR DESCRIPTION
With this PR our validator client (VC) will be able to select the best scored attestation data when using configurations with multiple beacon nodes.
To achieve maximum performance you should enable VC's block monitoring feature using `--block-monitor-type=poll` (polling BN's for latest head 3 times per slot) or `--block-monitor-type=event` (using BN's `/eth/v1/events` interface).

When block monitoring is enabled - VC will be able to obtain "perfect" score and continue attesting without waiting for responses from all the beacon nodes. Without this feature VC will wait for all BN responses and selects the best response using scoring algorithm.

"perfect score" - is score when `attestation data slot equal to block's slot` and `target epoch = source epoch + 1`.