### PR TITLE
Fix REST JSON KzgCommitment encoding/decoding to use hex strings per spec

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -428,12 +428,13 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + prune states                                                                               OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
-## REST JSON decoding
+## REST JSON encoding and decoding
 ```diff
 + DenebSignedBlockContents                                                                   OK
++ KzgCommitment                                                                              OK
 + RestPublishedSignedBlockContents                                                           OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
+OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Remove keystore testing suite
 ```diff
 + Many remotes                                                                               OK
@@ -711,4 +712,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 400/405 Fail: 0/405 Skip: 5/405
+OK: 401/406 Fail: 0/406 Skip: 5/406

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -950,6 +950,21 @@ proc writeValue*(
 ) {.raises: [IOError].} =
   writeValue(writer, hexOriginal(distinctBase(value)))
 
+## KzgCommitment
+# https://github.com/ethereum/beacon-APIs/blob/d934a03187729635bef06ca7f3c067645c3eab15/types/primitive.yaml#L135-L140
+proc readValue*(reader: var JsonReader[RestJson], value: var KzgCommitment) {.
+     raises: [IOError, SerializationError].} =
+  try:
+    hexToByteArray(reader.readValue(string), distinctBase(value))
+  except ValueError:
+    raiseUnexpectedValue(reader,
+                         "KzgCommitment value should be a valid hex string")
+
+proc writeValue*(
+    writer: var JsonWriter[RestJson], value: KzgCommitment
+) {.raises: [IOError].} =
+  writeValue(writer, hexOriginal(distinctBase(value)))
+
 ## GraffitiBytes
 proc writeValue*(
     writer: var JsonWriter[RestJson], value: GraffitiBytes
@@ -1821,7 +1836,7 @@ proc readValue*(reader: var JsonReader[RestJson],
       value = RestPublishedSignedBlockContents(
         kind: ConsensusFork.Deneb,
         denebData: DenebSignedBlockContents(
-          # Constructed to be interally consistent
+          # Constructed to be internally consistent
           signed_block: signed_message.get().distinctBase.denebData,
           signed_blob_sidecars: signed_blob_sidecars.get()
         )


### PR DESCRIPTION
It was creating
```
"blob_kzg_commitments":[["146","250","119","83","129","165","229","234","112","111","64","50","154","30","190","84","7","74","174","60","239","143","40","162","58","11","215","145","52","68","23","159","145","67","150","14","170","14","201","88","178","144","254","32","29","156","255","44"],["148","37","112","152","143","101","155","146","13","56","212","56","178","68","78","132","247","246","249","15","79","135","152","105","195","10","29","97","119","142","168","115","158","28","198","226","204","138","151","3","183","28","44","135","16","111","248","239"],["173","217","48","220","29","15","154","33","117","82","210","152","74","135","80","237","140","239","16","35","57","230","108","158","18","32","63","77","214","10","53","149","60","164","82","208","183","63","22","161","223","189","170","227","244","7","153","198"],["129","150","75","200","164","200","54","248","13","231","237","103","24","243","227","226","16","98","150","138","81","19","148","157","37","77","29","175","158","164","189","239","21","230","42","253","67","142","168","104","222","120","182","214","163","232","139","41"],["132","183","6","204","212","175","207","253","132","147","99","107","172","141","64","44","175","41","80","37","194","158","184","232","44","95","255","87","182","112","78","203","189","92","176","111","47","31","152","243","68","16","98","70","55","114","237","64"],["133","6","14","157","227","98","176","227","62","108","166","189","162","4","152","252","120","53","54","135","227","93","244","77","233","6","208","160","97","198","167","89","77","41","236","163","239","123","208","153","84","147","215","23","71","56","169","177"]]
```

But https://github.com/ethereum/beacon-APIs/blob/d934a03187729635bef06ca7f3c067645c3eab15/types/primitive.yaml#L135-L140 defines the REST JSON encoding for a `KZGCommitment` to be
```
KZGCommitment:
  type: string
  format: hex
  pattern: "^0x[a-fA-F0-9]{96}$"
  description: "A G1 curve point. Same as BLS standard \"is valid pubkey\" check but also allows `0x00..00` for point-at-infinity"
  example: "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a"
```