### PR TITLE
bump `geth` to `v1.13.11`

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -21,7 +21,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.13.8-b20b4a71"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.13.11-8f7eb9cc"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in

--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.13.9
- https://github.com/ethereum/go-ethereum/releases/tag/v1.13.10
- https://github.com/ethereum/go-ethereum/releases/tag/v1.13.11