### PR TITLE
remove `XDeclaredButNotUsed` exclusion from Nim configurations

### DIFF
--- a/beacon_chain/nim.cfg
+++ b/beacon_chain/nim.cfg
@@ -4,6 +4,5 @@
 -d:chronosStrictException
 --styleCheck:usages
 --styleCheck:hint
---hint[XDeclaredButNotUsed]:off
 --hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off

--- a/beacon_chain/nim.cfg
+++ b/beacon_chain/nim.cfg
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 # Use only `secp256k1` public key cryptography as an identity in LibP2P.
 -d:"libp2p_pki_schemes=secp256k1"
 

--- a/ncli/nim.cfg
+++ b/ncli/nim.cfg
@@ -5,6 +5,5 @@
 -d:chronosStrictException
 --styleCheck:usages
 --styleCheck:hint
---hint[XDeclaredButNotUsed]:off
 --hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off

--- a/ncli/nim.cfg
+++ b/ncli/nim.cfg
@@ -1,3 +1,10 @@
+# beacon_chain
+# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 -u:metrics
 
 -d:"libp2p_pki_schemes=secp256k1"

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -11,6 +11,5 @@
 -d:chronosStrictException
 --styleCheck:usages
 --styleCheck:hint
---hint[XDeclaredButNotUsed]:off
 --hint[ConvFromXtoItselfNotNeeded]:off
 --hint[Processing]:off


### PR DESCRIPTION
It's a useful hint, generally pointing to issues which can and should be addressed.

Since no hints show up at usual `make foo` build settings, it'll regardless only show up when people specifically request them, so it doesn't add verbosity to typical builds, in CI or otherwise.