### PR TITLE
cleanup `{.raises.}` for `writeValue`

### DIFF
--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
   std/[options, strutils, uri],
   stew/results, chronicles, confutils,

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -83,8 +83,8 @@ proc readValue*(reader: var TomlReader, value: var EngineApiRoles)
     else:
       reader.raiseError(unknownRoleMsg role)
 
-proc writeValue*(writer: var JsonWriter, roles: EngineApiRoles)
-                {.raises: [Defect, SerializationError, IOError].} =
+proc writeValue*(
+    writer: var JsonWriter, roles: EngineApiRoles) {.raises: [IOError].} =
   var strRoles: seq[string]
 
   for role in EngineApiRole:

--- a/beacon_chain/networking/libp2p_json_serialization.nim
+++ b/beacon_chain/networking/libp2p_json_serialization.nim
@@ -10,8 +10,8 @@
 import libp2p/[peerid, multiaddress], json_serialization
 export json_serialization
 
-proc writeValue*(writer: var JsonWriter, value: PeerId) {.
-    raises: [Defect, IOError].} =
+proc writeValue*(
+    writer: var JsonWriter, value: PeerId) {.raises: [IOError].} =
   writer.writeValue $value
 
 proc readValue*(reader: var JsonReader, value: var PeerId) {.
@@ -22,8 +22,8 @@ proc readValue*(reader: var JsonReader, value: var PeerId) {.
   else:
     raiseUnexpectedValue(reader, $res.error)
 
-proc writeValue*(writer: var JsonWriter, value: MultiAddress) {.
-    raises: [Defect, IOError].} =
+proc writeValue*(
+    writer: var JsonWriter, value: MultiAddress) {.raises: [IOError].} =
   writer.writeValue $value
 
 proc readValue*(reader: var JsonReader, value: var MultiAddress) {.

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -93,8 +93,7 @@ template ethTimeUnit*(typ: type) {.dirty.} =
   template shortLog*(v: typ): auto = distinctBase(v)
 
   # Serialization
-  proc writeValue*(writer: var JsonWriter, value: typ)
-                  {.raises: [IOError, Defect].}=
+  proc writeValue*(writer: var JsonWriter, value: typ) {.raises: [IOError].} =
     writeValue(writer, uint64 value)
 
   proc readValue*(reader: var JsonReader, value: var typ)

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -458,8 +458,9 @@ template `<`*(x, y: ValidatorPubKey): bool =
 
 {.pragma: serializationRaises, raises: [SerializationError, IOError, Defect].}
 
-proc writeValue*(writer: var JsonWriter, value: ValidatorPubKey | CookedPubKey) {.
-    inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: ValidatorPubKey | CookedPubKey
+) {.inline, raises: [IOError].} =
   writer.writeValue(value.toHex())
 
 proc readValue*(reader: var JsonReader, value: var ValidatorPubKey)
@@ -471,8 +472,9 @@ proc readValue*(reader: var JsonReader, value: var ValidatorPubKey)
     # TODO: Can we provide better diagnostic?
     raiseUnexpectedValue(reader, "Valid hex-encoded public key expected")
 
-proc writeValue*(writer: var JsonWriter, value: ValidatorSig) {.
-    inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: ValidatorSig
+) {.inline, raises: [IOError].} =
   # Workaround: https://github.com/status-im/nimbus-eth2/issues/374
   writer.writeValue(value.toHex())
 
@@ -485,8 +487,9 @@ proc readValue*(reader: var JsonReader, value: var ValidatorSig)
     # TODO: Can we provide better diagnostic?
     raiseUnexpectedValue(reader, "Valid hex-encoded signature expected")
 
-proc writeValue*(writer: var JsonWriter, value: ValidatorPrivKey) {.
-    inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: ValidatorPrivKey
+) {.inline, raises: [IOError].} =
   writer.writeValue(value.toHex())
 
 proc readValue*(reader: var JsonReader, value: var ValidatorPrivKey)

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -566,8 +566,7 @@ template makeLimitedUInt*(T: untyped, limit: SomeUnsignedInt) =
     for i in 0'u64..<limit:
       yield T(i)
 
-  proc writeValue*(writer: var JsonWriter, value: T)
-                  {.raises: [IOError, Defect].} =
+  proc writeValue*(writer: var JsonWriter, value: T) {.raises: [IOError].} =
     writeValue(writer, distinctBase value)
 
   proc readValue*(reader: var JsonReader, value: var T)
@@ -661,8 +660,8 @@ proc readValue*(reader: var JsonReader, value: var JustificationBits)
   except ValueError:
     raiseUnexpectedValue(reader, "Hex string of 1 byte expected")
 
-proc writeValue*(writer: var JsonWriter, value: JustificationBits)
-    {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: JustificationBits) {.raises: [IOError].} =
   writer.writeValue $value
 
 # `ValidatorIndex` seq handling.
@@ -888,8 +887,8 @@ func defaultGraffitiBytes*(): GraffitiBytes =
   static: doAssert graffitiBytes.len <= MAX_GRAFFITI_SIZE
   distinctBase(result)[0 ..< graffitiBytes.len] = graffitiBytes
 
-proc writeValue*(w: var JsonWriter, value: GraffitiBytes)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter, value: GraffitiBytes) {.raises: [IOError].} =
   w.writeValue $value
 
 template `==`*(lhs, rhs: GraffitiBytes): bool =

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -370,8 +370,8 @@ func fromHex*(T: typedesc[ExecutionAddress], s: string): T {.
      raises: [Defect, ValueError].} =
   hexToByteArray(s, result.data)
 
-proc writeValue*(writer: var JsonWriter, value: ExecutionAddress) {.
-     raises: [Defect, IOError].} =
+proc writeValue*(
+    writer: var JsonWriter, value: ExecutionAddress) {.raises: [IOError].} =
   writer.writeValue to0xHex(value.data)
 
 proc readValue*(reader: var JsonReader, value: var ExecutionAddress) {.

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -145,7 +145,7 @@ func `==`*(a, b: Eth2Digest): bool =
 func isZero*(x: Eth2Digest): bool =
   x.isZeroMemory
 
-proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [Defect, IOError, SerializationError].} =
+proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a
 
 proc readValue*(r: var JsonReader, a: var Eth2Digest) {.raises: [Defect, IOError, SerializationError].} =

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -573,8 +573,8 @@ proc decodeJsonString*[T](t: typedesc[T],
     err("Unable to deserialize data")
 
 ## uint64
-proc writeValue*(w: var JsonWriter[RestJson], value: uint64) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter[RestJson], value: uint64) {.raises: [IOError].} =
   writeValue(w, Base10.toString(value))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var uint64) {.
@@ -587,8 +587,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var uint64) {.
     reader.raiseUnexpectedValue($res.error() & ": " & svalue)
 
 ## uint8
-proc writeValue*(w: var JsonWriter[RestJson], value: uint8) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter[RestJson], value: uint8) {.raises: [IOError].} =
   writeValue(w, Base10.toString(value))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var uint8) {.
@@ -601,8 +601,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var uint8) {.
     reader.raiseUnexpectedValue($res.error() & ": " & svalue)
 
 ## JustificationBits
-proc writeValue*(w: var JsonWriter[RestJson], value: JustificationBits) {.
-    raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter[RestJson], value: JustificationBits
+) {.raises: [IOError].} =
   w.writeValue hexOriginal([uint8(value)])
 
 proc readValue*(reader: var JsonReader[RestJson], value: var JustificationBits) {.
@@ -615,8 +616,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var JustificationBits) 
                         "The `justification_bits` value must be a hex string")
 
 ## UInt256
