### PR TITLE
exclude `*.service` files from lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
           excluded_files="config.yaml"
-          excluded_extensions="ans|json|md|png|ssz|txt"
+          excluded_extensions="ans|json|md|png|service|ssz|txt"
 
           current_year=$(date +"%Y")
           outdated_files=()


### PR DESCRIPTION
These `*.service` files are installed on user installations, so referring to a license file outside their installation doesn't make too much sense.