### PR TITLE
propagate newPayload-VALID to block ancestors

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -51,6 +51,9 @@ proc addResolvedHeadBlock(
 
   link(parent, blockRef)
 
+  if executionValid:
+    dag.markBlockVerified(blockRef)
+
   dag.forkBlocks.incl(KeyedBlockRef.init(blockRef))
 
   # Resolved blocks should be stored in database


### PR DESCRIPTION
This keeps it consistent with `fcU`-`VALID` handling.