-proc writeValue*(w: var JsonWriter[RestJson], value: UInt256) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter[RestJson], value: UInt256) {.raises: [IOError].} =
   writeValue(w, toString(value))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var UInt256) {.
@@ -629,8 +630,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var UInt256) {.
                          "UInt256 value should be a valid decimal string")
 
 ## Slot
-proc writeValue*(writer: var JsonWriter[RestJson], value: Slot) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Slot) {.raises: [IOError].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var Slot) {.
@@ -643,8 +644,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Slot) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## Epoch
-proc writeValue*(writer: var JsonWriter[RestJson], value: Epoch) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Epoch) {.raises: [IOError].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var Epoch) {.
@@ -657,9 +658,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Epoch) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## EpochParticipationFlags
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 epochFlags: EpochParticipationFlags)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], epochFlags: EpochParticipationFlags
+) {.raises: [IOError].} =
   for e in writer.stepwiseArrayCreation(epochFlags.asList):
     writer.writeValue $e
 
@@ -682,8 +683,9 @@ proc readValue*(reader: var JsonReader[RestJson],
         "The participation flags list size exceeds limit")
 
 ## ValidatorIndex
-proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorIndex)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ValidatorIndex
+) {.raises: [IOError].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex)
@@ -701,8 +703,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorIndex)
     reader.raiseUnexpectedValue($res.error())
 
 ## IndexInSyncCommittee
