### PR TITLE
update Deneb for latest builder-specs flow

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -99,7 +99,7 @@ type
     SetGasLimitRequest |
     bellatrix_mev.SignedBlindedBeaconBlock |
     capella_mev.SignedBlindedBeaconBlock |
-    deneb_mev.SignedBlindedBeaconBlockContents |
+    deneb_mev.SignedBlindedBeaconBlock |
     SignedValidatorRegistrationV1 |
     SignedVoluntaryExit |
     Web3SignerRequest |

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -245,7 +245,7 @@ proc publishBlindedBlock*(body: capella_mev.SignedBlindedBeaconBlock):
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
 
-proc publishBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlockContents):
+proc publishBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlock):
        RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/blinded_blocks",
      meth: MethodPost.}

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -317,7 +317,8 @@ template kind*(
       capella.TrustedBeaconBlockBody |
       capella.SigVerifiedSignedBeaconBlock |
       capella.MsgTrustedSignedBeaconBlock |
-      capella.TrustedSignedBeaconBlock]): ConsensusFork =
+      capella.TrustedSignedBeaconBlock |
+      capella_mev.SignedBlindedBeaconBlock]): ConsensusFork =
   ConsensusFork.Capella
 
 template kind*(
@@ -335,7 +336,8 @@ template kind*(
       deneb.TrustedBeaconBlockBody |
       deneb.SigVerifiedSignedBeaconBlock |
       deneb.MsgTrustedSignedBeaconBlock |
-      deneb.TrustedSignedBeaconBlock]): ConsensusFork =
+      deneb.TrustedSignedBeaconBlock |
+      deneb_mev.SignedBlindedBeaconBlock]): ConsensusFork =
   ConsensusFork.Deneb
 
 template BeaconState*(kind: static ConsensusFork): auto =
@@ -415,6 +417,16 @@ template ExecutionPayloadForSigning*(kind: static ConsensusFork): auto =
     typedesc[capella.ExecutionPayloadForSigning]
   elif kind == ConsensusFork.Bellatrix:
     typedesc[bellatrix.ExecutionPayloadForSigning]
