### PR TITLE
avoid `read`/`readError` in favor of `value`/`error`

### DIFF
--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import std/strutils
 import chronicles, stew/base10
 import ".."/spec/eth2_apis/eth2_rest_serialization,
@@ -123,7 +125,7 @@ proc apiResponseOr[T](future: FutureBase, timerFut: Future[void],
     if future.failed():
       ApiResponse[T].err($future.error.msg)
     else:
-      ApiResponse[T].ok(Future[T](future).read())
+      ApiResponse[T].ok(Future[T](future).value())
   else:
     if timerFut.finished():
       ApiResponse[T].err(message)

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   std/[tables, os, sets, sequtils, strutils, uri, algorithm],
   results,
@@ -1045,12 +1047,12 @@ proc getValidatorRegistration(
     if sigfut.finished():
       # This is short-path if we able to create signature locally.
       if not(sigfut.completed()):
-        let exc = sigfut.readError()
+        let exc = sigfut.error()
         debug "Got unexpected exception while signing validator registration",
               validator = shortLog(validator), error_name = $exc.name,
               error_msg = $exc.msg
         return err(RegistrationKind.ErrorSignature)
-      let sigres = sigfut.read()
+      let sigres = sigfut.value()
       if sigres.isErr():
         debug "Failed to get signature for validator registration",
               validator = shortLog(validator), error = sigres.error()


### PR DESCRIPTION
In VC logic, bump 3 remaining uses of `readError`/`read` to use `error`/`value` instead. The surrounding logic guarantees success.