### PR TITLE
update `nim-blscurve` link to follow renamed file

### DIFF
--- a/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
+++ b/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
@@ -13,9 +13,9 @@ Example: secp256k1
 
 ### Compiling directly the C files
 
-Example: Apache Milagro Crypto
+Example: MIRACL Core
 
-[https://github.com/status-im/nim-blscurve/blob/master/blscurve/milagro.nim](https://github.com/status-im/nim-blscurve/blob/master/blscurve/milagro.nim)
+[https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim](https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim)
 
 ## Wrapping C++
 


### PR DESCRIPTION
`milagro.nim` was renamed to `miracl.nim`. Point to the new filename from auditors handbook.

- https://github.com/status-im/nim-blscurve/pull/166