### PR TITLE
opt-out support for v1.4.0 attestation stability subnets

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -238,6 +238,11 @@ type
       desc: "Number of worker threads (\"0\" = use as many threads as there are CPU cores available)"
       name: "num-threads" .}: int
 
+    useOldStabilitySubnets* {.
+      hidden
+      defaultValue: true
+      name: "temporary-debug-use-old-attestation-stability-subnets" .}: bool
+
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
     jwtSecret* {.
       desc: "A file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens"

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -241,7 +241,7 @@ type
     useOldStabilitySubnets* {.
       hidden
       defaultValue: true
-      name: "temporary-debug-use-old-attestation-stability-subnets" .}: bool
+      name: "debug-use-old-attestation-stability-subnets" .}: bool
 
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
     jwtSecret* {.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -324,7 +324,8 @@ proc initFullNode(
     blobQuarantine = newClone(BlobQuarantine())
     consensusManager = ConsensusManager.new(
       dag, attestationPool, quarantine, node.elManager,
-      ActionTracker.init(rng, config.subscribeAllSubnets),
+      ActionTracker.init(rng, node.network.nodeId, config.subscribeAllSubnets,
+                         config.useOldStabilitySubnets),
       node.dynamicFeeRecipientsStore, config.validatorsDir,
       config.defaultFeeRecipient, config.suggestedGasLimit)
     blockProcessor = BlockProcessor.new(

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -23,7 +23,6 @@ const
 
   # Constants from `validator.md` not covered by config/presets in the spec
   TARGET_AGGREGATORS_PER_COMMITTEE*: uint64 = 16
-  RANDOM_SUBNETS_PER_VALIDATOR*: uint64 = 1
   EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION*: uint64 = 256
 
 type
@@ -91,6 +90,7 @@ const
   ignoredValues = [
     "TRANSITION_TOTAL_DIFFICULTY", # Name that appears in some altair alphas, obsolete, remove when no more testnets
     "MIN_ANCHOR_POW_BLOCK_DIFFICULTY", # Name that appears in some altair alphas, obsolete, remove when no more testnets
+    "RANDOM_SUBNETS_PER_VALIDATOR",    # Removed in consensus-specs v1.4.0
   ]
 
 when const_preset == "mainnet":
@@ -562,7 +562,6 @@ proc readRuntimeConfig(
   checkCompatibility MAX_VOLUNTARY_EXITS
 
   checkCompatibility TARGET_AGGREGATORS_PER_COMMITTEE
-  checkCompatibility RANDOM_SUBNETS_PER_VALIDATOR
   checkCompatibility EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION
   checkCompatibility ATTESTATION_SUBNET_COUNT
 

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -127,6 +127,8 @@ The following options are available:
 ...
 ```
 
+Any `debug`-prefixed flags are considered ephemeral and subject to removal without notice.
+
 ## Configuration files
 
 All command line options can also be provided in a [TOML](https://toml.io/en/)

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -16,7 +16,7 @@ suite "subnet tracker":
     let rng = HmacDrbgContext.new()
 
   test "should register stability subnets on attester duties":
-    var tracker = ActionTracker.init(rng, false)
+    var tracker = ActionTracker.init(rng, default(UInt256), false, true)
 
     check:
       tracker.stabilitySubnets(Slot(0)).countOnes() == 0
@@ -62,7 +62,7 @@ suite "subnet tracker":
 
   test "should register sync committee duties":
     var
-      tracker = ActionTracker.init(rng, false)
+      tracker = ActionTracker.init(rng, default(UInt256), false, true)
       pk0 = ValidatorPubKey.fromHex("0xb4102a1f6c80e5c596a974ebd930c9f809c3587dc4d1d3634b77ff66db71e376dbc86c3252c6d140ce031f4ec6167798").get()
       pk1 = ValidatorPubKey.fromHex("0xa00d2954717425ce047e0928e5f4ec7c0e3bbe1058db511303fd659770ddace686ee2e22ac180422e516f4c503eb2228").get()
 


### PR DESCRIPTION
If/when this works well enough to become the default, the runtime switch machinery, including the command-line option, might disappear without notice.