### PR TITLE
explicit `int` array indices for Nim 2.0

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -65,7 +65,7 @@ type
     ## "free" attestations with those found in past blocks - these votes
     ## are tracked separately in the fork choice.
 
-    candidates*: array[ATTESTATION_LOOKBACK, AttestationTable] ## \
+    candidates*: array[ATTESTATION_LOOKBACK.int, AttestationTable] ## \
       ## We keep one item per slot such that indexing matches slot number
       ## together with startingSlot
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -131,7 +131,7 @@ type
     timeOffset*: Opt[TimeOffset]
 
   EpochSelectionProof* = object
-    signatures*: array[SLOTS_PER_EPOCH, Opt[ValidatorSig]]
+    signatures*: array[SLOTS_PER_EPOCH.int, Opt[ValidatorSig]]
     sync_committee_index*: IndexInSyncCommittee
 
   SyncCommitteeSelectionProof* = seq[EpochSelectionProof]
@@ -1350,7 +1350,7 @@ proc waitForBlock*(
 iterator chunks*[T](data: openArray[T], maxCount: Positive): seq[T] =
   for i in countup(0, len(data) - 1, maxCount):
     yield @(data.toOpenArray(i, min(i + maxCount, len(data)) - 1))
-    
+
 func init*(t: typedesc[TimeOffset], duration: Duration): TimeOffset =
   TimeOffset(value: duration.nanoseconds)
 


### PR DESCRIPTION
In Nim, when using a `distinct` capacity for an array, `int` lookups don't work. Therefore, define the array with `int` capacity.