### PR TITLE
align `Beacon(Block(Body)?|State)Type` with other fork sugar

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -580,7 +580,7 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 OK: 24/24 Fail: 0/24 Skip: 0/24
 ## Type helpers
 ```diff
-+ BeaconBlockType                                                                            OK
++ BeaconBlock                                                                                OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Validator Client test suite

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -2503,15 +2503,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## EF - Phase 0 - Finality  [Preset: mainnet]
-```diff
-+ [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_1 [Preset: mainnet]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_2 [Preset: mainnet]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_3 [Preset: mainnet]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_4 [Preset: mainnet]                      OK
-```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase 0 - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: ma OK
@@ -2654,26 +2645,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 ```
 OK: 9/9 Fail: 0/9 Skip: 0/9
-## EF - Phase 0 - Random  [Preset: mainnet]
-```diff
-+ [Valid]   EF - Phase 0 - Random - randomized_0 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_1 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_10 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_11 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_12 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_13 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_14 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_15 [Preset: mainnet]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_2 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_3 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_4 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_5 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_6 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_7 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_8 [Preset: mainnet]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_9 [Preset: mainnet]                           OK
-```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Phase 0 - Rewards  [Preset: mainnet]
 ```diff
 + EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                 OK
@@ -2758,50 +2729,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 27/27 Fail: 0/27 Skip: 0/27
-## EF - Phase 0 - Sanity - Blocks  [Preset: mainnet]
-```diff
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]        OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block  OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: m OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_proposer_slashings_same_block OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_validator_exit_same_block [Pr OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_block_sig [Preset: mainnet]   OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_expec OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_propo OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_state_root [Preset: mainnet]  OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_only_increase_deposit_count [Preset: ma OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_parent_from_same_slot [Preset: mainnet] OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_prev_slot_block_transition [Preset: mai OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposal_for_genesis_slot [Preset: main OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_same_slot_block_transition [Preset: mai OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_similar_proposer_slashings_same_block [ OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]     OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - attestation [Preset: mainnet]                   OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - attester_slashing [Preset: mainnet]             OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - balance_driven_status_transitions [Preset: main OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: mainnet]              OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: mainnet]                OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - duplicate_attestation_same_block [Preset: mainn OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition [Preset: mainnet]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: mainnet]           OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - historical_batch [Preset: mainnet]              OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset: OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pr OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_proposer_slashings_same_bloc OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_validator_exits_same_block [ OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_after_inactive_index [Preset: mainnet] OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: mainnet]             OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - skipped_slots [Preset: mainnet]                 OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]     OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
-```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Phase 0 - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Phase 0 - Slots - double_empty_epoch [Preset: mainnet]                                OK
@@ -2812,6 +2739,79 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + EF - Phase 0 - Slots - slots_2 [Preset: mainnet]                                           OK
 ```
 OK: 6/6 Fail: 0/6 Skip: 0/6
+## EF - Phase0 - Finality  [Preset: mainnet]
+```diff
++ [Valid]   EF - Phase0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]        OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_1 [Preset: mainnet]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_2 [Preset: mainnet]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_3 [Preset: mainnet]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_4 [Preset: mainnet]                       OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## EF - Phase0 - Random  [Preset: mainnet]
+```diff
++ [Valid]   EF - Phase0 - Random - randomized_0 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_1 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_10 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_11 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_12 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_13 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_14 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_15 [Preset: mainnet]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_2 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_3 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_4 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_5 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_6 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_7 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_8 [Preset: mainnet]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_9 [Preset: mainnet]                            OK
+```
+OK: 16/16 Fail: 0/16 Skip: 0/16
+## EF - Phase0 - Sanity - Blocks  [Preset: mainnet]
+```diff
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]         OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: ma OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_proposer_slashings_same_block  OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_validator_exit_same_block [Pre OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_block_sig [Preset: mainnet]    OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_expect OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_propos OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_state_root [Preset: mainnet]   OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_only_increase_deposit_count [Preset: mai OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_parent_from_same_slot [Preset: mainnet]  OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_prev_slot_block_transition [Preset: main OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_proposal_for_genesis_slot [Preset: mainn OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_same_slot_block_transition [Preset: main OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_similar_proposer_slashings_same_block [P OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - slash_and_exit_same_index [Preset: mainnet]      OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - attestation [Preset: mainnet]                    OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - attester_slashing [Preset: mainnet]              OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - balance_driven_status_transitions [Preset: mainn OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - deposit_in_block [Preset: mainnet]               OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - deposit_top_up [Preset: mainnet]                 OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - duplicate_attestation_same_block [Preset: mainne OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_block_transition [Preset: mainnet]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_epoch_transition [Preset: mainnet]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_0 [Preset: mainnet]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_1 [Preset: mainnet]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_2 [Preset: mainnet]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_3 [Preset: mainnet]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - high_proposer_index [Preset: mainnet]            OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - historical_batch [Preset: mainnet]               OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset:  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pre OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_different_proposer_slashings_same_block OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_different_validator_exits_same_block [P OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_after_inactive_index [Preset: mainnet]  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_self_slashing [Preset: mainnet]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_slashing [Preset: mainnet]              OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - skipped_slots [Preset: mainnet]                  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]      OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                 OK
+```
+OK: 40/40 Fail: 0/40 Skip: 0/40
 ## ForkChoice
 ```diff
 + ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -2647,15 +2647,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## EF - Phase 0 - Finality  [Preset: minimal]
-```diff
-+ [Valid]   EF - Phase 0 - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_1 [Preset: minimal]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_2 [Preset: minimal]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_3 [Preset: minimal]                      OK
-+ [Valid]   EF - Phase 0 - Finality - finality_rule_4 [Preset: minimal]                      OK
-```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase 0 - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: mi OK
@@ -2799,26 +2790,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 ```
 OK: 10/10 Fail: 0/10 Skip: 0/10
-## EF - Phase 0 - Random  [Preset: minimal]
-```diff
-+ [Valid]   EF - Phase 0 - Random - randomized_0 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_1 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_10 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_11 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_12 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_13 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_14 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_15 [Preset: minimal]                          OK
-+ [Valid]   EF - Phase 0 - Random - randomized_2 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_3 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_4 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_5 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_6 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_7 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_8 [Preset: minimal]                           OK
-+ [Valid]   EF - Phase 0 - Random - randomized_9 [Preset: minimal]                           OK
-```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Phase 0 - Rewards  [Preset: minimal]
 ```diff
 + EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: minimal]                 OK
@@ -2903,55 +2874,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 +   Testing    VoluntaryExit                                                                 OK
 ```
 OK: 27/27 Fail: 0/27 Skip: 0/27
-## EF - Phase 0 - Sanity - Blocks  [Preset: minimal]
-```diff
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]        OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block  OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: m OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_proposer_slashings_same_block OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_duplicate_validator_exit_same_block [Pr OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_block_sig [Preset: minimal]   OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_expec OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_propo OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_incorrect_state_root [Preset: minimal]  OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_only_increase_deposit_count [Preset: mi OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_parent_from_same_slot [Preset: minimal] OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_prev_slot_block_transition [Preset: min OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_proposal_for_genesis_slot [Preset: mini OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_same_slot_block_transition [Preset: min OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - invalid_similar_proposer_slashings_same_block [ OK
-+ [Invalid] EF - Phase 0 - Sanity - Blocks - slash_and_exit_same_index [Preset: minimal]     OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - attestation [Preset: minimal]                   OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - attester_slashing [Preset: minimal]             OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - balance_driven_status_transitions [Preset: mini OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_in_block [Preset: minimal]              OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - deposit_top_up [Preset: minimal]                OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - duplicate_attestation_same_block [Preset: minim OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition [Preset: minimal]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_block_transition_large_validator_set [Pre OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition [Preset: minimal]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition_large_validator_set [Pre OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset:  OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]     OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]  OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_0 [Preset: minimal]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_1 [Preset: minimal]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_2 [Preset: minimal]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - full_random_operations_3 [Preset: minimal]      OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - high_proposer_index [Preset: minimal]           OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - historical_batch [Preset: minimal]              OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset: OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pr OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_proposer_slashings_same_bloc OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - multiple_different_validator_exits_same_block [ OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_after_inactive_index [Preset: minimal] OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_self_slashing [Preset: minimal]        OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - proposer_slashing [Preset: minimal]             OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - skipped_slots [Preset: minimal]                 OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]     OK
-+ [Valid]   EF - Phase 0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
-```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## EF - Phase 0 - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Phase 0 - Slots - double_empty_epoch [Preset: minimal]                                OK
@@ -2962,6 +2884,84 @@ OK: 45/45 Fail: 0/45 Skip: 0/45
 + EF - Phase 0 - Slots - slots_2 [Preset: minimal]                                           OK
 ```
 OK: 6/6 Fail: 0/6 Skip: 0/6
+## EF - Phase0 - Finality  [Preset: minimal]
+```diff
++ [Valid]   EF - Phase0 - Finality - finality_no_updates_at_genesis [Preset: minimal]        OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_1 [Preset: minimal]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_2 [Preset: minimal]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_3 [Preset: minimal]                       OK
++ [Valid]   EF - Phase0 - Finality - finality_rule_4 [Preset: minimal]                       OK
+```
+OK: 5/5 Fail: 0/5 Skip: 0/5
+## EF - Phase0 - Random  [Preset: minimal]
+```diff
++ [Valid]   EF - Phase0 - Random - randomized_0 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_1 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_10 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_11 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_12 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_13 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_14 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_15 [Preset: minimal]                           OK
++ [Valid]   EF - Phase0 - Random - randomized_2 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_3 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_4 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_5 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_6 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_7 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_8 [Preset: minimal]                            OK
++ [Valid]   EF - Phase0 - Random - randomized_9 [Preset: minimal]                            OK
+```
+OK: 16/16 Fail: 0/16 Skip: 0/16
+## EF - Phase0 - Sanity - Blocks  [Preset: minimal]
+```diff
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]         OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_attester_slashing_same_block [ OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_deposit_same_block [Preset: mi OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_proposer_slashings_same_block  OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_duplicate_validator_exit_same_block [Pre OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_block_sig [Preset: minimal]    OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_expect OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_proposer_index_sig_from_propos OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_incorrect_state_root [Preset: minimal]   OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_only_increase_deposit_count [Preset: min OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_parent_from_same_slot [Preset: minimal]  OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_prev_slot_block_transition [Preset: mini OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_proposal_for_genesis_slot [Preset: minim OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_same_slot_block_transition [Preset: mini OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - invalid_similar_proposer_slashings_same_block [P OK
++ [Invalid] EF - Phase0 - Sanity - Blocks - slash_and_exit_same_index [Preset: minimal]      OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - attestation [Preset: minimal]                    OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - attester_slashing [Preset: minimal]              OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - balance_driven_status_transitions [Preset: minim OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - deposit_in_block [Preset: minimal]               OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - deposit_top_up [Preset: minimal]                 OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - duplicate_attestation_same_block [Preset: minima OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_block_transition [Preset: minimal]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_block_transition_large_validator_set [Pres OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_epoch_transition [Preset: minimal]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_epoch_transition_large_validator_set [Pres OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - empty_epoch_transition_not_finalizing [Preset: m OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - eth1_data_votes_consensus [Preset: minimal]      OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - eth1_data_votes_no_consensus [Preset: minimal]   OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_0 [Preset: minimal]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_1 [Preset: minimal]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_2 [Preset: minimal]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - full_random_operations_3 [Preset: minimal]       OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - high_proposer_index [Preset: minimal]            OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - historical_batch [Preset: minimal]               OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_attester_slashings_no_overlap [Preset:  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_attester_slashings_partial_overlap [Pre OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_different_proposer_slashings_same_block OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - multiple_different_validator_exits_same_block [P OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_after_inactive_index [Preset: minimal]  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_self_slashing [Preset: minimal]         OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - proposer_slashing [Preset: minimal]              OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - skipped_slots [Preset: minimal]                  OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]      OK
++ [Valid]   EF - Phase0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                 OK
+```
+OK: 45/45 Fail: 0/45 Skip: 0/45
 ## ForkChoice
 ```diff
 + ForkChoice - minimal/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1013,18 +1013,15 @@ proc initialize_beacon_state_from_eth1*(
       current_version: forkVersion,
       epoch: GENESIS_EPOCH)
 
-  type BeaconState = BeaconStateType(consensusFork)
-
   # TODO https://github.com/nim-lang/Nim/issues/19094
   template state(): untyped = result
-  result = BeaconState(
+  result = consensusFork.BeaconState(
     fork: fork,
     genesis_time: genesis_time_from_eth1_timestamp(cfg, eth1_timestamp),
-    eth1_data:
-      Eth1Data(block_hash: eth1_block_hash, deposit_count: uint64(len(deposits))),
-    latest_block_header:
-      BeaconBlockHeader(
-        body_root: hash_tree_root(default BeaconBlockBodyType(consensusFork))))
+    eth1_data: Eth1Data(
+      block_hash: eth1_block_hash, deposit_count: uint64(len(deposits))),
+    latest_block_header: BeaconBlockHeader(
+      body_root: hash_tree_root(default consensusFork.BeaconBlockBody)))
 
   # Seed RANDAO with Eth1 entropy
   state.randao_mixes.data.fill(eth1_block_hash)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -335,7 +335,7 @@ proc state_transition*(
   state_transition_block(
     cfg, state, signedBlock, cache, flags, rollback)
 
-template partialBeaconBlock*(
+func partialBeaconBlock*(
     cfg: RuntimeConfig,
     state: var ForkyHashedBeaconState,
     proposer_index: ValidatorIndex,
@@ -351,11 +351,11 @@ template partialBeaconBlock*(
   const consensusFork = typeof(state).kind
 
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#preparing-for-a-beaconblock
-  var res = consensusFork.BeaconBlockType(
+  var res = consensusFork.BeaconBlock(
     slot: state.data.slot,
     proposer_index: proposer_index.uint64,
     parent_root: state.latest_block_root,
-    body: consensusFork.BeaconBlockBodyType(
+    body: consensusFork.BeaconBlockBody(
       randao_reveal: randao_reveal,
       eth1_data: eth1data,
       graffiti: graffiti,

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -69,8 +69,8 @@ suite "EF - Light client - Single merkle proof" & preset():
         for kind, path in walkDir(suitePath, relative = true, checkDir = true):
           case objName
           of "BeaconBlockBody":
-            runTest(suiteName, suitePath/path, BeaconBlockBodyType(consensusFork))
+            runTest(suiteName, suitePath/path, consensusFork.BeaconBlockBody)
           of "BeaconState":
-            runTest(suiteName, suitePath/path, BeaconStateType(consensusFork))
+            runTest(suiteName, suitePath/path, consensusFork.BeaconState)
           else:
             raiseAssert "Unknown test object: " & suitePath/path

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -9,21 +9,21 @@
 
 import
   chronicles,
-  ../../beacon_chain/spec/datatypes/phase0,
+  ../../beacon_chain/spec/forks,
   ../../beacon_chain/spec/state_transition,
   ./os_ops,
   ../testutil
 
 from std/sequtils import toSeq
-from ../../beacon_chain/spec/forks import
-  ForkedEpochInfo, ForkedHashedBeaconState, fromSszBytes, getStateRoot, new
+from std/strutils import toLowerAscii
 from ../../beacon_chain/spec/presets import
   const_preset, defaultRuntimeConfig
 from ./fixtures_utils import
   SSZ, SszTestsDir, hash_tree_root, parseTest, readSszBytes, toSszType
 
 proc runTest(
-    BS, SBB: type, testName, testDir: static[string], suiteName, unitTestName: string) =
+    consensusFork: static ConsensusFork,
+    testName, testDir: static[string], suiteName, unitTestName: string) =
   let testPath = testDir / unitTestName
 
   let
@@ -31,7 +31,8 @@ proc runTest(
     prefix = if hasPostState: "[Valid]   " else: "[Invalid] "
 
   test prefix & testName & " - " & unitTestName & preset():
-    let preState = newClone(parseTest(testPath/"pre.ssz_snappy", SSZ, BS))
+    let preState = newClone(parseTest(testPath/"pre.ssz_snappy",
+      SSZ, consensusFork.BeaconState))
     var
       fhPreState = ForkedHashedBeaconState.new(preState[])
       cache = StateCache()
@@ -41,7 +42,8 @@ proc runTest(
     # so purely lexicographic sorting wouldn't sort properly.
     let numBlocks = toSeq(walkPattern(testPath/"blocks_*.ssz_snappy")).len
     for i in 0 ..< numBlocks:
-      let blck = parseTest(testPath/"blocks_" & $i & ".ssz_snappy", SSZ, SBB)
+      let blck = parseTest(testPath/"blocks_" & $i & ".ssz_snappy",
+        SSZ, consensusFork.SignedBeaconBlock)
 
       if hasPostState:
         state_transition(
@@ -55,15 +57,16 @@ proc runTest(
           "We didn't expect these invalid blocks to be processed"
 
     if hasPostState:
-      let postState = newClone(parseTest(testPath/"post.ssz_snappy", SSZ, BS))
+      let postState = newClone(parseTest(testPath/"post.ssz_snappy",
+        SSZ, consensusFork.BeaconState))
       when false:
         reportDiff(hashedPreState.phase0Data.data, postState)
       doAssert getStateRoot(fhPreState[]) == postState[].hash_tree_root()
 
-template runForkBlockTests(
-    forkDirName, forkHumanName: static[string], BeaconStateType,
-    BeaconBlockType: untyped) =
+template runForkBlockTests(consensusFork: static ConsensusFork) =
   const
+    forkHumanName = $consensusFork
+    forkDirName = forkHumanName.toLowerAscii()
     FinalityDir =
       SszTestsDir/const_preset/forkDirName/"finality"/"finality"/"pyspec_tests"
     RandomDir =
@@ -73,41 +76,21 @@ template runForkBlockTests(
 
   suite "EF - " & forkHumanName & " - Sanity - Blocks " & preset():
     for kind, path in walkDir(SanityBlocksDir, relative = true, checkDir = true):
-      runTest(
-        BeaconStateType, BeaconBlockType,
-        "EF - " & forkHumanName & " - Sanity - Blocks", SanityBlocksDir, suiteName, path)
+      consensusFork.runTest(
+        "EF - " & forkHumanName & " - Sanity - Blocks",
+        SanityBlocksDir, suiteName, path)
 
   suite "EF - " & forkHumanName & " - Finality " & preset():
     for kind, path in walkDir(FinalityDir, relative = true, checkDir = true):
-      runTest(
-        BeaconStateType, BeaconBlockType,
-        "EF - " & forkHumanName & " - Finality", FinalityDir, suiteName, path)
+      consensusFork.runTest(
+        "EF - " & forkHumanName & " - Finality",
+        FinalityDir, suiteName, path)
 
   suite "EF - " & forkHumanName & " - Random " & preset():
     for kind, path in walkDir(RandomDir, relative = true, checkDir = true):
-      runTest(
-        BeaconStateType, BeaconBlockType,
-        "EF - " & forkHumanName & " - Random", RandomDir, suiteName, path)
+      consensusFork.runTest(
+        "EF - " & forkHumanName & " - Random",
+        RandomDir, suiteName, path)
 
-runForkBlockTests(
-  "phase0", "Phase 0", phase0.BeaconState, phase0.SignedBeaconBlock)
-
-from ../../beacon_chain/spec/datatypes/altair import
-  BeaconState, SignedBeaconBlock
-runForkBlockTests(
-  "altair", "Altair", altair.BeaconState, altair.SignedBeaconBlock)
-
-from ../../beacon_chain/spec/datatypes/bellatrix import
-  BeaconState, SignedBeaconBlock
-runForkBlockTests(
-  "bellatrix", "Bellatrix", bellatrix.BeaconState, bellatrix.SignedBeaconBlock)
-
-from ../../beacon_chain/spec/datatypes/capella import
-  BeaconState, SignedBeaconBlock
-runForkBlockTests(
-  "capella", "Capella", capella.BeaconState, capella.SignedBeaconBlock)
-
-from ../../beacon_chain/spec/datatypes/deneb import
-  BeaconState, SignedBeaconBlock
-runForkBlockTests(
-  "deneb", "Deneb", deneb.BeaconState, deneb.SignedBeaconBlock)
+withAll(ConsensusFork):
+  runForkBlockTests(consensusFork)

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -36,18 +36,18 @@ template testTrustedSignedBeaconBlock(T: type, s: Slot) =
     forked.kind == T.kind
 
 suite "Type helpers":
-  test "BeaconBlockType":
+  test "BeaconBlock":
     check:
-      BeaconBlockType(ConsensusFork.Phase0) is phase0.BeaconBlock
-      BeaconBlockType(ConsensusFork.Altair) is altair.BeaconBlock
-      BeaconBlockType(ConsensusFork.Bellatrix) is bellatrix.BeaconBlock
-      BeaconBlockType(ConsensusFork.Capella) is capella.BeaconBlock
-      BeaconBlockType(ConsensusFork.Deneb) is deneb.BeaconBlock
-      BeaconBlockBodyType(ConsensusFork.Phase0) is phase0.BeaconBlockBody
-      BeaconBlockBodyType(ConsensusFork.Altair) is altair.BeaconBlockBody
-      BeaconBlockBodyType(ConsensusFork.Bellatrix) is bellatrix.BeaconBlockBody
-      BeaconBlockBodyType(ConsensusFork.Capella) is capella.BeaconBlockBody
-      BeaconBlockBodyType(ConsensusFork.Deneb) is deneb.BeaconBlockBody
+      ConsensusFork.Phase0.BeaconBlock is phase0.BeaconBlock
+      ConsensusFork.Altair.BeaconBlock is altair.BeaconBlock
+      ConsensusFork.Bellatrix.BeaconBlock is bellatrix.BeaconBlock
+      ConsensusFork.Capella.BeaconBlock is capella.BeaconBlock
+      ConsensusFork.Deneb.BeaconBlock is deneb.BeaconBlock
+      ConsensusFork.Phase0.BeaconBlockBody is phase0.BeaconBlockBody
+      ConsensusFork.Altair.BeaconBlockBody is altair.BeaconBlockBody
+      ConsensusFork.Bellatrix.BeaconBlockBody is bellatrix.BeaconBlockBody
+      ConsensusFork.Capella.BeaconBlockBody is capella.BeaconBlockBody
+      ConsensusFork.Deneb.BeaconBlockBody is deneb.BeaconBlockBody
 
 suite "Forked SSZ readers":
   let cfg = block:

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -43,7 +43,7 @@ proc makeTestDB*(
       forkyState.data.fork.previous_version =
         forkyState.data.fork.current_version
       forkyState.data.latest_block_header.body_root =
-        hash_tree_root(default(BeaconBlockBodyType(consensusFork)))
+        hash_tree_root(default(BeaconBlockBody(consensusFork)))
       forkyState.root = hash_tree_root(forkyState.data)
 
   result = BeaconChainDB.new("", cfg = cfg, inMemory = true)


### PR DESCRIPTION
The templates for `BeaconBlock`, `BeaconBlockBody` and `BeaconState` are the only ones using a `macro` mechanism for code generation. This prevents using the dot-syntax style `consensusFork.BeaconFoo` in some situations, and also tends to trigger naming conflicts, requiring the `Type` suffix. Furthermore, the `macro` only works for types that are re-defined in every single `ConsensusFork`.

Replacing with the simpler but more verbose approach used for other types for consistency and to avoid the downsides of the `macro`.

Furthermore, simplify `test_fixture_sanity_blocks` to use `forks` sugar.