### PR TITLE
rm unused RPC signatures replaced by Plain versions

### DIFF
--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -33,11 +33,6 @@ proc getStateRoot*(state_id: StateIdent): RestResponse[GetStateRootResponse] {.
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateRoot
 
-proc getStateFork*(state_id: StateIdent): RestResponse[GetStateForkResponse] {.
-     rest, endpoint: "/eth/v1/beacon/states/{state_id}/fork",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateFork
-
 proc getStateForkPlain*(state_id: StateIdent): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/fork",
      meth: MethodGet.}
@@ -49,13 +44,6 @@ proc getStateFinalityCheckpoints*(state_id: StateIdent
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateFinalityCheckpoints
 
-proc getStateValidators*(state_id: StateIdent,
-                         id: seq[ValidatorIdent]
-                        ): RestResponse[GetStateValidatorsResponse] {.
-     rest, endpoint: "/eth/v1/beacon/states/{state_id}/validators",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators
-
 proc getStateValidatorsPlain*(
        state_id: StateIdent,
        id: seq[ValidatorIdent]
@@ -63,14 +51,6 @@ proc getStateValidatorsPlain*(
      rest, endpoint: "/eth/v1/beacon/states/{state_id}/validators",
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidators
-
-proc getStateValidator*(state_id: StateIdent,
-                        validator_id: ValidatorIdent
-                       ): RestResponse[GetStateValidatorResponse] {.
-     rest,
-     endpoint: "/eth/v1/beacon/states/{state_id}/validators/{validator_id}",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/getStateValidator
 
 proc getStateValidatorPlain*(state_id: StateIdent,
                         validator_id: ValidatorIdent
@@ -109,11 +89,6 @@ proc getBlockHeaders*(slot: Option[Slot], parent_root: Option[Eth2Digest]
      rest, endpoint: "/eth/v1/beacon/headers",
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeaders
-
-# proc getBlockHeader*(block_id: BlockIdent): RestResponse[GetBlockHeaderResponse] {.
-#      rest, endpoint: "/eth/v1/beacon/headers/{block_id}",
-#      meth: MethodGet.}
-#   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeader
 
 proc getBlockHeaderPlain*(block_id: BlockIdent): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/headers/{block_id}",
@@ -314,11 +289,6 @@ proc getBlockV2*(client: RestClientRef, block_id: BlockIdent,
         msg: msg, status: error.code, message: error.message)
     else:
       raiseRestResponseError(resp)
-
-proc getBlockRoot*(block_id: BlockIdent): RestResponse[GetBlockRootResponse] {.
-     rest, endpoint: "/eth/v1/beacon/blocks/{block_id}/root",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockRoot
 
 proc getBlockRootPlain*(block_id: BlockIdent): RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/blocks/{block_id}/root",

--- a/beacon_chain/spec/eth2_apis/rest_config_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_config_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -11,10 +11,6 @@ import
   "."/[rest_types, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization
-
-proc getForkSchedule*(): RestResponse[GetForkScheduleResponse] {.
-     rest, endpoint: "/eth/v1/config/fork_schedule", meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Config/getForkSchedule
 
 proc getForkSchedulePlain*(): RestPlainResponse {.
      rest, endpoint: "/eth/v1/config/fork_schedule", meth: MethodGet.}

--- a/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_validator_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,14 +12,6 @@ import
 
 export chronos, client, rest_types, eth2_rest_serialization
 
-proc getAttesterDuties*(
-       epoch: Epoch,
-       body: seq[ValidatorIndex]
-     ): RestResponse[GetAttesterDutiesResponse] {.
-     rest, endpoint: "/eth/v1/validator/duties/attester/{epoch}",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/getAttesterDuties
-
 proc getAttesterDutiesPlain*(
        epoch: Epoch,
        body: seq[ValidatorIndex]
@@ -28,27 +20,12 @@ proc getAttesterDutiesPlain*(
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/getAttesterDuties
 
-proc getProposerDuties*(
-       epoch: Epoch
-     ): RestResponse[GetProposerDutiesResponse] {.
-     rest, endpoint: "/eth/v1/validator/duties/proposer/{epoch}",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties
-
 proc getProposerDutiesPlain*(
        epoch: Epoch
      ): RestPlainResponse {.
      rest, endpoint: "/eth/v1/validator/duties/proposer/{epoch}",
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties
-
-proc getSyncCommitteeDuties*(
-       epoch: Epoch,
-       body: seq[ValidatorIndex]
-     ): RestResponse[GetSyncCommitteeDutiesResponse] {.
-     rest, endpoint: "/eth/v1/validator/duties/sync/{epoch}",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/getSyncCommitteeDuties
 
 proc getSyncCommitteeDutiesPlain*(
        epoch: Epoch,
@@ -76,14 +53,6 @@ proc produceBlindedBlockPlain*(
      accept: preferSSZ, meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/produceBlindedBlock
 
-proc produceAttestationData*(
-       slot: Slot,
-       committee_index: CommitteeIndex
-     ): RestResponse[ProduceAttestationDataResponse] {.
-     rest, endpoint: "/eth/v1/validator/attestation_data",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/produceAttestationData
-
 proc produceAttestationDataPlain*(
        slot: Slot,
        committee_index: CommitteeIndex
@@ -91,14 +60,6 @@ proc produceAttestationDataPlain*(
      rest, endpoint: "/eth/v1/validator/attestation_data",
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/produceAttestationData
-
-proc getAggregatedAttestation*(
-       attestation_data_root: Eth2Digest,
-       slot: Slot
-     ): RestResponse[GetAggregatedAttestationResponse] {.
-     rest, endpoint: "/eth/v1/validator/aggregate_attestation"
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/getAggregatedAttestation
 
 proc getAggregatedAttestationPlain*(
        attestation_data_root: Eth2Digest,
@@ -128,15 +89,6 @@ proc prepareSyncCommitteeSubnets*(
      rest, endpoint: "/eth/v1/validator/sync_committee_subscriptions",
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/prepareSyncCommitteeSubnets
-
-proc produceSyncCommitteeContribution*(
-       slot: Slot,
-       subcommittee_index: SyncSubcommitteeIndex,
-       beacon_block_root: Eth2Digest
-     ): RestResponse[ProduceSyncCommitteeContributionResponse] {.
-     rest, endpoint: "/eth/v1/validator/sync_committee_contribution",
-     meth: MethodGet.}
-  ## https://ethereum.github.io/beacon-APIs/#/Validator/produceSyncCommitteeContribution
 
 proc produceSyncCommitteeContributionPlain*(
        slot: Slot,
@@ -181,4 +133,3 @@ proc submitSyncCommitteeSelectionsPlain*(
      rest, endpoint: "/eth/v1/validator/sync_committee_selections",
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Validator/submitSyncCommitteeSelections
-

--- a/beacon_chain/validator_client/fallback_service.nim
+++ b/beacon_chain/validator_client/fallback_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -376,7 +376,7 @@ proc checkOffsetStatus(node: BeaconNodeServerRef, offset: TimeOffset) =
 
 proc runTimeMonitor(service: FallbackServiceRef,
                     node: BeaconNodeServerRef) {.async.} =
-  const NimbusExtensionsLog = "Beacon node do not support nimbus extensions"
+  const NimbusExtensionsLog = "Beacon node does not support Nimbus extensions"
   let
     vc = service.client
     roles = AllBeaconNodeRoles


### PR DESCRIPTION
Various updates have switched from the non-`Plain` versions to `Plain` versions to  better recover and report errors, rather than having them swallowed by the REST JSON deserializer and other components.

For example:
- https://github.com/status-im/nimbus-eth2/pull/3318 (`getStateForkPlain`)
- https://github.com/status-im/nimbus-eth2/pull/4673 (`getBlockRootPlain`, `getForkSchedulePlain`, and `getStateValidatorsPlain`, `getSyncCommitteeDutiesPlain`, and others)

The non-`Plain` versions are attractive nuisances at this point, because their further usage means that they'll swallow details of failure modes in ways which hinder reacting to them and informing users about them.