### PR TITLE
bump `nim-ssz-serialization` to `a5767c1b4992dca3e5bd72557aadd4df0f183bf8`

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -3320,10 +3320,10 @@ func readSszResBytes(T: typedesc[RestBlockTypes],
   try:
     readSszBytes(data, res)
     ok(res)
-  except MalformedSszError as exc:
-    err("Invalid SSZ object")
   except SszSizeMismatchError:
     err("Incorrect SSZ object's size")
+  except SszError:
+    err("Invalid SSZ object")
 
 proc decodeBytes*[T: DecodeConsensysTypes](
        t: typedesc[T],

--- a/beacon_chain/spec/eth2_ssz_serialization.nim
+++ b/beacon_chain/spec/eth2_ssz_serialization.nim
@@ -20,8 +20,9 @@ from ./datatypes/deneb import SignedBeaconBlock, TrustedSignedBeaconBlock
 
 export phase0, altair, ssz_codec, ssz_serialization, eth2_merkleization
 
-proc readAndUpdateRoot(data: openArray[byte], val: var auto, updateRoot = true) {.
-     raises: [MalformedSszError, SszSizeMismatchError].} =
+proc readAndUpdateRoot(
+    data: openArray[byte], val: var auto, updateRoot = true
+) {.raises: [SszError].} =
   readSszValue(data, val)
   if updateRoot:
     val.root = hash_tree_root(val.message)
@@ -64,8 +65,9 @@ template readSszBytes*(
     data: openArray[byte], val: var auto, updateRoot: bool) =
   readSszValue(data, val)
 
-func readSszBytes(T: type, data: openArray[byte], updateRoot = true): T {.
-    raises: [MalformedSszError, SszSizeMismatchError].} =
+func readSszBytes(
+    T: type, data: openArray[byte], updateRoot = true
+): T {.raises: [SszError].} =
   var res: T
   readSszBytes(data, res, updateRoot)
   res

--- a/beacon_chain/spec/ssz_codec.nim
+++ b/beacon_chain/spec/ssz_codec.nim
@@ -6,7 +6,6 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 {.push raises: [].}
-{.pragma: raisesssz, raises: [MalformedSszError, SszSizeMismatchError].}
 
 import
   std/[typetraits],
@@ -27,7 +26,8 @@ template toSszType*(v: Version): auto = distinctBase(v)
 template toSszType*(v: JustificationBits): auto = distinctBase(v)
 template toSszType*(v: EpochParticipationFlags): auto = asList v
 
-func fromSszBytes*(T: type GraffitiBytes, data: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type GraffitiBytes, data: openArray[byte]): T {.raises: [SszError].} =
   if data.len != sizeof(result):
     raiseIncorrectSize T
   copyMem(result.addr, unsafeAddr data[0], sizeof(result))
@@ -41,22 +41,28 @@ template fromSszBytes*(T: type Epoch, bytes: openArray[byte]): T =
 template fromSszBytes*(T: type SyncCommitteePeriod, bytes: openArray[byte]): T =
   T fromSszBytes(uint64, bytes)
 
-func fromSszBytes*(T: type ForkDigest, bytes: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type ForkDigest, bytes: openArray[byte]): T {.raises: [SszError].} =
   if bytes.len != sizeof(result):
     raiseIncorrectSize T
   copyMem(result.addr, unsafeAddr bytes[0], sizeof(result))
 
-func fromSszBytes*(T: type Version, bytes: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type Version, bytes: openArray[byte]): T {.raises: [SszError].} =
   if bytes.len != sizeof(result):
     raiseIncorrectSize T
   copyMem(result.addr, unsafeAddr bytes[0], sizeof(result))
 
-func fromSszBytes*(T: type JustificationBits, bytes: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type JustificationBits, bytes: openArray[byte]
+): T {.raises: [SszError].} =
   if bytes.len != sizeof(result):
     raiseIncorrectSize T
   copyMem(result.addr, unsafeAddr bytes[0], sizeof(result))
 
-func fromSszBytes*(T: type EpochParticipationFlags, bytes: openArray[byte]): T {.raisesssz.} =
+func fromSszBytes*(
+    T: type EpochParticipationFlags, bytes: openArray[byte]
+): T {.raises: [SszError].} =
   # TODO https://github.com/nim-lang/Nim/issues/21123
   let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr result)
   readSszValue(bytes, tmp[])


### PR DESCRIPTION
- nimble/ci updates
- use common super-type in `raisesssz` pragma