### PR TITLE
align `Blobs` limit for SSZ transport

### DIFF
--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -38,7 +38,7 @@ const
 
 type
   KzgCommitments* = List[KzgCommitment, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
-  Blobs* = List[Blob, Limit MAX_BLOBS_PER_BLOCK]
+  Blobs* = List[Blob, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
 
   # TODO this apparently is suppposed to be SSZ-equivalent to Bytes32, but
   # current spec doesn't ever SSZ-serialize it or hash_tree_root it


### PR DESCRIPTION
Capacity should be set to theoretical limit to ensure correct hash root. Actual length may be shorter. Only use is `ExecutionPayloadForSigning` so it doesn't matter yet in practice, but still worth fixing.