### PR TITLE
lower number of `--remote-validators-count` in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ local-testnet-minimal:
 		--preset minimal \
 		--nodes 2 \
 		--signer-nodes 1 \
-		--remote-validators-count 1024 \
+		--remote-validators-count 512 \
 		--signer-type $(SIGNER_TYPE) \
 		--capella-fork-epoch 3 \
 		--deneb-fork-epoch 20 \


### PR DESCRIPTION
The CI signing node sometimes becomes overloaded, leading to late block.

```
{"lvl":"DBG","ts":"2023-09-05 23:46:34.515+01:00","msg":"REST request body has been sent","remote":"127.0.0.1:5201","request":"/api/v1/eth2/sign/0x82ad1b336ce728978983cbe7c7dd25f757fdc66536f3457cf9f0120c07943f8d464eec55fefcaef9c0d5da6e9f7c1443","size":549,"http_method":"POST"}
```

```
DBG 2023-09-05 23:46:36.098+01:00 Received request                           peer=127.0.0.1:51194 meth=POST uri=/api/v1/eth2/sign/0x82ad1b336ce728978983cbe7c7dd25f757fdc66536f3457cf9f0120c07943f8d464eec55fefcaef9c0d5da6e9f7c1443
```

Especially on the `minimal` preset with short slot timings, this leads to attestations and sync duties being made for an old head, ultimately:

```
{"lvl":"FAT","ts":"2023-09-05 23:46:41.915+01:00","msg":"Low sync committee participation","topics":"chaindag","slot":15,"num_active_participants":8}
```

Looking at `nimbus_signing_node.0.jsonl` shows that the signing node is very busy. Lowering the validator count should reduce the latency a bit.