### PR TITLE
extend linter to enforce exception tracking is turned on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,18 +241,37 @@ jobs:
           excluded_extensions="ans|cfg|json|json\\.template|md|png|service|ssz|txt"
 
           current_year=$(date +"%Y")
-          outdated_files=()
+          problematic_files=()
           while read -r file; do
             if ! grep -qE 'Copyright \(c\) .*'$current_year' Status Research & Development GmbH' "$file"; then
-              outdated_files+=("$file")
+              problematic_files+=("$file")
             fi
           done < <(git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -vE '(\.('$excluded_extensions')|'$excluded_files')$' || true)
 
-          if (( ${#outdated_files[@]} )); then
+          if (( ${#problematic_files[@]} )); then
             echo "The following files do not have an up-to-date copyright year:"
-            for file in "${outdated_files[@]}"; do
+            for file in "${problematic_files[@]}"; do
               echo "- $file"
             done
+            exit 2
+          fi
+
+      - name: Check exception tracking
+        if: ${{ !cancelled() }} && github.event_name == 'pull_request'
+        run: |
+          problematic_files=()
+          while read -r file; do
+            if ! grep -qE '^{\.push raises: \[\]\.}' "$file"; then
+              problematic_files+=("$file")
+            fi
+          done < <(git diff --name-only --diff-filter=AM --ignore-submodules HEAD^ HEAD | grep -E '\.nim$' || true)
+
+          if (( ${#problematic_files[@]} )); then
+            echo "The following files do not have '{.push raises: []}':"
+            for file in "${problematic_files[@]}"; do
+              echo "- $file"
+            done
+            echo "See https://status-im.github.io/nim-style-guide/errors.exceptions.html"
             exit 2
           fi
 


### PR DESCRIPTION
Status Nim style mandates `{.push raises: []}.` at start of modules. Add a CI task to ensure exceptions keep getting properly tracked.

- https://status-im.github.io/nim-style-guide/errors.exceptions.html
- https://github.com/status-im/nim-eth/pull/614#discussion_r1220906149