### PR TITLE
log execution payload (header) `block_hash` and `parent_hash` in block shortLogs

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -605,7 +605,9 @@ func shortLog*(v: SomeBeaconBlock): auto =
     voluntary_exits_len: v.body.voluntary_exits.len(),
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: 0'u64, # Bellatrix compat
-    fee_recipient: "",
+    block_hash: "",      # Bellatrix compat
+    parent_hash: "",     # Bellatrix compat
+    fee_recipient: "",   # Bellatrix compat
     bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -401,6 +401,8 @@ func shortLog*(v: SomeBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload.parent_hash.data),
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
     bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -608,6 +608,8 @@ func shortLog*(v: SomeBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload.parent_hash.data),
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
     bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: 0,  # Deneb compat

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -526,6 +526,8 @@ func shortLog*(v: SomeBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload.block_number,
     # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload.parent_hash.data),
     fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
     bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: v.body.blob_kzg_commitments.len(),

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -297,7 +297,9 @@ func shortLog*(v: SomeBeaconBlock): auto =
     voluntary_exits_len: v.body.voluntary_exits.len(),
     sync_committee_participants: -1, # Altair logging compatibility
     block_number: 0'u64, # Bellatrix compat
-    fee_recipient: "",
+    block_hash: "",      # Bellatrix compat
+    parent_hash: "",     # Bellatrix compat
+    fee_recipient: "",   # Bellatrix compat
     bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat
   )

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -28,6 +28,8 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     voluntary_exits_len: 0,
     sync_committee_participants: 0,
     block_number: 0'u64,
+    block_hash: "",
+    parent_hash: "",
     fee_recipient: "",
     bls_to_execution_changes_len: 0,  # Capella compat
     blob_kzg_commitments_len: 0,  # Deneb compat

--- a/beacon_chain/spec/mev/capella_mev.nim
+++ b/beacon_chain/spec/mev/capella_mev.nim
@@ -104,6 +104,8 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload_header.block_number,
     # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload_header.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload_header.parent_hash.data),
     fee_recipient: to0xHex(v.body.execution_payload_header.fee_recipient.data),
     bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: 0,  # Deneb compat

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -94,6 +94,8 @@ func shortLog*(v: BlindedBeaconBlock): auto =
     sync_committee_participants: v.body.sync_aggregate.num_active_participants,
     block_number: v.body.execution_payload_header.block_number,
     # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload_header.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload_header.parent_hash.data),
     fee_recipient: to0xHex(v.body.execution_payload_header.fee_recipient.data),
     bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
     blob_kzg_commitments_len: 0,  # Deneb compat


### PR DESCRIPTION
Useful both to diagnose interactions with `mev-boost` and EL clients, the latter because that's all they know  pending EIP-4788 and `mev-boost` because the builder API `getHeader` call similarly only knows about the `ExecutionPayloadHeader`, so that's all it can log.

https://github.com/flashbots/mev-boost/blob/bdabd0e6181990f9c3e0fef9f750b40f71d50c6c/server/service.go#L494-L503
```go
	// Log result
	valueEth := weiBigIntToEthBigFloat(result.bidInfo.value.ToBig())
	result.relays = relays[BlockHashHex(result.bidInfo.blockHash.String())]
	log.WithFields(logrus.Fields{
		"blockHash":   result.bidInfo.blockHash.String(),
		"blockNumber": result.bidInfo.blockNumber,
		"txRoot":      result.bidInfo.txRoot,
		"value":       valueEth.Text('f', 18),
		"relays":      strings.Join(RelayEntriesToStrings(result.relays), ", "),
	}).Info("best bid")
```
and https://github.com/flashbots/mev-boost/blob/bdabd0e6181990f9c3e0fef9f750b40f71d50c6c/server/service.go#L532-L540
```go
	// Prepare logger
	ua := UserAgent(req.Header.Get("User-Agent"))
	log = log.WithFields(logrus.Fields{
		"ua":         ua,
		"slot":       payload.Message.Slot,
		"blockHash":  payload.Message.Body.ExecutionPayloadHeader.BlockHash.String(),
		"parentHash": payload.Message.Body.ExecutionPayloadHeader.ParentHash.String(),
		"slotUID":    slotUID,
	})
```

log `block_hash` and `parent_hash`, so this allows linking logs across `mev-boost`, `nimbus-eth2`, and EL clients by a shared primary key.