### PR TITLE
`investigated` -> `inspected` in `libnimbus_lc` docs

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -1142,7 +1142,7 @@ void ETHTransactionsDestroy(ETHTransactions *transactions);
 /**
  * Indicates the total number of transactions in a transaction sequence.
  *
- * - Individual transactions may be investigated using `ETHTransactionsGet`.
+ * - Individual transactions may be inspected using `ETHTransactionsGet`.
  *
  * @param      transactions         Transaction sequence.
  *
@@ -1352,7 +1352,7 @@ const ETHAccessList *ETHTransactionGetAccessList(const ETHTransaction *transacti
 /**
  * Indicates the total number of access tuples in a transaction access list.
  *
- * - Individual access tuples may be investigated using `ETHAccessListGet`.
+ * - Individual access tuples may be inspected using `ETHAccessListGet`.
  *
  * @param      accessList           Transaction access list.
  *
@@ -1401,7 +1401,7 @@ const ETHExecutionAddress *ETHAccessTupleGetAddress(const ETHAccessTuple *access
 /**
  * Indicates the total number of storage keys in an access tuple.
  *
- * - Individual storage keys may be investigated using
+ * - Individual storage keys may be inspected using
  *   `ETHAccessTupleGetStorageKey`.
  *
  * @param      accessTuple          Access tuple.
@@ -1446,7 +1446,7 @@ const uint64_t *ETHTransactionGetMaxFeePerBlobGas(const ETHTransaction *transact
 /**
  * Indicates the total number of blob versioned hashes of a transaction.
  *
- * - Individual blob versioned hashes may be investigated using
+ * - Individual blob versioned hashes may be inspected using
  *   `ETHTransactionGetBlobVersionedHash`.
  *
  * @param      transaction          Transaction.
@@ -1553,7 +1553,7 @@ void ETHReceiptsDestroy(ETHReceipts *receipts);
 /**
  * Indicates the total number of receipts in a receipt sequence.
  *
- * - Individual receipts may be investigated using `ETHReceiptsGet`.
+ * - Individual receipts may be inspected using `ETHReceiptsGet`.
  *
  * @param      receipts             Receipt sequence.
  *
@@ -1677,7 +1677,7 @@ const ETHLogs *ETHReceiptGetLogs(const ETHReceipt *receipt);
 /**
  * Indicates the total number of logs in a log sequence.
  *
- * - Individual logs may be investigated using `ETHLogsGet`.
+ * - Individual logs may be inspected using `ETHLogsGet`.
  *
  * @param      logs                 Log sequence.
  *
@@ -1725,7 +1725,7 @@ const ETHExecutionAddress *ETHLogGetAddress(const ETHLog *log);
 /**
  * Indicates the total number of topics in a log.
  *
- * - Individual topics may be investigated using `ETHLogGetTopic`.
+ * - Individual topics may be inspected using `ETHLogGetTopic`.
  *
  * @param      log                  Log.
  *
@@ -1788,7 +1788,7 @@ const void *ETHReceiptGetBytes(
 /**
  * Indicates the total number of withdrawals in a withdrawal sequence.
  *
- * - Individual withdrawals may be investigated using `ETHWithdrawalsGet`.
+ * - Individual withdrawals may be inspected using `ETHWithdrawalsGet`.
  *
  * @param      withdrawals          Withdrawal sequence.
  *

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1650,7 +1650,7 @@ func ETHTransactionsGetCount(
     transactions: ptr seq[ETHTransaction]): cint {.exported.} =
   ## Indicates the total number of transactions in a transaction sequence.
   ##
-  ## * Individual transactions may be investigated using `ETHTransactionsGet`.
+  ## * Individual transactions may be inspected using `ETHTransactionsGet`.
   ##
   ## Parameters:
   ## * `transactions` - Transaction sequence.
@@ -1871,7 +1871,7 @@ func ETHAccessListGetCount(
     accessList: ptr seq[ETHAccessTuple]): cint {.exported.} =
   ## Indicates the total number of access tuples in a transaction access list.
   ##
-  ## * Individual access tuples may be investigated using `ETHAccessListGet`.
+  ## * Individual access tuples may be inspected using `ETHAccessListGet`.
   ##
   ## Parameters:
   ## * `accessList` - Transaction access list.
@@ -1917,7 +1917,7 @@ func ETHAccessTupleGetNumStorageKeys(
     accessTuple: ptr ETHAccessTuple): cint {.exported.} =
   ## Indicates the total number of storage keys in an access tuple.
   ##
-  ## * Individual storage keys may be investigated using
+  ## * Individual storage keys may be inspected using
   ##   `ETHAccessTupleGetStorageKey`.
   ##
   ## Parameters:
@@ -1964,7 +1964,7 @@ func ETHTransactionGetNumBlobVersionedHashes(
     transaction: ptr ETHTransaction): cint {.exported.} =
   ## Indicates the total number of blob versioned hashes of a transaction.
   ##
-  ## * Individual blob versioned hashes may be investigated using
+  ## * Individual blob versioned hashes may be inspected using
   ##   `ETHTransactionGetBlobVersionedHash`.
   ##
   ## Parameters:
@@ -2219,7 +2219,7 @@ func ETHReceiptsGetCount(
     receipts: ptr seq[ETHReceipt]): cint {.exported.} =
   ## Indicates the total number of receipts in a receipt sequence.
   ##
-  ## * Individual receipts may be investigated using `ETHReceiptsGet`.
+  ## * Individual receipts may be inspected using `ETHReceiptsGet`.
   ##
   ## Parameters:
   ## * `receipts` - Receipt sequence.
@@ -2346,7 +2346,7 @@ func ETHLogsGetCount(
     logs: ptr seq[ETHLog]): cint {.exported.} =
   ## Indicates the total number of logs in a log sequence.
   ##
-  ## * Individual logs may be investigated using `ETHLogsGet`.
+  ## * Individual logs may be inspected using `ETHLogsGet`.
   ##
   ## Parameters:
   ## * `logs` - Log sequence.
@@ -2391,7 +2391,7 @@ func ETHLogGetNumTopics(
     log: ptr ETHLog): cint {.exported.} =
   ## Indicates the total number of topics in a log.
   ##
-  ## * Individual topics may be investigated using `ETHLogGetTopic`.
+  ## * Individual topics may be inspected using `ETHLogGetTopic`.
   ##
   ## Parameters:
   ## * `log` - Log.
@@ -2465,7 +2465,7 @@ func ETHWithdrawalsGetCount(
     withdrawals: ptr seq[ETHWithdrawal]): cint {.exported.} =
   ## Indicates the total number of withdrawals in a withdrawal sequence.
   ##
-  ## * Individual withdrawals may be investigated using `ETHWithdrawalsGet`.
+  ## * Individual withdrawals may be inspected using `ETHWithdrawalsGet`.
   ##
   ## Parameters:
   ## * `withdrawals` - Withdrawal sequence.


### PR DESCRIPTION
Consistently use `inspected` instead of `investigted` terminology in documentation of `libnimbus_lc` functions.