### PR TITLE
skip upcoming FC tests for intentional block reorgs until implemented

### DIFF
--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -354,6 +354,12 @@ proc runTest(suiteName: static[string], path: string, fork: ConsensusFork) =
     "too_late_for_merge",
     "block_lookup_failed",
     "all_valid",
+
+    # TODO intentional reorgs
+    "should_override_forkchoice_update__false",
+    "should_override_forkchoice_update__true",
+    "basic_is_parent_root",
+    "basic_is_head_root",
   ]
 
   test suiteName & " - " & path.relativePath(SszTestsDir):


### PR DESCRIPTION
v1.4.0-beta.4 adds tests for intentional block reorgs. To reflect the implementation status, skip those tests for now and mark them as such.