### PR TITLE
Increase default file limit on startup

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2166,6 +2166,7 @@ programMain:
     # permissions are insecure.
     quit QuitFailure
 
+  setupFileLimits()
   setupLogging(config.logLevel, config.logStdout, config.logFile)
 
   ## This Ctrl+C handler exits the program in non-graceful way.

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -106,6 +106,17 @@ when defaultChroniclesStream.outputs.type.arity == 2:
   from std/os import splitFile
   from "."/filepath import secureCreatePath
 
+proc setupFileLimits*() =
+  when not defined(windows):
+    # In addition to databases and sockets, we need a file descriptor for every
+    # validator - setting it to 16k should provide sufficient margin
+    let
+      limit = getMaxOpenFiles2().valueOr(16384)
+
+    if limit < 16384:
+      setMaxOpenFiles2(16384).isOkOr:
+        warn "Cannot increase open file limit", err = osErrorMsg(error)
+
 proc setupLogging*(
     logLevel: string, stdoutKind: StdoutLogKind, logFile: Option[OutFile]) =
   # In the cfg file for nimbus, we create two formats: textlines and json.

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -534,5 +534,6 @@ programMain:
     # and avoid using system resources (such as urandom) after that
     rng = HmacDrbgContext.new()
 
+  setupFileLimits()
   setupLogging(config.logLevel, config.logStdout, config.logFile)
   waitFor runValidatorClient(config, rng)

--- a/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
+++ b/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
@@ -48,6 +48,9 @@ Environment=METRICS_PORT=8008
 Environment=REST_ENABLED=Yes
 Environment=METRICS_ENABLED=Yes
 
+# Apart from sockets and databases, a file descriptor is needed for every local validator
+LimitNOFILE=16384
+
 # Default group = nimbus
 User=nimbus
 WorkingDirectory=/var/lib/nimbus

--- a/scripts/package_src/nimbus_validator_client/image/lib/systemd/system/nimbus_validator_client.service
+++ b/scripts/package_src/nimbus_validator_client/image/lib/systemd/system/nimbus_validator_client.service
@@ -39,6 +39,9 @@ Environment=METRICS_PORT=8108
 # Interaction and monitoring
 Environment=METRICS_ENABLED=Yes
 
+# Apart from sockets and databases, a file descriptor is needed for every local validator
+LimitNOFILE=16384
+
 # Default group = nimbus
 User=nimbus
 WorkingDirectory=/var/lib/nimbus


### PR DESCRIPTION
We use file descriptors for validators and sockets and might run out of either on high-validator setups - increasing the limit here is harmless and avoids a common limiting factor in setup