### PR TITLE
track block/blob matching/quarantines using both indices and commitments

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -16,7 +16,8 @@ const
 
 type
   BlobQuarantine* = object
-    blobs*: OrderedTable[(Eth2Digest, BlobIndex), ref BlobSidecar]
+    blobs*:
+      OrderedTable[(Eth2Digest, BlobIndex, KzgCommitment), ref BlobSidecar]
   BlobFetchRecord* = object
     block_root*: Eth2Digest
     indices*: seq[BlobIndex]
@@ -32,22 +33,19 @@ func put*(quarantine: var BlobQuarantine, blobSidecar: ref BlobSidecar) =
     # FIFO if full. For example, sync manager and request manager can race to
     # put blobs in at the same time, so one gets blob insert -> block resolve
     # -> blob insert sequence, which leaves garbage blobs.
-    var oldest_blob_key: (Eth2Digest, BlobIndex)
+    #
+    # This also therefore automatically garbage-collects otherwise valid garbage
+    # blobs which are correctly signed, point to either correct block roots or a
+    # block root which isn't ever seen, and then are for any reason simply never
+    # used.
+    var oldest_blob_key: (Eth2Digest, BlobIndex, KzgCommitment)
     for k in quarantine.blobs.keys:
       oldest_blob_key = k
       break
     quarantine.blobs.del oldest_blob_key
   let block_root = hash_tree_root(blobSidecar.signed_block_header.message)
   discard quarantine.blobs.hasKeyOrPut(
-    (block_root, blobSidecar.index), blobSidecar)
-
-func blobIndices*(quarantine: BlobQuarantine, digest: Eth2Digest):
-     seq[BlobIndex] =
-  var r: seq[BlobIndex] = @[]
-  for i in 0..<MAX_BLOBS_PER_BLOCK:
-    if quarantine.blobs.hasKey((digest, i)):
-      r.add(i)
-  r
+    (block_root, blobSidecar.index, blobSidecar.kzg_commitment), blobSidecar)
 
 func hasBlob*(
     quarantine: BlobQuarantine,
@@ -62,22 +60,20 @@ func hasBlob*(
       return true
   false
 
-func popBlobs*(quarantine: var BlobQuarantine, digest: Eth2Digest):
-     seq[ref BlobSidecar] =
+func popBlobs*(
+    quarantine: var BlobQuarantine, digest: Eth2Digest,
+    blck: deneb.SignedBeaconBlock): seq[ref BlobSidecar] =
   var r: seq[ref BlobSidecar] = @[]
-  for i in 0..<MAX_BLOBS_PER_BLOCK:
+  for idx, kzg_commitment in blck.message.body.blob_kzg_commitments:
     var b: ref BlobSidecar
-    if quarantine.blobs.pop((digest, i), b):
+    if quarantine.blobs.pop((digest, BlobIndex idx, kzg_commitment), b):
       r.add(b)
   r
 
 func hasBlobs*(quarantine: BlobQuarantine, blck: deneb.SignedBeaconBlock):
      bool =
-  let idxs = quarantine.blobIndices(blck.root)
-  if len(blck.message.body.blob_kzg_commitments) != len(idxs):
-    return false
-  for i in 0..<len(idxs):
-    if idxs[i] != uint64(i):
+  for idx, kzg_commitment in blck.message.body.blob_kzg_commitments:
+    if (blck.root, BlobIndex idx, kzg_commitment) notin quarantine.blobs:
       return false
   true
 
@@ -86,6 +82,7 @@ func blobFetchRecord*(quarantine: BlobQuarantine, blck: deneb.SignedBeaconBlock)
   var indices: seq[BlobIndex]
   for i in 0..<len(blck.message.body.blob_kzg_commitments):
     let idx = BlobIndex(i)
-    if not quarantine.blobs.hasKey((blck.root, idx)):
+    if not quarantine.blobs.hasKey(
+        (blck.root, idx, blck.message.body.blob_kzg_commitments[i])):
       indices.add(idx)
   BlobFetchRecord(block_root: blck.root, indices: indices)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -746,7 +746,8 @@ proc storeBlock(
              error = res.error()
             continue
           if self.blobQuarantine[].hasBlobs(forkyBlck):
-            let blobs = self.blobQuarantine[].popBlobs(forkyBlck.root)
+            let blobs = self.blobQuarantine[].popBlobs(
+              forkyBlck.root, forkyBlck)
             self[].enqueueBlock(MsgSource.gossip, quarantined, Opt.some(blobs))
           else:
             if not self.consensusManager.quarantine[].addBlobless(

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -242,7 +242,7 @@ proc processSignedBeaconBlock*(
     let blobs =
       when typeof(signedBlock).kind >= ConsensusFork.Deneb:
         if self.blobQuarantine[].hasBlobs(signedBlock):
-          Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root))
+          Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root, signedBlock))
         else:
           if not self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
                                                signedBlock):
@@ -310,7 +310,7 @@ proc processBlobSidecar*(
       self.blockProcessor[].enqueueBlock(
         MsgSource.gossip,
         ForkedSignedBeaconBlock.init(blobless),
-        Opt.some(self.blobQuarantine[].popBlobs(block_root)))
+        Opt.some(self.blobQuarantine[].popBlobs(block_root, blobless)))
     else:
       discard self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
                                             blobless)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -408,7 +408,7 @@ proc initFullNode(
                 Result[void, VerifierError].err(VerifierError.MissingParent),
                 "rmanBlockVerifier")
           else:
