### PR TITLE
fix branch check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,11 +222,11 @@ jobs:
               echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi
-            if ! error="$(git -C "$file" fetch -q origin "$branch")"; then
+            if ! error="$(git -C "$file" fetch -q origin "+refs/heads/$branch:refs/remotes/origin/$branch")"; then
               echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2
             fi
-            if ! git -C "$file" merge-base --is-ancestor "$commit" "origin/$branch"; then
+            if ! git -C "$file" merge-base --is-ancestor "$commit" "refs/remotes/origin/$branch"; then
               echo "Submodule '$file': '$commit' is not on '$branch'"
               exit 2
             fi


### PR DESCRIPTION
Use explicit refs to avoid occasional issues with branch check reporting incorrectly that commit is not an ancestor of upstream head.