### PR TITLE
Apply EIP-7044 to block signature batch verification

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -284,7 +284,8 @@ proc addHeadBlockWithParent*(
     var sigs: seq[SignatureSet]
     if (let e = sigs.collectSignatureSets(
         signedBlock, dag.db.immutableValidators,
-        dag.clearanceState, dag.cfg.genesisFork(), cache); e.isErr()):
+        dag.clearanceState, dag.cfg.genesisFork(), dag.cfg.capellaFork(),
+        cache); e.isErr()):
       # A PublicKey or Signature isn't on the BLS12-381 curve
       info "Unable to load signature sets",
         err = e.error()


### PR DESCRIPTION
Discovered on `devnet-11`, when Deneb exits caused all the Nimbus nodes to stall/fork off on their own sidechain because they rejected a block https://dora.dencun-devnet-11.ethpandaops.io/slot/208919 containing such a voluntary exit:
```
INF 2023-11-29 11:53:52.513+00:00 Block batch signature verification failed  topics="gossip_blocks" signature=8971136c blockRoot=676f87eb blck="(slot: 208919, proposer_index: 1291, parent_root: \"c06e6069\", state_root: \"dd13a832\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 9a4512b2be6f9e2ff5093635831a8e3bcadda73319a2ea8349233f1f7d2ccbb6), graffiti: \"lighthouse/reth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 1, sync_committee_participants: 350, block_number: 207122, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)"
NOT 2023-11-29 11:53:52.514+00:00 Received invalid block                     topics="requman" peer=16U*1cyViS blocks=[676f87eb] peer_score=200
INF 2023-11-29 11:53:52.750+00:00 Block batch signature verification failed  topics="gossip_blocks" signature=8971136c blockRoot=676f87eb blck="(slot: 208919, proposer_index: 1291, parent_root: \"c06e6069\", state_root: \"dd13a832\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 9a4512b2be6f9e2ff5093635831a8e3bcadda73319a2ea8349233f1f7d2ccbb6), graffiti: \"lighthouse/reth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 1, sync_committee_participants: 350, block_number: 207122, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)"
INF 2023-11-29 11:53:53.602+00:00 Block batch signature verification failed  topics="gossip_blocks" signature=8971136c blockRoot=676f87eb blck="(slot: 208919, proposer_index: 1291, parent_root: \"c06e6069\", state_root: \"dd13a832\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 9a4512b2be6f9e2ff5093635831a8e3bcadda73319a2ea8349233f1f7d2ccbb6), graffiti: \"lighthouse/reth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 1, sync_committee_participants: 350, block_number: 207122, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)"
NOT 2023-11-29 11:53:53.602+00:00 Received invalid block                     topics="requman" peer=16U*XxZuva blocks=[676f87eb] peer_score=0
INF 2023-11-29 11:53:54.849+00:00 Block batch signature verification failed  topics="gossip_blocks" signature=8971136c blockRoot=676f87eb blck="(slot: 208919, proposer_index: 1291, parent_root: \"c06e6069\", state_root: \"dd13a832\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 9a4512b2be6f9e2ff5093635831a8e3bcadda73319a2ea8349233f1f7d2ccbb6), graffiti: \"lighthouse/reth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 1, sync_committee_participants: 350, block_number: 207122, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)"
INF 2023-11-29 11:53:56.005+00:00 Aggregated attestation sent                topics="message_router" attestation="(aggregation_bits: 0b0110000100000100001000010000000000000000100000000000010000000001000000010000000001110, data: (slot: 208919, index: 0, beacon_block_root: \"c06e6069\", source: \"6515:4dc17292\", target: \"6528:a3cb5143\"), signature: \"b8889ceb\")" aggregator_index=1089 selection_proof=a17b251f signature=afcaec5a delay=3ms897us591ns
INF 2023-11-29 11:53:56.010+00:00 Contribution sent                          topics="message_router" contribution="(slot: 208919, beacon_block_root: \"c06e6069\", subcommittee_index: 0, aggregation_bits: \"0b11010101110010100011101111011110100000000101110001111001100111110000101011111111110101110100111111011101110111001101110011110011\")" aggregator_index=1082 selection_proof=99141418 signature=b0cca44f delay=10ms6us93ns
INF 2023-11-29 11:53:57.955+00:00 Block batch signature verification failed  topics="gossip_blocks" signature=8971136c blockRoot=676f87eb blck="(slot: 208919, proposer_index: 1291, parent_root: \"c06e6069\", state_root: \"dd13a832\", eth1data: (deposit_root: d70a234731285c6804c2a4f56711ddb8c82c99740f207854891028af34e27e5e, deposit_count: 0, block_hash: 9a4512b2be6f9e2ff5093635831a8e3bcadda73319a2ea8349233f1f7d2ccbb6), graffiti: \"lighthouse/reth\", proposer_slashings_len: 0, attester_slashings_len: 0, attestations_len: 1, deposits_len: 0, voluntary_exits_len: 1, sync_committee_participants: 350, block_number: 207122, fee_recipient: \"0xf97e180c050e5ab072211ad2c213eb5aee4df134\", bls_to_execution_changes_len: 0, blob_kzg_commitments_len: 3)"
INF 2023-11-29 11:53:58.018+00:00 Slot end                                   topics="beacnde" slot=208919 nextActionWait=1s981ms527us878ns nextAttestationSlot=208920 nextProposalSlot=208928 syncCommitteeDuties=current head=c06e6069:208918
```

