### PR TITLE
don't require C compiler to codegen or link in CI when binaries won't be tested/used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Build binaries (with trace logging enabled)
         run: |
-          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="-u:release --opt:none ${{ matrix.nimflags-extra }} deps"  # ensure generate_makefile is genuinely built
+          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="-u:release --opt:none ${{ matrix.nimflags-extra }}" deps  # ensure generate_makefile is genuinely built
           ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="--passC=-fsyntax-only --noLinking:on ${{ matrix.nimflags-extra }}"
           # The Windows image runs out of disk space, so make some room
           rm -rf build nimcache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
 
       - name: Build binaries (with trace logging enabled)
         run: |
+          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="-u:release --opt:none ${{ matrix.nimflags-extra }} deps"  # ensure generate_makefile is genuinely built
           ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="--passC=-fsyntax-only --noLinking:on ${{ matrix.nimflags-extra }}"
           # The Windows image runs out of disk space, so make some room
           rm -rf build nimcache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Build binaries (with trace logging enabled)
         run: |
-          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="-u:release --opt:none ${{ matrix.nimflags-extra }}"
+          ${make_cmd} -j ${ncpu} V=1 NIM_COMMIT=${{ matrix.branch }} LOG_LEVEL=TRACE NIMFLAGS="--passC=-fsyntax-only --noLinking:on ${{ matrix.nimflags-extra }}"
           # The Windows image runs out of disk space, so make some room
           rm -rf build nimcache
 


### PR DESCRIPTION
On a system with `nproc` of 16, this brings `tests/all_tests` compilation from, with -d:debug --opt:none (which uses `-0g` at the gcc level) i.e. already not optimizing, and not using LTO:
```
real	4m0.017s
user	21m20.552s
sys	1m1.970s
```
to
```
real	2m8.371s
user	2m35.644s
sys	0m22.738s
```

It should have even more effect with fewer cores, such as the macOS and Windows cloud GitHub Actions CI builders with two cores only, because the `nim c -c` portion is intrinsically single-threaded regardless so doesn't depend on core count, and this cuts out the parallelizable portion.

Currently, the GitHub Actions CI binary building for the targets it only builds but doesn't run (i.e. `make` all, in the `Build binaries (with trace logging enabled)` phase, not `make test`, the latter of which do run) compile debug/`-Og` binaries, without LTO, which also aren't run. 

It is important to ensure that Nim isn't generating incorrect C code, because definitely has one that regularly (https://github.com/nim-lang/Nim/issues/7593, https://github.com/nim-lang/Nim/issues/18080, https://github.com/nim-lang/Nim/issues/18081, https://github.com/nim-lang/Nim/issues/22888, and https://github.com/nim-lang/Nim/issues/22913 for some C examples, and https://github.com/nim-lang/Nim/issues/22101 for C++). CI should catch this class of build issue.

This PR adjusts this to use [`-fsyntax-only`](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-syntax-checking) to avoid the codegen and linking phases.

It calls itself `syntax-only`, but that implies being able to resolve types sufficiently to figure out the kinds of tokens available, along with other compilation steps, so it would have caught For example,
```c
int main() {
	return x;
}
```
can be argued to have valid syntax, for a narrow definition of syntax but
```
c.c: In function ‘main’:
c.c:2:16: error: ‘x’ undeclared (first use in this function)
    2 |         return x;
      |                ^
c.c:2:16: note: each undeclared identifier is reported only once for each function it appears in
```
because it can't figure out what `x` is supposed to be.

This should catch all the issues of the sort liked in the Nim issue tracker where Nim generated invalid C code, while requiring half or less of the time for this part of the CI build.