### PR TITLE
use `forks` sugar in `nimbus_light_client`

### DIFF
--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -150,31 +150,14 @@ programMain:
 
   info "Listening to incoming network requests"
   network.initBeaconSync(cfg, forkDigests, genesisBlockRoot, getBeaconTime)
-  network.addValidator(
-    getBeaconBlocksTopic(forkDigests.phase0),
-    proc (signedBlock: phase0.SignedBeaconBlock): ValidationResult =
-      toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
-  network.addValidator(
-    getBeaconBlocksTopic(forkDigests.altair),
-    proc (signedBlock: altair.SignedBeaconBlock): ValidationResult =
-      toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
-  network.addValidator(
-    getBeaconBlocksTopic(forkDigests.bellatrix),
-    proc (signedBlock: bellatrix.SignedBeaconBlock): ValidationResult =
-      toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
-  network.addValidator(
-    getBeaconBlocksTopic(forkDigests.capella),
-    proc (signedBlock: capella.SignedBeaconBlock): ValidationResult =
-      toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
-  network.addValidator(
-    getBeaconBlocksTopic(forkDigests.deneb),
-    proc (signedBlock: deneb.SignedBeaconBlock): ValidationResult =
-      toValidationResult(
-        optimisticProcessor.processSignedBeaconBlock(signedBlock)))
+  withAll(ConsensusFork):
+    let digest = forkDigests[].atConsensusFork(consensusFork)
+    network.addValidator(
+      getBeaconBlocksTopic(digest), proc (
+          signedBlock: consensusFork.SignedBeaconBlock
+      ): ValidationResult =
+        toValidationResult(
+          optimisticProcessor.processSignedBeaconBlock(signedBlock)))
   lightClient.installMessageValidators()
   waitFor network.startListening()
   waitFor network.start()

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -151,9 +151,9 @@ programMain:
   info "Listening to incoming network requests"
   network.initBeaconSync(cfg, forkDigests, genesisBlockRoot, getBeaconTime)
   withAll(ConsensusFork):
-    let digest = forkDigests[].atConsensusFork(consensusFork)
+    let forkDigest = forkDigests[].atConsensusFork(consensusFork)
     network.addValidator(
-      getBeaconBlocksTopic(digest), proc (
+      getBeaconBlocksTopic(forkDigest), proc (
           signedBlock: consensusFork.SignedBeaconBlock
       ): ValidationResult =
         toValidationResult(


### PR DESCRIPTION
Reduce code duplication and maintenance burden by using `withAll` sugar.