### PR TITLE
avoid marking blocks as unviable if `blobless` quarantine is full

### DIFF
--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -303,7 +303,7 @@ proc addBlobless*(
   quarantine.cleanupBlobless(finalizedSlot)
 
   if quarantine.blobless.lenu64 >= MaxBlobless:
-    return false
+    return true
 
   debug "block quarantine: Adding blobless", blck = shortLog(signedBlock)
   quarantine.blobless[signedBlock.root] = signedBlock

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -742,11 +742,8 @@ proc storeBlock(
               forkyBlck.root, forkyBlck)
             self[].enqueueBlock(MsgSource.gossip, quarantined, Opt.some(blobs))
           else:
-            if not self.consensusManager.quarantine[].addBlobless(
-              dag.finalizedHead.slot, forkyBlck):
-              notice "Block quarantine full (blobless)",
-               blockRoot = shortLog(quarantined.root),
-               signature = shortLog(quarantined.signature)
+            discard self.consensusManager.quarantine[].addBlobless(
+              dag.finalizedHead.slot, forkyBlck)
 
   ok blck.value()
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -246,12 +246,8 @@ proc processSignedBeaconBlock*(
         if self.blobQuarantine[].hasBlobs(signedBlock):
           Opt.some(self.blobQuarantine[].popBlobs(signedBlock.root, signedBlock))
         else:
-          if not self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
-                                               signedBlock):
-            notice "Block quarantine full (blobless)",
-              blockRoot = shortLog(signedBlock.root),
-              blck = shortLog(signedBlock.message),
-              signature = shortLog(signedBlock.signature)
+          discard self.quarantine[].addBlobless(self.dag.finalizedHead.slot,
+                                                signedBlock)
           return v
       else:
         Opt.none(BlobSidecars)


### PR DESCRIPTION
Full caches should not be used to mark blocks as unviable. The unviable status is quite persistent and a block marked as such won't be processed again once the cache empties. Problem originally introduced in #4808.