### PR TITLE
add Prater/Goerli deprecation notice

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -361,8 +361,8 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
       fatal "config.yaml not found for network", networkName
       quit 1
 
-  if networkName == "ropsten":
-    warn "Ropsten is unsupported; https://blog.ethereum.org/2022/11/30/ropsten-shutdown-announcement suggests migrating to Goerli or Sepolia"
+  if networkName in ["goerli", "prater"]:
+    warn "Goerli is deprecated and will stop being supported; https://blog.ethereum.org/2023/11/30/goerli-lts-update suggests migrating to Holesky or Sepolia"
 
   let metadata =
     when const_preset == "gnosis":


### PR DESCRIPTION
At this point, if anyone's still trying to use Ropsten, that's very likely deliberate.