### PR TITLE
load Goerli metadata from `goerli` repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019-2023 Status Research & Development GmbH
+# Copyright (c) 2019-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).

--- a/.gitmodules
+++ b/.gitmodules
@@ -220,6 +220,11 @@
 	url = https://github.com/arnetheduck/nim-results.git
 	ignore = untracked
 	branch = master
+[submodule "vendor/goerli"]
+	path = vendor/goerli
+	url = https://github.com/eth-clients/goerli
+	ignore = untracked
+	branch = main
 [submodule "vendor/holesky"]
 	path = vendor/holesky
 	url = https://github.com/eth-clients/holesky

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -302,7 +302,7 @@ elif const_preset == "mainnet":
         vendorDir & "/eth2-networks/shared/mainnet/genesis.ssz")
 
       praterGenesis* = slurp(
-        vendorDir & "/eth2-networks/shared/prater/genesis.ssz")
+        vendorDir & "/goerli/prater/genesis.ssz")
 
       sepoliaGenesis* = slurp(
         vendorDir & "/sepolia/bepolia/genesis.ssz")
@@ -314,7 +314,7 @@ elif const_preset == "mainnet":
       useBakedInGenesis = some "mainnet")
 
     praterMetadata = loadCompileTimeNetworkMetadata(
-      vendorDir & "/eth2-networks/shared/prater",
+      vendorDir & "/goerli/prater",
       some goerli,
       useBakedInGenesis = some "prater")
 

--- a/beacon_chain/networking/network_metadata_mainnet.S
+++ b/beacon_chain/networking/network_metadata_mainnet.S
@@ -36,7 +36,7 @@ cdecl(eth2_mainnet_genesis_size):
     .quad    eth2_mainnet_genesis_end - eth2_mainnet_genesis_data
 
 eth2_goerli_genesis_data:
-    .incbin "eth2-networks/shared/prater/genesis.ssz"
+    .incbin "goerli/prater/genesis.ssz"
 eth2_goerli_genesis_end:
     .global cdecl(eth2_goerli_genesis_size)
     .p2align 3

--- a/beacon_chain/networking/network_metadata_mainnet.S
+++ b/beacon_chain/networking/network_metadata_mainnet.S
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
The `eth2-networks` repo often receives metadata updates with a delay. Switch to `goerli` repo to obtain the latest config (Dencun scheduling) when it is updated. This is in line with how Sepolia / Holesky work.

- https://github.com/eth-clients/goerli/pull/178