### PR TITLE
update network chain ID reference URL(s)

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1377,11 +1377,11 @@ proc exchangeConfigWithSingleEL(m: ELManager, connection: ELConnection) {.async.
             rpcClient.eth_chainId(),
             web3RequestsTimeout)
 
-        # https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids
+        # https://chainid.network/
         expectedChain = case m.eth1Network.get
           of mainnet: 1.Quantity
           of goerli:  5.Quantity
-          of sepolia: 11155111.Quantity   # https://chainid.network/
+          of sepolia: 11155111.Quantity
           of holesky: 17000.Quantity
       if expectedChain != providerChain:
         warn "The specified EL client is connected to a different chain",


### PR DESCRIPTION
Something of a followup to https://github.com/status-im/nimbus-eth2/pull/5586, after which the only two networks in the list remaining from https://eips.ethereum.org/EIPS/eip-155#list-of-chain-ids were mainnet and Goerli. With the announcement of https://blog.ethereum.org/2023/11/30/goerli-lts-update it will within some months likely become only mainnet.

After that, this section of EIP-155 doesn't appear to be receiving updates, so it doesn't help to use it as a reference anymore.