### PR TITLE
convert remaining `toFork` -> `kind` for consistency

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -779,7 +779,7 @@ proc putBlock*(
     db: BeaconChainDB,
     value: phase0.TrustedSignedBeaconBlock | altair.TrustedSignedBeaconBlock) =
   db.withManyWrites:
-    db.blocks[type(value).toFork].putSnappySSZ(value.root.data, value)
+    db.blocks[type(value).kind].putSnappySSZ(value.root.data, value)
     db.putBeaconBlockSummary(value.root, value.message.toBeaconBlockSummary())
 
 proc putBlock*(
@@ -787,7 +787,7 @@ proc putBlock*(
     value: bellatrix.TrustedSignedBeaconBlock |
            capella.TrustedSignedBeaconBlock | deneb.TrustedSignedBeaconBlock) =
   db.withManyWrites:
-    db.blocks[type(value).toFork].putSZSSZ(value.root.data, value)
+    db.blocks[type(value).kind].putSZSSZ(value.root.data, value)
     db.putBeaconBlockSummary(value.root, value.message.toBeaconBlockSummary())
 
 proc putBlobSidecar*(
@@ -838,14 +838,14 @@ proc putState*(
     db: BeaconChainDB, key: Eth2Digest,
     value: phase0.BeaconState | altair.BeaconState) =
   db.updateImmutableValidators(value.validators.asSeq())
-  db.statesNoVal[type(value).toFork()].putSnappySSZ(
+  db.statesNoVal[type(value).kind].putSnappySSZ(
     key.data, toBeaconStateNoImmutableValidators(value))
 
 proc putState*(
     db: BeaconChainDB, key: Eth2Digest,
     value: bellatrix.BeaconState | capella.BeaconState | deneb.BeaconState) =
   db.updateImmutableValidators(value.validators.asSeq())
-  db.statesNoVal[type(value).toFork()].putSZSSZ(
+  db.statesNoVal[type(value).kind].putSZSSZ(
     key.data, toBeaconStateNoImmutableValidators(value))
 
 proc putState*(db: BeaconChainDB, state: ForkyHashedBeaconState) =
@@ -951,7 +951,7 @@ proc getBlock*(
     T: type phase0.TrustedSignedBeaconBlock): Opt[T] =
   # We only store blocks that we trust in the database
   result.ok(default(T))
-  if db.blocks[T.toFork].getSnappySSZ(key.data, result.get) != GetResult.found:
+  if db.blocks[T.kind].getSnappySSZ(key.data, result.get) != GetResult.found:
     # During the initial releases phase0, we stored blocks in a different table
     result = db.v0.getPhase0Block(key)
   else:
@@ -963,7 +963,7 @@ proc getBlock*(
     T: type altair.TrustedSignedBeaconBlock): Opt[T] =
   # We only store blocks that we trust in the database
   result.ok(default(T))
-  if db.blocks[T.toFork].getSnappySSZ(key.data, result.get) == GetResult.found:
+  if db.blocks[T.kind].getSnappySSZ(key.data, result.get) == GetResult.found:
     # set root after deserializing (so it doesn't get zeroed)
     result.get().root = key
   else:
@@ -976,7 +976,7 @@ proc getBlock*[
     T: type X): Opt[T] =
   # We only store blocks that we trust in the database
   result.ok(default(T))
-  if db.blocks[T.toFork].getSZSSZ(key.data, result.get) == GetResult.found:
+  if db.blocks[T.kind].getSZSSZ(key.data, result.get) == GetResult.found:
     # set root after deserializing (so it doesn't get zeroed)
     result.get().root = key
   else:
@@ -1022,7 +1022,7 @@ proc getBlockSSZ*(
   func decode(data: openArray[byte]) =
     dataPtr[] = snappy.decode(data)
     success = dataPtr[].len > 0
-  db.blocks[T.toFork].get(key.data, decode).expectDb() and success
+  db.blocks[T.kind].get(key.data, decode).expectDb() and success
 
 proc getBlockSSZ*[
     X: bellatrix.TrustedSignedBeaconBlock | capella.TrustedSignedBeaconBlock |
@@ -1033,7 +1033,7 @@ proc getBlockSSZ*[
   func decode(data: openArray[byte]) =
     dataPtr[] = decodeFramed(data, checkIntegrity = false)
     success = dataPtr[].len > 0
-  db.blocks[T.toFork].get(key.data, decode).expectDb() and success
+  db.blocks[T.kind].get(key.data, decode).expectDb() and success
 
 proc getBlockSSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
@@ -1077,7 +1077,7 @@ proc getBlockSZ*(
   func decode(data: openArray[byte]) =
     dataPtr[] = snappy.encodeFramed(snappy.decode(data))
     success = dataPtr[].len > 0
-  db.blocks[T.toFork].get(key.data, decode).expectDb() and success
+  db.blocks[T.kind].get(key.data, decode).expectDb() and success
 
 proc getBlockSZ*[
     X: bellatrix.TrustedSignedBeaconBlock | capella.TrustedSignedBeaconBlock |
@@ -1086,7 +1086,7 @@ proc getBlockSZ*[
   let dataPtr = addr data # Short-lived
   func decode(data: openArray[byte]) =
     assign(dataPtr[], data)
-  db.blocks[T.toFork].get(key.data, decode).expectDb()
+  db.blocks[T.kind].get(key.data, decode).expectDb()
 
 proc getBlockSZ*(
     db: BeaconChainDB, key: Eth2Digest, data: var seq[byte],
@@ -1258,7 +1258,7 @@ proc getState*(
   type T = type(output)
 
   if not getStateOnlyMutableValidators(
-      db.immutableValidators, db.statesNoVal[T.toFork], key.data, output, rollback):
+      db.immutableValidators, db.statesNoVal[T.kind], key.data, output, rollback):
     db.v0.getState(db.immutableValidators, key, output, rollback)
   else:
     true
@@ -1278,7 +1278,7 @@ proc getState*(
   #      https://github.com/nim-lang/Nim/issues/14126
   type T = type(output)
   getStateOnlyMutableValidators(
-    db.immutableValidators, db.statesNoVal[T.toFork], key.data, output,
+    db.immutableValidators, db.statesNoVal[T.kind], key.data, output,
     rollback)
 
 proc getState*(
@@ -1340,14 +1340,14 @@ proc containsBlock*(db: BeaconChainDBV0, key: Eth2Digest): bool =
 proc containsBlock*(
     db: BeaconChainDB, key: Eth2Digest,
     T: type phase0.TrustedSignedBeaconBlock): bool =
-  db.blocks[T.toFork].contains(key.data).expectDb() or
+  db.blocks[T.kind].contains(key.data).expectDb() or
     db.v0.containsBlock(key)
 
 proc containsBlock*[
     X: altair.TrustedSignedBeaconBlock | bellatrix.TrustedSignedBeaconBlock |
        capella.TrustedSignedBeaconBlock | deneb.TrustedSignedBeaconBlock](
     db: BeaconChainDB, key: Eth2Digest, T: type X): bool =
-  db.blocks[X.toFork].contains(key.data).expectDb()
+  db.blocks[X.kind].contains(key.data).expectDb()
 
 proc containsBlock*(db: BeaconChainDB, key: Eth2Digest, fork: ConsensusFork): bool =
   case fork

--- a/beacon_chain/consensus_object_pools/exit_pool.nim
+++ b/beacon_chain/consensus_object_pools/exit_pool.nim
@@ -241,7 +241,7 @@ proc getBeaconBlockValidatorChanges*(
     pool.proposer_slashings, cfg, state, indices, res.proposer_slashings)
   getValidatorChangeMessagesForBlock(
     pool.voluntary_exits, cfg, state, indices, res.voluntary_exits)
-  when typeof(state).toFork() >= ConsensusFork.Capella:
+  when typeof(state).kind >= ConsensusFork.Capella:
     # Prioritize these
     getValidatorChangeMessagesForBlock(
       pool.bls_to_execution_changes_api, cfg, state, indices,

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -899,13 +899,13 @@ template payload(response: engine_api.GetPayloadV3Response): engine_api.Executio
 template toEngineWithdrawals*(withdrawals: seq[capella.Withdrawal]): seq[WithdrawalV1] =
   mapIt(withdrawals, toEngineWithdrawal(it))
 
-template toFork(T: type ExecutionPayloadV1): ConsensusFork =
+template kind(T: type ExecutionPayloadV1): ConsensusFork =
   ConsensusFork.Bellatrix
 
-template toFork(T: typedesc[ExecutionPayloadV1OrV2|ExecutionPayloadV2]): ConsensusFork =
+template kind(T: typedesc[ExecutionPayloadV1OrV2|ExecutionPayloadV2]): ConsensusFork =
   ConsensusFork.Capella
 
-template toFork(T: type ExecutionPayloadV3): ConsensusFork =
+template kind(T: type ExecutionPayloadV3): ConsensusFork =
   ConsensusFork.Deneb
 
 proc getPayload*(m: ELManager,
@@ -950,7 +950,7 @@ proc getPayload*(m: ELManager,
              url = m.elConnections[idx].engineUrl.url,
              err = req.error.msg
     else:
-      const payloadFork = PayloadType.toFork
+      const payloadFork = PayloadType.kind
       when payloadFork >= ConsensusFork.Capella:
         when payloadFork == ConsensusFork.Capella:
           # TODO: The engine_api module may offer an alternative API where it is guaranteed

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -183,7 +183,7 @@ proc storeBackfillBlock(
   # Establish blob viability before calling addbackfillBlock to avoid
   # writing the block in case of blob error.
   var blobsOk = true
-  when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
+  when typeof(signedBlock).kind >= ConsensusFork.Deneb:
     if blobsOpt.isSome:
       let blobs = blobsOpt.get()
       let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
@@ -245,7 +245,7 @@ proc expectValidForkchoiceUpdated(
       finalizedBlockHash = finalizedBlockHash,
       payloadAttributes = none headBlockPayloadAttributesType)
     receivedExecutionBlockHash =
-      when typeof(receivedBlock).toFork >= ConsensusFork.Bellatrix:
+      when typeof(receivedBlock).kind >= ConsensusFork.Bellatrix:
         receivedBlock.message.body.execution_payload.block_hash
       else:
         # https://github.com/nim-lang/Nim/issues/19802
@@ -487,7 +487,7 @@ proc storeBlock(
         # progress in its own sync.
         NewPayloadStatus.noResponse
       else:
-        when typeof(signedBlock).toFork() >= ConsensusFork.Bellatrix:
+        when typeof(signedBlock).kind >= ConsensusFork.Bellatrix:
           await self.consensusManager.elManager.getExecutionValidity(signedBlock)
         else:
           NewPayloadStatus.valid # vacuously
@@ -508,7 +508,7 @@ proc storeBlock(
     # Client software MUST validate `blockHash` value as being equivalent to
     # `Keccak256(RLP(ExecutionBlockHeader))`
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#specification
-    when typeof(signedBlock).toFork() >= ConsensusFork.Bellatrix:
+    when typeof(signedBlock).kind >= ConsensusFork.Bellatrix:
       template payload(): auto = signedBlock.message.body.execution_payload
       if  signedBlock.message.is_execution_block and
           payload.block_hash !=
@@ -527,7 +527,7 @@ proc storeBlock(
   # TODO with v1.4.0, not sure this is still relevant
   # Establish blob viability before calling addHeadBlock to avoid
   # writing the block in case of blob error.
-  when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
+  when typeof(signedBlock).kind >= ConsensusFork.Deneb:
     if blobsOpt.isSome:
       let blobs = blobsOpt.get()
       let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
@@ -732,7 +732,7 @@ proc storeBlock(
       quarantined = shortLog(quarantined.root)
 
     withBlck(quarantined):
-      when typeof(forkyBlck).toFork() < ConsensusFork.Deneb:
+      when typeof(forkyBlck).kind < ConsensusFork.Deneb:
         self[].enqueueBlock(
           MsgSource.gossip, quarantined, Opt.none(BlobSidecars))
       else:

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -240,7 +240,7 @@ proc processSignedBeaconBlock*(
     trace "Block validated"
 
     let blobs =
-      when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
+      when typeof(signedBlock).kind >= ConsensusFork.Deneb:
         if self.blobQuarantine[].hasBlobs(signedBlock):
           Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root))
         else:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -344,7 +344,7 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] =
       withBlck(signedBlock):
-        when typeof(forkyBlck).toFork() >= ConsensusFork.Deneb:
+        when typeof(forkyBlck).kind >= ConsensusFork.Deneb:
           if not blobQuarantine[].hasBlobs(forkyBlck):
             # We don't have all the blobs for this block, so we have
             # to put it in blobless quarantine.
@@ -1190,7 +1190,7 @@ proc pruneBlobs(node: BeaconNode, slot: Slot) =
     for i in startIndex..<SLOTS_PER_EPOCH:
       let blck = node.dag.getForkedBlock(blocks[int(i)]).valueOr: continue
       withBlck(blck):
-        when typeof(forkyBlck).toFork() < ConsensusFork.Deneb: continue
+        when typeof(forkyBlck).kind < ConsensusFork.Deneb: continue
         else:
           for j in 0..len(forkyBlck.message.body.blob_kzg_commitments) - 1:
             if node.db.delBlobSidecar(blocks[int(i)].root, BlobIndex(j)):

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -636,7 +636,7 @@ proc check_attestation*(
       data,
       get_committee_count_per_slot(state, epoch, cache))
 
-  ? check_attestation_inclusion((typeof state).toFork, slot, state.slot)
+  ? check_attestation_inclusion((typeof state).kind, slot, state.slot)
 
   let committee_len = get_beacon_committee_len(
     state, slot, committee_index, cache)
@@ -1005,7 +1005,7 @@ proc initialize_beacon_state_from_eth1*(
   # at that point :)
   doAssert deposits.lenu64 >= SLOTS_PER_EPOCH
 
-  const consensusFork = typeof(execution_payload_header).toFork
+  const consensusFork = typeof(execution_payload_header).kind
   let
     forkVersion = cfg.forkVersion(consensusFork)
     fork = Fork(

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -178,7 +178,7 @@ proc publishSszBlock*(
      ): Future[RestPlainResponse] {.async.} =
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlock
   let
-    consensus = typeof(blck).toFork.toString()
+    consensus = typeof(blck).kind.toString()
     resp = await client.publishBlock(
       blck, restContentType = $OctetStreamMediaType,
       extraHeaders = @[("eth-consensus-version", consensus)])
@@ -216,7 +216,7 @@ proc publishBlockV2*(
        deneb.SignedBeaconBlock
      ): Future[RestPlainResponse] {.async} =
   let
-    consensus = typeof(blck).toFork.toString()
+    consensus = typeof(blck).kind.toString()
     resp = await client.publishBlockV2Plain(
       blck, extraHeaders = @[
         ("eth-consensus-version", consensus),
@@ -251,7 +251,7 @@ proc publishSszBlindedBlock*(
      ): Future[RestPlainResponse] {.async.} =
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
   let
-    consensus = typeof(blck).toFork.toString()
+    consensus = typeof(blck).kind.toString()
     resp = await client.publishBlindedBlock(
       blck, restContentType = $OctetStreamMediaType,
       extraHeaders = @[("eth-consensus-version", consensus)])

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -256,27 +256,86 @@ type
 
 template kind*(
     x: typedesc[
-      phase0.HashedBeaconState]): ConsensusFork =
+      phase0.BeaconState |
+      phase0.HashedBeaconState |
+      phase0.BeaconBlock |
+      phase0.SignedBeaconBlock |
+      phase0.TrustedBeaconBlock |
+      phase0.BeaconBlockBody |
+      phase0.SigVerifiedBeaconBlockBody |
+      phase0.TrustedBeaconBlockBody |
+      phase0.SigVerifiedSignedBeaconBlock |
+      phase0.MsgTrustedSignedBeaconBlock |
+      phase0.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Phase0
 
 template kind*(
     x: typedesc[
-      altair.HashedBeaconState]): ConsensusFork =
+      altair.BeaconState |
+      altair.HashedBeaconState |
+      altair.BeaconBlock |
+      altair.SignedBeaconBlock |
+      altair.TrustedBeaconBlock |
+      altair.BeaconBlockBody |
+      altair.SigVerifiedBeaconBlockBody |
+      altair.TrustedBeaconBlockBody |
+      altair.SigVerifiedSignedBeaconBlock |
+      altair.MsgTrustedSignedBeaconBlock |
+      altair.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Altair
 
 template kind*(
     x: typedesc[
-      bellatrix.HashedBeaconState]): ConsensusFork =
+      bellatrix.BeaconState |
+      bellatrix.HashedBeaconState |
+      bellatrix.ExecutionPayload |
+      bellatrix.ExecutionPayloadForSigning |
+      bellatrix.ExecutionPayloadHeader |
+      bellatrix.BeaconBlock |
+      bellatrix.SignedBeaconBlock |
+      bellatrix.TrustedBeaconBlock |
+      bellatrix.BeaconBlockBody |
+      bellatrix.SigVerifiedBeaconBlockBody |
+      bellatrix.TrustedBeaconBlockBody |
+      bellatrix.SigVerifiedSignedBeaconBlock |
+      bellatrix.MsgTrustedSignedBeaconBlock |
+      bellatrix.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Bellatrix
 
 template kind*(
     x: typedesc[
-      capella.HashedBeaconState]): ConsensusFork =
+      capella.BeaconState |
+      capella.HashedBeaconState |
+      capella.ExecutionPayload |
+      capella.ExecutionPayloadForSigning |
+      capella.ExecutionPayloadHeader |
+      capella.BeaconBlock |
+      capella.SignedBeaconBlock |
+      capella.TrustedBeaconBlock |
+      capella.BeaconBlockBody |
+      capella.SigVerifiedBeaconBlockBody |
+      capella.TrustedBeaconBlockBody |
+      capella.SigVerifiedSignedBeaconBlock |
+      capella.MsgTrustedSignedBeaconBlock |
+      capella.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Capella
 
 template kind*(
     x: typedesc[
-      deneb.HashedBeaconState]): ConsensusFork =
+      deneb.BeaconState |
+      deneb.HashedBeaconState |
+      deneb.ExecutionPayload |
+      deneb.ExecutionPayloadForSigning |
+      deneb.ExecutionPayloadHeader |
+      deneb.BeaconBlock |
+      deneb.SignedBeaconBlock |
+      deneb.TrustedBeaconBlock |
+      deneb.BeaconBlockBody |
+      deneb.SigVerifiedBeaconBlockBody |
+      deneb.TrustedBeaconBlockBody |
+      deneb.SigVerifiedSignedBeaconBlock |
+      deneb.MsgTrustedSignedBeaconBlock |
+      deneb.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Deneb
 
 macro getSymbolFromForkModule(fork: static ConsensusFork,
@@ -484,90 +543,6 @@ template toString*(kind: ConsensusFork): string =
     "capella"
   of ConsensusFork.Deneb:
     "deneb"
-
-template toFork*[T:
-    phase0.BeaconState |
-    phase0.HashedBeaconState |
-    phase0.BeaconBlock |
-    phase0.SignedBeaconBlock |
-    phase0.TrustedBeaconBlock |
-    phase0.BeaconBlockBody |
-    phase0.SigVerifiedBeaconBlockBody |
-    phase0.TrustedBeaconBlockBody |
-    phase0.SigVerifiedSignedBeaconBlock |
-    phase0.MsgTrustedSignedBeaconBlock |
-    phase0.TrustedSignedBeaconBlock](
-    t: type T): ConsensusFork =
-  ConsensusFork.Phase0
-
-template toFork*[T:
-    altair.BeaconState |
-    altair.HashedBeaconState |
-    altair.BeaconBlock |
-    altair.SignedBeaconBlock |
-    altair.TrustedBeaconBlock |
-    altair.BeaconBlockBody |
-    altair.SigVerifiedBeaconBlockBody |
-    altair.TrustedBeaconBlockBody |
-    altair.SigVerifiedSignedBeaconBlock |
-    altair.MsgTrustedSignedBeaconBlock |
-    altair.TrustedSignedBeaconBlock](
-    t: type T): ConsensusFork =
-  ConsensusFork.Altair
-
-template toFork*[T:
-    bellatrix.BeaconState |
-    bellatrix.HashedBeaconState |
-    bellatrix.ExecutionPayload |
-    bellatrix.ExecutionPayloadForSigning |
-    bellatrix.ExecutionPayloadHeader |
-    bellatrix.BeaconBlock |
-    bellatrix.SignedBeaconBlock |
-    bellatrix.TrustedBeaconBlock |
-    bellatrix.BeaconBlockBody |
-    bellatrix.SigVerifiedBeaconBlockBody |
-    bellatrix.TrustedBeaconBlockBody |
-    bellatrix.SigVerifiedSignedBeaconBlock |
-    bellatrix.MsgTrustedSignedBeaconBlock |
-    bellatrix.TrustedSignedBeaconBlock](
-    t: type T): ConsensusFork =
-  ConsensusFork.Bellatrix
-
-template toFork*[T:
-    capella.BeaconState |
-    capella.HashedBeaconState |
-    capella.ExecutionPayload |
-    capella.ExecutionPayloadForSigning |
-    capella.ExecutionPayloadHeader |
-    capella.BeaconBlock |
-    capella.SignedBeaconBlock |
-    capella.TrustedBeaconBlock |
-    capella.BeaconBlockBody |
-    capella.SigVerifiedBeaconBlockBody |
-    capella.TrustedBeaconBlockBody |
-    capella.SigVerifiedSignedBeaconBlock |
-    capella.MsgTrustedSignedBeaconBlock |
-    capella.TrustedSignedBeaconBlock](
-    t: type T): ConsensusFork =
-  ConsensusFork.Capella
-
-template toFork*[T:
-    deneb.BeaconState |
-    deneb.HashedBeaconState |
-    deneb.ExecutionPayload |
-    deneb.ExecutionPayloadForSigning |
-    deneb.ExecutionPayloadHeader |
-    deneb.BeaconBlock |
-    deneb.SignedBeaconBlock |
-    deneb.TrustedBeaconBlock |
-    deneb.BeaconBlockBody |
-    deneb.SigVerifiedBeaconBlockBody |
-    deneb.TrustedBeaconBlockBody |
-    deneb.SigVerifiedSignedBeaconBlock |
-    deneb.MsgTrustedSignedBeaconBlock |
-    deneb.TrustedSignedBeaconBlock](
-    t: type T): ConsensusFork =
-  ConsensusFork.Deneb
 
 template init*(T: type ForkedEpochInfo, info: phase0.EpochInfo): T =
   T(kind: EpochInfoFork.Phase0, phase0Data: info)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -349,7 +349,7 @@ func is_merge_transition_complete*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/sync/optimistic.md#helpers
 func is_execution_block*(blck: SomeForkyBeaconBlock): bool =
-  when typeof(blck).toFork >= ConsensusFork.Bellatrix:
+  when typeof(blck).kind >= ConsensusFork.Bellatrix:
     const defaultExecutionPayload =
       default(typeof(blck.body.execution_payload))
     blck.body.execution_payload != defaultExecutionPayload
@@ -432,22 +432,22 @@ proc blockToBlockHeader*(blck: ForkyBeaconBlock): ExecutionBlockHeader =
   let
     txRoot = payload.computeTransactionsTrieRoot()
     withdrawalsRoot =
-      when typeof(payload).toFork >= ConsensusFork.Capella:
+      when typeof(payload).kind >= ConsensusFork.Capella:
         some payload.computeWithdrawalsTrieRoot()
       else:
         none(ExecutionHash256)
     blobGasUsed =
-      when typeof(payload).toFork >= ConsensusFork.Deneb:
+      when typeof(payload).kind >= ConsensusFork.Deneb:
         some payload.blob_gas_used
       else:
         none(uint64)
     excessBlobGas =
-      when typeof(payload).toFork >= ConsensusFork.Deneb:
+      when typeof(payload).kind >= ConsensusFork.Deneb:
         some payload.excess_blob_gas
       else:
         none(uint64)
     parentBeaconBlockRoot =
-      when typeof(payload).toFork >= ConsensusFork.Deneb:
+      when typeof(payload).kind >= ConsensusFork.Deneb:
         some ExecutionHash256(data: blck.parent_root.data)
       else:
         none(ExecutionHash256)

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -427,7 +427,7 @@ proc collectSignatureSets*(
 
   block:
     # 8. BLS to execution changes
-    when typeof(signed_block).toFork() >= ConsensusFork.Capella:
+    when typeof(signed_block).kind >= ConsensusFork.Capella:
       withState(state):
         when consensusFork >= ConsensusFork.Capella:
           for bls_change in signed_block.message.body.bls_to_execution_changes:

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -297,7 +297,7 @@ proc state_transition_block*(
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
 
   let res = withState(state):
-    when consensusFork == type(signedBlock).toFork:
+    when consensusFork == type(signedBlock).kind:
       state_transition_block_aux(cfg, forkyState, signedBlock, cache, flags)
     else:
       err("State/block fork mismatch")
@@ -482,7 +482,7 @@ proc makeBeaconBlock*(
 
     ok(blck)
 
-  const payloadFork = typeof(executionPayload).toFork
+  const payloadFork = typeof(executionPayload).kind
   when payloadFork == ConsensusFork.Bellatrix:
     case state.kind
     of ConsensusFork.Phase0:    makeBeaconBlock(phase0)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -366,7 +366,7 @@ proc check_voluntary_exit*(
   # Verify signature
   if skipBlsValidation notin flags:
     let exitSignatureFork =
-      when typeof(state).toFork >= ConsensusFork.Deneb:
+      when typeof(state).kind >= ConsensusFork.Deneb:
         Fork(
           previous_version: cfg.CAPELLA_FORK_VERSION,
           current_version: cfg.CAPELLA_FORK_VERSION,
@@ -446,7 +446,7 @@ proc process_operations(cfg: RuntimeConfig,
     ? process_deposit(cfg, state, op, flags)
   for op in body.voluntary_exits:
     ? process_voluntary_exit(cfg, state, op, flags, cache)
-  when typeof(body).toFork >= ConsensusFork.Capella:
+  when typeof(body).kind >= ConsensusFork.Capella:
     for op in body.bls_to_execution_changes:
       ? process_bls_to_execution_change(cfg, state, op)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -840,7 +840,7 @@ func process_registry_updates*(
   ## Queue validators eligible for activation and not dequeued for activation
   var activation_queue: HeapQueue[(uint64, uint32)]
   let churn_limit =
-    when typeof(state).toFork >= ConsensusFork.Deneb:
+    when typeof(state).kind >= ConsensusFork.Deneb:
       get_validator_activation_churn_limit(cfg, state, cache)
     else:
       get_validator_churn_limit(cfg, state, cache)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -469,7 +469,7 @@ proc makeBeaconBlockForHeadAndSlot*(
         var modified_execution_payload = execution_payload
         withState(state[]):
           when  consensusFork >= ConsensusFork.Capella and
-                PayloadType.toFork >= ConsensusFork.Capella:
+                PayloadType.kind >= ConsensusFork.Capella:
             let withdrawals = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
               get_expected_withdrawals(forkyState.data))
             if  withdrawals_root.isNone or

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -107,7 +107,7 @@ proc routeSignedBeaconBlock*(
         signature = shortLog(blck.signature), error = res.error()
       return err(res.error()[1])
 
-    when typeof(blck).toFork() >= ConsensusFork.Deneb:
+    when typeof(blck).kind >= ConsensusFork.Deneb:
       if blobsOpt.isSome:
         let blobs = blobsOpt.get()
         let kzgCommits = blck.message.body.blob_kzg_commitments.asSeq

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -467,7 +467,7 @@ proc doCreateTestnet*(config: CliConfig,
     let outSszGenesis = outGenesis.changeFileExt "ssz"
     SSZ.saveFile(outSszGenesis, initialState[])
     info "SSZ genesis file written",
-          path = outSszGenesis, fork = toFork(typeof initialState[])
+          path = outSszGenesis, fork = kind(typeof initialState[])
 
     SSZ.saveFile(
       config.outputDepositTreeSnapshot.string,

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -83,7 +83,7 @@ proc initialLoad(
   let
     forkedState = loadForkedState(
       path/"anchor_state.ssz_snappy",
-      StateType.toFork)
+      StateType.kind)
 
     blck = parseTest(
       path/"anchor_block.ssz_snappy",
@@ -246,7 +246,7 @@ proc stepOnBlock(
        invalidatedRoots: Table[Eth2Digest, Eth2Digest]):
        Result[BlockRef, VerifierError] =
   # 1. Validate blobs
-  when typeof(signedBlock).toFork() >= ConsensusFork.Deneb:
+  when typeof(signedBlock).kind >= ConsensusFork.Deneb:
     let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
     if kzgCommits.len > 0 or blobData.isSome:
       if blobData.isNone or kzgCommits.validate_blobs(

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -14,7 +14,7 @@ template testHashedBeaconState(T: type, s: Slot) =
   forked[] = readSszForkedHashedBeaconState(cfg, bytes)
 
   check:
-    forked.kind == T.toFork()
+    forked.kind == T.kind
 
 template testTrustedSignedBeaconBlock(T: type, s: Slot) =
   let blck = (ref T)()
@@ -26,7 +26,7 @@ template testTrustedSignedBeaconBlock(T: type, s: Slot) =
   forked[] = readSszForkedSignedBeaconBlock(cfg, bytes)
 
   check:
-    forked.kind == T.toFork()
+    forked.kind == T.kind
 
 suite "Type helpers":
   test "BeaconBlockType":

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 {.used.}
 
 import


### PR DESCRIPTION
We currently have multiple ways to obtain `ConsensusFork` or `LcDataFork` from a forky type. Rename `toFork` to `kind` for a consistent API naming.