### PR TITLE
optimize epoch registry processing

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -669,12 +669,14 @@ template `[]`*[T](a: seq[T], b: ValidatorIndex): auto = # Also var seq (!)
 
 iterator vindices*(
     a: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]): ValidatorIndex =
-  for i in 0..<a.len():
+  static: doAssert distinctBase(ValidatorIndex) is uint32
+  for i in 0..<a.len.uint32:
     yield i.ValidatorIndex
 
 iterator vindices*(
     a: List[Validator, Limit VALIDATOR_REGISTRY_LIMIT]): ValidatorIndex =
-  for i in 0..<a.len():
+  static: doAssert distinctBase(ValidatorIndex) is uint32
+  for i in 0..<a.len.uint32:
     yield i.ValidatorIndex
 
 template `==`*(x, y: JustificationBits): bool =


### PR DESCRIPTION
This increases validator registry processing speed by around 35%, along with eliminating lots of unnecessary allocation in situations where lots of validators are ready to become active, and the queuing mechanism is necessary.

Before:
```
{"lvl":"NOT","ts":"2023-09-09 16:26:15.043+00:00","msg":"FOO1","topics":"state_transition","a":0.1676774160000001,"b":0.03502624999999959}
{"lvl":"NOT","ts":"2023-09-09 16:26:17.238+00:00","msg":"FOO1","topics":"state_transition","a":0.118771916,"b":0.017796916}
{"lvl":"NOT","ts":"2023-09-09 16:26:18.237+00:00","msg":"FOO1","topics":"state_transition","a":0.1221844160000014,"b":0.0179054169999997}
{"lvl":"NOT","ts":"2023-09-09 16:29:10.188+00:00","msg":"FOO1","topics":"state_transition","a":0.1798309600000039,"b":0.01882328899999663}
{"lvl":"NOT","ts":"2023-09-09 16:35:34.168+00:00","msg":"FOO1","topics":"state_transition","a":0.1666638739999939,"b":0.03451641600003086}
{"lvl":"NOT","ts":"2023-09-09 16:41:58.120+00:00","msg":"FOO1","topics":"state_transition","a":0.1185114569999541,"b":0.01771962500004065}
{"lvl":"NOT","ts":"2023-09-09 16:48:22.196+00:00","msg":"FOO1","topics":"state_transition","a":0.1903170460000183,"b":0.03469783700006701}
{"lvl":"NOT","ts":"2023-09-09 16:54:46.160+00:00","msg":"FOO1","topics":"state_transition","a":0.1565173740000319,"b":0.03454149900017001}
{"lvl":"NOT","ts":"2023-09-09 17:01:10.569+00:00","msg":"FOO1","topics":"state_transition","a":0.1562184160000015,"b":0.0344846250000046}
{"lvl":"NOT","ts":"2023-09-09 17:07:37.565+00:00","msg":"FOO1","topics":"state_transition","a":0.1223492069998429,"b":0.01799466700003904}
{"lvl":"NOT","ts":"2023-09-09 17:07:37.756+00:00","msg":"FOO1","topics":"state_transition","a":0.08452908300000672,"b":0.01809354100009841}
```

After:
```
{"lvl":"NOT","ts":"2023-09-09 17:09:56.197+00:00","msg":"FOO1","topics":"state_transition","a":0.1435221670000004,"b":0.02115370900000002}
{"lvl":"NOT","ts":"2023-09-09 17:09:57.382+00:00","msg":"FOO1","topics":"state_transition","a":0.1435530830000005,"b":0.02115166700000159}
{"lvl":"NOT","ts":"2023-09-09 17:09:58.615+00:00","msg":"FOO1","topics":"state_transition","a":0.1015347079999991,"b":0.01058954199999995}
{"lvl":"NOT","ts":"2023-09-09 17:13:58.215+00:00","msg":"FOO1","topics":"state_transition","a":0.1052292499999794,"b":0.01054637499998989}
{"lvl":"NOT","ts":"2023-09-09 17:20:22.443+00:00","msg":"FOO1","topics":"state_transition","a":0.1435341249999738,"b":0.02124762500000088}
{"lvl":"NOT","ts":"2023-09-09 17:26:46.180+00:00","msg":"FOO1","topics":"state_transition","a":0.1725479650000352,"b":0.02130945800001882}
{"lvl":"NOT","ts":"2023-09-09 17:33:10.143+00:00","msg":"FOO1","topics":"state_transition","a":0.1309946239999817,"b":0.01104862199997569}
{"lvl":"NOT","ts":"2023-09-09 17:39:37.547+00:00","msg":"FOO1","topics":"state_transition","a":0.1436525419999271,"b":0.02123566699992807}
{"lvl":"NOT","ts":"2023-09-09 17:39:37.733+00:00","msg":"FOO1","topics":"state_transition","a":0.07677658300008261,"b":0.0105516250000619}
{"lvl":"NOT","ts":"2023-09-09 17:46:01.654+00:00","msg":"FOO1","topics":"state_transition","a":0.1428387900000416,"b":0.02126775000010639}
{"lvl":"NOT","ts":"2023-09-09 17:46:01.939+00:00","msg":"FOO1","topics":"state_transition","a":0.1433185830001094,"b":0.02116858399995181}
{"lvl":"NOT","ts":"2023-09-09 17:52:22.525+00:00","msg":"FOO1","topics":"state_transition","a":0.1439325410001402,"b":0.0212659999999687}
{"lvl":"NOT","ts":"2023-09-09 17:58:46.149+00:00","msg":"FOO1","topics":"state_transition","a":0.144189207999716,"b":0.02149554200013881}
{"lvl":"NOT","ts":"2023-09-09 18:05:10.159+00:00","msg":"FOO1","topics":"state_transition","a":0.137970174000202,"b":0.01057816699994873}
{"lvl":"NOT","ts":"2023-09-09 18:11:34.155+00:00","msg":"FOO1","topics":"state_transition","a":0.148142671000187,"b":0.0109835859998384}
{"lvl":"NOT","ts":"2023-09-09 18:17:58.177+00:00","msg":"FOO1","topics":"state_transition","a":0.1708660039998904,"b":0.02210833200024354}
```

Data from an RK3588-based SBC on mainnet. `a` is whole epoch processing time, which therefore improves as well. `b` is registry update processing time specifically, which decreases from an average of 26ms to 17ms.

This helps with state replays, therefore, as well, especially the sort used to discover validator duties.