### PR TITLE
replace `ValidIpAddress` with `IpAddress` in configurations

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -36,7 +36,7 @@ from consensus_object_pools/block_pools_types_light_client
 
 export
   uri, nat, enr,
-  defaultEth2TcpPort, enabledLogLevel, ValidIpAddress,
+  defaultEth2TcpPort, enabledLogLevel,
   defs, parseCmdArg, completeCmdArg, network_metadata,
   el_conf, network, BlockHashOrNumber,
   confTomlDefs, confTomlNet, confTomlUri,
@@ -47,8 +47,8 @@ declareGauge network_name, "network name", ["name"]
 const
   # TODO: How should we select between IPv4 and IPv6
   # Maybe there should be a config option for this.
-  defaultListenAddress* = (static ValidIpAddress.init("0.0.0.0"))
-  defaultAdminListenAddress* = (static ValidIpAddress.init("127.0.0.1"))
+  defaultListenAddress* = (static parseIpAddress("0.0.0.0"))
+  defaultAdminListenAddress* = (static parseIpAddress("127.0.0.1"))
   defaultSigningNodeRequestTimeout* = 60
   defaultBeaconNode* = "http://127.0.0.1:" & $defaultEth2RestPort
   defaultBeaconNodeUri* = parseUri(defaultBeaconNode)
@@ -292,7 +292,7 @@ type
         desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
         defaultValue: defaultListenAddress
         defaultValueDesc: $defaultListenAddressDesc
-        name: "listen-address" .}: ValidIpAddress
+        name: "listen-address" .}: IpAddress
 
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
@@ -408,7 +408,7 @@ type
         desc: "Listening address of the metrics server"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "metrics-address" .}: ValidIpAddress
+        name: "metrics-address" .}: IpAddress
 
       metricsPort* {.
         desc: "Listening HTTP port of the metrics server"
@@ -449,7 +449,7 @@ type
         # Deprecated > 1.7.0
         hidden
         desc: "Deprecated for removal"
-        name: "rpc-address" .}: Option[ValidIpAddress]
+        name: "rpc-address" .}: Option[IpAddress]
 
       restEnabled* {.
         desc: "Enable the REST server"
@@ -466,7 +466,7 @@ type
         desc: "Listening address of the REST server"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "rest-address" .}: ValidIpAddress
+        name: "rest-address" .}: IpAddress
 
       restAllowedOrigin* {.
         desc: "Limit the access to the REST API to a particular hostname " &
@@ -520,7 +520,7 @@ type
         desc: "Listening port for the REST keymanager API"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "keymanager-address" .}: ValidIpAddress
+        name: "keymanager-address" .}: IpAddress
 
       keymanagerAllowedOrigin* {.
         desc: "Limit the access to the Keymanager API to a particular hostname " &
@@ -776,7 +776,7 @@ type
       of RecordCmd.create:
         ipExt* {.
           desc: "External IP address"
-          name: "ip" .}: ValidIpAddress
+          name: "ip" .}: IpAddress
 
         tcpPortExt* {.
           desc: "External TCP port"
@@ -973,7 +973,7 @@ type
       desc: "Listening port for the REST keymanager API"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "keymanager-address" .}: ValidIpAddress
+      name: "keymanager-address" .}: IpAddress
 
     keymanagerAllowedOrigin* {.
       desc: "Limit the access to the Keymanager API to a particular hostname " &
@@ -993,7 +993,7 @@ type
       desc: "Listening address of the metrics server (BETA)"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "metrics-address" .}: ValidIpAddress
+      name: "metrics-address" .}: IpAddress
 
     metricsPort* {.
       desc: "Listening HTTP port of the metrics server (BETA)"
@@ -1091,7 +1091,7 @@ type
       desc: "Listening address of the REST HTTP server"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "bind-address" .}: ValidIpAddress
+      name: "bind-address" .}: IpAddress
 
     tlsEnabled* {.
       desc: "Use secure TLS communication for REST server"

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -65,7 +65,7 @@ type LightClientConf* = object
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
     defaultValue: defaultListenAddress
     defaultValueDesc: $defaultListenAddressDesc
-    name: "listen-address" .}: ValidIpAddress
+    name: "listen-address" .}: IpAddress
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2315,7 +2315,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
       cfg, getBeaconTime().slotOrZero.epoch, genesis_validators_root)
 
     (extIp, extTcpPort, extUdpPort) = try: setupAddress(
-      config.nat, config.listenAddress, config.tcpPort, config.udpPort, clientId)
+      config.nat, ValidIpAddress.init config.listenAddress, config.tcpPort,
+      config.udpPort, clientId)
     except CatchableError as exc: raise exc
     except Exception as exc: raiseAssert exc.msg
 
@@ -2337,7 +2338,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
         info "Adding privileged direct peer", peerId, address
       res
 
