### PR TITLE
use correct decimal or hex encoding/decoding for REST GetSpec

### DIFF
--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -221,11 +221,11 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
           # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#constants
           TIMELY_SOURCE_FLAG_INDEX:
-            to0xHex([byte(TIMELY_SOURCE_FLAG_INDEX)]),
+            Base10.toString(uint64(ord(TIMELY_SOURCE_FLAG_INDEX))),
           TIMELY_TARGET_FLAG_INDEX:
-            to0xHex([byte(TIMELY_TARGET_FLAG_INDEX)]),
+            Base10.toString(uint64(ord(TIMELY_TARGET_FLAG_INDEX))),
           TIMELY_HEAD_FLAG_INDEX:
-            to0xHex([byte(TIMELY_HEAD_FLAG_INDEX)]),
+            Base10.toString(uint64(ord(TIMELY_HEAD_FLAG_INDEX))),
           TIMELY_SOURCE_WEIGHT:
             Base10.toString(uint64(TIMELY_SOURCE_WEIGHT)),
           TIMELY_TARGET_WEIGHT:

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -921,10 +921,11 @@ proc readValue*(reader: var JsonReader[RestJson], T: type GraffitiBytes): T
   except ValueError as err:
     reader.raiseUnexpectedValue err.msg
 
-## Version | ForkDigest | DomainType | GraffitiBytes
+## Version | ForkDigest | DomainType | GraffitiBytes | RestWithdrawalPrefix
 proc readValue*(
     reader: var JsonReader[RestJson],
-    value: var (Version | ForkDigest | DomainType | GraffitiBytes)) {.
+    value: var (Version | ForkDigest | DomainType | GraffitiBytes |
+                RestWithdrawalPrefix)) {.
      raises: [IOError, SerializationError].} =
   try:
     hexToByteArray(reader.readValue(string), distinctBase(value))

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -273,6 +273,8 @@ type
     index*: ValidatorIndex
     is_live*: bool
 
+  RestWithdrawalPrefix* = distinct array[1, byte]
+
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#executionpayload
   RestExecutionPayload* = object
     # Execution block header fields
@@ -441,8 +443,8 @@ type
     # DEPOSIT_CONTRACT_TREE_DEPTH
     # JUSTIFICATION_BITS_LENGTH
     # ENDIANNESS
-    BLS_WITHDRAWAL_PREFIX*: byte
-    ETH1_ADDRESS_WITHDRAWAL_PREFIX*: byte
+    BLS_WITHDRAWAL_PREFIX*: RestWithdrawalPrefix
+    ETH1_ADDRESS_WITHDRAWAL_PREFIX*: RestWithdrawalPrefix
     DOMAIN_BEACON_PROPOSER*: DomainType
     DOMAIN_BEACON_ATTESTER*: DomainType
     DOMAIN_RANDAO*: DomainType
@@ -998,3 +1000,5 @@ func init*(t: typedesc[RestSignedContributionAndProof],
       message.contribution
     ),
     signature: signature)
+
+func len*(p: RestWithdrawalPrefix): int = sizeof(p)


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/5362

https://github.com/ethereum/beacon-APIs/blob/v2.4.2/apis/config/spec.yaml describes that
```
                  Values are returned with following format:
                    - any value starting with 0x in the spec is returned as a hex string
                    - numeric values are returned as a quoted integer
```