### PR TITLE
treat more formerly-constants as quasi-runtime-presets per v1.4.0 consensus specs

### DIFF
--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -23,8 +23,8 @@ const
   EPOCHS_PER_SUBNET_SUBSCRIPTION* = 256'u64
   SUBNETS_PER_NODE* = 2'u64
   ATTESTATION_SUBNET_COUNT*: uint64 = 64
-  ATTESTATION_SUBNET_EXTRA_BITS* = 0
-  ATTESTATION_SUBNET_PREFIX_BITS* = 6 ## \
+  ATTESTATION_SUBNET_EXTRA_BITS* = 0'u64
+  ATTESTATION_SUBNET_PREFIX_BITS* = 6'u64 ## \
     ## int(ceillog2(ATTESTATION_SUBNET_COUNT) + ATTESTATION_SUBNET_EXTRA_BITS)
 
 static: doAssert 1 shl (ATTESTATION_SUBNET_PREFIX_BITS - ATTESTATION_SUBNET_EXTRA_BITS) ==
@@ -73,3 +73,6 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/p2p-interface.md#configuration
   GOSSIP_MAX_SIZE* = 10'u64 * 1024 * 1024 # bytes
   MAX_CHUNK_SIZE* = 10'u64 * 1024 * 1024 # bytes
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/deneb/p2p-interface.md#configuration
+  MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS* = 4096'u64

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -39,9 +39,6 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/polynomial-commitments.md#constants
   BLS_MODULUS* = "52435875175126190479447740508185965837690552500527637822603658699938581184513".u256
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/deneb/p2p-interface.md#configuration
-  MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS* = 4096'u64
-
 type
   KzgCommitments* = List[KzgCommitment, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
   Blobs* = List[Blob, Limit MAX_BLOBS_PER_BLOCK]

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -581,6 +581,10 @@ proc readRuntimeConfig*(
   checkCompatibility EPOCHS_PER_SUBNET_SUBSCRIPTION
   checkCompatibility MAX_CHUNK_SIZE
   checkCompatibility SUBNETS_PER_NODE
+  checkCompatibility ATTESTATION_SUBNET_EXTRA_BITS
+  checkCompatibility ATTESTATION_SUBNET_PREFIX_BITS
+  checkCompatibility BLOB_SIDECAR_SUBNET_COUNT
+  checkCompatibility MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
 
   # Never pervasively implemented, still under discussion
   checkCompatibility TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -471,7 +471,7 @@ func livenessFailsafeInEffect*(
 
   false
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/phase0/p2p-interface.md#attestation-subnet-subcription
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/p2p-interface.md#attestation-subnet-subscription
 func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
     SubnetId =
   # Ensure neither `truncate` loses information
@@ -482,7 +482,8 @@ func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
 
   let
     node_id_prefix = truncate(
-      node_id shr (NODE_ID_BITS - ATTESTATION_SUBNET_PREFIX_BITS), uint64)
+      node_id shr (
+        NODE_ID_BITS - static(ATTESTATION_SUBNET_PREFIX_BITS.int)), uint64)
     node_offset = truncate(
       node_id mod static(EPOCHS_PER_SUBNET_SUBSCRIPTION.u256), uint64)
     permutation_seed = eth2digest(uint_to_bytes(
@@ -494,7 +495,7 @@ func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
     )
   SubnetId((permutated_prefix + index) mod ATTESTATION_SUBNET_COUNT)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/phase0/p2p-interface.md#attestation-subnet-subcription
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/p2p-interface.md#attestation-subnet-subscription
 iterator compute_subscribed_subnets*(node_id: UInt256, epoch: Epoch): SubnetId =
   for index in 0'u64 ..< SUBNETS_PER_NODE:
     yield compute_subscribed_subnet(node_id, epoch, index)


### PR DESCRIPTION
in https://github.com/ethereum/consensus-specs/blob/dev/configs/mainnet.yaml and https://github.com/ethpandaops/dencun-testnet/blob/master/network-configs/devnet-8/config.yaml

They've not actually changed value yet, so this is enough for now, but they're formally part of the network configuration now.