### PR TITLE
remove extraneous length checks in KZG batch proofs

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1507,6 +1507,9 @@ func syncStatus(node: BeaconNode, wallSlot: Slot): string =
   else:
     "synced"
 
+when defined(windows):
+  from winservice import reportServiceStatusSuccess
+
 proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
                  lastSlot: Slot): Future[bool] {.async.} =
   ## Called at the beginning of a slot - usually every slot, but sometimes might

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1508,7 +1508,7 @@ func syncStatus(node: BeaconNode, wallSlot: Slot): string =
     "synced"
 
 when defined(windows):
-  from winservice import reportServiceStatusSuccess
+  from winservice import establishWindowsService, reportServiceStatusSuccess
 
 proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
                  lastSlot: Slot): Future[bool] {.async.} =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -23,8 +23,7 @@ import
   ./validators/[keystore_management, beacon_validators],
   "."/[
     beacon_node, beacon_node_light_client, deposits,
-    nimbus_binary_common, statusbar, trusted_node_sync, wallets,
-    winservice]
+    nimbus_binary_common, statusbar, trusted_node_sync, wallets]
 
 when defined(posix):
   import system/ansi_c

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -7,10 +7,10 @@
 
 # State transition - block processing, as described in
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/beacon-chain.md#block-processing
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/altair/beacon-chain.md#block-processing
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/beacon-chain.md#block-processing
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/bellatrix/beacon-chain.md#block-processing
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/capella/beacon-chain.md#block-processing
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/deneb/beacon-chain.md#block-processing
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/beacon-chain.md#block-processing
 #
 # The entry point is `process_block` which is at the bottom of this file.
 #
@@ -726,22 +726,14 @@ func kzg_commitment_to_versioned_hash*(
   res[1 .. 31] = eth2digest(kzg_commitment).data.toOpenArray(1, 31)
   res
 
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/fork-choice.md#validate_blobs
-proc validate_blobs*(expected_kzg_commitments: seq[KzgCommitment],
-                     blobs: seq[KzgBlob],
-                     proofs: seq[KzgProof]):
-                       Result[void, cstring] =
-  if expected_kzg_commitments.len != blobs.len:
-    return err("validate_blobs: different commitment and blob lengths")
-
-  if proofs.len != blobs.len:
-    return err("validate_blobs: different proof and blob lengths")
-
+proc validate_blobs*(
+    expected_kzg_commitments: seq[KzgCommitment], blobs: seq[KzgBlob],
+    proofs: seq[KzgProof]): Result[void, string] =
   let res = verifyProofs(blobs, expected_kzg_commitments, proofs).valueOr:
-    return err("validate_blobs: proof verification error")
+    return err("validate_blobs proof verification error: " & error())
 
   if not res:
-    return err("validate_blobs: proof verification failed")
+    return err("validate_blobs proof verification failed")
 
   ok()
 

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -82,7 +82,7 @@ template blockProcessor(router: MessageRouter): ref BlockProcessor =
 template getCurrentBeaconTime(router: MessageRouter): BeaconTime =
   router.processor[].getCurrentBeaconTime()
 
-type RouteBlockResult = Result[Opt[BlockRef], cstring]
+type RouteBlockResult = Result[Opt[BlockRef], string]
 proc routeSignedBeaconBlock*(
     router: ref MessageRouter, blck: ForkySignedBeaconBlock,
     blobsOpt: Opt[seq[BlobSidecar]]): Future[RouteBlockResult] {.async.} =
@@ -101,7 +101,7 @@ proc routeSignedBeaconBlock*(
       warn "Block failed validation",
         blockRoot = shortLog(blck.root), blck = shortLog(blck.message),
         signature = shortLog(blck.signature), error = res.error()
-      return err(res.error()[1])
+      return err($(res.error()[1]))
 
     when typeof(blck).kind >= ConsensusFork.Deneb:
       if blobsOpt.isSome:


### PR DESCRIPTION
These are replicated in https://github.com/ethereum/c-kzg-4844/blob/d637761a2ece4f13dbcffcae09253408e430a6e1/bindings/nim/kzg.nim#L181-L202
```nim
proc verifyProofs*(ctx: KzgCtx,
                  blobs: openArray[KzgBlob],
                  commitments: openArray[KzgBytes48],
                  proofs: openArray[KzgBytes48]): Result[bool, string] {.gcsafe.} =
  if blobs.len != commitments.len:
    return err($KZG_BADARGS)

  if blobs.len != proofs.len:
    return err($KZG_BADARGS)

  if blobs.len == 0:
    return ok(true)

...
```

Which is recognized by https://github.com/ethereum/consensus-specs/commit/468b5be7b8a516d6fbc60ad8abec8830a5181bf4 and https://github.com/ethereum/consensus-specs/pull/3368

As such, the spec removed the wrapper function. It's useful to keep the wrapper here, because it coalesces the two failure modes of failure-in-trying-to-verify with successful verification, procedurally, which rejected the proof/commitment/blob tuple. Downstream code largely doesn't care, except insofar as it would like to be able to generate more informative error messages, so keeping this wrapper avoids code duplication elsewhere.

Still, it's not in spec as of v1.4.0, so remove consensus spec reference URL.