### PR TITLE
use correct signing fork after Deneb when using `deposits exit` command

### DIFF
--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -254,7 +254,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
            reason = exc.msg
     quit 1
 
-  debug "Signing fork obtained", fork = fork
+  debug "Signing fork obtained", fork, signingFork
 
   if not config.printData:
     case askForExitConfirmation()
@@ -292,7 +292,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
                                         validatorKeyAsStr,
                                         exitAtEpoch,
                                         validatorIdx,
-                                        fork,
+                                        signingFork,
                                         genesis_validators_root)
 
     if config.printData:


### PR DESCRIPTION
In #5120, the `nimbus_beacon_node deposits exit` command was updated for compatibility with EIP-7044, which forces signatures to be made using `CAPELLA_FORK_VERSION` regardless of the `VoluntaryExit`'s `epoch` after Deneb is activated.

This update had a regression, as an older mechanism was used to fetch `RuntimeConfig`, resulting in an encoding issue (#5362). This was then fixed in #5370, restoring general `deposits exit` functionality.

However, the logic from #5120 has another flaw, as it uses an incorrect fork version based on the pre-Deneb logic even after Deneb and EIP-7044 are activated. Fix this now, so that `deposits exit` continues to work correctly after Deneb activates.