### PR TITLE
rename --stop-at-epoch flag to --debug-stop-at-epoch

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -364,7 +364,7 @@ type
         hidden
         desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
-        name: "stop-at-epoch" .}: uint64
+        name: "debug-stop-at-epoch" .}: uint64
 
       stopAtSyncedEpoch* {.
         hidden
@@ -959,7 +959,7 @@ type
     stopAtEpoch* {.
       desc: "A positive epoch selects the epoch at which to stop"
       defaultValue: 0
-      name: "stop-at-epoch" .}: uint64
+      name: "debug-stop-at-epoch" .}: uint64
 
     payloadBuilderEnable* {.
       desc: "Enable usage of beacon node with external payload builder (BETA)"

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -155,7 +155,7 @@ type LightClientConf* = object
     hidden
     desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
     defaultValue: 0
-    name: "stop-at-epoch" .}: uint64
+    name: "debug-stop-at-epoch" .}: uint64
 
 template databaseDir*(config: LightClientConf): string =
   config.dataDir.databaseDir

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -220,7 +220,7 @@ while true; do
       ;;
     --stop-at-epoch)
       STOP_AT_EPOCH=$2
-      STOP_AT_EPOCH_FLAG="--stop-at-epoch=$2"
+      STOP_AT_EPOCH_FLAG="--debug-stop-at-epoch=$2"
       shift 2
       ;;
     --disable-htop)


### PR DESCRIPTION
To align with https://github.com/status-im/nimbus-eth2/blob/stable/docs/the_nimbus_book/src/options.md#available-options
> Any `debug`-prefixed flags are considered ephemeral and subject to removal without notice.

This has been fairly empirically long-lived due to usage in the CI, but it's fundamentally something for testing and CI use, and by definition anyone using it won't want their Nimbus instance to run long anyway.

This PR makes this intent clear per documented policy.