### PR TITLE
stop building `test_libnimbus_lc` and force UBSAN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,7 @@ jobs:
 
           # Stack usage test and UBSAN on recent enough gcc:
           if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'amd64' ]]; then
-            if [[ '${{ github.sha }}' =~ ^7 ]]; then
-              export NIMFLAGS="${NIMFLAGS} -d:limitStackUsage --passC:-fsanitize=undefined --passL:-fsanitize=undefined"
-            else
-              export NIMFLAGS="${NIMFLAGS} -d:limitStackUsage"
-            fi
+            export NIMFLAGS="${NIMFLAGS} -d:limitStackUsage --passC:-fsanitize=undefined --passL:-fsanitize=undefined"
             echo "NIMFLAGS=${NIMFLAGS}" >> $GITHUB_ENV
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -285,8 +285,7 @@ XML_TEST_BINARIES := \
 # test suite
 TEST_BINARIES := \
 	state_sim \
-	block_sim \
-	test_libnimbus_lc
+	block_sim
 .PHONY: $(TEST_BINARIES) $(XML_TEST_BINARIES) force_build_alone_all_tests
 
 # Preset-dependent tests


### PR DESCRIPTION
Mainly, don't merge because it's probably too much to run UBSAN every commit in CI.

But also, there might be a better approach to the `test_libnimbus_lc` removal (e.g., fixing instead). This exists to verify in CI what
```
make NIMFLAGS="--passC:-fsanitize=undefined --passL:-fsanitize=undefined" test_libnimbus_lc
```
shows locally, i.e. that it triggers some UBSAN linking error on that specific target which removing that target removes, that no other target has this issue.