### PR TITLE
replace integer cast with conversion and remove `CastSizes` warnings

### DIFF
--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.push raises: [].}
 
 import
@@ -148,9 +155,8 @@ proc readHeader(f: IoHandle): Result[Header, string] =
     typ: Type
   discard typ.copyFrom(buf)
 
-  # Cast safe because we had only 4 bytes of length data
-  let
-    len = cast[int64](uint32.fromBytesLE(buf.toOpenArray(2, 5)))
+  # Conversion safe because we had only 4 bytes of length data
+  let len = (uint32.fromBytesLE(buf.toOpenArray(2, 5))).int64
 
   # No point reading these..
   if len > int.high(): return err("header length exceeds int.high")


### PR DESCRIPTION
These compile to the same C code:
```nim
proc casting(n: uint32): int64 = cast[int64](n)
proc converting(n: uint32): int64 = n.int64

var x: uint32
discard casting(x)
discard converting(x)
```

```c
N_LIB_PRIVATE N_NIMCALL(NI64, casting__a_3)(NU32 n) {
  NI64 result;
  result = (NI64) 0;
  result = ((NI64)(n));
  popFrame();
  return result;
}

N_LIB_PRIVATE N_NIMCALL(NI64, converting__a_6)(NU32 n) {
  NI64 result;
  result = (NI64) 0;
  result = ((NI64)(n));
  popFrame();
  return result;
}
```

Currently:
```
$ make
Building: build/deposit_contract
Building: build/resttest
Building: build/logtrace
Building: build/mev_mock
Building: build/ncli_db
Building: build/ncli
Building: build/ncli_split_keystore
Building: build/fakeee
Building: build/wss_sim
Building: build/nimbus_light_client
Building: build/nimbus_validator_client
Building: build/nimbus_signing_node
Building: build/stack_sizes
Building: build/validator_db_aggregator
Building: build/ncli_testnet
Building: build/libnfuzz.so
...
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
...
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
...
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
...
nimbus-eth2/ncli/e2store.nim(153, 11) Warning: target type is larger than source type [CastSizes]
```