-proc writeValue*(writer: var JsonWriter[RestJson], value: IndexInSyncCommittee)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: IndexInSyncCommittee
+) {.raises: [IOError].} =
   writeValue(writer, Base10.toString(distinctBase(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var IndexInSyncCommittee)
@@ -720,9 +723,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var IndexInSyncCommitte
     reader.raiseUnexpectedValue($res.error())
 
 ## RestValidatorIndex
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RestValidatorIndex) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RestValidatorIndex
+) {.raises: [IOError].} =
   writeValue(writer, Base10.toString(uint64(value)))
 
 proc readValue*(reader: var JsonReader[RestJson],
@@ -737,8 +740,9 @@ proc readValue*(reader: var JsonReader[RestJson],
     reader.raiseUnexpectedValue($res.error())
 
 ## CommitteeIndex
-proc writeValue*(writer: var JsonWriter[RestJson], value: CommitteeIndex) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: CommitteeIndex
+) {.raises: [IOError].} =
   writeValue(writer, value.asUInt64)
 
 proc readValue*(reader: var JsonReader[RestJson], value: var CommitteeIndex) {.
@@ -753,8 +757,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var CommitteeIndex) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## ValidatorSig
-proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorSig) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ValidatorSig
+) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(toRaw(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorSig) {.
@@ -767,8 +772,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorSig) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## TrustedSig
-proc writeValue*(writer: var JsonWriter[RestJson], value: TrustedSig) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: TrustedSig
+) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(toRaw(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var TrustedSig) {.
@@ -781,8 +787,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var TrustedSig) {.
     reader.raiseUnexpectedValue($res.error())
 
 ## ValidatorPubKey
-proc writeValue*(writer: var JsonWriter[RestJson], value: ValidatorPubKey) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ValidatorPubKey
+) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(toRaw(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], value: var ValidatorPubKey) {.
@@ -802,8 +809,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var BitSeq) {.
   except ValueError:
     raiseUnexpectedValue(reader, "A BitSeq value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: BitSeq) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: BitSeq) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(value.bytes()))
 
 ## BitList
@@ -812,8 +819,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var BitList) {.
   type T = type(value)
   value = T readValue(reader, BitSeq)
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: BitList) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: BitList) {.raises: [IOError].} =
   writeValue(writer, BitSeq value)
 
 ## BitArray
@@ -825,8 +832,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var BitArray) {.
     raiseUnexpectedValue(reader,
                          "A BitArray value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: BitArray) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: BitArray) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(value.bytes))
 
 ## BlockHash
@@ -838,8 +845,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var BlockHash) {.
     raiseUnexpectedValue(reader,
                          "BlockHash value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: BlockHash) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: BlockHash) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(distinctBase(value)))
 
 ## Eth2Digest
@@ -851,8 +858,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Eth2Digest) {.
     raiseUnexpectedValue(reader,
                          "Eth2Digest value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: Eth2Digest) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Eth2Digest) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(value.data))
 
 ## BloomLogs
@@ -864,8 +871,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var BloomLogs) {.
     raiseUnexpectedValue(reader,
                          "BloomLogs value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: BloomLogs) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: BloomLogs) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(value.data))
 
 ## HashArray
@@ -873,8 +880,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var HashArray) {.
      raises: [IOError, SerializationError, Defect].} =
   readValue(reader, value.data)
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: HashArray) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: HashArray) {.raises: [IOError].} =
   writeValue(writer, value.data)
 
 ## HashList
@@ -883,8 +890,8 @@ proc readValue*(reader: var JsonReader[RestJson], value: var HashList) {.
   readValue(reader, value.data)
   value.resetCache()
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: HashList) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: HashList) {.raises: [IOError].} =
   writeValue(writer, value.data)
 
 ## Eth1Address
@@ -896,13 +903,15 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Eth1Address) {.
     raiseUnexpectedValue(reader,
                          "Eth1Address value should be a valid hex string")
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: Eth1Address) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Eth1Address
+) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(distinctBase(value)))
 
 ## GraffitiBytes