-            let blobs = blobQuarantine[].popBlobs(forkyBlck.root)
+            let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
             blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
                                       Opt.some(blobs),
                                       maybeFinalized = maybeFinalized)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -504,8 +504,6 @@ proc makeBeaconBlock*(
   else:
     {.error: "Unsupported fork".}
 
-# workaround for https://github.com/nim-lang/Nim/issues/20900 rather than have
-# these be default arguments
 proc makeBeaconBlock*(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState,
     proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -293,7 +293,6 @@ proc getMissingBlobs(rman: RequestManager): seq[BlobIdentifier] =
       if len(missing.indices) == 0:
         warn "quarantine missing blobs, but missing indices is empty",
          blk=blobless.root,
-         indices=rman.blobQuarantine[].blobIndices(blobless.root),
          commitments=len(blobless.message.body.blob_kzg_commitments)
       for idx in missing.indices:
         let id = BlobIdentifier(block_root: blobless.root, index: idx)
@@ -303,7 +302,6 @@ proc getMissingBlobs(rman: RequestManager): seq[BlobIdentifier] =
       # this is a programming error should it occur.
       warn "missing blob handler found blobless block with all blobs",
          blk=blobless.root,
-         indices=rman.blobQuarantine[].blobIndices(blobless.root),
          commitments=len(blobless.message.body.blob_kzg_commitments)
       discard rman.blockVerifier(ForkedSignedBeaconBlock.init(blobless),
                                  false)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -560,8 +560,6 @@ proc makeBeaconBlockForHeadAndSlot*(
   else:
     err(blck.error)
 
-# workaround for https://github.com/nim-lang/Nim/issues/20900 to avoid default
-# parameters
 proc makeBeaconBlockForHeadAndSlot*(
     PayloadType: type ForkyExecutionPayloadForSigning, node: BeaconNode, randao_reveal: ValidatorSig,
     validator_index: ValidatorIndex, graffiti: GraffitiBytes, head: BlockRef,


### PR DESCRIPTION
https://github.com/nim-lang/Nim/issues/20900 was, indeed, the initial cause of those forwarding functions, but it's nice to statically know that one's getting either all the "optional" parameters or none, not a random mix.

The KZG commitment change targets a couple of issues

One, found by Hive, is
```
DBG 2023-10-27 19:15:06.804+00:00 Blob received                              topics="gossip_eth2" delay=804ms22us732ns blob="(block_root: \"f0e6aaa0\", index: 0, slot: 1, block_parent_root: \"40bafc55\", proposer_index: 118, bloblen: 131072)" wallSlot=1 signature=995feb22
DBG 2023-10-27 19:15:06.806+00:00 Blob validated, putting in blob quarantine topics="gossip_eth2" blob="(block_root: \"f0e6aaa0\", index: 0, slot: 1, block_parent_root: \"40bafc55\", proposer_index: 118, bloblen: 131072)" wallSlot=1 signature=995feb22
DBG 2023-10-27 19:15:06.807+00:00 Block received                             topics="beacnde" delay=807ms811us523ns blockRoot=f0e6aaa0 wallSlot=1 signature=88159023 blck="(slot: 1, proposer_index: 118, parent_root: \"40bafc55\", state_root: \"caf5c9f2\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 37a6da948e53b96f8c9be04f5b67e16ec901733ddac0414aa439103306671ddc), graffiti: \"Nimbus/v23.10.0-51a590-stateofus\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 0, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 0, block_number: 1, fee_recipient: \"0x0000000000000000000000000000000000000000\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 0)"
WRN 2023-10-27 19:15:08.003+00:00 quarantine missing blobs, but missing indices is empty topics="requman" blk=f0e6aaa0 indices=@[0] kzgs=0
WRN 2023-10-27 19:15:09.003+00:00 quarantine missing blobs, but missing indices is empty topics="requman" blk=f0e6aaa0 indices=@[0] kzgs=0
WRN 2023-10-27 19:15:10.003+00:00 quarantine missing blobs, but missing indices is empty topics="requman" blk=f0e6aaa0 indices=@[0] kzgs=0
WRN 2023-10-27 19:15:11.004+00:00 quarantine missing blobs, but missing indices is empty topics="requman" blk=f0e6aaa0 indices=@[0] kzgs=0
WRN 2023-10-27 19:15:12.005+00:00 quarantine missing blobs, but missing indices is empty topics="requman" blk=f0e6aaa0 indices=@[0] kzgs=0
```

which is because `hasBlobs` saw the quarantine had one blob claiming to be from this block which required/had no blobs, and the block itself noted it had 0 KZG commitments, and that mismatch stalled the processing. This changes the matching scheme not to check
```nim
  if len(blck.message.body.blob_kzg_commitments) != len(idxs):
    return false
```
because this check is too aggressive against malicious or accidental stuffing of otherwise valid blob sidecars (correct or unknown block root, correct signature) into the quarantine, when they should be ignored. Rather it uses the block as the only source of truth, and checks whether the blob quarantine contains all the sidecars (index/KZG commitment pairs) it requires.

As part of this change, `blobIndices` would have been salvageable, but not worthwhile, Its semantics fundamentally require being able to iterate across all possible blob sidecars in the quarantine, which could have been achieved, but it was only used in two other functions in the blob quarantine, for which it was now unnecessary, and some logging where the entire point was that there weren't any missing blobs (and its a bit of a potential DoS vector to then allow sidecar blob-stuffing as before), so better to just remove.