### PR TITLE
extract LC sync task scheduling helper function

### DIFF
--- a/beacon_chain/sync/light_client_sync_helpers.nim
+++ b/beacon_chain/sync/light_client_sync_helpers.nim
@@ -11,7 +11,9 @@ import
   std/typetraits,
   chronos,
   stew/base10,
-  ../spec/[forks_light_client, network]
+  eth/p2p/discoveryv5/random2,
+  ../spec/[forks_light_client, network],
+  ../beacon_clock
 
 func checkLightClientUpdates*(
     updates: openArray[ForkedLightClientUpdate],
@@ -49,6 +51,15 @@ func checkLightClientUpdates*(
         return err("Invalid context bytes")
   ok()
 
+func isGossipSupported*(
+    period: SyncCommitteePeriod,
+    finalizedPeriod: SyncCommitteePeriod,
+    isNextSyncCommitteeKnown: bool): bool =
+  if isNextSyncCommitteeKnown:
+    period <= finalizedPeriod + 1
+  else:
+    period <= finalizedPeriod
+
 type
   LcSyncKind* {.pure.} = enum
     UpdatesByRange
@@ -64,9 +75,9 @@ type
       discard
 
 func nextLightClientSyncTask*(
+    current: SyncCommitteePeriod,
     finalized: SyncCommitteePeriod,
     optimistic: SyncCommitteePeriod,
-    current: SyncCommitteePeriod,
     isNextSyncCommitteeKnown: bool): LcSyncTask =
   if finalized == optimistic and not isNextSyncCommitteeKnown:
     if finalized >= current:
@@ -88,3 +99,41 @@ func nextLightClientSyncTask*(
     LcSyncTask(kind: LcSyncKind.FinalityUpdate)
   else:
     LcSyncTask(kind: LcSyncKind.OptimisticUpdate)
+
+func computeDelayWithJitter*(
+    rng: ref HmacDrbgContext, duration: Duration): Duration =
+  let
+    minDelay = max(duration div 8, chronos.seconds(10))
+    jitterSeconds = (minDelay * 2).seconds
+    jitterDelay = chronos.seconds(rng[].rand(jitterSeconds).int64)
+  minDelay + jitterDelay
+
+func nextLcSyncTaskDelay*(
+    rng: ref HmacDrbgContext,
+    wallTime: BeaconTime,
+    finalized: SyncCommitteePeriod,
+    optimistic: SyncCommitteePeriod,
+    isNextSyncCommitteeKnown: bool,
+    didLatestSyncTaskProgress: bool
+): Duration =
+  let
+    current = wallTime.slotOrZero().sync_committee_period
+    remainingDuration =
+      if not current.isGossipSupported(finalized, isNextSyncCommitteeKnown):
+        if didLatestSyncTaskProgress:
+          # Now
+          return chronos.seconds(0)
+        # Soon
+        chronos.seconds(0)
+      elif finalized != optimistic:
+        # Current sync committee period
+        let
+          wallPeriod = wallTime.slotOrZero().sync_committee_period
+          deadlineSlot = (wallPeriod + 1).start_slot - 1
+          deadline = deadlineSlot.start_beacon_time()
+        chronos.nanoseconds((deadline - wallTime).nanoseconds)
+      else:
+        # Next sync committee period
+        chronos.seconds(
+          (SLOTS_PER_SYNC_COMMITTEE_PERIOD * SECONDS_PER_SLOT).int64)
+  rng.computeDelayWithJitter(remainingDuration)


### PR DESCRIPTION
The helper function to compute delay until next light client sync task can be useful from more general purpose contexts. Move to helpers, and change it to return `Duration` instead of `BeaconTime` for flexibility.