### PR TITLE
rename `U` to `maxLen` in `statediff` for Nim 2.0

### DIFF
--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -11,19 +11,19 @@ import
   stew/assign2,
   ./spec/forks
 
-func diffModIncEpoch[T, U](hl: HashArray[U, T], startSlot: uint64):
+func diffModIncEpoch[maxLen, T](hl: HashArray[maxLen, T], startSlot: uint64):
     array[SLOTS_PER_EPOCH, T] =
-  static: doAssert U.uint64 mod SLOTS_PER_EPOCH == 0
+  static: doAssert maxLen.uint64 mod SLOTS_PER_EPOCH == 0
   doAssert startSlot mod SLOTS_PER_EPOCH == 0
   for i in startSlot ..< startSlot + SLOTS_PER_EPOCH:
-    result[i mod SLOTS_PER_EPOCH] = hl[i mod U.uint64]
+    result[i mod SLOTS_PER_EPOCH] = hl[i mod maxLen.uint64]
 
-func applyModIncrement[T, U](
-    ha: var HashArray[U, T], hl: array[SLOTS_PER_EPOCH, T], slot: uint64) =
+func applyModIncrement[maxLen, T](
+    ha: var HashArray[maxLen, T], hl: array[SLOTS_PER_EPOCH, T], slot: uint64) =
   var indexSlot = slot
 
   for item in hl:
-    ha[indexSlot mod U.uint64] = item
+    ha[indexSlot mod maxLen.uint64] = item
     indexSlot += 1
 
 func applyValidatorIdentities(
@@ -51,9 +51,9 @@ func setValidatorStatusesNoWithdrawals(
     validator[].exit_epoch = hl[i].exit_epoch
     validator[].withdrawable_epoch = hl[i].withdrawable_epoch
 
-func replaceOrAddEncodeEth1Votes[T, U](
-    votes0: openArray[T], votes0_len: int, votes1: HashList[T, U]):
-    (bool, List[T, U]) =
+func replaceOrAddEncodeEth1Votes[T, maxLen](
+    votes0: openArray[T], votes0_len: int, votes1: HashList[T, maxLen]):
+    (bool, List[T, maxLen]) =
   let
     num_votes0 = votes0.len
     lower_bound =
@@ -67,17 +67,17 @@ func replaceOrAddEncodeEth1Votes[T, U](
       else:
         num_votes0
 
-  var res = (lower_bound == 0, default(List[T, U]))
+  var res = (lower_bound == 0, default(List[T, maxLen]))
   for i in lower_bound ..< votes1.len:
     if not result[1].add votes1[i]:
       raiseAssert "same limit"
   res
 
-func replaceOrAddDecodeEth1Votes[T, U](
-    votes0: var HashList[T, U], eth1_data_votes_replaced: bool,
-    votes1: List[T, U]) =
+func replaceOrAddDecodeEth1Votes[T, maxLen](
+    votes0: var HashList[T, maxLen], eth1_data_votes_replaced: bool,
+    votes1: List[T, maxLen]) =
   if eth1_data_votes_replaced:
-    votes0 = HashList[T, U]()
+    votes0 = HashList[T, maxLen]()
 
   for item in votes1:
     if not votes0.add item:
@@ -209,7 +209,8 @@ func applyDiff*(
     state: var capella.BeaconState,
     immutableValidators: openArray[ImmutableValidatorData2],
     stateDiff: BeaconStateDiff) =
-  template assign[T, U](tgt: var HashList[T, U], src: List[T, U]) =
+  template assign[T, maxLen](
+      tgt: var HashList[T, maxLen], src: List[T, maxLen]) =
     assign(tgt.data, src)
     tgt.resetCache()
 


### PR DESCRIPTION
Nim 2.0 gets confused when compiling `all_tests`:

```
Error: undeclared identifier: 'maxLen'
candidates (edit distance, scope distance); see '--spellSuggest':
 (3, 7): 'Table'
 (3, 7): 'len'
 (3, 7): 'max'
```

Renaming the generic parameter `U` to `maxLen` fixes this somehow. It also increases readability to use the same name consistently.