### PR TITLE
remove unnecessary Builder API status endpoint usage

### DIFF
--- a/beacon_chain/spec/mev/rest_capella_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_capella_mev_calls.nim
@@ -19,11 +19,6 @@ proc registerValidator*(body: seq[SignedValidatorRegistrationV1]
   ## https://github.com/ethereum/builder-specs/blob/v0.3.0/apis/builder/validators.yaml
   ## https://github.com/ethereum/beacon-APIs/blob/v2.3.0/apis/validator/register_validator.yaml
 
-proc checkBuilderStatus*(): RestPlainResponse {.
-     rest, endpoint: "/eth/v1/builder/status",
-     meth: MethodGet, connection: {Dedicated, Close}.}
-  ## https://github.com/ethereum/builder-specs/blob/v0.3.0/apis/builder/status.yaml
-
 proc getHeaderCapella*(slot: Slot,
                        parent_hash: Eth2Digest,
                        pubkey: ValidatorPubKey

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -50,7 +50,6 @@ const
   delayBuckets = [-Inf, -4.0, -2.0, -1.0, -0.5, -0.1, -0.05,
                   0.05, 0.1, 0.5, 1.0, 2.0, 4.0, 8.0, Inf]
 
-  BUILDER_STATUS_DELAY_TOLERANCE = 3.seconds
   BUILDER_VALIDATOR_REGISTRATION_DELAY_TOLERANCE = 6.seconds
 
 # Metrics for tracking attestation and beacon block loss
@@ -1680,17 +1679,6 @@ proc registerValidatorsPerBuilder(
     if payloadBuilderClient.isNil:
       debug "registerValidatorsPerBuilder: got nil payload builder REST client reference",
         payloadBuilderAddress, epoch
-      return
-
-    let restBuilderStatus = awaitWithTimeout(payloadBuilderClient.checkBuilderStatus(),
-                                             BUILDER_STATUS_DELAY_TOLERANCE):
-      debug "Timeout when obtaining builder status"
-      return
-
-    if restBuilderStatus.status != HttpOk:
-      warn "registerValidators: specified builder or relay not available",
-        builderUrl = node.config.payloadBuilderUrl,
-        builderStatus = restBuilderStatus
       return
 
     const emptyNestedSeq = @[newSeq[SignedValidatorRegistrationV1](0)]


### PR DESCRIPTION
The useful endpoint is the actual `registerValidators` one. If the status endpoint works, but the registerValidators one does not, well, the relay still isn't useful. It's a nice call for the API to provide for `curl`-sanity-checking purposes, but not salient for the Nimbus BN.