-proc writeValue*(writer: var JsonWriter[RestJson], value: GraffitiBytes)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: GraffitiBytes
+) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(distinctBase(value)))
 
 proc readValue*(reader: var JsonReader[RestJson], T: type GraffitiBytes): T
@@ -1204,10 +1213,8 @@ proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
       "Web3Signer implementation supports Bellatrix and newer")
   value = Web3SignerForkedBeaconBlock(kind: version.get(), data: res.get())
 
-proc writeValue*[
-    BlockType: Web3SignerForkedBeaconBlock](
-    writer: var JsonWriter[RestJson],
-    value: BlockType) {.raises: [IOError, Defect].} =
+proc writeValue*[BlockType: Web3SignerForkedBeaconBlock](
+    writer: var JsonWriter[RestJson], value: BlockType) {.raises: [IOError].} =
   # https://consensys.github.io/web3signer/web3signer-eth2.html#tag/Signing/operation/ETH2_SIGN
   # https://github.com/ConsenSys/web3signer/blob/d51337e96ba5ce410222943556bed7c4856b8e57/core/src/main/java/tech/pegasys/web3signer/core/service/http/handlers/signing/eth2/json/BlockRequestDeserializer.java#L42-L58
   writer.beginRecord()
@@ -1215,10 +1222,8 @@ proc writeValue*[
   writer.writeField("block_header", value.data)
   writer.endRecord()
 
-proc writeValue*[
-    BlockType: ForkedBeaconBlock](
-    writer: var JsonWriter[RestJson],
-    value: BlockType) {.raises: [IOError, Defect].} =
+proc writeValue*[BlockType: ForkedBeaconBlock](
+    writer: var JsonWriter[RestJson], value: BlockType) {.raises: [IOError].} =
 
   template forkIdentifier(id: string): auto =
     when BlockType is ForkedBeaconBlock:
@@ -1883,9 +1888,9 @@ proc readValue*(reader: var JsonReader[RestJson],
   withBlck(value):
     blck.root = hash_tree_root(blck.message)
 
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: ForkedSignedBeaconBlock) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ForkedSignedBeaconBlock
+) {.raises: [IOError].} =
   writer.beginRecord()
   case value.kind
   of ConsensusFork.Phase0:
@@ -2007,8 +2012,9 @@ proc readValue*(reader: var JsonReader[RestJson],
       reader.raiseUnexpectedValue("Incorrect deneb beacon state format")
     toValue(denebData)
 
-proc writeValue*(writer: var JsonWriter[RestJson], value: ForkedHashedBeaconState)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ForkedHashedBeaconState
+) {.raises: [IOError].} =
   writer.beginRecord()
   case value.kind
   of ConsensusFork.Phase0:
@@ -2072,9 +2078,9 @@ proc readValue*[T: SomeForkedLightClientObject](
       reader.raiseUnexpectedValue("Unsupported fork " & $version.get)
 
 ## Web3SignerRequest
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: Web3SignerRequest) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Web3SignerRequest
+) {.raises: [IOError].} =
   writer.beginRecord()
   case value.kind
   of Web3SignerRequestKind.AggregationSlot:
