### PR TITLE
avoid repeated total active balance computation in fork choice

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -113,6 +113,7 @@ type
 
   BalanceCheckpoint* = object
     checkpoint*: Checkpoint
+    total_active_balance*: Gwei
     balances*: seq[Gwei]
 
   Checkpoints* = object


### PR DESCRIPTION
We currently compute `justified_total_active_balance` inside `calculateProposerBoost`, despite that sum already being known in the `EpochRef` cache. Tracking `justified_total_active_balance` whenever the justified checkpoint updates allows replacing the repeated computation with a lookup, at minimal memory cost.