### PR TITLE
ensure blob quarantine insertion always succeeds

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -7,18 +7,16 @@
 
 {.push raises: [].}
 
-import
-  std/[sequtils, strutils, tables],
-  ../spec/datatypes/deneb
-
+import ../spec/datatypes/deneb
+from std/sequtils import mapIt
+from std/strutils import join
 
 const
   MaxBlobs = SLOTS_PER_EPOCH * MAX_BLOBS_PER_BLOCK
 
-
 type
   BlobQuarantine* = object
-    blobs*: Table[(Eth2Digest, BlobIndex), ref BlobSidecar]
+    blobs*: OrderedTable[(Eth2Digest, BlobIndex), ref BlobSidecar]
   BlobFetchRecord* = object
     block_root*: Eth2Digest
     indices*: seq[BlobIndex]
@@ -31,7 +29,14 @@ func shortLog*(x: seq[BlobFetchRecord]): string =
 
 func put*(quarantine: var BlobQuarantine, blobSidecar: ref BlobSidecar) =
   if quarantine.blobs.lenu64 > MaxBlobs:
-    return
+    # FIFO if full. For example, sync manager and request manager can race to
+    # put blobs in at the same time, so one gets blob insert -> block resolve
+    # -> blob insert sequence, which leaves garbage blobs.
+    var oldest_blob_key: (Eth2Digest, BlobIndex)
+    for k in quarantine.blobs.keys:
+      oldest_blob_key = k
+      break
+    quarantine.blobs.del oldest_blob_key
   discard quarantine.blobs.hasKeyOrPut((blobSidecar.block_root,
                                         blobSidecar.index), blobSidecar)
 
@@ -43,7 +48,7 @@ func blobIndices*(quarantine: BlobQuarantine, digest: Eth2Digest):
       r.add(i)
   r
 
-func hasBlob*(quarantine: BlobQuarantine, blobSidecar: BlobSidecar) : bool =
+func hasBlob*(quarantine: BlobQuarantine, blobSidecar: BlobSidecar): bool =
   quarantine.blobs.hasKey((blobSidecar.block_root, blobSidecar.index))
 
 func popBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
@@ -54,18 +59,6 @@ func popBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
     if quarantine.blobs.pop((digest, i), b):
       r.add(b)
   r
-
-func peekBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
-     seq[ref BlobSidecar] =
-  var r: seq[ref BlobSidecar] = @[]
-  for i in 0..<MAX_BLOBS_PER_BLOCK:
-    quarantine.blobs.withValue((digest, i), value):
-      r.add(value[])
-  r
-
-func removeBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest) =
-  for i in 0..<MAX_BLOBS_PER_BLOCK:
-    quarantine.blobs.del((digest, i))
 
 func hasBlobs*(quarantine: BlobQuarantine, blck: deneb.SignedBeaconBlock):
      bool =

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -305,7 +305,6 @@ proc processSignedBlobSidecar*(
 
   debug "Blob validated, putting in blob quarantine"
   self.blobQuarantine[].put(newClone(signedBlobSidecar.message))
-  var toAdd: seq[deneb.SignedBeaconBlock]
 
   var skippedBlocks = false
 


### PR DESCRIPTION
`devnet-8`

Example scenario (reproduced with smaller quarantine; it otherwise can take hours to manifest).

One set of blob requests will come in from here:
```
DBG 2023-08-28 18:22:00.182 Requesting blobs by root                   topics="requman" peer=16U*7ZZQ28 blobs="[bc03f4b3/0, bc03f4b3/1, bc03f4b3/2]" peer_score=200
```

And they arrive and are processed (ordinarily no special logging occurs here, but it's between 18:22:03.704 and 18:22:04.553):
```
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 0; len = 0 of 20
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 1; len = 1 of 20
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 2; len = 2 of 20
```

Which allows the block to be resolved immediately:
```
18:22:04.585 Block resolved                             topics="gossip_blocks" blockRoot=bc03f4b3 blck="(slot: 88106, proposer_index: 94, parent_root: \"50c24b2a\", state_root: \"d325aab5\", eth1data: (deposit_root: 12cd7d13b27351d2744b1a39e74d59b7d4918a19081a9ccd0bd19c6170c45087, deposit_count: 47, block_hash: e64f468925f3667039a299dfd9b8c592c0bc4aabc83bd5f31faf579468746def), graffiti: \"teku/geth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 465, block_number: 81103, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)" executionValid=false heads=2 stateDataDur=18ms265us942ns sigVerifyDur=2ms71us306ns stateVerifyDur=104us131ns putBlockDur=86us462ns epochRefDur=4us819ns
```

But then, in this case it's request manager probably requesting from two peers and getting answers from both, shortly after 18:22:06.653,
```
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 0; len = 0 of 20
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 1; len = 1 of 20
FOOBAR2: root = bc03f4b33cedfeed94bae781d0b8170be5016e7e7f983868cf38c9aa1519a86e; idx = 2; len = 2 of 20
```
which stays in the blob queue uselessly.

In general, the blob queue entries get used quickly, because either the block is ready, or the request manager (as here) re-requests the blobs when it re-requests the Deneb blocks. So it's nice to have some facility to deal with slightly out-of-order blob/block interleaving, but it's fine to, if they're that out of order, try again to re-request.

Currently, once the blob queue fills, it just gets stuck, effectively deadlocked and unable to resolve blocks.