### PR TITLE
remove emoji from function names

### DIFF
--- a/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
@@ -37,13 +37,13 @@ type
 # Created by http://beatscribe.com/ (beatscribe#1008 on Discord)
 # These need to be the main body of the log not to be reformatted or escaped.
 
-proc mono🐼*()  = notice "\n" & staticRead("bellatrix" / "mono.txt")
-proc color🐼*() = notice "\n" & staticRead("bellatrix" / "color.ans")
-proc blink🐼*() = notice "\n" & staticRead("bellatrix" / "blink.ans")
+proc bellatrixMono*()  = notice "\n" & staticRead("bellatrix" / "mono.txt")
+proc bellatrixColor*() = notice "\n" & staticRead("bellatrix" / "color.ans")
+proc bellatrixBlink*() = notice "\n" & staticRead("bellatrix" / "blink.ans")
 
-proc mono🦉*()  = notice "\n" & staticRead("capella" / "mono.txt")
-proc color🦉*() = notice "\n" & staticRead("capella" / "color.ans")
-proc blink🦉*() = notice "\n" & staticRead("capella" / "blink.ans")
+proc capellaMono*()  = notice "\n" & staticRead("capella" / "mono.txt")
+proc capellaColor*() = notice "\n" & staticRead("capella" / "color.ans")
+proc capellaBlink*() = notice "\n" & staticRead("capella" / "blink.ans")
 
-proc mono🐟*()  = notice "\n" & staticRead("deneb" / "mono.txt")
-proc color🐟*() = notice "\n" & staticRead("deneb" / "color.ans")
+proc denebMono*()  = notice "\n" & staticRead("deneb" / "mono.txt")
+proc denebColor*() = notice "\n" & staticRead("deneb" / "color.ans")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -170,18 +170,18 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   of StdoutLogKind.Auto: raiseAssert "inadmissable here"
   of StdoutLogKind.Colors:
     VanityLogs(
-      onMergeTransitionBlock:          color🐼,
-      onFinalizedMergeTransitionBlock: blink🐼,
-      onUpgradeToCapella:              color🦉,
-      onKnownBlsToExecutionChange:     blink🦉,
-      onUpgradeToDeneb:                color🐟)
+      onMergeTransitionBlock:          bellatrixColor,
+      onFinalizedMergeTransitionBlock: bellatrixBlink,
+      onUpgradeToCapella:              capellaColor,
+      onKnownBlsToExecutionChange:     capellaBlink,
+      onUpgradeToDeneb:                denebColor)
   of StdoutLogKind.NoColors:
     VanityLogs(
-      onMergeTransitionBlock:          mono🐼,
-      onFinalizedMergeTransitionBlock: mono🐼,
-      onUpgradeToCapella:              mono🦉,
-      onKnownBlsToExecutionChange:     mono🦉,
-      onUpgradeToDeneb:                mono🐟)
+      onMergeTransitionBlock:          bellatrixMono,
+      onFinalizedMergeTransitionBlock: bellatrixMono,
+      onUpgradeToCapella:              capellaMono,
+      onKnownBlsToExecutionChange:     capellaMono,
+      onUpgradeToDeneb:                denebMono)
   of StdoutLogKind.Json, StdoutLogKind.None:
     VanityLogs(
       onMergeTransitionBlock:


### PR DESCRIPTION
Some editors seem to have issues with those. The ones in strings seem to be alright, though. Rename the affected symbols.