### PR TITLE
in VC, extract all fork versions/epochs instead of just altair epoch

### DIFF
--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -220,33 +220,20 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
            reason = exc.msg
     quit 1
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#voluntary-exits
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/deneb/beacon-chain.md#modified-process_voluntary_exit
   let signingFork = try:
     let response = await client.getSpecVC()
     if response.status == 200:
-      let
-        spec = response.data.data
-        denebForkEpoch =
-          block:
-            let s = spec.getOrDefault("DENEB_FORK_EPOCH", $FAR_FUTURE_EPOCH)
-            Epoch(Base10.decode(uint64, s).get(uint64(FAR_FUTURE_EPOCH)))
-      # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#voluntary-exits
-      # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/deneb/beacon-chain.md#modified-process_voluntary_exit
-      if currentEpoch >= denebForkEpoch:
-        let capellaForkVersion =
-          block:
-            var res: Version
-            # CAPELLA_FOR_VERSION has specific format - "0x01000000", so
-            # default empty string is invalid, so `hexToByteArrayStrict`
-            # will raise exception on empty string.
-            let s = spec.getOrDefault("CAPELLA_FORK_VERSION", "")
-            hexToByteArrayStrict(s, distinctBase(res))
-            res
-        Fork(
-          current_version: capellaForkVersion,
-          previous_version: capellaForkVersion,
-          epoch: GENESIS_EPOCH)  # irrelevant when current/previous identical
-      else:
-        fork
+      let forkConfig = response.data.data.getConsensusForkConfig()
+      if forkConfig.isErr:
+        raise newException(RestError, "Invalid config: " & forkConfig.error)
+      let capellaForkVersion =
+        forkConfig.get.consensusForkVersion(ConsensusFork.Capella).valueOr:
+          raise newException(RestError,
+            ConsensusFork.Capella.forkVersionConfigKey() & " missing")
+      withConsensusFork(forkConfig.get.consensusForkAtEpoch(currentEpoch)):
+        consensusFork.voluntary_exit_signature_fork(fork, capellaForkVersion)
     else:
       raise newException(RestError, "Error response (" & $response.status & ")")
   except CatchableError as exc:

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -210,7 +210,8 @@ proc pollForSyncCommitteeDuties*(
   let
     vc = service.client
     indices = toSeq(vc.attachedValidators[].indices())
-    epoch = max(period.start_epoch(), vc.runtimeConfig.altairEpoch.get())
+    altairEpoch = vc.consensusForkEpoch(ConsensusFork.Altair).get()
+    epoch = max(period.start_epoch(), altairEpoch)
     relevantDuties =
       block:
         var duties: seq[RestSyncCommitteeDuty]
@@ -369,7 +370,7 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef) {.async.} =
   let
     currentSlot = vc.getCurrentSlot().get(Slot(0))
     currentEpoch = currentSlot.epoch()
-    altairEpoch = vc.runtimeConfig.altairEpoch.valueOr:
+    altairEpoch = vc.consensusForkEpoch(ConsensusFork.Altair).valueOr:
       return
 
   if currentEpoch < altairEpoch:


### PR DESCRIPTION
In the past, VC needed to know `ALTAIR_FORK_EPOCH` to determine whether sync committee duties need to be performed. Now, with EIP-7044, it additionally needs to know `CAPELLA_FORK_VERSION` and `DENEB_FORK_EPOCH` to create `VoluntaryExit` signatures post-Deneb.

These specific constants need to be accessed by name. They cannot be derived from the `/eth/v1/config/fork_schedule` endpoint, because that endpoint only provides the information needed for regular signatures. Notably, it does not state what `Fork` belongs to which `ConsensusFork`, and also does not indicate whether the underlying schedule is canonical, or whether it may be from a completely unsupported network, e.g., devnet for Verkle which currently uses a Verkle fork on top of Capella instead of Deneb. So, a heuristic which simply assumes that the fifth fork is Deneb is not reliable.

As it seems to be recurring practice that VC needs to access fork config related config.yaml keys, extend `ValidatorRuntimeConfig` to extract all `ConsensusFork` specific constants. Further validate that the retrieved info is consistent (monotonically increasing `_FORK_EPOCH`) and avoid extracting information about forks that are still subject to change (scheduled at `FAR_FUTURE_EPOCH`).

Note that this is a pre-requisite for implementing EIP-7044 into keymanager. Submitted separately due to the size of this patch.