### PR TITLE
rm unused code; fix a `Deprecated` warning; `proc` to `func`

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2261,8 +2261,9 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
 
     hostAddress = tcpEndPoint(
       ValidIpAddress.init config.listenAddress, config.tcpPort)
-    announcedAddresses = if extIp.isNone() or extTcpPort.isNone(): @[]
-                         else: @[tcpEndPoint(ValidIpAddress.init(extIp.get()), extTcpPort.get())]
+    announcedAddresses =
+      if extIp.isNone() or extTcpPort.isNone(): @[]
+      else: @[tcpEndPoint(extIp.get(), extTcpPort.get())]
 
   debug "Initializing networking", hostAddress,
                                    network_public_key = netKeys.pubkey,

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -425,22 +425,22 @@ proc getRuntimeConfig*(eth2Network: Option[string]): RuntimeConfig =
 
   metadata.cfg
 
-template bakedInGenesisStateAsBytes(networkName: untyped): untyped =
-  when incbinEnabled:
-    `networkName Genesis`.toOpenArray(0, `networkName GenesisSize` - 1)
-  else:
-    `networkName Genesis`.toOpenArrayByte(0, `networkName Genesis`.high)
-
-const
-  availableOnlyInMainnetBuild =
-    "Baked-in genesis states for the official Ethereum " &
-    "networks are available only in the mainnet build of Nimbus"
-
-  availableOnlyInGnosisBuild =
-    "Baked-in genesis states for the Gnosis network " &
-    "are available only in the gnosis build of Nimbus"
-
 when const_preset in ["mainnet", "gnosis"]:
+  template bakedInGenesisStateAsBytes(networkName: untyped): untyped =
+    when incbinEnabled:
+      `networkName Genesis`.toOpenArray(0, `networkName GenesisSize` - 1)
+    else:
+      `networkName Genesis`.toOpenArrayByte(0, `networkName Genesis`.high)
+
+  const
+    availableOnlyInMainnetBuild =
+      "Baked-in genesis states for the official Ethereum " &
+      "networks are available only in the mainnet build of Nimbus"
+
+    availableOnlyInGnosisBuild =
+      "Baked-in genesis states for the Gnosis network " &
+      "are available only in the gnosis build of Nimbus"
+
   template bakedBytes*(metadata: GenesisMetadata): auto =
     case metadata.networkName
     of "mainnet":

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1153,7 +1153,7 @@ proc maybeUpdateActionTrackerNextEpoch(
       #
       # There are no penalties associated with TIMELY_HEAD_FLAG_INDEX, but a
       # reward exists. effective_balance == MAX_EFFECTIVE_BALANCE ensures if
-      # even so, then the effective balanace cannot change as a result.
+      # even so, then the effective balance cannot change as a result.
       #
       # It's not truly necessary to avoid all rewards and penalties, but only
       # to bound them to ensure they won't unexpected alter effective balance

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -709,16 +709,6 @@ template firstSuccessSequential*(
     if exitNow:
       break
 
-proc getIndexedErrorMessage(response: RestPlainResponse): string =
-  let res = decodeBytes(RestIndexedErrorMessage, response.data,
-                        response.contentType)
-  if res.isOk():
-    let errorObj = res.get()
-    let failures = errorObj.failures.mapIt($it.index & ": " & it.message)
-    errorObj.message & ": [" & failures.join(", ") & "]"
-  else:
-    "Unable to decode error response: [" & $res.error & "]"
-
 proc getErrorMessage*(response: RestPlainResponse): string =
   let res = decodeBytes(RestErrorMessage, response.data,
                         response.contentType)

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1011,7 +1011,6 @@ proc getValidatorRegistration(
     return err(RegistrationKind.MissingIndex)
 
   let
-    vindex = validator.index.get()
     cached = vc.validatorsRegCache.getOrDefault(validator.pubkey)
     currentSlot =
       block:

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -77,7 +77,7 @@ type
     process: AsyncProcessRef
     reader: Future[seq[byte]]
 
-proc getNodePort(basePort: int, rt: RemoteSignerType): int =
+func getNodePort(basePort: int, rt: RemoteSignerType): int =
   # Individual port numbers derived by adding to configurable base port
   case rt
   of RemoteSignerType.Web3Signer:
@@ -118,7 +118,7 @@ proc getBlock(fork: ConsensusFork,
                       $fork).tryGet()
   ForkedBeaconBlock.init(b)
 
-proc init(t: typedesc[Web3SignerForkedBeaconBlock],
+func init(t: typedesc[Web3SignerForkedBeaconBlock],
           forked: ForkedBeaconBlock): Web3SignerForkedBeaconBlock =
   case forked.kind
   of ConsensusFork.Phase0, ConsensusFork.Altair:
@@ -192,7 +192,7 @@ proc createDataDir(pathName: string): Result[void, string] =
                    KeystorePassword)
   ok()
 
-proc getTestDir(rt: RemoteSignerType): string =
+func getTestDir(rt: RemoteSignerType): string =
   case rt
   of RemoteSignerType.Web3Signer:
     TestDirectoryName
@@ -225,14 +225,7 @@ proc removeTestDir(rt: RemoteSignerType) =
   discard removeDir(signingDir)
   discard removeDir(pathName)
 
-proc getPrivateKey(data: string): Result[ValidatorPrivKey, string] =
-  var key: blscurve.SecretKey
-  if fromHex(key, data):
-    ok(ValidatorPrivKey(key))
-  else:
-    err("Unable to initialize private key")
-
-proc getLocalKeystoreData(data: string): Result[KeystoreData, string] =
+func getLocalKeystoreData(data: string): Result[KeystoreData, string] =
   let privateKey =
     block:
       var key: blscurve.SecretKey
@@ -246,7 +239,7 @@ proc getLocalKeystoreData(data: string): Result[KeystoreData, string] =
     version: uint64(4),
     pubkey: privateKey.toPubKey().toPubKey())
 
-proc getRemoteKeystoreData(data: string, basePort: int,
+func getRemoteKeystoreData(data: string, basePort: int,
                            rt: RemoteSignerType): Result[KeystoreData, string] =
   let
     publicKey = ValidatorPubKey.fromHex(data).valueOr:


### PR DESCRIPTION
- `ValidIpAddress` is deprecated, so remove penultimate use of it in `eth2_network`. That use is only used as part of `debug` logging
- `bakedInGenesisStateAsBytes`, `availableOnlyInMainnetBuild`, and `availableOnlyInGnosisBuild` are only used within a `when` scope, but declared outside of it, resulting in `DeclaredButNotUsed` hints resolved by moving them within said `when` scope so they're declared under exactly the conditions they're used
- `getIndexedErrorMessage()`, `vindex`, and `getPrivateKey()` were unused
- some `proc`s in `test_signing_node` can be `func`s