### PR TITLE
clean up `XDeclaredButNotUsed` for light client

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -47,7 +47,7 @@ type
 
     pendingBest*:
       Table[(SyncCommitteePeriod, Eth2Digest), ForkedLightClientUpdate]
-      ## Same as `bestUpdates`, but for `SyncCommitteePeriod` with not yet
+      ## Same as `db.bestUpdates`, but for `SyncCommitteePeriod` with not yet
       ## finalized `next_sync_committee`. Key is `(attested_period,
       ## hash_tree_root(current_sync_committee | next_sync_committee)`.
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -456,7 +456,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
     `name _ ptr`: ptr[data_fork.LightClientHeader]
     `name _ ok` = true
   template `assign _ name`(
-      obj: var SomeForkyLightClientObject, bid: BlockId): untyped =
+      obj: var SomeForkyLightClientObject, bid: BlockId): untyped {.used.} =
     if `name _ ptr` != nil:
       obj.name = `name _ ptr`[]
     elif `name _ ok`:
@@ -472,7 +472,7 @@ template lazy_header(name: untyped): untyped {.dirty.} =
         `name _ ptr` = addr obj.name
     `name _ ok`
   template `assign _ name _ with_migration`(
-      obj: var SomeForkedLightClientObject, bid: BlockId): untyped =
+      obj: var SomeForkedLightClientObject, bid: BlockId): untyped {.used.} =
     if `name _ ptr` != nil:
       obj.migrateToDataFork(data_fork)
       obj.forky(data_fork).name = `name _ ptr`[]

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -501,6 +501,7 @@ func toFull*(
     update: SomeForkyLightClientUpdate): auto =
   type ResultType = typeof(update).kind.LightClientUpdate
   when update is ForkyLightClientUpdate:
+    static: doAssert update is ResultType
     update
   elif update is SomeForkyLightClientUpdateWithFinality:
     ResultType(

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -78,9 +78,10 @@ proc validate_light_client_update*(
       return err(VerifierError.MissingParent)
 
   # Verify update is relevant
-  let attested_period = update.attested_header.beacon.slot.sync_committee_period
   when update is SomeForkyLightClientUpdateWithSyncCommittee:
-    let is_sync_committee_update = update.is_sync_committee_update
+    let
+      attested_period = update.attested_header.beacon.slot.sync_committee_period
+      is_sync_committee_update = update.is_sync_committee_update
   if update.attested_header.beacon.slot <= store.finalized_header.beacon.slot:
     when update is SomeForkyLightClientUpdateWithSyncCommittee:
       if is_next_sync_committee_known:


### PR DESCRIPTION
Handle remaining `XDeclaredButNotUsed` warnings for light client.