### PR TITLE
send LC finality update on event stream on supermajority

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -563,6 +563,11 @@ proc createLightClientUpdates(
     var finalized_slot = attested_data.finalized_slot
     if finalized_slot == forkyLatest.finalized_header.beacon.slot:
       forkyLatest.finality_branch = attested_data.finality_branch
+      let old_num_active_participants =
+        forkyLatest.sync_aggregate.num_active_participants.uint64
+      if not hasSupermajoritySyncParticipation(old_num_active_participants) and
+          hasSupermajoritySyncParticipation(num_active_participants):
+        newFinality = true
     elif finalized_slot < dag.tail.slot or
         not load_finalized_bid(finalized_slot):
       forkyLatest.finalized_header.reset()

--- a/beacon_chain/consensus_object_pools/light_client_pool.nim
+++ b/beacon_chain/consensus_object_pools/light_client_pool.nim
@@ -19,6 +19,10 @@ type
       ## Latest finality update that was forwarded on libp2p gossip.
       ## Tracks `finality_update.finalized_header.beacon.slot`.
 
+    latestForwardedFinalityHasSupermajority*: bool
+      ## Whether or not the latest finality update that was forwarded on
+      ## libp2p gossip had supermajority (> 2/3) sync committee participation.
+
     latestForwardedOptimisticSlot*: Slot
       ## Latest optimistic update that was forwarded on libp2p gossip.
       ## Tracks `optimistic_update.attested_header.beacon.slot`.

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -638,6 +638,14 @@ func init*(T: type SyncAggregate): SyncAggregate =
 func num_active_participants*(v: SomeSyncAggregate): int =
   countOnes(v.sync_committee_bits)
 
+func hasSupermajoritySyncParticipation*(
+    num_active_participants: uint64): bool =
+  const max_active_participants = SYNC_COMMITTEE_SIZE.uint64
+  num_active_participants * 3 >= static(max_active_participants * 2)
+
+func hasSupermajoritySyncParticipation*(v: SomeSyncAggregate): bool =
+  hasSupermajoritySyncParticipation(v.num_active_participants.uint64)
+
 func shortLog*(v: SyncAggregate): auto =
   $(v.sync_committee_bits)
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -327,12 +327,11 @@ template toMeta*(update: ForkedLightClientUpdate): LightClientUpdateMetadata =
 
 func is_better_data*(new_meta, old_meta: LightClientUpdateMetadata): bool =
   # Compare supermajority (> 2/3) sync committee participation
-  const max_active_participants = SYNC_COMMITTEE_SIZE.uint64
   let
     new_has_supermajority =
-      new_meta.num_active_participants * 3 >= max_active_participants * 2
+      hasSupermajoritySyncParticipation(new_meta.num_active_participants)
     old_has_supermajority =
-      old_meta.num_active_participants * 3 >= max_active_participants * 2
+      hasSupermajoritySyncParticipation(old_meta.num_active_participants)
   if new_has_supermajority != old_has_supermajority:
     return new_has_supermajority > old_has_supermajority
   if not new_has_supermajority:


### PR DESCRIPTION
When new finality is reached without supermajority sync committee support, trigger another event push on beacon-API and libp2p once the finality gains supermajority support.

- https://github.com/ethereum/consensus-specs/pull/3549