### PR TITLE
fix regression in remote signing REST schema

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1212,7 +1212,7 @@ proc writeValue*[
   # https://github.com/ConsenSys/web3signer/blob/d51337e96ba5ce410222943556bed7c4856b8e57/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java#L42-L58
   writer.beginRecord()
   writer.writeField("version", value.kind.toString.toUpperAscii)
-  writer.writeField("block", value.data)
+  writer.writeField("block_header", value.data)
   writer.endRecord()
 
 proc writeValue*[
@@ -2109,8 +2109,8 @@ proc writeValue*(writer: var JsonWriter[RestJson],
     if isSome(value.signingRoot):
       writer.writeField("signingRoot", value.signingRoot)
 
-    # https://github.com/ConsenSys/web3signer/blob/41c0cbfabcb1fca9587b59e058b7eb29f152c60c/core/src/main/resources/openapi-specs/eth2/signing/schemas.yaml#L418-L497
-    writer.writeField("beacon_block", value.beaconBlock)
+    # https://github.com/Consensys/web3signer/blob/2d956c019663ac70f60640d23196d1d321c1b1fa/core/src/main/resources/openapi-specs/eth2/signing/schemas.yaml#L483-L500
+    writer.writeField("beacon_block", value.beaconBlockHeader)
 
     if isSome(value.proofs):
       writer.writeField("proofs", value.proofs.get())
@@ -2312,13 +2312,13 @@ proc readValue*(reader: var JsonReader[RestJson],
       if len(proofs) > 0:
         Web3SignerRequest(
           kind: Web3SignerRequestKind.BlockV2,
-          forkInfo: forkInfo, signingRoot: signingRoot, beaconBlock: data,
+          forkInfo: forkInfo, signingRoot: signingRoot, beaconBlockHeader: data,
           proofs: Opt.some(proofs)
         )
       else:
         Web3SignerRequest(
           kind: Web3SignerRequestKind.BlockV2,
-          forkInfo: forkInfo, signingRoot: signingRoot, beaconBlock: data
+          forkInfo: forkInfo, signingRoot: signingRoot, beaconBlockHeader: data
         )
     of Web3SignerRequestKind.Deposit:
       if dataName != "deposit":

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -594,7 +594,9 @@ type
     of Web3SignerRequestKind.Attestation:
       attestation*: AttestationData
     of Web3SignerRequestKind.BlockV2:
-      beaconBlock* {.
+      # https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Signing/operation/ETH2_SIGN
+      # https://github.com/Consensys/web3signer/blob/2d956c019663ac70f60640d23196d1d321c1b1fa/core/src/main/resources/openapi-specs/eth2/signing/schemas.yaml#L483-L500
+      beaconBlockHeader* {.
         serializedFieldName: "beacon_block".}: Web3SignerForkedBeaconBlock
       proofs*: Opt[seq[Web3SignerMerkleProof]]
     of Web3SignerRequestKind.Deposit:
@@ -823,7 +825,7 @@ func init*(t: typedesc[Web3SignerRequest], fork: Fork,
       fork: fork, genesis_validators_root: genesis_validators_root
     )),
     signingRoot: signingRoot,
-    beaconBlock: data
+    beaconBlockHeader: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], fork: Fork,
@@ -839,7 +841,7 @@ func init*(t: typedesc[Web3SignerRequest], fork: Fork,
     )),
     signingRoot: signingRoot,
     proofs: Opt.some(@proofs),
-    beaconBlock: data
+    beaconBlockHeader: data
   )
 
 func init*(t: typedesc[Web3SignerRequest], genesisForkVersion: Version,


### PR DESCRIPTION
The `beaconBlock` to `beaconBlockHeader` change is just to clarify the nature of that field. In Bellatrix and later, which is what's supported in this context, it's only ever the header.

The `block` to `block_header` field name change is the main thing.