### PR TITLE
do not download Holesky genesis on `git clone`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ endif
 
 # We don't need the `vendor/holesky/public-keys/all.txt` file but fetching it
 # may trigger 'This repository is over its data quota' from GitHub
-GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt
+GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.

--- a/Makefile
+++ b/Makefile
@@ -118,10 +118,9 @@ ifneq ($(OS), Windows_NT)
 PLATFORM_SPECIFIC_TARGETS += gnosis-build
 endif
 
-# We don't need the `vendor/holesky/public-keys/all.txt` and
-# `/custom_config_data/genesis.ssz` files but fetching them
+# We don't need these `vendor/holesky` files but fetching them
 # may trigger 'This repository is over its data quota' from GitHub
-GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz
+GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz,/custom_config_data/parsedBeaconState.json
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,8 @@ ifneq ($(OS), Windows_NT)
 PLATFORM_SPECIFIC_TARGETS += gnosis-build
 endif
 
-# We don't need the `vendor/holesky/public-keys/all.txt` file but fetching it
+# We don't need the `vendor/holesky/public-keys/all.txt` and
+# `/custom_config_data/genesis.ssz` files but fetching them
 # may trigger 'This repository is over its data quota' from GitHub
 GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz
 

--- a/ci/Jenkinsfile.benchmarks
+++ b/ci/Jenkinsfile.benchmarks
@@ -23,7 +23,7 @@ node("metal") {
 				/* source code checkout */
 				checkout scm
 				/* we need to update the submodules before caching kicks in */
-				sh "git -c lfs.fetchexclude=/public-keys/all.txt submodule update --init --recursive"
+				sh "git -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz submodule update --init --recursive"
 			}
 
 			stage("Build") {

--- a/ci/Jenkinsfile.benchmarks
+++ b/ci/Jenkinsfile.benchmarks
@@ -23,7 +23,7 @@ node("metal") {
 				/* source code checkout */
 				checkout scm
 				/* we need to update the submodules before caching kicks in */
-				sh "git -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz submodule update --init --recursive"
+				sh "git -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz,/custom_config_data/parsedBeaconState.json submodule update --init --recursive"
 			}
 
 			stage("Build") {


### PR DESCRIPTION
Holesky genesis.ssz file may be unavailable due to quota limits on `eth-clients/holesky`; do not download it by default during checkout. Nimbus will download it on first startup from a mirror instead.