-    hostAddress = tcpEndPoint(config.listenAddress, config.tcpPort)
+    hostAddress = tcpEndPoint(
+      ValidIpAddress.init config.listenAddress, config.tcpPort)
     announcedAddresses = if extIp.isNone() or extTcpPort.isNone(): @[]
                          else: @[tcpEndPoint(extIp.get(), extTcpPort.get())]
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2057,7 +2057,7 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     let record = enr.Record.init(
       config.seqNumber,
       netKeys.seckey.asEthKey,
-      some(config.ipExt),
+      some(ValidIpAddress.init config.ipExt),
       some(config.tcpPortExt),
       some(config.udpPortExt),
       fieldPairs).expect("Record within size limits")

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -117,9 +117,9 @@ type
 
       bootstrapAddress* {.
         desc: "The public IP address that will be advertised as a bootstrap node for the testnet"
-        defaultValue: init(ValidIpAddress, defaultAdminListenAddress)
+        defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "bootstrap-address" .}: ValidIpAddress
+        name: "bootstrap-address" .}: IpAddress
 
       bootstrapPort* {.
         desc: "The TCP/UDP port that will be used by the bootstrap node"
@@ -194,9 +194,9 @@ type
 
       enrAddress* {.
         desc: "The public IP address of that ENR"
-        defaultValue: init(ValidIpAddress, defaultAdminListenAddress)
+        defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "enr-address" .}: ValidIpAddress
+        name: "enr-address" .}: IpAddress
 
       enrPort* {.
         desc: "The TCP/UDP port of that ENR"


### PR DESCRIPTION
Removes warnings from `make test`:
```
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(459, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(461, 24) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(459, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(461, 24) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_pool.nim(70, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_pool.nim(133, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_pool.nim(165, 25) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(912, 50) template/generic instantiation of `configurationRtti` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(709, 19) template/generic instantiation of `setField` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(686, 16) template/generic instantiation of `makeDefaultValue` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(632, 10) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/tests/test_validator_pool.nim(70, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_pool.nim(133, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_pool.nim(165, 25) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_pool.nim(70, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_pool.nim(133, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_pool.nim(165, 25) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_client.nim(240, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_client.nim(255, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_client.nim(259, 34) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_client.nim(240, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_client.nim(255, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_client.nim(259, 34) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_client.nim(240, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_client.nim(296, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_client.nim(300, 34) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_validator_client.nim(240, 7) template/generic instantiation of `suite` from here
nimbus-eth2/tests/test_validator_client.nim(296, 13) template/generic instantiation of `asyncTest` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(18, 16) template/generic instantiation of `async` from here
nimbus-eth2/vendor/nim-chronos/chronos/unittest2/asynctests.nim(19, 9) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_validator_client.nim(300, 34) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(551, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(553, 33) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_keymanager_api.nim(279, 40) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_keymanager_api.nim(312, 44) template/generic instantiation of `async` from here
nimbus-eth2/tests/test_keymanager_api.nim(313, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_keymanager_api.nim(318, 56) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/tests/test_keymanager_api.nim(312, 44) template/generic instantiation of `async` from here
nimbus-eth2/tests/test_keymanager_api.nim(313, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/tests/test_keymanager_api.nim(318, 56) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
```

and warnings from `make` (all):
```
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(459, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(461, 24) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(459, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_signing_node.nim(461, 24) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(551, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(553, 33) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(551, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_validator_client.nim(553, 33) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/nimbus_light_client.nim(25, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_light_client.nim(40, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_light_client.nim(25, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_light_client.nim(40, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(51, 45) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(52, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(121, 3) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(51, 45) template/generic instantiation of `async` from here
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(52, 3) template/generic instantiation of `setResult` from here
nimbus-eth2/beacon_chain/validators/message_router_mev.nim(121, 3) Warning: unreachable code after 'return' statement or '{.noReturn.}' proc [UnreachableCode]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1762, 3) Warning: use exitprocs.addExitProc; addQuitProc is deprecated [Deprecated]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1970, 7) Warning: Please use MetricsHttpServerRef API; startMetricsHttpServer is deprecated [Deprecated]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(912, 50) template/generic instantiation of `configurationRtti` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(709, 19) template/generic instantiation of `setField` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(686, 16) template/generic instantiation of `makeDefaultValue` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(632, 10) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(218, 18) template/generic instantiation of `addConfigFile` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(860, 39) template/generic instantiation of `loadFile` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization.nim(156, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(499, 8) template/generic instantiation of `decodeInlineTable` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(377, 19) template/generic instantiation of `fieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(256, 34) template/generic instantiation of `makeFieldReadersTable` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(218, 26) template/generic instantiation of `enumAllSerializedFields` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(152, 32) template/generic instantiation of `enumAllSerializedFieldsImpl` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(235, 52) template/generic instantiation of `readFieldIMPL` from here
nimbus-eth2/vendor/nim-serialization/serialization/object_serialization.nim(203, 13) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(31, 9) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(445, 19) template/generic instantiation of `readValue` from here
nimbus-eth2/vendor/nim-serialization/serialization.nim(30, 19) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(912, 50) template/generic instantiation of `configurationRtti` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(709, 19) template/generic instantiation of `setField` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(686, 16) template/generic instantiation of `makeDefaultValue` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(632, 10) Warning: The 'ValidIpAddress' type doesn't have a valid default value [UnsafeDefault]
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2250, 1) template/generic instantiation of `programMain` from here
nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2251, 35) template/generic instantiation of `makeBannerAndConfig` from here
nimbus-eth2/beacon_chain/nimbus_binary_common.nim(211, 13) template/generic instantiation of `load` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(1181, 13) template/generic instantiation of `loadImpl` from here
nimbus-eth2/vendor/nim-confutils/confutils.nim(937, 23) Warning: Cannot prove that 'result' is initialized. This will become a compile time error in the future. [ProveInit]
```