### PR TITLE
fix validation of blob index against gossip topic

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -308,18 +308,22 @@ proc validateBlobSidecar*(
     blobQuarantine: ref BlobQuarantine, sbs: SignedBlobSidecar,
     wallTime: BeaconTime, subnet_id: BlobId): Result[void, ValidationError] =
 
-  # [REJECT] The sidecar is for the correct topic --
-  # i.e. sidecar.index matches the topic {index}.
-  if sbs.message.index != subnet_id:
-    return dag.checkedReject("SignedBlobSidecar: mismatched gossip topic index")
+  # [REJECT] The sidecar's index is consistent with `MAX_BLOBS_PER_BLOCK`
+  # -- i.e. `blob_sidecar.index < MAX_BLOBS_PER_BLOCK`
+  if not (sbs.message.index < MAX_BLOBS_PER_BLOCK):
+    return dag.checkedReject("SignedBlobSidecar: index inconsistent")
+
+  # [REJECT] The sidecar is for the correct subnet -- i.e.
+  # `compute_subnet_for_blob_sidecar(blob_sidecar.index) == subnet_id`.
+  if not (compute_subnet_for_blob_sidecar(sbs.message.index) == subnet_id):
+    return dag.checkedReject("SignedBlobSidecar: subnet incorrect")
 
   if dag.getBlockRef(sbs.message.block_root).isSome():
     return errIgnore("SignedBlobSidecar: already have block")
 
   # [IGNORE] The sidecar is not from a future slot (with a
-  # MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. validate that
-  # sidecar.slot <= current_slot (a client MAY queue future sidecars
-  # for processing at the appropriate slot).
+  # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance) -- i.e. validate that
+  # `block_header.slot <= current_slot` (a client MAY queue future sidecars
   if not (sbs.message.slot <=
       (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero):
     return errIgnore("SignedBlobSidecar: slot too high")


### PR DESCRIPTION
In `v1.4.0-alpha.0`, the blob index validation on gossip was changed to use `compute_subnet_for_blob_sidecar` instead of having a separate topic for each individual blob. We updated the spec reference in #5363 without updating the code accordingly. Fixing this now, and also adding the new `MAX_BLOBS_PER_BLOCK` check from `v1.4.0-beta.3` as it shares the theme.