### PR TITLE
mention Holesky in the book

### DIFF
--- a/docs/the_nimbus_book/src/attestation-performance.md
+++ b/docs/the_nimbus_book/src/attestation-performance.md
@@ -35,9 +35,9 @@ The following options are available:
 
 Where:
 
-- The `network` can be `mainnet`, `prater`, or `sepolia`.
+- The `network` can be `mainnet`, `holesky`, or `sepolia`.
 
-- The default location of the `db`  is `build/data/shared_mainnet_0/db` for `mainnet`, `build/data/shared_prater_0/db` for `prater`, etc.
+- The default location of the `db`  is `build/data/shared_mainnet_0/db` for `mainnet`, `build/data/shared_holesky_0/db` for `holesky`, etc.
 
 
 Near the bottom, you should see:
@@ -55,11 +55,11 @@ Use `start-slot` and `slots` to restrict the analysis on a specific block range.
 
 ### 3. Run
 
-To view the performance of all validators on Prater so far across the entire block range stored in your database, run:
+To view the performance of all validators on Holesky so far across the entire block range stored in your database, run:
 ```sh
 build/ncli_db validatorPerf \
---network=prater \
---db=build/data/shared_prater_0/db
+--network=holesky \
+--db=build/data/shared_holesky_0/db
 ```
 
 You should see output that looks like to the following:
@@ -77,8 +77,8 @@ validator_index,attestation_hits,attestation_misses,head_attestation_hits,head_a
 To restrict the analysis to the performance between slots 0 and 128, say, run:
 ```sh
 build/ncli_db validatorPerf \
---network=prater \
---db=build/data/shared_prater_0/db \
+--network=holesky \
+--db=build/data/shared_holesky_0/db \
 --start-slot=0 \
 --slots=128
 ```

--- a/docs/the_nimbus_book/src/beacon-node-systemd.md
+++ b/docs/the_nimbus_book/src/beacon-node-systemd.md
@@ -56,7 +56,7 @@ sudo systemctl edit nimbus_beacon_node.service
 The service file contains several options for controlling Nimbus.
 Important options include:
 
-* `Environment=NETWORK`: set this to `mainnet`, `prater` or `sepolia`, depending on which network you want to connect to
+* `Environment=NETWORK`: set this to `mainnet`, `holesky` or `sepolia`, depending on which network you want to connect to
 * `Environment=WEB3_URL`: point this to your execution client, see the [Execution Client](./eth1.md) setup guide
 * `Environment=REST_ENABLED`: REST is used to interact with the beacon node, in particular when setting up a separate Validator Client, see the [REST API](./rest-api.md) guide
 * `Environment=METRICS_ENABLED`: metrics are used for monitoring the node, see the [metrics](./metrics-pretty-pictures.md) setup guide
@@ -141,5 +141,5 @@ When running multiple beacon nodes, make sure that each service:
 
 ## Further examples
 
