### PR TITLE
adjust log level to reduce ci log spam

### DIFF
--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,5 +1,13 @@
+# beacon_chain
+# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # Use only `secp256k1` public key cryptography as an identity in LibP2P.
 -d:"libp2p_pki_schemes=secp256k1"
+-d:"chronicles_runtime_filtering=on"
 -d:chronosStrictException
 --styleCheck:usages
 --styleCheck:hint

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -277,7 +277,7 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   addPreTestRemoteKeystores(nodeValidatorsDir)
 
   let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
-    "--log-level=TRACE;DEBUG:libp2p,gossipsub"
+    "--log-level=TRACE;DEBUG:libp2p,gossipsub",
     "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--discv5=off",

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -277,7 +277,7 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   addPreTestRemoteKeystores(nodeValidatorsDir)
 
   for topicName in ["libp2p", "gossipsub"]:
-    setTopicState(topicName, Disabled)
+    doAssert setTopicState(topicName, Disabled)
 
   let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
     "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -10,7 +10,7 @@
 import
   std/[typetraits, os, options, json, sequtils, uri, algorithm],
   testutils/unittests, chronicles, stint, json_serialization, confutils,
-  chronicles, chronos, blscurve, libp2p/crypto/crypto as lcrypto,
+  chronos, blscurve, libp2p/crypto/crypto as lcrypto,
   stew/[byteutils, io2], stew/shims/net,
 
   ../beacon_chain/spec/[crypto, keystore, eth2_merkleization],
@@ -275,9 +275,6 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
 
   copyHalfValidators(nodeDataDir, true)
   addPreTestRemoteKeystores(nodeValidatorsDir)
-
-  for topicName in ["libp2p", "gossipsub"]:
-    doAssert setTopicState(topicName, Disabled)
 
   let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
     "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
@@ -1494,5 +1491,8 @@ let
     except ValueError as exc:
       fatal "Invalid base port arg", basePort = basePortStr, exc = exc.msg
       quit 1
+
+for topicName in ["libp2p", "gossipsub"]:
+  doAssert setTopicState(topicName, Disabled)
 
 waitFor main(basePort)

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -277,6 +277,7 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   addPreTestRemoteKeystores(nodeValidatorsDir)
 
   let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
+    "--log-level=TRACE;DEBUG:libp2p,gossipsub"
     "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--discv5=off",

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -10,7 +10,7 @@
 import
   std/[typetraits, os, options, json, sequtils, uri, algorithm],
   testutils/unittests, chronicles, stint, json_serialization, confutils,
-  chronos, blscurve, libp2p/crypto/crypto as lcrypto,
+  chronicles, chronos, blscurve, libp2p/crypto/crypto as lcrypto,
   stew/[byteutils, io2], stew/shims/net,
 
   ../beacon_chain/spec/[crypto, keystore, eth2_merkleization],
@@ -276,8 +276,10 @@ proc startBeaconNode(basePort: int) {.raises: [Defect, CatchableError].} =
   copyHalfValidators(nodeDataDir, true)
   addPreTestRemoteKeystores(nodeValidatorsDir)
 
+  for topicName in ["libp2p", "gossipsub"]:
+    setTopicState(topicName, Disabled)
+
   let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
-    "--log-level=TRACE;DEBUG:libp2p,gossipsub",
     "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
     "--discv5=off",

--- a/tests/test_keymanager_api.nim.cfg
+++ b/tests/test_keymanager_api.nim.cfg
@@ -1,0 +1,8 @@
+# beacon_chain
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+-d:"chronicles_runtime_filtering=on"

--- a/tests/test_keymanager_api.nim.cfg
+++ b/tests/test_keymanager_api.nim.cfg
@@ -1,8 +1,0 @@
-# beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
-# Licensed and distributed under either of
-#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
-#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
-# at your option. This file may not be copied, modified, or distributed except according to those terms.
-
--d:"chronicles_runtime_filtering=on"


### PR DESCRIPTION
In keymanager test, logs are currently not analyzable due to large number of `libp2p gossipsub` logs. Hide those.