+  else:
+    static: raiseAssert "Unreachable"
+
+template SignedBlindedBeaconBlock*(kind: static ConsensusFork): auto =
+  when kind == ConsensusFork.Deneb:
+    typedesc[deneb_mev.SignedBlindedBeaconBlock]
+  elif kind == ConsensusFork.Capella:
+    typedesc[capella_mev.SignedBlindedBeaconBlock]
+  elif kind == ConsensusFork.Bellatrix:
+    static: raiseAssert "Unsupported"
   else:
     static: raiseAssert "Unreachable"
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -235,30 +235,6 @@ func create_blob_sidecars*(
     res.add(sidecar)
   res
 
-func create_blob_sidecars*(
-    forkyBlck: deneb_mev.SignedBlindedBeaconBlock,
-    kzg_proofs: KzgProofs,
-    blob_roots: BlobRoots): seq[BlindedBlobSidecar] =
-  template kzg_commitments: untyped =
-    forkyBlck.message.body.blob_kzg_commitments
-  doAssert kzg_proofs.len == blob_roots.len
-  doAssert kzg_proofs.len == kzg_commitments.len
-
-  var res = newSeqOfCap[BlindedBlobSidecar](blob_roots.len)
-  let signedBlockHeader = forkyBlck.toSignedBeaconBlockHeader()
-  for i in 0 ..< blob_roots.lenu64:
-    var sidecar = BlindedBlobSidecar(
-      index: i,
-      blob_root: blob_roots[i],
-      kzg_commitment: kzg_commitments[i],
-      kzg_proof: kzg_proofs[i],
-      signed_block_header: signedBlockHeader)
-    forkyBlck.message.body.build_proof(
-      kzg_commitment_inclusion_proof_gindex(i),
-      sidecar.kzg_commitment_inclusion_proof).expect("Valid gindex")
-    res.add(sidecar)
-  res
-
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/altair/light-client/sync-protocol.md#is_sync_committee_update
 template is_sync_committee_update*(update: SomeForkyLightClientUpdate): bool =
   when update is SomeForkyLightClientUpdateWithSyncCommittee:

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -13,16 +13,10 @@ from stew/byteutils import to0xHex
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 
 type
-  # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#blindedblobsbundle
-  BlindedBlobsBundle* = object
-    commitments*: List[KZGCommitment, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    proofs*: List[KZGProof, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    blob_roots*: List[Eth2Digest, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]
-
   # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#builderbid
   BuilderBid* = object
     header*: deneb.ExecutionPayloadHeader # [Modified in Deneb]
-    blinded_blobs_bundle*: BlindedBlobsBundle # [New in Deneb]
+    blob_kzg_commitments*: KzgCommitments # [New in Deneb]
     value*: UInt256
     pubkey*: ValidatorPubKey
 
@@ -67,30 +61,15 @@ type
     message*: BlindedBeaconBlock
     signature*: ValidatorSig
 
-  # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#blindedblobsidecar
-  BlindedBlobSidecar* = object
-    index*: uint64
-    blob_root*: Eth2Digest
-    kzg_commitment*: KZGCommitment
-    kzg_proof*: KZGProof
-    signed_block_header*: SignedBeaconBlockHeader
-    kzg_commitment_inclusion_proof*:
-      array[KZG_COMMITMENT_INCLUSION_PROOF_DEPTH, Eth2Digest]
-
-  # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#signedblindedblockcontents
-  SignedBlindedBeaconBlockContents* = object
-    signed_blinded_block*: deneb_mev.SignedBlindedBeaconBlock
-    blinded_blob_sidecars*: List[BlindedBlobSidecar, Limit MAX_BLOBS_PER_BLOCK]
-
   # https://github.com/ethereum/builder-specs/blob/534e4f81276b8346d785ed9aba12c4c74b927ec6/specs/deneb/builder.md#executionpayloadandblobsbundle
   ExecutionPayloadAndBlobsBundle* = object
     execution_payload*: deneb.ExecutionPayload
     blobs_bundle*: BlobsBundle
 
   # Not spec, but suggested by spec
-  ExecutionPayloadHeaderAndBlindedBlobsBundle* = object
+  BlindedExecutionPayloadAndBlobsBundle* = object
     execution_payload_header*: deneb.ExecutionPayloadHeader
-    blinded_blobs_bundle*: BlindedBlobsBundle
+    blob_kzg_commitments*: KzgCommitments # [New in Deneb]
 
 func shortLog*(v: BlindedBeaconBlock): auto =
   (
@@ -117,11 +96,4 @@ func shortLog*(v: SignedBlindedBeaconBlock): auto =
   (
     blck: shortLog(v.message),
     signature: shortLog(v.signature)
-  )
-
-# needs to match SignedBlindedBeaconBlock
-func shortLog*(v: SignedBlindedBeaconBlockContents): auto =
-  (
-    blck: shortLog(v.signed_blinded_block.message),
-    signature: shortLog(v.signed_blinded_block.signature)
   )

--- a/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
@@ -20,7 +20,7 @@ proc getHeaderDeneb*(slot: Slot,
      meth: MethodGet, connection: {Dedicated, Close}.}
   ## https://github.com/ethereum/builder-specs/blob/34509da74237942aa15a4c0ca828f67acdf77652/apis/builder/header.yaml
 
-proc submitBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlockContents
+proc submitBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlock
                         ): RestResponse[SubmitBlindedBlockResponseDeneb] {.
      rest, endpoint: "/eth/v1/builder/blinded_blocks",
      meth: MethodPost, connection: {Dedicated, Close}.}

--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -42,19 +42,20 @@ macro copyFields*(
       result.add newAssignment(
         newDotExpr(dst, ident(name)), newDotExpr(src, ident(name)))
 
-# TODO when https://github.com/nim-lang/Nim/issues/21346 and/or
-# https://github.com/nim-lang/Nim/issues/21347 fixed, combine and make generic
-# these two very similar versions of unblindAndRouteBlockMEV
 proc unblindAndRouteBlockMEV*(
     node: BeaconNode, payloadBuilderRestClient: RestClientRef,
-    blindedBlock: capella_mev.SignedBlindedBeaconBlock):
+    blindedBlock:
+      capella_mev.SignedBlindedBeaconBlock |
+      deneb_mev.SignedBlindedBeaconBlock):
     Future[Result[Opt[BlockRef], string]] {.async.} =
+  const consensusFork = typeof(blindedBlock).kind
+
   info "Proposing blinded Builder API block",
     blindedBlock = shortLog(blindedBlock)
 
   # By time submitBlindedBlock is called, must already have done slashing
   # protection check
-  let unblindedPayload =
+  let bundle =
     try:
       awaitWithTimeout(
           payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
@@ -68,132 +69,70 @@ proc unblindAndRouteBlockMEV*(
       return err("exception in submitBlindedBlock: " & exc.msg)
 
   const httpOk = 200
-  if unblindedPayload.status == httpOk:
-    if  hash_tree_root(
-          blindedBlock.message.body.execution_payload_header) !=
-        hash_tree_root(unblindedPayload.data.data):
-      err("unblinded payload doesn't match blinded payload header: " &
-        $blindedBlock.message.body.execution_payload_header)
-    else:
-      # Signature provided is consistent with unblinded execution payload,
-      # so construct full beacon block
-      # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#block-proposal
-      var signedBlock = capella.SignedBeaconBlock(
-        signature: blindedBlock.signature)
-      copyFields(
-        signedBlock.message, blindedBlock.message,
-        getFieldNames(typeof(signedBlock.message)))
-      copyFields(
-        signedBlock.message.body, blindedBlock.message.body,
-        getFieldNames(typeof(signedBlock.message.body)))
-      signedBlock.message.body.execution_payload = unblindedPayload.data.data
-
-      signedBlock.root = hash_tree_root(signedBlock.message)
-
-      doAssert signedBlock.root == hash_tree_root(blindedBlock.message)
-
-      debug "unblindAndRouteBlockMEV: proposing unblinded block",
-        blck = shortLog(signedBlock)
-
-      let newBlockRef =
-        (await node.router.routeSignedBeaconBlock(
-          signedBlock, Opt.none(seq[BlobSidecar]))).valueOr:
-          # submitBlindedBlock has run, so don't allow fallback to run
-          return err("routeSignedBeaconBlock error") # Errors logged in router
-
-      if newBlockRef.isSome:
-        beacon_block_builder_proposed.inc()
-        notice "Block proposed (MEV)",
-          blockRoot = shortLog(signedBlock.root), blck = shortLog(signedBlock),
-          signature = shortLog(signedBlock.signature)
-
-      ok newBlockRef
-  else:
+  if bundle.status != httpOk:
     # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#proposer-slashing
     # This means if a validator publishes a signature for a
     # `BlindedBeaconBlock` (via a dissemination of a
     # `SignedBlindedBeaconBlock`) then the validator **MUST** not use the
     # local build process as a fallback, even in the event of some failure
     # with the external builder network.
-    err("submitBlindedBlock failed with HTTP error code" &
-      $unblindedPayload.status & ": " & $shortLog(blindedBlock))
+    return err("submitBlindedBlock failed with HTTP error code " &
+      $bundle.status & ": " & $shortLog(blindedBlock))
 
-# TODO currently cannot be combined into one generic function
-proc unblindAndRouteBlockMEV*(
-    node: BeaconNode, payloadBuilderRestClient: RestClientRef,
-    blindedBlockContents: deneb_mev.SignedBlindedBeaconBlockContents):
-    Future[Result[Opt[BlockRef], string]] {.async.} =
-  template blindedBlock: untyped = blindedBlockContents.signed_blinded_block
-
-  info "Proposing blinded Builder API block and blobs",
-    blindedBlock = shortLog(blindedBlock)
-
-  # By time submitBlindedBlock is called, must already have done slashing
-  # protection check
-  let unblindedPayload =
-    try:
-      awaitWithTimeout(
-          payloadBuilderRestClient.submitBlindedBlock(blindedBlockContents),
-          BUILDER_BLOCK_SUBMISSION_DELAY_TOLERANCE):
-        return err("Submitting blinded block and blobs timed out")
-      # From here on, including error paths, disallow local EL production by
-      # returning Opt.some, regardless of whether on head or newBlock.
-    except RestDecodingError as exc:
-      return err("REST decoding error submitting blinded block and blobs: " & exc.msg)
-    except CatchableError as exc:
-      return err("exception in submitBlindedBlock: " & exc.msg)
-
-  const httpOk = 200
-  if unblindedPayload.status == httpOk:
-    if  hash_tree_root(
-          blindedBlock.message.body.execution_payload_header) !=
-        hash_tree_root(unblindedPayload.data.data.execution_payload):
-      err("unblinded payload doesn't match blinded payload header: " &
-        $blindedBlock.message.body.execution_payload_header)
-    else:
-      # Signature provided is consistent with unblinded execution payload,
-      # so construct full beacon block
-      # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#block-proposal
-      var signedBlock = deneb.SignedBeaconBlock(
-        signature: blindedBlock.signature)
-      copyFields(
-        signedBlock.message, blindedBlock.message,
-        getFieldNames(typeof(signedBlock.message)))
-      copyFields(
-        signedBlock.message.body, blindedBlock.message.body,
-        getFieldNames(typeof(signedBlock.message.body)))
-      assign(
-        signedBlock.message.body.execution_payload,
-        unblindedPayload.data.data.execution_payload)
-
-      signedBlock.root = hash_tree_root(signedBlock.message)
-
-      doAssert signedBlock.root == hash_tree_root(blindedBlock.message)
-
-      debug "unblindAndRouteBlockMEV: proposing unblinded block and blobs",
-        blck = shortLog(signedBlock)
-
-      let newBlockRef =
-        (await node.router.routeSignedBeaconBlock(
-          signedBlock, Opt.none(seq[BlobSidecar]))).valueOr:
-          # submitBlindedBlock has run, so don't allow fallback to run
-          return err("routeSignedBeaconBlock error") # Errors logged in router
-
-      if newBlockRef.isSome:
-        beacon_block_builder_proposed.inc()
-        notice "Block proposed (MEV)",
-          blockRoot = shortLog(signedBlock.root), blck = shortLog(signedBlock),
-          signature = shortLog(signedBlock.signature)
-
-      discard $denebImplementationMissing & ": route unblinded blobs"
-
-      ok newBlockRef
+  when consensusFork >= ConsensusFork.Deneb:
+    template execution_payload: untyped = bundle.data.data.execution_payload
   else:
-    # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#proposer-slashing
-    # This means if a validator publishes a signature for a
-    # `BlindedBeaconBlock` (via a dissemination of a
-    # `SignedBlindedBeaconBlock`) then the validator **MUST** not use the
-    # local build process as a fallback, even in the event of some failure
-    # with the external builder network.
-    err("submitBlindedBlock failed with HTTP error code" &
-      $unblindedPayload.status & ": " & $shortLog(blindedBlock))
+    template execution_payload: untyped = bundle.data.data
+  if hash_tree_root(blindedBlock.message.body.execution_payload_header) !=
+      hash_tree_root(execution_payload):
+    return err("unblinded payload doesn't match blinded payload header: " &
+      $blindedBlock.message.body.execution_payload_header)
+
+  # Signature provided is consistent with unblinded execution payload,
+  # so construct full beacon block
+  # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#block-proposal
+  var signedBlock = consensusFork.SignedBeaconBlock(
+    signature: blindedBlock.signature)
+  copyFields(
+    signedBlock.message, blindedBlock.message,
+    getFieldNames(typeof(signedBlock.message)))
+  copyFields(
+    signedBlock.message.body, blindedBlock.message.body,
+    getFieldNames(typeof(signedBlock.message.body)))
+  assign(signedBlock.message.body.execution_payload, execution_payload)
+  signedBlock.root = hash_tree_root(signedBlock.message)
+  doAssert signedBlock.root == hash_tree_root(blindedBlock.message)
+
+  let blobsOpt =
+    when consensusFork >= ConsensusFork.Deneb:
+      template blobs_bundle: untyped = bundle.data.data.blobs_bundle
+      if blindedBlock.message.body.blob_kzg_commitments !=
+          bundle.data.data.blobs_bundle.commitments:
+        return err("unblinded blobs bundle has unexpected commitments")
+      let ok = verifyProofs(
+          asSeq blobs_bundle.blobs,
+          asSeq blobs_bundle.commitments,
+          asSeq blobs_bundle.proofs).valueOr:
+        return err("unblinded blobs bundle fails verification")
+      if not ok:
+        return err("unblinded blobs bundle is invalid")
+      Opt.some(signedBlock.create_blob_sidecars(
+        blobs_bundle.proofs, blobs_bundle.blobs))
+    else:
+      Opt.none(seq[BlobSidecar])
+
+  debug "unblindAndRouteBlockMEV: proposing unblinded block",
+    blck = shortLog(signedBlock)
+
+  let newBlockRef =
+    (await node.router.routeSignedBeaconBlock(signedBlock, blobsOpt)).valueOr:
+      # submitBlindedBlock has run, so don't allow fallback to run
+      return err("routeSignedBeaconBlock error") # Errors logged in router
+
+  if newBlockRef.isSome:
+    beacon_block_builder_proposed.inc()
+    notice "Block proposed (MEV)",
+      blockRoot = shortLog(signedBlock.root), blck = shortLog(signedBlock),
+      signature = shortLog(signedBlock.signature)
+
+  ok newBlockRef


### PR DESCRIPTION
The `BlobSidecar` construction has been moved to the relay and is no longer done by the BN / VC in blinded flow. Builder bid contents have been shrinked from full `BlindedBlobBundle` to `blob_kzg_commitments`.

- https://github.com/ethereum/builder-specs/pull/90
- https://github.com/ethereum/beacon-APIs/pull/369