### PR TITLE
in lint, fix timestamp comparison when timezone does not match

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         run: |
           while read -r file; do
             commit="$(git -C "$file" rev-parse HEAD)"
-            commit_date=$(git -C "$file" show -s --format='%ci' HEAD)
+            commit_date=$(TZ=UTC0 git -C "$file" show -s --format='%cd' --date=iso-local HEAD)
             if ! branch="$(git config -f .gitmodules --get "submodule.$file.branch")"; then
               echo "Submodule '$file': '.gitmodules' lacks 'branch' entry"
               exit 2
@@ -248,7 +248,7 @@ jobs:
               echo "Submodule '$file': Failed to fetch '$branch': $error (1)"
               exit 2
             fi
-            branch_commit_date=$(git -C "$file" show -s --format='%ci' "refs/remotes/origin/${branch}")
+            branch_commit_date=$(TZ=UTC0 git -C "$file" show -s --format='%cd' --date=iso-local "refs/remotes/origin/${branch}")
             if [[ "${commit_date}" > "${branch_commit_date}" ]]; then
               echo "Submodule '$file': '$commit' ($commit_date) is more recent than latest '$branch' ($branch_commit_date) (branch config: '.gitmodules')"
               exit 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Git by defaults returns commit timestamp according to the committer's time zone instead of the local one, breaking the simple alphanumeric comparison for timestamps that we use in lint. Force the timezone to UTC so that comparison is correct regardless of committer timezone.