### PR TITLE
don't prematurely process blocks waiting for blobs; fix cosmetic head block opt/non-opt logging

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -70,7 +70,7 @@ func removeBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest) =
 func hasBlobs*(quarantine: BlobQuarantine, blck: deneb.SignedBeaconBlock):
      bool =
   let idxs = quarantine.blobIndices(blck.root)
-  if len(blck.message.body.blob_kzg_commitments) < len(idxs):
+  if len(blck.message.body.blob_kzg_commitments) != len(idxs):
     return false
   for i in 0..<len(idxs):
     if idxs[i] != uint64(i):

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2426,7 +2426,7 @@ proc updateHead*(
       justified = shortLog(getStateField(
         dag.headState, current_justified_checkpoint)),
       finalized = shortLog(getStateField(dag.headState, finalized_checkpoint)),
-      isOptHead = newHead.executionValid
+      isOptHead = not newHead.executionValid
 
     if not(isNil(dag.onHeadChanged)):
       let

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -301,8 +301,7 @@ template validateBeaconBlockBellatrix(
   # cannot occur here, because Nimbus's optimistic sync waits for either
   # `ACCEPTED` or `SYNCING` from the EL to get this far.
 
-
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#blob_sidecar_index
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
 proc validateBlobSidecar*(
     dag: ChainDAGRef, quarantine: ref Quarantine,
     blobQuarantine: ref BlobQuarantine,sbs: SignedBlobSidecar,


### PR DESCRIPTION
`devnet-8` fix; mitigates some stuttering in block updates when blobs arrived after blocks. `hasBlobs` fired prematurely, leading to `block_processor` correctly rejecting the block/blobs combination:
https://github.com/status-im/nimbus-eth2/blob/060e89a07d499cf0f287f90d8246d967b39a4c14/beacon_chain/gossip_processing/block_processor.nim#L526-L542

The head block being optimistic or not, here, was only logged incorrectly, not handled incorrectly in any other way, in terms of validation duties or REST API endpoints, so this did not create otherwise incorrect functionality.