### PR TITLE
allow to pass trusted node sync options during BN startup

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -335,6 +335,30 @@ type
         defaultValue: false
         name: "enable-yamux" .}: bool
 
+      # A copy of the TNS options also exists for `BNStartUpCmd.trustedNodeSync`
+
+      tnsTrustedNodeUrl* {.
+        desc: "URL of the trusted REST API to sync from"
+        name: "trusted-node-url" .}: Option[string]
+
+      tnsStateId* {.
+        desc: "State id to sync to - this can be \"finalized\", a slot number or state hash or \"head\""
+        name: "state-id" .}: Option[string]
+
+      tnsBackfillBlocks* {.
+        desc: "Backfill blocks directly from REST server instead of fetching via API"
+        defaultValue: true
+        name: "backfill" .}: bool
+
+      tnsReindex* {.
+        desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
+        defaultValue: false .}: bool
+
+      tnsDownloadDepositSnapshot* {.
+        desc: "Also try to download a snapshot of the deposit contract state"
+        defaultValue: false
+        name: "with-deposit-snapshot" .}: bool
+
       weakSubjectivityCheckpoint* {.
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
@@ -826,6 +850,8 @@ type
           argument .}: OutFile
 
     of BNStartUpCmd.trustedNodeSync:
+      # A copy of the TNS options also exists for `BNStartUpCmd.noCommand`
+
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
         defaultValue: defaultBeaconNode

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -335,43 +335,31 @@ type
         defaultValue: false
         name: "enable-yamux" .}: bool
 
-      # A copy of the TNS options also exists for `BNStartUpCmd.trustedNodeSync`
-
-      tnsTrustedNodeUrl* {.
-        desc: "URL of the trusted REST API to sync from"
-        name: "trusted-node-url" .}: Option[string]
-
-      tnsStateId* {.
-        desc: "State id to sync to - this can be \"finalized\", a slot number or state hash or \"head\""
-        name: "state-id" .}: Option[string]
-
-      tnsBackfillBlocks* {.
-        desc: "Backfill blocks directly from REST server instead of fetching via API"
-        defaultValue: true
-        name: "backfill" .}: bool
-
-      tnsReindex* {.
-        desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
-        defaultValue: false .}: bool
-
-      tnsDownloadDepositSnapshot* {.
-        desc: "Also try to download a snapshot of the deposit contract state"
-        defaultValue: false
-        name: "with-deposit-snapshot" .}: bool
-
       weakSubjectivityCheckpoint* {.
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
 
+      externalBeaconApiUrl* {.
+        desc: "External beacon API to use for syncing (on empty database)"
+        name: "external-beacon-api-url" .}: Option[string]
+
       syncLightClient* {.
-        desc: "Accelerate execution layer sync using light client"
+        hidden
+        desc: "Accelerate sync using light client"
         defaultValue: true
         name: "sync-light-client" .}: bool
 
       trustedBlockRoot* {.
-        hidden
-        desc: "Recent trusted finalized block root to initialize light client from"
+        desc: "Recent trusted finalized block root to sync from external " &
+              "beacon API (with `--external-beacon-api-url`). " &
+              "Uses the light client sync protocol to obtain the latest " &
+              "finalized checkpoint (LC is initialized from trusted block root)"
         name: "trusted-block-root" .}: Option[Eth2Digest]
+
+      trustedStateRoot* {.
+        desc: "Recent trusted finalized state root to sync from external " &
+              "beacon API (with `--external-beacon-api-url`)"
+        name: "trusted-state-root" .}: Option[Eth2Digest]
 
       finalizedCheckpointState* {.
         desc: "SSZ file specifying a recent finalized state"
@@ -850,8 +838,6 @@ type
           argument .}: OutFile
 
     of BNStartUpCmd.trustedNodeSync:
-      # A copy of the TNS options also exists for `BNStartUpCmd.noCommand`
-
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
         defaultValue: defaultBeaconNode

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -344,7 +344,6 @@ type
         name: "external-beacon-api-url" .}: Option[string]
 
       syncLightClient* {.
-        hidden
         desc: "Accelerate sync using light client"
         defaultValue: true
         name: "sync-light-client" .}: bool

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -555,6 +555,18 @@ proc init*(T: type BeaconNode,
     )
     db = BeaconChainDB.new(config.databaseDir, cfg, inMemory = false)
 
+  if config.tnsTrustedNodeUrl.isSome and ChainDAGRef.isInitialized(db).isErr:
+    await db.doRunTrustedNodeSync(
+      metadata,
+      config.databaseDir,
+      config.eraDir,
+      config.tnsTrustedNodeUrl.get,
+      config.tnsStateId,
+      config.trustedBlockRoot,
+      config.tnsBackfillBlocks,
+      config.tnsReindex,
+      config.tnsDownloadDepositSnapshot)
+
   if config.finalizedCheckpointBlock.isSome:
     warn "--finalized-checkpoint-block has been deprecated, ignoring"
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -555,17 +555,25 @@ proc init*(T: type BeaconNode,
     )
     db = BeaconChainDB.new(config.databaseDir, cfg, inMemory = false)
 
