### PR TITLE
fix relative import paths for Nim 2.0

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_rewards.nim
+++ b/tests/consensus_spec/altair/test_fixture_rewards.nim
@@ -9,8 +9,8 @@
 
 import
   # Beacon chain internals
-  ../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/altair,
+  ../../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
+  ../../../beacon_chain/spec/datatypes/altair,
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -14,7 +14,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/altair,
+  ../../../beacon_chain/spec/datatypes/altair,
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
@@ -9,8 +9,8 @@
 
 import
   # Beacon chain internals
-  ../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/[altair, bellatrix],
+  ../../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
+  ../../../beacon_chain/spec/datatypes/[altair, bellatrix],
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -11,7 +11,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/[altair, bellatrix],
+  ../../../beacon_chain/spec/datatypes/[altair, bellatrix],
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/capella/test_fixture_rewards.nim
+++ b/tests/consensus_spec/capella/test_fixture_rewards.nim
@@ -9,8 +9,8 @@
 
 import
   # Beacon chain internals
-  ../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/[altair, capella],
+  ../../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
+  ../../../beacon_chain/spec/datatypes/[altair, capella],
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -14,13 +14,13 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/[altair, capella],
+  ../../../beacon_chain/spec/datatypes/[altair, capella],
   # Status libraries
   snappy,
   # Test utilities
   ../../testutil, ../fixtures_utils, ../os_ops
 
-from ../../beacon_chain/spec/datatypes/bellatrix import PowBlock
+from ../../../beacon_chain/spec/datatypes/bellatrix import PowBlock
 
 # SSZ tests of consensus objects (minimal/mainnet preset specific)
 

--- a/tests/consensus_spec/deneb/test_fixture_rewards.nim
+++ b/tests/consensus_spec/deneb/test_fixture_rewards.nim
@@ -9,8 +9,8 @@
 
 import
   # Beacon chain internals
-  ../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/[altair, deneb],
+  ../../../beacon_chain/spec/[beaconstate, validator, helpers, state_transition_epoch],
+  ../../../beacon_chain/spec/datatypes/[altair, deneb],
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -14,14 +14,14 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/[altair, deneb],
+  ../../../beacon_chain/spec/datatypes/[altair, deneb],
   # Status libraries
   snappy,
   # Test utilities
   ../../testutil, ../fixtures_utils, ../os_ops
 
-from ../../beacon_chain/spec/datatypes/bellatrix import PowBlock
-from ../../beacon_chain/spec/datatypes/capella import
+from ../../../beacon_chain/spec/datatypes/bellatrix import PowBlock
+from ../../../beacon_chain/spec/datatypes/capella import
   BLSToExecutionChange, SignedBLSToExecutionChange, HistoricalSummary,
   Withdrawal
 

--- a/tests/consensus_spec/phase0/test_fixture_rewards.nim
+++ b/tests/consensus_spec/phase0/test_fixture_rewards.nim
@@ -10,8 +10,8 @@
 import
   # Standard library
   # Beacon chain internals
-  ../../beacon_chain/spec/[validator, helpers, state_transition_epoch],
-  ../../beacon_chain/spec/datatypes/phase0,
+  ../../../beacon_chain/spec/[validator, helpers, state_transition_epoch],
+  ../../../beacon_chain/spec/datatypes/phase0,
   # Test utilities
   ../../testutil,
   ../fixtures_utils, ../os_ops

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -14,7 +14,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../beacon_chain/spec/datatypes/phase0,
+  ../../../beacon_chain/spec/datatypes/phase0,
   # Status libraries
   snappy,
   # Test utilities

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -15,7 +15,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../../beacon_chain/spec/helpers,
+  ../../beacon_chain/spec/helpers,
   # Test utilities
   ../testutil,
   ./fixtures_utils, ./os_ops

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -15,7 +15,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../../beacon_chain/spec/[forks, light_client_sync],
+  ../../beacon_chain/spec/[forks, light_client_sync],
   # Test utilities
   ../testutil,
   ./fixtures_utils, ./os_ops

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -15,7 +15,7 @@ import
   # Third-party
   yaml,
   # Beacon chain internals
-  ../../../beacon_chain/spec/helpers,
+  ../../beacon_chain/spec/helpers,
   # Test utilities
   ../testutil,
   ./fixtures_utils, ./os_ops

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -15,9 +15,9 @@ import
   ../testutil
 
 from std/sequtils import toSeq
