### PR TITLE
`...ExecutionPayloadHash` --> `...ExecutionBlockHash`

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -71,8 +71,8 @@ proc initLightClient*(
               template callForkchoiceUpdated(attributes: untyped) =
                 discard await node.elManager.forkchoiceUpdated(
                   headBlockHash = blckPayload.block_hash,
-                  safeBlockHash = beaconHead.safeExecutionPayloadHash,
-                  finalizedBlockHash = beaconHead.finalizedExecutionPayloadHash,
+                  safeBlockHash = beaconHead.safeExecutionBlockHash,
+                  finalizedBlockHash = beaconHead.finalizedExecutionBlockHash,
                   payloadAttributes = none attributes)
 
               case node.dag.cfg.consensusForkAtEpoch(

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -761,18 +761,18 @@ func getAggregatedAttestation*(pool: var AttestationPool,
 
 type BeaconHead* = object
   blck*: BlockRef
-  safeExecutionPayloadHash*, finalizedExecutionPayloadHash*: Eth2Digest
+  safeExecutionBlockHash*, finalizedExecutionBlockHash*: Eth2Digest
 
 proc getBeaconHead*(
     pool: AttestationPool, headBlock: BlockRef): BeaconHead =
   let
-    finalizedExecutionPayloadHash =
+    finalizedExecutionBlockHash =
       pool.dag.loadExecutionBlockHash(pool.dag.finalizedHead.blck)
 
     # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/fork_choice/safe-block.md#get_safe_execution_payload_hash
     safeBlockRoot = pool.forkChoice.get_safe_beacon_block_root()
     safeBlock = pool.dag.getBlockRef(safeBlockRoot)
-    safeExecutionPayloadHash =
+    safeExecutionBlockHash =
       if safeBlock.isErr:
         # Safe block is currently the justified block determined by fork choice.
         # If finality already advanced beyond the current justified checkpoint,
@@ -780,14 +780,14 @@ proc getBeaconHead*(
         # the justified block may end up not having a `BlockRef` anymore.
         # Because we know that a different fork already finalized a later point,
         # let's just report the finalized execution payload hash instead.
-        finalizedExecutionPayloadHash
+        finalizedExecutionBlockHash
       else:
         pool.dag.loadExecutionBlockHash(safeBlock.get)
 
   BeaconHead(
     blck: headBlock,
-    safeExecutionPayloadHash: safeExecutionPayloadHash,
-    finalizedExecutionPayloadHash: finalizedExecutionPayloadHash)
+    safeExecutionBlockHash: safeExecutionBlockHash,
+    finalizedExecutionBlockHash: finalizedExecutionBlockHash)
 
 proc selectOptimisticHead*(
     pool: var AttestationPool, wallTime: BeaconTime): Opt[BeaconHead] =

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -145,7 +145,7 @@ func shouldSyncOptimistically*(self: ConsensusManager, wallSlot: Slot): bool =
 func optimisticHead*(self: ConsensusManager): BlockId =
   self.optimisticHead.bid
 
-func optimisticExecutionPayloadHash*(self: ConsensusManager): Eth2Digest =
+func optimisticExecutionBlockHash*(self: ConsensusManager): Eth2Digest =
   self.optimisticHead.execution_block_hash
 
 func setOptimisticHead*(

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -165,8 +165,8 @@ proc updateExecutionClientHead(self: ref ConsensusManager,
   template callForkchoiceUpdated(attributes: untyped): auto =
     await self.elManager.forkchoiceUpdated(
       headBlockHash = headExecutionPayloadHash,
-      safeBlockHash = newHead.safeExecutionPayloadHash,
-      finalizedBlockHash = newHead.finalizedExecutionPayloadHash,
+      safeBlockHash = newHead.safeExecutionBlockHash,
+      finalizedBlockHash = newHead.finalizedExecutionBlockHash,
       payloadAttributes = none attributes)
 
   # Can't use dag.head here because it hasn't been updated yet
@@ -352,13 +352,13 @@ proc runProposalForkchoiceUpdated*(
   if headBlockHash.isZero:
     return err()
 
-  let safeBlockHash = beaconHead.safeExecutionPayloadHash
+  let safeBlockHash = beaconHead.safeExecutionBlockHash
 
   withState(self.dag.headState):
     template callForkchoiceUpdated(fcPayloadAttributes: auto) =
       let (status, _) = await self.elManager.forkchoiceUpdated(
         headBlockHash, safeBlockHash,
-        beaconHead.finalizedExecutionPayloadHash,
+        beaconHead.finalizedExecutionBlockHash,
         payloadAttributes = some fcPayloadAttributes)
       debug "Fork-choice updated for proposal", status
 

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -155,16 +155,16 @@ func setOptimisticHead*(
 
 proc updateExecutionClientHead(self: ref ConsensusManager,
                                newHead: BeaconHead): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
-  let headExecutionPayloadHash = self.dag.loadExecutionBlockHash(newHead.blck)
+  let headExecutionBlockHash = self.dag.loadExecutionBlockHash(newHead.blck)
 
-  if headExecutionPayloadHash.isZero:
+  if headExecutionBlockHash.isZero:
     # Blocks without execution payloads can't be optimistic.
     self.dag.markBlockVerified(newHead.blck)
     return Opt[void].ok()
 
   template callForkchoiceUpdated(attributes: untyped): auto =
     await self.elManager.forkchoiceUpdated(
-      headBlockHash = headExecutionPayloadHash,
+      headBlockHash = headExecutionBlockHash,
       safeBlockHash = newHead.safeExecutionBlockHash,
       finalizedBlockHash = newHead.finalizedExecutionBlockHash,
       payloadAttributes = none attributes)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -16,7 +16,7 @@ import
 from std/deques import Deque, addLast, contains, initDeque, items, len, shrink
 from std/sequtils import mapIt
 from ../consensus_object_pools/consensus_manager import
-  ConsensusManager, checkNextProposer, optimisticExecutionPayloadHash,
+  ConsensusManager, checkNextProposer, optimisticExecutionBlockHash,
   runProposalForkchoiceUpdated, shouldSyncOptimistically, updateHead,
   updateHeadWithExecution
 from ../consensus_object_pools/blockchain_dag import
@@ -636,10 +636,10 @@ proc storeBlock(
 
       template callForkchoiceUpdated(attributes: untyped) =
         if  NewPayloadStatus.noResponse != payloadStatus and
-            not self.consensusManager[].optimisticExecutionPayloadHash.isZero:
+            not self.consensusManager[].optimisticExecutionBlockHash.isZero:
           discard await elManager.forkchoiceUpdated(
             headBlockHash =
-              self.consensusManager[].optimisticExecutionPayloadHash,
+              self.consensusManager[].optimisticExecutionBlockHash,
             safeBlockHash = newHead.get.safeExecutionBlockHash,
             finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
             payloadAttributes = none attributes)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -640,8 +640,8 @@ proc storeBlock(
           discard await elManager.forkchoiceUpdated(
             headBlockHash =
               self.consensusManager[].optimisticExecutionPayloadHash,
-            safeBlockHash = newHead.get.safeExecutionPayloadHash,
-            finalizedBlockHash = newHead.get.finalizedExecutionPayloadHash,
+            safeBlockHash = newHead.get.safeExecutionBlockHash,
+            finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
             payloadAttributes = none attributes)
 
       let consensusFork = self.consensusManager.dag.cfg.consensusForkAtEpoch(
@@ -667,8 +667,8 @@ proc storeBlock(
           await elManager.expectValidForkchoiceUpdated(
             headBlockPayloadAttributesType = payloadAttributeType,
             headBlockHash = headExecutionPayloadHash,
-            safeBlockHash = newHead.get.safeExecutionPayloadHash,
-            finalizedBlockHash = newHead.get.finalizedExecutionPayloadHash,
+            safeBlockHash = newHead.get.safeExecutionBlockHash,
+            finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
             receivedBlock = signedBlock)
 
         template callForkChoiceUpdated: auto =

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -651,10 +651,10 @@ proc storeBlock(
           callForkchoiceUpdated(consensusFork.PayloadAttributes)
     else:
       let
-        headExecutionPayloadHash =
+        headExecutionBlockHash =
           dag.loadExecutionBlockHash(newHead.get.blck)
         wallSlot = self.getBeaconTime().slotOrZero
-      if  headExecutionPayloadHash.isZero or
+      if  headExecutionBlockHash.isZero or
           NewPayloadStatus.noResponse == payloadStatus:
         # Blocks without execution payloads can't be optimistic, and don't try
         # to fcU to a block the EL hasn't seen
@@ -666,7 +666,7 @@ proc storeBlock(
         template callExpectValidFCU(payloadAttributeType: untyped): auto =
           await elManager.expectValidForkchoiceUpdated(
             headBlockPayloadAttributesType = payloadAttributeType,
-            headBlockHash = headExecutionPayloadHash,
+            headBlockHash = headExecutionBlockHash,
             safeBlockHash = newHead.get.safeExecutionBlockHash,
             finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
             receivedBlock = signedBlock)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -389,8 +389,8 @@ proc getExecutionPayload(
         forkyState.data.latest_execution_payload_header.block_hash
       else:
         (static(default(Eth2Digest)))
-    latestSafe = beaconHead.safeExecutionPayloadHash
-    latestFinalized = beaconHead.finalizedExecutionPayloadHash
+    latestSafe = beaconHead.safeExecutionBlockHash
+    latestFinalized = beaconHead.finalizedExecutionBlockHash
     timestamp = withState(proposalState[]):
       compute_timestamp_at_slot(forkyState.data, forkyState.data.slot)
     random = withState(proposalState[]):

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -210,18 +210,18 @@ proc stepOnBlock(
   # would also have `true` validity because it'd not be known they weren't, so
   # adding this mock of the block processor is realistic and sufficient.
   when consensusFork >= ConsensusFork.Bellatrix:
-    let executionPayloadHash =
+    let executionBlockHash =
       signedBlock.message.body.execution_payload.block_hash
-    if executionPayloadHash in invalidatedRoots:
+    if executionBlockHash in invalidatedRoots:
       # Mocks fork choice INVALID list application. These tests sequence this
       # in a way the block processor does not, specifying each payload_status
       # before the block itself, while Nimbus fork choice treats invalidating
       # a non-existent block root as a no-op and does not remember it for the
       # future.
       let lvh = invalidatedRoots.getOrDefault(
-        executionPayloadHash, static(default(Eth2Digest)))
+        executionBlockHash, static(default(Eth2Digest)))
       fkChoice[].mark_root_invalid(dag.getEarliestInvalidBlockRoot(
-        signedBlock.message.parent_root, lvh, executionPayloadHash))
+        signedBlock.message.parent_root, lvh, executionBlockHash))
 
       return err VerifierError.Invalid
 


### PR DESCRIPTION
Finish the rename started in #4809 to have a consistent naming. `ExecutionPayloadHash` suggests hash over payload instead of block. `BlockHash` is also the canonical name in engine API.