### PR TITLE
rename new timing metrics, as `_total` suffix is implicit

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1845,7 +1845,7 @@ proc updateState*(
   let
     assignDur = assignTick - startTick
     replayDur = Moment.now() - assignTick
-  state_replay_seconds.set(replayDur.toFloatSeconds)
+  state_replay_seconds.inc(replayDur.toFloatSeconds)
 
   # TODO https://github.com/status-im/nim-chronicles/issues/108
   if (assignDur + replayDur) >= MinSignificantProcessingDuration:

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -49,7 +49,7 @@ declareGauge beacon_current_active_validators, "Number of validators in the acti
 declareGauge beacon_pending_deposits, "Number of pending deposits (state.eth1_data.deposit_count - state.eth1_deposit_index)" # On block
 declareGauge beacon_processed_deposits_total, "Number of total deposits included on chain" # On block
 
-declareCounter total_state_replay_seconds, "Total time spent replaying states"
+declareCounter state_replay_seconds, "Time spent replaying states"
 
 const
   EPOCHS_PER_STATE_SNAPSHOT* = 32
@@ -1845,7 +1845,7 @@ proc updateState*(
   let
     assignDur = assignTick - startTick
     replayDur = Moment.now() - assignTick
-  total_state_replay_seconds.inc(replayDur.toFloatSeconds)
+  state_replay_seconds.set(replayDur.toFloatSeconds)
 
   # TODO https://github.com/status-im/nim-chronicles/issues/108
   if (assignDur + replayDur) >= MinSignificantProcessingDuration:

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -49,7 +49,7 @@ declareGauge beacon_current_active_validators, "Number of validators in the acti
 declareGauge beacon_pending_deposits, "Number of pending deposits (state.eth1_data.deposit_count - state.eth1_deposit_index)" # On block
 declareGauge beacon_processed_deposits_total, "Number of total deposits included on chain" # On block
 
-declareCounter state_replay_seconds, "Time spent replaying states"
+declareCounter beacon_dag_state_replay_seconds, "Time spent replaying states"
 
 const
   EPOCHS_PER_STATE_SNAPSHOT* = 32
@@ -1845,7 +1845,7 @@ proc updateState*(
   let
     assignDur = assignTick - startTick
     replayDur = Moment.now() - assignTick
-  state_replay_seconds.inc(replayDur.toFloatSeconds)
+  beacon_dag_state_replay_seconds.inc(replayDur.toFloatSeconds)
 
   # TODO https://github.com/status-im/nim-chronicles/issues/108
   if (assignDur + replayDur) >= MinSignificantProcessingDuration:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -51,8 +51,8 @@ declareGauge ticks_delay,
 declareGauge next_action_wait,
   "Seconds until the next attestation will be sent"
 
-declareCounter total_db_checkpoint_seconds,
-  "Total time spent checkpointing the database to clear the WAL file"
+declareCounter db_checkpoint_seconds,
+  "Time spent checkpointing the database to clear the WAL file"
 
 proc doRunTrustedNodeSync(
     db: BeaconChainDB,
@@ -1392,7 +1392,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let
     dbCheckpointTick = Moment.now()
     dbCheckpointDur = dbCheckpointTick - gcCollectionTick
-  total_db_checkpoint_seconds.inc(dbCheckpointDur.toFloatSeconds)
+  db_checkpoint_seconds.set(dbCheckpointDur.toFloatSeconds)
   if dbCheckpointDur >= MinSignificantProcessingDuration:
     info "Database checkpointed", dur = dbCheckpointDur
   else:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1392,7 +1392,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let
     dbCheckpointTick = Moment.now()
     dbCheckpointDur = dbCheckpointTick - gcCollectionTick
-  db_checkpoint_seconds.set(dbCheckpointDur.toFloatSeconds)
+  db_checkpoint_seconds.inc(dbCheckpointDur.toFloatSeconds)
   if dbCheckpointDur >= MinSignificantProcessingDuration:
     info "Database checkpointed", dur = dbCheckpointDur
   else:


### PR DESCRIPTION
Change `db_checkpoint_seconds` and `state_replay_seconds` metrics to record the latest duration instead of the total. `nim-metrics` already synthesizes a `_total` metric from these implicitly.