### PR TITLE
search for validator indices backwards while processing deposits

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -269,9 +269,23 @@ func findValidatorIndex*(state: ForkyBeaconState, pubkey: ValidatorPubKey):
   # given that each block can hold no more than 16 deposits, it's slower to
   # build the table and use it for lookups than to scan it like this.
   # Once we have a reusable, long-lived cache, this should be revisited
-  for vidx in state.validators.vindices:
-    if state.validators.asSeq[vidx].pubkey == pubkey:
-      return Opt[ValidatorIndex].ok(vidx)
+  #
+  # For deposit processing purposes, two broad cases exist, either
+  #
+  # (a) someone has deposited all 32 required ETH as a single transaction,
+  #     in which case the index doesn't yet exist so the search order does
+  #     not matter so long as it's generally in an order memory controller
+  #     prefetching can predict; or
+  #
+  # (b) the deposit has been split into multiple parts, typically not far
+  #     apart from each other, such that on average one would expect this
+  #     validator index to be nearer the maximal than minimal index.
+  #
+  # countdown() infinite-loops if the lower bound with uint32 is 0, so
+  # shift indices by 1, which avoids triggering unsigned wraparound.
+  for vidx in countdown(state.validators.len.uint32, 1):
+    if state.validators.asSeq[vidx - 1].pubkey == pubkey:
+      return Opt[ValidatorIndex].ok((vidx - 1).ValidatorIndex)
 
 proc process_deposit*(cfg: RuntimeConfig,
                       state: var ForkyBeaconState,


### PR DESCRIPTION
Examples of either case (a), or it's split and there's no validator index yet because the first (typically 1 ETH but arbitrary) deposit portion has to happen before the validator index exists:
- https://beaconcha.in/slot/8453206#deposits has a 1 ETH transaction and https://beaconcha.in/validator/0xb22830193c7738cf86dc030566151e3000cace5f8165f4812b12dc01d04c95f95ecebb0dffb03fbde6dc3a9c81a17c10#deposits shows that the two deposits, 1 and 31 ETH, happened 14 hours apart
- https://beaconcha.in/slot/8453192#deposits https://beaconcha.in/slot/8453193#deposits https://beaconcha.in/slot/8453194#deposits https://beaconcha.in/slot/8453196#deposits all have single 32 ETH deposits per validator, before which no validator index existed, so search order isn't relevant as long as it's memory-bandwidth-and-latency-efficient.

Examples of case (b): https://beaconcha.in/slot/8453207#deposits https://beaconcha.in/slot/8453208#deposits https://beaconcha.in/slot/8453209#deposits https://beaconcha.in/slot/8453210#deposits where a search from the end is much faster.