### PR TITLE
unrevert more of https://github.com/status-im/nimbus-eth2/pull/5765

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -61,7 +61,7 @@ type
     blobs*: Opt[BlobSidecars]
     maybeFinalized*: bool
       ## The block source claims the block has been finalized already
-    resfut*: Future[Result[void, VerifierError]]
+    resfut*: Future[Result[void, VerifierError]].Raising([CancelledError])
     queueTick*: Moment # Moment when block was enqueued
     validationDur*: Duration # Time it took to perform gossip validation
     src*: MsgSource
@@ -385,7 +385,7 @@ proc checkBloblessSignature(self: BlockProcessor,
 proc enqueueBlock*(
     self: var BlockProcessor, src: MsgSource, blck: ForkedSignedBeaconBlock,
     blobs: Opt[BlobSidecars],
-    resfut: Future[Result[void, VerifierError]] = nil,
+    resfut: Future[Result[void, VerifierError]].Raising([CancelledError]) = nil,
     maybeFinalized = false,
     validationDur = Duration()) =
   withBlck(blck):
@@ -756,7 +756,7 @@ proc storeBlock(
 proc addBlock*(
     self: var BlockProcessor, src: MsgSource, blck: ForkedSignedBeaconBlock,
     blobs: Opt[BlobSidecars], maybeFinalized = false,
-    validationDur = Duration()): Future[Result[void, VerifierError]] =
+    validationDur = Duration()): Future[Result[void, VerifierError]] {.async: (raises: [CancelledError], raw: true).} =
   ## Enqueue a Gossip-validated block for consensus verification
   # Backpressure:
   #   There is no backpressure here - producers must wait for `resfut` to

--- a/beacon_chain/networking/peer_pool.nim
+++ b/beacon_chain/networking/peer_pool.nim
@@ -108,12 +108,15 @@ template outgoingEvent(eventType: EventType): AsyncEvent =
     pool.outNotFullEvent
 
 proc waitForEvent[A, B](pool: PeerPool[A, B], eventType: EventType,
-                        filter: set[PeerType]) {.async.} =
+                        filter: set[PeerType]) {.async: (raises: [CancelledError]).} =
   if filter == {PeerType.Incoming, PeerType.Outgoing} or filter == {}:
     var fut1 = incomingEvent(eventType).wait()
     var fut2 = outgoingEvent(eventType).wait()
     try:
-      discard await one(fut1, fut2)
+      try:
+        discard await one(fut1, fut2)
+      except ValueError:
+        raiseAssert "one precondition satisfied"
       if fut1.finished():
         if not(fut2.finished()):
           await fut2.cancelAndWait()
@@ -138,11 +141,11 @@ proc waitForEvent[A, B](pool: PeerPool[A, B], eventType: EventType,
     outgoingEvent(eventType).clear()
 
 proc waitNotEmptyEvent[A, B](pool: PeerPool[A, B],
-                             filter: set[PeerType]): Future[void] =
+                             filter: set[PeerType]) {.async: (raises: [CancelledError], raw: true).} =
   pool.waitForEvent(EventType.NotEmptyEvent, filter)
 
 proc waitNotFullEvent[A, B](pool: PeerPool[A, B],
-                            filter: set[PeerType]): Future[void] =
+                            filter: set[PeerType]){.async: (raises: [CancelledError], raw: true).} =
   pool.waitForEvent(EventType.NotFullEvent, filter)
 
 proc newPeerPool*[A, B](maxPeers = -1, maxIncomingPeers = -1,
@@ -451,7 +454,7 @@ proc getPeerSpaceMask[A, B](pool: PeerPool[A, B],
       {PeerType.Outgoing}
 
 proc waitForEmptySpace*[A, B](pool: PeerPool[A, B],
-                              peerType: PeerType) {.async.} =
+                              peerType: PeerType) {.async: (raises: [CancelledError]).} =
   ## This procedure will block until ``pool`` will have an empty space for peer
   ## of type ``peerType``.
   let mask = pool.getPeerSpaceMask(peerType)
@@ -459,7 +462,7 @@ proc waitForEmptySpace*[A, B](pool: PeerPool[A, B],
     await pool.waitNotFullEvent(mask)
 
 proc addPeer*[A, B](pool: PeerPool[A, B],
-                    peer: A, peerType: PeerType): Future[PeerStatus] {.async.} =
+                    peer: A, peerType: PeerType): Future[PeerStatus] {.async: (raises: [CancelledError]).} =
   ## Add peer ``peer`` of type ``peerType`` to PeerPool ``pool``.
   ##
   ## This procedure will wait for an empty space in PeerPool ``pool``, if
@@ -533,7 +536,7 @@ proc acquireItemImpl[A, B](pool: PeerPool[A, B],
 
 proc acquire*[A, B](pool: PeerPool[A, B],
                     filter = {PeerType.Incoming,
-                              PeerType.Outgoing}): Future[A] {.async.} =
+                              PeerType.Outgoing}): Future[A] {.async: (raises: [CancelledError]).} =
   ## Acquire peer from PeerPool ``pool``, which match the filter ``filter``.
   mixin getKey
   doAssert(filter != {}, "Filter must not be empty")
