### PR TITLE
Add "ethstakers.club" as an Alternative Beacon Chain Explorer/Monitoring Tool in Documentation

### DIFF
--- a/docs/the_nimbus_book/src/faq.md
+++ b/docs/the_nimbus_book/src/faq.md
@@ -184,7 +184,7 @@ In other words, if you stood to earn ≈0.01 ETH, you would instead be penalized
 
 ### How can I keep track of my validator?
 
-One way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Prater](https://prater.beaconcha.in).
+One way of keeping track is using an online service such as beaconcha.in ([Mainnet](https://beaconcha.in/) and [Prater](https://prater.beaconcha.in)) or [ethstakers.club](https://ethstakers.club/).
 
 Another way is to set up [validator monitoring](./validator-monitor.md) together with a [dashboard](./metrics-pretty-pictures.md) to keep track of its performance.
 

--- a/docs/the_nimbus_book/src/health.md
+++ b/docs/the_nimbus_book/src/health.md
@@ -11,7 +11,7 @@ Attestation effectiveness is a metric that directly affects your validator rewar
 The interval between a validator performing its duty and an attestation is called the *inclusion distance* of an attestation.
 As long as your validator is within the allowed inclusion distance, you will get the full reward.
 
-You can verify your validator's effectiveness on the [beaconcha.in](https://beaconcha.in/) website.
+You can verify your validator's effectiveness on the [beaconcha.in](https://beaconcha.in/) or [ethstakers.club](https://ethstakers.club/) website.
 
 ![](https://i.imgur.com/u80Ub2j.png)
 

--- a/docs/the_nimbus_book/src/keep-an-eye.md
+++ b/docs/the_nimbus_book/src/keep-an-eye.md
@@ -2,7 +2,7 @@
 
 Once your validator has been activated, you can set up [validator monitoring](./validator-monitor.md) together with a [dashboard](./metrics-pretty-pictures.md) to keep track of its performance.
 
-Another way of keeping track is using an online service such as beaconcha.in: [Mainnet](https://beaconcha.in/) or [Prater](https://prater.beaconcha.in).
+Another way of keeping track is using an online service such as beaconcha.in ([Mainnet](https://beaconcha.in/) and [Prater](https://prater.beaconcha.in)) or [ethstakers.club](https://ethstakers.club/).
 
 Both online services and dashboards allow setting up alerts for when the validator is offline.
 

--- a/docs/the_nimbus_book/src/migration.md
+++ b/docs/the_nimbus_book/src/migration.md
@@ -150,7 +150,7 @@ As part of the migration process, you need to stop your existing client and expo
     This will export your history in the correct format to `slashing-protection.json`.
 
 !!! tip
-    To be extra sure that your validator has stopped, wait a few epochs and confirm that your validator has stopped attesting (check its recent history on [beaconcha.in](https://beaconcha.in/)).
+    To be extra sure that your validator has stopped, wait a few epochs and confirm that your validator has stopped attesting (check its recent history on [beaconcha.in](https://beaconcha.in/) or [ethstakers.club](https://ethstakers.club/)).
     Only after that, continue with the next step of this guide.
 
 


### PR DESCRIPTION
Added "ethstakers.club" as an alternative beacon chain explorer/monitoring tool to various relevant places in the documentation.

Please let me know if I missed any relevant places.
