### PR TITLE
simplify beacon validator sync committee production for blocks slightly

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -409,11 +409,6 @@ proc makeBeaconBlockForHeadAndSlot*(
     exits = withState(state[]):
       node.validatorChangePool[].getBeaconBlockValidatorChanges(
         node.dag.cfg, forkyState.data)
-    syncAggregate =
-      if slot.epoch >= node.dag.cfg.ALTAIR_FORK_EPOCH:
-        node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot)
-      else:
-        SyncAggregate.init()
     payload = (await payloadFut).valueOr:
       beacon_block_production_errors.inc()
       warn "Unable to get execution payload. Skipping block proposal",
@@ -430,7 +425,7 @@ proc makeBeaconBlockForHeadAndSlot*(
       attestations,
       eth1Proposal.deposits,
       exits,
-      syncAggregate,
+      node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot),
       payload,
       noRollback, # Temporary state - no need for rollback
       cache,
@@ -1466,9 +1461,7 @@ proc getValidatorRegistration(
 
 proc registerValidators*(node: BeaconNode, epoch: Epoch) {.async.} =
   try:
-    if  (not node.config.payloadBuilderEnable) or
-        node.currentSlot.epoch < node.dag.cfg.BELLATRIX_FORK_EPOCH:
-      return
+    if not node.config.payloadBuilderEnable: return
 
     const HttpOk = 200
 


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/blob/060e89a07d499cf0f287f90d8246d967b39a4c14/beacon_chain/consensus_object_pools/sync_committee_msg_pool.nim#L336-L348

already has logic to handle the `if slot.epoch >= node.dag.cfg.ALTAIR_FORK_EPOCH:` check in a slightly different way, so that was redundant.

If someone really wants to enable payload building on some remaining pre-Bellatrix network, it's not going to be particularly useful, but the protocol itself doesn't mind the validator registration part, so this optimizes for code clarity and removing unnecessary references to specific forks in `beacon_validators`.