### PR TITLE
less confusing lint error msg when bumping to very recent commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,15 +225,20 @@ jobs:
             fi
             # Without the `--depth=1` fetch, may run into 'error processing shallow info: 4'
             if ! error="$(git -C "$file" fetch -q --depth=1 origin "+refs/heads/${branch}:refs/remotes/origin/${branch}")"; then
-              echo "Submodule '$file': Failed to fetch '$branch': $error"
+              echo "Submodule '$file': Failed to fetch '$branch': $error (1)"
+              exit 2
+            fi
+            branch_commit_date=$(git -C "$file" show -s --format='%ci' "refs/remotes/origin/${branch}")
+            if [[ "${commit_date}" > "${branch_commit_date}" ]]; then
+              echo "Submodule '$file': '$commit' ($commit_date) is more recent than latest '$branch' ($branch_commit_date) (branch config: '.gitmodules')"
               exit 2
             fi
             if ! error="$(git -C "$file" fetch -q --shallow-since="$commit_date" origin "+refs/heads/${branch}:refs/remotes/origin/${branch}")"; then
-              echo "Submodule '$file': Failed to fetch '$branch': $error"
+              echo "Submodule '$file': Failed to fetch '$branch': $error (2)"
               exit 2
             fi
             if ! git -C "$file" merge-base --is-ancestor "$commit" "refs/remotes/origin/$branch"; then
-              echo "Submodule '$file': '$commit' is not on '$branch' as of '$commit_date' (branch config: '.gitmodules')"
+              echo "Submodule '$file': '$commit' is not on '$branch' as of $commit_date (branch config: '.gitmodules')"
               exit 2
             fi
           done < <(git diff --name-only --diff-filter=AM HEAD^ HEAD | grep -f <(git config --file .gitmodules --get-regexp path | awk '{ print $2 }') || true)


### PR DESCRIPTION
When bumping to a more recent commit than the configured `branch`, currently the lint error message is confusing:

```
fatal: error processing shallow info: 4
Submodule 'vendor/nim-chronos': Failed to fetch 'master':
```

This happens when the selected commit is more recent than the latest one on the `branch`. Comparing the commit dates allows a better message.