### PR TITLE
switch engine authentication from `Option` to `Opt`

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1436,8 +1436,8 @@ func defaultFeeRecipient*(conf: AnyConf): Opt[Eth1Address] =
 proc loadJwtSecret*(
     rng: var HmacDrbgContext,
     dataDir: string,
-    jwtSecret: Option[InputFile],
-    allowCreate: bool): Option[seq[byte]] =
+    jwtSecret: Opt[InputFile],
+    allowCreate: bool): Opt[seq[byte]] =
   # Some Web3 endpoints aren't compatible with JWT, but if explicitly chosen,
   # use it regardless.
   if jwtSecret.isSome or allowCreate:
@@ -1447,15 +1447,21 @@ proc loadJwtSecret*(
         err = secret.error
       quit 1
 
-    some secret.get
+    Opt.some secret.get
   else:
-    none(seq[byte])
+    Opt.none seq[byte]
 
 proc loadJwtSecret*(
     rng: var HmacDrbgContext,
     config: BeaconNodeConf,
-    allowCreate: bool): Option[seq[byte]] =
-  rng.loadJwtSecret(string(config.dataDir), config.jwtSecret, allowCreate)
+    allowCreate: bool): Opt[seq[byte]] =
+  rng.loadJwtSecret(
+    string(config.dataDir),
+    (if config.jwtSecret.isSome:
+       Opt.some config.jwtSecret.get
+     else:
+       Opt.none InputFile),
+    allowCreate)
 
 proc engineApiUrls*(config: BeaconNodeConf): seq[EngineApiUrl] =
   let elUrls = if config.noEl:

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1471,7 +1471,11 @@ proc engineApiUrls*(config: BeaconNodeConf): seq[EngineApiUrl] =
   else:
     config.elUrls
 
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(config.jwtSecret)
+  (elUrls & config.web3Urls).toFinalEngineApiUrls(
+    if config.jwtSecret.isSome:
+      Opt.some config.jwtSecret.get
+    else:
+      Opt.none InputFile)
 
 proc loadKzgTrustedSetup*(): Result[void, string] =
   const

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -174,4 +174,5 @@ proc engineApiUrls*(config: LightClientConf): seq[EngineApiUrl] =
   else:
     config.elUrls
 
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(config.jwtSecret)
+  (elUrls & config.web3Urls).toFinalEngineApiUrls(
+    config.jwtSecret.configJwtSecretOpt)

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -28,7 +28,7 @@ type
 
   EngineApiUrl* = object
     url: string
-    jwtSecret: Option[seq[byte]]
+    jwtSecret: Opt[seq[byte]]
     roles: EngineApiRoles
 
   EngineApiUrlConfigValue* = object
@@ -52,14 +52,14 @@ chronicles.formatIt EngineApiUrl:
 
 proc init*(T: type EngineApiUrl,
            url: string,
-           jwtSecret = none seq[byte],
+           jwtSecret = Opt.none seq[byte],
            roles = defaultEngineApiRoles): T =
   T(url: url, jwtSecret: jwtSecret, roles: roles)
 
 func url*(engineUrl: EngineApiUrl): string =
   engineUrl.url
 
-func jwtSecret*(engineUrl: EngineApiUrl): Option[seq[byte]] =
+func jwtSecret*(engineUrl: EngineApiUrl): Opt[seq[byte]] =
   engineUrl.jwtSecret
 
 func roles*(engineUrl: EngineApiUrl): EngineApiRoles =
@@ -157,14 +157,14 @@ proc fixupWeb3Urls*(web3Url: var string) =
     web3Url = "ws://" & web3Url
 
 proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
-                 confJwtSecret: Option[seq[byte]]): Result[EngineApiUrl, cstring] =
+                 confJwtSecret: Opt[seq[byte]]): Result[EngineApiUrl, cstring] =
   if confValue.jwtSecret.isSome and confValue.jwtSecretFile.isSome:
     return err "The options `jwtSecret` and `jwtSecretFile` should not be specified together"
 
   let jwtSecret = if confValue.jwtSecret.isSome:
-    some(? parseJwtTokenValue(confValue.jwtSecret.get))
+    Opt.some(? parseJwtTokenValue(confValue.jwtSecret.get))
   elif confValue.jwtSecretFile.isSome:
