### PR TITLE
Revert "Github Runner: test use of self hosted runner for build"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             nimflags-extra: --mm:refc
           - target:
               os: linux
-            builder: ['self-hosted','ubuntu-22.04']
+            builder: ubuntu-22.04
             shell: bash
           - target:
               os: macos


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#4886

merged prematurely (but for the record, not opposed to merging)