### PR TITLE
rm ropsten and rinkleby chain IDs from EL manager

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1380,8 +1380,6 @@ proc exchangeConfigWithSingleEL(m: ELManager, connection: ELConnection) {.async.
         # https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids
         expectedChain = case m.eth1Network.get
           of mainnet: 1.Quantity
-          of ropsten: 3.Quantity
-          of rinkeby: 4.Quantity
           of goerli:  5.Quantity
           of sepolia: 11155111.Quantity   # https://chainid.network/
           of holesky: 17000.Quantity

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -41,8 +41,6 @@ type
 
   Eth1Network* = enum
     mainnet
-    ropsten
-    rinkeby
     goerli
     sepolia
     holesky


### PR DESCRIPTION
I'm not sure Nimbus has ever supported rinkleby, and hadn't ropsten for literal years.