### PR TITLE
extend `hasBlob` to all blocks from same proposer and slot

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -37,8 +37,8 @@ func put*(quarantine: var BlobQuarantine, blobSidecar: ref BlobSidecar) =
       oldest_blob_key = k
       break
     quarantine.blobs.del oldest_blob_key
-  discard quarantine.blobs.hasKeyOrPut((blobSidecar.block_root,
-                                        blobSidecar.index), blobSidecar)
+  discard quarantine.blobs.hasKeyOrPut(
+    (blobSidecar.block_root, blobSidecar.index), blobSidecar)
 
 func blobIndices*(quarantine: BlobQuarantine, digest: Eth2Digest):
      seq[BlobIndex] =
@@ -48,8 +48,17 @@ func blobIndices*(quarantine: BlobQuarantine, digest: Eth2Digest):
       r.add(i)
   r
 
-func hasBlob*(quarantine: BlobQuarantine, blobSidecar: BlobSidecar): bool =
-  quarantine.blobs.hasKey((blobSidecar.block_root, blobSidecar.index))
+func hasBlob*(
+    quarantine: BlobQuarantine,
+    slot: Slot,
+    proposer_index: uint64,
+    index: BlobIndex): bool =
+  for blob_sidecar in quarantine.blobs.values:
+    if blob_sidecar.slot == slot and
+        blob_sidecar.proposer_index == proposer_index and
+        blob_sidecar.index == index:
+      return true
+  false
 
 func popBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
      seq[ref BlobSidecar] =


### PR DESCRIPTION
`v1.4.0-beta.4` made the Gossip rules more strict and now requires to ignore blobs from other branches if there are equivocating blocks. Those blobs are only requestable via Req/Resp.