### PR TITLE
avoid `Taskpool.spawn` within `{.async.}` for Nim 2.0

### DIFF
--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -229,10 +229,10 @@ proc batchVerifyTask(task: ptr BatchTask) {.nimcall.} =
   discard task[].signal.fireSync()
 
 proc spawnBatchVerifyTask(tp: Taskpool, task: ptr BatchTask) =
-  # Inlining this `proc` leads to problems on Nim 2.0
+  # Inlining this `proc` leads to compilation problems on Nim 2.0
   # - Error: cannot generate destructor for generic type: Isolated
   # Workaround: Ensure that `tp.spawn` is not used within an `{.async.}` proc
-  # https://github.com/nim-lang/Nim/issues/22305
+  # Possibly related to: https://github.com/nim-lang/Nim/issues/22305
   tp.spawn batchVerifyTask(task)
 
 proc batchVerifyAsync*(

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -232,6 +232,7 @@ proc spawnBatchVerifyTask(tp: Taskpool, task: ptr BatchTask) =
   # Inlining this `proc` leads to problems on Nim 2.0
   # - Error: cannot generate destructor for generic type: Isolated
   # Workaround: Ensure that `tp.spawn` is not used within an `{.async.}` proc
+  # https://github.com/nim-lang/Nim/issues/22305
   tp.spawn batchVerifyTask(task)
 
 proc batchVerifyAsync*(


### PR DESCRIPTION
In Nim 2.0, attempting to use `Taskpool.spawn` inside `{.async.}` `proc` leads to `Error: cannot generate destructor for generic type: Isolated`.

Add an intermediate wrapper `proc` that performs the `spawn` operation to workaround the problem.