### PR TITLE
consistently use SignedBlindedBeaconBlockContents; remove more Bellatrix Builder API remnants

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -994,16 +994,16 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     case currentEpochFork
     of ConsensusFork.Deneb:
       let
-        restBlock = decodeBodyJsonOrSsz(deneb_mev.SignedBlindedBeaconBlock,
-                                        body).valueOr:
+        restBlockContents = decodeBodyJsonOrSsz(deneb_mev.SignedBlindedBeaconBlockContents,
+                                                body).valueOr:
           return RestApiResponse.jsonError(error)
 
         payloadBuilderClient = node.getPayloadBuilderClient(
-            restBlock.message.proposer_index).valueOr:
+            restBlockContents.signed_blinded_block.message.proposer_index).valueOr:
           return RestApiResponse.jsonError(
             Http400, "Unable to initialize payload builder client: " & $error)
         res = await node.unblindAndRouteBlockMEV(
-          payloadBuilderClient, restBlock)
+          payloadBuilderClient, restBlockContents)
 
       if res.isErr():
         return RestApiResponse.jsonError(

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -119,3 +119,10 @@ func shortLog*(v: SignedBlindedBeaconBlock): auto =
     blck: shortLog(v.message),
     signature: shortLog(v.signature)
   )
+
+# needs to match SignedBlindedBeaconBlock
+func shortLog*(v: SignedBlindedBeaconBlockContents): auto =
+  (
+    blck: shortLog(v.signed_blinded_block.message),
+    signature: shortLog(v.signed_blinded_block.signature)
+  )

--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -16,7 +16,7 @@ from ../spec/datatypes/bellatrix import SignedBeaconBlock
 from ../spec/mev/rest_capella_mev_calls import submitBlindedBlock
 
 const
-  BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE = 4.seconds
+  BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE = 5.seconds
 
 declareCounter beacon_block_builder_proposed,
   "Number of beacon chain blocks produced using an external block builder"
@@ -76,7 +76,7 @@ proc unblindAndRouteBlockMEV*(
     else:
       # Signature provided is consistent with unblinded execution payload,
       # so construct full beacon block
-      # https://github.com/ethereum/builder-specs/blob/v0.2.0/specs/validator.md#block-proposal
+      # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#block-proposal
       var signedBlock = capella.SignedBeaconBlock(
         signature: blindedBlock.signature)
       copyFields(
@@ -111,17 +111,17 @@ proc unblindAndRouteBlockMEV*(
     debug "unblindAndRouteBlockMEV: submitBlindedBlock failed",
       blindedBlock, payloadStatus = unblindedPayload.status
 
-  # https://github.com/ethereum/builder-specs/blob/v0.2.0/specs/validator.md#proposer-slashing
+  # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#proposer-slashing
   # This means if a validator publishes a signature for a
   # `BlindedBeaconBlock` (via a dissemination of a
   # `SignedBlindedBeaconBlock`) then the validator **MUST** not use the
   # local build process as a fallback, even in the event of some failure
-  # with the external buildernetwork.
+  # with the external builder network.
   return err("unblindAndRouteBlockMEV error")
 
 # TODO currently cannot be combined into one generic function
 proc unblindAndRouteBlockMEV*(
     node: BeaconNode, payloadBuilderRestClient: RestClientRef,
-    blindedBlock: deneb_mev.SignedBlindedBeaconBlock):
+    blindedBlockContents: deneb_mev.SignedBlindedBeaconBlockContents):
     Future[Result[Opt[BlockRef], string]] {.async.} =
   debugRaiseAssert $denebImplementationMissing & ": makeBlindedBeaconBlockForHeadAndSlot"


### PR DESCRIPTION
Also increase the builder unblind timeout to 5 seconds, because at that point there's no real choice, and update some spec URLs.

Having the what will be a similar-but-separate `blindedBlockCheckSlashingAndSign` (because it will refer to the `signed_blinded_block`) is not great, but also a temporary inelegance which has the virtue of leaving that aspect of the working/tested Capella Builder API unchanged.

Removes one `$denebImplementationMissing`, adds another, but does so in a deeper and more specific part of the logic flow, so a net gain.