### PR TITLE
launch_local_testnet: add debugging for port conflicts

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -725,6 +725,9 @@ fi
 # instance as the parent and the target process name as a pattern to the
 # "pkill" command.
 cleanup() {
+  echo "Current port usage:"
+  lsof -i -P | grep LISTEN
+
   echo "Cleaning up"
 
   # Avoid the trap enterring an infinite loop

--- a/scripts/start_geth_nodes.sh
+++ b/scripts/start_geth_nodes.sh
@@ -24,6 +24,7 @@ for GETH_NODE_IDX in $(seq 0 $GETH_LAST_NODE_IDX); do
   GETH_LOG="${DATA_DIR}/logs/geth.${GETH_NODE_IDX}.txt"
   ${GETH_BINARY} version > "$GETH_LOG"
   ${GETH_BINARY} --datadir "${GETH_DATA_DIRS[GETH_NODE_IDX]}" init "${EXECUTION_GENESIS_JSON}" >> "$GETH_LOG" 2>&1
+  set -x
   ${GETH_BINARY} \
     --syncmode full \
     --datadir "${GETH_DATA_DIRS[GETH_NODE_IDX]}" \
@@ -34,6 +35,7 @@ for GETH_NODE_IDX in $(seq 0 $GETH_LAST_NODE_IDX); do
     --authrpc.port ${GETH_AUTH_RPC_PORTS[GETH_NODE_IDX]} \
     --authrpc.jwtsecret "${JWT_FILE}" \
         >> "${GETH_LOG}" 2>&1 &
+  set +x
   PID=$!
   echo $PID > "${DATA_DIR}/pids/geth.${GETH_NODE_IDX}"
 done


### PR DESCRIPTION
We have been seeing some port conflicts like:
```
[2023-08-15T00:31:47.625Z] Geth 0 failed to start
```
```
$ tail -n1 local-testnet-mainnet/logs/geth.?.txt
==> local-testnet-mainnet/logs/geth.0.txt <==
Fatal: Error starting protocol stack: listen tcp :6801: bind: address already in use

==> local-testnet-mainnet/logs/geth.1.txt <==
Fatal: Error starting protocol stack: listen tcp :6806: bind: address already in use

==> local-testnet-mainnet/logs/geth.2.txt <==
Fatal: Error starting protocol stack: listen tcp :6811: bind: address already in use
```
In order to debug this we'll need to add printing of some extra info into `unstable` so feature branches include it.

Related:
* https://github.com/status-im/nimbus-eth2/issues/4575