### PR TITLE
prevent concurrent `storeBlock` calls (fixes #5285)

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -239,20 +239,22 @@ proc processSignedBeaconBlock*(
     # propagation of seemingly good blocks
     trace "Block validated"
 
-    var blobs = Opt.none(BlobSidecars)
-    when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
-      if self.blobQuarantine[].hasBlobs(signedBlock):
-        blobs = Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root))
+    let blobs =
+      when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
+        if self.blobQuarantine[].hasBlobs(signedBlock):
+          Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root))
+        else:
+          if not self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
+                                              signedBlock):
+            notice "Block quarantine full (blobless)",
+              blockRoot = shortLog(signedBlock.root),
+              blck = shortLog(signedBlock.message),
+              signature = shortLog(signedBlock.signature)
+          return v
       else:
-        if not self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
-                                             signedBlock):
-          notice "Block quarantine full (blobless)",
-           blockRoot = shortLog(signedBlock.root),
-           blck = shortLog(signedBlock.message),
-           signature = shortLog(signedBlock.signature)
-        return v
+        Opt.none(BlobSidecars)
 
-    self.blockProcessor[].addBlock(
+    self.blockProcessor[].enqueueBlock(
       src, ForkedSignedBeaconBlock.init(signedBlock),
       blobs,
       maybeFinalized = maybeFinalized,
@@ -293,7 +295,7 @@ proc processSignedBlobSidecar*(
     debug "Blob received", delay
 
   let v =
-    self.dag.validateBlobSidecar(self.quarantine, self.blob_quarantine,
+    self.dag.validateBlobSidecar(self.quarantine, self.blobQuarantine,
                                  signedBlobSidecar, wallTime, idx)
 
   if v.isErr():
@@ -312,7 +314,7 @@ proc processSignedBlobSidecar*(
     let blobless = o.unsafeGet()
 
     if self.blobQuarantine[].hasBlobs(blobless):
-      self.blockProcessor[].addBlock(
+      self.blockProcessor[].enqueueBlock(
         MsgSource.gossip,
         ForkedSignedBeaconBlock.init(blobless),
         Opt.some(self.blobQuarantine[].popBlobs(

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -164,16 +164,18 @@ proc routeSignedBeaconBlock*(
         notice "Blob sent", blob = shortLog(signedBlobs[i]), error = res.error[]
     blobs = Opt.some(blobsOpt.get().mapIt(newClone(it.message)))
 
-  let newBlockRef = await router[].blockProcessor.storeBlock(
-    MsgSource.api, sendTime, blck, blobs)
+  let addedFut = newFuture[Result[void, VerifierError]]("routeSignedBeaconBlock")
+  router[].blockProcessor[].addBlock(
+    MsgSource.api, ForkedSignedBeaconBlock.init(blck), blobs, addedFut)
+  let added = await addedFut
 
   # The boolean we return tells the caller whether the block was integrated
   # into the chain
-  if newBlockRef.isErr():
-    return if newBlockRef.error()[0] != VerifierError.Duplicate:
+  if added.isErr():
+    return if added.error() != VerifierError.Duplicate:
       warn "Unable to add routed block to block pool",
         blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
-        signature = shortLog(blck.signature), err = newBlockRef.error()
+        signature = shortLog(blck.signature), err = added.error()
       ok(Opt.none(BlockRef))
     else:
       # If it's duplicate, there's an existing BlockRef to return. The block
@@ -183,10 +185,16 @@ proc routeSignedBeaconBlock*(
       if blockRef.isErr:
         warn "Unable to add routed duplicate block to block pool",
           blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
-          signature = shortLog(blck.signature), err = newBlockRef.error()
+          signature = shortLog(blck.signature), err = added.error()
       ok(blockRef)
 
-  return ok(Opt.some(newBlockRef.get()))
+
+  let blockRef = router[].dag.getBlockRef(blck.root)
+  if blockRef.isErr:
+    warn "Block finalised while waiting for block processor",
+      blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
+      signature = shortLog(blck.signature)
+  ok(blockRef)
 
 proc routeAttestation*(
     router: ref MessageRouter, attestation: Attestation,

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -164,10 +164,8 @@ proc routeSignedBeaconBlock*(
         notice "Blob sent", blob = shortLog(signedBlobs[i]), error = res.error[]
     blobs = Opt.some(blobsOpt.get().mapIt(newClone(it.message)))
 
-  let addedFut = newFuture[Result[void, VerifierError]]("routeSignedBeaconBlock")
-  router[].blockProcessor[].addBlock(
-    MsgSource.api, ForkedSignedBeaconBlock.init(blck), blobs, addedFut)
-  let added = await addedFut
+  let added = await router[].blockProcessor[].addBlock(
+    MsgSource.api, ForkedSignedBeaconBlock.init(blck), blobs)
 
   # The boolean we return tells the caller whether the block was integrated
   # into the chain

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -63,12 +63,9 @@ suite "Block processor" & preset():
 
   asyncTest "Reverse order block add & get" & preset():
     let
-      missingFut = newFuture[Result[void, VerifierError]]("t0")
-    processor[].addBlock(
-      MsgSource.gossip, ForkedSignedBeaconBlock.init(b2), Opt.none(BlobSidecars),
-      missingFut)
-    let
-      missing = await missingFut
+      missing = await processor[].addBlock(
+        MsgSource.gossip, ForkedSignedBeaconBlock.init(b2),
+        Opt.none(BlobSidecars))
 
     check: missing.error == VerifierError.MissingParent
 
@@ -78,12 +75,9 @@ suite "Block processor" & preset():
       FetchRecord(root: b1.root) in quarantine[].checkMissing(32)
 
     let
-      statusFut = newFuture[Result[void, VerifierError]]("t0")
-    processor[].addBlock(
-      MsgSource.gossip, ForkedSignedBeaconBlock.init(b1), Opt.none(BlobSidecars),
-      statusFut)
-    let
-      status = await statusFut
+      status = await processor[].addBlock(
+        MsgSource.gossip, ForkedSignedBeaconBlock.init(b1),
+        Opt.none(BlobSidecars))
       b1Get = dag.getBlockRef(b1.root)
 
     check:


### PR DESCRIPTION
When a block is introduced to the system both via REST and gossip at the same time, we will call `storeBlock` from two locations leading to a duplicate check race condition as we wait for the EL.

This issue may manifest in particular when using an external block builder that itself publishes the block onto the gossip network.