### PR TITLE
rm i386 test_blockchain_dag workaround

### DIFF
--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -279,9 +279,6 @@ suite "Block pool processing" & preset():
       tmpState[].latest_block_root == b1Add[].parent.root
       getStateField(tmpState[], slot) == b1Add[].parent.slot
 
-when declared(GC_fullCollect): # i386 test machines seem to run low..
-  GC_fullCollect()
-
 suite "Block pool altair processing" & preset():
   setup:
     let rng = HmacDrbgContext.new()


### PR DESCRIPTION
The problem eventually became acute enough that it proved necessary to disable `test_blockchain_dag` from running in an i386 CI at all:
https://github.com/status-im/nimbus-eth2/blob/d014d0a51cca1dda13d34e3de860aa4287afdb36/tests/all_tests.nim#L55-L63

so this `GC_fullCollect` became irrelevant.