### PR TITLE
pin specific setup-msys2 using node16 rather than node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@3a80e3a675f6a4aeef450a4235dc97366f862e15
         with:
           path-type: inherit
           install: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: MSYS2 (Windows amd64)
         if: runner.os == 'Windows' && matrix.target.cpu == 'amd64'
-        uses: msys2/setup-msys2@3a80e3a675f6a4aeef450a4235dc97366f862e15
+        uses: msys2/setup-msys2@v2.20.1
         with:
           path-type: inherit
           install: >-


### PR DESCRIPTION
```
##[debug]action.yml for action: '/github-runner/workspace/_actions/msys2/setup-msys2/v2/action.yml'.
Error: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter ''using: node20' is not supported, use 'docker', 'node12' or 'node16' instead.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Fail to load msys2/setup-msys2/v2/action.yml
##[debug]System.ArgumentException: Fail to load msys2/setup-msys2/v2/action.yml
##[debug]   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
##[debug]   at GitHub.Runner.Worker.ActionManager.PrepareRepositoryActionAsync(IExecutionContext executionContext, ActionStep repositoryAction)
##[debug]   at GitHub.Runner.Worker.ActionManager.PrepareActionsRecursiveAsync(IExecutionContext executionContext, PrepareActionsState state, IEnumerable`1 actions, Int32 depth, Guid parentStepId)
##[debug]   at GitHub.Runner.Worker.ActionManager.PrepareActionsAsync(IExecutionContext executionContext, IEnumerable`1 steps, Guid rootStepId)
##[debug]   at GitHub.Runner.Worker.JobExtension.InitializeJob(IExecutionContext jobContext, AgentJobRequestMessage message)
```
e.g., from https://github.com/status-im/nimbus-eth2/actions/runs/6660794454/job/18108988926

This is because https://github.com/actions/runner/releases/tag/v2.308.0 introduces `node20` support, while that (and some other) GitHub Action runner uses an older version:
```
##[debug]Starting: Set up job
Current runner version: '2.303.0'
Runner name: 'runner-nimbus-eth2-linux-01'
Runner group name: 'Default'
Machine name: 'linux-01'
```

This reverts `setup-msys2` to a commit which still uses `node16`.