### PR TITLE
bump Jenkins build timeout

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
     }
 
     stage('Build') {
-      steps { timeout(40) {
+      steps { timeout(50) {
         sh 'make LOG_LEVEL=TRACE'
         /* Check documentation reflects `nimbus_beacon_node --help`. */
         sh '''#!/usr/bin/env bash


### PR DESCRIPTION
With the gnosis binary, building all targets sometimes exceeds the 40m. Bump timeout to 50m.

```
Cancelling nested steps due to timeout
Sending interrupt signal to process
gcc: fatal error: Terminated signal terminated program lto1
compilation terminated.
make[2]: *** [/tmp/cctcWxAN.mk:134: /tmp/cciCtCWJ.ltrans44.ltrans.o] Error 1
make[2]: *** Waiting for unfinished jobs....
gcc: fatal error: Terminated signal terminated program lto1
compilation terminated.
make[2]: *** [/tmp/cctcWxAN.mk:155: /tmp/cciCtCWJ.ltrans51.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
compilation terminated.
/usr/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
make[1]: *** [nimcache/release/nimbus_beacon_node_gnosis/nimbus_beacon_node_gnosis.makefile:3148: build] Error 1
make: *** [Makefile:699: gnosis-build] Error 2
```