### PR TITLE
reduce memory allocations during state transition

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -26,6 +26,19 @@ export base, sets
 from ssz_serialization/proofs import GeneralizedIndex
 export proofs.GeneralizedIndex
 
+type
+  TimelyFlag* {.pure.} = enum
+    TIMELY_SOURCE_FLAG_INDEX
+    TIMELY_TARGET_FLAG_INDEX
+    TIMELY_HEAD_FLAG_INDEX
+
+static:
+  # Verify that ordinals follow spec values (the spec uses these as shifts for bit flags)
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#participation-flag-indices
+  doAssert ord(TIMELY_SOURCE_FLAG_INDEX) == 0
+  doAssert ord(TIMELY_TARGET_FLAG_INDEX) == 1
+  doAssert ord(TIMELY_HEAD_FLAG_INDEX) == 2
+
 const
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#incentivization-weights
   TIMELY_SOURCE_WEIGHT* = 14
@@ -35,8 +48,8 @@ const
   PROPOSER_WEIGHT* = 8
   WEIGHT_DENOMINATOR* = 64
 
-  PARTICIPATION_FLAG_WEIGHTS* =
-    [TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]
+  PARTICIPATION_FLAG_WEIGHTS*: array[TimelyFlag, uint64] =
+    [uint64 TIMELY_SOURCE_WEIGHT, TIMELY_TARGET_WEIGHT, TIMELY_HEAD_WEIGHT]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/altair/validator.md#misc
   TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE* = 16
@@ -51,11 +64,6 @@ const
   FINALIZED_ROOT_INDEX* = 105.GeneralizedIndex # `finalized_checkpoint` > `root`
   CURRENT_SYNC_COMMITTEE_INDEX* = 54.GeneralizedIndex # `current_sync_committee`
   NEXT_SYNC_COMMITTEE_INDEX* = 55.GeneralizedIndex # `next_sync_committee`
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#participation-flag-indices
-  TIMELY_SOURCE_FLAG_INDEX* = 0
-  TIMELY_TARGET_FLAG_INDEX* = 1
-  TIMELY_HEAD_FLAG_INDEX* = 2
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#inactivity-penalties
   INACTIVITY_SCORE_BIAS* = 4
@@ -310,7 +318,7 @@ type
     next_sync_committee*: SyncCommittee        # [New in Altair]
 
   UnslashedParticipatingBalances* = object
-    previous_epoch*: array[PARTICIPATION_FLAG_WEIGHTS.len, Gwei]
+    previous_epoch*: array[TimelyFlag, Gwei]
     current_epoch_TIMELY_TARGET*: Gwei
     current_epoch*: Gwei # aka total_active_balance
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -200,13 +200,13 @@ func get_seed*(state: ForkyBeaconState, epoch: Epoch, domain_type: DomainType):
   state.get_seed(epoch, domain_type, mix)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#add_flag
