### PR TITLE
fix standalone compilation of `trusted_node_sync.nim`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,7 @@ jobs:
       - name: Build with developer flags
         run: |
           make -j nimbus_beacon_node LOG_LEVEL=TRACE NIMFLAGS="-d:has_deposit_root_checks=1"
+          nim c beacon_chain/trusted_node_sync
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,10 @@ jobs:
       - name: Build with developer flags
         run: |
           make -j nimbus_beacon_node LOG_LEVEL=TRACE NIMFLAGS="-d:has_deposit_root_checks=1"
+
+      - name: Build files with isMainModule
+        run: |
+          source env.sh
           nim c beacon_chain/trusted_node_sync
 
   lint:

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -540,16 +540,18 @@ proc doTrustedNodeSync*(
 
 when isMainModule:
   import
-    std/[os],
+    std/os,
     networking/network_metadata
 
   let
+    cfg = getRuntimeConfig(some os.paramStr(1))
+    databaseDir = os.paramStr(2)
     syncTarget = TrustedNodeSyncTarget(
       kind: TrustedNodeSyncKind.StateId,
       stateId: os.paramStr(5))
     backfill = os.paramCount() > 5 and os.paramStr(6) == "true"
     db = BeaconChainDB.new(databaseDir, cfg, inMemory = false)
   waitFor db.doTrustedNodeSync(
-    getRuntimeConfig(some os.paramStr(1)), os.paramStr(2), os.paramStr(3),
+    cfg, databaseDir, os.paramStr(3),
     os.paramStr(4), syncTarget, backfill, false, true)
   db.close()


### PR DESCRIPTION
#5544 contained a regression that broke standalone compilation of `trusted_node_sync` as a main module. Fix it, and add to CI.