### PR TITLE
wait a few slots into an epoch to schedule next epoch's duties

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1105,8 +1105,10 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
           "Getting head EpochRef should never fail")
         node.consensusManager[].actionTracker.updateActions(epochRef)
 
-      if node.consensusManager[].actionTracker.needsUpdate(
-          forkyState, slot.epoch + 1):
+      # Avoid some empty slot transition overhead and reorg risk
+      if  slot mod SLOTS_PER_EPOCH >= SLOTS_PER_EPOCH div 4 and
+          node.consensusManager[].actionTracker.needsUpdate(
+            forkyState, slot.epoch + 1):
         let epochRef = node.dag.getEpochRef(head, slot.epoch + 1, false).expect(
           "Getting head EpochRef should never fail")
         node.consensusManager[].actionTracker.updateActions(epochRef)
@@ -1230,8 +1232,10 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let head = node.dag.head
   if node.isSynced(head) and head.executionValid:
     withState(node.dag.headState):
-      if node.consensusManager[].actionTracker.needsUpdate(
-          forkyState, slot.epoch + 1):
+      # Avoid some empty slot transition overhead and reorg risk
+      if  slot mod SLOTS_PER_EPOCH >= SLOTS_PER_EPOCH div 4 and
+          node.consensusManager[].actionTracker.needsUpdate(
+            forkyState, slot.epoch + 1):
         let epochRef = node.dag.getEpochRef(head, slot.epoch + 1, false).expect(
           "Getting head EpochRef should never fail")
         node.consensusManager[].actionTracker.updateActions(epochRef)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1106,7 +1106,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
         node.consensusManager[].actionTracker.updateActions(epochRef)
 
       # Avoid some empty slot transition overhead and reorg risk
-      if  slot mod SLOTS_PER_EPOCH >= SLOTS_PER_EPOCH div 4 and
+      if  slot.since_epoch_start >= SLOTS_PER_EPOCH div 4 and
           node.consensusManager[].actionTracker.needsUpdate(
             forkyState, slot.epoch + 1):
         let epochRef = node.dag.getEpochRef(head, slot.epoch + 1, false).expect(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1105,7 +1105,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
           "Getting head EpochRef should never fail")
         node.consensusManager[].actionTracker.updateActions(epochRef)
 
-      # Avoid some empty slot transition overhead and reorg risk
+      # Avoid some empty slot transition overhead and reorg risk, and increase
+      # prediction accuracy by waiting slightly longer.
       if  slot.since_epoch_start >= SLOTS_PER_EPOCH div 4 and
           node.consensusManager[].actionTracker.needsUpdate(
             forkyState, slot.epoch + 1):
@@ -1232,8 +1233,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let head = node.dag.head
   if node.isSynced(head) and head.executionValid:
     withState(node.dag.headState):
-      # Avoid some empty slot transition overhead and reorg risk
-      if  slot mod SLOTS_PER_EPOCH >= SLOTS_PER_EPOCH div 4 and
+      # Avoid some empty slot transition overhead and reorg risk, and increase
+      # prediction accuracy by waiting slightly longer.
+      if  slot.since_epoch_start >= SLOTS_PER_EPOCH div 4 and
           node.consensusManager[].actionTracker.needsUpdate(
             forkyState, slot.epoch + 1):
         let epochRef = node.dag.getEpochRef(head, slot.epoch + 1, false).expect(


### PR DESCRIPTION
This changes the lookahead slot range from `SLOTS_PER_EPOCH` to `2*SLOTS_PER_EPOCH` to 0.75 epochs to 1.75 epochs, to avoid some empty slot overhead when calculating these duties.