### PR TITLE
update some deprecated stew/results to results imports

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -9,7 +9,8 @@
 
 import
   std/[typetraits, tables],
-  stew/[arrayops, assign2, byteutils, endians2, io2, objects, results],
+  results,
+  stew/[arrayops, assign2, byteutils, endians2, io2, objects],
   serialization, chronicles, snappy,
   eth/db/[kvstore, kvstore_sqlite3],
   ./networking/network_metadata, ./beacon_chain_db_immutable,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -9,7 +9,8 @@
 
 import
   chronicles,
-  stew/[assign2, results],
+  results,
+  stew/assign2,
   ../spec/[
     beaconstate, forks, signatures, signatures_batch,
     state_transition, state_transition_epoch],

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -9,8 +9,8 @@
 
 import
   std/[algorithm, sequtils, tables, sets],
-  stew/[arrayops, assign2, byteutils, results],
-  metrics, snappy, chronicles,
+  stew/[arrayops, assign2, byteutils],
+  metrics, results, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
     state_transition, validator],
   ../spec/forks,

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -9,7 +9,7 @@
 
 import
   std/sequtils,
-  stew/results,
+  results,
   chronicles,
   ../extras,
   ../spec/[beaconstate, helpers, network, signatures, validator],

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
@@ -7,7 +7,7 @@
 
 import
   std/[options, uri],
-  stew/results, chronicles, confutils,
+  results, chronicles, confutils,
   confutils/toml/defs as confTomlDefs,
   confutils/toml/std/net as confTomlNet,
   confutils/toml/std/uri as confTomlUri,

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -14,7 +14,8 @@ import
   json_rpc/[client, errors],
   web3, web3/[engine_api, primitives, conversions],
   eth/common/[eth_types, transaction],
-  eth/async_utils, stew/[assign2, byteutils, objects, results, shims/hashes, endians2],
+  eth/async_utils, results,
+  stew/[assign2, byteutils, objects, shims/hashes, endians2],
   # Local modules:
   ../spec/[deposit_snapshots, eth2_merkleization, forks, helpers],
   ../networking/network_metadata,

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -7,7 +7,7 @@
 import
   std/os,
   chronicles,
-  stew/results, snappy, taskpools,
+  results, snappy, taskpools,
   ../ncli/e2store,
   ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/[beaconstate, forks, signatures_batch],

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   std/[sequtils, tables],
   # Status libraries
-  stew/[results], chronicles,
+  results, chronicles,
   # Internal
   ../spec/[beaconstate, helpers, state_transition_block],
   ../spec/datatypes/[phase0, altair, bellatrix],

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -11,7 +11,7 @@ import
   # Standard library
   std/tables,
   # Status
-  stew/results,
+  results,
   chronicles,
   # Internal
   ../spec/datatypes/base,

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -12,7 +12,7 @@ import
   std/[tables, typetraits],
   # Status libraries
   chronicles,
-  stew/results,
+  results,
   # Internal
   ../spec/datatypes/base,
   ../spec/helpers,

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -10,7 +10,7 @@
 import
   # Status
   chronicles, chronos, metrics,
-  stew/results,
+  results,
   # Internals
   ../spec/[
     beaconstate, state_transition_block, forks, helpers, network, signatures],

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -12,7 +12,8 @@ import
   std/[typetraits, os, sequtils, strutils, algorithm, math, tables],
 
   # Status libs
-  stew/[leb128, endians2, results, byteutils, io2, bitops2],
+  results,
+  stew/[leb128, endians2, byteutils, io2, bitops2],
   stew/shims/net as stewNet,
   stew/shims/[macros],
   snappy,

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -9,7 +9,7 @@ import std/[tables, os, strutils]
 import serialization, json_serialization,
        json_serialization/std/[options, net],
        chronos, presto, presto/secureserver, chronicles, confutils,
-       stew/[base10, results, byteutils, io2, bitops2]
+       results, stew/[base10, byteutils, io2, bitops2]
 import "."/spec/datatypes/[base, altair, phase0],
        "."/spec/[crypto, digest, network, signatures, forks],
        "."/spec/eth2_apis/[rest_types, eth2_rest_serialization],

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -10,7 +10,7 @@
 
 import std/[tables, strutils, uri]
 import chronos, chronicles, confutils,
