### PR TITLE
use "reason" instead of "error"/"validationError" to log gossip ignore/reject reasons

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -408,7 +408,7 @@ proc processAttestation*(
 
     ok()
   else:
-    debug "Dropping attestation", validationError = v.error
+    debug "Dropping attestation", reason = v.error
     beacon_attestations_dropped.inc(1, [$v.error[0]])
     err(v.error())
 
@@ -464,7 +464,7 @@ proc processSignedAggregateAndProof*(
 
     ok()
   else:
-    debug "Dropping aggregate", error = v.error
+    debug "Dropping aggregate", reason = v.error
     beacon_aggregates_dropped.inc(1, [$v.error[0]])
 
     err(v.error())
@@ -488,7 +488,7 @@ proc processBlsToExecutionChange*(
     self.validatorChangePool[].addMessage(
       blsToExecutionChange, src == MsgSource.api)
   else:
-    debug "Dropping BLS to execution change", validationError = v.error
+    debug "Dropping BLS to execution change", reason = v.error
     beacon_attester_slashings_dropped.inc(1, [$v.error[0]])
 
   return v
@@ -512,7 +512,7 @@ proc processAttesterSlashing*(
 
     beacon_attester_slashings_received.inc()
   else:
-    debug "Dropping attester slashing", validationError = v.error
+    debug "Dropping attester slashing", reason = v.error
     beacon_attester_slashings_dropped.inc(1, [$v.error[0]])
 
   v
@@ -535,7 +535,7 @@ proc processProposerSlashing*(
 
     beacon_proposer_slashings_received.inc()
   else:
-    debug "Dropping proposer slashing", validationError = v.error
+    debug "Dropping proposer slashing", reason = v.error
     beacon_proposer_slashings_dropped.inc(1, [$v.error[0]])
 
   v
@@ -559,7 +559,7 @@ proc processSignedVoluntaryExit*(
 
     beacon_voluntary_exits_received.inc()
   else:
-    debug "Dropping voluntary exit", error = v.error
+    debug "Dropping voluntary exit", reason = v.error
     beacon_voluntary_exits_dropped.inc(1, [$v.error[0]])
 
   v
@@ -605,7 +605,7 @@ proc processSyncCommitteeMessage*(
 
     ok()
   else:
-    debug "Dropping sync committee message", error = v.error
+    debug "Dropping sync committee message", reason = v.error
     beacon_sync_committee_messages_dropped.inc(1, [$v.error[0]])
     err(v.error())
 
@@ -650,7 +650,7 @@ proc processSignedContributionAndProof*(
 
     ok()
   else:
-    debug "Dropping contribution", error = v.error
+    debug "Dropping contribution", reason = v.error
     beacon_sync_committee_contributions_dropped.inc(1, [$v.error[0]])
 
     err(v.error())


### PR DESCRIPTION
These aren't Nimbus errors, and it can be surprising for people reading the logs to see errors which aren't.