### PR TITLE
provide hint when Git LFS is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ ifeq ($(NIM_PARAMS),)
 # The `git reset ...` will try to fix a `make update` that was interrupted
 # with Ctrl+C after deleting the working copy and before getting a chance to
 # restore it in $(BUILD_SYSTEM_DIR).
+
+# `vendor/holesky` requires Git LFS
 ifeq (, $(shell which git-lfs))
 ifeq ($(shell uname), Darwin)
 $(error Git LFS not installed. Run 'brew install git-lfs' to set up)

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,12 @@ ifeq ($(NIM_PARAMS),)
 # The `git reset ...` will try to fix a `make update` that was interrupted
 # with Ctrl+C after deleting the working copy and before getting a chance to
 # restore it in $(BUILD_SYSTEM_DIR).
+ifeq (, $(shell which git-lfs))
 ifeq ($(shell uname), Darwin)
-	LFS_MISSING_MSG := "Git LFS not installed. Run 'brew install git-lfs' to set up."
+	$(error Git LFS not installed. Run 'brew install git-lfs' to set up.)
 else
-	LFS_MISSING_MSG := "Git LFS not installed."
+	$(error Git LFS not installed.)
+endif
 endif
 
 GIT_SUBMODULE_UPDATE := git submodule update --init --recursive

--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,7 @@ endif
 
 GIT_SUBMODULE_UPDATE := git submodule update --init --recursive
 .DEFAULT:
-	+@ if ! which git-lfs >/dev/null; then echo -e $(LFS_MISSING_MSG)'\n'; exit 1; fi; \
-		echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
+	+@ echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
 		$(GIT_SUBMODULE_UPDATE) && \
 		git submodule foreach --quiet 'git reset --quiet --hard' && \
 		echo

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,16 @@ ifeq ($(NIM_PARAMS),)
 # The `git reset ...` will try to fix a `make update` that was interrupted
 # with Ctrl+C after deleting the working copy and before getting a chance to
 # restore it in $(BUILD_SYSTEM_DIR).
+ifeq ($(shell uname), Darwin)
+	LFS_MISSING_MSG := "Git LFS not installed. Run 'brew install git-lfs' to set up."
+else
+	LFS_MISSING_MSG := "Git LFS not installed."
+endif
+
 GIT_SUBMODULE_UPDATE := git submodule update --init --recursive
 .DEFAULT:
-	+@ echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
+	+@ if ! which git-lfs >/dev/null; then echo -e $(LFS_MISSING_MSG)'\n'; exit 1; fi; \
+		echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
 		$(GIT_SUBMODULE_UPDATE) && \
 		git submodule foreach --quiet 'git reset --quiet --hard' && \
 		echo

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ ifeq ($(NIM_PARAMS),)
 # restore it in $(BUILD_SYSTEM_DIR).
 ifeq (, $(shell which git-lfs))
 ifeq ($(shell uname), Darwin)
-	$(error Git LFS not installed. Run 'brew install git-lfs' to set up.)
+$(error Git LFS not installed. Run 'brew install git-lfs' to set up.)
 else
-	$(error Git LFS not installed.)
+$(error Git LFS not installed.)
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ ifeq ($(NIM_PARAMS),)
 # restore it in $(BUILD_SYSTEM_DIR).
 ifeq (, $(shell which git-lfs))
 ifeq ($(shell uname), Darwin)
-$(error Git LFS not installed. Run 'brew install git-lfs' to set up.)
+$(error Git LFS not installed. Run 'brew install git-lfs' to set up)
 else
-$(error Git LFS not installed.)
+$(error Git LFS not installed)
 endif
 endif
 


### PR DESCRIPTION
Add a hint message during git clone to direct the user to install Git LFS if it is missing. It is required to clone Holesky submodule.