### PR TITLE
update Docker base images to include `git-lfs`

### DIFF
--- a/docker/dist/base_image/Dockerfile.amd64
+++ b/docker/dist/base_image/Dockerfile.amd64
@@ -12,7 +12,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
 RUN apt-get -qq update \
- && apt-get -qq -y install build-essential git &>/dev/null \
+ && apt-get -qq -y install build-essential git-lfs &>/dev/null \
  && apt-get -qq clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/docker/dist/base_image/Dockerfile.amd64
+++ b/docker/dist/base_image/Dockerfile.amd64
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # This Docker image can change from one build to another, because the upstream
 # Debian/Ubuntu package index is continuously updated and we have to run
 # `apt-get update` in here.

--- a/docker/dist/base_image/Dockerfile.arm
+++ b/docker/dist/base_image/Dockerfile.arm
@@ -12,7 +12,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
 RUN apt-get -qq update \
- && apt-get -qq -y install build-essential git \
+ && apt-get -qq -y install build-essential git-lfs \
   libc6-armhf-armel-cross libc6-dev-armel-armhf-cross binutils-arm-linux-gnueabihf gcc-arm-linux-gnueabihf &>/dev/null \
  && apt-get -qq clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/dist/base_image/Dockerfile.arm
+++ b/docker/dist/base_image/Dockerfile.arm
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # This Docker image can change from one build to another, because the upstream
 # Debian/Ubuntu package index is continuously updated and we have to run
 # `apt-get update` in here.

--- a/docker/dist/base_image/Dockerfile.arm64
+++ b/docker/dist/base_image/Dockerfile.arm64
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # This Docker image can change from one build to another, because the upstream
 # Debian/Ubuntu package index is continuously updated and we have to run
 # `apt-get update` in here.

--- a/docker/dist/base_image/Dockerfile.arm64
+++ b/docker/dist/base_image/Dockerfile.arm64
@@ -14,7 +14,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
 RUN apt-get -qq update \
- && apt-get -qq -y install build-essential git \
+ && apt-get -qq -y install build-essential git-lfs \
   binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu &>/dev/null \
  && apt-get -qq clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/dist/base_image/Dockerfile.macos
+++ b/docker/dist/base_image/Dockerfile.macos
@@ -12,7 +12,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
 RUN apt-get -qq update \
- && apt-get -qq -y install build-essential git clang-11 llvm-11-dev cmake curl libssl-dev lzma-dev libxml2-dev &>/dev/null \
+ && apt-get -qq -y install build-essential git-lfs clang-11 llvm-11-dev cmake curl libssl-dev lzma-dev libxml2-dev &>/dev/null \
  && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-11 100 \
  && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100 \
  && apt-get -qq clean \

--- a/docker/dist/base_image/Dockerfile.macos
+++ b/docker/dist/base_image/Dockerfile.macos
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # This Docker image can change from one build to another, because the upstream
 # Debian/Ubuntu package index is continuously updated and we have to run
 # `apt-get update` in here.

--- a/docker/dist/base_image/Dockerfile.win64
+++ b/docker/dist/base_image/Dockerfile.win64
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # This Docker image can change from one build to another, because the upstream
 # Debian/Ubuntu package index is continuously updated and we have to run
 # `apt-get update` in here.

--- a/docker/dist/base_image/Dockerfile.win64
+++ b/docker/dist/base_image/Dockerfile.win64
@@ -13,7 +13,7 @@ SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive TZ="Etc/UTC"
 RUN \
  apt-get -qq update \
- && apt-get -qq -y install git gnupg software-properties-common lsb cmake &>/dev/null \
+ && apt-get -qq -y install git-lfs gnupg software-properties-common lsb cmake &>/dev/null \
  && apt-get -qq -y install \
     autoconf \
     automake \


### PR DESCRIPTION
Current method of getting Holesky information requires `git-lfs`

The various distributions all have `git-lfs` depend on `git`, so no need to specify both, only `git-lfs`: https://packages.ubuntu.com/focal/git-lfs https://packages.debian.org/bullseye/git-lfs https://packages.debian.org/buster/git-lfs