### PR TITLE
VC/BN: Dynamic keystores filter

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -10,7 +10,7 @@
 # Everything needed to run a full Beacon Node
 
 import
-  std/osproc,
+  std/[osproc, sets],
 
   # Nimble packages
   chronos, presto, bearssl/rand,
@@ -32,7 +32,7 @@ import
   ./rpc/state_ttl_cache
 
 export
-  osproc, chronos, presto, action_tracker,
+  osproc, sets, chronos, presto, action_tracker,
   beacon_clock, beacon_chain_db, conf, light_client,
   attestation_pool, sync_committee_msg_pool, validator_change_pool,
   eth2_network, el_manager, branch_discovery, request_manager, sync_manager,
@@ -80,6 +80,7 @@ type
     keymanagerHost*: ref KeymanagerHost
     keymanagerServer*: RestServerRef
     keystoreCache*: KeystoreCacheRef
+    keysFilter*: HashSet[ValidatorPubKey]
     eventBus*: EventBus
     vcProcess*: Process
     requestManager*: RequestManager

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -187,6 +187,10 @@ type
       name: "web3-signer-update-interval"
       defaultValue: 3600 .}: Natural
 
+    web3SignersKeyFilter* {.
+      desc: "Validator keys which will be used with remote Web3Signer"
+      name: "web3-signer-key" .}: seq[ValidatorPubKey]
+
     secretsDirFlag* {.
       desc: "A directory containing validator keystore passwords"
       name: "secrets-dir" .}: Option[InputDir]
@@ -937,6 +941,10 @@ type
     web3Signers* {.
       desc: "Remote Web3Signer URL that will be used as a source of validators"
       name: "web3-signer-url" .}: seq[Uri]
+
+    web3SignersKeyFilter* {.
+      desc: "Validator keys which will be used with remote Web3Signer"
+      name: "web3-signer-key" .}: seq[ValidatorPubKey]
 
     secretsDirFlag* {.
       desc: "A directory containing validator keystore passwords"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -890,7 +890,8 @@ proc init*(T: type BeaconNode,
     beaconClock: beaconClock,
     validatorMonitor: validatorMonitor,
     stateTtlCache: stateTtlCache,
-    dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()))
+    dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()),
+    keysFilter: toHashSet(config.web3SignersKeyFilter))
 
   node.initLightClient(
     rng, cfg, dag.forkDigests, getBeaconTime, dag.genesis_validators_root)

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -235,6 +235,7 @@ type
     rootsSeen*: Table[Eth2Digest, Slot]
     processingDelay*: Opt[Duration]
     finalizedEpoch*: Opt[Epoch]
+    keysFilter*: HashSet[ValidatorPubKey]
     rng*: ref HmacDrbgContext
 
   ApiStrategyKind* {.pure.} = enum
@@ -906,24 +907,6 @@ proc getSubcommitteeIndex*(index: IndexInSyncCommittee): SyncSubcommitteeIndex =
 proc currentSlot*(vc: ValidatorClientRef): Slot =
   vc.beaconClock.now().slotOrZero()
 
-proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
-  let
-    withdrawalAddress =
-      if vc.keymanagerHost.isNil:
-        Opt.none Eth1Address
-      else:
-        vc.keymanagerHost[].getValidatorWithdrawalAddress(keystore.pubkey)
-    perValidatorDefaultFeeRecipient = getPerValidatorDefaultFeeRecipient(
-      vc.config.defaultFeeRecipient, withdrawalAddress)
-    feeRecipient = vc.config.validatorsDir.getSuggestedFeeRecipient(
-      keystore.pubkey, perValidatorDefaultFeeRecipient).valueOr(
-        perValidatorDefaultFeeRecipient)
-    gasLimit = vc.config.validatorsDir.getSuggestedGasLimit(
-      keystore.pubkey, vc.config.suggestedGasLimit).valueOr(
-        vc.config.suggestedGasLimit)
-
-  discard vc.attachedValidators[].addValidator(keystore, feeRecipient, gasLimit)
-
 proc removeValidator*(vc: ValidatorClientRef,
                       pubkey: ValidatorPubKey) {.async.} =
   let validator = vc.attachedValidators[].getValidator(pubkey).valueOr:
