### PR TITLE
delay `onSlotEnd` if there are duties

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1144,7 +1144,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
   # next slot
 
-  # By waiting for close before slot end, ensure that preparation work for next
+  # By waiting until close before slot end, ensure that preparation for next
   # slot does not interfere with propagation of messages and with VC duties.
   const endOffset = aggregateSlotOffset + nanos(
     (NANOSECONDS_PER_SLOT - aggregateSlotOffset.nanoseconds.uint64).int64 div 2)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1370,7 +1370,8 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
     if endSlotCutoff.inFuture:
       debug "Waiting for validator duties to complete",
         endSlotCutoff = shortLog(endSlotCutoff.offset),
-        numAttachedValidators = node.attachedValidators[].count
+        numAttachedValidators = node.attachedValidators[].count,
+        nextAttestationSlot, nextProposalSlot, isInCurrentSyncCommittee
       await sleepAsync(endSlotCutoff.offset)
 
   await onSlotEnd(node, wallSlot)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1140,6 +1140,14 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   node.updateBlocksGossipStatus(slot, isBehind)
   node.updateLightClientGossipStatus(slot, isBehind)
 
+# -1 is a more useful output than 18446744073709551615 as an indicator of
+# no future attestation/proposal known.
+template formatAsGaugeInt64(x: Slot): int64 =
+  if x == high(uint64).Slot:
+    -1'i64
+  else:
+    toGaugeValue(x)
+
 proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
   # next slot
@@ -1207,14 +1215,6 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     nextActionWaitTime = saturate(fromNow(
       node.beaconClock, min(nextAttestationSlot, nextProposalSlot)))
 
-  # -1 is a more useful output than 18446744073709551615 as an indicator of
-  # no future attestation/proposal known.
-  template formatInt64(x: Slot): int64 =
-    if x == high(uint64).Slot:
-      -1'i64
-    else:
-      toGaugeValue(x)
-
   template formatSyncCommitteeStatus(): string =
     let slotsToNextSyncCommitteePeriod =
       SLOTS_PER_SYNC_COMMITTEE_PERIOD - since_sync_committee_period_start(slot)
@@ -1237,8 +1237,8 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
         "n/a"
       else:
         shortLog(nextActionWaitTime),
-    nextAttestationSlot = formatInt64(nextAttestationSlot),
-    nextProposalSlot = formatInt64(nextProposalSlot),
+    nextAttestationSlot = formatAsGaugeInt64(nextAttestationSlot),
+    nextProposalSlot = formatAsGaugeInt64(nextProposalSlot),
     syncCommitteeDuties = formatSyncCommitteeStatus(),
     head = shortLog(head)
 
@@ -1351,12 +1351,13 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
   # We don't have an efficient tracker that separates VC duties from local ones.
   # Therefore, wait whenever there are duties from any source for wall slot.
   let
+    previousSlot = max(wallSlot, 1.Slot) - 1
     nextAttestationSlot =
-      node.consensusManager[].actionTracker.getNextAttestationSlot(wallSlot)
+      node.consensusManager[].actionTracker.getNextAttestationSlot(previousSlot)
     nextProposalSlot =
-      node.consensusManager[].actionTracker.getNextProposalSlot(wallSlot)
+      node.consensusManager[].actionTracker.getNextProposalSlot(previousSlot)
     isInCurrentSyncCommittee =
-      not node.getCurrentSyncCommiteeSubnets(wallSlot.epoch).isZeros
+      not node.getCurrentSyncCommiteeSubnets(previousSlot.epoch).isZeros
     hasDutiesForWallSlot =
       nextAttestationSlot == wallSlot or
       nextProposalSlot == wallSlot or
@@ -1369,9 +1370,11 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
       wallSlot.start_beacon_time + endSlotOffset)
     if endSlotCutoff.inFuture:
       debug "Waiting for validator duties to complete",
-        endSlotCutoff = shortLog(endSlotCutoff.offset),
+        wallSlot, endSlotCutoff = shortLog(endSlotCutoff.offset),
         numAttachedValidators = node.attachedValidators[].count,
-        nextAttestationSlot, nextProposalSlot, isInCurrentSyncCommittee
+        nextAttestationSlot = nextAttestationSlot.formatAsGaugeInt64,
+        nextProposalSlot = nextProposalSlot.formatAsGaugeInt64,
+        isInCurrentSyncCommittee
       await sleepAsync(endSlotCutoff.offset)
 
   await onSlotEnd(node, wallSlot)

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -48,7 +48,7 @@ const
 
   FAR_FUTURE_BEACON_TIME* = BeaconTime(ns_since_genesis: int64.high())
 
-  NANOSECONDS_PER_SLOT = SECONDS_PER_SLOT * 1_000_000_000'u64
+  NANOSECONDS_PER_SLOT* = SECONDS_PER_SLOT * 1_000_000_000'u64
 
 template ethTimeUnit*(typ: type) {.dirty.} =
   func `+`*(x: typ, y: uint64): typ {.borrow.}

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -48,7 +48,7 @@ const
 
   FAR_FUTURE_BEACON_TIME* = BeaconTime(ns_since_genesis: int64.high())
 
-  NANOSECONDS_PER_SLOT* = SECONDS_PER_SLOT * 1_000_000_000'u64
+  NANOSECONDS_PER_SLOT = SECONDS_PER_SLOT * 1_000_000_000'u64
 
 template ethTimeUnit*(typ: type) {.dirty.} =
   func `+`*(x: typ, y: uint64): typ {.borrow.}


### PR DESCRIPTION
We currently call `onSlotEnd` whenever all in-BN validator duties are completed. VC validator duties are not awaited. When `onSlotEnd` is processed close to the slot start, a VC may therefore miss duties. Adding a delay before `onSlotEnd` improves this situation. The logic can be optimized further if `ActionTracker` would track `knownValidators` from REST separately from in-process ones.