### PR TITLE
add `-d:has_deposit_root_checks` build to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Build with developer flags
         run: |
-          make -j nimbus_beacon_node NIMFLAGS="-d:chronicles_log_level=TRACE -d:has_deposit_root_checks=1"
+          make -j nimbus_beacon_node LOG_LEVEL=TRACE NIMFLAGS="-d:has_deposit_root_checks=1"
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,19 @@ jobs:
           name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
           path: build/*.xml
 
+  devbuild:
+    name: "Developer builds"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: Build with developer flags
+        run: |
+          make -j nimbus_beacon_node NIMFLAGS="-d:chronicles_log_level=TRACE -d:has_deposit_root_checks=1"
+
   lint:
     name: "Lint"
     runs-on: ubuntu-latest


### PR DESCRIPTION
To prevent accidental breakage of builds with non-standard developer flags, add the `-d:has_deposit_root_checks` build to CI. This is only a quick compilation check, and is only run on Linux.