### PR TITLE
fix code for Nim `v1.6.14` compatibility

### DIFF
--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -150,7 +150,7 @@ proc doTrustedNodeSync*(
                 client.getStateV2(StateIdent.init(StateIdentType.Genesis), cfg),
                 largeRequestsTimeout):
               info "Attempt to download genesis state timed out"
-              nil
+              (ref ForkedHashedBeaconState)(nil)
           except CatchableError as exc:
             info "Unable to download genesis state",
               error = exc.msg, restUrl

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -150,6 +150,7 @@ proc doTrustedNodeSync*(
                 client.getStateV2(StateIdent.init(StateIdentType.Genesis), cfg),
                 largeRequestsTimeout):
               info "Attempt to download genesis state timed out"
+              # https://github.com/nim-lang/Nim/issues/22180
               (ref ForkedHashedBeaconState)(nil)
           except CatchableError as exc:
             info "Unable to download genesis state",


### PR DESCRIPTION
With `v1.6.14` there is compilation issue in `trusted_node_sync` where a type is not inferred automatically anymore for a `nil` instance. Fix it so we can bump the compiler.

See https://github.com/status-im/nimbus-build-system/pull/63