### PR TITLE
disallow htr on Opt[Foo]

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -825,6 +825,8 @@ func hash_tree_root*(x: ForkedBeaconBlock): Eth2Digest =
 func hash_tree_root*(x: Web3SignerForkedBeaconBlock): Eth2Digest =
   hash_tree_root(x.data)
 
+func hash_tree_root*(_: Opt[auto]) {.error.}
+
 template getForkedBlockField*(
     x: ForkedSignedBeaconBlock |
        ForkedMsgTrustedSignedBeaconBlock |


### PR DESCRIPTION
The error produced is
```
Error: usage of 'hash_tree_root' is an {.error.} defined at nimbus-eth2/beacon_chain/spec/forks.nim(828, 1)
```

This otherwise incorrectly compiles and produces results different than `hash_tree_root` on `Foo`.

There is no Ethereum usecase in Nimbus for doing this operation.