### PR TITLE
Revert "use `RestPlainResponse` to improve builder API rerror reporting"

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -15,7 +15,7 @@ import
   web3, web3/[engine_api, primitives, conversions],
   eth/common/[eth_types, transaction],
   eth/async_utils, results,
-  stew/[assign2, byteutils, objects],
+  stew/[assign2, byteutils, objects, shims/hashes, endians2],
   eth/async_utils, stew/[assign2, byteutils, objects],
   # Local modules:
   ../spec/[eth2_merkleization, forks, helpers],

--- a/beacon_chain/spec/mev/rest_capella_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_capella_mev_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -22,13 +22,13 @@ proc registerValidator*(body: seq[SignedValidatorRegistrationV1]
 proc getHeaderCapella*(slot: Slot,
                        parent_hash: Eth2Digest,
                        pubkey: ValidatorPubKey
-                      ): RestPlainResponse {.
+                      ): RestResponse[GetHeaderResponseCapella] {.
      rest, endpoint: "/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}",
      meth: MethodGet, connection: {Dedicated, Close}.}
   ## https://github.com/ethereum/builder-specs/blob/v0.3.0/apis/builder/header.yaml
 
 proc submitBlindedBlock*(body: capella_mev.SignedBlindedBeaconBlock
-                        ): RestPlainResponse {.
+                        ): RestResponse[SubmitBlindedBlockResponseCapella] {.
      rest, endpoint: "/eth/v1/builder/blinded_blocks",
      meth: MethodPost, connection: {Dedicated, Close}.}
   ## https://github.com/ethereum/builder-specs/blob/v0.3.0/apis/builder/blinded_blocks.yaml

--- a/beacon_chain/spec/mev/rest_capella_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_capella_mev_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -15,13 +15,13 @@ export chronos, client, rest_types, eth2_rest_serialization
 proc getHeaderDeneb*(slot: Slot,
                      parent_hash: Eth2Digest,
                      pubkey: ValidatorPubKey
-                    ): RestPlainResponse {.
+                    ): RestResponse[GetHeaderResponseDeneb] {.
      rest, endpoint: "/eth/v1/builder/header/{slot}/{parent_hash}/{pubkey}",
      meth: MethodGet, connection: {Dedicated, Close}.}
   ## https://github.com/ethereum/builder-specs/blob/34509da74237942aa15a4c0ca828f67acdf77652/apis/builder/header.yaml
 
 proc submitBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlock
-                        ): RestPlainResponse {.
+                        ): RestResponse[SubmitBlindedBlockResponseDeneb] {.
      rest, endpoint: "/eth/v1/builder/blinded_blocks",
      meth: MethodPost, connection: {Dedicated, Close}.}
   ## https://github.com/ethereum/builder-specs/blob/34509da74237942aa15a4c0ca828f67acdf77652/apis/builder/blinded_blocks.yaml

--- a/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_deneb_mev_calls.nim
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -55,7 +55,7 @@ proc unblindAndRouteBlockMEV*(
 
   # By time submitBlindedBlock is called, must already have done slashing
   # protection check
-  let response =
+  let bundle =
     try:
       awaitWithTimeout(
           payloadBuilderRestClient.submitBlindedBlock(blindedBlock),
@@ -63,11 +63,13 @@ proc unblindAndRouteBlockMEV*(
         return err("Submitting blinded block timed out")
       # From here on, including error paths, disallow local EL production by
       # returning Opt.some, regardless of whether on head or newBlock.
+    except RestDecodingError as exc:
+      return err("REST decoding error submitting blinded block: " & exc.msg)
     except CatchableError as exc:
       return err("exception in submitBlindedBlock: " & exc.msg)
 
   const httpOk = 200
-  if response.status != httpOk:
+  if bundle.status != httpOk:
     # https://github.com/ethereum/builder-specs/blob/v0.3.0/specs/bellatrix/validator.md#proposer-slashing
     # This means if a validator publishes a signature for a
     # `BlindedBeaconBlock` (via a dissemination of a
@@ -75,31 +77,12 @@ proc unblindAndRouteBlockMEV*(
     # local build process as a fallback, even in the event of some failure
     # with the external builder network.
     return err("submitBlindedBlock failed with HTTP error code " &
-      $response.status & ": " & $shortLog(blindedBlock))
+      $bundle.status & ": " & $shortLog(blindedBlock))
 
   when consensusFork >= ConsensusFork.Deneb:
-    let
-      res = decodeBytes(
-        SubmitBlindedBlockResponseDeneb, response.data, response.contentType)
-
-      bundle = res.valueOr:
-        return err("Could not decode Deneb blinded block: " & $res.error &
-          " with HTTP status " & $response.status & ", Content-Type " &
-          $response.contentType & " and content " & $response.data)
-
-    template execution_payload: untyped = bundle.data.execution_payload
+    template execution_payload: untyped = bundle.data.data.execution_payload
   else:
-    let
-      res = decodeBytes(
-        SubmitBlindedBlockResponseCapella, response.data, response.contentType)
-
-      bundle = res.valueOr:
-        return err("Could not decode Capella blinded block: " & $res.error &
-          " with HTTP status " & $response.status & ", Content-Type " &
-          $response.contentType & " and content " & $response.data)
-
-    template execution_payload: untyped = bundle.data
-
+    template execution_payload: untyped = bundle.data.data
   if hash_tree_root(blindedBlock.message.body.execution_payload_header) !=
       hash_tree_root(execution_payload):
     return err("unblinded payload doesn't match blinded payload header: " &
@@ -122,9 +105,9 @@ proc unblindAndRouteBlockMEV*(
 
   let blobsOpt =
     when consensusFork >= ConsensusFork.Deneb:
-      template blobs_bundle: untyped = bundle.data.blobs_bundle
+      template blobs_bundle: untyped = bundle.data.data.blobs_bundle
       if blindedBlock.message.body.blob_kzg_commitments !=
-          bundle.data.blobs_bundle.commitments:
+          bundle.data.data.blobs_bundle.commitments:
         return err("unblinded blobs bundle has unexpected commitments")
       let ok = verifyProofs(
           asSeq blobs_bundle.blobs,


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#5777

It's not getting fleet testing and is too risky otherwise.

Have revert ready to go in case that's not resolved in time.

It's looked fine so far, but it can't go out with this (lack of) fleet testing.