-  if config.tnsTrustedNodeUrl.isSome and ChainDAGRef.isInitialized(db).isErr:
-    await db.doRunTrustedNodeSync(
-      metadata,
-      config.databaseDir,
-      config.eraDir,
-      config.tnsTrustedNodeUrl.get,
-      config.tnsStateId,
-      config.trustedBlockRoot,
-      config.tnsBackfillBlocks,
-      config.tnsReindex,
-      config.tnsDownloadDepositSnapshot)
+  if config.externalBeaconApiUrl.isSome and ChainDAGRef.isInitialized(db).isErr:
+    if config.trustedStateRoot.isNone and config.trustedBlockRoot.isNone:
+      warn "Ignoring `--external-beacon-api-url`, neither " &
+        "`--trusted-block-root` nor `--trusted-state-root` are provided",
+        externalBeaconApiUrl = config.externalBeaconApiUrl.get,
+        trustedBlockRoot = config.trustedBlockRoot,
+        trustedStateRoot = config.trustedStateRoot
+    else:
+      await db.doRunTrustedNodeSync(
+        metadata,
+        config.databaseDir,
+        config.eraDir,
+        config.externalBeaconApiUrl.get,
+        config.trustedStateRoot.map do (x: Eth2Digest) -> string:
+          "0x" & x.data.toHex,
+        config.trustedBlockRoot,
+        backfill = false,
+        reindex = false,
+        downloadDepositSnapshot = false)
 
   if config.finalizedCheckpointBlock.isSome:
     warn "--finalized-checkpoint-block has been deprecated, ignoring"

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -72,6 +72,7 @@ The following options are available:
                                latest finalized checkpoint (LC is initialized from trusted block root).
      --trusted-state-root      Recent trusted finalized state root to sync from external beacon API (with
                                `--external-beacon-api-url`).
+     --sync-light-client       Accelerate sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.
      --genesis-state           SSZ file specifying the genesis state of the network (for networks without a
                                built-in genesis state).

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -65,15 +65,13 @@ The following options are available:
      --enr-auto-update         Discovery can automatically update its ENR with the IP address and UDP port as
                                seen by other nodes it communicates with. This option allows to enable/disable
                                this functionality [=false].
