### PR TITLE
fix checkpoint block potentially not getting backfilled into DB

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -23,11 +23,12 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Backfill
 ```diff
++ Backfill to genesis                                                                        OK
 + Init without genesis / block                                                               OK
-+ backfill to genesis                                                                        OK
-+ reload backfill position                                                                   OK
++ Reload backfill position                                                                   OK
++ Restart after each block                                                                   OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
+OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -986,4 +987,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 667/672 Fail: 0/672 Skip: 5/672
+OK: 668/673 Fail: 0/673 Skip: 5/673

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -204,6 +204,9 @@ type
     slot*: Slot
     parent_root*: Eth2Digest
 
+func shortLog*(v: BeaconBlockSummary): auto =
+  (v.slot, shortLog(v.parent_root))
+
 # Subkeys essentially create "tables" within the key-value store by prefixing
 # each entry with a table id
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -156,6 +156,12 @@ type
       ## The backfill points to the oldest block with an unbroken ancestry from
       ## dag.tail - when backfilling, we'll move backwards in time starting
       ## with the parent of this block until we reach `frontfill`.
+      ##
+      ## - `backfill.slot` points to the earliest block that has been synced,
+      ##   or, if no blocks have been synced yet, to `checkpoint_state.slot + 1`
+      ##   which is the earliest slot that may have `parent_root` as ancestor.
+      ## - `backfill.parent_root` is the latest block that is not yet synced.
+      ## - Once backfill completes, `backfill.slot` refers to `GENESIS_SLOT`.
 
     frontfillBlocks*: seq[Eth2Digest]
       ## A temporary cache of blocks that we could load from era files, once

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -117,7 +117,7 @@ proc updateFrontfillBlocks*(dag: ChainDAGRef) =
   # era files match the chain
   if dag.db.db.readOnly: return # TODO abstraction leak - where to put this?
 
-  if dag.frontfillBlocks.len == 0 or dag.backfill.slot > 0:
+  if dag.frontfillBlocks.len == 0 or dag.backfill.slot > GENESIS_SLOT:
     return
 
   info "Writing frontfill index", slots = dag.frontfillBlocks.len
@@ -210,6 +210,9 @@ func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): Opt[BlockSlotId] =
 proc containsBlock(
     cfg: RuntimeConfig, db: BeaconChainDB, slot: Slot, root: Eth2Digest): bool =
   db.containsBlock(root, cfg.consensusForkAtEpoch(slot.epoch))
+
+proc containsBlock*(dag: ChainDAGRef, bid: BlockId): bool =
+  dag.cfg.containsBlock(dag.db, bid.slot, bid.root)
 
 proc getForkedBlock*(db: BeaconChainDB, root: Eth2Digest):
     Opt[ForkedTrustedSignedBeaconBlock] =
@@ -1179,9 +1182,14 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
       db.getBeaconBlockSummary(backfillRoot).expect(
         "Backfill block must have a summary: " & $backfillRoot)
-    else:
+    elif dag.containsBlock(dag.tail):
       db.getBeaconBlockSummary(dag.tail.root).expect(
         "Tail block must have a summary: " & $dag.tail.root)
+    else:
+      # Checkpoint sync, checkpoint block unavailable
+      BeaconBlockSummary(
+        slot: dag.tail.slot + 1,
+        parent_root: dag.tail.root)
 
   dag.forkDigests = newClone ForkDigests.init(
     cfg, getStateField(dag.headState, genesis_validators_root))
@@ -1193,8 +1201,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   let finalizedTick = Moment.now()
 
-  if dag.backfill.slot > 0: # See if we can frontfill blocks from era files
-    dag.frontfillBlocks = newSeqOfCap[Eth2Digest](dag.backfill.slot.int)
+  if dag.backfill.slot > GENESIS_SLOT:  # Try frontfill from era files
+    let backfillSlot = dag.backfill.slot - 1
+    dag.frontfillBlocks = newSeqOfCap[Eth2Digest](backfillSlot.int)
 
     let
       historical_roots = getStateField(dag.headState, historical_roots).asSeq()
@@ -1207,7 +1216,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     # blocks from genesis to backfill, if possible.
     for bid in dag.era.getBlockIds(
         historical_roots, historical_summaries, Slot(0), Eth2Digest()):
-      if bid.slot >= dag.backfill.slot:
+      if bid.slot >= backfillSlot:
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
         fatal "Era summaries don't lead up to backfill, database or era files corrupt?",
@@ -1256,7 +1265,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     head = shortLog(dag.head),
     finalizedHead = shortLog(dag.finalizedHead),
     tail = shortLog(dag.tail),
-    backfill = (dag.backfill.slot, shortLog(dag.backfill.parent_root)),
+    backfill = shortLog(dag.backfill),
 
     loadDur = loadTick - startTick,
     summariesDur = summariesTick - loadTick,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -323,7 +323,10 @@ proc initFullNode(
     dag.finalizedHead.slot
 
   func getBackfillSlot(): Slot =
-    dag.backfill.slot
+    if dag.backfill.parent_root != dag.tail.root:
+      dag.backfill.slot
+    else:
+      dag.tail.slot
 
   func getFrontfillSlot(): Slot =
     max(dag.frontfill.get(BlockId()).slot, dag.horizon)

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -407,7 +407,7 @@ proc doTrustedNodeSync*(
   let
     validatorMonitor = newClone(ValidatorMonitor.init(false, false))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, eraPath = eraDir)
-    backfillSlot = dag.backfill.slot
+    backfillSlot = max(dag.backfill.slot, 1.Slot) - 1
     horizon = max(dag.horizon, dag.frontfill.valueOr(BlockId()).slot)
 
   let canReindex = if backfillSlot <= horizon:
@@ -418,7 +418,7 @@ proc doTrustedNodeSync*(
     # detection to kick in, in addBackfillBlock
     let missingSlots = dag.backfill.slot - horizon + 1
 
-    notice "Downloading historical blocks - you can interrupt this process at any time and it automatically be completed when you start the beacon node",
+    notice "Downloading historical blocks - you can interrupt this process at any time and it will automatically be completed when you start the beacon node",
       backfillSlot, horizon, missingSlots
 
     var # Same averaging as SyncManager


### PR DESCRIPTION
When using checkpoint sync, only checkpoint state is available, block is not downloaded and backfilled later.

`dag.backfill` tracks latest filled `slot`, and latest `parent_root` for which no block has been synced yet.

In checkpoint sync, this assumption is broken, because there, the start `dag.backfill.slot` is set based on checkpoint state slot, and the block is also not available.

However, sync manager in backward mode also requests `dag.backfill.slot` and `block_clearance` then backfills the checkpoint block once it is synced. But, there is no guarantee that a peer ever sends us that block. They could send us all parent blocks and solely omit the checkpoint block itself. In that situation, we would accept the parent blocks and advance `dag.backfill`, and subsequently never request the checkpoint block again, resulting in gap inside blocks DB that is never filled.

To mitigate that, the assumption is restored that `dag.backfill.slot` is the latest filled `slot`, and `dag.backfill.parent_root` is the next block that needs to be synced. By setting `slot` to `tail.slot + 1` and `parent_root` to `tail.root`, we put a fake summary into `dag.backfill` so that `block_clearance` only proceeds once checkpoint block exists.