### PR TITLE
further adjust `test_keymanager_api` logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,8 +391,8 @@ endif
 		NIMBUS_TEST_KEYMANAGER_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 6 + 0 )) \
 		NIMBUS_TEST_SIGNING_NODE_BASE_PORT=$$(( $(UNIT_TEST_BASE_PORT) + EXECUTOR_NUMBER * 6 + 4 )) \
 			build/$${TEST_BINARY} $${PARAMS} || { \
-				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 1000 lines from the log:"; \
-				tail -n1000 "$${TEST_BINARY}.log"; exit 1; \
+				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 2000 lines from the log:"; \
+				tail -n2000 "$${TEST_BINARY}.log"; exit 1; \
 			}; \
 		done; \
 		rm -rf 0000-*.json t_slashprot_migration.* *.log block_sim_db
@@ -406,13 +406,13 @@ endif
 		echo -e "\nRunning $${TEST_BINARY} $${PARAMS}\n"; \
 		if [[ "$${REDIRECT}" != "" ]]; then \
 			build/$${TEST_BINARY} $${PARAMS} > "$${REDIRECT}" && echo "OK" || { \
-				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 1000 lines from the log:"; \
-				tail -n1000 "$${TEST_BINARY}.log"; exit 1; \
+				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 2000 lines from the log:"; \
+				tail -n2000 "$${TEST_BINARY}.log"; exit 1; \
 			}; \
 		else \
 			build/$${TEST_BINARY} $${PARAMS} || { \
-				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 1000 lines from the log:"; \
-				tail -n1000 "$${TEST_BINARY}.log"; exit 1; \
+				echo -e "\n$${TEST_BINARY} $${PARAMS} failed; Last 2000 lines from the log:"; \
+				tail -n2000 "$${TEST_BINARY}.log"; exit 1; \
 			}; \
 		fi; \
 		done; \

--- a/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
+++ b/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim
@@ -17,6 +17,9 @@ import
 
 export hashes, sets, tables, altair
 
+logScope:
+  topics = "syncpool"
+
 const
   syncCommitteeMsgsRetentionSlots = 3
     ## How many slots to retain sync committee

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -22,6 +22,9 @@ from  ../spec/state_transition_block import validate_blobs
 
 export eth2_processor, eth2_network
 
+logScope:
+  topics = "message_router"
+
 declareCounter beacon_voluntary_exits_sent,
   "Number of beacon voluntary sent by this node"
 

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -930,7 +930,7 @@ if [[ "${LIGHTHOUSE_VC_NODES}" != "0" ]]; then
 fi
 
 dump_logs() {
-  LOG_LINES=1000
+  LOG_LINES=100
   for LOG in "${DATA_DIR}"/logs/*; do
     echo "Last ${LOG_LINES} lines of ${LOG}:"
     tail -n ${LOG_LINES} "${LOG}"

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -1492,7 +1492,9 @@ let
       fatal "Invalid base port arg", basePort = basePortStr, exc = exc.msg
       quit 1
 
-for topicName in ["libp2p", "gossipsub", "gossip_eth2"]:
+for topicName in [
+    "libp2p", "gossipsub", "gossip_eth2", "message_router", "batch_validation",
+    "syncpool"]:
   doAssert setTopicState(topicName, Disabled)
 
 waitFor main(basePort)


### PR DESCRIPTION
It is still unclear how `test_keymanager_api` sometimes fails in CI; further adjust logging parameters.