### PR TITLE
add dark theme for nimbus.guide

### DIFF
--- a/docs/the_nimbus_book/mkdocs.yml
+++ b/docs/the_nimbus_book/mkdocs.yml
@@ -16,9 +16,20 @@ theme:
     - navigation.top
     - content.tabs.link
   palette:
-    scheme: default
-    primary: orange
-    accent: amber
+    - scheme: default
+      primary: orange
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: black
+      accent: light blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+extra_css:
+  - stylesheets/extra.css
 
 # Support urls previously used by mdbook
 use_directory_urls: false
@@ -29,7 +40,6 @@ docs_dir: src
 
 markdown_extensions:
   - admonition
-  - meta
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true

--- a/docs/the_nimbus_book/src/stylesheets/extra.css
+++ b/docs/the_nimbus_book/src/stylesheets/extra.css
@@ -1,0 +1,6 @@
+[data-md-color-scheme="slate"] {
+    --md-hue: 180;
+    --md-default-bg-color: hsla(var(--md-hue), 0%, 0%, 1);
+    --md-footer-bg-color: hsla(var(--md-hue), 0%, 0%, 1);
+    --md-footer-bg-color--dark: hsla(var(--md-hue), 0%, 0%, 1);
+  }


### PR DESCRIPTION
This adds a dark theme to the `nimbus.guide`, to make it look compatible with `dev.nimbus.team`, i.e. to make it black-and-white.
Unlike `dev.nimbus.team`, some color is still retained (links, notes/tips/warnings, etc.), as it should, IMO — the guide is used more frequently and it is important to have important elements easily visible and distinguishable.

The light theme is still available and it remains the default one.

Here are some screenshots of the new theme:

![](https://i.imgur.com/Wbe8d05.png)

![](https://i.imgur.com/Y3vOMjW.png)