@@ -2441,8 +2447,9 @@ proc readValue*(reader: var JsonReader[RestJson],
       )
 
 ## RemoteKeystoreStatus
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RemoteKeystoreStatus) {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RemoteKeystoreStatus
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("status", $value.status)
   if value.message.isSome():
@@ -2501,8 +2508,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ScryptSalt) {.
   value = ScryptSalt(res)
 
 ## Pbkdf2Params
-proc writeValue*(writer: var JsonWriter[RestJson], value: Pbkdf2Params) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Pbkdf2Params
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("dklen", JsonString(Base10.toString(value.dklen)))
   writer.writeField("c", JsonString(Base10.toString(value.c)))
@@ -2560,8 +2568,9 @@ proc readValue*(reader: var JsonReader[RestJson], value: var Pbkdf2Params) {.
   )
 
 ## ScryptParams
-proc writeValue*(writer: var JsonWriter[RestJson], value: ScryptParams) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ScryptParams
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("dklen", JsonString(Base10.toString(value.dklen)))
   writer.writeField("n", JsonString(Base10.toString(uint64(value.n))))
@@ -2634,18 +2643,19 @@ proc readValue*(reader: var JsonReader[RestJson], value: var ScryptParams) {.
   )
 
 ## Keystore
-proc writeValue*(writer: var JsonWriter[RestJson], value: Keystore) {.
-     error: "keystores must be converted to json with Json.encode(keystore). " &
-            "There is no REST-specific encoding" .}
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: Keystore
+) {.error: "keystores must be converted to json with Json.encode(keystore). " &
+           "There is no REST-specific encoding" .}
 
 proc readValue*(reader: var JsonReader[RestJson], value: var Keystore) {.
      error: "Keystores must be loaded with `parseKeystore`. " &
             "There is no REST-specific encoding".}
 
 ## KeystoresAndSlashingProtection
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: KeystoresAndSlashingProtection) {.
-     raises: [IOError, SerializationError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: KeystoresAndSlashingProtection
+) {.raises: [IOError].} =
   writer.beginRecord()
   let keystores =
     block:
@@ -2722,9 +2732,9 @@ proc readValue*(reader: var JsonReader[RestJson],
   )
 
 ## RestActivityItem
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RestActivityItem) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RestActivityItem
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("index", value.index)
   writer.writeField("epoch", value.epoch)
@@ -2769,9 +2779,9 @@ proc readValue*(reader: var JsonReader[RestJson],
                            active: active.get())
 
 ## RestLivenessItem
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RestLivenessItem) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RestLivenessItem
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("index", value.index)
   writer.writeField("is_live", value.is_live)
@@ -2806,9 +2816,9 @@ proc readValue*(reader: var JsonReader[RestJson],
   value = RestLivenessItem(index: index.get(), is_live: isLive.get())
 
 ## HeadChangeInfoObject
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: HeadChangeInfoObject) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: HeadChangeInfoObject
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("slot", value.slot)
   writer.writeField("block", value.block_root)
@@ -2823,9 +2833,9 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   writer.endRecord()
 
 ## ReorgInfoObject
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: ReorgInfoObject) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: ReorgInfoObject
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("slot", value.slot)
   writer.writeField("depth", value.depth)
@@ -2838,9 +2848,9 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   writer.endRecord()
 
 ## FinalizationInfoObject
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: FinalizationInfoObject) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: FinalizationInfoObject
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("block", value.block_root)
   writer.writeField("state", value.state_root)
@@ -2850,9 +2860,9 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   writer.endRecord()
 
 ## EventBeaconBlockObject
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: EventBeaconBlockObject) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: EventBeaconBlockObject
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("slot", value.slot)
   writer.writeField("block", value.block_root)
@@ -2861,15 +2871,15 @@ proc writeValue*(writer: var JsonWriter[RestJson],
   writer.endRecord()
 
 ## RestNodeValidity
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RestNodeValidity) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RestNodeValidity
+) {.raises: [IOError].} =
   writer.writeValue($value)
 
 ## RestSyncInfo
