### PR TITLE
log `extra_data` instead of `extra_data_len` for `ExecutionPayload`

### DIFF
--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -16,6 +16,7 @@
 {.push raises: [].}
 
 import
+  std/typetraits,
   stew/byteutils,
   json_serialization,
   ssz_serialization/types as sszTypes,
@@ -425,7 +426,7 @@ func shortLog*(v: ExecutionPayload): auto =
     gas_limit: v.gas_limit,
     gas_used: v.gas_used,
     timestamp: v.timestamp,
-    extra_data_len: len(v.extra_data),
+    extra_data: toPrettyString(distinctBase v.extra_data),
     base_fee_per_gas: $(v.base_fee_per_gas),
     block_hash: shortLog(v.block_hash),
     num_transactions: len(v.transactions)

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -16,6 +16,7 @@
 {.push raises: [].}
 
 import
+  std/typetraits,
   chronicles,
   stew/[bitops2, byteutils],
   json_serialization,
@@ -632,7 +633,7 @@ func shortLog*(v: ExecutionPayload): auto =
     gas_limit: v.gas_limit,
     gas_used: v.gas_used,
     timestamp: v.timestamp,
-    extra_data_len: len(v.extra_data),
+    extra_data: toPrettyString(distinctBase v.extra_data),
     base_fee_per_gas: $(v.base_fee_per_gas),
     block_hash: shortLog(v.block_hash),
     num_transactions: len(v.transactions),

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -16,6 +16,7 @@
 {.push raises: [].}
 
 import
+  std/typetraits,
   chronicles,
   std/[sequtils, strutils],
   stew/[bitops2, byteutils],
@@ -584,7 +585,7 @@ func shortLog*(v: ExecutionPayload): auto =
     gas_limit: v.gas_limit,
     gas_used: v.gas_used,
     timestamp: v.timestamp,
-    extra_data_len: len(v.extra_data),
+    extra_data: toPrettyString(distinctBase v.extra_data),
     base_fee_per_gas: $(v.base_fee_per_gas),
     block_hash: shortLog(v.block_hash),
     num_transactions: len(v.transactions),


### PR DESCRIPTION
Add more details to execution payload logs, reusing the same facilities that we already use for `GraffitiBytes`.