### PR TITLE
fix Deneb builder API block body type; introduce and use `ExecutionPayloadHeaderAndBlindedBlobsBundle`

### DIFF
--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -7,8 +7,10 @@
 
 {.push raises: [].}
 
-import ".."/datatypes/[altair, capella, deneb]
+import ".."/datatypes/[altair, deneb]
+
 from stew/byteutils import to0xHex
+from ".."/datatypes/capella import SignedBLSToExecutionChange
 
 type
   # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#blindedblobsbundle
@@ -43,8 +45,7 @@ type
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
     sync_aggregate*: SyncAggregate
-    execution_payload_header*:
-      capella.ExecutionPayloadHeader
+    execution_payload_header*: deneb.ExecutionPayloadHeader
     bls_to_execution_changes*:
       List[SignedBLSToExecutionChange,
         Limit MAX_BLS_TO_EXECUTION_CHANGES]
@@ -84,7 +85,7 @@ type
 
   # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#signedblindedblockcontents
   SignedBlindedBeaconBlockContents* = object
-    signed_blinded_block*: SignedBlindedBeaconBlock
+    signed_blinded_block*: deneb_mev.SignedBlindedBeaconBlock
     signed_blinded_blob_sidecars*:
       List[SignedBlindedBlobSidecar, Limit MAX_BLOBS_PER_BLOCK]
 
@@ -92,6 +93,11 @@ type
   ExecutionPayloadAndBlobsBundle* = object
     execution_payload*: deneb.ExecutionPayload
     blobs_bundle*: BlobsBundle
+
+  # Not spec, but suggested by spec
+  ExecutionPayloadHeaderAndBlindedBlobsBundle* = object
+    execution_payload_header*: deneb.ExecutionPayloadHeader
+    blinded_blobs_bundle*: BlindedBlobsBundle
 
 func shortLog*(v: BlindedBeaconBlock): auto =
   (


### PR DESCRIPTION
Deneb `getHeader` returns not only blinded blocks and block values, but blinded blobs.

While Capella and Deneb builder API support coexist, moving this out of the `ExecutionPayloadHeader`-bundled type would mean adding it to `BlindedBlockResult`, which would mean some kind of `Opt` or otherwise-signaled value for the Capella builder API for the blinded blob list, which would be less statically type-safe. Once Capella support is dropped, it might make sense to refactor this, but even then, it keeps some similar options together -- generally speaking, they have to be signed and verified together, so it's at least reasonable and arguably better regardless to use this `ExecutionPayloadHeaderAndBlindedBlobsBundle` type.

In general, because Capella builder API support will be droppable after the relays disappear, probably within a year, either the `when` branches or generic functions with some code duplication to handle the slight structural differences are temporary kludges which are removable as soon as the Capella builder API is, at which point (unless the E-consensus-spec adds other builder API-relevant structural changes on par with blobs) the Dencun and E-spec versions can share codepaths again.