### PR TITLE
add missing `std/` prefix to more imports

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -50,7 +50,7 @@ requires(
 
 requires "https://gitlab.com/status-im/nimbus-security-resources.git"
 
-import tables
+import std/tables
 let namedBin = {
   "beacon_chain/nimbus_beacon_node": "nimbus_beacon_node",
   "beacon_chain/nimbus_validator_client": "nimbus_validator_client",

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,7 +12,7 @@ import
   chronos/timer, chronicles,
   ./spec/beacon_time
 
-from times import Time, getTime, fromUnix, `<`, `-`, inNanoseconds
+from std/times import Time, getTime, fromUnix, `<`, `-`, inNanoseconds
 
 export timer.Duration, Moment, now, beacon_time
 

--- a/beacon_chain/el/deposit_contract.nim
+++ b/beacon_chain/el/deposit_contract.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  os, sequtils, strutils, options, json, terminal,
+  std/[os, sequtils, strutils, options, json, terminal],
   chronos, chronicles, confutils, stint, json_serialization,
   ../filepath,
   ../networking/network_metadata,

--- a/beacon_chain/el/merkle_minimal.nim
+++ b/beacon_chain/el/merkle_minimal.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,7 +13,7 @@
 # ---------------------------------------------------------------
 
 import
-  sequtils,
+  std/sequtils,
   stew/endians2,
   # Specs
   ../spec/[eth2_merkleization, digest],

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -464,9 +464,7 @@ when isMainModule:
   # Testing EraDB gets messy because of the large amounts of data involved:
   # this snippet contains some sanity checks for mainnet at least
 
-  import
-    os,
-    stew/arrayops
+  import stew/arrayops
 
   let
     dbPath =

--- a/beacon_chain/networking/network_metadata_downloads.nim
+++ b/beacon_chain/networking/network_metadata_downloads.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,7 @@ import
   stew/io2, chronos, chronos/apps/http/httpclient, snappy,
   ../spec/[digest, forks], ../spec/datatypes/base
 
-import network_metadata
+import ./network_metadata
 export network_metadata
 
 type

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,7 @@
 import
   stew/[bitops2, bitseqs, objects],
   datatypes/altair,
-  helpers
+  ./helpers
 
 from ../consensus_object_pools/block_pools_types import VerifierError
 export block_pools_types.VerifierError

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,7 +9,7 @@ import
   chronicles,
   ".."/validators/activity_metrics,
   ".."/spec/forks,
-  common, api, fallback_service
+  "."/[common, api, fallback_service]
 
 const
   ServiceName = "block_service"

--- a/beacon_chain/validator_client/doppelganger_service.nim
+++ b/beacon_chain/validator_client/doppelganger_service.nim
@@ -1,12 +1,12 @@
 # beacon_chain
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import chronicles
-import common, api
+import "."/[common, api]
 
 const
   ServiceName = "doppelganger_service"

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 
 import std/[sets, sequtils]
 import chronicles, metrics
-import common, api, block_service, selection_proofs
+import "."/[common, api, block_service, selection_proofs]
 
 const
   ServiceName = "duties_service"

--- a/beacon_chain/validator_client/fallback_service.nim
+++ b/beacon_chain/validator_client/fallback_service.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import common
+import ./common
 
 const
   ServiceName = "fallback_service"

--- a/beacon_chain/validator_client/fork_service.nim
+++ b/beacon_chain/validator_client/fork_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 
 import std/algorithm
 import chronicles
-import common, api
+import "."/[common, api]
 
 const
   ServiceName = "fork_service"

--- a/beacon_chain/validator_client/selection_proofs.nim
+++ b/beacon_chain/validator_client/selection_proofs.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 
 import std/[algorithm, sequtils]
 import chronicles, chronos, metrics
-import common, api
+import "."/[common, api]
 
 {.push raises: [].}
 

--- a/config.nims
+++ b/config.nims
@@ -1,11 +1,11 @@
 # beacon_chain
-# Copyright (c) 2020-2023 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import strutils
+import std/strutils
 
 --noNimblePath
 

--- a/ncli/ncli_query.nim
+++ b/ncli/ncli_query.nim
@@ -1,5 +1,13 @@
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import
-  confutils, os, strutils, json_serialization,
+  std/[os, strutils],
+  confutils, json_serialization,
   stew/byteutils,
   ../beacon_chain/spec/[crypto, datatypes]
 

--- a/ncli/nimquery.nim
+++ b/ncli/nimquery.nim
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  strutils, strformat, parseutils
+  std/[strutils, strformat, parseutils]
 
 type
   TokenKind* = enum
@@ -124,4 +124,3 @@ func expr(parser: var Parser): Node =
 func parse*(input: string): Node =
   var p = Parser.init(input)
   p.expr
-

--- a/research/stack_sizes.nim
+++ b/research/stack_sizes.nim
@@ -1,6 +1,13 @@
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
 import ../beacon_chain/spec/datatypes/phase0
 
-import typetraits, strformat, strutils
+import std/[typetraits, strformat, strutils]
 
 proc print(t: auto, n: string, indent: int) =
   echo fmt"{sizeof(t):>8}  {spaces(indent)}{n}: {typeof(t).name}"

--- a/scripts/run_fuzzing_test.nims
+++ b/scripts/run_fuzzing_test.nims
@@ -1,6 +1,13 @@
-import os except dirExists
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import std/os except dirExists
 import
-  sequtils, strformat,
+  std/[sequtils, strformat],
   confutils, testutils/fuzzing_engines
 
 const
@@ -26,4 +33,3 @@ cli do (testname {.argument.}: string,
     testProgram = nimFiles[0]
 
   exec &"""ntu fuzz --fuzzer={fuzzer} --corpus="{corpusDir}" "{testProgram}" """
-

--- a/scripts/run_ssz_fuzzing_test.nims
+++ b/scripts/run_ssz_fuzzing_test.nims
@@ -1,5 +1,12 @@
-import os except dirExists
-import strformat, confutils
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import std/os except dirExists
+import std/[strformat, confutils]
 import testutils/fuzzing_engines
 
 const
@@ -37,4 +44,3 @@ cli do (testname {.argument.}: string,
 
   let testProgram = fuzzingTestsDir / &"ssz_decode_{testname}.nim"
   exec &"""ntu fuzz --fuzzer={fuzzer} --corpus="{corpusDir}" "{testProgram}" """
-

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,9 @@
 
 import
   # Standard library
-  strutils, streams, strformat,
-  macros,
+  std/[
+    strutils, streams, strformat,
+    macros],
   # Third-party
   yaml,
   # Beacon chain internals

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,9 @@
 
 import
   # Standard library
-  strutils, streams, strformat,
-  macros, sets,
+  std/[
+    strutils, streams, strformat,
+    macros, sets],
   # Third-party
   yaml,
   # Beacon chain internals

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2023 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,9 @@
 
 import
   # Standard library
-  strutils, streams, strformat,
-  macros, sets,
+  std/[
+    strutils, streams, strformat,
+    macros, sets],
   # Third-party
   yaml,
   # Beacon chain internals

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,9 @@
 
 import
   # Standard library
-  strutils, streams, strformat,
-  macros, sets,
+  std/[
+    strutils, streams, strformat,
+    macros, sets],
   # Third-party
   yaml,
   # Beacon chain internals

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,9 @@
 
 import
   # Standard library
-  strutils, streams, strformat, strscans,
-  macros, typetraits,
+  std/[
+    strutils, streams, strformat, strscans,
+    macros, typetraits],
   # Status libraries
   faststreams, snappy, stint, ../testutil,
   # Third-party

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2023 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,7 +13,7 @@ import
   ./os_ops
 
 from std/sequtils import toSeq
-from streams import close, openFileStream
+from std/streams import close, openFileStream
 from ../testutil import preset, suite, test
 from ./fixtures_utils import SszTestsDir, parseTest
 

--- a/tests/fuzzing/ssz_decode_Attestation.nim
+++ b/tests/fuzzing/ssz_decode_Attestation.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest Attestation
-

--- a/tests/fuzzing/ssz_decode_AttesterSlashing.nim
+++ b/tests/fuzzing/ssz_decode_AttesterSlashing.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest AttesterSlashing
-

--- a/tests/fuzzing/ssz_decode_BeaconState.nim
+++ b/tests/fuzzing/ssz_decode_BeaconState.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest BeaconState
-

--- a/tests/fuzzing/ssz_decode_ProposerSlashing.nim
+++ b/tests/fuzzing/ssz_decode_ProposerSlashing.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest ProposerSlashing
-

--- a/tests/fuzzing/ssz_decode_SignedAggregateAndProof.nim
+++ b/tests/fuzzing/ssz_decode_SignedAggregateAndProof.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest SignedAggregateAndProof
-

--- a/tests/fuzzing/ssz_decode_SignedBeaconBlock.nim
+++ b/tests/fuzzing/ssz_decode_SignedBeaconBlock.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest SignedBeaconBlock
-

--- a/tests/fuzzing/ssz_decode_VoluntaryExit.nim
+++ b/tests/fuzzing/ssz_decode_VoluntaryExit.nim
@@ -1,4 +1,10 @@
-import ssz_fuzzing
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import ./ssz_fuzzing
 
 sszFuzzingTest SignedVoluntaryExit
-

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -1,12 +1,12 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  macros,
+  std/macros,
   ssz_serialization/types,
   ../../beacon_chain/spec/datatypes/base
   # digest is necessary for them to be printed as hex

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,7 @@
 
 import
   # Standard library
-  math,
+  std/math,
 
   # Specs
   ../../beacon_chain/spec/[eth2_merkleization, keystore, forks, signatures],

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2023 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -15,7 +15,7 @@ import
   ../beacon_chain/spec/[crypto, keystore],
   ./testutil
 
-from strutils import replace
+from std/strutils import replace
 
 func isEqual(a, b: ValidatorPrivKey): bool =
   # `==` on secret keys is not allowed

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -1,5 +1,5 @@
 # nimbus_signing_node
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -15,7 +15,7 @@ import
   ../beacon_chain/filepath,
   ../beacon_chain/validators/validator_pool
 
-from os import getEnv, osErrorMsg
+from std/os import getEnv, osErrorMsg
 
 {.used.}
 

--- a/tools/generate_makefile.nim
+++ b/tools/generate_makefile.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Status Research & Development GmbH
+# Copyright (c) 2020-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 # "--compileOnly". Suitable for Make-controlled parallelisation, down to the GCC
 # LTO level.
 
-import json, os, strutils
+import std/[json, os, strutils]
 
 # Ripped off from Nim's `linkViaResponseFile()` in "compiler/extccomp.nim".
 # It lets us get around a command line length limit on Windows.
@@ -91,4 +91,3 @@ proc main() =
       makefile.writeLine("\t+ $#" % cmd.getStr().replace('\\', '/'))
 
 main()
-


### PR DESCRIPTION
Bumping some `std` imports to explicitly include the prefix. Also add explicit `./` prefix for local directory imports.