### PR TITLE
state loading optimizations

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1524,7 +1524,7 @@ proc computeRandaoMix(
   # Fall back to database
   dag.computeRandaoMixFromDatabase(bid, lowSlot)
 
-proc computeRandaoMix*(dag: ChainDAGRef, bid: BlockId): Opt[Eth2Digest] {.deprecated.} =
+proc computeRandaoMix*(dag: ChainDAGRef, bid: BlockId): Opt[Eth2Digest] =
   ## Compute requested RANDAO mix for `bid`.
   const maxSlotDistance = SLOTS_PER_HISTORICAL_ROOT
   let lowSlot = max(bid.slot, maxSlotDistance.Slot) - maxSlotDistance

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -1825,9 +1825,6 @@ template runShufflingTests(cfg: RuntimeConfig, numRandomTests: int) =
       # If shuffling is computable from DAG, check its correctness
       epochRef.checkShuffling dag.computeShufflingRefFromMemory(blck, epoch)
 
-      # If shuffling is computable from DB, check its correctness
-      epochRef.checkShuffling dag.computeShufflingRefFromDatabase(blck, epoch)
-
       # Shuffling should be correct when starting from any cached state
       for state in states:
         withState(state[]):
@@ -1903,9 +1900,6 @@ template runShufflingTests(cfg: RuntimeConfig, numRandomTests: int) =
 
       # If shuffling is computable from DAG, check its correctness
       epochRef.checkShuffling dag.computeShufflingRefFromMemory(blck, epoch)
-
-      # If shuffling is computable from DB, check its correctness
-      epochRef.checkShuffling dag.computeShufflingRefFromDatabase(blck, epoch)
 
 suite "Shufflings":
   let cfg = defaultRuntimeConfig


### PR DESCRIPTION
* compute post-merge randao mix without loading state
* avoid copying state on shuffling computation and compute epochref
* speed up state copy for block production