### PR TITLE
`noCancel` in `test_gossip_validation`

### DIFF
--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -332,7 +333,7 @@ suite "Gossip validation - Altair":
         (validator, _, msg) = dag.getSyncCommitteeMessage(
           slot, subcommitteeIdx, indexInSubcommittee,
           signatureSlot = Opt.some(signatureSlot))
-        msgVerdict = waitFor dag.validateSyncCommitteeMessage(
+        msgVerdict = waitFor noCancel dag.validateSyncCommitteeMessage(
           quarantine, batchCrypto, syncCommitteePool,
           msg, subcommitteeIdx, slot.start_beacon_time(),
           checkSignature = true)
@@ -372,15 +373,15 @@ suite "Gossip validation - Altair":
           contrib.message.contribution)
         syncCommitteePool[].addContribution(
           contrib[], bid, contrib.message.contribution.signature.load.get)
-        let signRes = waitFor validator.getContributionAndProofSignature(
+        let res = waitFor noCancel validator.getContributionAndProofSignature(
           getStateField(dag.headState, fork),
           getStateField(dag.headState, genesis_validators_root),
           contrib[].message)
-        doAssert(signRes.isOk())
-        contrib[].signature = signRes.get()
+        doAssert(res.isOk())
+        contrib[].signature = res.get()
         contrib
       syncCommitteePool[] = SyncCommitteeMsgPool.init(rng, cfg)
-      let contribVerdict = waitFor dag.validateContribution(
+      let contribVerdict = waitFor noCancel dag.validateContribution(
         quarantine, batchCrypto, syncCommitteePool,
         contrib[], slot.start_beacon_time(),
         checkSignature = true)


### PR DESCRIPTION
To avoid spurious warnings, mark futures that are not cancelled by test as such when waiting for them. Variable rename is for max line length.