### PR TITLE
handle distinct `nil` more rigorously

### DIFF
--- a/beacon_chain/beacon_chain_db_light_client.nim
+++ b/beacon_chain/beacon_chain_db_light_client.nim
@@ -140,7 +140,7 @@ type
 template disposeSafe(s: untyped): untyped =
   if distinctBase(s) != nil:
     s.dispose()
-    s = nil
+    s = typeof(s)(nil)
 
 proc initHeadersStore(
     backend: SqStoreRef,


### PR DESCRIPTION
This is the result of Nim 2.0 and `devel` not special-casing `nil` anymore, either `== nil` (comparison) or `= nil` (assignment), with distinct pointer types.

```nim
type W = distinct ptr int
type X = distinct pointer
var p: W
var c: X
p = nil
c = nil
```

```
Nim Compiler Version 1.6.14 [Linux: amd64]
Compiled at 2023-06-29
Copyright (c) 2006-2023 by Andreas Rumpf

active boot switches: -d:release
```
compiles this fine.

`version-2-0` and `devel` both display
```
Error: type mismatch: got 'typeof(nil)' for 'nil' but expected 'W = distinct ptr int'
```
or
```
Error: type mismatch: got 'typeof(nil)' for 'nil' but expected 'X = distinct pointer'
```
depending on whether one comments out `p = nil`, based on
```
Nim Compiler Version 1.9.5 [Linux: amd64]
Compiled at 2023-07-11
Copyright (c) 2006-2023 by Andreas Rumpf

git hash: 9ddd768cce291e5c562cde23baeeefb47aa79c86
active boot switches: -d:release
```

Another option is to report this upstream to Nim as a regression.