### PR TITLE
move mock genesis block hash to `tests`

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -998,11 +998,6 @@ func clear*(cache: var StateCache) =
   cache.beacon_proposer_indices.clear
   cache.sync_committees.clear
 
-const eth1BlockHash* = block:
-  var x: Eth2Digest
-  for v in x.data.mitems: v = 0x42
-  x
-
 func checkForkConsistency*(cfg: RuntimeConfig) =
   let forkVersions =
     [cfg.GENESIS_FORK_VERSION, cfg.ALTAIR_FORK_VERSION,

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -19,6 +19,7 @@ import
   ../beacon_chain/spec/datatypes/base,
   ../beacon_chain/spec/eth2_apis/eth2_rest_serialization,
   ../beacon_chain/validators/keystore_management,
+  ../tests/mocking/mock_genesis,
   ./logtrace
 
 # Compiled version of /scripts/depositContract.v.py in this repo
@@ -339,7 +340,7 @@ proc doCreateTestnet*(config: CliConfig,
     else:
       uint64(times.toUnix(times.getTime()) + config.genesisOffset.get(0))
     outGenesis = config.outputGenesis.string
-    eth1Hash = eth1BlockHash # TODO: Can we set a more appropriate value?
+    eth1Hash = mockEth1BlockHash # TODO: Can we set a more appropriate value?
     cfg = getRuntimeConfig(config.eth2Network)
 
   # This is intentionally left default initialized, when the user doesn't

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -14,6 +14,9 @@ import
   # Mocking procs
   ./mock_deposits
 
+const mockEth1BlockHash* =
+  Eth2Digest.fromHex("0x4242424242424242424242424242424242424242")
+
 proc initGenesisState*(
     num_validators = 8'u64 * SLOTS_PER_EPOCH,
     cfg = defaultRuntimeConfig): ref ForkedHashedBeaconState =
@@ -26,7 +29,7 @@ proc initGenesisState*(
   result = (ref ForkedHashedBeaconState)(
     kind: ConsensusFork.Phase0,
     phase0Data: initialize_hashed_beacon_state_from_eth1(
-      cfg, eth1BlockHash, 0, deposits, {}))
+      cfg, mockEth1BlockHash, 0, deposits, {}))
 
   maybeUpgradeState(cfg, result[])
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -15,6 +15,7 @@ import
   ../beacon_chain/consensus_object_pools/blockchain_dag,
   eth/db/kvstore,
   # test utilies
+  ./mocking/mock_genesis,
   ./testutil, ./testdbutil, ./testblockutil, ./teststateutil
 
 from std/algorithm import sort
@@ -727,7 +728,7 @@ suite "Beacon chain DB" & preset():
 
     let
       state = newClone(initialize_hashed_beacon_state_from_eth1(
-        defaultRuntimeConfig, eth1BlockHash, 0,
+        defaultRuntimeConfig, mockEth1BlockHash, 0,
         makeInitialDeposits(SLOTS_PER_EPOCH), {skipBlsValidation}))
 
     db.putState(state[].root, state[].data)


### PR DESCRIPTION
From old interop tests, a mock `eth1BlockHash` was defined in `base`. To avoid accidental use by Nimbus, move to `tests` and rename it to `mockEth1BlockHash`.