### PR TITLE
remove obsolete `curSlot` variable

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1906,8 +1906,6 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async.} =
   withState(node.dag.headState):
     node.updateValidators(forkyState.data.validators.asSeq())
 
-  var curSlot = lastSlot + 1
-
   let newHead = await handleProposal(node, head, slot)
   head = newHead
 


### PR DESCRIPTION
#5773 removed catching up on validator duties after lag. The `curSlot` variable that was used originally to track catch-up progress no longer has a use and is also no longer properly updated. Remove it.