### PR TITLE
modernize `simutils`

### DIFF
--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   stew/io2,
   ../tests/testblockutil, ../tests/consensus_spec/os_ops,
@@ -70,40 +72,64 @@ proc loadGenesis*(validators: Natural, validate: bool):
     quit 1
 
   let
+    suffix = const_preset & "_" & $validators & "_" & SPEC_VERSION
     genesisFn = genesisDir /
-      &"genesis_{const_preset}_{validators}_{SPEC_VERSION}.ssz"
+      "genesis_" & suffix & ".ssz"
     contractSnapshotFn = genesisDir /
-      &"deposit_contract_snapshot_{const_preset}_{validators}_{SPEC_VERSION}.ssz"
+      "deposit_contract_snapshot_" & suffix & ".ssz"
   const cfg = getSimulationConfig()
 
   if fileExists(genesisFn) and fileExists(contractSnapshotFn):
-    let res = newClone(readSszForkedHashedBeaconState(
-      cfg, readAllBytes(genesisFn).tryGet()))
+    let res =
+      try:
+        newClone(readSszForkedHashedBeaconState(
+          cfg, readAllBytes(genesisFn).tryGet()))
+      except ResultError[IoErrorCode] as exc:
+        fatal "Genesis file failed to load",
+          fileName = genesisFn, exc = exc.msg
+        quit 1
+      except SerializationError as exc:
+        fatal "Genesis file malformed",
+          fileName = genesisFn, exc = exc.msg
+        quit 1
 
     withState(res[]):
       if forkyState.data.slot != GENESIS_SLOT:
-        echo "Can only start from genesis state"
+        fatal "Can only start from genesis state"
         quit 1
 
       if forkyState.data.validators.len != validators:
-        echo &"Supplied genesis file has {forkyState.data.validators.len} validators, while {validators} where requested, running anyway"
+        fatal "Supplied genesis file has unexpected number of validators",
+          numExpectedValidators = validators,
+          numActualValidators = forkyState.data.validators.len
+        quit 1
 
-      echo &"Loaded {genesisFn}..."
+      info "Loaded genesis file", fileName = genesisFn
 
       # TODO check that the private keys are EF test keys
 
-      let contractSnapshot = SSZ.loadFile(contractSnapshotFn,
-                                          DepositTreeSnapshot)
+      let contractSnapshot =
+        try:
+          SSZ.loadFile(contractSnapshotFn, DepositTreeSnapshot)
+        except IOError as exc:
+          fatal "Deposit contract snapshot failed to load",
+            fileName = contractSnapshotFn, exc = exc.msg
+          quit 1
+        except SerializationError as exc:
+          fatal "Deposit contract snapshot malformed",
+            fileName = contractSnapshotFn, exc = exc.msg
+          quit 1
       (res, contractSnapshot)
   else:
-    echo "Genesis file not found, making one up (use nimbus_beacon_node createTestnet to make one)"
+    warn "Genesis file not found, making one up",
+      hint = "use nimbus_beacon_node createTestnet to make one"
 
-    echo "Preparing validators..."
+    info "Preparing validators..."
     let
       flags = if validate: {} else: {skipBlsValidation}
       deposits = makeInitialDeposits(validators.uint64, flags)
 
-    echo "Generating Genesis..."
+    info "Generating Genesis..."
     var merkleizer = init DepositsMerkleizer
     for d in deposits:
       merkleizer.addChunk hash_tree_root(d).data
@@ -117,34 +143,51 @@ proc loadGenesis*(validators: Natural, validate: bool):
           cfg, ZERO_HASH, 0, deposits,
           default(capella.ExecutionPayloadHeader), {skipBlsValidation})))
 
-    echo &"Saving to {genesisFn}..."
-    SSZ.saveFile(genesisFn, res.capellaData.data)
-    echo &"Saving to {contractSnapshotFn}..."
-    SSZ.saveFile(contractSnapshotFn, contractSnapshot)
+    info "Saving genesis file", fileName = genesisFn
+    try:
+      SSZ.saveFile(genesisFn, res.capellaData.data)
+    except IOError as exc:
+      fatal "Genesis file failed to save",
+        fileName = genesisFn, exc = exc.msg
+      quit 1
+    info "Saving deposit contract snapshot", fileName = contractSnapshotFn
+    try:
+      SSZ.saveFile(contractSnapshotFn, contractSnapshot)
+    except IOError as exc:
+      fatal "Deposit contract snapshot failed to save",
+        fileName = contractSnapshotFn, exc = exc.msg
+      quit 1
 
     (res, contractSnapshot)
 
 proc printTimers*[Timers: enum](
-  validate: bool,
-  timers: array[Timers, RunningStat]
-) =
-  func fmtTime(t: float): string = &"{t * 1000 :>12.3f}, "
+    validate: bool,
+    timers: array[Timers, RunningStat]) =
+  func fmtTime(t: float): string =
+    try:
+      &"{t * 1000 :>12.3f}, "
+    except ValueError as exc:
+      raiseAssert "formatValue failed unexpectedly: " & $exc.msg
 
-  echo "All time are ms"
-  echo &"{\"Average\" :>12}, {\"StdDev\" :>12}, {\"Min\" :>12}, " &
-    &"{\"Max\" :>12}, {\"Samples\" :>12}, {\"Test\" :>12}"
+  try:
+    echo "All time are ms"
+    echo &"{\"Average\" :>12}, {\"StdDev\" :>12}, {\"Min\" :>12}, " &
+      &"{\"Max\" :>12}, {\"Samples\" :>12}, {\"Test\" :>12}"
 
-  if not validate:
-    echo "Validation is turned off meaning that no BLS operations are performed"
+    if not validate:
+      echo "Validation is turned off; no BLS operations are performed"
 
-  for t in Timers:
-    echo fmtTime(timers[t].mean), fmtTime(timers[t].standardDeviationS),
-      fmtTime(timers[t].min), fmtTime(timers[t].max), &"{timers[t].n :>12}, ",
-      $t
+    for t in Timers:
+      echo fmtTime(timers[t].mean), fmtTime(timers[t].standardDeviationS),
+        fmtTime(timers[t].min), fmtTime(timers[t].max), &"{timers[t].n :>12}, ",
+        $t
+  except ValueError as exc:
+    raiseAssert "formatValue failed unexpectedly: " & $exc.msg
 
 proc printTimers*[Timers: enum](
     state: ForkedHashedBeaconState, attesters: RunningStat, validate: bool,
     timers: array[Timers, RunningStat]) =
-  echo "Validators: ", getStateField(state, validators).len, ", epoch length: ", SLOTS_PER_EPOCH
+  echo "Validators: ", getStateField(state, validators).len,
+    ", epoch length: ", SLOTS_PER_EPOCH
   echo "Validators per attestation (mean): ", attesters.mean
   printTimers(validate, timers)


### PR DESCRIPTION
`simutils.nim` is quite outdated w.r.t. code style. Apply the following:

- Use string concatenation instead of `strformat` for simple cases
- Catch `IOError` and `SerializationError` when loading/saving SSZ files
- Catch `ValueError` for remaining `strformat` usage
- Consistently use `chronicles` in `loadGenesis`