### PR TITLE
avoid invalidating validators htr cache within epoch

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1112,9 +1112,16 @@ proc getBlockSZ*(
 func toBeaconStateSummary(state: ForkyBeaconState): BeaconStateSummary =
   # Two states with identical BeaconStateSummary fields have the same
   # hash_tree_root(state.validators).
+
+  doAssert not state.slot.is_epoch
+
   let
     epoch = state.slot.epoch
-    root_idx = epoch.start_slot mod SLOTS_PER_HISTORICAL_ROOT
+
+    # state.block_roots and state.state_roots don't register process_epoch()
+    # updates until the first interior slot of an epoch.
+    root_idx = (epoch.start_slot + 1) mod SLOTS_PER_HISTORICAL_ROOT
+
   BeaconStateSummary(
     epoch: epoch,
     num_validators: state.validators.len,

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1112,14 +1112,14 @@ proc getBlockSZ*(
 func toBeaconStateSummary(state: ForkyBeaconState): BeaconStateSummary =
   # Two states with identical BeaconStateSummary fields have the same
   # hash_tree_root(state.validators).
-
-  doAssert not state.slot.is_epoch
-
   let
     epoch = state.slot.epoch
 
     # state.block_roots and state.state_roots don't register process_epoch()
-    # updates until the first interior slot of an epoch.
+    # updates until the first interior epoch slot. When state.slot.is_epoch,
+    # this function returns nothing particularly useful effectively wrapping
+    # backwards to the oldest still-present slot in the circular buffer, but
+    # validatorsPotentiallyChanged excludes this case separately.
     root_idx = (epoch.start_slot + 1) mod SLOTS_PER_HISTORICAL_ROOT
 
   BeaconStateSummary(

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1112,12 +1112,14 @@ proc getBlockSZ*(
 func toBeaconStateSummary(state: ForkyBeaconState): BeaconStateSummary =
   # Two states with identical BeaconStateSummary fields have the same
   # hash_tree_root(state.validators).
-  let slot = state.slot
+  let
+    epoch = state.slot.epoch
+    root_idx = epoch.start_slot mod SLOTS_PER_HISTORICAL_ROOT
   BeaconStateSummary(
-    epoch: slot.epoch,
+    epoch: epoch,
     num_validators: state.validators.len,
-    latest_block_root: state.block_roots[slot mod SLOTS_PER_HISTORICAL_ROOT],
-    latest_state_root: state.state_roots[slot mod SLOTS_PER_HISTORICAL_ROOT])
+    latest_block_root: state.block_roots[root_idx],
+    latest_state_root: state.state_roots[root_idx])
 
 proc getStateOnlyMutableValidators(
     immutableValidators: openArray[ImmutableValidatorData2],


### PR DESCRIPTION
In general, `validators` doesn't change between `process_epoch()` calls.