### PR TITLE
remove MIRACL Core support

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -47,7 +47,7 @@ const
   RawSigSize* = 96
   RawPubKeySize* = 48
   UncompressedPubKeySize* = 96
-  # RawPrivKeySize* = 48 for Miracl / 32 for BLST
+  # RawPrivKeySize* = 32 for BLST
 
 type
   ValidatorPubKey* = object ##\
@@ -388,13 +388,9 @@ func `$`*(x: ValidatorPubKey | ValidatorSig): string =
 
 func toRaw*(x: ValidatorPrivKey): array[32, byte] =
   # TODO: distinct type - see https://github.com/status-im/nim-blscurve/pull/67
-  when BLS_BACKEND == BLST:
-    result = SecretKey(x).exportRaw()
-  else:
-    # Miracl exports to 384-bit arrays, but Curve order is 256-bit
-    let raw = SecretKey(x).exportRaw()
-    result[0..32-1] = raw.toOpenArray(48-32, 48-1)
-
+  static: doAssert BLS_BACKEND == BLST
+  result = SecretKey(x).exportRaw()
+  
 template toRaw*(x: ValidatorPubKey | ValidatorSig): auto =
   x.blob
 

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -45,7 +45,7 @@ type
   PubKeyBytes* = array[RawPubKeySize, byte]
     ## This is the serialized byte representation
     ## of a Validator Public Key.
-    ## Portable between Miracl/BLST
+    ## Portable between backend implementations
     ## and limits serialization/deserialization call
 
   PubKey0x* = distinct PubKeyBytes

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -789,7 +789,7 @@ proc getValidatorInternalID(
     db.internalIds.withValue(index.get(), internal) do:
       return Opt.some(internal[])
 
-  let serializedPubkey = validator.toRaw() # Miracl/BLST to bytes
+  let serializedPubkey = validator.toRaw() # Backend-specific to bytes
   var valID: ValidatorInternalID
   let status = db.sqlGetValidatorInternalID.exec(serializedPubkey) do (res: ValidatorInternalID):
     valID = res
@@ -1080,7 +1080,7 @@ proc registerValidator(db: SlashingProtectionDB_v2, validator: ValidatorPubKey) 
   ## Get validator from the database
   ## or register it
   ## Assumes the validator does not exist
-  let serializedPubkey = validator.toRaw() # Miracl/BLST to bytes
+  let serializedPubkey = validator.toRaw() # Backend-specific to bytes
   let status = db.sqlInsertValidator.exec(serializedPubkey)
   doAssert status.isOk()
 

--- a/config.nims
+++ b/config.nims
@@ -225,9 +225,6 @@ put("aesctr_drbg.always", "-fno-lto")
 put("hmac_drbg.always", "-fno-lto")
 put("sysrng.always", "-fno-lto")
 
-# Miracl - only ECP to derive public key from private key
-put("ecp_BLS12381.always", "-fno-lto")
-
 # ############################################################
 #
 #                    Spurious warnings

--- a/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
+++ b/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
@@ -13,9 +13,9 @@ Example: secp256k1
 
 ### Compiling directly the C files
 
-Example: zlib
+Example: MIRACL Core
 
-[https://github.com/status-im/nim-zlib/blob/master/zlib/zlib_api.nim](https://github.com/status-im/nim-zlib/blob/master/zlib/zlib_api.nim)
+[https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim](https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim)
 
 ## Wrapping C++
 

--- a/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
+++ b/docs/the_auditors_handbook/src/02.5_foreign_lang_to_from_interop.md
@@ -13,9 +13,9 @@ Example: secp256k1
 
 ### Compiling directly the C files
 
-Example: MIRACL Core
+Example: zlib
 
-[https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim](https://github.com/status-im/nim-blscurve/blob/master/blscurve/miracl/miracl.nim)
+[https://github.com/status-im/nim-zlib/blob/master/zlib/zlib_api.nim](https://github.com/status-im/nim-zlib/blob/master/zlib/zlib_api.nim)
 
 ## Wrapping C++
 


### PR DESCRIPTION
EIP-4844 requires BLST via `nim-kzg4844`; MIRACL Core is not supported. Therefore, remove support for the MIRACL Core backend.

- https://github.com/status-im/nim-blscurve/pull/170