### PR TITLE
set `topic` for `eth1_chain` logs

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -30,7 +30,7 @@ export
   eth1_chain, el_conf, engine_api, base
 
 logScope:
-  topics = "elmon"
+  topics = "elman"
 
 type
   PubKeyBytes = DynamicBytes[48, 48]

--- a/beacon_chain/el/eth1_chain.nim
+++ b/beacon_chain/el/eth1_chain.nim
@@ -16,6 +16,9 @@ import
 
 export beacon_chain_db, deques, digest, base, forks
 
+logScope:
+  topics = "elchain"
+
 declarePublicGauge eth1_finalized_head,
   "Block number of the highest Eth1 block finalized by Eth2 consensus"
 


### PR DESCRIPTION
`eth1_chain` no longer logs with `topics` since #5768, making it hard to filter messages from this module. Re-add the `topics`, and also fix outdated `topics` in `el_manager` (formerly `*_monitor`).