### PR TITLE
rm unused `GenesisStateRef`

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -98,8 +98,6 @@ type
   Eth1BlockTimestamp* = uint64
   Eth1BlockHeader = engine_api.BlockHeader
 
-  GenesisStateRef = ref phase0.BeaconState
-
   Eth1Block* = ref object
     hash*: Eth2Digest
     number*: Eth1BlockNumber


### PR DESCRIPTION
In `el_manager`, there was an unused `GenesisStateRef` type. Remove it.