### PR TITLE
update port assignments to support more Jenkins executors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ libbacktrace:
 # Make sure ports don't overlap to support concurrent execution of tests
 # Avoid selecting ephemeral ports that may be used by others; safe = 5001-9999
 #
-# EXECUTOR_NUMBER: [0, 1] (depends on max number of concurrent CI jobs)
+# EXECUTOR_NUMBER: [0, 2] (depends on max number of concurrent CI jobs)
 #
 # The following port ranges are allocated (entire continuous range):
 #
@@ -181,9 +181,9 @@ libbacktrace:
 # - NIMBUS_TEST_SIGNING_NODE_BASE_PORT + [0, 2)
 #
 # REST tests:
-# - --base-port
-# - --base-rest-port
-# - --base-metrics-port
+# - --base-port (REST_TEST_BASE_PORT + 0)
+# - --base-rest-port (REST_TEST_BASE_PORT + 1)
+# - --base-metrics-port (REST_TEST_BASE_PORT + 2)
 #
 # Local testnets (entire continuous range):
 # - --base-port + [0, --nodes + --light-clients)
@@ -200,13 +200,14 @@ libbacktrace:
 # - --base-el-ws-port + --el-port-offset * [0, --nodes + --light-clients)
 # - --base-el-auth-rpc-port + --el-port-offset * [0, --nodes + --light-clients)
 UNIT_TEST_BASE_PORT := 9950
+REST_TEST_BASE_PORT := 9990
 
 restapi-test:
 	./tests/simulation/restapi.sh \
 		--data-dir resttest0_data \
-		--base-port $$(( 5001 + EXECUTOR_NUMBER * 500 )) \
-		--base-rest-port $$(( 5031 + EXECUTOR_NUMBER * 500 )) \
-		--base-metrics-port $$(( 5061 + EXECUTOR_NUMBER * 500 )) \
+		--base-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 0 )) \
+		--base-rest-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 1 )) \
+		--base-metrics-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 2 )) \
 		--resttest-delay 30 \
 		--kill-old-processes
 
@@ -226,17 +227,17 @@ local-testnet-minimal:
 		--disable-htop \
 		--enable-payload-builder \
 		--enable-logtrace \
-		--base-port $$(( 6001 + EXECUTOR_NUMBER * 500 )) \
-		--base-rest-port $$(( 6031 + EXECUTOR_NUMBER * 500 )) \
-		--base-metrics-port $$(( 6061 + EXECUTOR_NUMBER * 500 )) \
-		--base-vc-keymanager-port $$(( 6131 + EXECUTOR_NUMBER * 500 )) \
-		--base-vc-metrics-port $$(( 6161 + EXECUTOR_NUMBER * 500 )) \
-		--base-remote-signer-port $$(( 6201 + EXECUTOR_NUMBER * 500 )) \
-		--base-remote-signer-metrics-port $$(( 6251 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-net-port $$(( 6301 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-rpc-port $$(( 6302 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-ws-port $$(( 6303 + EXECUTOR_NUMBER * 500 )) \
-		--base-el-auth-rpc-port $$(( 6304 + EXECUTOR_NUMBER * 500 )) \
+		--base-port $$(( 5001 + EXECUTOR_NUMBER * 500 )) \
+		--base-rest-port $$(( 5031 + EXECUTOR_NUMBER * 500 )) \
+		--base-metrics-port $$(( 5061 + EXECUTOR_NUMBER * 500 )) \
+		--base-vc-keymanager-port $$(( 5131 + EXECUTOR_NUMBER * 500 )) \
+		--base-vc-metrics-port $$(( 5161 + EXECUTOR_NUMBER * 500 )) \
+		--base-remote-signer-port $$(( 5201 + EXECUTOR_NUMBER * 500 )) \
+		--base-remote-signer-metrics-port $$(( 5251 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-net-port $$(( 5301 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-rpc-port $$(( 5302 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-ws-port $$(( 5303 + EXECUTOR_NUMBER * 500 )) \
+		--base-el-auth-rpc-port $$(( 5304 + EXECUTOR_NUMBER * 500 )) \
 		--el-port-offset 5 \
 		--timeout 648 \
 		--kill-old-processes \
@@ -387,8 +388,8 @@ endif
 	for TEST_BINARY in $(XML_TEST_BINARIES); do \
 		PARAMS="--xml:build/$${TEST_BINARY}.xml --console"; \
 		echo -e "\nRunning $${TEST_BINARY} $${PARAMS}\n"; \
-		NIMBUS_TEST_KEYMANAGER_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 25 + 0 )) \
-		NIMBUS_TEST_SIGNING_NODE_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 25 + 4 )) \
+		NIMBUS_TEST_KEYMANAGER_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 6 + 0 )) \
+		NIMBUS_TEST_SIGNING_NODE_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 6 + 4 )) \
 			build/$${TEST_BINARY} $${PARAMS} || { \
 				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 1000 lines from the log:"; \
 				tail -n1000 "$${TEST_BINARY}.log"; exit 1; \


### PR DESCRIPTION
Some Linux hosts have 3 concurrent executors. To avoid job failure due to network port conflicts, adjust the port assignments.