### PR TITLE
add helpers for processing withdrawals to `libnimbus_lc.a`

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -1081,6 +1081,26 @@ const ETHRoot *ETHExecutionBlockHeaderGetWithdrawalsRoot(
     const ETHExecutionBlockHeader *executionBlockHeader);
 
 /**
+ * Withdrawal sequence.
+ */
+typedef struct ETHWithdrawals ETHWithdrawals;
+
+/**
+ * Obtains the withdrawal sequence of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Withdrawal sequence.
+ */
+ETH_RESULT_USE_CHECK
+const ETHWithdrawals *ETHExecutionBlockHeaderGetWithdrawals(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
  * Transaction sequence.
  */
 typedef struct ETHTransactions ETHTransactions;
@@ -1763,6 +1783,114 @@ const void *ETHLogGetDataBytes(
 ETH_RESULT_USE_CHECK
 const void *ETHReceiptGetBytes(
     const ETHReceipt *receipt,
+    int *numBytes);
+
+/**
+ * Indicates the total number of withdrawals in a withdrawal sequence.
+ *
+ * - Individual withdrawals may be investigated using `ETHWithdrawalsGet`.
+ *
+ * @param      withdrawals          Withdrawal sequence.
+ *
+ * @return Number of available withdrawals.
+ */
+ETH_RESULT_USE_CHECK
+int ETHWithdrawalsGetCount(const ETHWithdrawals *withdrawals);
+
+/**
+ * Withdrawal.
+ */
+typedef struct ETHWithdrawal ETHWithdrawal;
+
+/**
+ * Obtains an individual withdrawal by sequential index
+ * in a withdrawal sequence.
+ *
+ * - The returned value is allocated in the given withdrawal sequence.
+ *   It must neither be released nor written to, and the withdrawal
+ *   sequence must not be released while the returned value is in use.
+ *
+ * @param      withdrawals          Withdrawal sequence.
+ * @param      withdrawalIndex      Sequential withdrawal index.
+ *
+ * @return Withdrawal.
+ */
+ETH_RESULT_USE_CHECK
+const ETHWithdrawal *ETHWithdrawalsGet(
+    const ETHWithdrawals *withdrawals,
+    int withdrawalIndex);
+
+/**
+ * Obtains the index of a withdrawal.
+ *
+ * - The returned value is allocated in the given withdrawal.
+ *   It must neither be released nor written to, and the withdrawal
+ *   must not be released while the returned value is in use.
+ *
+ * @param      withdrawal           Withdrawal.
+ *
+ * @return Index.
+ */
+ETH_RESULT_USE_CHECK
+const uint64_t *ETHWithdrawalGetIndex(const ETHWithdrawal *withdrawal);
+
+/**
+ * Obtains the validator index of a withdrawal.
+ *
+ * - The returned value is allocated in the given withdrawal.
+ *   It must neither be released nor written to, and the withdrawal
+ *   must not be released while the returned value is in use.
+ *
+ * @param      withdrawal           Withdrawal.
+ *
+ * @return Validator index.
+ */
+ETH_RESULT_USE_CHECK
+const uint64_t *ETHWithdrawalGetValidatorIndex(const ETHWithdrawal *withdrawal);
+
+/**
+ * Obtains the address of a withdrawal.
+ *
+ * - The returned value is allocated in the given withdrawal.
+ *   It must neither be released nor written to, and the withdrawal
+ *   must not be released while the returned value is in use.
+ *
+ * @param      withdrawal           Withdrawal.
+ *
+ * @return Address.
+ */
+ETH_RESULT_USE_CHECK
+const ETHExecutionAddress *ETHWithdrawalGetAddress(const ETHWithdrawal *withdrawal);
+
+/**
+ * Obtains the amount of a withdrawal.
+ *
+ * - The returned value is allocated in the given withdrawal.
+ *   It must neither be released nor written to, and the withdrawal
+ *   must not be released while the returned value is in use.
+ *
+ * @param      withdrawal           Withdrawal.
+ *
+ * @return Amount.
+ */
+ETH_RESULT_USE_CHECK
+const uint64_t *ETHWithdrawalGetAmount(const ETHWithdrawal *withdrawal);
+
+/**
+ * Obtains the raw byte representation of a withdrawal.
+ *
+ * - The returned value is allocated in the given withdrawal.
+ *   It must neither be released nor written to, and the withdrawal
+ *   must not be released while the returned value is in use.
+ *
+ * @param      withdrawal           Withdrawal.
+ * @param[out] numBytes             Length of buffer.
+ *
+ * @return Buffer with raw withdrawal data.
+ */
+ETH_RESULT_USE_CHECK
+const void *ETHWithdrawalGetBytes(
+    const ETHWithdrawal *withdrawal,
     int *numBytes);
 
 #if __has_feature(nullability)

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -375,7 +375,7 @@ int main(void)
     ETHRootDestroy(copiedExecutionHash);
     ETHLightClientHeaderDestroy(copiedHeader);
 
-    printf("- finalized_header (execution block header):\n");
+    printf("\nFinalized_header (execution block header):\n");
 
     const ETHRoot *executionTransactionsRoot =
         ETHExecutionBlockHeaderGetTransactionsRoot(executionBlockHeader);
@@ -388,6 +388,34 @@ int main(void)
     printf("    - withdrawals_root: ");
     printHexString(executionWithdrawalsRoot, sizeof *executionWithdrawalsRoot);
     printf("\n");
+
+    const ETHWithdrawals *withdrawals =
+        ETHExecutionBlockHeaderGetWithdrawals(executionBlockHeader);
+    int numWithdrawals = ETHWithdrawalsGetCount(withdrawals);
+    printf("    - withdrawals:\n");
+    for (int withdrawalIndex = 0; withdrawalIndex < numWithdrawals; withdrawalIndex++) {
+        const ETHWithdrawal *withdrawal = ETHWithdrawalsGet(withdrawals, withdrawalIndex);
+
+        const uint64_t *index = ETHWithdrawalGetIndex(withdrawal);
+        printf("        - index: %" PRIu64 "\n", *index);
+
+        const uint64_t *validatorIndex = ETHWithdrawalGetValidatorIndex(withdrawal);
+        printf("            - validator_index: %" PRIu64 "\n", *validatorIndex);
+
+        const ETHExecutionAddress *address = ETHWithdrawalGetAddress(withdrawal);
+        printf("            - address: ");
+        printHexString(address, sizeof *address);
+        printf("\n");
+
+        const uint64_t *amount = ETHWithdrawalGetAmount(withdrawal);
+        printf("            - amount: %" PRIu64 "\n", *amount);
+
+        int numBytes;
+        const void *bytes = ETHWithdrawalGetBytes(withdrawal, &numBytes);
+        printf("            - bytes: ");
+        printHexString(bytes, numBytes);
+        printf("\n");
+    }
 
     ETHExecutionBlockHeaderDestroy(executionBlockHeader);
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -34,7 +34,7 @@ type
   ExecutionHash256* = eth_types.Hash256
   ExecutionTransaction* = eth_types.Transaction
   ExecutionReceipt* = eth_types.Receipt
-  ExecutionWithdrawal = eth_types.Withdrawal
+  ExecutionWithdrawal* = eth_types.Withdrawal
   ExecutionBlockHeader* = eth_types.BlockHeader
 
   FinalityCheckpoints* = object


### PR DESCRIPTION
Similar to the existing helpers for processing transactions / receipts, extend `libnimbus_lc.a` with support for processing withdrawals as well.