-from ../../../beacon_chain/spec/forks import
+from ../../beacon_chain/spec/forks import
   ForkedEpochInfo, ForkedHashedBeaconState, fromSszBytes, getStateRoot, new
-from ../../../beacon_chain/spec/presets import
+from ../../beacon_chain/spec/presets import
   const_preset, defaultRuntimeConfig
 from ./fixtures_utils import
   SSZ, SszTestsDir, hash_tree_root, parseTest, readSszBytes, toSszType
@@ -92,22 +92,22 @@ template runForkBlockTests(
 runForkBlockTests(
   "phase0", "Phase 0", phase0.BeaconState, phase0.SignedBeaconBlock)
 
-from ../../../beacon_chain/spec/datatypes/altair import
+from ../../beacon_chain/spec/datatypes/altair import
   BeaconState, SignedBeaconBlock
 runForkBlockTests(
   "altair", "Altair", altair.BeaconState, altair.SignedBeaconBlock)
 
-from ../../../beacon_chain/spec/datatypes/bellatrix import
+from ../../beacon_chain/spec/datatypes/bellatrix import
   BeaconState, SignedBeaconBlock
 runForkBlockTests(
   "bellatrix", "Bellatrix", bellatrix.BeaconState, bellatrix.SignedBeaconBlock)
 
-from ../../../beacon_chain/spec/datatypes/capella import
+from ../../beacon_chain/spec/datatypes/capella import
   BeaconState, SignedBeaconBlock
 runForkBlockTests(
   "capella", "Capella", capella.BeaconState, capella.SignedBeaconBlock)
 
-from ../../../beacon_chain/spec/datatypes/deneb import
+from ../../beacon_chain/spec/datatypes/deneb import
   BeaconState, SignedBeaconBlock
 runForkBlockTests(
   "deneb", "Deneb", deneb.BeaconState, deneb.SignedBeaconBlock)

--- a/tests/consensus_spec/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/test_fixture_sanity_slots.nim
@@ -70,7 +70,7 @@ suite "EF - Bellatrix - Sanity - Slots " & preset():
       bellatrixSanitySlotsDir, relative = true, checkDir = true):
     runTest(bellatrix.BeaconState, bellatrixSanitySlotsDir, "Bellatrix", suiteName, path)
 
-from ../../../beacon_chain/spec/datatypes/capella import BeaconState
+from ../../beacon_chain/spec/datatypes/capella import BeaconState
 
 suite "EF - Capella - Sanity - Slots " & preset():
   const capellaSanitySlotsDir = sanitySlotsDir("capella")
@@ -78,7 +78,7 @@ suite "EF - Capella - Sanity - Slots " & preset():
       capellaSanitySlotsDir, relative = true, checkDir = true):
     runTest(capella.BeaconState, capellaSanitySlotsDir, "Capella", suiteName, path)
 
-from ../../../beacon_chain/spec/datatypes/deneb import BeaconState
+from ../../beacon_chain/spec/datatypes/deneb import BeaconState
 
 suite "EF - Deneb - Sanity - Slots " & preset():
   const denebSanitySlotsDir = sanitySlotsDir("deneb")

--- a/tests/test_deposit_snapshots.nim
+++ b/tests/test_deposit_snapshots.nim
@@ -10,8 +10,8 @@
 import
   std/[os, random, strutils, times],
   chronos, stew/results, unittest2, chronicles,
-  ../../beacon_chain/beacon_chain_db,
-  ../../beacon_chain/spec/deposit_snapshots
+  ../beacon_chain/beacon_chain_db,
+  ../beacon_chain/spec/deposit_snapshots
 
 from eth/db/kvstore import kvStore
 from nimcrypto import toDigest

--- a/tests/test_helpers.nim
+++ b/tests/test_helpers.nim
@@ -16,7 +16,7 @@ import
   ../beacon_chain/spec/[forks, helpers, state_transition],
   ../beacon_chain/spec/datatypes/[bellatrix, capella],
   # Test utilities
-  ./unittest2, mocking/mock_genesis
+  unittest2, mocking/mock_genesis
 
 suite "Spec helpers":
   test "integer_squareroot":


### PR DESCRIPTION
In Nim 2.0, relative `import` paths are validated more strictly; this fixes the incorrect paths used in some tests.