### PR TITLE
stop calling engine_exchangeTransitionConfigurationV1 with Dencun-ready ELs

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1400,6 +1400,11 @@ proc exchangeConfigWithSingleEL(m: ELManager, connection: ELConnection) {.async.
 
   connection.etcStatus = EtcStatus.match
 
+  # https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#deprecate-engine_exchangetransitionconfigurationv1
+  # Consensus layer clients MUST NOT call this method.
+  if m.eth1Chain.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
+    return
+
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_exchangetransitionconfigurationv1
   let
     ourConf = TransitionConfigurationV1(


### PR DESCRIPTION
https://github.com/ethereum/execution-apis/pull/420

Once Dencun has become the baseline enough that a sufficient portion of the network is running a Dencun-capable EL, all `engine_exchangeTransitionConfigurationV1`-related infrastructure can be removed (e.g., `TransitionConfigurationV1`, etc), but this keeps it in place until then.

It won't be necessary to wait until the very last holdout, because it's mainly to avoid the ELs creating warnings -- and at that point, the fix can be, update your EL client.