### PR TITLE
don't explicitly filter removed file parsedBeaconState.json from holesky

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ endif
 
 # We don't need these `vendor/holesky` files but fetching them
 # may trigger 'This repository is over its data quota' from GitHub
-GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz,/custom_config_data/parsedBeaconState.json
+GIT_SUBMODULE_CONFIG := -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz
 
 ifeq ($(NIM_PARAMS),)
 # "variables.mk" was not included, so we update the submodules.

--- a/ci/Jenkinsfile.benchmarks
+++ b/ci/Jenkinsfile.benchmarks
@@ -23,7 +23,7 @@ node("metal") {
 				/* source code checkout */
 				checkout scm
 				/* we need to update the submodules before caching kicks in */
-				sh "git -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz,/custom_config_data/parsedBeaconState.json submodule update --init --recursive"
+				sh "git -c lfs.fetchexclude=/public-keys/all.txt,/custom_config_data/genesis.ssz submodule update --init --recursive"
 			}
 
 			stage("Build") {


### PR DESCRIPTION
It helped, but since https://github.com/eth-clients/holesky/pull/90 and https://github.com/status-im/nimbus-eth2/pull/5574 the file doesn't exist in the upstream repo regardess, so now it's unnecessary.