### PR TITLE
explicitly indicate type of `nil` in LC db `disposeSafe`

### DIFF
--- a/beacon_chain/light_client_db.nim
+++ b/beacon_chain/light_client_db.nim
@@ -57,10 +57,10 @@ type
       ## SyncCommitteePeriod -> altair.SyncCommittee
       ## Stores finalized `SyncCommittee` by sync committee period.
 
-template disposeSafe(s: untyped): untyped =
+template disposeSafe(s: var SqliteStmt): untyped =
   if distinctBase(s) != nil:
     s.dispose()
-    s = nil
+    s = typeof(s)(nil)
 
 proc initLegacyLightClientHeadersStore(
     backend: SqStoreRef,


### PR DESCRIPTION
In Nim 2.0, compiler fails to infer the type of `nil` within the `disposeSafe` template. Avoid that problem by explicitly indicating it.