-       stew/[base10, results, io2], blscurve, presto
+       results, stew/[base10, io2], blscurve, presto
 import ".."/spec/[keystore, crypto]
 import ".."/spec/eth2_apis/rest_keymanager_types
 import ".."/validators/[slashing_protection, keystore_management,

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -25,7 +25,8 @@
 
 import
   # Status
-  stew/[bitseqs, endians2, objects, results, byteutils],
+  results,
+  stew/[bitseqs, endians2, objects, byteutils],
   blscurve,
   chronicles,
   bearssl/rand,

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -62,7 +62,8 @@
 
 import
   std/[macros, hashes, sets, strutils, tables, typetraits],
-  stew/[assign2, byteutils, endians2, results],
+  results,
+  stew/[assign2, byteutils, endians2],
   chronicles,
   json_serialization,
   ssz_serialization/types as sszTypes,

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -9,7 +9,8 @@ import
   chronicles, confutils/defs,
   bearssl/rand,
   nimcrypto/[hmac, utils],
-  stew/[byteutils, results]
+  results,
+  stew/byteutils
 
 from std/base64 import encode
 from std/json import JsonNode, `$`, `%*`

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import std/[typetraits, strutils]
-import stew/[assign2, results, base10, byteutils, endians2], presto/common,
+import results, stew/[assign2, base10, byteutils, endians2], presto/common,
        libp2p/peerid, serialization, json_serialization,
        json_serialization/std/[net, sets],
        json_serialization/stew/results as jsonSerializationResults,

--- a/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
@@ -8,7 +8,8 @@
 
 import
   chronos,
-  stew/[results, endians2],
+  results,
+  stew/endians2,
   presto/client,
   ../helpers,
   "."/[rest_common, eth2_rest_serialization]

--- a/beacon_chain/spec/eth2_apis/rest_remote_signer_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_remote_signer_calls.nim
@@ -9,7 +9,8 @@
 import
   chronicles, metrics,
   chronos, presto/client,
-  stew/[results, base10, byteutils],
+  results,
+  stew/[base10, byteutils],
   "."/[rest_types, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization, results

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -9,8 +9,8 @@
 
 import
   std/macros,
+  results,
   stew/assign2,
-  stew/results,
   chronicles,
   ../extras,
   "."/[

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -14,7 +14,8 @@ import
   # Third-party libraries
   normalize,
   # Status libraries
-  stew/[results, bitops2, base10, io2, endians2], stew/shims/macros,
+  results,
+  stew/[bitops2, base10, io2, endians2], stew/shims/macros,
   eth/keyfile/uuid, blscurve,
   json_serialization, json_serialization/std/options,
   chronos/timer,

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -15,7 +15,8 @@
 import
   # Status lib
   blscurve,
-  stew/[byteutils, results],
+  stew/byteutils,
+  results,
   taskpools,
   bearssl/rand,
   # Internal

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -42,7 +42,7 @@
 
 import
   chronicles,
-  stew/results,
+  results,
   ../extras,
   "."/[
     beaconstate, eth2_merkleization, forks, helpers, signatures,

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -7,7 +7,8 @@
 
 import
   std/[tables, os, sets, sequtils, strutils, uri, algorithm],
-  stew/[base10, results, byteutils],
+  results,
+  stew/[base10, byteutils],
   bearssl/rand, chronos, presto, presto/client as presto_client,
   chronicles, confutils,
   metrics, metrics/chronos_httpserver,

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -12,7 +12,8 @@ import
   std/[os, algorithm, sequtils],
   # Status
   eth/db/[kvstore, kvstore_sqlite3],
-  stew/[results, byteutils],
+  results,
+  stew/byteutils,
   chronicles, chronicles/timings,
   # Internal
   ../spec/datatypes/base,

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -11,7 +11,8 @@ import
   # Stdlib
   std/[typetraits, strutils, algorithm],
   # Status
-  stew/[byteutils, results],
+  stew/byteutils,
+  results,
   serialization,
   json_serialization, json_serialization/std/options,
   chronicles,

--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -9,7 +9,8 @@
 
 import
   std/strformat,
-  stew/[arrayops, endians2, io2, results],
+  results,
+  stew/[arrayops, endians2, io2],
   snappy,
   ../beacon_chain/spec/[beacon_time, forks],
   ../beacon_chain/spec/eth2_ssz_serialization

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -5,10 +5,12 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import std/[strutils, os, options, uri, json, tables]
-import stew/[results, io2, base10]
-import confutils, chronicles, httputils,
-       chronos, chronos/streams/[asyncstream, tlsstream]
+import
+  std/[strutils, os, options, uri, json, tables],
+  results,
+  stew/[io2, base10],
+  confutils, chronicles, httputils,
+  chronos, chronos/streams/[asyncstream, tlsstream]
 
 const
   RestTesterName* = "Ethereum2 REST API Tester"


### PR DESCRIPTION
`stew/results.nim` is now
```nim
# This module has graduated from stew and is now available from the
# `results` nimble package instead (https://github.com/arnetheduck/nim-results)

when defined(stewWarnResults):
  # This deprecation notice will be made default in some future stew commit
  {.deprecated: "`stew/results` is now availabe as `import results` via the `results` Nimble package".}

import pkg/results
export results
```