### PR TITLE
exclude 'public-keys/all.txt' file from checkout

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -222,6 +222,6 @@
 	branch = master
 [submodule "vendor/holesky"]
 	path = vendor/holesky
-  url = https://github.com/eth-clients/holesky
-  ignore = untracked
-  branch = main
+	url = https://github.com/eth-clients/holesky
+	ignore = untracked
+	branch = main

--- a/Makefile
+++ b/Makefile
@@ -134,11 +134,12 @@ $(error Git LFS not installed)
 endif
 endif
 
-GIT_SUBMODULE_UPDATE := git submodule update --init --recursive
+GIT_SUBMODULE_CONFIG := lfs.fetchexclude=/public-keys/all.txt
+GIT_SUBMODULE_UPDATE := git -c $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
 .DEFAULT:
 	+@ echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
 		$(GIT_SUBMODULE_UPDATE) && \
-		git submodule foreach --quiet 'git reset --quiet --hard' && \
+		git submodule foreach --quiet 'git -c $(GIT_SUBMODULE_CONFIG) reset --quiet --hard' && \
 		echo
 # Now that the included *.mk files appeared, and are newer than this file, Make will restart itself:
 # https://www.gnu.org/software/make/manual/make.html#Remaking-Makefiles

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ ifneq ($(OS), Windows_NT)
 PLATFORM_SPECIFIC_TARGETS += gnosis-build
 endif
 
+GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt
+
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.
 #
@@ -134,12 +136,11 @@ $(error Git LFS not installed)
 endif
 endif
 
-GIT_SUBMODULE_CONFIG := lfs.fetchexclude=/public-keys/all.txt
-GIT_SUBMODULE_UPDATE := git -c $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
+GIT_SUBMODULE_UPDATE := git $(GIT_SUBMODULE_CONFIG) submodule update --init --recursive
 .DEFAULT:
 	+@ echo -e "Git submodules not found. Running '$(GIT_SUBMODULE_UPDATE)'.\n"; \
 		$(GIT_SUBMODULE_UPDATE) && \
-		git submodule foreach --quiet 'git -c $(GIT_SUBMODULE_CONFIG) reset --quiet --hard' && \
+		git submodule foreach --quiet 'git $(GIT_SUBMODULE_CONFIG) reset --quiet --hard' && \
 		echo
 # Now that the included *.mk files appeared, and are newer than this file, Make will restart itself:
 # https://www.gnu.org/software/make/manual/make.html#Remaking-Makefiles

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ ifneq ($(OS), Windows_NT)
 PLATFORM_SPECIFIC_TARGETS += gnosis-build
 endif
 
+# We don't need the `vendor/holesky/public-keys/all.txt` file but fetching it
+# may trigger 'This repository is over its data quota' from GitHub
 GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt
 
 ifeq ($(NIM_PARAMS),)

--- a/ci/Jenkinsfile.benchmarks
+++ b/ci/Jenkinsfile.benchmarks
@@ -1,3 +1,11 @@
+/* beacon_chain
+ * Copyright (c) 2022-2023 Status Research & Development GmbH
+ * Licensed and distributed under either of
+ *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+ *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+ * at your option. This file may not be copied, modified, or distributed except according to those terms.
+ */
+
 // https://stackoverflow.com/questions/40760716/jenkins-abort-running-build-if-new-one-is-started
 // We should only abort older jobs in PR branches, so we have a nice CI history in "master" and "devel".
 if (env.BRANCH_NAME != "master" && env.BRANCH_NAME != "devel") {

--- a/ci/Jenkinsfile.benchmarks
+++ b/ci/Jenkinsfile.benchmarks
@@ -15,7 +15,7 @@ node("metal") {
 				/* source code checkout */
 				checkout scm
 				/* we need to update the submodules before caching kicks in */
-				sh "git submodule update --init --recursive"
+				sh "git -c lfs.fetchexclude=/public-keys/all.txt submodule update --init --recursive"
 			}
 
 			stage("Build") {
@@ -42,4 +42,3 @@ node("metal") {
 		}
 	}
 }
-


### PR DESCRIPTION
The 'vendor/holesky/public-keys/all.txt' file is not used by Nimbus, but sometimes fails to download due to payment issues in `@eth-clients`. Skipping the download of that file should reduce that risk.

```
Downloading public-keys/all.txt (240 MB)
Error downloading object: public-keys/all.txt (ba977b5): Smudge error: Error downloading public-keys/all.txt (ba977b5b1da180914c934623fce187860e1b54cff939e6208533b2cb5f589e07): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.
```