### PR TITLE
further reduce CI keymanager test log spam

### DIFF
--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -1492,7 +1492,7 @@ let
       fatal "Invalid base port arg", basePort = basePortStr, exc = exc.msg
       quit 1
 
-for topicName in ["libp2p", "gossipsub"]:
+for topicName in ["libp2p", "gossipsub", "gossip_eth2"]:
   doAssert setTopicState(topicName, Disabled)
 
 waitFor main(basePort)


### PR DESCRIPTION
Remove verbose `gossip_eth2` logs not relevant for `test_keymanager_api` from the log to debug CI issue.