### PR TITLE
prevent accidentally hashing `BeaconState`/`BeaconBlock` in Deneb

### DIFF
--- a/beacon_chain/spec/eth2_merkleization.nim
+++ b/beacon_chain/spec/eth2_merkleization.nim
@@ -39,8 +39,6 @@ func hash_tree_root*(
        deneb.SignedBeaconBlock) {.
   error: "SignedBeaconBlock should not be hashed".}
 
-static: doAssert ConsensusFork.high == ConsensusFork.Deneb
-
 func depositCountBytes*(x: uint64): array[32, byte] =
   doAssert(x <= 4294967295'u64)
   var z = x

--- a/beacon_chain/spec/eth2_merkleization.nim
+++ b/beacon_chain/spec/eth2_merkleization.nim
@@ -18,6 +18,7 @@ from ./datatypes/phase0 import HashedBeaconState, SignedBeaconBlock
 from ./datatypes/altair import HashedBeaconState, SignedBeaconBlock
 from ./datatypes/bellatrix import HashedBeaconState, SignedBeaconBlock
 from ./datatypes/capella import HashedBeaconState, SignedBeaconBlock
+from ./datatypes/deneb import HashedBeaconState, SignedBeaconBlock
 
 export ssz_codec, merkleization, proofs
 
@@ -28,13 +29,17 @@ type
 # creating recursive module dependency through `forks`.
 func hash_tree_root*(
     x: phase0.HashedBeaconState | altair.HashedBeaconState |
-       bellatrix.HashedBeaconState | capella.HashedBeaconState) {.
+       bellatrix.HashedBeaconState | capella.HashedBeaconState |
+       deneb.HashedBeaconState) {.
   error: "HashedBeaconState should not be hashed".}
 
 func hash_tree_root*(
     x: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-       bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock) {.
+       bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
+       deneb.SignedBeaconBlock) {.
   error: "SignedBeaconBlock should not be hashed".}
+
+static: doAssert ConsensusFork.high == ConsensusFork.Deneb
 
 func depositCountBytes*(x: uint64): array[32, byte] =
   doAssert(x <= 4294967295'u64)

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -551,6 +551,10 @@ template PayloadAttributes*(
   else:
     {.error: "PayloadAttributes does not support " & $kind.}
 
+# `eth2_merkleization` cannot import `forks` (circular), so the check is here
+static: doAssert ConsensusFork.high == ConsensusFork.Deneb,
+  "eth2_merkleization has been checked and `hash_tree_root` is up to date"
+
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
 # `ref T`
 func new*(T: type ForkedHashedBeaconState, data: phase0.BeaconState):


### PR DESCRIPTION
Extend protection against accidentally calling computationally expensive functions when a cache is available to Deneb, as done for earlier forks.