### PR TITLE
stop checking beacon parent root for fcU caching

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -17,7 +17,6 @@ import
   eth/async_utils, stew/[assign2, byteutils, objects, results, shims/hashes, endians2],
   # Local modules:
   ../spec/[deposit_snapshots, eth2_merkleization, forks, helpers],
-  ../spec/datatypes/[base, phase0, bellatrix, deneb],
   ../networking/network_metadata,
   ../consensus_object_pools/block_pools_types,
   ".."/[beacon_chain_db, beacon_node_status, beacon_clock, future_combinators],
@@ -758,8 +757,7 @@ func areSameAs(expectedParams: Option[NextExpectedPayloadParams],
                timestamp: uint64,
                randomData: Eth2Digest,
                feeRecipient: Eth1Address,
-               withdrawals: seq[WithdrawalV1],
-               parentBeaconBlockRoot: FixedBytes[32]): bool =
+               withdrawals: seq[WithdrawalV1]): bool =
   expectedParams.isSome and
     expectedParams.get.headBlockHash == latestHead and
     expectedParams.get.safeBlockHash == latestSafe and
@@ -767,9 +765,7 @@ func areSameAs(expectedParams: Option[NextExpectedPayloadParams],
     expectedParams.get.payloadAttributes.timestamp.uint64 == timestamp and
     expectedParams.get.payloadAttributes.prevRandao.bytes == randomData.data and
     expectedParams.get.payloadAttributes.suggestedFeeRecipient == feeRecipient and
-    expectedParams.get.payloadAttributes.withdrawals == withdrawals and
-    expectedParams.get.payloadAttributes.parentBeaconBlockRoot ==
-      parentBeaconBlockRoot
+    expectedParams.get.payloadAttributes.withdrawals == withdrawals
 
 proc forkchoiceUpdated(rpcClient: RpcClient,
                        state: ForkchoiceStateV1,
@@ -906,8 +902,7 @@ proc getPayload*(m: ELManager,
     engineApiWithdrawals = toEngineWithdrawals withdrawals
     isFcUpToDate = m.nextExpectedPayloadParams.areSameAs(
       headBlock, safeBlock, finalizedBlock, timestamp,
-      randomData, suggestedFeeRecipient, engineApiWithdrawals,
-      consensusHead.asBlockHash)
+      randomData, suggestedFeeRecipient, engineApiWithdrawals)
 
   # `getPayloadFromSingleEL` may introduce additional latency
   const extraProcessingOverhead = 500.milliseconds

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -342,7 +342,7 @@ proc requestManagerBlobLoop(rman: RequestManager) {.async.} =
              failed = (len(workers) - succeed),
              sync_speed = speed(start, finish)
 
-      except CancelledError as exc:
+      except CancelledError:
         break
       except CatchableError as exc:
         warn "Unexpected error in request manager blob loop", exc = exc.msg


### PR DESCRIPTION
Discovered on `devnet-12`.

Otherwise, pre-Deneb, it sends two identical fcUs for each proposal around one slot apart from each other, because the caching was comparing a placeholder `ZERO_HASH` `parentBeaconBlockRoot` with the actual `consensusHead.asBlockHash`, and inevitably discovering they differed.

For pre-Deneb cases, one straightforwardly doesn't have to check `parentBeaconBlockRoot` (CL head), and even for Deneb, that differs if and only if `headBlockHash` / `latestHead` differs, so it's either harmful (pre-Deneb) or redundant (Deneb or later) to check both.

https://github.com/paradigmxyz/reth/issues/5623 has some more discussion.