### PR TITLE
send DenebBlockContents in produceBlockV2

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -444,9 +444,9 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             static: raiseAssert "produceBlockV2 received unexpected version"
         if contentType == sszMediaType:
           let headers = [("eth-consensus-version", message.blck.kind.toString())]
-          RestApiResponse.sszResponse(forkyBlck, headers)
+          RestApiResponse.sszResponse(data, headers)
         elif contentType == jsonMediaType:
-          RestApiResponse.jsonResponseWVersion(forkyBlck, message.blck.kind)
+          RestApiResponse.jsonResponseWVersion(data, message.blck.kind)
         else:
           raiseAssert "preferredContentType() returns invalid content type"
 


### PR DESCRIPTION
Found via
```
./hive --client-file ./configs/cancun.yaml --client go-ethereum,nimbus-bn,nimbus-vc --sim eth2/dencun --sim.limit "eth2-deneb-testnet/test-deneb-genesis" --sim.loglevel 5
```

Fixes
```
DBG 2023-10-23 22:19:05.620+00:00 Got REST response headers from remote server remote=172.17.0.5:4000 request="/eth/v2/validator/blocks/1?randao_reveal=0x832a7ae5aa055155d4091f9e4f051444a098dd0c6131bda62a7b063f52433f9efd7cab40d13b02ce2ee0c333326a7ef00cfb2e0d13351bccd4f9a50f96164bc62217111312901fde4d9f9275710d3a3f904845fb43717194305153f5ec4b7e1b&graffiti=0x4e696d6275732f7632332e31302e302d6139383661312d73746174656f667573" status=200 http_method=GET
DBG 2023-10-23 22:19:05.620+00:00 Received REST response body from remote server remote=172.17.0.5:4000 request="/eth/v2/validator/blocks/1?randao_reveal=0x832a7ae5aa055155d4091f9e4f051444a098dd0c6131bda62a7b063f52433f9efd7cab40d13b02ce2ee0c333326a7ef00cfb2e0d13351bccd4f9a50f96164bc62217111312901fde4d9f9275710d3a3f904845fb43717194305153f5ec4b7e1b&graffiti=0x4e696d6275732f7632332e31302e302d6139383661312d73746174656f667573" contentType=application/octet-stream size=10934
ERR 2023-10-23 22:19:05.620+00:00 Beacon node provides unexpected response   reason="Invalid SSZ object;200;produceBlockV2(best);unexpected-data" node=http://172.17.0.5:4000[Nimbus/v23.10.0-a986a1-stateofus] node_index=0 node_roles=AGBSDT
WRN 2023-10-23 22:19:05.620+00:00 Unable to retrieve block data              reason="Invalid SSZ object;200;produceBlockV2(best);unexpected-data" wall_slot=1 service=block_service slot=1 validator=933387a2
```