@@ -955,6 +938,19 @@ proc getGasLimit(vc: ValidatorClientRef,
                  validator: AttachedValidator): uint64 =
   getGasLimit(vc.config.validatorsDir, vc.config.suggestedGasLimit,
               validator.pubkey)
+
+proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
+  let
+    currentEpoch = vc.beaconClock.now().slotOrZero().epoch()
+    feeRecipient = getFeeRecipient(
+      vc.dynamicFeeRecipientsStore, keystore.pubkey, Opt.none(ValidatorIndex),
+      Opt.none(Validator), vc.config.defaultFeeRecipient(),
+      vc.config.validatorsDir(), currentEpoch)
+    gasLimit =
+      getGasLimit(vc.config.validatorsDir, vc.config.suggestedGasLimit,
+      keystore.pubkey)
+
+  discard vc.attachedValidators[].addValidator(keystore, feeRecipient, gasLimit)
 
 proc prepareProposersList*(vc: ValidatorClientRef,
                            epoch: Epoch): seq[PrepareBeaconProposer] =

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -655,9 +655,9 @@ proc dynamicValidatorsLoop*(service: DutiesServiceRef,
               debug "Web3Signer has been polled for validators",
                     keystores_found = len(keystores),
                     web3signer_url = web3signerUrl.url
-              vc.attachedValidators.updateDynamicValidators(web3signerUrl,
-                                                            keystores,
-                                                            addValidatorProc)
+              vc.attachedValidators.updateDynamicValidators(
+                web3signerUrl, keystores, vc.keysFilter,
+                addValidatorProc)
               seconds(intervalInSeconds)
             else:
               seconds(5)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -121,22 +121,22 @@ proc addValidatorsFromWeb3Signer(
     (await queryValidatorsSource(web3signerUrl)).valueOr(
       default(seq[KeystoreData]))
 
-  for keystore in dynamicStores:
+  proc addValidatorProc(keystore: KeystoreData) =
     let
-      data =
-        withState(node.dag.headState):
-          getValidator(forkyState.data.validators.asSeq(), keystore.pubkey)
-      index =
-        if data.isSome():
-          Opt.some(data.get().index)
-        else:
-          Opt.none(ValidatorIndex)
+      epoch = node.currentSlot().epoch
+      index = Opt.none(ValidatorIndex)
       feeRecipient =
         node.consensusManager[].getFeeRecipient(keystore.pubkey, index, epoch)
-      gasLimit = node.consensusManager[].getGasLimit(keystore.pubkey)
-      v = node.attachedValidators[].addValidator(keystore, feeRecipient,
-                                                 gasLimit)
-    v.updateValidator(data)
+      gasLimit =
+        node.consensusManager[].getGasLimit(keystore.pubkey)
+    discard node.attachedValidators[].addValidator(keystore, feeRecipient,
+                                                   gasLimit)
+
+  debug "Validators source has been polled for validators",
+        keystores_found = len(dynamicStores),
+        web3signer_url = web3signerUrl.url
+  node.attachedValidators.updateDynamicValidators(
+    web3signerUrl, dynamicStores, node.keysFilter, addValidatorProc)
 
 proc addValidators*(node: BeaconNode) {.async: (raises: [CancelledError]).} =
   info "Loading validators", validatorsDir = node.config.validatorsDir(),

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -38,6 +38,7 @@ The following options are available:
                                verifying Web3Signer (for example ".execution_payload.fee_recipient").
      --web3-signer-url         Remote Web3Signer URL that will be used as a source of validators.
      --web3-signer-update-interval  Number of seconds between validator list updates [=3600].
+     --web3-signer-key         Validator keys which will be used with remote Web3Signer.
      --secrets-dir             A directory containing validator keystore passwords.
      --wallets-dir             A directory containing wallet files.
      --web3-url                One or more execution layer Engine API URLs.


### PR DESCRIPTION
This feature was missing in Nimbus, but Prysm supports it https://docs.prylabs.network/docs/wallet/web3signer