### PR TITLE
remove workaround for long-since-fixed Nim bug

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -49,11 +49,6 @@ type
   Eth2NetworkMetadata* = object
     case incompatible*: bool
     of false:
-      # TODO work-around a Nim codegen issue where upon constant assignment
-      #      the compiler will copy `incompatibilityDesc` even when the case
-      #      branch is not active and thus it will override the first variable
-      #      in this branch.
-      dummy: string
       # If the eth1Network is specified, the ELManager will perform some
       # additional checks to ensure we are connecting to a web3 provider
       # serving data for the same network. The value can be set to `None`


### PR DESCRIPTION
A short way to reproduce this bug is:
```nim
type
  Eth2NetworkMetadata = object
    case incompatible: bool
    of false:
      eth1Network: int
    else:
      incompatibilityDesc: string

const mainnetMetadata = Eth2NetworkMetadata(
  incompatible: false,
  eth1Network: 200)

proc f(): Eth2NetworkMetadata = mainnetMetadata

let x = f()
echo x
```

The relevant fix is https://github.com/nim-lang/Nim/commit/2288188fe9a9d854a167dd270eb8d72d19676865 which landed/was backported between Nim  v1.2.6 and v1.2.8.

v1.2.6 output:
```
(incompatible: false, eth1Network: 0)
```

because
```c
struct tyObject_Eth2NetworkMetadata__Hx9cLN9b6J3GocCAZV1d60Sw {
    NIM_BOOL incompatible;
    union{
        struct {NI eth1Network;
        } _incompatible_1;
        struct {NimStringDesc* incompatibilityDesc;
        } _incompatible_2;
    };
};

...

N_LIB_PRIVATE N_NIMCALL(void, f__yJtYVDIuyNNFutWlB9aUaiw)(tyObject_Eth2NetworkMetadata__Hx9cLN9b6J3GocCAZV1d60Sw* Result) {
	chckNil((void*)Result);
	switch ((*Result).incompatible) {
	case NIM_FALSE:
	(*Result)._incompatible_1.eth1Network = 0;
	break;
	default:
	unsureAsgnRef((void**)&(*Result)._incompatible_2.incompatibilityDesc, NIM_NIL);
	break;
	} 
	(*Result).incompatible = 0;
	(*Result).incompatible = NIM_FALSE;
	(*Result)._incompatible_1.eth1Network = ((NI) 200);
	unsureAsgnRef((void**) (&(*Result)._incompatible_2.incompatibilityDesc), ((NimStringDesc*) NIM_NIL));
	popFrame();
}
```

That is, it assigns to the `_incompatible_1` part of the `union` first, then overwrites it via (pointlessly/incorrectly) also assigning to the `_incompatible_2` branch.

v1.2.8 output:
```
(incompatible: false, eth1Network: 200)
```

which is the result of the same `struct` definition, but:
```c
N_LIB_PRIVATE NIM_CONST tyObject_Eth2NetworkMetadata__Hx9cLN9b6J3GocCAZV1d60Sw mainnetMetadata__ptyWndWuDvu8P09a3eK5tXQ = {NIM_FALSE, {._incompatible_1 = {((NI) 200)}}};

...

N_LIB_PRIVATE N_NIMCALL(void, f__yJtYVDIuyNNFutWlB9aUaiw)(tyObject_Eth2NetworkMetadata__Hx9cLN9b6J3GocCAZV1d60Sw* Result) {
    genericAssign((void*)Result, (void*)(&mainnetMetadata__ptyWndWuDvu8P09a3eK5tXQ), (&NTI__Hx9cLN9b6J3GocCAZV1d60Sw_));
    popFrame();
}

...

N_LIB_PRIVATE N_NIMCALL(void, rDatInit000)(void) {
    static TNimNode TM__O9ck8QE34G7SWmidGMuOitg_0[3];
    NTI__Hx9cLN9b6J3GocCAZV1d60Sw_.size = sizeof(tyObject_Eth2NetworkMetadata__Hx9cLN9b6J3GocCAZV1d60Sw);
    NTI__Hx9cLN9b6J3GocCAZV1d60Sw_.kind = 18;
    NTI__Hx9cLN9b6J3GocCAZV1d60Sw_.base = 0;
    NTI__Hx9cLN9b6J3GocCAZV1d60Sw_.flags = 2;
```

That is, per the change in https://github.com/nim-lang/Nim/commit/2288188fe9a9d854a167dd270eb8d72d19676865 it doesn't inline it because it's now a `const` `nkObjConstr`, but instead uses `genericAssign`.