-func add_flag*(flags: ParticipationFlags, flag_index: int): ParticipationFlags =
-  let flag = ParticipationFlags(1'u8 shl flag_index)
+func add_flag*(flags: ParticipationFlags, flag_index: TimelyFlag): ParticipationFlags =
+  let flag = ParticipationFlags(1'u8 shl ord(flag_index))
   flags or flag
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/altair/beacon-chain.md#has_flag
-func has_flag*(flags: ParticipationFlags, flag_index: int): bool =
-  let flag = ParticipationFlags(1'u8 shl flag_index)
+func has_flag*(flags: ParticipationFlags, flag_index: TimelyFlag): bool =
+  let flag = ParticipationFlags(1'u8 shl ord(flag_index))
   (flags and flag) == flag
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/altair/light-client/sync-protocol.md#is_sync_committee_update

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -288,7 +288,7 @@ proc collectEpochRewardsAndPenalties*(
       total_active_balance)
     finality_delay = get_finality_delay(state)
 
-  for flag_index in 0 ..< PARTICIPATION_FLAG_WEIGHTS.len:
+  for flag_index in TimelyFlag:
     for validator_index, delta in get_flag_index_deltas(
         state, flag_index, base_reward_per_increment, info, finality_delay):
       template rp: untyped = rewardsAndPenalties[validator_index]
@@ -302,7 +302,7 @@ proc collectEpochRewardsAndPenalties*(
         max_flag_index_reward = get_flag_index_reward(
           state, base_reward, active_increments,
           unslashed_participating_increment,
-          PARTICIPATION_FLAG_WEIGHTS[flag_index].uint64,
+          PARTICIPATION_FLAG_WEIGHTS[flag_index],
           finality_delay)
 
       case flag_index
@@ -315,8 +315,6 @@ proc collectEpochRewardsAndPenalties*(
       of TIMELY_HEAD_FLAG_INDEX:
         rp.head_outcome = delta.getOutcome
         rp.max_head_reward = max_flag_index_reward
-      else:
-        raiseAssert(&"Unknown flag index {flag_index}.")
 
   for validator_index, penalty in get_inactivity_penalty_deltas(
       cfg, state, info):

--- a/tests/consensus_spec/altair/test_fixture_rewards.nim
+++ b/tests/consensus_spec/altair/test_fixture_rewards.nim
@@ -49,9 +49,8 @@ proc runTest(rewardsDir, identifier: string) =
         total_balance = info.balances.current_epoch
         base_reward_per_increment = get_base_reward_per_increment(total_balance)
 
-      static: doAssert PARTICIPATION_FLAG_WEIGHTS.len == 3
       var
-        flagDeltas2 = [
+        flagDeltas2: array[TimelyFlag, Deltas] = [
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len)]
@@ -59,7 +58,7 @@ proc runTest(rewardsDir, identifier: string) =
 
       let finality_delay = get_finality_delay(state[])
 
-      for flag_index in 0 ..< PARTICIPATION_FLAG_WEIGHTS.len:
+      for flag_index in TimelyFlag:
         for validator_index, delta in get_flag_index_deltas(
             state[], flag_index, base_reward_per_increment, info, finality_delay):
           if not is_eligible_validator(info.validators[validator_index]):

--- a/tests/consensus_spec/altair/test_fixture_rewards.nim
+++ b/tests/consensus_spec/altair/test_fixture_rewards.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
@@ -49,9 +49,8 @@ proc runTest(rewardsDir, identifier: string) =
         total_balance = info.balances.current_epoch
         base_reward_per_increment = get_base_reward_per_increment(total_balance)
 
-      static: doAssert PARTICIPATION_FLAG_WEIGHTS.len == 3
       var
-        flagDeltas2 = [
+        flagDeltas2: array[TimelyFlag, Deltas] = [
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len)]
@@ -59,7 +58,7 @@ proc runTest(rewardsDir, identifier: string) =
 
       let finality_delay = get_finality_delay(state[])
 
-      for flag_index in 0 ..< PARTICIPATION_FLAG_WEIGHTS.len:
+      for flag_index in TimelyFlag:
         for validator_index, delta in get_flag_index_deltas(
             state[], flag_index, base_reward_per_increment, info, finality_delay):
           if not is_eligible_validator(info.validators[validator_index]):

--- a/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/capella/test_fixture_rewards.nim
+++ b/tests/consensus_spec/capella/test_fixture_rewards.nim
@@ -49,9 +49,8 @@ proc runTest(rewardsDir, identifier: string) =
         total_balance = info.balances.current_epoch
         base_reward_per_increment = get_base_reward_per_increment(total_balance)
 
-      static: doAssert PARTICIPATION_FLAG_WEIGHTS.len == 3
       var
-        flagDeltas2 = [
+        flagDeltas2: array[TimelyFlag, Deltas] = [
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len)]
@@ -59,7 +58,7 @@ proc runTest(rewardsDir, identifier: string) =
 
       let finality_delay = get_finality_delay(state[])
 
-      for flag_index in 0 ..< PARTICIPATION_FLAG_WEIGHTS.len:
+      for flag_index in TimelyFlag:
         for validator_index, delta in get_flag_index_deltas(
             state[], flag_index, base_reward_per_increment, info, finality_delay):
           if not is_eligible_validator(info.validators[validator_index]):

--- a/tests/consensus_spec/capella/test_fixture_rewards.nim
+++ b/tests/consensus_spec/capella/test_fixture_rewards.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2022 Status Research & Development GmbH
+# Copyright (c) 2020-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/deneb/test_fixture_rewards.nim
+++ b/tests/consensus_spec/deneb/test_fixture_rewards.nim
@@ -49,9 +49,8 @@ proc runTest(rewardsDir, identifier: string) =
         total_balance = info.balances.current_epoch
         base_reward_per_increment = get_base_reward_per_increment(total_balance)
 
-      static: doAssert PARTICIPATION_FLAG_WEIGHTS.len == 3
       var
-        flagDeltas2 = [
+        flagDeltas2: array[TimelyFlag, Deltas] = [
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len),
           Deltas.init(state[].validators.len)]
@@ -59,7 +58,7 @@ proc runTest(rewardsDir, identifier: string) =
 
       let finality_delay = get_finality_delay(state[])
 
-      for flag_index in 0 ..< PARTICIPATION_FLAG_WEIGHTS.len:
+      for flag_index in TimelyFlag:
         for validator_index, delta in get_flag_index_deltas(
             state[], flag_index, base_reward_per_increment, info, finality_delay):
           if not is_eligible_validator(info.validators[validator_index]):


### PR DESCRIPTION
This PR removes a few hundred thousand temporary seq allocations during state transition - in particular, the flag seq was allocated per validator while committees are computed per attestation.