### PR TITLE
use `PayloadAttributesV3` in `nimbus_light_client` for Deneb

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -168,19 +168,14 @@ proc updateExecutionClientHead(self: ref ConsensusManager,
       payloadAttributes = none attributes)
 
   # Can't use dag.head here because it hasn't been updated yet
-  let (payloadExecutionStatus, _) =
-    case self.dag.cfg.consensusForkAtEpoch(newHead.blck.bid.slot.epoch)
-    of ConsensusFork.Deneb:
-      callForkchoiceUpdated(PayloadAttributesV3)
-    of ConsensusFork.Capella:
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#specification-1
-      # Consensus layer client MUST call this method instead of
-      # `engine_forkchoiceUpdatedV1` under any of the following conditions:
-      # `headBlockHash` references a block which `timestamp` is greater or
-      # equal to the Shanghai timestamp
-      callForkchoiceUpdated(PayloadAttributesV2)
-    of ConsensusFork.Phase0, ConsensusFork.Altair, ConsensusFork.Bellatrix:
-      callForkchoiceUpdated(PayloadAttributesV1)
+  let
+    consensusfork =
+      self.dag.cfg.consensusForkAtEpoch(newHead.blck.bid.slot.epoch)
+    (payloadExecutionStatus, _) = withConsensusFork(consensusFork):
+      when consensusFork >= ConsensusFork.Bellatrix:
+        callForkchoiceUpdated(consensusFork.PayloadAttributes)
+      else:
+        callForkchoiceUpdated(PayloadAttributesV1)
 
   case payloadExecutionStatus
   of PayloadExecutionStatus.valid:

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -169,7 +169,7 @@ proc updateExecutionClientHead(self: ref ConsensusManager,
 
   # Can't use dag.head here because it hasn't been updated yet
   let
-    consensusfork =
+    consensusFork =
       self.dag.cfg.consensusForkAtEpoch(newHead.blck.bid.slot.epoch)
     (payloadExecutionStatus, _) = withConsensusFork(consensusFork):
       when consensusFork >= ConsensusFork.Bellatrix:

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -109,12 +109,7 @@ programMain:
         opt = signedBlock.toBlockId(),
         wallSlot = getBeaconTime().slotOrZero
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Capella:
-          # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#specification-1
-          # Consensus layer client MUST call this method instead of
-          # `engine_forkchoiceUpdatedV1` under any of the following conditions:
-          # `headBlockHash` references a block which `timestamp` is greater or
-          # equal to the Shanghai timestamp
+        when consensusFork >= ConsensusFork.Bellatrix:
           if forkyBlck.message.is_execution_block:
             template payload(): auto = forkyBlck.message.body.execution_payload
 
@@ -124,18 +119,7 @@ programMain:
                 headBlockHash = payload.block_hash,
                 safeBlockHash = payload.block_hash,  # stub value
                 finalizedBlockHash = ZERO_HASH,
-                payloadAttributes = none PayloadAttributesV2)
-        elif consensusFork >= ConsensusFork.Bellatrix:
-          if forkyBlck.message.is_execution_block:
-            template payload(): auto = forkyBlck.message.body.execution_payload
-
-            if elManager != nil and not payload.block_hash.isZero:
-              discard await elManager.newExecutionPayload(forkyBlck.message)
-              discard await elManager.forkchoiceUpdated(
-                headBlockHash = payload.block_hash,
-                safeBlockHash = payload.block_hash,  # stub value
-                finalizedBlockHash = ZERO_HASH,
-                payloadAttributes = none PayloadAttributesV1)
+                payloadAttributes = none(consensusFork.PayloadAttributes))
         else: discard
     optimisticProcessor = initOptimisticProcessor(
       getBeaconTime, optimisticHandler)

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -531,6 +531,17 @@ template BlindedBlockContents*(
   else:
     {.error: "BlindedBlockContents does not support " & $kind.}
 
+template PayloadAttributes*(
+    kind: static ConsensusFork): auto =
+  when kind >= ConsensusFork.Deneb:
+    typedesc[PayloadAttributesV3]
+  elif kind >= ConsensusFork.Capella:
+    typedesc[PayloadAttributesV2]
+  elif kind >= ConsensusFork.Bellatrix:
+    typedesc[PayloadAttributesV1]
+  else:
+    {.error: "PayloadAttributes does not support " & $kind.}
+
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
 # `ref T`
 func new*(T: type ForkedHashedBeaconState, data: phase0.BeaconState):


### PR DESCRIPTION
From Deneb onward, `forkchoiceUpdated` requires `PayloadAttributesV3`. In `nimbus_light_client` we still used `PayloadAttributesV2`.

Also clean up two other locations that were already correctly using `PayloadAttributesV3`, to reduce code duplication.