In `nimbus-eth2`, not these minimized reproductions,
```c

struct tyObject_Eth2NetworkMetadata__4ucRh0Fi9bCRgGEzwRNYPaQ {NIM_BOOL incompatible;
    union{
        struct {tyObject_Option__kQacroE1i5VgtU0KW0x9blg eth1Network;
            tyObject_RuntimeConfig__h9bFiO02aYrSsiQuX4I6lCA cfg;
            tySequence__sM4lkSb7zS6F7OVMvW9cffQ* bootstrapNodes;
            NU64 depositContractBlock;
            tyObject_MDigest__sonz1Q4qEjQxue9bhMfa9bfg depositContractBlockHash;
            tySequence__6H5Oh5UUvVCLiakt9aTwtUQ* genesisData;
            NimStringDesc* genesisDepositsSnapshot;
        } _incompatible_1;
        struct {NimStringDesc* incompatibilityDesc;
        } _incompatible_2;
    };
}; 
```
is how this `Eth2NetworkMetadata` case object is represented (the subsequent fields in the first branch aren't relevant to this bug, either way)
```c
N_LIB_PRIVATE NIM_CONST tyObject_Eth2NetworkMetadata__4ucRh0Fi9bCRgGEzwRNYPaQ mainnetMetadata__networkingZnetwork95metadata_665 = {NIM_FALSE, {._incompatible_1 = {{((tyEnum_Eth1Network__X5d20xqYKVvidfFSuwjFng) 0), NIM_TRUE}
                        , {((NimStringDesc*) &TM__ocu39c15Y0ukNaw04Gw1coQ_5), ((NimStringDesc*) &TM__ocu39c15Y0ukNaw04Gw1coQ_5), {{{15566869308787654656ULL, 3184ULL}
                                        , {0ULL, 0ULL}
                                    }
                                }
                                , {((NU8) 0),
                                    ((NU8) 0),
...
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 16384ULL, 1606824000ULL, {((NU8) 0),
                                    ((NU8) 0),
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 604800ULL, {((NU8) 1),
                                    ((NU8) 0),
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 74240ULL, {((NU8) 2),
                                    ((NU8) 0),
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 144896ULL, {((NU8) 3),
                                    ((NU8) 0),
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 194048ULL, {((NU8) 4),
                                    ((NU8) 0),
                                    ((NU8) 0),
                                ((NU8) 0)}
                                , 18446744073709551615ULL, 14ULL, 256ULL, 256ULL, 2048ULL, 4ULL, 16ULL, 16000000000ULL, 4ULL, 65536ULL, 1ULL, 1ULL, {((NU8) 0),
                                    ((NU8) 0),
                                    ((NU8) 0),
...
                                    ((NU8) 5),
                                ((NU8) 250)}
                            },
((tySequence__sM4lkSb7zS6F7OVMvW9cffQ*)&TM__ocu39c15Y0ukNaw04Gw1coQ_22), 11052984ULL, {{((NU8) 68),
                                    ((NU8) 188),
                                    ((NU8) 168),
...
                                    ((NU8) 238),
                                ((NU8) 41)}
                            },
((tySequence__6H5Oh5UUvVCLiakt9aTwtUQ*)&TM__ocu39c15Y0ukNaw04Gw1coQ_23), ((NimStringDesc*) NIM_NIL)}}};
```
is an example of a const object constructor, and
```c
N_LIB_PRIVATE N_NIMCALL(void, getRuntimeConfig__OOZbeacon95chainZnetworkingZnetwork95metadata_1615)(tyObject_Option__ulnotnWzrobw9b9bRpPpH3hQ eth2Network, tyObject_RuntimeConfig__h9bFiO02aYrSsiQuX4I6lCA* Result) {
    tyObject_Eth2NetworkMetadata__4ucRh0Fi9bCRgGEzwRNYPaQ metadata;{ nimZeroMem((void*)(&metadata), sizeof(tyObject_Eth2NetworkMetadata__4ucRh0Fi9bCRgGEzwRNYPaQ));
        { NIM_BOOL T3_; NimStringDesc** T6_;
            T3_ = (NIM_BOOL)0;  T3_ = isSome__OOZvendorZnim45web51Zweb51Zconversions_2472(eth2Network); if (!T3_) goto LA4_;
            T6_ = (NimStringDesc**)0; T6_ = get__OOZbeacon95chainZnetworkingZnetwork95metadata_1648((&eth2Network));
getMetadataForNetwork__OOZbeacon95chainZnetworkingZnetwork95metadata_1074((*T6_), (&metadata));
        }
        goto LA1_;
        LA4_: ;
        { nimCopyMem((void*)(&metadata), (NIM_CONST void*)(&mainnetMetadata__OOZbeacon95chainZnetworkingZnetwork95metadata_945), sizeof(metadata));  }
        LA1_: ;
```

is how the Nim v1.6.14 now compiles
```nim
proc getRuntimeConfig*(
    eth2Network: Option[string]): RuntimeConfig {.raises: [IOError].} =
...
  let metadata =
    if eth2Network.isSome:
      getMetadataForNetwork(eth2Network.get)
    else:
      when const_preset == "mainnet":
        mainnetMetadata
...
```