### PR TITLE
libp2p: revert scoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	path = vendor/nim-libp2p
 	url = https://github.com/status-im/nim-libp2p.git
 	ignore = untracked
-	branch = unstable
+	branch = b2eac7e-and-revert-c6aa085
 [submodule "vendor/nimbus-build-system"]
 	path = vendor/nimbus-build-system
 	url = https://github.com/status-im/nimbus-build-system.git


### PR DESCRIPTION
New IWANT duplicate handling contains a down-scoring feature which is suspected of causing gossip mesh problems on certain setups - this PR rolls back that scoring function