### PR TITLE
implement Confirmation rule prerequisite - fork choice filter change

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -33,6 +33,9 @@ type
     ## Controls which version of fork choice to run.
     Stable = "stable"
       ## Use current version from stable Ethereum consensus specifications
+    Pr3431 = "pr3431"
+      ## https://github.com/ethereum/consensus-specs/pull/3431
+      ## https://github.com/ethereum/consensus-specs/issues/3466
 
   fcKind* = enum
     ## Fork Choice Error Kinds

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1903,7 +1903,12 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
   if config.forkChoiceVersion.isNone:
-    config.forkChoiceVersion = some(ForkChoiceVersion.Stable)
+    config.forkChoiceVersion =
+      if metadata.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        # https://github.com/ethereum/pm/issues/844#issuecomment-1673359012
+        some(ForkChoiceVersion.Pr3431)
+      else:
+        some(ForkChoiceVersion.Stable)
 
   ## Ctrl+C handling
   proc controlCHandler() {.noconv.} =


### PR DESCRIPTION
To support confirmation rule via beacon-APIs as described in spec PR, add `--debug-fork-choice-version=pr3431` option and enable when Deneb fork is scheduled. To opt-out, `--debug-fork-choice-version=stable`, or don't schedule Deneb.

- https://github.com/ethereum/consensus-specs/pull/3431
- https://github.com/ethereum/consensus-specs/issues/3466

"will bundle this with deneb release":

- https://github.com/ethereum/pm/issues/844#issuecomment-1673359012