### PR TITLE
clean up `UnusedImport` and `Deprecated` warnings

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2258,8 +2258,7 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
         info "Adding privileged direct peer", peerId, address
       res
 
-    hostAddress = tcpEndPoint(
-      ValidIpAddress.init config.listenAddress, config.tcpPort)
+    hostAddress = tcpEndPoint(config.listenAddress, config.tcpPort)
     announcedAddresses =
       if extIp.isNone() or extTcpPort.isNone(): @[]
       else: @[tcpEndPoint(extIp.get(), extTcpPort.get())]

--- a/ncli/validator_db_aggregator.nim
+++ b/ncli/validator_db_aggregator.nim
@@ -6,13 +6,9 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  std/parsecsv,
   stew/[io2, byteutils], chronicles, confutils, snappy,
   ../beacon_chain/spec/datatypes/base,
   ./ncli_common
-
-from std/os import fileExists
-from std/strutils import parseBiggestInt, parseBiggestUInt
 
 type
   AggregatorConf = object
@@ -159,6 +155,9 @@ proc advanceEpochs*(aggregator: var ValidatorDbAggregator, epoch: Epoch,
 
 when isMainModule:
   import std/streams
+  from std/os import fileExists
+  from std/parsecsv import CsvParser, CsvRow, open, readRow
+  from std/strutils import parseBiggestInt, parseBiggestUInt
 
   when defined(posix):
     import system/ansi_c

--- a/tests/test_validator_client.nim
+++ b/tests/test_validator_client.nim
@@ -576,7 +576,7 @@ suite "Validator Client test suite":
         else:
           return await request.respond(Http404, "Page not found")
       else:
-        return dumbResponse()
+        return defaultResponse()
 
     let  server = createServer(initTAddress("127.0.0.1:0"), process, false)
     server.start()
@@ -660,7 +660,7 @@ suite "Validator Client test suite":
         else:
           return await request.respond(Http404, "Page not found")
       else:
-        return dumbResponse()
+        return defaultResponse()
 
     let  server = createServer(initTAddress("127.0.0.1:0"), process, false)
     server.start()


### PR DESCRIPTION
The `ValidIpAddress.init` usage was via
https://github.com/status-im/nimbus-eth2/blob/0e63f8fdba66ab3eba28078cc249a97fd584f1e2/beacon_chain/networking/eth2_network.nim#L2167-L2168

which used the converter `toNormalIp` at https://github.com/status-im/nim-stew/blob/3aa92ab843ee2dbf2198e2d517ceeeb29dcda3d9/stew/shims/net.nim#L40-L41 to fit with the `MultiAddress.init` function at https://github.com/status-im/nim-libp2p/blob/2725be64bacb46997c0959560d833ff946c8cb3b/libp2p/multiaddress.nim#L961-L981 so it was converting from an `IpAddress` to `ValidIpAddress` and back, pointlessly. This also removed a `Deprecated` warning source.

`std/os`, `std/parsecsv`, and `std/strutils` in `validator_db_aggregation` are only used when it's the main module, and otherwise triggered 3 `UnusedImport` warnings.