### PR TITLE
load Ethereum mainnet KZG setup on Gnosis networks

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1483,10 +1483,8 @@ proc loadKzgTrustedSetup*(): Result[void, string] =
     trustedSetup = staticRead(
       vendorDir & "/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt")
 
-  if const_preset == "mainnet" or const_preset == "minimal":
-    Kzg.loadTrustedSetupFromString(trustedSetup)
-  else:
-    ok()
+  static: doAssert const_preset in ["mainnet", "gnosis", "minimal"]
+  Kzg.loadTrustedSetupFromString(trustedSetup)
 
 proc loadKzgTrustedSetup*(trustedSetupPath: string): Result[void, string] =
   try:

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -559,7 +559,7 @@ elif const_preset == "minimal":
   )
 
 else:
-  {.error: "Only mainnet and minimal presets supported".}
+  {.error: "Only mainnet, gnosis, and minimal presets supported".}
   # macro createConstantsFromPreset*(path: static string): untyped =
   #   result = newStmtList()
 


### PR DESCRIPTION
Gnosis networks re-use the trusted setup from Ethereum mainnet. Load it to support Deneb.