### PR TITLE
bump `geth` to `1.13.5` in CI

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -21,7 +21,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.13.5-unstable-f20b334f"  # not actually a stable version but first with macOS ARM64
+    GETH_VERSION="1.13.5-916d6a44"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in


### PR DESCRIPTION
Use stable Geth version in CI, the previous unstable one is no longer available and fails CI builds.