### PR TITLE
fix VC builder API registration expiry check sense

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1006,7 +1006,7 @@ proc isExpired(vc: ValidatorClientRef,
       block:
         let res = vc.beaconClock.toSlot(regTime)
         if not(res.afterGenesis):
-          # This case should not have happend, but it could in case of time
+          # This case should not have happened, but it could in case of time
           # jumps (time could be modified by admin or ntpd).
           return false
         uint64(res.slot)
@@ -1041,6 +1041,10 @@ proc getValidatorRegistration(
         res.slot
 
   if cached.isDefault() or vc.isExpired(cached, currentSlot):
+    if not cached.isDefault():
+      # Want to send it to relay, but not recompute perfectly fine cache
+      return ok(PendingValidatorRegistration(registration: cached, future: nil))
+
     let feeRecipient = vc.getFeeRecipient(validator.pubkey, vindex,
                                           currentSlot.epoch())
     if feeRecipient.isNone():

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -41,9 +41,6 @@ const
   # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#constants
   EPOCHS_BETWEEN_VALIDATOR_REGISTRATION* = 1
 
-  DelayBuckets* = [-Inf, -4.0, -2.0, -1.0, -0.5, -0.1, -0.05,
-                   0.05, 0.1, 0.5, 1.0, 2.0, 4.0, 8.0, Inf]
-
   ZeroTimeDiff* = TimeDiff(nanoseconds: 0'i64)
 
 type


### PR DESCRIPTION
The validator registrations should be counted as expired precisely as/when `slot - regSlot` grows, not only until then.

This also meant that on startup, it spammed all the registrations every slot for the first 32 slots:
```
{"lvl":"DBG","ts":"2023-12-11 14:56:36.130+00:00","msg":"Validator registrations prepared","total":8000,"succeed":0,"cached":7945,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:56:59.421+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:57:05.851+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:57:29.575+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:57:53.676+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:58:17.592+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:58:41.552+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:59:05.779+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:59:29.683+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 14:59:53.666+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 15:00:05.610+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
{"lvl":"DBG","ts":"2023-12-11 15:00:17.667+00:00","msg":"Validator registrations prepared","total":8000,"succeed":7945,"cached":0,"bad":0,"errors":0,"index_missing":55,"fee_missing":0,"incorrect_time":0}
...
```