### PR TITLE
do not cache zero block hash if block unavailable

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -768,6 +768,7 @@ proc getBeaconHead*(
   let
     finalizedExecutionBlockHash =
       pool.dag.loadExecutionBlockHash(pool.dag.finalizedHead.blck)
+        .get(ZERO_HASH)
 
     # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/fork_choice/safe-block.md#get_safe_execution_payload_hash
     safeBlockRoot = pool.forkChoice.get_safe_beacon_block_root()
@@ -783,6 +784,7 @@ proc getBeaconHead*(
         finalizedExecutionBlockHash
       else:
         pool.dag.loadExecutionBlockHash(safeBlock.get)
+          .get(finalizedExecutionBlockHash)
 
   BeaconHead(
     blck: headBlock,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -652,7 +652,7 @@ proc storeBlock(
     else:
       let
         headExecutionBlockHash =
-          dag.loadExecutionBlockHash(newHead.get.blck)
+          dag.loadExecutionBlockHash(newHead.get.blck).get(ZERO_HASH)
         wallSlot = self.getBeaconTime().slotOrZero
       if  headExecutionBlockHash.isZero or
           NewPayloadStatus.noResponse == payloadStatus:

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -285,8 +285,18 @@ template validateBeaconBlockBellatrix(
   # shows that `state.latest_execution_payload_header` being default or not is
   # exactly equivalent to whether that block's execution payload is default or
   # not, so test cached block information rather than reconstructing a state.
-  if  signed_beacon_block.message.is_execution_block or
-      not dag.loadExecutionBlockHash(parent).isZero:
+  let isExecutionEnabled =
+    if signed_beacon_block.message.is_execution_block:
+      true
+    else:
+      let parentExecutionBlockHash = dag.loadExecutionBlockHash(parent).valueOr:
+        # To disallow transitions from post-merge to pre-merge, ignore this if
+        # we cannot reliably determine whether the parent had execution enabled.
+        # E.g., with checkpoint sync, the checkpoint block may be unavailable,
+        # and it could already be the parent of the new block before backfill.
+        return errIgnore("BeaconBlock: parent execution payload unavailable")
+      not parentExecutionBlockHash.isZero
+  if isExecutionEnabled:
     # [REJECT] The block's execution payload timestamp is correct with respect
     # to the slot -- i.e. execution_payload.timestamp ==
     # compute_timestamp_at_slot(state, block.slot).
@@ -523,15 +533,34 @@ proc validateBeaconBlock*(
       # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/p2p-interface.md#beacon_block
       # `is_execution_enabled(state, block.body)` check, but unlike in
       # validateBeaconBlockBellatrix() don't have parent BlockRef.
-      if  signed_beacon_block.message.is_execution_block or
-          not dag.loadExecutionBlockHash(dag.finalizedHead.blck).isZero:
+      if signed_beacon_block.message.is_execution_block:
         # Blocks with execution enabled will be permitted to propagate
         # regardless of the validity of the execution payload. This prevents
         # network segregation between optimistic and non-optimistic nodes.
         #
-        # [IGNORE] The block's parent (defined by `block.parent_root`)
-        # passes all validation (including execution node verification of the
-        # `block.body.execution_payload`).
+        # If execution_payload verification of block's parent by an execution
+        # node is not complete:
+        #
+        # - [REJECT] The block's parent (defined by `block.parent_root`) passes
+        #   all validation (excluding execution node verification of the
+        #   `block.body.execution_payload`).
+        #
+        # otherwise:
+        #
+        # - [IGNORE] The block's parent (defined by `block.parent_root`) passes
+        #   all validation (including execution node verification of the
+        #   `block.body.execution_payload`).
+
+        # Implementation restrictions:
+        #
+        # - We don't know if the parent state had execution enabled.
+        #   If it had, and the block doesn't have it enabled anymore,
+        #   we end up in the pre-Merge path below (`else`) and REJECT.
+        #   Such a block is clearly invalid, though, without asking the EL.
+        #
+        # - We know that the parent was marked unviable, but don't know
+        #   whether it was marked unviable due to consensus (REJECT) or
+        #   execution (IGNORE) verification failure. We err on the IGNORE side.
         return errIgnore("BeaconBlock: ignored, parent from unviable fork")
       else:
         # [REJECT] The block's parent (defined by `block.parent_root`) passes

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -126,7 +126,8 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
               RestNodeValidity.optimistic
             else:
               RestNodeValidity.valid,
-        execution_block_hash: node.dag.loadExecutionBlockHash(item.bid),
+        execution_block_hash:
+          node.dag.loadExecutionBlockHash(item.bid).get(ZERO_HASH),
         extra_data: some RestNodeExtraData(
           justified_root: item.checkpoints.justified.root,
           finalized_root: item.checkpoints.finalized.root,

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -771,7 +771,7 @@ proc getBlindedBlockParts[
       # With checkpoint sync, the checkpoint block may be unavailable,
       # and it could already be the parent of the new block before backfill.
       # Fallback to EL, hopefully the block is available on the local path.
-      warn "Failed to load parent execution block hash",
+      warn "Failed to load parent execution block hash, skipping block builder",
         slot, validator_index, head = shortLog(head)
       return err("loadExecutionBlockHash failed")
 


### PR DESCRIPTION
With checkpoint sync, the checkpoint block is typically unavailable at the start, and only backfilled later. To avoid treating it as having zero hash, execution disabled in some contexts, wrap the result of `loadExecutionBlockHash` in `Opt` and handle block hash being unknown.