### PR TITLE
remove expensive logging from function called in prepareBeaconProposer inner loop

### DIFF
--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -1071,11 +1071,21 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           dres.get()
       currentEpoch = node.beaconClock.now.slotOrZero.epoch
 
+    var
+      numUpdated = 0
+      numRefreshed = 0
     for proposerData in body:
-      node.dynamicFeeRecipientsStore[].addMapping(
-        proposerData.validator_index,
-        proposerData.fee_recipient,
-        currentEpoch)
+      if node.dynamicFeeRecipientsStore[].addMapping(
+          proposerData.validator_index,
+          proposerData.fee_recipient,
+          currentEpoch):
+        inc numUpdated
+      else:
+        inc numRefreshed
+
+    info "Prepared beacon proposers",
+      numUpdatedFeeRecipients = numUpdated,
+      numRefreshedFeeRecipients = numRefreshed
 
     return RestApiResponse.response("", Http200, "text/plain")
 

--- a/beacon_chain/spec/eth2_apis/dynamic_fee_recipients.nim
+++ b/beacon_chain/spec/eth2_apis/dynamic_fee_recipients.nim
@@ -7,7 +7,7 @@
 
 import
   std/tables,
-  stew/results,
+  results,
   chronicles,
   ../datatypes/base
 
@@ -24,24 +24,20 @@ type
 func init*(T: type DynamicFeeRecipientsStore): T =
   T(mappings: initTable[ValidatorIndex, Entry]())
 
-proc addMapping*(store: var DynamicFeeRecipientsStore,
+func addMapping*(store: var DynamicFeeRecipientsStore,
                  validator: ValidatorIndex,
                  feeRecipient: Eth1Address,
-                 currentEpoch: Epoch) =
+                 currentEpoch: Epoch): bool =
   var updated = false
   store.mappings.withValue(validator, entry) do:
-    updated = not (entry[].recipient == feeRecipient)
+    updated = entry[].recipient != feeRecipient
     entry[] = Entry(recipient: feeRecipient, addedAt: currentEpoch)
   do:
     updated = true
     store.mappings[validator] = Entry(recipient: feeRecipient,
                                       addedAt: currentEpoch)
-  if updated:
-    info "Updating fee recipient",
-      validator, feeRecipient = feeRecipient.toHex(), currentEpoch
-  else:
-    debug "Refreshing fee recipient",
-      validator, feeRecipient = feeRecipient.toHex(), currentEpoch
+
+  updated
 
 func getDynamicFeeRecipient*(store: var DynamicFeeRecipientsStore,
                              validator: ValidatorIndex,


### PR DESCRIPTION
Janky benchmark with/without from
```nim
import chronicles
import "."/beacon_chain/spec/eth2_apis/dynamic_fee_recipients
import "."/beacon_chain/beacon_node
import times

let feerecip = default(Eth1Address)

var a = newClone(DynamicFeeRecipientsStore.init())
let b = cpuTime()
for i in 0.ValidatorIndex ..< 2000.ValidatorIndex:
  a[].addMapping(0.ValidatorIndex, feerecip, GENESIS_EPOCH)
echo cpuTime() - b
```

goes from 40ms on local machine for 2000 `addMapping` calls to 6.547e-05 seconds.

This function spends essentially all its time logging, if it logs at all.