### PR TITLE
wrap `applyExecutionPayload` in factories for Nim 2.0

### DIFF
--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -126,17 +126,19 @@ suite baseDescription & "Deposit " & preset():
       OpDepositsDir, suiteName, "Deposit", "deposit", applyDeposit, path)
 
 suite baseDescription & "Execution Payload " & preset():
-  for path in walkTests(OpExecutionPayloadDir):
-    proc applyExecutionPayload(
+  proc makeApplyExecutionPayloadCb(path: string): auto =
+    return proc(
         preState: var bellatrix.BeaconState, body: bellatrix.BeaconBlockBody):
         Result[void, cstring] =
-      let payloadValid =
-        os_ops.readFile(OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml").
-          contains("execution_valid: true")
+      let payloadValid = os_ops.readFile(
+          OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
+        ).contains("execution_valid: true")
       func executePayload(_: bellatrix.ExecutionPayload): bool = payloadValid
       process_execution_payload(
         preState, body.execution_payload, executePayload)
 
+  for path in walkTests(OpExecutionPayloadDir):
+    let applyExecutionPayload = makeApplyExecutionPayloadCb(path)
     runTest[bellatrix.BeaconBlockBody, typeof applyExecutionPayload](
       OpExecutionPayloadDir, suiteName, "Execution Payload", "body",
       applyExecutionPayload, path)

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -143,17 +143,19 @@ suite baseDescription & "Deposit " & preset():
       OpDepositsDir, suiteName, "Deposit", "deposit", applyDeposit, path)
 
 suite baseDescription & "Execution Payload " & preset():
-  for path in walkTests(OpExecutionPayloadDir):
-    proc applyExecutionPayload(
+  proc makeApplyExecutionPayloadCb(path: string): auto =
+    return proc(
         preState: var capella.BeaconState, body: capella.BeaconBlockBody):
         Result[void, cstring] =
-      let payloadValid =
-        os_ops.readFile(OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml").
-          contains("execution_valid: true")
+      let payloadValid = os_ops.readFile(
+          OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
+        ).contains("execution_valid: true")
       func executePayload(_: capella.ExecutionPayload): bool = payloadValid
       process_execution_payload(
         preState, body.execution_payload, executePayload)
 
+  for path in walkTests(OpExecutionPayloadDir):
+    let applyExecutionPayload = makeApplyExecutionPayloadCb(path)
     runTest[capella.BeaconBlockBody, typeof applyExecutionPayload](
       OpExecutionPayloadDir, suiteName, "Execution Payload", "body",
       applyExecutionPayload, path)


### PR DESCRIPTION
In Nim 2.0, the `test_fixture_operations` files fail to compile with:

```
Error: 'result' is of type <Result[system.void, system.cstring]> which cannot be captured as it would violate memory safety, declared here: /nimbus-eth2/tests/consensus_spec/bellatrix/test_fixture_operations.nim(130, 5); using '-d:nimNoLentIterators' helps in some cases. Consider using a <ref Result[system.void, system.cstring]> which can be captured.
```

Wrapping the `applyExecutionPayload` in a factory that takes `path` avoids this problem.