### PR TITLE
allow `getBlockIdAtSlot` to answer queries from available states

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -814,6 +814,11 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Starting state without block                                                               OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## State history
+```diff
++ getBlockIdAtSlot                                                                           OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Sync committee pool
 ```diff
 + Aggregating votes                                                                          OK
@@ -986,4 +991,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 667/672 Fail: 0/672 Skip: 5/672
+OK: 668/673 Fail: 0/673 Skip: 5/673


### PR DESCRIPTION
After checkpoint sync, historical block IDs cannot yet be queried. However, they are needed to compute dependent roots of `ShufflingRef`. To allow lookup, enable `getBlockIdAtSlot` to answer from compatible states in memory; as long as they descend from the finalized checkpoint and the requested slot is sufficiently recent, `block_roots` contains everything to recover `BlockSlotId` up to `SLOTS_PER_HISTORICAL_ROOT`. This is similar to how `attester_dependent_root` etc. are computed.

This accelerates the first couple minutes of checkpoint sync on Mainnet, especially the time until finality advances past the synced checkpoint.