### PR TITLE
add hint when `options.md` is outdated

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -70,13 +70,16 @@ pipeline {
         sh 'make LOG_LEVEL=TRACE'
         /* Check documentation reflects `nimbus_beacon_node --help`. */
         sh '''#!/usr/bin/env bash
-          diff -u \\
-            <(sed -n '/Usage/,/^...$/ { /^...$/d; p; }' \\
-              docs/the_nimbus_book/src/options.md) \\
-            <(COLUMNS=200 build/nimbus_beacon_node --help | \\
-              sed -n '/Usage/,/Available sub-commands/ { /Available sub-commands/d; p; }' | \\
-              sed 's/\\x1B\\[[0-9;]*[mG]//g' | \\
-              sed 's/[[:space:]]*$//')
+          if ! diff -u \\
+              <(sed -n '/Usage/,/^...$/ { /^...$/d; p; }' \\
+                docs/the_nimbus_book/src/options.md) \\
+              <(COLUMNS=200 build/nimbus_beacon_node --help | \\
+                sed -n '/Usage/,/Available sub-commands/ { /Available sub-commands/d; p; }' | \\
+                sed 's/\\x1B\\[[0-9;]*[mG]//g' | \\
+                sed 's/[[:space:]]*$//'); then \\
+            echo "Please update 'options.md' to match 'nimbus_beacon_node --version'"; \\
+            false; \\
+          fi
         '''
       } }
     }


### PR DESCRIPTION
Make it clearer what went wrong when lint fails due to 'options.md' being out of date.