### PR TITLE
apply proposer boost to first block in case of equivocation

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -291,7 +291,9 @@ proc process_block*(self: var ForkChoice,
 
   # Add proposer score boost if the block is timely
   let slot = self.checkpoints.time.slotOrZero
-  if slot == blck.slot and self.checkpoints.time < slot.attestation_deadline:
+  if slot == blck.slot and
+      self.checkpoints.time < slot.attestation_deadline and
+      self.checkpoints.proposer_boost_root == ZERO_HASH:
     self.checkpoints.proposer_boost_root = blckRef.root
 
   # Update checkpoints in store if necessary


### PR DESCRIPTION
Implement spec changes to fork choice; this only affects equivocation when multiple blocks are signed for the same slot. Regular operation is not changed.

- https://github.com/ethereum/consensus-specs/pull/3352