### PR TITLE
pass parent block root to Deneb EL

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -51,8 +51,7 @@ proc initLightClient*(
 
             if not blckPayload.block_hash.isZero:
               # engine_newPayloadV1
-              discard await node.elManager.newExecutionPayload(
-                blck.message.body)
+              discard await node.elManager.newExecutionPayload(blck.message)
 
               # Retain optimistic head for other `forkchoiceUpdated` callers.
               # May temporarily block `forkchoiceUpdatedV1` calls, e.g., Geth:

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1058,10 +1058,12 @@ proc sendNewPayloadToSingleEL(connection: ELConnection,
 
 proc sendNewPayloadToSingleEL(connection: ELConnection,
                               payload: engine_api.ExecutionPayloadV3,
-                              versioned_hashes: seq[engine_api.VersionedHash]):
+                              versioned_hashes: seq[engine_api.VersionedHash],
+                              parent_beacon_block_root: FixedBytes[32]):
                               Future[PayloadStatusV1] {.async.} =
   let rpcClient = await connection.connectedRpcClient()
-  return await rpcClient.engine_newPayloadV3(payload, versioned_hashes)
+  return await rpcClient.engine_newPayloadV3(
+    payload, versioned_hashes, parent_beacon_block_root)
 
 type
   StatusRelation = enum
@@ -1153,13 +1155,13 @@ proc processResponse[ELResponseType](
             url2 = connections[idx].engineUrl.url,
             status2 = status
 
-proc sendNewPayload*(m: ELManager, blockBody: SomeForkyBeaconBlockBody):
+proc sendNewPayload*(m: ELManager, blck: SomeForkyBeaconBlock):
                      Future[PayloadExecutionStatus] {.async.} =
   let
     earlyDeadline = sleepAsync(chronos.seconds 1)
     startTime = Moment.now
     deadline = sleepAsync(NEWPAYLOAD_TIMEOUT)
-    payload = blockBody.execution_payload.asEngineExecutionPayload
+    payload = blck.body.execution_payload.asEngineExecutionPayload
     requests = m.elConnections.mapIt:
       let req =
         when payload is engine_api.ExecutionPayloadV3:
@@ -1167,9 +1169,11 @@ proc sendNewPayload*(m: ELManager, blockBody: SomeForkyBeaconBlockBody):
           # Verify the execution payload is valid
           # [Modified in Deneb] Pass `versioned_hashes` to Execution Engine
           let versioned_hashes = mapIt(
-            blockBody.blob_kzg_commitments,
+            blck.body.blob_kzg_commitments,
             engine_api.VersionedHash(kzg_commitment_to_versioned_hash(it)))
-          sendNewPayloadToSingleEL(it, payload, versioned_hashes)
+          sendNewPayloadToSingleEL(
+            it, payload, versioned_hashes,
+            FixedBytes[32] blck.parent_root.data)
         elif payload is engine_api.ExecutionPayloadV1 or
              payload is engine_api.ExecutionPayloadV2:
           sendNewPayloadToSingleEL(it, payload)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -303,11 +303,10 @@ from ../spec/datatypes/capella import
 from ../spec/datatypes/deneb import SignedBeaconBlock, asTrusted, shortLog
 
 proc newExecutionPayload*(
-    elManager: ELManager,
-    blockBody: SomeForkyBeaconBlockBody):
+    elManager: ELManager, blck: SomeForkyBeaconBlock):
     Future[Opt[PayloadExecutionStatus]] {.async.} =
 
-  template executionPayload: untyped = blockBody.execution_payload
+  template executionPayload: untyped = blck.body.execution_payload
 
   if not elManager.hasProperlyConfiguredConnection:
     if elManager.hasConnection:
@@ -322,7 +321,7 @@ proc newExecutionPayload*(
     executionPayload = shortLog(executionPayload)
 
   try:
-    let payloadStatus = await elManager.sendNewPayload(blockBody)
+    let payloadStatus = await elManager.sendNewPayload(blck)
 
     debug "newPayload: succeeded",
       parentHash = executionPayload.parent_hash,
@@ -349,7 +348,7 @@ proc getExecutionValidity(
 
   try:
     let executionPayloadStatus = await elManager.newExecutionPayload(
-      blck.message.body)
+      blck.message)
     if executionPayloadStatus.isNone:
       return NewPayloadStatus.noResponse
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -113,7 +113,7 @@ programMain:
             template payload(): auto = blck.message.body.execution_payload
 
             if elManager != nil and not payload.block_hash.isZero:
-              discard await elManager.newExecutionPayload(blck.message.body)
+              discard await elManager.newExecutionPayload(blck.message)
               discard await elManager.forkchoiceUpdated(
                 headBlockHash = payload.block_hash,
                 safeBlockHash = payload.block_hash,  # stub value
@@ -124,7 +124,7 @@ programMain:
             template payload(): auto = blck.message.body.execution_payload
 
             if elManager != nil and not payload.block_hash.isZero:
-              discard await elManager.newExecutionPayload(blck.message.body)
+              discard await elManager.newExecutionPayload(blck.message)
               discard await elManager.forkchoiceUpdated(
                 headBlockHash = payload.block_hash,
                 safeBlockHash = payload.block_hash,  # stub value


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/pull/3421
https://github.com/ethereum/execution-apis/pull/420

Will presumably be required as part of https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0-beta.0 for Dencun devnet7.

The web3 bump is required to provide the `engine_newPayloadV3` call, and in general, has:
- https://github.com/status-im/nim-web3/pull/88
- [adjust newPayloadV3 signature ](https://github.com/status-im/nim-web3/commit/b3face022b5948153a7da3cb93e92c912c05a1b0)
- [test with Nim 2.0 in CI](https://github.com/status-im/nim-web3/pull/89)