### PR TITLE
avoid Nim 2.0 issue when loading config

### DIFF
--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -201,7 +201,7 @@ template makeBannerAndConfig*(clientId: string, ConfType: type): untyped =
       version = version, # but a short version string makes more sense...
       copyrightBanner = clientId,
       secondarySources = proc (
-          config: ConfType, sources: auto
+          config: ConfType, sources: ref SecondarySources
       ) {.raises: [ConfigurationError].} =
         if config.configFile.isSome:
           sources.addConfigFile(Toml, config.configFile.get)

--- a/ncli/deposit_downloader.nim
+++ b/ncli/deposit_downloader.nim
@@ -82,6 +82,8 @@ proc main(flags: CliFlags) {.async.} =
 
 waitFor main(
   load(CliFlags,
-       secondarySources = proc (config: CliFlags, sources: auto) =
+       secondarySources = proc (
+          config: CliFlags, sources: ref SecondarySources
+       ) {.raises: [ConfigurationError].} =
         if config.configFile.isSome:
           sources.addConfigFile(Toml, config.configFile.get)))

--- a/ncli/deposit_downloader.nim
+++ b/ncli/deposit_downloader.nim
@@ -83,7 +83,7 @@ proc main(flags: CliFlags) {.async.} =
 waitFor main(
   load(CliFlags,
        secondarySources = proc (
-          config: CliFlags, sources: ref SecondarySources
+           config: CliFlags, sources: ref SecondarySources
        ) {.raises: [ConfigurationError].} =
         if config.configFile.isSome:
           sources.addConfigFile(Toml, config.configFile.get)))

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -21,7 +21,9 @@ type
 proc loadExampleConfig(content: string, cmdLine = newSeq[string]()): ExampleConfigFile =
   ExampleConfigFile.load(
     cmdLine = cmdLine,
-    secondarySources = proc (config: ExampleConfigFile, sources: auto) =
+    secondarySources = proc (
+        config: ExampleConfigFile, sources: ref SecondarySources
+    ) {.raises: [ConfigurationError].} =
       sources.addConfigFileContent(Toml, content))
 
 const


### PR DESCRIPTION
To avoid Nim 2.0 issue https://github.com/nim-lang/Nim/issues/22284, explicitly specify `ref SecondarySources` instead of using `auto`, and add `{.raises.}` annotation