### PR TITLE
move lint checks to separate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2022 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Check copyright year
-        if: ${{ always() }} && github.event_name == 'pull_request'
+        if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
           excluded_files="config.yaml"
           excluded_extensions="ans|json|md|png|ssz|txt"
@@ -212,7 +212,7 @@ jobs:
           fi
 
       - name: Check submodules
-        if: ${{ always() }} && github.event_name == 'pull_request'
+        if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
           while read -r file; do
             commit="$(git -C "$file" rev-parse HEAD)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
             done
             exit 2
           fi
+        continue-on-error: true
 
       - name: Check submodules
         if: github.event_name == 'pull_request'
@@ -229,6 +230,7 @@ jobs:
               exit 2
             fi
           done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
+        continue-on-error: true
 
   # https://github.com/EnricoMi/publish-unit-test-result-action
   event_file:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,31 +57,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
-          # submodules: true  # Fails on nimyaml tests
-
-      - name: Check copyright year (Linux)
-        if: github.event_name == 'pull_request' && runner.os == 'Linux'
-        run: |
-          excluded_files="config.yaml"
-          excluded_extensions="ans|json|md|png|ssz|txt"
-
-          current_year=$(date +"%Y")
-          outdated_files=()
-          while read -r file; do
-            if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
-              outdated_files+=("$file")
-            fi
-          done < <(git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '(\.('$excluded_extensions')|'$excluded_files')$' || true)
-
-          if (( ${#outdated_files[@]} )); then
-            echo "The following files do not have an up-to-date copyright year:"
-            for file in "${outdated_files[@]}"; do
-              echo "- $file"
-            done
-            exit 2
-          fi
 
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
@@ -164,25 +139,6 @@ jobs:
           ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
           ./env.sh nim --version
 
-      - name: Check submodules (Linux)
-        if: github.event_name == 'pull_request' && runner.os == 'Linux'
-        run: |
-          while read -r file; do
-            commit="$(git -C "$file" rev-parse HEAD)"
-            if ! branch="$(git config -f .gitmodules --get "submodule.$file.branch")"; then
-              echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
-              exit 2
-            fi
-            if ! error="$(git -C "$file" fetch -q origin "$branch")"; then
-              echo "Submodule '$file': Failed to fetch '$branch': $error"
-              exit 2
-            fi
-            if ! git -C "$file" merge-base --is-ancestor "$commit" "origin/$branch"; then
-              echo "Submodule '$file': '$commit' is not on '$branch'"
-              exit 2
-            fi
-          done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
-
       - name: Get latest fixtures commit hash
         id: fixtures_version
         run: |
@@ -223,13 +179,64 @@ jobs:
           name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
           path: build/*.xml
 
+  lint:
+    name: "Lint"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
+          submodules: 'recursive'
+
+      - name: Check copyright year
+        if: github.event_name == 'pull_request'
+        run: |
+          excluded_files="config.yaml"
+          excluded_extensions="ans|json|md|png|ssz|txt"
+
+          current_year=$(date +"%Y")
+          outdated_files=()
+          while read -r file; do
+            if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
+              outdated_files+=("$file")
+            fi
+          done < <(git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '(\.('$excluded_extensions')|'$excluded_files')$' || true)
+
+          if (( ${#outdated_files[@]} )); then
+            echo "The following files do not have an up-to-date copyright year:"
+            for file in "${outdated_files[@]}"; do
+              echo "- $file"
+            done
+            exit 2
+          fi
+
+      - name: Check submodules
+        if: github.event_name == 'pull_request'
+        run: |
+          while read -r file; do
+            commit="$(git -C "$file" rev-parse HEAD)"
+            if ! branch="$(git config -f .gitmodules --get "submodule.$file.branch")"; then
+              echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
+              exit 2
+            fi
+            if ! error="$(git -C "$file" fetch -q origin "$branch")"; then
+              echo "Submodule '$file': Failed to fetch '$branch': $error"
+              exit 2
+            fi
+            if ! git -C "$file" merge-base --is-ancestor "$commit" "origin/$branch"; then
+              echo "Submodule '$file': '$commit' is not on '$branch'"
+              exit 2
+            fi
+          done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
+
   # https://github.com/EnricoMi/publish-unit-test-result-action
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest
     steps:
-    - name: Upload
-      uses: actions/upload-artifact@v3
-      with:
-        name: Event File
-        path: ${{ github.event_path }}
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: Event File
+          path: ${{ github.event_path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Check copyright year
-        if: github.event_name == 'pull_request'
+        if: ${{ always() }} && github.event_name == 'pull_request'
         run: |
           excluded_files="config.yaml"
           excluded_extensions="ans|json|md|png|ssz|txt"
@@ -210,10 +210,9 @@ jobs:
             done
             exit 2
           fi
-        continue-on-error: true
 
       - name: Check submodules
-        if: github.event_name == 'pull_request'
+        if: ${{ always() }} && github.event_name == 'pull_request'
         run: |
           while read -r file; do
             commit="$(git -C "$file" rev-parse HEAD)"
@@ -230,7 +229,6 @@ jobs:
               exit 2
             fi
           done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)
-        continue-on-error: true
 
   # https://github.com/EnricoMi/publish-unit-test-result-action
   event_file:


### PR DESCRIPTION
Running the lint checks separately allows running tests to check code correctness even when targeting non-master branches or having outdated copyright headers.