@@ -586,7 +589,7 @@ proc release*[A, B](pool: PeerPool[A, B], peers: openArray[A]) {.inline.} =
 proc acquire*[A, B](pool: PeerPool[A, B],
                     number: int,
                     filter = {PeerType.Incoming,
-                              PeerType.Outgoing}): Future[seq[A]] {.async.} =
+                              PeerType.Outgoing}): Future[seq[A]] {.async: (raises: [CancelledError]).} =
   ## Acquire ``number`` number of peers from PeerPool ``pool``, which match the
   ## filter ``filter``.
   doAssert(filter != {}, "Filter must not be empty")
@@ -735,7 +738,7 @@ proc clear*[A, B](pool: PeerPool[A, B]) =
   pool.acqIncPeersCount = 0
   pool.acqOutPeersCount = 0
 
-proc clearSafe*[A, B](pool: PeerPool[A, B]) {.async.} =
+proc clearSafe*[A, B](pool: PeerPool[A, B]) {.async: (raises: [CancelledError]).} =
   ## Performs "safe" clear. Safe means that it first acquires all the peers
   ## in PeerPool, and only after that it will reset storage.
   var acquired = newSeq[A]()

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -50,8 +50,8 @@ proc collector(queue: AsyncQueue[BlockEntry]): BlockVerifier =
   # the BlockProcessor and this test
   proc verify(signedBlock: ForkedSignedBeaconBlock, blobs: Opt[BlobSidecars],
               maybeFinalized: bool):
-      Future[Result[void, VerifierError]] {.async: (raises: [CancelledError], raw: true).} =
-    let fut = Future[Result[void, VerifierError]].Raising([CancelledError]).init()
+      Future[Result[void, VerifierError]] =
+    let fut = newFuture[Result[void, VerifierError]]()
     try: queue.addLastNoWait(BlockEntry(blck: signedBlock, resfut: fut))
     except CatchableError as exc: raiseAssert exc.msg
     return fut

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -50,8 +50,8 @@ proc collector(queue: AsyncQueue[BlockEntry]): BlockVerifier =
   # the BlockProcessor and this test
   proc verify(signedBlock: ForkedSignedBeaconBlock, blobs: Opt[BlobSidecars],
               maybeFinalized: bool):
-      Future[Result[void, VerifierError]] =
-    let fut = newFuture[Result[void, VerifierError]]()
+      Future[Result[void, VerifierError]] {.async: (raises: [CancelledError], raw: true).} =
+    let fut = Future[Result[void, VerifierError]].Raising([CancelledError]).init()
     try: queue.addLastNoWait(BlockEntry(blck: signedBlock, resfut: fut))
     except CatchableError as exc: raiseAssert exc.msg
     return fut


### PR DESCRIPTION
Followup to https://github.com/status-im/nimbus-eth2/pull/5833, which reverted more than strictly required. This keeps at module boundaries for simplicity, and restores:
- `beacon_chain/gossip_processing/block_processor.nim`
- `beacon_chain/networking/peer_pool.nim`

While keeping reverted from https://github.com/status-im/nimbus-eth2/pull/5765
- `beacon_chain/nimbus_beacon_node.nim`
- `beacon_chain/sync/request_manager.nim`
- `beacon_chain/sync/sync_manager.nim`
- `beacon_chain/sync/sync_queue.nim`
- `tests/test_sync_manager.nim`

```
$ grep "Slot start" ~/nimbus_working.log | jq -r '[.slot, .head]|@tsv' | tail -n50
7499650	47d6925b:7499649
7499651	0910a130:7499650
7499652	59477fc5:7499651
7499653	74eb41b5:7499652
7499654	642b44a1:7499653
7499655	cb9c7df4:7499654
7499656	6fb4cfe6:7499655
7499657	4104e7fa:7499656
7499658	3a62101f:7499657
7499659	1fefec4b:7499658
7499660	1fefec4b:7499658
7499661	1fefec4b:7499658
7499662	1fefec4b:7499658
7499663	59be4b3f:7499662
7499664	59be4b3f:7499662
7499665	fcd4fc4b:7499664
7499666	fcd4fc4b:7499664
7499667	fcd4fc4b:7499664
7499668	10cecda5:7499667
7499669	63af8e2b:7499668
7499670	c06bd6ac:7499669
7499671	c06bd6ac:7499669
7499672	898cca36:7499671
7499673	0720e898:7499672
7499674	c2c5c2b4:7499673
7499675	9c6692ac:7499674
7499676	9c2134d2:7499675
7499677	0681ca19:7499676
7499678	9cae3fa3:7499677
7499679	9cae3fa3:7499677
7499680	41623e50:7499679
7499681	298942d7:7499680
7499682	298942d7:7499680
7499683	c760ba62:7499682
7499684	c760ba62:7499682
7499685	b9fcea8c:7499684
7499686	b9fcea8c:7499684
7499687	296dc050:7499686
7499688	296dc050:7499686
7499689	93ef15cf:7499688
7499690	ab4a66c5:7499689
7499691	137767f7:7499690
7499692	cbc64915:7499691
7499693	cbc64915:7499691
7499694	e1cf9859:7499693
7499695	a4e6c38d:7499694
7499696	ff798196:7499695
7499697	ff798196:7499695
7499698	c6ac2200:7499697
7499699	73dd625b:7499698
```
where repeated heads match https://goerli.beaconcha.in/epoch/234364 and https://goerli.beaconcha.in/epoch/234365 missing blocks exactly.