### PR TITLE
increase `getPayloadFromSingleEL` timeout

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -906,8 +906,10 @@ proc getPayload*(m: ELManager,
     headBlock, safeBlock, finalizedBlock, timestamp,
     randomData, suggestedFeeRecipient, engineApiWithdrawals)
 
+  # `getPayloadFromSingleEL` may introduce additional latency
+  const extraProcessingOverhead = 500.milliseconds
   let
-    timeout = GETPAYLOAD_TIMEOUT
+    timeout = GETPAYLOAD_TIMEOUT + extraProcessingOverhead
     deadline = sleepAsync(timeout)
     requests = m.elConnections.mapIt(it.getPayloadFromSingleEL(
       EngineApiResponseType(PayloadType),


### PR DESCRIPTION
When producing a local block and `runProposalForkchoiceUpdated` was missed, `getPayloadFromSingleEL` adds additional ~500ms of latency. Quick fix to avoid missing blocks to that.