### PR TITLE
fix sync contribution validation for first slot per period

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1170,14 +1170,11 @@ proc validateContribution*(
     checkSignature: bool
 ): Future[Result[
     (BlockId, CookedSig, seq[ValidatorIndex]), ValidationError]] {.async.} =
-  let
-    syncCommitteeSlot = msg.message.contribution.slot
-
-  # [IGNORE] The contribution's slot is for the current slot
-  # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
-  # i.e. contribution.slot == current_slot.
   block:
-    let v = check_slot_exact(syncCommitteeSlot, wallTime)
+    # [IGNORE] The contribution's slot is for the current slot
+    # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
+    # i.e. contribution.slot == current_slot.
+    let v = check_slot_exact(msg.message.contribution.slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 
@@ -1220,7 +1217,7 @@ proc validateContribution*(
     #      between validation and use - nonetheless, a design that avoids it and
     #      stays safe would be nice
     participants = dag.syncCommitteeParticipants(
-      msg.message.contribution.slot, subcommitteeIdx)
+      msg.message.contribution.slot + 1, subcommitteeIdx)
   if aggregator_index notin participants:
     return dag.checkedReject("Contribution: aggregator not in subcommittee")
 


### PR DESCRIPTION
Sync committee duties are performed by the sync committee as determined by slot + 1. We did it correctly for individual messages, but selected the incorrect participants for aggregate contributions for the very first slot per period (roughly 1 per ~27 hrs on Mainnet). The faulty participants selection code was originally introduced in #2925.