-    some(? loadJwtSecretFile(confValue.jwtSecretFile.get))
+    Opt.some(? loadJwtSecretFile(confValue.jwtSecretFile.get))
   else:
     confJwtSecret
 
@@ -176,19 +176,19 @@ proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
     jwtSecret = jwtSecret,
     roles = confValue.roles.get(defaultEngineApiRoles))
 
-proc loadJwtSecret*(jwtSecret: Option[InputFile]): Option[seq[byte]] =
+proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[seq[byte]] =
   if jwtSecret.isSome:
     let res = loadJwtSecretFile(jwtSecret.get)
     if res.isOk:
-      some res.value
+      Opt.some res.value
     else:
       fatal "Failed to load JWT secret file", err = res.error
       quit 1
   else:
-    none seq[byte]
+    Opt.none seq[byte]
 
 proc toFinalEngineApiUrls*(elUrls: seq[EngineApiUrlConfigValue],
-                           confJwtSecret: Option[InputFile]): seq[EngineApiUrl] =
+                           confJwtSecret: Opt[InputFile]): seq[EngineApiUrl] =
   let jwtSecret = loadJwtSecret confJwtSecret
 
   for elUrl in elUrls:

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -688,7 +688,7 @@ func hash*(x: Eth1Data): Hash =
 func isConnected(connection: ELConnection): bool =
   connection.web3.isSome
 
-func getJsonRpcRequestHeaders(jwtSecret: Option[seq[byte]]):
+func getJsonRpcRequestHeaders(jwtSecret: Opt[seq[byte]]):
     auto =
   if jwtSecret.isSome:
     let secret = jwtSecret.get
@@ -2189,7 +2189,7 @@ func `$`(x: BlockObject): string =
 
 proc testWeb3Provider*(web3Url: Uri,
                        depositContractAddress: Eth1Address,
-                       jwtSecret: Option[seq[byte]]) {.async.} =
+                       jwtSecret: Opt[seq[byte]]) {.async.} =
   stdout.write "Establishing web3 connection..."
   var web3: Web3
   try:

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -13,7 +13,6 @@ import
 
 from std/base64 import encode
 from std/json import JsonNode, `$`, `%*`
-from std/options import Option, get, isNone
 from std/os import `/`
 from std/strutils import replace
 
@@ -83,7 +82,7 @@ proc loadJwtSecretFile*(jwtSecretFile: InputFile): Result[seq[byte], cstring] =
     err("invalid JWT hex string")
 
 proc checkJwtSecret*(
-    rng: var HmacDrbgContext, dataDir: string, jwtSecret: Option[InputFile]):
+    rng: var HmacDrbgContext, dataDir: string, jwtSecret: Opt[InputFile]):
     Result[seq[byte], cstring] =
   # If such a parameter is given, but the file cannot be read, or does not
   # contain a hex-encoded key of 256 bits, the client should treat this as an

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -40,8 +40,8 @@ suite "EL Configuration":
       url1.jwtSecretFile.isNone
 
     let
-      url1Final1 = url1.toFinalUrl(some validJwtToken)
-      url1Final2 = url1.toFinalUrl(none seq[byte])
+      url1Final1 = url1.toFinalUrl(Opt.some validJwtToken)
+      url1Final2 = url1.toFinalUrl(Opt.none seq[byte])
 
     check:
       url1Final1.isOk
@@ -70,7 +70,7 @@ suite "EL Configuration":
       url3.jwtSecret == some("ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba")
       url3.jwtSecretFile.isNone
 
-    let url3Final = url3.toFinalUrl(some validJwtToken)
+    let url3Final = url3.toFinalUrl(Opt.some validJwtToken)
     check:
       url3Final.isOk
       url3Final.get.jwtSecret.get.toHex == "ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba"
@@ -84,7 +84,7 @@ suite "EL Configuration":
       url4.jwtSecret == some("ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba23")
       url4.jwtSecretFile.isNone
 
-    let url4Final = url4.toFinalUrl(some validJwtToken)
+    let url4Final = url4.toFinalUrl(Opt.some validJwtToken)
     check:
       not url4Final.isOk # the JWT secret is invalid
 


### PR DESCRIPTION
This can't remove it entirely, but moves it right up to the `nim-confutils` boundary.