### PR TITLE
Windows GitHub Action builds OOM; disable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
             cpu: amd64
           - os: macos
             cpu: amd64
-          - os: windows
-            cpu: amd64
+          #- os: windows
+          #  cpu: amd64
         branch: [~, upstream/version-1-6, upstream/version-2-0]
         exclude:
           - target:


### PR DESCRIPTION
Starting with https://github.com/status-im/nimbus-eth2/commit/c7db7d0f2c2cc2de72c5689854e7eb474992edf2

https://github.com/status-im/nimbus-eth2/actions/runs/6120513027/job/16612519428
```
2023-09-08T11:57:38.0259243Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
2023-09-08T11:57:38.0260669Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
2023-09-08T11:57:38.0261583Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
2023-09-08T11:57:38.0262553Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization.nim(30, 9) template/generic instantiation of `readValue` from here
2023-09-08T11:57:38.0272133Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-toml-serialization\toml_serialization\reader.nim(445, 19) template/generic instantiation of `readValue` from here
2023-09-08T11:57:38.0273094Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization.nim(29, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
2023-09-08T11:57:43.8682662Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2150, 37) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T11:57:43.8683996Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T11:57:43.8685017Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T11:57:43.8685934Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(912, 50) template/generic instantiation of `configurationRtti` from here
2023-09-08T11:57:43.8710694Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(709, 19) template/generic instantiation of `setField` from here
2023-09-08T11:57:43.8711459Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(686, 16) template/generic instantiation of `makeDefaultValue` from here
2023-09-08T11:57:43.8712243Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(632, 10) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
2023-09-08T11:57:44.1977690Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2150, 37) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T11:57:44.1979332Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T11:57:44.1980092Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T11:57:44.1980913Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
2023-09-08T11:57:51.0946075Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2156, 1) template/generic instantiation of `programMain` from here
2023-09-08T11:57:51.0975255Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2157, 35) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T11:57:51.0992920Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T11:57:51.1003138Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T11:57:51.1093952Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
2023-09-08T12:00:18.2168457Z out of memory
2023-09-08T12:00:19.8489292Z mingw32-make: *** [Makefile:433: nimbus_beacon_node] Error 1
2023-09-08T12:00:19.9286742Z ##[error]Process completed with exit code 2.
2023-09-08T12:00:20.1179505Z Post job cleanup.
```

https://github.com/status-im/nimbus-eth2/actions/runs/6120705566/job/16613048718
```
2023-09-08T12:46:39.0027773Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization.nim(30, 9) template/generic instantiation of `readValue` from here
2023-09-08T12:46:39.0028555Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-toml-serialization\toml_serialization\reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
2023-09-08T12:46:39.0029386Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-toml-serialization\toml_serialization\reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
2023-09-08T12:46:39.0030231Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
2023-09-08T12:46:39.0031392Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
2023-09-08T12:46:39.0032345Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
2023-09-08T12:46:39.0033257Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
2023-09-08T12:46:39.0034115Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization\object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
2023-09-08T12:46:39.0035047Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization.nim(30, 9) template/generic instantiation of `readValue` from here
2023-09-08T12:46:39.0035921Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-toml-serialization\toml_serialization\reader.nim(445, 19) template/generic instantiation of `readValue` from here
2023-09-08T12:46:39.0036757Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-serialization\serialization.nim(29, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
2023-09-08T12:46:43.1508681Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2150, 37) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T12:46:43.1509963Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T12:46:43.1510961Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T12:46:43.1511833Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(912, 50) template/generic instantiation of `configurationRtti` from here
2023-09-08T12:46:43.1512621Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(709, 19) template/generic instantiation of `setField` from here
2023-09-08T12:46:43.1514448Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(686, 16) template/generic instantiation of `makeDefaultValue` from here
2023-09-08T12:46:43.1515333Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(632, 10) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
2023-09-08T12:46:43.3942923Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2150, 37) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T12:46:43.3944175Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T12:46:43.3945026Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T12:46:43.3945955Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
2023-09-08T12:46:48.7358987Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2156, 1) template/generic instantiation of `programMain` from here
2023-09-08T12:46:48.7360118Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_beacon_node.nim(2157, 35) template/generic instantiation of `makeBannerAndConfig` from here
2023-09-08T12:46:48.7360911Z D:\a\nimbus-eth2\nimbus-eth2\beacon_chain\nimbus_binary_common.nim(200, 13) template/generic instantiation of `load` from here
2023-09-08T12:46:48.7361693Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
2023-09-08T12:46:48.7362621Z D:\a\nimbus-eth2\nimbus-eth2\vendor\nim-confutils\confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
2023-09-08T12:48:16.7861066Z out of memory
2023-09-08T12:48:18.2388331Z mingw32-make: *** [Makefile:433: nimbus_beacon_node] Error 1
2023-09-08T12:48:18.3039736Z ##[error]Process completed with exit code 2.
2023-09-08T12:48:18.4550101Z Post job cleanup.
```