### PR TITLE
refactor addHeadBlock() to research/ and tests/ helper

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -314,25 +314,6 @@ proc addHeadBlockWithParent*(
     sigVerifyDur = sigVerifyTick - stateDataTick,
     stateVerifyDur = stateVerifyTick - sigVerifyTick)
 
-proc addHeadBlock*(
-    dag: ChainDAGRef, verifier: var BatchVerifier,
-    signedBlock: ForkySignedBeaconBlock,
-    executionValid: bool,
-    onBlockAdded: OnForkyBlockAdded
-    ): Result[BlockRef, VerifierError] =
-  addHeadBlockWithParent(
-    dag, verifier, signedBlock, ? dag.checkHeadBlock(signedBlock),
-    executionValid, onBlockAdded)
-
-proc addHeadBlock*(
-    dag: ChainDAGRef, verifier: var BatchVerifier,
-    signedBlock: ForkySignedBeaconBlock,
-    onBlockAdded: OnForkyBlockAdded
-    ): Result[BlockRef, VerifierError] =
-  addHeadBlockWithParent(
-    dag, verifier, signedBlock, ? dag.checkHeadBlock(signedBlock),
-    executionValid = true, onBlockAdded)
-
 proc addBackfillBlock*(
     dag: ChainDAGRef,
     signedBlock: ForkySignedBeaconBlock | ForkySigVerifiedSignedBeaconBlock):

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -39,6 +39,7 @@ from ../beacon_chain/spec/beaconstate import
   get_beacon_committee, get_beacon_proposer_index,
   get_committee_count_per_slot, get_committee_indices
 from ../beacon_chain/spec/state_transition_block import process_block
+from ../tests/testbcutil import addHeadBlock
 
 type Timers = enum
   tBlock = "Process non-epoch slot with block"

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -27,6 +27,7 @@ from std/json import
   JsonNode, getBool, getInt, getStr, hasKey, items, len, pairs, `$`, `[]`
 from std/sequtils import mapIt, toSeq
 from std/strutils import contains
+from ../testbcutil import addHeadBlock
 
 # Test format described at https://github.com/ethereum/consensus-specs/tree/v1.3.0/tests/formats/fork_choice
 # Note that our implementation has been optimized with "ProtoArray"

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -8,7 +8,6 @@
 {.used.}
 
 import
-  std/sequtils,
   # Status lib
   unittest2,
   chronicles, chronos,
@@ -24,6 +23,9 @@ import
   ../beacon_chain/beacon_clock,
   # Test utilities
   ./testutil, ./testdbutil, ./testblockutil
+
+from std/sequtils import toSeq
+from ./testbcutil import addHeadBlock
 
 func combine(tgt: var Attestation, src: Attestation) =
   ## Combine the signature and participation bitfield, with the assumption that

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -8,7 +8,6 @@
 {.used.}
 
 import
-  std/[random, sequtils],
   unittest2,
   taskpools,
   ../beacon_chain/el/merkle_minimal,
@@ -19,8 +18,11 @@ import
     attestation_pool, blockchain_dag, block_quarantine, block_clearance],
   ./testutil, ./testdbutil, ./testblockutil
 
+from std/random import rand, randomize, sample
+from std/sequtils import toSeq
 from ../beacon_chain/spec/datatypes/capella import
   SignedBLSToExecutionChangeList
+from ./testbcutil import addHeadBlock
 
 func `$`(x: BlockRef): string = shortLog(x)
 

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -8,8 +8,6 @@
 {.used.}
 
 import
-  # Standard library
-  std/sequtils,
   # Status lib
   unittest2,
   chronos,
@@ -27,6 +25,9 @@ import
   ../beacon_chain/validators/validator_pool,
   # Test utilities
   ./testutil, ./testdbutil, ./testblockutil
+
+from std/sequtils import count, toSeq
+from ./testbcutil import addHeadBlock
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -17,6 +17,8 @@ import
   # Test utilities
   ./testutil, ./testdbutil
 
+from ./testbcutil import addHeadBlock
+
 suite "Light client" & preset():
   const  # Test config, should be long enough to cover interesting transitions
     headPeriod = 3.SyncCommitteePeriod

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -18,6 +18,8 @@ import
   # Test utilities
   ./testutil, ./testdbutil
 
+from ./testbcutil import addHeadBlock
+
 suite "Light client processor" & preset():
   const  # Test config, should be long enough to cover interesting transitions
     lowPeriod = 0.SyncCommitteePeriod

--- a/tests/testbcutil.nim
+++ b/tests/testbcutil.nim
@@ -1,0 +1,25 @@
+# beacon_chain
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import results
+
+from ../beacon_chain/consensus_object_pools/block_clearance import
+  addHeadBlockWithParent
+from ../beacon_chain/consensus_object_pools/block_dag import BlockRef
+from ../beacon_chain/consensus_object_pools/block_pools_types import
+  ChainDAGRef, OnForkyBlockAdded, VerifierError
+from ../beacon_chain/spec/forks import ForkySignedBeaconBlock
+from ../beacon_chain/spec/signatures_batch import BatchVerifier
+
+proc addHeadBlock*(
+    dag: ChainDAGRef, verifier: var BatchVerifier,
+    signedBlock: ForkySignedBeaconBlock,
+    onBlockAdded: OnForkyBlockAdded
+    ): Result[BlockRef, VerifierError] =
+  addHeadBlockWithParent(
+    dag, verifier, signedBlock, ? dag.checkHeadBlock(signedBlock),
+    executionValid = true, onBlockAdded)


### PR DESCRIPTION
`nimbus_beacon_node` itself uses only `addHeadBlockWithParent()`. In anticipation of adding information to that `addHeadBlockWithParent()` flow, refactor two of the callers away to make it clear that any changes there only have to function for testing purposes, not in a more general-purpose way, leaving exactly one codepath which involves `addHeadBlockWithParent()`.