### PR TITLE
bump nim-web3 to rm web3_consensus_const_preset

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -710,7 +710,7 @@ done
 
 if [[ "${REUSE_BINARIES}" == "0" || "${BINARIES_MISSING}" == "1" ]]; then
   log "Rebuilding binaries ${BINARIES}"
-  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET} -d:web3_consensus_const_preset=mainnet -d:FIELD_ELEMENTS_PER_BLOB=4096" ${BINARIES}
+  ${MAKE} -j ${NPROC} LOG_LEVEL=TRACE NIMFLAGS="${NIMFLAGS} -d:local_testnet -d:const_preset=${CONST_PRESET} -d:FIELD_ELEMENTS_PER_BLOB=4096" ${BINARIES}
 fi
 
 if [[ "${RUN_NIMBUS_ETH1}" == "1" ]]; then


### PR DESCRIPTION
For https://github.com/status-im/nim-web3/pull/107 as `web3_consensus_const_preset` has been rendered unnecessary by `v1.4.0-beta.3` consensus specs and tended to cause surprise build problems when trying to build minimal-preset `nimbus-eth2`.