### PR TITLE
Update to current (deprecated, but) version of `produceBlindedBlock`

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -423,7 +423,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           raiseAssert "preferredContentType() returns invalid content type"
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceBlindedBlock
-  # https://github.com/ethereum/beacon-APIs/blob/v2.4.0/apis/validator/blinded_block.yaml
+  # https://github.com/ethereum/beacon-APIs/blob/c097f1a62c9a12c30e8175a39f205f92d3b931a9/apis/validator/blinded_block.yaml
   router.api(MethodGet, "/eth/v1/validator/blinded_blocks/{slot}") do (
       slot: Slot, randao_reveal: Option[ValidatorSig],
       graffiti: Option[GraffitiBytes],


### PR DESCRIPTION
https://ethereum.github.io/beacon-APIs/#/Validator/produceBlindedBlock is deprecated (https://github.com/ethereum/beacon-APIs/pull/339) and https://github.com/status-im/nimbus-eth2/pull/5474 has been merged, but pending Nimbus validator client of `produceBlockV3`, add some Deneb builder API support to `produceBlindedBlock` as specified.

As of https://github.com/ethereum/beacon-APIs/pull/369 for Deneb blinded blocks, it returns only the block, nothing related to sidecars.

Eventually, this entire function can be marked `Http410` and the supporting infrastructure can be removed, once `produceBlockV3` is supported widely enough.