### PR TITLE
fix validators not registered when VC is used with web3signer (#5730)

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -968,6 +968,10 @@ proc getFeeRecipient*(vc: ValidatorClientRef, pubkey: ValidatorPubKey,
         vc.config.validatorsDir, pubkey, perValidatorDefaultFeeRecipient)
     if staticRecipient.isOk():
       Opt.some(staticRecipient.get())
+    elif len(vc.config.web3SignerUrls) > 0 or len(vc.config.verifyingWeb3Signers) > 0:
+      # See issue 5730: getSuggestedFeeRecipient returns err if the validator directory
+      # does not exist, which is the case when a web3signer is used
+      Opt.some(perValidatorDefaultFeeRecipient)
     else:
       Opt.none(Eth1Address)
 


### PR DESCRIPTION
This change ensures that suggested-fee-recipient will be used as default even if the validator directory does not exist when a web3-signer-url is specified.