-     --trusted-node-url        URL of the trusted REST API to sync from.
-     --state-id                State id to sync to - this can be "finalized", a slot number or state hash or
-                               "head".
-     --backfill                Backfill blocks directly from REST server instead of fetching via API [=true].
-     --tnsReindex              Recreate historical state index at end of backfill, allowing full history access
-                               (requires full backfill) [=false].
-     --with-deposit-snapshot   Also try to download a snapshot of the deposit contract state [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
-     --sync-light-client       Accelerate execution layer sync using light client [=true].
+     --external-beacon-api-url  External beacon API to use for syncing (on empty database).
+     --trusted-block-root      Recent trusted finalized block root to sync from external beacon API (with
+                               `--external-beacon-api-url`). Uses the light client sync protocol to obtain the
+                               latest finalized checkpoint (LC is initialized from trusted block root).
+     --trusted-state-root      Recent trusted finalized state root to sync from external beacon API (with
+                               `--external-beacon-api-url`).
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.
      --genesis-state           SSZ file specifying the genesis state of the network (for networks without a
                                built-in genesis state).

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -67,12 +67,12 @@ The following options are available:
                                this functionality [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
      --external-beacon-api-url  External beacon API to use for syncing (on empty database).
+     --sync-light-client       Accelerate sync using light client [=true].
      --trusted-block-root      Recent trusted finalized block root to sync from external beacon API (with
                                `--external-beacon-api-url`). Uses the light client sync protocol to obtain the
                                latest finalized checkpoint (LC is initialized from trusted block root).
      --trusted-state-root      Recent trusted finalized state root to sync from external beacon API (with
                                `--external-beacon-api-url`).
-     --sync-light-client       Accelerate sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.
      --genesis-state           SSZ file specifying the genesis state of the network (for networks without a
                                built-in genesis state).

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -65,6 +65,13 @@ The following options are available:
      --enr-auto-update         Discovery can automatically update its ENR with the IP address and UDP port as
                                seen by other nodes it communicates with. This option allows to enable/disable
                                this functionality [=false].
+     --trusted-node-url        URL of the trusted REST API to sync from.
+     --state-id                State id to sync to - this can be "finalized", a slot number or state hash or
+                               "head".
+     --backfill                Backfill blocks directly from REST server instead of fetching via API [=true].
+     --tnsReindex              Recreate historical state index at end of backfill, allowing full history access
+                               (requires full backfill) [=false].
+     --with-deposit-snapshot   Also try to download a snapshot of the deposit contract state [=false].
      --weak-subjectivity-checkpoint  Weak subjectivity checkpoint in the format block_root:epoch_number.
      --sync-light-client       Accelerate execution layer sync using light client [=true].
      --finalized-checkpoint-state  SSZ file specifying a recent finalized state.

--- a/docs/the_nimbus_book/src/start-syncing.md
+++ b/docs/the_nimbus_book/src/start-syncing.md
@@ -82,3 +82,49 @@ More information is available from the [options](./options.md) page.
 ## Keep track of your sync progress
 
 See [here](./keep-an-eye.md#keep-track-of-your-syncing-progress) for how to keep track of your sync progress.
+
+## Checkpoint sync
+
+!!! note ""
+    This feature is available from `v23.11.0` onwards.
+
+You can use an existing synced node or a third-party service to accelerate sync significantly. Instead of downloading and verifying the entire blockchain, you can point Nimbus to a trusted block.
+
+!!! warning
+    Selecting a block from an untrusted source or using an outdated block or state may lead to Nimbus syncing to an unexpected state. Especially when [running a validator](./run-a-validator.md), it is vital to pick a recent trusted block for checkpoint sync, and to verify that Nimbus is synced to the correct state before starting validator duties.
+
+!!! note
+    The Nimbus database must be empty to use checkpoint sync. When using a pre-existing database, checkpoint sync options are ignored.
+
+!!! tip
+    A list of community-operated checkpoint sync nodes can be found [here](https://eth-clients.github.io/checkpoint-sync-endpoints/).
+
+To use checkpoint sync, run the following commands (inserting the checkpoint sync endpoint and your own trusted block root):
+
+=== "Holesky"
+    ```sh
+    CHECKPOINT_SYNC_ENDPOINT=http://127.0.0.1:8551
+    TRUSTED_BLOCK_ROOT=0x1234567890123456789012345678901234567890123456789012345678901234
+    ./run-holesky-beacon-node.sh \
+        --external-beacon-api-url=$CHECKPOINT_SYNC_ENDPOINT \
+        --trusted-block-root=$TRUSTED_BLOCK_ROOT
+    ```
+
+=== "Mainnet"
+    ```sh
+    TRUSTED_BLOCK_ROOT=0x1234567890123456789012345678901234567890123456789012345678901234
+    ./run-mainnet-beacon-node.sh \
+        --external-beacon-api-url=$CHECKPOINT_SYNC_ENDPOINT \
+        --trusted-block-root=$TRUSTED_BLOCK_ROOT
+    ```
+
+The following [configuration options](./options.md) control checkpoint sync behaviour:
+
+| Option                                   | Description |
+|------------------------------------------|-------------|
+| <nobr>`--external-beacon-api-url`</nobr> | <ul><li>External beacon API to use for checkpoint sync</li></ul> |
+| <nobr>`--trusted-block-root`</nobr>      | <ul><li>Recent trusted finalized block root to sync from external beacon API</li><li>Uses the [light client sync protocol](https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/altair/light-client/sync-protocol.md) to obtain the latest finalized checkpoint</li></ul> |
+| <nobr>`--trusted-state-root`</nobr>      | <ul><li>Recent trusted finalized state root to sync from external beacon API</li><li>Takes precedence over `--trusted-block-root` if both are specified</li></ul> |
+
+!!! info
+    If the external beacon API does not support serving [light client data](./light-client-data.md), use the `--trusted-state-root` option instead of `--trusted-block-root`.

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -61,6 +61,9 @@ After this the application will terminate and you can now [start the beacon node
     Because trusted node sync by default copies blocks via REST, you may hit API limits if you are using a third-party provider.
     If this happens to you, you may need to use the `--backfill` option to [delay the backfill of the block history](./trusted-node-sync.md#delay-block-history-backfill).
 
+!!! note
+    Since `v23.11.0` onward, it is possible to have the beacon node start immediately after trusted node sync completes by removing the `trustedNodeSync` word of the command. If the database is already initialized, the `--trusted-node-url` option is ignored.
+
 
 ## Verify you synced the correct chain
 

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -61,9 +61,6 @@ After this the application will terminate and you can now [start the beacon node
     Because trusted node sync by default copies blocks via REST, you may hit API limits if you are using a third-party provider.
     If this happens to you, you may need to use the `--backfill` option to [delay the backfill of the block history](./trusted-node-sync.md#delay-block-history-backfill).
 
-!!! note
-    Since `v23.11.0` onward, it is possible to have the beacon node start immediately after trusted node sync completes by removing the `trustedNodeSync` word of the command. If the database is already initialized, the `--trusted-node-url` option is ignored.
-
 
 ## Verify you synced the correct chain
 


### PR DESCRIPTION
Using trusted node sync currently requires to run two commands - first the `trustedNodeSync` command to initialize the database, followed by the regular startup command to continue syncing.

The `trustedNodeSync` options are now also available during regular startup, and are used when the database is empty to simplify setting up a new Nimbus beacon node. This also aligns behaviour closer with other Ethereum consensus implementations.

The new logic only applies if the database has not yet been initialized; same as before. Also, the database needs to be removed under the same conditions as before when a fresh sync is desired.