-- A [service template file](https://github.com/chfast/ethereum-node/blob/main/nimbus%40.service) by Pawel Bylica which allows you to start two services at the same time, e.g. `nimbus@prater.service` and `nimbus@mainnet.service`.
+- A [service template file](https://github.com/chfast/ethereum-node/blob/main/nimbus%40.service) by Pawel Bylica which allows you to start two services at the same time, e.g. `nimbus@holesky.service` and `nimbus@mainnet.service`.
 - The [EthereumOnARM](https://github.com/diglos/ethereumonarm/blob/main/fpm-package-builder/nimbus/extras/nimbus.service) project maintains a service file as part of their Ethereum installation package repository.

--- a/docs/the_nimbus_book/src/data-dir.md
+++ b/docs/the_nimbus_book/src/data-dir.md
@@ -3,7 +3,7 @@
 Nimbus stores all the information it needs to run in a data directory.
 In this directory, you'll find a database, your validator keys and secrets, and several other items.
 
-When following the installation guide, the chain data will be stored in `build/data` with separate directories for each chain (mainnet, prater, etc).
+When following the installation guide, the chain data will be stored in `build/data` with separate directories for each chain (mainnet, holesky, etc).
 
 !!! tip "The `--data-dir` option"
     The `--data-dir=/path/to/data` allows picking a specific data directory to store the chain.

--- a/docs/the_nimbus_book/src/database-backup.md
+++ b/docs/the_nimbus_book/src/database-backup.md
@@ -3,7 +3,7 @@
 
 The best way to do this is to use `.backup` sqlite command:
 
-1. Navigate to either `build/data/shared_mainnet_0/db/` (if you're running Prater: `shared_prater_0`) or the directory you supplied to the `--data-dir` argument when you launched Nimbus.
+1. Navigate to either `build/data/shared_mainnet_0/db/` (if you're running Holesky: `shared_holesky_0`) or the directory you supplied to the `--data-dir` argument when you launched Nimbus.
 
 2. Run the following command:
   ```

--- a/docs/the_nimbus_book/src/el-light-client.md
+++ b/docs/the_nimbus_book/src/el-light-client.md
@@ -80,9 +80,9 @@ The following sections explain how to do this for certain EL clients.
         geth --authrpc.jwtsecret="$HOME/jwtsecret"
         ```
 
-    === "Goerli"
+    === "Holesky"
         ```sh
-        geth --goerli --authrpc.jwtsecret="$HOME/jwtsecret"
+        geth --holesky --authrpc.jwtsecret="$HOME/jwtsecret"
         ```
 
 === "Nethermind"
@@ -92,9 +92,9 @@ The following sections explain how to do this for certain EL clients.
         nethermind --JsonRpc.JwtSecretFile="$HOME/jwtsecret"
         ```
 
-    === "Goerli"
+    === "Holesky"
         ```sh
-        nethermind --config goerli --JsonRpc.JwtSecretFile="$HOME/jwtsecret"
+        nethermind --config holesky --JsonRpc.JwtSecretFile="$HOME/jwtsecret"
         ```
 
 === "Others"
@@ -119,7 +119,7 @@ A block root may be obtained from another trusted beacon node, or from a trusted
     ```
 
 === "Beaconcha.in"
-    On the [beaconcha.in](https://beaconcha.in) website ([Goerli](https://prater.beaconcha.in)), navigate to the `Epochs` section and select a recent `Finalized` epoch.
+    On the [beaconcha.in](https://beaconcha.in) website ([Holesky](https://holesky.beaconcha.in)), navigate to the `Epochs` section and select a recent `Finalized` epoch.
     Then, scroll down to the bottom of the page.
     If the bottom-most slot has a `Proposed` status, copy its `Root Hash`.
     Otherwise, for example if the bottom-most slot was `Missed`, go back and pick a different epoch.
@@ -141,10 +141,10 @@ To start the light client, run the following commands (inserting your own truste
         --trusted-block-root=$TRUSTED_BLOCK_ROOT
     ```
 
-=== "Goerli"
+=== "Holesky"
     ```sh
     TRUSTED_BLOCK_ROOT=0x1234567890123456789012345678901234567890123456789012345678901234
-    build/nimbus_light_client --network=goerli \
+    build/nimbus_light_client --network=holesky \
         --web3-url=http://127.0.0.1:8551 --jwt-secret="$HOME/jwtsecret" \
         --trusted-block-root=$TRUSTED_BLOCK_ROOT
     ```

--- a/docs/the_nimbus_book/src/eth1.md
+++ b/docs/the_nimbus_book/src/eth1.md
@@ -37,9 +37,9 @@ Select an execution client and install it, configuring it such that that the aut
         geth --authrpc.addr localhost --authrpc.port 8551 --authrpc.vhosts localhost --authrpc.jwtsecret /tmp/jwtsecret
         ```
 
-    === "Goerli"
+    === "Holesky"
         ```
-        geth --goerli --authrpc.addr localhost --authrpc.port 8551 --authrpc.vhosts localhost --authrpc.jwtsecret /tmp/jwtsecret
+        geth --holesky --authrpc.addr localhost --authrpc.port 8551 --authrpc.vhosts localhost --authrpc.jwtsecret /tmp/jwtsecret
         ```
 
 === "Nethermind"
@@ -87,9 +87,9 @@ You will need to pass the path to the token file to Nimbus together with the web
       --jwt-secret=/tmp/jwtsecret
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    ./run-prater-beacon-node.sh \
+    ./run-holesky-beacon-node.sh \
       --el=http://127.0.0.1:8551 \
       --jwt-secret=/tmp/jwtsecret
     ```

--- a/docs/the_nimbus_book/src/external-block-builder.md
+++ b/docs/the_nimbus_book/src/external-block-builder.md
@@ -33,9 +33,9 @@ Additionally, the URL of the service exposing the [builder API](https://ethereum
     ./run-mainnet-beacon-node.sh --payload-builder=true --payload-builder-url=https://${HOST}:${PORT}/
     ```
 
-=== "Prater Beacon Node"
+=== "Holesky Beacon Node"
     ```sh
-    ./run-prater-beacon-node.sh --payload-builder=true --payload-builder-url=https://${HOST}:${PORT}/
+    ./run-holesky-beacon-node.sh --payload-builder=true --payload-builder-url=https://${HOST}:${PORT}/
     ```
 
 === "Validator Client"

--- a/docs/the_nimbus_book/src/faq.md
+++ b/docs/the_nimbus_book/src/faq.md
@@ -62,7 +62,7 @@ While we strongly recommend against it, you can disable doppelganger detection w
 
 ### What is the best way to stress test my execution+consensus setup before committing with real ETH?
 
-We recommend running [a Nimbus beacon node](./quick-start.md) on [Prater](./prater.md) and a mainnet [execution client](./eth1.md) on the same machine.
+We recommend running [a Nimbus beacon node](./quick-start.md) on [Holesky](./holesky.md) and a mainnet [execution client](./eth1.md) on the same machine.
 This will simulate the load of running a mainnet validator.
 
 To stress test it, add `--subscribe-all-subnets` to the [beacon node options](./options.md).
@@ -184,7 +184,7 @@ In other words, if you stood to earn ≈0.01 ETH, you would instead be penalized
 
 ### How can I keep track of my validator?
 
-One way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Prater](https://prater.beaconcha.in).
+One way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Holesky](https://holesky.beaconcha.in).
 
 Another way is to set up [validator monitoring](./validator-monitor.md) together with a [dashboard](./metrics-pretty-pictures.md) to keep track of its performance.
 

--- a/docs/the_nimbus_book/src/graffiti.md
+++ b/docs/the_nimbus_book/src/graffiti.md
@@ -12,8 +12,8 @@ The graffiti can be either a string or, if you want to specify raw bytes, you ca
     ./run-mainnet-beacon-node.sh --graffiti="<YOUR_WORDS>"
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    ./run-prater-beacon-node.sh --graffiti="<YOUR_WORDS>"
+    ./run-holesky-beacon-node.sh --graffiti="<YOUR_WORDS>"
     ```
 

--- a/docs/the_nimbus_book/src/history.md
+++ b/docs/the_nimbus_book/src/history.md
@@ -39,7 +39,7 @@ In order to recreate deep history in a pruned node, download the [era archive of
     ./run-mainnet-beacon-node.sh --history=prune ...
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    ./run-prater-beacon-node.sh --history=prune ...
+    ./run-holesky-beacon-node.sh --history=prune ...
     ```

--- a/docs/the_nimbus_book/src/holesky.md
+++ b/docs/the_nimbus_book/src/holesky.md
@@ -23,7 +23,7 @@ If you come across any issues, please [report them here](https://github.com/stat
 3. Download the [latest release](./binaries.md) and install it by unpacking the archive.
 
 4. Choose one of Nethermind, Besu, Erigon, or Geth as an execution client.
-   Download, install, and [run it](https://notes.ethereum.org/@launchpad/goerli#Run-an-Execution-Layer-Client).
+   Download, install, and [run it](https://notes.ethereum.org/@launchpad/holesky#Run-an-Execution-Layer-Client).
 
     === "Nethermind"
 

--- a/docs/the_nimbus_book/src/keep-an-eye.md
+++ b/docs/the_nimbus_book/src/keep-an-eye.md
@@ -2,7 +2,7 @@
 
 Once your validator has been activated, you can set up [validator monitoring](./validator-monitor.md) together with a [dashboard](./metrics-pretty-pictures.md) to keep track of its performance.
 
-Another way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Prater](https://prater.beaconcha.in).
+Another way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Holesky](https://holesky.beaconcha.in).
 
 Both online services and dashboards allow setting up alerts for when the validator is offline.
 

--- a/docs/the_nimbus_book/src/keymanager-api.md
+++ b/docs/the_nimbus_book/src/keymanager-api.md
@@ -8,7 +8,7 @@ By default, we disable the Keymanager API.
 To enable it, start the beacon node with the `--keymanager` option enabled:
 
 ```
-./run-prater-beacon-node.sh --keymanager
+./run-holesky-beacon-node.sh --keymanager
 ```
 
 Once the node is running, you'll be able to access the API from [http://localhost:5052/](http://localhost:5052/).

--- a/docs/the_nimbus_book/src/log-rotate.md
+++ b/docs/the_nimbus_book/src/log-rotate.md
@@ -70,7 +70,7 @@ The final step is to redirect logs to `rotatelogs` using a pipe when starting Ni
 
 ```bash
 build/nimbus_beacon_node \
-  --network:prater \
+  --network:holesky \
   --web3-url="$WEB3URL" \
   --data-dir:$DATADIR 2>&1 | rotatelogs -L "$DATADIR/nbc_bn.log" -p "/path/to/rotatelogs-compress.sh" -D -f -c "$DATADIR/log/nbc_bn_%Y%m%d%H%M%S.log" 3600
 ```

--- a/docs/the_nimbus_book/src/metrics-pretty-pictures.md
+++ b/docs/the_nimbus_book/src/metrics-pretty-pictures.md
@@ -14,7 +14,7 @@ You can learn more about Grafana [here](https://github.com/grafana/grafana).
 To enable the metrics server, run the beacon node  with the `--metrics` flag:
 
 ```
-./run-prater-beacon-node.sh --metrics
+./run-holesky-beacon-node.sh --metrics
 ```
 
 Visit [http://127.0.0.1:8008/metrics](http://127.0.0.1:8008/metrics) with a browser or `curl`.

--- a/docs/the_nimbus_book/src/more-keys.md
+++ b/docs/the_nimbus_book/src/more-keys.md
@@ -37,12 +37,12 @@ Run the following command from the directory which contains the `deposit` execut
     --chain mainnet
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
     ./deposit existing-mnemonic \
     --validator_start_index 0 \
     --num_validators 1 \
-    --chain prater
+    --chain holesky
     ```
 
 You'll be prompted to enter your mnemonic, and a new password for your keystore.
@@ -70,12 +70,12 @@ Run the following command from the directory which contains the `deposit` execut
     --chain mainnet
     ```
 
-=== "Prater"
+=== "Holesky"
     ```
     ./deposit existing-mnemonic \
     --validator_start_index 1 \
     --num_validators 1 \
-    --chain prater
+    --chain holesky
     ```
 
 You'll be prompted to enter your mnemonic and a new password for your keystore.

--- a/docs/the_nimbus_book/src/pi-guide.md
+++ b/docs/the_nimbus_book/src/pi-guide.md
@@ -353,7 +353,7 @@ Depending on your installation method, run these commands to import your signing
 
     ```sh
     # Run import command as the `nimbus` user
-    sudo -u nimbus /usr/bin/nimbus_beacon_node deposits import --data-dir=/var/lib/nimbus/shared_prater_0 /path/to/keys
+    sudo -u nimbus /usr/bin/nimbus_beacon_node deposits import --data-dir=/var/lib/nimbus/shared_holesky_0 /path/to/keys
     ```
 
 === "Manual installation"
@@ -361,7 +361,7 @@ Depending on your installation method, run these commands to import your signing
     To import your signing key into Nimbus, from the `nimbus-eth2` directory run.
 
     ```sh
-    build/nimbus_beacon_node deposits import --data-dir=build/data/shared_prater_0 ../validator_keys
+    build/nimbus_beacon_node deposits import --data-dir=build/data/shared_holesky_0 ../validator_keys
     ```
 
  You'll be asked to enter the password you created to encrypt your keystore(s).
@@ -369,26 +369,26 @@ Depending on your installation method, run these commands to import your signing
  Your validator client needs both your signing keystore(s) and the password encrypting it to import your [key](https://blog.ethereum.org/2020/05/21/keys/) (since it needs to decrypt the keystore in order to be able to use it to sign on your behalf).
 
 
-### 15. Connect to Prater
+### 15. Connect to Holesky
 
-We're finally ready to connect to the Prater testnet!
+We're finally ready to connect to the Holesky testnet!
 
 !!! note
     If you haven't already, we recommend registering for, and running, your own eth1 node in parallel.
     For instructions on how to do so, see the [eth1 page](./eth1.md).
 
-To connect to Prater, run:
+To connect to Holesky, run:
 
 === "Using package manager"
 
     ```sh
-    sudo -u nimbus /usr/bin/nimbus_beacon_node --network=prater --data-dir=/var/lib/nimbus/shared_prater_0
+    sudo -u nimbus /usr/bin/nimbus_beacon_node --network=holesky --data-dir=/var/lib/nimbus/shared_holesky_0
     ```
 
 === "Manual installation"
 
     ```sh
-    ./run-prater-beacon-node.sh
+    ./run-holesky-beacon-node.sh
     ```
 
 
@@ -397,19 +397,19 @@ To connect to Prater, run:
 If you look near the top of the logs printed to your console, you should see confirmation that your beacon node has started, with your local validator attached:
 
 ```
-INF 2020-12-01 11:25:33.487+01:00 Launching beacon node
+INF 2023-10-01 11:25:33.487+01:00 Launching beacon node
 ...
-INF 2020-12-01 11:25:34.556+01:00 Loading block dag from database            topics="beacnde" tid=19985314 file=nimbus_beacon_node.nim:198 path=build/data/shared_prater_0/db
-INF 2020-12-01 11:25:35.921+01:00 Block dag initialized
-INF 2020-12-01 11:25:37.073+01:00 Generating new networking key
+INF 2023-10-01 11:25:34.556+01:00 Loading block dag from database            topics="beacnde" tid=19985314 file=nimbus_beacon_node.nim:198 path=build/data/shared_holesky_0/db
+INF 2023-10-01 11:25:35.921+01:00 Block dag initialized
+INF 2023-10-01 11:25:37.073+01:00 Generating new networking key
 ...
-NOT 2020-12-01 11:25:45.267+00:00 Local validator attached                   tid=22009 file=validator_pool.nim:33 pubkey=95e3cbe88c71ab2d0e3053b7b12ead329a37e9fb8358bdb4e56251993ab68e46b9f9fa61035fe4cf2abf4c07dfad6c45 validator=95e3cbe8
+NOT 2023-10-01 11:25:45.267+00:00 Local validator attached                   tid=22009 file=validator_pool.nim:33 pubkey=95e3cbe88c71ab2d0e3053b7b12ead329a37e9fb8358bdb4e56251993ab68e46b9f9fa61035fe4cf2abf4c07dfad6c45 validator=95e3cbe8
 ...
-NOT 2020-12-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
-NOT 2020-12-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
+NOT 2023-10-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
+NOT 2023-10-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
 ...
-INF 2020-12-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
-INF 2020-12-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014
+INF 2023-10-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
+INF 2023-10-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014
 ```
 
 To keep track of your syncing progress, have a look at the output at the very bottom of the terminal window in which your validator is running.
@@ -422,7 +422,7 @@ peers: 15 ❯ finalized: ada7228a:8765 ❯ head: b2fe11cd:8767:2 ❯ time: 9900:
 Keep an eye on the number of peers you're currently connected to (in the above case that's `15`), as well as your [sync progress](./keep-an-eye.md#syncing-progress).
 
 !!! note
-    15 - 20 peers and an average sync speed of **0.5 - 1.0** blocks per second is normal on `Prater` with a Pi.
+    15 - 20 peers and an average sync speed of **0.5 - 1.0** blocks per second is normal on `Holesky` with a Pi.
     If your sync speed is much slower than this, the root of the problem may be your USB3.0 to SSD adapter.
     See [this post](https://www.raspberrypi.org/forums/viewtopic.php?f=28&t=245931) for a recommended workaround.
 
@@ -432,8 +432,8 @@ Keep an eye on the number of peers you're currently connected to (in the above c
 Whether or not your Pi is up to the task will depend on a number of factors such as SSD speed, network connectivity, etc.
 As such, it's best to verify performance on a testnet first.
 
-The best thing you can do is to set your Pi to run Prater.
-If you have no trouble syncing and attesting on Prater, your setup should good enough for mainnet as well.
+The best thing you can do is to set your Pi to run Holesky.
+If you have no trouble syncing and attesting on Holesky, your setup should good enough for mainnet as well.
 
 <blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">We&#39;ve been running lots of PIs and NanoPCs 24/7 for 3 years and never got a hardware fail. It is easy (and cheap) to get redundancy of components (even spare PIs in different locations, more of this to come).</p>&mdash; Ethereum on ARM (@EthereumOnARM) <a href="https://twitter.com/EthereumOnARM/status/1332772217420177408?ref_src=twsrc%5Etfw">November 28, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 

--- a/docs/the_nimbus_book/src/quick-start.md
+++ b/docs/the_nimbus_book/src/quick-start.md
@@ -12,8 +12,8 @@ Running a beacon node is a [worthwhile endeavor](https://vitalik.ca/general/2021
 The guide assumes [Ubuntu Linux](https://ubuntu.com/download/server) is being used, and therefore some familiarity with [the Linux command line](https://ubuntu.com/tutorials/command-line-for-beginners) is needed.
 
 !!! tip
-    You can practice running the node safely on the [Prater testnet](./prater.md).
-    Throughout, we'll provide instructions for both Prater and Mainnet.
+    You can practice running the node safely on the [Holesky testnet](./holesky.md).
+    Throughout, we'll provide instructions for both Holesky and Mainnet.
 
 
 ## Steps
@@ -70,11 +70,11 @@ cd nimbus-eth2
     ./run-mainnet-beacon-node.sh --web3-url=http://127.0.0.1:8551 --jwt-secret=/tmp/jwtsecret
     ```
 
-=== "Prater"
+=== "Holesky"
 
     ```sh
-    # Start a prater testnet node
-    ./run-prater-beacon-node.sh --web3-url=http://127.0.0.1:8551 --jwt-secret=/tmp/jwtsecret
+    # Start a holesky testnet node
+    ./run-holesky-beacon-node.sh --web3-url=http://127.0.0.1:8551 --jwt-secret=/tmp/jwtsecret
     ```
 
 Once the beacon node starts, you'll see it logging information to the console, like so:

--- a/docs/the_nimbus_book/src/rest-api.md
+++ b/docs/the_nimbus_book/src/rest-api.md
@@ -15,7 +15,7 @@ If you wish to expose the beacon node to the public internet, it is recommended 
 
 * `http://testing.mainnet.beacon-api.nimbus.team/`
 * `http://unstable.mainnet.beacon-api.nimbus.team/`
-* `http://unstable.prater.beacon-api.nimbus.team/`
+* `http://unstable.holesky.beacon-api.nimbus.team/`
 
 You can make requests as follows (here we are requesting the version the Nimbus software version of the node in question):
 
@@ -29,9 +29,9 @@ You can make requests as follows (here we are requesting the version the Nimbus 
     curl -X GET http://unstable.mainnet.beacon-api.nimbus.team/eth/v1/node/version
     ```
 
-=== "Prater unstable branch"
+=== "Holesky unstable branch"
     ```
-    curl -X GET  http://unstable.prater.beacon-api.nimbus.team/eth/v1/node/version
+    curl -X GET  http://unstable.holesky.beacon-api.nimbus.team/eth/v1/node/version
     ```
 
 The test endpoints are part of pre-release testing and run an unstable version of Nimbus.

--- a/docs/the_nimbus_book/src/run-a-validator.md
+++ b/docs/the_nimbus_book/src/run-a-validator.md
@@ -29,10 +29,10 @@ To make a deposit, you will need to generate keys then submit a deposit transact
     The process of setting up a validator is also documented at the Ethereum launchpad site:
 
     * [Mainnet](https://launchpad.ethereum.org/)
-    * [Goerli/Prater EthStaker Launchpad](https://goerli.launchpad.ethstaker.cc/en/) or [Goerli/Prater EF Launchpad](https://prater.launchpad.ethereum.org/)
+    * [Holesky EthStaker Launchpad](https://holesky.launchpad.ethstaker.cc/en/) or [Holesky EF Launchpad](https://holesky.launchpad.ethereum.org/)
 
 !!! tip
-    Before running your validator on Mainnet, you can (and should) verify that your setup works as expected by running it on the [Prater testnet](./prater.md).
+    Before running your validator on Mainnet, you can (and should) verify that your setup works as expected by running it on the [Holesky testnet](./holesky.md).
 
 
 ### 1. Download the deposit tool
@@ -67,10 +67,10 @@ The deposit tool generates a seed phrase, and uses this to create validator and 
     ./deposit new-mnemonic --chain mainnet
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
     # Run the deposit tool and follow the instructions on screen
-    ./deposit new-mnemonic --chain prater
+    ./deposit new-mnemonic --chain holesky
     ```
 
 ### 3. Make the deposit
@@ -116,9 +116,9 @@ We'll import the signing key of each validator to the [data directory](./data-di
     build/nimbus_beacon_node deposits import --data-dir=build/data/shared_mainnet_0
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    build/nimbus_beacon_node deposits import --data-dir=build/data/shared_prater_0
+    build/nimbus_beacon_node deposits import --data-dir=build/data/shared_holesky_0
     ```
 
 On success, a message will be printed that your keys have been imported:
@@ -146,10 +146,10 @@ If your `validator_keys` folder is stored elsewhere, you can pass its location t
       /path/to/keys
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
     build/nimbus_beacon_node deposits import \
-      --data-dir=build/data/shared_prater_0 \
+      --data-dir=build/data/shared_holesky_0 \
       /path/to/keys
     ```
 
@@ -197,9 +197,9 @@ Press `Ctrl-c` to stop the beacon node if it's running, then use the same comman
     ./run-mainnet-beacon-node.sh --web3-url=http://127.0.0.1:8551 --suggested-fee-recipient=0x...
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    ./run-prater-beacon-node.sh --web3-url=http://127.0.0.1:8551 --suggested-fee-recipient=0x...
+    ./run-holesky-beacon-node.sh --web3-url=http://127.0.0.1:8551 --suggested-fee-recipient=0x...
     ```
 
 ### 3. Check the logs

--- a/docs/the_nimbus_book/src/start-syncing.md
+++ b/docs/the_nimbus_book/src/start-syncing.md
@@ -24,10 +24,10 @@ Later, when everything is working, you can easily switch to mainnet.
 
 === "Testnet"
 
-    To start syncing the `prater` testnet from the `nimbus-eth2` repository, run:
+    To start syncing the `holesky` testnet from the `nimbus-eth2` repository, run:
 
     ```
-     ./run-prater-beacon-node.sh
+     ./run-holesky-beacon-node.sh
     ```
 
 === "Mainnet"
@@ -43,17 +43,17 @@ Later, when everything is working, you can easily switch to mainnet.
 You should see the following output:
 
 ```
-INF 2020-12-01 11:25:33.487+01:00 Launching beacon node
+INF 2023-10-01 11:25:33.487+01:00 Launching beacon node
 ...
-INF 2020-12-01 11:25:34.556+01:00 Loading block dag from database            topics="beacnde" tid=19985314 path=build/data/shared_prater_0/db
-INF 2020-12-01 11:25:35.921+01:00 Block dag initialized
-INF 2020-12-01 11:25:37.073+01:00 Generating new networking key
+INF 2023-10-01 11:25:34.556+01:00 Loading block dag from database            topics="beacnde" tid=19985314 path=build/data/shared_holesky_0/db
+INF 2023-10-01 11:25:35.921+01:00 Block dag initialized
+INF 2023-10-01 11:25:37.073+01:00 Generating new networking key
 ...
-NOT 2020-12-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
-NOT 2020-12-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
+NOT 2023-10-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
+NOT 2023-10-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
 ...
-INF 2020-12-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
-INF 2020-12-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014
+INF 2023-10-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
+INF 2023-10-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014
 ...
 ```
 
@@ -68,7 +68,7 @@ You can add command line options to the startup command.
 For example, to change the port to 9100, use:
 
 ```sh
-./run-prater-beacon-node.sh --tcp-port=9100 --udp-port=9100
+./run-holesky-beacon-node.sh --tcp-port=9100 --udp-port=9100
 ```
 
 To see a list of the command line options available to you, with descriptions, run:

--- a/docs/the_nimbus_book/src/suggested-fee-recipient.md
+++ b/docs/the_nimbus_book/src/suggested-fee-recipient.md
@@ -36,9 +36,9 @@ If this Nimbus node has two validators, one of which has its own suggested fee r
     ./run-mainnet-beacon-node.sh --suggested-fee-recipient=0x70E47C843E0F6ab0991A3189c28F2957eb6d3842
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
-    ./run-prater-beacon-node.sh --suggested-fee-recipient=0x70E47C843E0F6ab0991A3189c28F2957eb6d3842
+    ./run-holesky-beacon-node.sh --suggested-fee-recipient=0x70E47C843E0F6ab0991A3189c28F2957eb6d3842
     ```
 
 === "Validator Client"

--- a/docs/the_nimbus_book/src/troubleshooting.md
+++ b/docs/the_nimbus_book/src/troubleshooting.md
@@ -2,7 +2,7 @@
 
 !!! note
     The commands on this page refer to mainnet.
-    If you're running on `prater` or another testnet, replace `mainnet` accordingly.
+    If you're running on `holesky` or another testnet, replace `mainnet` accordingly.
 
 We are continuously making improvements to both stability and resource usage.
 If you run into any problem with Nimbus and are not running the latest version, chances are they have already been fixed.

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -35,11 +35,11 @@ To start trusted node sync, run:
       --trusted-node-url=http://localhost:5052
     ```
 
-=== "Prater"
+=== "Holesky"
     ```sh
     build/nimbus_beacon_node trustedNodeSync \
-      --network:prater \
-      --data-dir=build/data/shared_prater_0 \
+      --network:holesky \
+      --data-dir=build/data/shared_holesky_0 \
       --trusted-node-url=http://localhost:5052
     ```
 

--- a/docs/the_nimbus_book/src/validator-client.md
+++ b/docs/the_nimbus_book/src/validator-client.md
@@ -21,7 +21,7 @@ Next, choose a data directory for the validator client and import the keys there
 
 ```sh
 build/nimbus_beacon_node deposits import \
-  --data-dir:build/data/vc_shared_prater_0 "<YOUR VALIDATOR KEYS DIRECTORY>"
+  --data-dir:build/data/vc_shared_holesky_0 "<YOUR VALIDATOR KEYS DIRECTORY>"
 ```
 
 !!! warning
@@ -35,7 +35,7 @@ With the keys imported, you are ready to start validator client:
 
 ```sh
 build/nimbus_validator_client \
-  --data-dir:build/data/vc_shared_prater_0
+  --data-dir:build/data/vc_shared_holesky_0
 ```
 
 # Options

--- a/run-holesky-beacon-node.sh
+++ b/run-holesky-beacon-node.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2020-2023 Status Research & Development GmbH. Licensed under
+# either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+cd "$(dirname $0)"
+# Allow the binary to receive signals directly.
+exec scripts/run-beacon-node.sh nimbus_beacon_node holesky "$@"
+


### PR DESCRIPTION
This replaces mentions of Prater/Goerli with Holesky.

It also introduces `run-holesky-beacon-node.sh` (based on the existing `run-prater-beacon-node.sh`), which is referenced throughout the guide.

Some links currently don't work (which is expected), but I'll re-check them after Thursday.