### PR TITLE
stop calling `exchangeTransitionConfiguration`

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1275,26 +1275,6 @@ proc exchangeConfigWithSingleEL(m: ELManager, connection: ELConnection) {.async.
 
   connection.etcStatus = EtcStatus.match
 
-  # https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#deprecate-engine_exchangetransitionconfigurationv1
-  # Consensus layer clients MUST NOT call this method.
-  if m.eth1Chain.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
-    return
-
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_exchangetransitionconfigurationv1
-  let
-    ourConf = TransitionConfigurationV1(
-      terminalTotalDifficulty: m.eth1Chain.cfg.TERMINAL_TOTAL_DIFFICULTY,
-      terminalBlockHash: m.eth1Chain.cfg.TERMINAL_BLOCK_HASH,
-      terminalBlockNumber: Quantity 0)
-  try:
-    discard connection.trackedRequestWithTimeout(
-      "exchangeTransitionConfiguration",
-      rpcClient.engine_exchangeTransitionConfigurationV1(ourConf),
-      timeout = 1.seconds)
-  except CatchableError as err:
-    warn "Failed to exchange transition configuration",
-          url = connection.engineUrl, err = err.msg
-
 proc exchangeTransitionConfiguration*(m: ELManager) {.async.} =
   if m.elConnections.len == 0:
     return


### PR DESCRIPTION
As https://github.com/ethereum/execution-apis/blob/c4089414bbbe975bbc4bf1ccf0a3d31f76feb3e1/src/engine/cancun.md#deprecate-engine_exchangetransitionconfigurationv1 notes
> Consensus layer clients MUST NOT call this method.

for Dencun-capable networks.

The phrasing was unclear at the time whether that meant networks in Dencun or scheduled for Dencun, but it was determined to mean scheduled for Dencun, which is now true for all supported networks, EF and Gnosis.