### PR TITLE
Batch slashing protection registration

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -315,27 +315,23 @@ proc handleLightClientUpdates*(node: BeaconNode, slot: Slot) {.async.} =
 proc createAndSendAttestation(node: BeaconNode,
                               fork: Fork,
                               genesis_validators_root: Eth2Digest,
-                              validator: AttachedValidator,
-                              data: AttestationData,
-                              committeeLen: int,
-                              indexInCommittee: int,
+                              registered: RegisteredAttestation,
                               subnet_id: SubnetId) {.async.} =
   try:
     let
       signature = block:
-        let res = await validator.getAttestationSignature(
-          fork, genesis_validators_root, data)
+        let res = await registered.validator.getAttestationSignature(
+          fork, genesis_validators_root, registered.data)
         if res.isErr():
-          warn "Unable to sign attestation", validator = shortLog(validator),
-                attestationData = shortLog(data), error_msg = res.error()
+          warn "Unable to sign attestation",
+                validator = shortLog(registered.validator),
+                attestationData = shortLog(registered.data),
+                error_msg = res.error()
           return
         res.get()
-      attestation =
-        Attestation.init(
-          [uint64 indexInCommittee], committeeLen, data, signature).expect(
-            "valid data")
+      attestation = registered.toAttestation(signature)
 
