### PR TITLE
rm some unnecessary stew/shims/net imports to reduce deprecation warnings

### DIFF
--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -9,7 +9,7 @@
 
 import
   testutils/unittests,
-  chronos, stew/shims/net, eth/keys, eth/p2p/discoveryv5/enr,
+  chronos, eth/keys, eth/p2p/discoveryv5/enr,
   ../beacon_chain/spec/[forks, network],
   ../beacon_chain/networking/[eth2_network, eth2_discovery],
   ./testutil

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -11,7 +11,7 @@ import
   std/[typetraits, os, options, json, sequtils, uri, algorithm],
   testutils/unittests, chronicles, stint, json_serialization, confutils,
   chronos, blscurve, libp2p/crypto/crypto as lcrypto,
-  stew/[byteutils, io2], stew/shims/net,
+  stew/[byteutils, io2],
 
   ../beacon_chain/spec/[crypto, keystore, eth2_merkleization],
   ../beacon_chain/spec/datatypes/base,


### PR DESCRIPTION
There are a couple more in `beacon_chain/`, while these are only in `tests/`, so splitting off this PR.

Importing `stew/shims/net` triggers a deprecation warning around `ValidIpAddress`, and it has no purpose but to provide some utility/support functions around this deprecated type.