Which caused them to get stuck:
```
INF 2023-11-29 21:36:12.000+00:00 Slot start                                 topics="beacnde" slot=211831 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=33 head=2826cf49:209174 finalized=6514:2463cefc delay=895us720ns
INF 2023-11-29 21:36:12.004+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211831 headSlot=209174
INF 2023-11-29 21:36:22.061+00:00 Slot end                                   topics="beacnde" slot=211831 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:36:24.001+00:00 Slot start                                 topics="beacnde" slot=211832 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=32 head=2826cf49:209174 finalized=6514:2463cefc delay=1ms57us11ns
INF 2023-11-29 21:36:24.012+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211832 headSlot=209174
INF 2023-11-29 21:36:34.055+00:00 Slot end                                   topics="beacnde" slot=211832 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:36:36.000+00:00 Slot start                                 topics="beacnde" slot=211833 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=32 head=2826cf49:209174 finalized=6514:2463cefc delay=797us526ns
INF 2023-11-29 21:36:36.004+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211833 headSlot=209174
INF 2023-11-29 21:36:46.069+00:00 Slot end                                   topics="beacnde" slot=211833 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:36:48.000+00:00 Slot start                                 topics="beacnde" slot=211834 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=32 head=2826cf49:209174 finalized=6514:2463cefc delay=370us590ns
INF 2023-11-29 21:36:48.006+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211834 headSlot=209174
INF 2023-11-29 21:36:58.053+00:00 Slot end                                   topics="beacnde" slot=211834 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:37:00.001+00:00 Slot start                                 topics="beacnde" slot=211835 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=32 head=2826cf49:209174 finalized=6514:2463cefc delay=1ms152us25ns
INF 2023-11-29 21:37:00.005+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211835 headSlot=209174
INF 2023-11-29 21:37:10.035+00:00 Slot end                                   topics="beacnde" slot=211835 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:37:12.004+00:00 Slot start                                 topics="beacnde" slot=211836 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=32 head=2826cf49:209174 finalized=6514:2463cefc delay=4ms213us68ns
INF 2023-11-29 21:37:12.042+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211836 headSlot=209174
INF 2023-11-29 21:37:22.038+00:00 Slot end                                   topics="beacnde" slot=211836 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=current head=2826cf49:209174
INF 2023-11-29 21:37:24.001+00:00 Slot start                                 topics="beacnde" slot=211837 epoch=6619 sync="--h--m (98.61%) 0.0000slots/s (QQQUQQQQQU:208895)" peers=33 head=2826cf49:209174 finalized=6514:2463cefc delay=1ms33us64ns
INF 2023-11-29 21:37:24.006+00:00 Beacon node not in sync; skipping validator duties for now topics="beacval" slot=211837 headSlot=209174
```

EIP-7044 had already been implemented for the state transition function itself.