### PR TITLE
small attestation pool clean up

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -536,7 +536,8 @@ func get_attestation_participation_flag_indices(
   doAssert is_matching_source
 
   var participation_flag_indices: set[TimelyFlag]
-  if is_matching_source and inclusion_delay <= integer_squareroot(SLOTS_PER_EPOCH):
+  if is_matching_source and inclusion_delay <=
+      static(integer_squareroot(SLOTS_PER_EPOCH)):
     participation_flag_indices.incl(TIMELY_SOURCE_FLAG_INDEX)
   if is_matching_target and inclusion_delay <= SLOTS_PER_EPOCH:
     participation_flag_indices.incl(TIMELY_TARGET_FLAG_INDEX)


### PR DESCRIPTION
- the various `spec/datatypes/phase0` and similar imports were Nim 1.2 workarounds, which now come in through `forks` in Nim 1.6, so the individual fork imports are unnecessary (this is a general transformation which can be safely applied anywhere there are both types of imports: either the `forks` one is unnecessary, in which case it can be removed, if actual `forks` functionality isn't referenced, or if it is, the individual fork imports can be removed);

- unexporting most of the data structures not intended as part of the public API will clarify that further refactoring for the Altair and newer participation flags, which are currently collapsed into just some participation or no participation, do not change the public interface or how the rest of `nimbus-eth2` uses this module;

- `integer_squareroot(SLOTS_PER_EPOCH)` was called in a loop, pointlessly, and while this probably isn't a major improvement, removing repeated and redundant `integer_squareroot` calculations elsewhere has proven a performance win;

- the `if newBlockSlot < MIN_ATTESTATION_INCLUSION_DELAY:` early return was implicitly using `result` set to its default value

- some treatment of phase0/altair-and-newer is handled more naturally in terms of function overloading rather than `when`s which need to be maintained each new fork. There has been change in attestation handling in Deneb, but it's orthogonal to the degrees of freedom already modified. Adding a parameter to `AttestationCache.init()` for phase0 is a worthwhile tradeoff to remove the `when` later on.