### PR TITLE
ensure `ValidatorPubKey` int-compatibly aligned to fix UB

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -54,7 +54,10 @@ type
     ## eagerly load keys - deserialization is slow, as are equality checks -
     ## however, it is not guaranteed that the key is valid (except in some
     ## cases, like the database state)
-    blob*: array[RawPubKeySize, byte]
+    ##
+    ## It must be 8-byte aligned because `hash(ValidatorPubKey)` just casts a
+    ## ptr to one to a ptr to the other, so it needs a compatible alignment.
+    blob* {.align: 8.}: array[RawPubKeySize, byte]
 
   UncompressedPubKey* = object
     ## Uncompressed variation of ValidatorPubKey - this type is faster to

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -57,7 +57,7 @@ type
     ##
     ## It must be 8-byte aligned because `hash(ValidatorPubKey)` just casts a
     ## ptr to one to a ptr to the other, so it needs a compatible alignment.
-    blob* {.align: 8.}: array[RawPubKeySize, byte]
+    blob* {.align: sizeof(Hash).}: array[RawPubKeySize, byte]
 
   UncompressedPubKey* = object
     ## Uncompressed variation of ValidatorPubKey - this type is faster to


### PR DESCRIPTION
It addresses the UB found by UBSAN as part of `make test`
```
[Suite] saveKeystore()
  [OK] Save [LOCAL] keystore after [LOCAL] keystore with same id
  [OK] Save [REMOTE] keystore after [REMOTE] keystore with same id
  [OK] Save [REMOTE] keystore after [LOCAL] keystore with same id
  [OK] Save [LOCAL] keystore after [REMOTE] keystore with same id
  [OK] Save [LOCAL] keystore after [LOCAL] keystore with different id
  [OK] Save [REMOTE] keystore after [REMOTE] keystore with different id
  [OK] Save [LOCAL] keystore after [REMOTE] keystore with different id
  [OK] Save [REMOTE] keystore after [LOCAL] keystore with different id
Wrote test_keymanager_api/bootstrap_node.enr
nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/pure/collections/hashcommon.nim:64:11: runtime error: load of misaligned address 0x7f18271647a1 for type 'NI', which requires 8 byte alignment
0x7f18271647a1: note: pointer points here
 50 f0 7e  49 82 ed 8f e6 a4 22 0a  c7 5d 37 99 60 07 ef e1  19 17 f9 9f c3 20 ed 6d  70 00 00 00 00
```

Despite nominally appearing in the Nim stdlib, it's the result of
https://github.com/status-im/nimbus-eth2/blob/60f0a2f6a662abb9c8332d9f0d3eb7cc998fab63/beacon_chain/spec/crypto.nim#L379-L383

which gets `template`-inlined into a `Table`-based hash lookup there.

One way to reproduce this is to use
```nim
import chronos
import beacon_chain/spec/crypto

proc f() {.async.} =
  var x: uint8
  var y: ValidatorPubKey
  echo cast[uint64](unsafeAddr y)

waitFor f()
```
as a test harness. Without this change, it will consistently produce non-int-compatible-aligned `y` variables:
```
$ for i in $(seq 1 10); do ./env.sh nim c -r --hints:off --passC="-fsanitize=undefined -fsanitize-undefined-trap-on-error" --passL:"-fsanitize=undefined -fsanitize-undefined-trap-on-error" b; done
140069358473313
140566133973089
140607116353633
139867829948513
140469387161697
140579688271969
140212582600801
139755126800481
139852498899041
140408405770337
```

whereas with this PR:
```
$ for i in $(seq 1 10); do ./env.sh nim c -r --hints:off --passC="-fsanitize=undefined -fsanitize-undefined-trap-on-error" --passL:"-fsanitize=undefined -fsanitize-undefined-trap-on-error" b; done
140478602514536
140402365259880
140243217064040
140004768759912
140309588856936
140614407958632
140173144457320
139832288231528
140406915104872
140207324840040
```