### PR TITLE
fix #4065, explicitly mention trusted node sync

### DIFF
--- a/docs/the_nimbus_book/src/migration.md
+++ b/docs/the_nimbus_book/src/migration.md
@@ -22,7 +22,7 @@ Given what's at stake, there is no such thing as a stupid question.
 
 No matter which client you are migrating over from, the first step is to sync the Nimbus beacon node.
 
-The easiest and the fastest way to do this is to follow the [beacon node quick start guide](./quick-start.md) and perform a [trusted node sync](./trusted-node-sync.md) from the source client.
+The easiest and fastest way to do this is to follow the [beacon node quick start guide](./quick-start.md) and perform a [trusted node sync](./trusted-node-sync.md) from the source client.
 
 Once your Nimbus beacon node has synced and you're satisfied that it's working, move to **Step 2**.
 

--- a/docs/the_nimbus_book/src/migration.md
+++ b/docs/the_nimbus_book/src/migration.md
@@ -22,7 +22,7 @@ Given what's at stake, there is no such thing as a stupid question.
 
 No matter which client you are migrating over from, the first step is to sync the Nimbus beacon node.
 
-The easiest way to do this is to follow the [beacon node quick start guide](./quick-start.md).
+The easiest and the fastest way to do this is to follow the [beacon node quick start guide](./quick-start.md) and perform a [trusted node sync](./trusted-node-sync.md) from the source client.
 
 Once your Nimbus beacon node has synced and you're satisfied that it's working, move to **Step 2**.
 


### PR DESCRIPTION
> When migrating from another client, our migration guide should suggest how to trusted-node-sync from the source client, to avoid a long way - this way, client migration can be completed withing 30 minutes, sync and all..

While the quick start guide now has trusted node sync as a default recommendation (step 4), after this PR we also explicitly mention trusted node sync in the migration guide.