### PR TITLE
rm some unnecessary stew/shims/net imports to reduce deprecation warnings

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -16,7 +16,7 @@ import
   confutils/toml/defs as confTomlDefs,
   confutils/toml/std/net as confTomlNet,
   confutils/toml/std/uri as confTomlUri,
-  serialization/errors, stew/shims/net as stewNet,
+  serialization/errors,
   stew/[io2, byteutils], unicodedb/properties, normalize,
   eth/common/eth_types as commonEthTypes, eth/net/nat,
   eth/p2p/discoveryv5/enr,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -14,8 +14,7 @@ import
   # Status libs
   results,
   stew/[leb128, endians2, byteutils, io2, bitops2],
-  stew/shims/net as stewNet,
-  stew/shims/[macros],
+  stew/shims/macros,
   snappy,
   json_serialization, json_serialization/std/[net, sets, options],
   chronos, chronos/ratelimit, chronicles, metrics,


### PR DESCRIPTION
Counterpart to https://github.com/status-im/nimbus-eth2/pull/5805

Importing `stew/shims/net` triggers a deprecation warning around `ValidIpAddress`, and it has no purpose but to provide some utility/support functions around this deprecated type.