### PR TITLE
generalize `ShufflingRef` acceleration logic (#5197)

### DIFF
--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -279,6 +279,12 @@ func keysToIndices*(cacheTable: var Table[ValidatorPubKey, ValidatorIndex],
         indices[listIndex[]] = some(ValidatorIndex(validatorIndex))
   indices
 
+proc getBidOptimistic*(node: BeaconNode, bid: BlockId): Option[bool] =
+  if node.currentSlot().epoch() >= node.dag.cfg.BELLATRIX_FORK_EPOCH:
+    some[bool](node.dag.is_optimistic(bid))
+  else:
+    none[bool]()
+
 proc getShufflingOptimistic*(node: BeaconNode,
                              dependentSlot: Slot,
                              dependentRoot: Eth2Digest): Option[bool] =


### PR DESCRIPTION
Split up the `ShufflingRef` acceleration logic into generically usable parts and attester shuffling specific parts. The generic parts could be used to accelerate other purposes, e.g., REST `/states/xxx/randao` API.