### PR TITLE
update required mdbook versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -768,9 +768,9 @@ book:
 	"$(MAKE)" -C docs book
 
 auditors-book:
-	[[ "$$(mdbook --version)" = "mdbook v0.4.18" ]] || { echo "'mdbook v0.4.18' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
+	[[ "$$(mdbook --version)" = "mdbook v0.4.28" ]] || { echo "'mdbook v0.4.28' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
 	[[ "$$(mdbook-toc --version)" == "mdbook-toc 0.8.0" ]] || { echo "'mdbook-toc 0.8.0' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
-	[[ "$$(mdbook-open-on-gh --version)" == "mdbook-open-on-gh 2.1.0" ]] || { echo "'mdbook-open-on-gh 2.1.0' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
+	[[ "$$(mdbook-open-on-gh --version)" == "mdbook-open-on-gh 2.3.3" ]] || { echo "'mdbook-open-on-gh 2.3.3' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
 	[[ "$$(mdbook-admonish --version)" == "mdbook-admonish 1.7.0" ]] || { echo "'mdbook-open-on-gh 1.7.0' not found in PATH. See 'docs/README.md'. Aborting."; exit 1; }
 	cd docs/the_auditors_handbook && \
 	mdbook build

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,9 +10,9 @@ Some books in this folder were produced using [mdBook](https://github.com/rust-l
 
 ```bash
 # Install or update tooling (make sure you add "~/.cargo/bin" to PATH):
-cargo install mdbook --version 0.4.18
+cargo install mdbook --version 0.4.28
 cargo install mdbook-toc --version 0.8.0
-cargo install mdbook-open-on-gh --version 2.1.0
+cargo install mdbook-open-on-gh --version 2.3.3
 cargo install mdbook-admonish --version 1.7.0
 
 # Work on the book locally - open "http://localhost:4000" for live version


### PR DESCRIPTION
I couldn't install those packages with the versions previously stated. The new versions install successfully,
and `make publish-book` works without errors.