### PR TITLE
workaround random `SIGSEGV` on macOS aarch64 CI

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1227,9 +1227,12 @@ proc proposeBlockAux(
     # This change, maybe combined with some macOS specific compiler specifics,
     # could this trigger the `SIGSEGV`? Maybe the extra state adds just enough
     # complexity to the function to disable certain problematic optimizations?
-    # Furthermore, the combination of `(await xyz).valueOr: return` is not very
-    # commonly used together with other `await` in the same `let` block, which
-    # could explain why this is not a more common trigger across Nimbus.
+    # The change in size of the environment changes a number of things such as
+    # alignment and which parts of an environment contain pointers and so on,
+    # which in turn may have surprising behavioural effects, ie most likely this
+    # extra state masks some underlying issue. Furthermore, the combination of
+    # `(await xyz).valueOr: return` is not very commonly used with other `await`
+    # in the same `let` block, which could explain this not being more common.
     #
     # Note that when compiling for Wasm, there are similar bugs with `results`
     # when inlining unwraps, e.g., in `eth2_rest_serialization.nim`.

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1190,7 +1190,7 @@ proc proposeBlockAux(
     # Issue has started occuring around 12 Jan 2024, in a CI run for PR #5731.
     # The PR did not change anything related to this, suggesting an environment
     # or hardware change. The issue is flaky; could have been introduced earlier
-    # before surfacing in the aforementioned mentioned PR. About 30% to hit bug.
+    # before surfacing in the aforementioned PR. About 30% to hit bug.
     #
     # [2024-01-12T11:54:21.011Z] Wrote test_keymanager_api/bootstrap_node.enr
     # [2024-01-12T11:54:29.294Z] Serialization/deserialization [Beacon Node] [Preset: mainnet] . (0.00s)


### PR DESCRIPTION
Separate a `let` block into multiple `let` statements to reduce probability of hitting random `SIGSEGV` during flaky CI tests.

whatever... 🤯