### PR TITLE
fix `blob_sidecar` SSE `versioned_hash` field to be 0x-prefixed hex

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -258,7 +258,8 @@ proc initFullNode(
         index: data.index,
         slot: data.signed_block_header.message.slot,
         kzg_commitment: data.kzg_commitment,
-        versioned_hash: data.kzg_commitment.kzg_commitment_to_versioned_hash))
+        versioned_hash:
+          data.kzg_commitment.kzg_commitment_to_versioned_hash.to0xHex))
   proc onBlockAdded(data: ForkedTrustedSignedBeaconBlock) =
     let optimistic =
       if node.currentSlot().epoch() >= dag.cfg.BELLATRIX_FORK_EPOCH:

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -40,6 +40,10 @@ type
 
   # TODO this apparently is suppposed to be SSZ-equivalent to Bytes32, but
   # current spec doesn't ever SSZ-serialize it or hash_tree_root it
+  # TODO make `distinct` then add a REST serialization for it specifically, via
+  # basically to0xHex, then fix BlobSidecarInfoObject to use VersionedHash, not
+  # string, and rely on REST serialization, rather than serialize VersionedHash
+  # field manually
   VersionedHash* = array[32, byte]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/deneb/beacon-chain.md#custom-types
@@ -68,7 +72,7 @@ type
     index*: BlobIndex
     slot*: Slot
     kzg_commitment*: KzgCommitment
-    versioned_hash*: VersionedHash
+    versioned_hash*: string  # TODO should be string; VersionedHash not distinct
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blobidentifier
   BlobIdentifier* = object


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/5843