### PR TITLE
fix blob sent/not sent logging

### DIFF
--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -89,8 +89,7 @@ func shortLog*(v: SignedBlobSidecars): auto =
 type RouteBlockResult = Result[Opt[BlockRef], cstring]
 proc routeSignedBeaconBlock*(
     router: ref MessageRouter, blck: ForkySignedBeaconBlock,
-  blobsOpt: Opt[SignedBlobSidecars]):
-    Future[RouteBlockResult] {.async.} =
+    blobsOpt: Opt[SignedBlobSidecars]): Future[RouteBlockResult] {.async.} =
   ## Validate and broadcast beacon block, then add it to the block database
   ## Returns the new Head when block is added successfully to dag, none when
   ## block passes validation but is not added, and error otherwise
@@ -159,9 +158,9 @@ proc routeSignedBeaconBlock*(
       doAssert res.finished()
       if res.failed():
         notice "Blob not sent",
-         blob = shortLog(signedBlobs[i])
+          blob = shortLog(signedBlobs[i]), error = res.error[]
       else:
-        notice "Blob sent", blob = shortLog(signedBlobs[i]), error = res.error[]
+        notice "Blob sent", blob = shortLog(signedBlobs[i])
     blobs = Opt.some(blobsOpt.get().mapIt(newClone(it.message)))
 
   let added = await router[].blockProcessor[].addBlock(


### PR DESCRIPTION
```
NOT 2023-08-18 06:34:36.723+00:00 Block sent                                 topics="beacval" blockRoot=22038b86 blck="(slot: 13173, proposer_index: 141, parent_root: \"b11f17f9\", state_root: \"ee2d7033\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 5fbf05188416b33e78c7c76baceb0df27f09c0f793719e33049d0159dc5ab7d2), graffiti: \"nimbus/geth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 0, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 499, block_number: 11681, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)" signature=828466bf delay=722ms761us674ns
Traceback (most recent call last, using override)
/root/nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(505) main
/root/nimbus-eth2/vendor/nim-libp2p/libp2p/stream/bufferstream.nim(498) NimMain
/root/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2151) main
/root/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1999) handleStartUpCmd
/root/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1900) doRunBeaconNode
/root/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1694) start
/root/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1641) run
/root/nimbus-eth2/vendor/nim-chronos/chronos/asyncloop.nim(263) poll
/root/nimbus-eth2/vendor/nim-chronos/chronos/asyncfutures2.nim(318) futureContinue
/root/nimbus-eth2/beacon_chain/validators/validator_duties.nim(1026) proposeBlockAux
/root/nimbus-eth2/beacon_chain/validators/message_router.nim(90) routeSignedBeaconBlock
/root/nimbus-eth2/vendor/nim-chronos/chronos/asyncfutures2.nim(318) futureContinue
/root/nimbus-eth2/vendor/nim-chronicles/chronicles/log_output.nim(775) routeSignedBeaconBlock
/root/nimbus-eth2/vendor/nim-chronicles/chronicles/log_output.nim(588) setProperty
/root/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/dollars.nim(108) dollar
/root/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/excpt.nim(631) signalHandler
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```