### PR TITLE
add registration of VC validators back in the new per validator management of builders

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1575,8 +1575,11 @@ proc registerValidatorsPerBuilder(
         validatorRegistrations.add @[validatorRegistration]
 
     # First, check for VC-added keys; cheaper because provided pre-signed
+    # See issue #5599: currently VC have no way to provide BN with per-validator builders per the specs, so we have to
+    #   resort to use the BN fallback default (--payload-builder-url value, obtained by calling getPayloadBuilderAddress)
     var nonExitedVcPubkeys: HashSet[ValidatorPubKey]
-    if node.externalBuilderRegistrations.len > 0:
+    if  node.externalBuilderRegistrations.len > 0 and
+        payloadBuilderAddress == node.config.getPayloadBuilderAddress.value:
       withState(node.dag.headState):
         let currentEpoch = node.currentSlot().epoch
         for i in 0 ..< forkyState.data.validators.len:
@@ -1663,6 +1666,12 @@ proc registerValidators*(node: BeaconNode, epoch: Epoch) {.async.} =
   if not node.config.payloadBuilderEnable: return
 
   var builderKeys: Table[string, seq[ValidatorPubKey]]
+
+  # Ensure VC validators are still registered if we have no attached validators
+  let externalPayloadBuilderAddress = node.config.getPayloadBuilderAddress
+  if externalPayloadBuilderAddress.isSome:
+    builderKeys[externalPayloadBuilderAddress.value] = newSeq[ValidatorPubKey](0)
+
   for pubkey in node.attachedValidators[].validators.keys:
     let payloadBuilderAddress = node.getPayloadBuilderAddress(pubkey).valueOr:
       continue


### PR DESCRIPTION
Fix handling of VC validators by per validator payload-builder registration (issue #5599).

The proposed change ensures that VC validators are registered with the builder specified by the `--payload-builder-url` argument even if the beacon node has no attached validators. It also prevent such validators from being unintentionally registered with builders configured for specific attached validators by the keymanager api.