### PR TITLE
allow higher `MIN_EPOCHS_FOR_BLOCK_REQUESTS` than safe minimum

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -586,6 +586,10 @@ else:
 const SLOTS_PER_SYNC_COMMITTEE_PERIOD* =
   SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/phase0/p2p-interface.md#configuration
+func safeMinEpochsForBlockRequests*(cfg: RuntimeConfig): uint64 =
+  cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY + cfg.CHURN_LIMIT_QUOTIENT div 2
+
 func parse(T: type uint64, input: string): T {.raises: [ValueError].} =
   var res: BiggestUInt
   if input.len > 2 and input[0] == '0' and input[1] == 'x':
@@ -784,11 +788,7 @@ proc readRuntimeConfig*(
       msg: "Config not compatible with binary, compile with -d:const_preset=" & cfg.PRESET_BASE)
 
   # Requires initialized `cfg`
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-alpha.3/specs/phase0/p2p-interface.md#configuration
-  let safeMinEpochsForBlockRequests =
-    cfg.MIN_VALIDATOR_WITHDRAWABILITY_DELAY + cfg.CHURN_LIMIT_QUOTIENT div 2
-  checkCompatibility safeMinEpochsForBlockRequests,
+  checkCompatibility cfg.safeMinEpochsForBlockRequests(),
                      "MIN_EPOCHS_FOR_BLOCK_REQUESTS", `>=`
 
   var unknowns: seq[string]

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -1145,7 +1145,7 @@ suite "Pruning":
         var res = defaultRuntimeConfig
         res.MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 4
         res.CHURN_LIMIT_QUOTIENT = 1
-        res.MIN_EPOCHS_FOR_BLOCK_REQUESTS = cfg.safeMinEpochsForBlockRequests()
+        res.MIN_EPOCHS_FOR_BLOCK_REQUESTS = res.safeMinEpochsForBlockRequests()
         doAssert res.MIN_EPOCHS_FOR_BLOCK_REQUESTS == 4
         res
       db = makeTestDB(SLOTS_PER_EPOCH)

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -1145,6 +1145,7 @@ suite "Pruning":
         var res = defaultRuntimeConfig
         res.MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 4
         res.CHURN_LIMIT_QUOTIENT = 1
+        res.MIN_EPOCHS_FOR_BLOCK_REQUESTS = cfg.safeMinEpochsForBlockRequests()
         doAssert res.MIN_EPOCHS_FOR_BLOCK_REQUESTS == 4
         res
       db = makeTestDB(SLOTS_PER_EPOCH)


### PR DESCRIPTION
Gnosis uses `MIN_EPOCHS_FOR_BLOCK_REQUESTS` = 33024, but the computed safe minimum (that Nimbus was using) is 2304. Relax the compatibility check to allow `MIN_EPOCHS_FOR_BLOCK_REQUESTS` above the safe minimum and honor `config.yaml` preferences for `MIN_EPOCHS_FOR_BLOCK_REQUESTS`.