### PR TITLE
run tests against both submodule and latest Nim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [version-1-6]
+        branch: [~, upstream/version-1-6]
         include:
           - target:
               os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' + matrix.branch + ')' || '' }}'
+    name: ${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' + matrix.branch + ')' || '' }}
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: ${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' + matrix.branch + ')' || '' }}
+    name: ${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' || '' }}${{ matrix.branch }}${{ matrix.branch != '' && ')' || '' }}
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != "" && " (Nim " + matrix.branch + ")" || "" }}'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' + matrix.branch + ')' || '' }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ if ne(matrix.branch, ""), " (Nim ${{ matrix.branch }})", "" }}'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != "" && " (Nim " + matrix.branch + ")" || "" }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ if ne(matrix.branch, ""), " (Nim ${{ matrix.branch }})", "" }}'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout


### PR DESCRIPTION
Currently CI only tests against status `version-1-6` branch. Update to test against the selected commit through submodule lock, as well as the latest upstream `version-1-6` instead.