### PR TITLE
log `const_preset` on beacon node startup

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2036,6 +2036,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   info "Launching beacon node",
       version = fullVersionStr,
       bls_backend = $BLS_BACKEND,
+      const_preset,
       cmdParams = commandLineParams(),
       config
 


### PR DESCRIPTION
To understand what binary is being used (regular / minimal / gnosis), extend launch logging.