### PR TITLE
display current fork (+ next fork if applicable) in slot start / status

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -440,6 +440,7 @@ type
         defaultValue: "peers: $connected_peers;" &
                       "finalized: $finalized_root:$finalized_epoch;" &
                       "head: $head_root:$head_epoch:$head_epoch_slot;" &
+                      "fork: $consensus_fork;" &
                       "time: $epoch:$epoch_slot ($slot);" &
                       "sync: $sync_status|" &
                       "ETH: $attached_validators_balance"

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -816,6 +816,20 @@ func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
   withState(x): forkyState.root = root
 {.pop.}
 
+func consensusForkEpoch*(
+    cfg: RuntimeConfig, consensusFork: ConsensusFork): Epoch =
+  case consensusFork
+  of ConsensusFork.Deneb:
+    cfg.DENEB_FORK_EPOCH
+  of ConsensusFork.Capella:
+    cfg.CAPELLA_FORK_EPOCH
+  of ConsensusFork.Bellatrix:
+    cfg.BELLATRIX_FORK_EPOCH
+  of ConsensusFork.Altair:
+    cfg.ALTAIR_FORK_EPOCH
+  of ConsensusFork.Phase0:
+    GENESIS_EPOCH
+
 func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
   ## Return the current fork for the given epoch.
   static:


### PR DESCRIPTION
Extend slot start message and default status bar with information about current head fork and the next fork transition (corresponding to head). This is useful to know whether a synced client is aware of a future fork and can also be useful when syncing from old forks to follow progress across the various forks.

```
 peers: 8 ❯ finalized: 741c2ce2:230474 ❯ head: b330f58b:230477:20 ❯ fork: Capella (next: Deneb:231680) ❯ time: 230599:24 (7379192) ❯ sync: 00h24m (99.63%) 2.6492slots/s (QwQUwQPQDQ:7375263)/opt
```

```
INF 2024-01-12 12:18:00.001+01:00 Slot start                                 topics="beacnde" slot=7379190 epoch=230599 fork="Capella (next: Deneb:231680)" sync="--h--m (99.62%) 0.0000slots/s (wwwwwwwwww:7375167)/opt" peers=0 head=741c2ce2:7375168 finalized=230472:723abe7e delay=1ms861us
```