### PR TITLE
bump `nim-eth` to remove `ValidIpAddress` and replace with `IpAddress`

### DIFF
--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -79,7 +79,7 @@ proc loadBootstrapFile*(bootstrapFile: string,
 
 proc new*(T: type Eth2DiscoveryProtocol,
           config: BeaconNodeConf | LightClientConf,
-          enrIp: Option[ValidIpAddress], enrTcpPort, enrUdpPort: Option[Port],
+          enrIp: Option[IpAddress], enrTcpPort, enrUdpPort: Option[Port],
           pk: PrivateKey,
           enrFields: openArray[(string, seq[byte])], rng: ref HmacDrbgContext):
           T =

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1806,7 +1806,7 @@ proc new(T: type Eth2Node,
          enrForkId: ENRForkID, discoveryForkId: ENRForkID,
          forkDigests: ref ForkDigests, getBeaconTime: GetBeaconTimeFn,
          switch: Switch, pubsub: GossipSub,
-         ip: Option[ValidIpAddress], tcpPort, udpPort: Option[Port],
+         ip: Option[IpAddress], tcpPort, udpPort: Option[Port],
          privKey: keys.PrivateKey, discovery: bool,
          directPeers: DirectPeers,
          rng: ref HmacDrbgContext): T {.raises: [CatchableError].} =
@@ -2304,8 +2304,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
       cfg, getBeaconTime().slotOrZero.epoch, genesis_validators_root)
 
     (extIp, extTcpPort, extUdpPort) = try: setupAddress(
-      config.nat, ValidIpAddress.init config.listenAddress, config.tcpPort,
-      config.udpPort, clientId)
+      config.nat, config.listenAddress, config.tcpPort, config.udpPort,
+      clientId)
     except CatchableError as exc: raise exc
     except Exception as exc: raiseAssert exc.msg
 
@@ -2330,7 +2330,7 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
     hostAddress = tcpEndPoint(
       ValidIpAddress.init config.listenAddress, config.tcpPort)
     announcedAddresses = if extIp.isNone() or extTcpPort.isNone(): @[]
-                         else: @[tcpEndPoint(extIp.get(), extTcpPort.get())]
+                         else: @[tcpEndPoint(ValidIpAddress.init(extIp.get()), extTcpPort.get())]
 
   debug "Initializing networking", hostAddress,
                                    network_public_key = netKeys.pubkey,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2132,7 +2132,7 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     let record = enr.Record.init(
       config.seqNumber,
       netKeys.seckey.asEthKey,
-      some(ValidIpAddress.init config.ipExt),
+      some(config.ipExt),
       some(config.tcpPortExt),
       some(config.udpPortExt),
       fieldPairs).expect("Record within size limits")

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -377,7 +377,7 @@ proc createEnr(rng: var HmacDrbgContext,
     bootstrapEnr = enr.Record.init(
       1, # sequence number
       networkKeys.seckey.asEthKey,
-      some(ValidIpAddress.init address),
+      some(address),
       some(port),
       some(port),
       [

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -21,13 +21,7 @@ proc new(T: type Eth2DiscoveryProtocol,
     enrFields: openArray[(string, seq[byte])] = [],
     rng: ref HmacDrbgContext):
     T {.raises: [CatchableError].} =
-  let optValidIpAddress =
-    if enrIp.isSome:
-      some ValidIpAddress.init enrIp.get
-    else:
-      none ValidIpAddress
-
-  newProtocol(pk, optValidIpAddress, enrTcpPort, enrUdpPort, enrFields,
+  newProtocol(pk, enrIp, enrTcpPort, enrUdpPort, enrFields,
     bindPort = bindPort, bindIp = bindIp, rng = rng)
 
 proc generateNode(rng: ref HmacDrbgContext, port: Port,


### PR DESCRIPTION
`tcpEndPoint`/`MultiAddress.init` is the last remnant, but that's for a separate PR, so two final `ValidIpAddress` adapters are added to enable a smoother transition until that's removed too.