### PR TITLE
reject invalid proofs when validating blobs

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -791,14 +791,10 @@ proc validate_blobs*(expected_kzg_commitments: seq[KzgCommitment],
   if proofs.len != blobs.len:
     return err("validate_blobs: different proof and blob lengths")
 
-  const infinityProof = KzgProof([
-    0xc0.byte, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-  if infinityProof in proofs:
-    return err("validate_blobs: proof at infinity is not allowed")
+  let res = verifyProofs(blobs, expected_kzg_commitments, proofs).valueOr:
+    return err("validate_blobs: proof verification error")
 
-  if verifyProofs(blobs, expected_kzg_commitments, proofs).isErr():
+  if not res:
     return err("validate_blobs: proof verification failed")
 
   ok()

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -791,6 +791,13 @@ proc validate_blobs*(expected_kzg_commitments: seq[KzgCommitment],
   if proofs.len != blobs.len:
     return err("validate_blobs: different proof and blob lengths")
 
+  const infinityProof = KzgProof([
+    0xc0.byte, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+  if infinityProof in proofs:
+    return err("validate_blobs: proof at infinity is not allowed")
+
   if verifyProofs(blobs, expected_kzg_commitments, proofs).isErr():
     return err("validate_blobs: proof verification failed")
 


### PR DESCRIPTION
Currently, passing `0xc00000...` proof seems to pass `verifyProofs`. Unsure why such a check is not necessary in spec, and also unsure whether it is correct to reject proof at infinity, or if it could occur, e.g., for a blob containing all 0 bytes. Weird overall...