### PR TITLE
re-add comment for `PayloadAttributesV2` usage

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -533,9 +533,15 @@ template BlindedBlockContents*(
 
 template PayloadAttributes*(
     kind: static ConsensusFork): auto =
+  # This also determines what `engine_forkchoiceUpdated` version will be used.
   when kind >= ConsensusFork.Deneb:
     typedesc[PayloadAttributesV3]
   elif kind >= ConsensusFork.Capella:
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#specification-1
+    # Consensus layer client MUST call this method instead of
+    # `engine_forkchoiceUpdatedV1` under any of the following conditions:
+    # `headBlockHash` references a block which `timestamp` is greater or
+    # equal to the Shanghai timestamp
     typedesc[PayloadAttributesV2]
   elif kind >= ConsensusFork.Bellatrix:
     typedesc[PayloadAttributesV1]


### PR DESCRIPTION
As followup from #5654, ensure that we still keep the comment around referring to the correct `forkchoiceUpdated` to use being driven by the fork schedule.