### PR TITLE
update macOS deprecation comment

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -100,14 +100,10 @@ if defined(windows):
 if defined(disableMarchNative):
   if defined(i386) or defined(amd64):
     if defined(macosx):
-      # macOS Catalina is EOL as of 2022-09
-      # https://support.apple.com/kb/sp833
-      # "macOS Big Sur - Technical Specifications" lists current oldest
-      # supported models: MacBook (2015 or later), MacBook Air (2013 or later),
-      # MacBook Pro (Late 2013 or later), Mac mini (2014 or later), iMac (2014
-      # or later), iMac Pro (2017 or later), Mac Pro (2013 or later).
-      #
-      # These all have Haswell or newer CPUs.
+      # macOS Big Sur is EOL as of 2023-11
+      # https://support.apple.com/en-us/HT212551
+      # "macOS Monterey is compatible with these computers" of which the
+      # oldest is "Mac Pro (Late 2013)". All have Haswell or newer CPUs.
       #
       # This ensures AVX2, AES-NI, PCLMUL, BMI1, and BMI2 instruction set support.
       switch("passC", "-march=haswell -mtune=generic")


### PR DESCRIPTION
macOS Big Sur isn't yet EOL, but the oldest supported machine remains unchanged, so this only modifies the comments explaining things.

Harmless/no-op now, useful in a couple months.