### PR TITLE
rename reference of `RangeError` to `RangeDefect`

### DIFF
--- a/docs/the_auditors_handbook/src/02.2_stack_ref_ptr_types.md
+++ b/docs/the_auditors_handbook/src/02.2_stack_ref_ptr_types.md
@@ -30,7 +30,7 @@ It is the preferred type to represent binary blobs, i.e. we use `seq[byte]` over
 
 Nim allows defining ranges of valid value which will be runtime checked everytime the value changes for example
 Nim defines by default `type Natural = range[0 .. high(int)]`. If the value of a Natural becomes less than 0
-an RangeError exception will be thrown.
+a `RangeDefect` will be thrown.
 
 This is valuable to catch / prevent underflows.
 


### PR DESCRIPTION
`RangeError` got deprecated in favor of `RangeDefect`. Update handbook.