### PR TITLE
respond even in not-yet-supported Deneb beacon+builder API case in REST server

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -524,7 +524,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       # TODO
       # We should return a block with sidecars here
       # https://github.com/ethereum/beacon-APIs/pull/302/files
-      debugRaiseAssert $denebImplementationMissing & ": GET /eth/v1/validator/blinded_blocks/{slot}"
+      return RestApiResponse.jsonError(
+        Http400, "Deneb builder API beacon API not yet supported: " & $denebImplementationMissing)
     of ConsensusFork.Capella:
       let res = await makeBlindedBeaconBlockForHeadAndSlot[
           capella_mev.BlindedBeaconBlock](


### PR DESCRIPTION
This attempts to address an issue in the finalization CI related to https://github.com/status-im/nimbus-eth2/pull/5626

One reason this race condition is triggering, and especially in the shorter (6s vs 12s slots minimal case), is that without this change, the REST server is returning HTTP status 410, which the VC responds to with:
```
DBG 2023-11-26 06:35:31.112+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request="/eth/v1/validator/blinded_blocks/25?randao_reveal=0xa34f639469eb17321bf8919c5f8c9c304c48fc6482f62d9711b7786bdd8c5b2847c7d84a27f7898d118a2b691e2a100110758418b3bcb6c52c38874572adb4e325c744c1e8882a35c9d9f2e7ddba7a88e5bb13792112e9d8de3e7627990e7383&graffiti=0x4e696d6275732f7632332e31302e312d3630393934342d73746174656f667573" status=410 http_method=GET
DBG 2023-11-26 06:35:31.112+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request="/eth/v1/validator/blinded_blocks/25?randao_reveal=0xa34f639469eb17321bf8919c5f8c9c304c48fc6482f62d9711b7786bdd8c5b2847c7d84a27f7898d118a2b691e2a100110758418b3bcb6c52c38874572adb4e325c744c1e8882a35c9d9f2e7ddba7a88e5bb13792112e9d8de3e7627990e7383&graffiti=0x4e696d6275732f7632332e31302e312d3630393934342d73746174656f667573" contentType=<missing> size=0
DBG 2023-11-26 06:35:31.112+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request=/eth/v1/validator/duties/proposer/3 status=200 http_method=GET
DBG 2023-11-26 06:35:31.112+02:00 REST request body has been sent            remote=127.0.0.1:5032 request=/eth/v1/validator/prepare_beacon_proposer size=22067 http_method=POST
DBG 2023-11-26 06:35:31.112+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/validator/duties/proposer/3 contentType=application/json size=1309
DBG 2023-11-26 06:35:31.113+02:00 Failed to deserialize REST JSON data       err="<data>(1, 0) Unexpected token 'tkEof' in place of 'object start bracket'" data=
ERR 2023-11-26 06:35:31.113+02:00 Beacon node provides unexpected status code reason="Unable to decode error response: [Serialization error];410;produceBlindedBlock(best);unexpected-code" node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT

...

DBG 2023-11-26 06:35:43.113+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request="/eth/v1/validator/blinded_blocks/27?randao_reveal=0x970f66d8a161dbde5eb0f986e7958f7db2fbe0f507e60c4eab8ea77d351285f7fbeeb7a3d564dc779f84eb135b6376b10b24121ea9bb6e6d0f3103daafab1d2f0adeb0d304a1ad0055fbcd9e492e77d28629338474ecff1178e94340a2e8bb6a&graffiti=0x4e696d6275732f7632332e31302e312d3630393934342d73746174656f667573" status=410 http_method=GET
DBG 2023-11-26 06:35:43.114+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/validator/duties/proposer/3 contentType=application/json size=1309
DBG 2023-11-26 06:35:43.114+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request="/eth/v1/validator/blinded_blocks/27?randao_reveal=0x970f66d8a161dbde5eb0f986e7958f7db2fbe0f507e60c4eab8ea77d351285f7fbeeb7a3d564dc779f84eb135b6376b10b24121ea9bb6e6d0f3103daafab1d2f0adeb0d304a1ad0055fbcd9e492e77d28629338474ecff1178e94340a2e8bb6a&graffiti=0x4e696d6275732f7632332e31302e312d3630393934342d73746174656f667573" contentType=<missing> size=0
DBG 2023-11-26 06:35:43.114+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request=/eth/v1/validator/duties/sync/0 status=200 http_method=POST
DBG 2023-11-26 06:35:43.114+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request=/nimbus/v1/timesync status=200 http_method=POST
DBG 2023-11-26 06:35:43.115+02:00 REST request body has been sent            remote=127.0.0.1:5032 request=/eth/v1/validator/prepare_beacon_proposer size=22067 http_method=POST
DBG 2023-11-26 06:35:43.115+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/validator/duties/sync/0 contentType=application/json size=1104
DBG 2023-11-26 06:35:43.115+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/nimbus/v1/timesync contentType=application/json size=124
DBG 2023-11-26 06:35:43.115+02:00 Failed to deserialize REST JSON data       err="<data>(1, 0) Unexpected token 'tkEof' in place of 'object start bracket'" data=
ERR 2023-11-26 06:35:43.115+02:00 Beacon node provides unexpected status code reason="Unable to decode error response: [Serialization error];410;produceBlindedBlock(best);unexpected-code" node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT
```

In each case respectively, it concludes adds a nearly 2 second delay (notably, enough for the sync committee message with the previous block root to go out for a second slot in a row, potentially) with no debug-level logging during those ~2s:
```
INF 2023-11-26 06:35:31.109+02:00 Slot start                                 slot=25 epoch=3 attestationIn=2s blockIn=24s validators=254 node_status=synced delay=109ms634us
...
DBG 2023-11-26 06:35:31.118+02:00 Sending block                              signingRoot=e270f77a wall_slot=25 validator_index=470 blck="(slot: 25, proposer_index: 470, parent_root: \"36474276\", state_root: \"8e1df273\", eth1data: (deposit_root: 0a8f804613a01c8e2914b099208b175824ab9192fbb20dd973feb7d48a5b12d7, deposit_count: 1024, block_hash: 4242424242424242424242424242424242424242000000000000000000000000), graffiti: \"Nimbus/v23.10.1-609944-stateofus\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 4, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 32, block_number: 23, fee_recipient: \"0x0000000000000000000000000000000000000000\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 0)" service=block_service slot=25 validator=b5e825ae block_root=ee7cf153
...
DBG 2023-11-26 06:35:31.169+02:00 Validator registrations prepared           total=254 succeed=254 cached=0 bad=0 errors=0 index_missing=0 fee_missing=0 incorrect_time=0
DBG 2023-11-26 06:35:32.921+02:00 Checking beacon node                       node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT status="unexpected code" service=fallback_service
DBG 2023-11-26 06:35:32.922+02:00 Checking beacon node status                service=fallback_service node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT
DBG 2023-11-26 06:35:32.922+02:00 Sending REST request to remote server      remote=127.0.0.1:5032 request=/eth/v1/node/version http_method=GET
DBG 2023-11-26 06:35:32.924+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request=/eth/v1/node/version status=200 http_method=GET
DBG 2023-11-26 06:35:32.925+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/node/version contentType=application/json size=55
NOT 2023-11-26 06:35:32.926+02:00 Beacon node is online                      agent_version=Nimbus/v23.10.1-609944-stateofus node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT
...
DBG 2023-11-26 06:35:32.990+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/beacon/blocks contentType=application/json size=84
DBG 2023-11-26 06:35:32.991+02:00 Got REST response headers from remote server remote=127.0.0.1:5201 request=/api/v1/eth2/sign/0xb1e93c2c5cd2aecea95a52292c9a7d6f7fea1b92c2932739383c93d90a73dd6ea5cc9545e42b9fbf2bef0aa61527f714 status=200 http_method=POST
DBG 2023-11-26 06:35:32.991+02:00 Received REST response body from remote server remote=127.0.0.1:5201 request=/api/v1/eth2/sign/0xb1e93c2c5cd2aecea95a52292c9a7d6f7fea1b92c2932739383c93d90a73dd6ea5cc9545e42b9fbf2bef0aa61527f714 contentType=application/json size=211
NOT 2023-11-26 06:35:32.991+02:00 Block published                            delay=1s991ms809us signingRoot=e270f77a wall_slot=25 validator_index=470 blck="(slot: 25, proposer_index: 470, parent_root: \"36474276\", state_root: \"8e1df273\", eth1data: (deposit_root: 0a8f804613a01c8e2914b099208b175824ab9192fbb20dd973feb7d48a5b12d7, deposit_count: 1024, block_hash: 4242424242424242424242424242424242424242000000000000000000000000), graffiti: \"Nimbus/v23.10.1-609944-stateofus\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 4, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 32, block_number: 23, fee_recipient: \"0x0000000000000000000000000000000000000000\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 0)" service=block_service slot=25 validator=b5e825ae block_root=ee7cf153

...

INF 2023-11-26 06:35:43.108+02:00 Slot start                                 slot=27 epoch=3 attestationIn=2s blockIn=12s validators=254 node_status=synced delay=108ms159us
...
DBG 2023-11-26 06:35:43.120+02:00 Sending block                              signingRoot=478f4116 wall_slot=27 validator_index=219 blck="(slot: 27, proposer_index: 219, parent_root: \"7a024296\", state_root: \"21bceb77\", eth1data: (deposit_root: 0a8f804613a01c8e2914b099208b175824ab9192fbb20dd973feb7d48a5b12d7, deposit_count: 1024, block_hash: 4242424242424242424242424242424242424242000000000000000000000000), graffiti: \"Nimbus/v23.10.1-609944-stateofus\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 4, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 32, block_number: 25, fee_recipient: \"0x0000000000000000000000000000000000000000\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 0)" service=block_service slot=27 validator=b4d16864 block_root=48239fa7
...
DBG 2023-11-26 06:35:43.177+02:00 Validator registrations prepared           total=254 succeed=254 cached=0 bad=0 errors=0 index_missing=0 fee_missing=0 incorrect_time=0
DBG 2023-11-26 06:35:44.951+02:00 Checking beacon node                       node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT status="unexpected code" service=fallback_service
DBG 2023-11-26 06:35:44.951+02:00 Checking beacon node status                service=fallback_service node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT
DBG 2023-11-26 06:35:44.951+02:00 Sending REST request to remote server      remote=127.0.0.1:5032 request=/eth/v1/node/version http_method=GET
DBG 2023-11-26 06:35:44.961+02:00 Got REST response headers from remote server remote=127.0.0.1:5032 request=/eth/v1/node/version status=200 http_method=GET
DBG 2023-11-26 06:35:44.962+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/node/version contentType=application/json size=55
NOT 2023-11-26 06:35:44.962+02:00 Beacon node is online                      agent_version=Nimbus/v23.10.1-609944-stateofus node=http://127.0.0.1:5032[Nimbus/v23.10.1-609944-stateofus] node_index=0 node_roles=AGBSDT
...
DBG 2023-11-26 06:35:45.069+02:00 Received REST response body from remote server remote=127.0.0.1:5032 request=/eth/v1/beacon/blocks contentType=application/json size=84
NOT 2023-11-26 06:35:45.069+02:00 Block published                            delay=2s69ms771us signingRoot=478f4116 wall_slot=27 validator_index=219 blck="(slot: 27, proposer_index: 219, parent_root: \"7a024296\", state_root: \"21bceb77\", eth1data: (deposit_root: 0a8f804613a01c8e2914b099208b175824ab9192fbb20dd973feb7d48a5b12d7, deposit_count: 1024, block_hash: 4242424242424242424242424242424242424242000000000000000000000000), graffiti: \"Nimbus/v23.10.1-609944-stateofus\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 4, deposits_len: 0, voluntary_exits_len: 0, sync_committee_participants: 32, block_number: 25, fee_recipient: \"0x0000000000000000000000000000000000000000\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 0)" service=block_service slot=27 validator=b4d16864 block_root=48239fa7
```

where all these logs are from https://ci.status.im/blue/organizations/jenkins/nimbus-eth2%2Fplatforms%2Fmacos%2Faarch64/detail/PR-5621/3/pipeline/

It's possible that using 400, which works in the Capella case to avoid this response, and is a more correct code regardless, will avoid these delays which only occur after the onset of Deneb.