-proc writeValue*(writer: var JsonWriter[RestJson],
-                 value: RestSyncInfo) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: RestSyncInfo
+) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("head_slot", value.head_slot)
   writer.writeField("sync_distance", value.sync_distance)
@@ -3780,4 +3790,3 @@ proc decodeString*(t: typedesc[EventBeaconBlockObject],
                        allowUnknownFields = true))
   except SerializationError as exc:
     err(exc.formatMsg("<data>"))
-

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -697,13 +697,13 @@ proc readValue*(reader: var JsonReader, value: var HttpHostUri) {.
     reader.raiseUnexpectedValue("Missing URL hostname")
   value = HttpHostUri(res)
 
-proc writeValue*(writer: var JsonWriter, value: HttpHostUri) {.
-     raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: HttpHostUri) {.raises: [IOError].} =
   writer.writeValue($distinctBase(value))
 
 # RemoteKeystore
-proc writeValue*(writer: var JsonWriter, value: RemoteKeystore)
-                {.raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: RemoteKeystore) {.raises: [IOError].} =
   writer.beginRecord()
   writer.writeField("version", value.version)
   writer.writeField("pubkey", "0x" & value.pubkey.toHex())
@@ -905,10 +905,6 @@ proc readValue*(reader: var JsonReader, value: var RemoteKeystore)
         provenBlockProperties: provenBlockProperties.get,
         remotes: remotes.get,
         threshold: threshold.get(1))
-
-template writeValue*(w: var JsonWriter,
-                     value: Pbkdf2Salt|SimpleHexEncodedTypes|Aes128CtrIv) =
-  writeJsonHexString(w.stream, distinctBase value)
 
 template bytes(value: Pbkdf2Salt|SimpleHexEncodedTypes|Aes128CtrIv): seq[byte] =
   distinctBase value
@@ -1178,8 +1174,9 @@ proc decryptKeystore*(keystore: JsonString,
                       password: KeystorePass): KsResult[ValidatorPrivKey] =
   decryptKeystore(keystore, password, nil)
 
-proc writeValue*(writer: var JsonWriter, value: lcrypto.PublicKey) {.
-     inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: lcrypto.PublicKey
+) {.inline, raises: [IOError].} =
   writer.writeValue(ncrutils.toHex(value.getBytes().get(),
                                    {HexFlags.LowerCase}))
 

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -196,8 +196,8 @@ func `==`*(a, b: BadProposal): bool =
 # Serialization
 # --------------------------------------------
 
-proc writeValue*(writer: var JsonWriter, value: PubKey0x)
-                {.inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    writer: var JsonWriter, value: PubKey0x) {.inline, raises: [IOError].} =
   writer.writeValue("0x" & value.PubKeyBytes.toHex())
 
 proc readValue*(reader: var JsonReader, value: var PubKey0x)
@@ -207,8 +207,8 @@ proc readValue*(reader: var JsonReader, value: var PubKey0x)
   except ValueError:
     raiseUnexpectedValue(reader, "Hex string expected")
 
-proc writeValue*(w: var JsonWriter, a: Eth2Digest0x)
-                {.inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter, a: Eth2Digest0x) {.inline, raises: [IOError].} =
   w.writeValue "0x" & a.Eth2Digest.data.toHex()
 
 proc readValue*(r: var JsonReader, a: var Eth2Digest0x)
@@ -218,8 +218,9 @@ proc readValue*(r: var JsonReader, a: var Eth2Digest0x)
   except ValueError:
     raiseUnexpectedValue(r, "Hex string expected")
 
-proc writeValue*(w: var JsonWriter, a: SlotString or EpochString)
-                {.inline, raises: [IOError, Defect].} =
+proc writeValue*(
+    w: var JsonWriter, a: SlotString or EpochString
+) {.inline, raises: [IOError].} =
   w.writeValue $distinctBase(a)
 
 proc readValue*(r: var JsonReader, a: var (SlotString or EpochString))


### PR DESCRIPTION
- Remove unnecessary `Defect` references
- Remove spurious `SerializationError` references
- Remove duplicate `writeValue` template in `keystore.nim`; same implementation already exists a bit further above in same file.