### PR TITLE
bolster `BlobSidecar` syncing on incomplete responses

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -181,8 +181,9 @@ func check_attestation_subnet(
 
 func check_blob_sidecar_inclusion_proof(
     blob_sidecar: deneb.BlobSidecar): Result[void, ValidationError] =
-  if blob_sidecar.verify_blob_sidecar_inclusion_proof().isErr:
-    return errReject("BlobSidecar: inclusion proof not valid")
+  let res = blob_sidecar.verify_blob_sidecar_inclusion_proof()
+  if res.isErr:
+    return errReject(res.error)
 
   ok()
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -179,16 +179,9 @@ func check_attestation_subnet(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#verify_blob_sidecar_inclusion_proof
-func verify_blob_sidecar_inclusion_proof(
+func check_blob_sidecar_inclusion_proof(
     blob_sidecar: deneb.BlobSidecar): Result[void, ValidationError] =
-  let gindex = kzg_commitment_inclusion_proof_gindex(blob_sidecar.index)
-  if not is_valid_merkle_branch(
-      hash_tree_root(blob_sidecar.kzg_commitment),
-      blob_sidecar.kzg_commitment_inclusion_proof,
-      KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
-      get_subtree_index(gindex),
-      blob_sidecar.signed_block_header.message.body_root):
+  if blob_sidecar.verify_blob_sidecar_inclusion_proof().isErr:
     return errReject("BlobSidecar: inclusion proof not valid")
 
   ok()
@@ -361,7 +354,7 @@ proc validateBlobSidecar*(
   # [REJECT] The sidecar's inclusion proof is valid as verified by
   # `verify_blob_sidecar_inclusion_proof(blob_sidecar)`.
   block:
-    let v = verify_blob_sidecar_inclusion_proof(blob_sidecar)
+    let v = check_blob_sidecar_inclusion_proof(blob_sidecar)
     if v.isErr:
       return dag.checkedReject(v.error)
 

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -616,6 +616,20 @@ func kzg_commitment_inclusion_proof_gindex*(
 
   BLOB_KZG_COMMITMENTS_FIRST_GINDEX + index
 
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#check_blob_sidecar_inclusion_proof
+func verify_blob_sidecar_inclusion_proof*(
+    blob_sidecar: BlobSidecar): Opt[void] =
+  let gindex = kzg_commitment_inclusion_proof_gindex(blob_sidecar.index)
+  if not is_valid_merkle_branch(
+      hash_tree_root(blob_sidecar.kzg_commitment),
+      blob_sidecar.kzg_commitment_inclusion_proof,
+      KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
+      get_subtree_index(gindex),
+      blob_sidecar.signed_block_header.message.body_root):
+    return err()
+
+  ok()
+
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/light-client/sync-protocol.md#modified-get_lc_execution_root
 func get_lc_execution_root*(
     header: LightClientHeader, cfg: RuntimeConfig): Eth2Digest =

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -616,20 +616,6 @@ func kzg_commitment_inclusion_proof_gindex*(
 
   BLOB_KZG_COMMITMENTS_FIRST_GINDEX + index
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#check_blob_sidecar_inclusion_proof
-func verify_blob_sidecar_inclusion_proof*(
-    blob_sidecar: BlobSidecar): Opt[void] =
-  let gindex = kzg_commitment_inclusion_proof_gindex(blob_sidecar.index)
-  if not is_valid_merkle_branch(
-      hash_tree_root(blob_sidecar.kzg_commitment),
-      blob_sidecar.kzg_commitment_inclusion_proof,
-      KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
-      get_subtree_index(gindex),
-      blob_sidecar.signed_block_header.message.body_root):
-    return err()
-
-  ok()
-
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/light-client/sync-protocol.md#modified-get_lc_execution_root
 func get_lc_execution_root*(
     header: LightClientHeader, cfg: RuntimeConfig): Eth2Digest =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -213,7 +213,7 @@ func has_flag*(flags: ParticipationFlags, flag_index: TimelyFlag): bool =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#check_blob_sidecar_inclusion_proof
 func verify_blob_sidecar_inclusion_proof*(
-    blob_sidecar: BlobSidecar): Opt[void] =
+    blob_sidecar: BlobSidecar): Result[void, string] =
   let gindex = kzg_commitment_inclusion_proof_gindex(blob_sidecar.index)
   if not is_valid_merkle_branch(
       hash_tree_root(blob_sidecar.kzg_commitment),
@@ -221,8 +221,7 @@ func verify_blob_sidecar_inclusion_proof*(
       KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
       get_subtree_index(gindex),
       blob_sidecar.signed_block_header.message.body_root):
-    return err()
-
+    return err("BlobSidecar: inclusion proof not valid")
   ok()
 
 func create_blob_sidecars*(

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -211,6 +211,20 @@ func has_flag*(flags: ParticipationFlags, flag_index: TimelyFlag): bool =
   let flag = ParticipationFlags(1'u8 shl ord(flag_index))
   (flags and flag) == flag
 
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#check_blob_sidecar_inclusion_proof
+func verify_blob_sidecar_inclusion_proof*(
+    blob_sidecar: BlobSidecar): Opt[void] =
+  let gindex = kzg_commitment_inclusion_proof_gindex(blob_sidecar.index)
+  if not is_valid_merkle_branch(
+      hash_tree_root(blob_sidecar.kzg_commitment),
+      blob_sidecar.kzg_commitment_inclusion_proof,
+      KZG_COMMITMENT_INCLUSION_PROOF_DEPTH,
+      get_subtree_index(gindex),
+      blob_sidecar.signed_block_header.message.body_root):
+    return err()
+
+  ok()
+
 func create_blob_sidecars*(
     forkyBlck: deneb.SignedBeaconBlock,
     kzg_proofs: KzgProofs,

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -262,7 +262,7 @@ func groupBlobs*[T](req: SyncRequest[T],
             return err("BlobSidecar: unexpected kzg_commitment")
           if blob_sidecar.signed_block_header != header:
             return err("BlobSidecar: unexpected signed_block_header")
-          if blob_sidecar.verify_blob_sidecar_inclusion_proof().isErr:
+          if blob_sidecar[].verify_blob_sidecar_inclusion_proof().isErr:
             return err("BlobSidecar: inclusion proof not valid")
           grouped[block_idx].add(blob_sidecar)
           inc blob_cursor

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -251,7 +251,7 @@ func groupBlobs*[T](req: SyncRequest[T],
         template commits: untyped = forkyBlck.message.body.blob_kzg_commitments
         if commits.len == 0:
           continue
-        let header = forkyBlck.toBeaconBlockHeader()
+        let header = forkyBlck.toSignedBeaconBlockHeader()
         for blob_idx, kzg_commitment in commits:
           if blob_cursor >= blobs.len:
             return err("BlobSidecar: response too short")

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -246,7 +246,7 @@ func groupBlobs*[T](req: SyncRequest[T],
     grouped = newSeq[BlobSidecars](len(blocks))
     blob_cursor = 0
   for block_idx, blck in blocks:
-    withBlck(blck):
+    withBlck(blck[]):
       when consensusFork >= ConsensusFork.Deneb:
         template commits: untyped = forkyBlck.message.body.blob_kzg_commitments
         if commits.len == 0:

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -477,14 +477,14 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
           info "Received blobs sequence is inconsistent",
             blobs_map = getShortMap(req, blobData), request = req, msg=groupedBlobs.error()
           return
-        if (let checkedBlobs = groupedBlobs.checkBlobs(); checkedBlobs.isErr):
+        if (let checkRes = groupedBlobs.get.checkBlobs(); checkRes.isErr):
           peer.updateScore(PeerScoreBadResponse)
           man.queue.push(req)
           warn "Received blobs sequence is invalid",
             blobs_count = len(blobData),
             blobs_map = getShortMap(req, blobData),
             request = req,
-            msg = checkedblobs.error
+            msg = checkRes.error
           return
         Opt.some(groupedBlobs.get())
       else:

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -279,8 +279,7 @@ func groupBlobs*[T](req: SyncRequest[T],
 func checkBlobs(blobs: seq[BlobSidecars]): Result[void, string] =
   for blob_sidecars in blobs:
     for blob_sidecar in blob_sidecars:
-      if blob_sidecar[].verify_blob_sidecar_inclusion_proof().isErr:
-        return err("BlobSidecar: inclusion proof not valid")
+      ? blob_sidecar[].verify_blob_sidecar_inclusion_proof()
   ok()
 
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -251,6 +251,9 @@ func groupBlobs*[T](req: SyncRequest[T],
         template commits: untyped = forkyBlck.message.body.blob_kzg_commitments
         if commits.len == 0:
           continue
+        # Clients MUST include all blob sidecars of each block from which they include blob sidecars.
+        # The following blob sidecars, where they exist, MUST be sent in consecutive (slot, index) order.
+        # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1
         let header = forkyBlck.toSignedBeaconBlockHeader()
         for blob_idx, kzg_commitment in commits:
           if blob_cursor >= blobs.len:

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -248,14 +248,14 @@ func groupBlobs*[T](req: SyncRequest[T],
   for block_idx, blck in blocks:
     withBlck(blck[]):
       when consensusFork >= ConsensusFork.Deneb:
-        template commits: untyped = forkyBlck.message.body.blob_kzg_commitments
-        if commits.len == 0:
+        template kzgs: untyped = forkyBlck.message.body.blob_kzg_commitments
+        if kzgs.len == 0:
           continue
         # Clients MUST include all blob sidecars of each block from which they include blob sidecars.
         # The following blob sidecars, where they exist, MUST be sent in consecutive (slot, index) order.
         # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blobsidecarsbyrange-v1
         let header = forkyBlck.toSignedBeaconBlockHeader()
-        for blob_idx, kzg_commitment in commits:
+        for blob_idx, kzg_commitment in kzgs:
           if blob_cursor >= blobs.len:
             return err("BlobSidecar: response too short")
           let blob_sidecar = blobs[blob_cursor]

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -473,21 +473,6 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
       else:
         Opt.none(seq[BlobSidecars])
 
-    if blobData.isSome:
-      let blobs = blobData.get()
-      if len(blobs) != len(blockData):
-        peer.updateScore(PeerScoreNoValues)
-        man.queue.push(req)
-        info "block and blobs have different lengths", blobs=len(blobs), blocks=len(blockData)
-        return
-      for i, blk in blockData:
-        if len(blobs[i]) > 0 and blk[].slot !=
-            blobs[i][0].signed_block_header.message.slot:
-          peer.updateScore(PeerScoreNoValues)
-          man.queue.push(req)
-          debug "block and blobs data have inconsistent slots"
-          return
-
     if len(blockData) == 0 and man.direction == SyncQueueKind.Backward and
         req.contains(man.getSafeSlot()):
       # The sync protocol does not distinguish between:

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -464,9 +464,9 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =
             return
         let groupedBlobs = groupBlobs(req, blockData, blobData)
         if groupedBlobs.isErr():
-          peer.updateScore(PeerScoreBadResponse)
+          peer.updateScore(PeerScoreNoValues)
           man.queue.push(req)
-          warn "Received blobs sequence is invalid",
+          info "Received blobs sequence is inconsistent",
             blobs_map = getShortMap(req, blobData), request = req, msg=groupedBlobs.error()
           return
         Opt.some(groupedBlobs.get())

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -273,10 +273,11 @@ func groupBlobs*[T](req: SyncRequest[T],
   else:
     Result[seq[BlobSidecars], string].ok grouped
 
-func checkBlobs(blob_sidecars: seq[BlobSidecars]): Result[void, string] =
-  for blob_sidecar in blob_sidecars:
-    if blob_sidecar[].verify_blob_sidecar_inclusion_proof().isErr:
-      return err("BlobSidecar: inclusion proof not valid")
+func checkBlobs(blobs: seq[BlobSidecars]): Result[void, string] =
+  for blob_sidecars in blobs:
+    for blob_sidecar in blob_sidecars:
+      if blob_sidecar[].verify_blob_sidecar_inclusion_proof().isErr:
+        return err("BlobSidecar: inclusion proof not valid")
   ok()
 
 proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A) {.async.} =


### PR DESCRIPTION
Avoid marking blocks invalid when corresponding `blobSidecarsByRange` returns an incomplete / incorrect response while syncing. The block itself may still be valid in that scenario.