### PR TITLE
collapse `partialBeaconBlock` templates into one

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -254,6 +254,31 @@ type
     capella*:   ForkDigest
     deneb*:     ForkDigest
 
+template kind*(
+    x: typedesc[
+      phase0.HashedBeaconState]): ConsensusFork =
+  ConsensusFork.Phase0
+
+template kind*(
+    x: typedesc[
+      altair.HashedBeaconState]): ConsensusFork =
+  ConsensusFork.Altair
+
+template kind*(
+    x: typedesc[
+      bellatrix.HashedBeaconState]): ConsensusFork =
+  ConsensusFork.Bellatrix
+
+template kind*(
+    x: typedesc[
+      capella.HashedBeaconState]): ConsensusFork =
+  ConsensusFork.Capella
+
+template kind*(
+    x: typedesc[
+      deneb.HashedBeaconState]): ConsensusFork =
+  ConsensusFork.Deneb
+
 macro getSymbolFromForkModule(fork: static ConsensusFork,
                               symbolName: static string): untyped =
   let moduleName = case fork


### PR DESCRIPTION
Have a single `Forky` template for `partialBeaconBlock` production rather than have several copies that are mostly identical.