### PR TITLE
introduce `BlobId` type for tracking blob subnets

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -275,7 +275,7 @@ proc processSignedBeaconBlock*(
 
 proc processSignedBlobSidecar*(
     self: var Eth2Processor, src: MsgSource,
-    signedBlobSidecar: deneb.SignedBlobSidecar, idx: BlobIndex): ValidationRes =
+    signedBlobSidecar: deneb.SignedBlobSidecar, subnet_id: BlobId): ValidationRes =
   let
     wallTime = self.getCurrentBeaconTime()
     (afterGenesis, wallSlot) = wallTime.toSlot()
@@ -296,7 +296,7 @@ proc processSignedBlobSidecar*(
 
   let v =
     self.dag.validateBlobSidecar(self.quarantine, self.blobQuarantine,
-                                 signedBlobSidecar, wallTime, idx)
+                                 signedBlobSidecar, wallTime, subnet_id)
 
   if v.isErr():
     debug "Dropping blob", error = v.error()

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -305,12 +305,12 @@ template validateBeaconBlockBellatrix(
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
 proc validateBlobSidecar*(
     dag: ChainDAGRef, quarantine: ref Quarantine,
-    blobQuarantine: ref BlobQuarantine,sbs: SignedBlobSidecar,
-    wallTime: BeaconTime, idx: BlobIndex): Result[void, ValidationError] =
+    blobQuarantine: ref BlobQuarantine, sbs: SignedBlobSidecar,
+    wallTime: BeaconTime, subnet_id: BlobId): Result[void, ValidationError] =
 
   # [REJECT] The sidecar is for the correct topic --
   # i.e. sidecar.index matches the topic {index}.
-  if sbs.message.index != idx:
+  if sbs.message.index != subnet_id:
     return dag.checkedReject("SignedBlobSidecar: mismatched gossip topic index")
 
   if dag.getBlockRef(sbs.message.block_root).isSome():

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2678,7 +2678,7 @@ proc broadcastBeaconBlock*(
   node.broadcast(topic, blck)
 
 proc broadcastBlobSidecar*(
-    node: Eth2Node, subnet_id: SubnetId, blob: deneb.SignedBlobSidecar):
+    node: Eth2Node, subnet_id: BlobId, blob: deneb.SignedBlobSidecar):
       Future[SendResult] =
   let
     forkPrefix = node.forkDigestAtEpoch(node.getWallEpoch)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1733,18 +1733,18 @@ proc installMessageValidators(node: BeaconNode) =
                 MsgSource.gossip, msg)))
 
       when consensusFork >= ConsensusFork.Deneb:
-        # blob_sidecar_{index}
+        # blob_sidecar_{subnet_id}
         # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
-        for i in 0 ..< BLOB_SIDECAR_SUBNET_COUNT:
+        for it in BlobId:
           closureScope:  # Needed for inner `proc`; don't lift it out of loop.
-            let idx = i
+            let subnet_id = it
             node.network.addValidator(
-              getBlobSidecarTopic(digest, SubnetId(idx)), proc (
+              getBlobSidecarTopic(digest, subnet_id), proc (
                 signedBlobSidecar: SignedBlobSidecar
               ): ValidationResult =
                 toValidationResult(
                   node.processor[].processSignedBlobSidecar(
-                    MsgSource.gossip, signedBlobSidecar, idx)))
+                    MsgSource.gossip, signedBlobSidecar, subnet_id)))
 
   node.installLightClientMessageValidators()
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -187,6 +187,13 @@ type
     ## The `SubnetId` type is constrained to values in the range
     ## `[0, ATTESTATION_SUBNET_COUNT)` during initialization.
 
+  BlobId* = distinct uint8
+    ## The blob id maps which gossip subscription to use to publish a
+    ## blob sidecar - it is distinct from the CommitteeIndex in particular
+    ##
+    ## The `BlobId` type is constrained to values in the range
+    ## `[0, BLOB_SIDECAR_SUBNET_COUNT)` during initialization.
+
   # BitVector[4] in the spec, ie 4 bits which end up encoded as a byte for
   # SSZ / hashing purposes
   JustificationBits* = distinct uint8
@@ -603,6 +610,7 @@ template makeLimitedU64*(T: untyped, limit: uint64) =
 
 makeLimitedU64(CommitteeIndex, MAX_COMMITTEES_PER_SLOT)
 makeLimitedU64(SubnetId, ATTESTATION_SUBNET_COUNT)
+makeLimitedU64(BlobId, BLOB_SIDECAR_SUBNET_COUNT)
 
 const
   validatorIndexLimit = min(uint64(int32.high), VALIDATOR_REGISTRY_LIMIT)

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -100,14 +100,14 @@ func getSyncCommitteeContributionAndProofTopic*(forkDigest: ForkDigest): string 
   ## For subscribing and unsubscribing to/from a subnet.
   eth2Prefix(forkDigest) & "sync_committee_contribution_and_proof/ssz_snappy"
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/p2p-interface.md#blob_sidecar_index
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
 func getBlobSidecarTopic*(forkDigest: ForkDigest,
-                          subnet_id: SubnetId): string =
+                          subnet_id: BlobId): string =
   eth2Prefix(forkDigest) & "blob_sidecar_" & $subnet_id & "/ssz_snappy"
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/deneb/validator.md#sidecar
-func compute_subnet_for_blob_sidecar*(blob_index: BlobIndex): SubnetId =
-  SubnetId(blob_index mod BLOB_SIDECAR_SUBNET_COUNT)
+func compute_subnet_for_blob_sidecar*(blob_index: BlobIndex): BlobId =
+  BlobId(blob_index mod BLOB_SIDECAR_SUBNET_COUNT)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/altair/light-client/p2p-interface.md#light_client_finality_update
 func getLightClientFinalityUpdateTopic*(forkDigest: ForkDigest): string =
@@ -220,5 +220,5 @@ func getSyncSubnets*(
   res
 
 iterator blobSidecarTopics*(forkDigest: ForkDigest): string =
-  for i in 0.SubnetId ..< static(BLOB_SIDECAR_SUBNET_COUNT.SubnetId):
-    yield getBlobSidecarTopic(forkDigest, i)
+  for subnet_id in BlobId:
+    yield getBlobSidecarTopic(forkDigest, subnet_id)

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -77,7 +77,7 @@ suite "Honest validator":
         "/eth2/00000000/sync_committee_1/ssz_snappy"
       getSyncCommitteeTopic(forkDigest, SyncSubcommitteeIndex(3)) ==
         "/eth2/00000000/sync_committee_3/ssz_snappy"
-      getBlobSidecarTopic(forkDigest, SubnetId(1)) ==
+      getBlobSidecarTopic(forkDigest, BlobId(1)) ==
         "/eth2/00000000/blob_sidecar_1/ssz_snappy"
       toSeq(blobSidecarTopics(forkDigest)) ==
         ["/eth2/00000000/blob_sidecar_0/ssz_snappy",


### PR DESCRIPTION
Instead of mixing up `SubnetId` (attestation subnet type) for blobs, introduce dedicated `BlobId` type.