### PR TITLE
fix branch check when bumping to commit outside of shallow range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
         run: |
           while read -r file; do
             commit="$(git -C "$file" rev-parse HEAD)"
+            commit_date=$(git -C "$file" show -s --format='%ci' HEAD)
             if ! branch="$(git config -f .gitmodules --get "submodule.$file.branch")"; then
               echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
@@ -227,7 +228,6 @@ jobs:
               echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2
             fi
-            commit_date=$(git -C "$file" show -s --format='%ci' HEAD)
             if ! error="$(git -C "$file" fetch -q --shallow-since="$commit_date" origin "+refs/heads/${branch}:refs/remotes/origin/${branch}")"; then
               echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,12 +222,18 @@ jobs:
               echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
             fi
-            if ! error="$(git -C "$file" fetch -q origin "+refs/heads/$branch:refs/remotes/origin/$branch")"; then
+            # Without the `--depth=1` fetch, may run into 'error processing shallow info: 4'
+            if ! error="$(git -C "$file" fetch -q --depth=1 origin "+refs/heads/${branch}:refs/remotes/origin/${branch}")"; then
+              echo "Submodule '$file': Failed to fetch '$branch': $error"
+              exit 2
+            fi
+            commit_date=$(git -C "$file" show -s --format='%ci' HEAD)
+            if ! error="$(git -C "$file" fetch -q --shallow-since="$commit_date" origin "+refs/heads/${branch}:refs/remotes/origin/${branch}")"; then
               echo "Submodule '$file': Failed to fetch '$branch': $error"
               exit 2
             fi
             if ! git -C "$file" merge-base --is-ancestor "$commit" "refs/remotes/origin/$branch"; then
-              echo "Submodule '$file': '$commit' is not on '$branch'"
+              echo "Submodule '$file': '$commit' is not on '$branch' as of '$commit_date' (branch config: '.gitmodules')"
               exit 2
             fi
           done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)


### PR DESCRIPTION
CI Lint check failed when bumping to a commit outside default shallow
range. Deepen the checkout through the bumped commit date to ensure
history is available for the ancestry check.