-    validator.doppelgangerActivity(attestation.data.slot.epoch)
+    registered.validator.doppelgangerActivity(attestation.data.slot.epoch)
 
     # Logged in the router
     let res = await node.router.routeAttestation(
@@ -344,7 +340,9 @@ proc createAndSendAttestation(node: BeaconNode,
       return
 
     if node.config.dumpEnabled:
-      dump(node.config.dumpDirOutgoing, attestation.data, validator.pubkey)
+      dump(
+        node.config.dumpDirOutgoing, attestation.data,
+        registered.validator.pubkey)
   except CatchableError as exc:
     # An error could happen here when the signature task fails - we must
     # not leak the exception because this is an asyncSpawn task
@@ -550,8 +548,8 @@ proc makeBeaconBlockForHeadAndSlot*(
     PayloadType: type ForkyExecutionPayloadForSigning, node: BeaconNode, randao_reveal: ValidatorSig,
     validator_index: ValidatorIndex, graffiti: GraffitiBytes, head: BlockRef,
     slot: Slot):
-    Future[ForkedBlockResult] {.async.} =
-  return await makeBeaconBlockForHeadAndSlot(
+    Future[ForkedBlockResult] =
+  return makeBeaconBlockForHeadAndSlot(
     PayloadType, node, randao_reveal, validator_index, graffiti, head, slot,
     execution_payload = Opt.none(PayloadType),
     transactions_root = Opt.none(Eth2Digest),
@@ -1290,41 +1288,51 @@ proc handleAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     committees_per_slot = get_committee_count_per_slot(epochRef.shufflingRef)
     fork = node.dag.forkAtEpoch(slot.epoch)
     genesis_validators_root = node.dag.genesis_validators_root
+    registeredRes = node.attachedValidators.slashingProtection.withContext:
+      var tmp: seq[(RegisteredAttestation, SubnetId)]
 
-  for committee_index in get_committee_indices(committees_per_slot):
-    let committee = get_beacon_committee(
-      epochRef.shufflingRef, slot, committee_index)
+      for committee_index in get_committee_indices(committees_per_slot):
+        let
+          committee = get_beacon_committee(
+            epochRef.shufflingRef, slot, committee_index)
+          subnet_id = compute_subnet_for_attestation(
+            committees_per_slot, slot, committee_index)
 
-    for index_in_committee, validator_index in committee:
-      let validator = node.getValidatorForDuties(validator_index, slot).valueOr:
-        continue
+        for index_in_committee, validator_index in committee:
+          let validator = node.getValidatorForDuties(validator_index, slot).valueOr:
+            continue
 
-      let
-        data = makeAttestationData(epochRef, attestationHead, committee_index)
-        # TODO signing_root is recomputed in produceAndSignAttestation/signAttestation just after
-        signingRoot = compute_attestation_signing_root(
-          fork, genesis_validators_root, data)
-        registered = node.attachedValidators
-          .slashingProtection
-          .registerAttestation(
-            validator_index,
-            validator.pubkey,
-            data.source.epoch,
-            data.target.epoch,
-            signingRoot)
-      if registered.isOk():
-        let subnet_id = compute_subnet_for_attestation(
-          committees_per_slot, data.slot, committee_index)
-        asyncSpawn createAndSendAttestation(
-          node, fork, genesis_validators_root, validator, data,
-          committee.len(), index_in_committee, subnet_id)
-      else:
-        warn "Slashing protection activated for attestation",
-          attestationData = shortLog(data),
-          signingRoot = shortLog(signingRoot),
-          validator_index,
-          validator = shortLog(validator),
-          badVoteDetails = $registered.error()
+          let
+            data = makeAttestationData(epochRef, attestationHead, committee_index)
+            # TODO signing_root is recomputed in produceAndSignAttestation/signAttestation just after
+            signingRoot = compute_attestation_signing_root(
+              fork, genesis_validators_root, data)
+            registered = registerAttestationInContext(
+              validator_index, validator.pubkey, data.source.epoch,
+              data.target.epoch, signingRoot)
+          if registered.isErr():
+            warn "Slashing protection activated for attestation",
+              attestationData = shortLog(data),
+              signingRoot = shortLog(signingRoot),
+              validator_index,
+              validator = shortLog(validator),
+              badVoteDetails = $registered.error()
+            continue
+
+          tmp.add((RegisteredAttestation(
+            validator: validator,
+            index_in_committee: uint64 index_in_committee,
+            committee_len: committee.len(), data: data), subnet_id
+          ))
+      tmp
+
+  if registeredRes.isErr():
+    warn "Could not update slashing database, skipping attestation duties",
+      error = registeredRes.error()
+  else:
+    for attestation in registeredRes[]:
+      asyncSpawn createAndSendAttestation(
+        node, fork, genesis_validators_root, attestation[0], attestation[1])
 
 proc createAndSendSyncCommitteeMessage(node: BeaconNode,
                                        validator: AttachedValidator,

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -9,9 +9,10 @@
 
 import
   # Standard library
-  std/[os, options, typetraits, decls, tables],
+  std/[os, typetraits, decls, tables],
   # Status
   stew/byteutils,
+  results,
   eth/db/[kvstore, kvstore_sqlite3],
   chronicles,
   sqlite3_abi,
@@ -19,6 +20,8 @@ import
   ../spec/datatypes/base,
   ../spec/helpers,
   ./slashing_protection_common
+
+export results
 
 # Requirements
 # --------------------------------------------
@@ -609,7 +612,7 @@ func getRawDBHandle*(db: SlashingProtectionDB_v2): SqStoreRef =
   ## Get the underlying raw DB handle
   db.backend
 
-proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Option[Eth2Digest] =
+proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Opt[Eth2Digest] =
   ## Check if the DB has v2 metadata
   ## and get its genesis root
   let existenceStmt = db.backend.prepareStmt("""
@@ -630,9 +633,9 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Option[Eth2Digest] =
 
 
   if v2exists.isErr():
-    return none(Eth2Digest)
+    return Opt.none(Eth2Digest)
   elif hasV2 == 0:
-    return none(Eth2Digest)
+    return Opt.none(Eth2Digest)
 
   let selectStmt = db.backend.prepareStmt(
     "SELECT * FROM metadata;",
@@ -655,9 +658,9 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Option[Eth2Digest] =
         found = version,
         expected = db.typeof.version()
       quit 1
-    return some(root)
+    return Opt.some(root)
   else:
-    return none(Eth2Digest)
+    return Opt.none(Eth2Digest)
 
 proc initCompatV1*(
     T: type SlashingProtectionDB_v2,
@@ -773,8 +776,8 @@ proc foundAnyResult(status: KvResult[bool]): bool {.inline.}=
 
 proc getValidatorInternalID(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
-       validator: ValidatorPubKey): Option[ValidatorInternalID] =
+       index: Opt[ValidatorIndex],
+       validator: ValidatorPubKey): Opt[ValidatorInternalID] =
   ## Retrieve a validator internal ID
   if index.isSome():
     # Validator keys are mapped to internal id:s instead of using the
@@ -785,7 +788,7 @@ proc getValidatorInternalID(
     # validator index. In the meantime, this cache avoids some of the
     # unnecessary read traffic when checking and registering entries.
     db.internalIds.withValue(index.get(), internal) do:
-      return some(internal[])
+      return Opt.some(internal[])
 
   let serializedPubkey = validator.toRaw() # Miracl/BLST to bytes
   var valID: ValidatorInternalID
@@ -796,9 +799,9 @@ proc getValidatorInternalID(
   if status.foundAnyResult():
     if index.isSome():
       db.internalIds[index.get()] = valID
-    some(valID)
+    Opt.some(valID)
   else:
-    none(ValidatorInternalID)
+    Opt.none(ValidatorInternalID)
 
 proc checkSlashableBlockProposalOther(
        db: SlashingProtectionDB_v2,
@@ -887,7 +890,7 @@ proc checkSlashableBlockProposalDoubleProposal(
 
 proc checkSlashableBlockProposal*(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey,
        slot: Slot
      ): Result[void, BadProposal] =
@@ -1049,7 +1052,7 @@ proc checkSlashableAttestationOther(
 
 proc checkSlashableAttestation*(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey,
        source: Epoch,
        target: Epoch
@@ -1084,7 +1087,7 @@ proc registerValidator(db: SlashingProtectionDB_v2, validator: ValidatorPubKey) 
 
 proc getOrRegisterValidator(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey): ValidatorInternalID =
   ## Get validator from the database
   ## or register it and then return it
@@ -1102,7 +1105,7 @@ proc getOrRegisterValidator(
 
 proc registerBlock*(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey,
        slot: Slot, block_root: Eth2Digest): Result[void, BadProposal] =
   ## Add a block to the slashing protection DB
@@ -1138,11 +1141,11 @@ proc registerBlock*(
        db: SlashingProtectionDB_v2,
        validator: ValidatorPubKey,
        slot: Slot, block_root: Eth2Digest): Result[void, BadProposal] =
-  registerBlock(db, none(ValidatorIndex), validator, slot, block_root)
+  registerBlock(db, Opt.none(ValidatorIndex), validator, slot, block_root)
 
 proc registerAttestation*(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey,
        source, target: Epoch,
        attestation_root: Eth2Digest): Result[void, BadVote] =
@@ -1187,13 +1190,45 @@ proc registerAttestation*(
        source, target: Epoch,
        attestation_root: Eth2Digest): Result[void, BadVote] =
   registerAttestation(
-    db, none(ValidatorIndex), validator, source, target, attestation_root)
+    db, Opt.none(ValidatorIndex), validator, source, target, attestation_root)
+
+template withContext*(dbParam: SlashingProtectionDB_v2, body: untyped): untyped =
+  let
+    db = dbParam
+
+  template registerAttestationInContextV2(
+      index: Opt[ValidatorIndex],
+      validator: ValidatorPubKey,
+      source, target: Epoch,
+      signing_root: Eth2Digest): Result[void, BadVote] =
+    registerAttestation(db, index, validator, source, target, signing_root)
+
+  discard db.backend.exec("BEGIN TRANSACTION;")
+  var
+    commit = false
+    res: Result[typeof(body), string]
+  try:
+      when type(body) is void:
+        body
+        commit = true
+      else:
+        res.ok(body)
+        commit = true
+  finally:
+    if commit:
+      let commit = db.backend.exec("COMMIT TRANSACTION;")
+      if commit.isErr:
+        res.err(commit.error())
+    else:
+      if isInsideTransaction(db.backend): # calls `sqlite3_get_autocommit`
+        discard db.backend.exec("ROLLBACK TRANSACTION;")
+  res
 
 # DB maintenance
 # --------------------------------------------
 proc pruneBlocks*(
     db: SlashingProtectionDB_v2,
-    index: Option[ValidatorIndex],
+    index: Opt[ValidatorIndex],
     validator: ValidatorPubKey, newMinSlot: Slot) =
   ## Prune all blocks from a validator before the specified newMinSlot
   ## This is intended for interchange import to ensure
@@ -1208,11 +1243,11 @@ proc pruneBlocks*(
 proc pruneBlocks*(
     db: SlashingProtectionDB_v2,
     validator: ValidatorPubKey, newMinSlot: Slot) =
-  pruneBlocks(db, none(ValidatorIndex), validator, newMinSlot)
+  pruneBlocks(db, Opt.none(ValidatorIndex), validator, newMinSlot)
 
 proc pruneAttestations*(
        db: SlashingProtectionDB_v2,
-       index: Option[ValidatorIndex],
+       index: Opt[ValidatorIndex],
        validator: ValidatorPubKey,
        newMinSourceEpoch: int64,
        newMinTargetEpoch: int64) =
@@ -1236,7 +1271,7 @@ proc pruneAttestations*(
        newMinSourceEpoch: int64,
        newMinTargetEpoch: int64) =
   pruneAttestations(
-    db, none(ValidatorIndex), validator, newMinSourceEpoch, newMinTargetEpoch)
+    db, Opt.none(ValidatorIndex), validator, newMinSourceEpoch, newMinTargetEpoch)
 
 proc pruneAfterFinalization*(
        db: SlashingProtectionDB_v2,
@@ -1274,11 +1309,11 @@ proc retrieveLatestValidatorData*(
        db: SlashingProtectionDB_v2,
        validator: ValidatorPubKey
      ): tuple[
-          maxBlockSlot: Option[Slot],
-          maxAttSourceEpoch: Option[Epoch],
-          maxAttTargetEpoch: Option[Epoch]] =
+          maxBlockSlot: Opt[Slot],
+          maxAttSourceEpoch: Opt[Epoch],
+          maxAttTargetEpoch: Opt[Epoch]] =
 
-  let valID = db.getOrRegisterValidator(none(ValidatorIndex), validator)
+  let valID = db.getOrRegisterValidator(Opt.none(ValidatorIndex), validator)
 
   var slot, source, target: int64
   let status = db.sqlMaxBlockAtt.exec(
@@ -1299,11 +1334,11 @@ proc retrieveLatestValidatorData*(
   #       but let's deal with those here
 
   if slot != 0:
-    result.maxBlockSlot = some(Slot slot)
+    result.maxBlockSlot = Opt.some(Slot slot)
   if source != 0:
-    result.maxAttSourceEpoch = some(Epoch source)
+    result.maxAttSourceEpoch = Opt.some(Epoch source)
   if target != 0:
-    result.maxAttTargetEpoch = some(Epoch target)
+    result.maxAttTargetEpoch = Opt.some(Epoch target)
 
 proc registerSyntheticAttestation*(
        db: SlashingProtectionDB_v2,
@@ -1314,7 +1349,7 @@ proc registerSyntheticAttestation*(
   # Spec require source < target (except genesis?), for synthetic attestation for slashing protection we want max(source, target)
   doAssert (source < target) or (source == Epoch(0) and target == Epoch(0))
 
-  let valID = db.getOrRegisterValidator(none(ValidatorIndex), validator)
+  let valID = db.getOrRegisterValidator(Opt.none(ValidatorIndex), validator)
 
   # Overflows in 14 trillion years (minimal) or 112 trillion years (mainnet)
   doAssert source <= high(int64).uint64

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -11,12 +11,29 @@ import
   chronos,
   results,
   ../consensus_object_pools/block_dag,
-  ../beacon_clock
+  ../beacon_clock,
+  "."/[validator_pool]
 
 export chronos, results, block_dag, beacon_clock
 
-# The validator_duties module contains logic and utilities related to performing
-# validator duties that are shared between beacon node and validator client.
+## The validator_duties module contains logic and utilities related to performing
+## validator duties that are shared between beacon node and validator client.
+
+type
+  RegisteredAttestation* = object
+    # A registered attestation is one that has been successfully registered in
+    # the slashing protection database and is therefore ready to be signed and
+    # sent
+    validator*: AttachedValidator
+    index_in_committee*: uint64
+    committee_len*: int
+    data*: AttestationData
+
+proc toAttestation*(
+    registered: RegisteredAttestation, signature: ValidatorSig): Attestation =
+  Attestation.init(
+    [registered.index_in_committee], registered.committee_len,
+    registered.data, signature).expect("valid data")
 
 proc waitAfterBlockCutoff*(clock: BeaconClock, slot: Slot,
                            head: Opt[BlockRef] = Opt.none(BlockRef)) {.async.} =

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -182,7 +182,8 @@ proc runTest(identifier: string) =
 
     for blck in step.blocks:
       let pubkey = ValidatorPubKey.fromRaw(blck.pubkey.PubKeyBytes).get()
-      let status = db.db_v2.checkSlashableBlockProposal(none(ValidatorIndex),
+      let status = db.db_v2.checkSlashableBlockProposal(
+        Opt.none(ValidatorIndex),
         pubkey,
         Slot blck.slot
       )
@@ -196,7 +197,7 @@ proc runTest(identifier: string) =
         # Successful blocks are to be incoporated in the DB
         if status.isOk(): # Skip duplicates
           let status = db.db_v2.registerBlock(
-            none(ValidatorIndex),
+            Opt.none(ValidatorIndex),
             pubkey, Slot blck.slot,
             Eth2Digest blck.signing_root
           )
@@ -212,7 +213,7 @@ proc runTest(identifier: string) =
     for att in step.attestations:
       let pubkey = ValidatorPubKey.fromRaw(att.pubkey.PubKeyBytes).get()
 
-      let status = db.db_v2.checkSlashableAttestation(none(ValidatorIndex),
+      let status = db.db_v2.checkSlashableAttestation(Opt.none(ValidatorIndex),
         pubkey,
         Epoch att.source_epoch,
         Epoch att.target_epoch
@@ -227,7 +228,7 @@ proc runTest(identifier: string) =
         # Successful attestations are to be incoporated in the DB
         if status.isOk(): # Skip duplicates
           let status = db.db_v2.registerAttestation(
-            none(ValidatorIndex),
+            Opt.none(ValidatorIndex),
             pubkey,
             Epoch att.source_epoch,
             Epoch att.target_epoch,

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -1,5 +1,5 @@
 # Nimbus
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2023 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This PR brings down the time to send 100 attestations from ~1s to ~100ms, making it feasible to run 10k validators on a single node (which regularly send 300 attestations / slot).

This is done by batching the slashing protection database write in a single transaction thus avoiding a slow fsync for every signature - effects will be more pronounced on slow drives.

The benefit applies both to beacon and client validators.