### PR TITLE
ensure LC runs `exchangeTransitionConfiguration` loop

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -2193,12 +2193,12 @@ proc startChainSyncingLoop(m: ELManager) {.async.} =
       await syncedConnectionFut.cancelAndWait()
       syncedConnectionFut = m.selectConnectionForChainSyncing()
 
-proc start*(m: ELManager) {.gcsafe.} =
+proc start*(m: ELManager, syncChain = true) {.gcsafe.} =
   if m.elConnections.len == 0:
     return
 
   ## Calling `ELManager.start()` on an already started ELManager is a noop
-  if m.chainSyncingLoopFut.isNil:
+  if syncChain and m.chainSyncingLoopFut.isNil:
     m.chainSyncingLoopFut =
       m.startChainSyncingLoop()
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -138,6 +138,10 @@ programMain:
       network, rng, config, cfg, forkDigests, getBeaconTime,
       genesis_validators_root, LightClientFinalizationMode.Optimistic)
 
+  # Run `exchangeTransitionConfiguration` loop
+  if elManager != nil:
+    elManager.start(syncChain = false)
+
   info "Listening to incoming network requests"
   network.initBeaconSync(cfg, forkDigests, genesisBlockRoot, getBeaconTime)
   network.addValidator(


### PR DESCRIPTION
In #4465, a regression was introduced by deleting the periodic call to `engine_exchangeTransitionConfiguration` in the Nimbus light client. This led to the light client never treating the EL as online and, subsequently, not sending `engine_newPayload` requests for new blocks. Strangely, `engine_forkchoiceUpdated` requests still make it through :)

Geth still requires both `engine_newPayload` and `fcU` to be called. By restoring the `exchangeTransitionConfiguration` loop, `newPayload` requests are once more issued to the EL.