### PR TITLE
reduce verbosity of `Got request for pre-backfill slot`

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1633,13 +1633,8 @@ proc getBlockRange*(
     head = shortLog(dag.head.root), requestedCount, startSlot, skipStep, headSlot
 
   if startSlot < dag.backfill.slot:
-    if startSlot < dag.horizon:
-      # We will not backfill these
-      debug "Got request for pre-horizon slot",
-        startSlot, backfillSlot = dag.backfill.slot
-    else:
-      notice "Got request for pre-backfill slot",
-        startSlot, backfillSlot = dag.backfill.slot
+    debug "Got request for pre-backfill slot",
+      startSlot, backfillSlot = dag.backfill.slot, horizonSlot = dag.horizon
     return output.len
 
   if headSlot <= startSlot or requestedCount == 0:


### PR DESCRIPTION
When syncing, we log a notice each time someone asks us for a block that we haven't backfilled yet. This is quite verbose and not unexpected, because the status message does not allow indicating backfill progress.