### PR TITLE
initialize KZG crypto before starting network

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2015,7 +2015,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
       bnStatus = BeaconNodeStatus.Stopping
     c_signal(ansi_c.SIGTERM, SIGTERMHandler)
 
-  if node.dag.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
+  if metadata.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
     let res =
       if config.trustedSetupFile.isNone:
         conf.loadKzgTrustedSetup()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2015,8 +2015,6 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
       bnStatus = BeaconNodeStatus.Stopping
     c_signal(ansi_c.SIGTERM, SIGTERMHandler)
 
-  let node = waitFor BeaconNode.init(rng, config, metadata)
-
   if node.dag.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
     let res =
       if config.trustedSetupFile.isNone:
@@ -2025,6 +2023,8 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
         conf.loadKzgTrustedSetup(config.trustedSetupFile.get)
     if res.isErr():
       raiseAssert res.error()
+
+  let node = waitFor BeaconNode.init(rng, config, metadata)
 
   if bnStatus == BeaconNodeStatus.Stopping:
     return


### PR DESCRIPTION
Move KZG trusted setup initialization before `BeaconNode.init` to avoid edge case where network message is received and processed before crypto library has been properly initialized. Followup from #4870.