### PR TITLE
remove unnecessary `mixin`

### DIFF
--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -236,7 +236,6 @@ proc addMonitor*(
     self.indices[index.get().uint64] = monitor
 
 template metricId: string =
-  mixin self, id
   if self.totals: total else: id
 
 proc addAutoMonitor*(


### PR DESCRIPTION
Nim 2.0 gets confused with the `mixin self, id` in `validator_monitor`. It looks like this is actually not needed, so removing it.