### PR TITLE
add EIP-7044 support to keymanager API

### DIFF
--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -220,33 +220,19 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
            reason = exc.msg
     quit 1
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#voluntary-exits
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/deneb/beacon-chain.md#modified-process_voluntary_exit
   let signingFork = try:
     let response = await client.getSpecVC()
     if response.status == 200:
-      let
-        spec = response.data.data
-        denebForkEpoch =
-          block:
-            let s = spec.getOrDefault("DENEB_FORK_EPOCH", $FAR_FUTURE_EPOCH)
-            Epoch(Base10.decode(uint64, s).get(uint64(FAR_FUTURE_EPOCH)))
-      # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#voluntary-exits
-      # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/deneb/beacon-chain.md#modified-process_voluntary_exit
-      if currentEpoch >= denebForkEpoch:
-        let capellaForkVersion =
-          block:
-            var res: Version
-            # CAPELLA_FOR_VERSION has specific format - "0x01000000", so
-            # default empty string is invalid, so `hexToByteArrayStrict`
-            # will raise exception on empty string.
-            let s = spec.getOrDefault("CAPELLA_FORK_VERSION", "")
-            hexToByteArrayStrict(s, distinctBase(res))
-            res
-        Fork(
-          current_version: capellaForkVersion,
-          previous_version: capellaForkVersion,
-          epoch: GENESIS_EPOCH)  # irrelevant when current/previous identical
-      else:
-        fork
+      let forkConfig = response.data.data.getConsensusForkConfig()
+      if forkConfig.isErr:
+        raise newException(RestError, "Invalid config: " & forkConfig.error)
+      let capellaForkVersion = forkConfig.get.CAPELLA_FORK_VERSION.valueOr:
+        raise newException(RestError,
+          ConsensusFork.Capella.forkVersionConfigKey() & " missing")
+      voluntary_exit_signature_fork(
+        fork, capellaForkVersion, currentEpoch, forkConfig.get.DENEB_FORK_EPOCH)
     else:
       raise newException(RestError, "Error response (" & $response.status & ")")
   except CatchableError as exc:

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -228,11 +228,11 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
       let forkConfig = response.data.data.getConsensusForkConfig()
       if forkConfig.isErr:
         raise newException(RestError, "Invalid config: " & forkConfig.error)
-      let capellaForkVersion = forkConfig.get.CAPELLA_FORK_VERSION.valueOr:
+      let capellaForkVersion = forkConfig.get.capellaVersion.valueOr:
         raise newException(RestError,
           ConsensusFork.Capella.forkVersionConfigKey() & " missing")
       voluntary_exit_signature_fork(
-        fork, capellaForkVersion, currentEpoch, forkConfig.get.DENEB_FORK_EPOCH)
+        fork, capellaForkVersion, currentEpoch, forkConfig.get.denebEpoch)
     else:
       raise newException(RestError, "Error response (" & $response.status & ")")
   except CatchableError as exc:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -758,6 +758,12 @@ proc init*(T: type BeaconNode,
     withState(dag.headState):
       getValidator(forkyState().data.validators.asSeq(), pubkey)
 
+  func getCapellaForkVersion(): Opt[Version] =
+    Opt.some(cfg.CAPELLA_FORK_VERSION)
+
+  func getDenebForkEpoch(): Opt[Epoch] =
+    Opt.some(cfg.DENEB_FORK_EPOCH)
+
   proc getForkForEpoch(epoch: Epoch): Opt[Fork] =
     Opt.some(dag.forkAtEpoch(epoch))
 
@@ -787,6 +793,8 @@ proc init*(T: type BeaconNode,
         config.getPayloadBuilderAddress,
         getValidatorAndIdx,
         getBeaconTime,
+        getCapellaForkVersion,
+        getDenebForkEpoch,
         getForkForEpoch,
         getGenesisRoot)
     else: nil

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -348,6 +348,18 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
   let
     keymanagerInitResult = initKeymanagerServer(vc.config, nil)
 
+  func getCapellaForkVersion(): Opt[Version] =
+    if vc.runtimeConfig.forkConfig.isSome():
+      vc.runtimeConfig.forkConfig.get().CAPELLA_FORK_VERSION
+    else:
+      Opt.none(Version)
+
+  func getDenebForkEpoch(): Opt[Epoch] =
+    if vc.runtimeConfig.forkConfig.isSome():
+      Opt.some(vc.runtimeConfig.forkConfig.get().DENEB_FORK_EPOCH)
+    else:
+      Opt.none(Epoch)
+
   proc getForkForEpoch(epoch: Epoch): Opt[Fork] =
     if len(vc.forks) > 0:
       Opt.some(vc.forkAtEpoch(epoch))
@@ -379,6 +391,8 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
         Opt.none(string),
         nil,
         vc.beaconClock.getBeaconTimeFn,
+        getCapellaForkVersion,
+        getDenebForkEpoch,
         getForkForEpoch,
         getGenesisRoot
         )

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -4,6 +4,9 @@
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import
   stew/io2, presto, metrics, metrics/chronos_httpserver,
   ./rpc/rest_key_management_api,
@@ -350,13 +353,13 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.async.} =
 
   func getCapellaForkVersion(): Opt[Version] =
     if vc.runtimeConfig.forkConfig.isSome():
-      vc.runtimeConfig.forkConfig.get().CAPELLA_FORK_VERSION
+      vc.runtimeConfig.forkConfig.get().capellaVersion
     else:
       Opt.none(Version)
 
   func getDenebForkEpoch(): Opt[Epoch] =
     if vc.runtimeConfig.forkConfig.isSome():
-      Opt.some(vc.runtimeConfig.forkConfig.get().DENEB_FORK_EPOCH)
+      Opt.some(vc.runtimeConfig.forkConfig.get().denebEpoch)
     else:
       Opt.none(Epoch)
 

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -241,6 +241,10 @@ const
     "The given Merkle proof is invalid"
   InvalidMerkleProofIndexError* =
     "The given Merkle proof index is invalid"
+  FailedToObtainForkVersionError* =
+    "Failed to obtain fork version"
+  FailedToObtainConsensusForkError* =
+    "Failed to obtain ConsensusFork information"
   FailedToObtainForkError* =
     "Failed to obtain fork information"
   InvalidTimestampValue* =

--- a/beacon_chain/rpc/rest_constants.nim
+++ b/beacon_chain/rpc/rest_constants.nim
@@ -244,7 +244,7 @@ const
   FailedToObtainForkVersionError* =
     "Failed to obtain fork version"
   FailedToObtainConsensusForkError* =
-    "Failed to obtain ConsensusFork information"
+    "Failed to obtain consensus fork information"
   FailedToObtainForkError* =
     "Failed to obtain fork information"
   InvalidTimestampValue* =

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -1,8 +1,11 @@
+# beacon_chain
 # Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 # NOTE: This module has been used in both `beacon_node` and `validator_client`,
 # please keep imports clear of `rest_utils` or any other module which imports

--- a/beacon_chain/spec/eth2_apis/rest_beacon_client.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_client.nim
@@ -13,7 +13,8 @@ import
     rest_beacon_calls, rest_builder_calls, rest_config_calls, rest_debug_calls,
     rest_keymanager_calls, rest_light_client_calls,
     rest_node_calls, rest_validator_calls,
-    rest_nimbus_calls, rest_event_calls, rest_common
+    rest_nimbus_calls, rest_event_calls, rest_common,
+    rest_fork_config
   ]
 
 export
@@ -21,4 +22,5 @@ export
   rest_beacon_calls, rest_builder_calls, rest_config_calls, rest_debug_calls,
   rest_keymanager_calls, rest_light_client_calls,
   rest_node_calls, rest_validator_calls,
-  rest_nimbus_calls, rest_event_calls, rest_common
+  rest_nimbus_calls, rest_event_calls, rest_common,
+  rest_fork_config

--- a/beacon_chain/spec/eth2_apis/rest_fork_config.nim
+++ b/beacon_chain/spec/eth2_apis/rest_fork_config.nim
@@ -12,16 +12,15 @@ import
   stew/[base10, byteutils],
   ../forks
 
-export forks
+from ./rest_types import VCRuntimeConfig
 
-type
-  VCRuntimeConfig* = Table[string, string]
+export forks, rest_types
 
-  VCForkConfig* = object
-    altairEpoch*: Epoch
-    capellaVersion*: Opt[Version]
-    capellaEpoch*: Epoch
-    denebEpoch*: Epoch
+type VCForkConfig* = object
+  altairEpoch*: Epoch
+  capellaVersion*: Opt[Version]
+  capellaEpoch*: Epoch
+  denebEpoch*: Epoch
 
 func forkVersionConfigKey*(consensusFork: ConsensusFork): string =
   if consensusFork > ConsensusFork.Phase0:

--- a/beacon_chain/spec/eth2_apis/rest_fork_config.nim
+++ b/beacon_chain/spec/eth2_apis/rest_fork_config.nim
@@ -46,7 +46,7 @@ func getForkVersion(
     info: VCRuntimeConfig,
     consensusFork: Consensusfork): Result[Opt[Version], string] =
   let key = consensusFork.forkVersionConfigKey()
-  let stringValue = info.getOrDefault("missing")
+  let stringValue = info.getOrDefault(key, "missing")
   if stringValue == "missing": return ok Opt.none(Version)
   var value: Version
   try:

--- a/beacon_chain/spec/eth2_apis/rest_fork_config.nim
+++ b/beacon_chain/spec/eth2_apis/rest_fork_config.nim
@@ -1,0 +1,98 @@
+# beacon_chain
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import
+  std/strutils,
+  stew/[base10, byteutils],
+  ../forks
+
+export forks
+
+type
+  VCRuntimeConfig* = Table[string, string]
+
+  VCForkConfig* = object
+    altairEpoch*: Epoch
+    capellaVersion*: Opt[Version]
+    capellaEpoch*: Epoch
+    denebEpoch*: Epoch
+
+func forkVersionConfigKey*(consensusFork: ConsensusFork): string =
+  if consensusFork > ConsensusFork.Phase0:
+    ($consensusFork).toUpperAscii() & "_FORK_VERSION"
+  else:
+    "GENESIS_FORK_VERSION"
+
+func forkEpochConfigKey*(consensusFork: ConsensusFork): string =
+  doAssert consensusFork > ConsensusFork.Phase0
+  ($consensusFork).toUpperAscii() & "_FORK_EPOCH"
+
+proc getOrDefault*(info: VCRuntimeConfig, name: string,
+                   default: uint64): uint64 =
+  let numstr = info.getOrDefault(name, "missing")
+  if numstr == "missing": return default
+  Base10.decode(uint64, numstr).valueOr:
+    return default
+
+proc getOrDefault*(info: VCRuntimeConfig, name: string, default: Epoch): Epoch =
+  Epoch(info.getOrDefault(name, uint64(default)))
+
+func getForkVersion(
+    info: VCRuntimeConfig,
+    consensusFork: Consensusfork): Result[Opt[Version], string] =
+  let key = consensusFork.forkVersionConfigKey()
+  let stringValue = info.getOrDefault("missing")
+  if stringValue == "missing": return ok Opt.none(Version)
+  var value: Version
+  try:
+    hexToByteArrayStrict(stringValue, distinctBase(value))
+  except ValueError as exc:
+    return err(key & " is invalid: " & exc.msg)
+  ok Opt.some value
+
+func getForkEpoch(info: VCRuntimeConfig, consensusFork: ConsensusFork): Epoch =
+  if consensusFork > ConsensusFork.Phase0:
+    let key = consensusFork.forkEpochConfigKey()
+    info.getOrDefault(key, FAR_FUTURE_EPOCH)
+  else:
+    GENESIS_EPOCH
+
+func getConsensusForkConfig*(
+    info: VCRuntimeConfig): Result[VCForkConfig, string] =
+  ## This extracts all `_FORK_VERSION` and `_FORK_EPOCH` constants
+  ## that are relevant for Validator Client operation.
+  ##
+  ## Note that the fork schedule (`/eth/v1/config/fork_schedule`) cannot be used
+  ## because it does not indicate whether the forks refer to `ConsensusFork` or
+  ## to a different fork sequence from an incompatible network (e.g., devnet)
+  let
+    res = VCForkConfig(
+      altairEpoch: info.getForkEpoch(ConsensusFork.Altair),
+      capellaVersion: ? info.getForkVersion(ConsensusFork.Capella),
+      capellaEpoch: info.getForkEpoch(ConsensusFork.Capella),
+      denebEpoch: info.getForkEpoch(ConsensusFork.Deneb))
+
+  if res.capellaEpoch < res.altairEpoch:
+    return err(
+      "Fork epochs are inconsistent, " & $ConsensusFork.Capella &
+      " is scheduled at epoch " & $res.capellaEpoch &
+      " which is before prior fork epoch " & $res.altairEpoch)
+  if res.denebEpoch < res.capellaEpoch:
+    return err(
+      "Fork epochs are inconsistent, " & $ConsensusFork.Deneb &
+      " is scheduled at epoch " & $res.denebEpoch &
+      " which is before prior fork epoch " & $res.capellaEpoch)
+
+  if res.capellaEpoch != FAR_FUTURE_EPOCH and res.capellaVersion.isNone:
+    return err(
+      "Beacon node has scheduled " &
+      ConsensusFork.Capella.forkEpochConfigKey() &
+      " but does not report " &
+      ConsensusFork.Capella.forkVersionConfigKey())
+  ok res

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -14,16 +14,18 @@
 # carefully!
 
 import
-  std/[json, strutils, tables],
-  stew/[base10, byteutils], web3/primitives, httputils,
+  std/[json, tables],
+  stew/base10, web3/primitives, httputils,
   ".."/forks,
   ".."/datatypes/[phase0, altair, bellatrix, deneb, electra],
   ".."/mev/[capella_mev, deneb_mev]
 
 from ".."/datatypes/capella import BeaconBlockBody
 
+from ./rest_fork_config import VCRuntimeConfig
+
 export forks, phase0, altair, bellatrix, capella, capella_mev, deneb_mev,
-       tables, httputils
+       tables, httputils, rest_fork_config
 
 const
   # https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/states/validator_balances.yaml#L17
@@ -367,13 +369,6 @@ type
 
   ProduceBlockResponseV3* = ForkedMaybeBlindedBeaconBlock
 
-  VCRuntimeConfig* = Table[string, string]
-  VCForkConfig* = object
-    ALTAIR_FORK_EPOCH*: Epoch
-    CAPELLA_FORK_VERSION*: Opt[Version]
-    CAPELLA_FORK_EPOCH*: Epoch
-    DENEB_FORK_EPOCH*: Epoch
-
   RestDepositContract* = object
     chain_id*: string
     address*: string
@@ -627,92 +622,6 @@ type
     finalized_checkpoint*: Checkpoint
     fork_choice_nodes*: seq[RestNode]
     extra_data*: RestExtraData
-
-func forkVersionConfigKey*(consensusFork: ConsensusFork): string =
-  if consensusFork > ConsensusFork.Phase0:
-    ($consensusFork).toUpperAscii() & "_FORK_VERSION"
-  else:
-    "GENESIS_FORK_VERSION"
-
-func forkEpochConfigKey*(consensusFork: ConsensusFork): string =
-  doAssert consensusFork > ConsensusFork.Phase0
-  ($consensusFork).toUpperAscii() & "_FORK_EPOCH"
-
-proc getOrDefault*(info: VCRuntimeConfig, name: string,
-                   default: uint64): uint64 =
-  let numstr = info.getOrDefault(name, "missing")
-  if numstr == "missing": return default
-  Base10.decode(uint64, numstr).valueOr:
-    return default
-
-proc getOrDefault*(info: VCRuntimeConfig, name: string, default: Epoch): Epoch =
-  Epoch(info.getOrDefault(name, uint64(default)))
-
-func getForkVersion(
-    info: VCRuntimeConfig,
-    consensusFork: Consensusfork): Result[Opt[Version], string] =
-  let key = consensusFork.forkVersionConfigKey()
-  if not info.hasKey(key):
-    return ok Opt.none(Version)
-  let stringValue =
-    try:
-      info[key]
-    except KeyError:
-      raiseAssert "just checked"
-  var value: Version
-  try:
-    hexToByteArrayStrict(stringValue, distinctBase(value))
-  except ValueError as exc:
-    return err(key & " is invalid: " & exc.msg)
-  ok Opt.some value
-
-func getForkEpoch(info: VCRuntimeConfig, consensusFork: ConsensusFork): Epoch =
-  if consensusFork > ConsensusFork.Phase0:
-    let key = consensusFork.forkEpochConfigKey()
-    info.getOrDefault(key, FAR_FUTURE_EPOCH)
-  else:
-    GENESIS_EPOCH
-
-func getConsensusForkConfig*(
-    info: VCRuntimeConfig): Result[VCForkConfig, string] =
-  ## This extracts all `_FORK_VERSION` and `_FORK_EPOCH` constants
-  ## that are relevant for Validator Client operation.
-  ##
-  ## Note that the fork schedule (`/eth/v1/config/fork_schedule`) cannot be used
-  ## because it does not indicate whether the forks refer to `ConsensusFork` or
-  ## to a different fork sequence from an incompatible network (e.g., devnet)
-  let
-    res = VCForkConfig(
-      ALTAIR_FORK_EPOCH: info.getForkEpoch(ConsensusFork.Altair),
-      CAPELLA_FORK_VERSION: ? info.getForkVersion(ConsensusFork.Capella),
-      CAPELLA_FORK_EPOCH: info.getForkEpoch(ConsensusFork.Capella),
-      DENEB_FORK_EPOCH: info.getForkEpoch(ConsensusFork.Deneb))
-
-  if res.CAPELLA_FORK_EPOCH < res.ALTAIR_FORK_EPOCH:
-    return err(
-      "Fork epochs are inconsistent, " &
-      $ConsensusFork.Capella &
-      " is scheduled at epoch " &
-      $res.CAPELLA_FORK_EPOCH &
-      " which is before prior fork epoch " &
-      $res.ALTAIR_FORK_EPOCH)
-  if res.DENEB_FORK_EPOCH < res.CAPELLA_FORK_EPOCH:
-    return err(
-      "Fork epochs are inconsistent, " &
-      $ConsensusFork.Deneb &
-      " is scheduled at epoch " &
-      $res.DENEB_FORK_EPOCH &
-      " which is before prior fork epoch " &
-      $res.CAPELLA_FORK_EPOCH)
-
-  if res.CAPELLA_FORK_EPOCH != FAR_FUTURE_EPOCH and
-      res.CAPELLA_FORK_VERSION.isNone:
-    return err(
-      "Beacon node has scheduled " &
-      ConsensusFork.Capella.forkEpochConfigKey() &
-      " but does not report " &
-      ConsensusFork.Capella.forkVersionConfigKey())
-  ok res
 
 func `==`*(a, b: RestValidatorIndex): bool =
   uint64(a) == uint64(b)

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -22,10 +22,8 @@ import
 
 from ".."/datatypes/capella import BeaconBlockBody
 
-from ./rest_fork_config import VCRuntimeConfig
-
 export forks, phase0, altair, bellatrix, capella, capella_mev, deneb_mev,
-       tables, httputils, rest_fork_config
+       tables, httputils
 
 const
   # https://github.com/ethereum/eth2.0-APIs/blob/master/apis/beacon/states/validator_balances.yaml#L17
@@ -368,6 +366,8 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.BlockContents
 
   ProduceBlockResponseV3* = ForkedMaybeBlindedBeaconBlock
+
+  VCRuntimeConfig* = Table[string, string]
 
   RestDepositContract* = object
     chain_id*: string

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -192,7 +192,7 @@ type
     waiters*: seq[BlockWaiter]
 
   ValidatorRuntimeConfig* = object
-    altairEpoch*: Opt[Epoch]
+    forkConfig*: Opt[VCForkConfig]
 
   ValidatorClient* = object
     config*: ValidatorClientConf
@@ -517,16 +517,6 @@ proc equals*(info: VCRuntimeConfig, name: string, check: DomainType): bool =
 
 proc equals*(info: VCRuntimeConfig, name: string, check: Epoch): bool =
   info.equals(name, uint64(check))
-
-proc getOrDefault*(info: VCRuntimeConfig, name: string,
-                   default: uint64): uint64 =
-  let numstr = info.getOrDefault(name, "missing")
-  if numstr == "missing": return default
-  Base10.decode(uint64, numstr).valueOr:
-    return default
-
-proc getOrDefault*(info: VCRuntimeConfig, name: string, default: Epoch): Epoch =
-  Epoch(info.getOrDefault(name, uint64(default)))
 
 proc checkConfig*(c: VCRuntimeConfig): bool =
   c.equals("MAX_VALIDATORS_PER_COMMITTEE", MAX_VALIDATORS_PER_COMMITTEE) and
@@ -1436,33 +1426,87 @@ func `==`*(a, b: SyncCommitteeDuty): bool =
 proc updateRuntimeConfig*(vc: ValidatorClientRef,
                           node: BeaconNodeServerRef,
                           info: VCRuntimeConfig): Result[void, string] =
-  if not(info.hasKey("ALTAIR_FORK_EPOCH")):
-    debug "Beacon node's configuration missing ALTAIR_FORK_EPOCH value",
-          node = node
+  var forkConfig = ? info.getConsensusForkConfig()
 
-  let
-    res = info.getOrDefault("ALTAIR_FORK_EPOCH", FAR_FUTURE_EPOCH)
-    wallEpoch = vc.beaconClock.now().slotOrZero().epoch()
+  if vc.runtimeConfig.forkConfig.isNone():
+    vc.runtimeConfig.forkConfig = Opt.some(forkConfig)
+  else:
+    template localForkConfig: untyped = vc.runtimeConfig.forkConfig.get()
+    let wallEpoch = vc.beaconClock.now().slotOrZero().epoch()
 
-  return
-    if vc.runtimeConfig.altairEpoch.get(FAR_FUTURE_EPOCH) == FAR_FUTURE_EPOCH:
-      vc.runtimeConfig.altairEpoch = Opt.some(res)
-      ok()
-    else:
-      if res == vc.runtimeConfig.altairEpoch.get():
-        ok()
+    proc validateForkVersionCompatibility(
+        consensusFork: ConsensusFork,
+        localForkVersion: Opt[Version],
+        localForkEpoch: Epoch,
+        forkVersion: Opt[Version]): Result[void, string] =
+      if localForkVersion.isNone():
+        discard  # Potentially discovered new fork, save it at end of function
       else:
-        if res == FAR_FUTURE_EPOCH:
-          if wallEpoch < vc.runtimeConfig.altairEpoch.get():
-            debug "Beacon node must be updated before Altair activates",
-                  node = node,
-                  altairForkEpoch = vc.runtimeConfig.altairEpoch.get()
-            ok()
+        if forkVersion.isSome():
+          if forkVersion.get() == localForkVersion.get():
+            discard  # Already known
           else:
-            err("Beacon node must be updated and report correct " &
-                "ALTAIR_FORK_EPOCH value")
+            return err("Beacon node has conflicting " &
+                       consensusFork.forkVersionConfigKey() & " value")
         else:
-          err("Beacon node has conflicting ALTAIR_FORK_EPOCH value")
+          if wallEpoch < localForkEpoch:
+            debug "Beacon node must be updated before fork activates",
+                  node = node,
+                  consensusFork,
+                  forkEpoch = localForkEpoch
+          else:
+            return err("Beacon node must be updated and report correct " &
+                       $consensusFork & " config value")
+
+    ? ConsensusFork.Capella.validateForkVersionCompatibility(
+      localForkConfig.CAPELLA_FORK_VERSION,
+      localForkConfig.CAPELLA_FORK_EPOCH,
+      forkConfig.CAPELLA_FORK_VERSION)
+
+    proc validateForkEpochCompatibility(
+        consensusFork: ConsensusFork,
+        localForkEpoch: Epoch,
+        forkEpoch: Epoch): Result[void, string] =
+      if localForkEpoch == FAR_FUTURE_EPOCH:
+        discard  # Potentially discovered new fork, save it at end of function
+      else:
+        if forkEpoch != FAR_FUTURE_EPOCH:
+          if forkEpoch == localForkEpoch:
+            discard  # Already known
+          else:
+            return err("Beacon node has conflicting " &
+                       consensusFork.forkEpochConfigKey() & " value")
+        else:
+          if wallEpoch < localForkEpoch:
+            debug "Beacon node must be updated before fork activates",
+                  node = node,
+                  consensusFork,
+                  forkEpoch = localForkEpoch
+          else:
+            return err("Beacon node must be updated and report correct " &
+                       $consensusFork & " config value")
+
+    ? ConsensusFork.Altair.validateForkEpochCompatibility(
+      localForkConfig.ALTAIR_FORK_EPOCH,
+      forkConfig.ALTAIR_FORK_EPOCH)
+    ? ConsensusFork.Capella.validateForkEpochCompatibility(
+      localForkConfig.CAPELLA_FORK_EPOCH,
+      forkConfig.CAPELLA_FORK_EPOCH)
+    ? ConsensusFork.Deneb.validateForkEpochCompatibility(
+      localForkConfig.DENEB_FORK_EPOCH,
+      forkConfig.DENEB_FORK_EPOCH)
+
+    # Save newly discovered forks.
+    if localForkConfig.ALTAIR_FORK_EPOCH == FAR_FUTURE_EPOCH:
+      localForkConfig.ALTAIR_FORK_EPOCH = forkConfig.ALTAIR_FORK_EPOCH
+    if localForkConfig.CAPELLA_FORK_VERSION.isNone():
+      localForkConfig.CAPELLA_FORK_VERSION = forkConfig.CAPELLA_FORK_VERSION
+    if localForkConfig.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH:
+      localForkConfig.CAPELLA_FORK_EPOCH = forkConfig.CAPELLA_FORK_EPOCH
+    if localForkConfig.DENEB_FORK_EPOCH == FAR_FUTURE_EPOCH:
+      localForkConfig.DENEB_FORK_EPOCH = forkConfig.DENEB_FORK_EPOCH
+
+  ok()
 
 proc `+`*(slot: Slot, epochs: Epoch): Slot =
   slot + uint64(epochs) * SLOTS_PER_EPOCH

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1459,9 +1459,9 @@ proc updateRuntimeConfig*(vc: ValidatorClientRef,
                        $consensusFork & " config value")
 
     ? ConsensusFork.Capella.validateForkVersionCompatibility(
-      localForkConfig.CAPELLA_FORK_VERSION,
-      localForkConfig.CAPELLA_FORK_EPOCH,
-      forkConfig.CAPELLA_FORK_VERSION)
+      localForkConfig.capellaVersion,
+      localForkConfig.capellaEpoch,
+      forkConfig.capellaVersion)
 
     proc validateForkEpochCompatibility(
         consensusFork: ConsensusFork,
@@ -1487,24 +1487,21 @@ proc updateRuntimeConfig*(vc: ValidatorClientRef,
                        $consensusFork & " config value")
 
     ? ConsensusFork.Altair.validateForkEpochCompatibility(
-      localForkConfig.ALTAIR_FORK_EPOCH,
-      forkConfig.ALTAIR_FORK_EPOCH)
+      localForkConfig.altairEpoch, forkConfig.altairEpoch)
     ? ConsensusFork.Capella.validateForkEpochCompatibility(
-      localForkConfig.CAPELLA_FORK_EPOCH,
-      forkConfig.CAPELLA_FORK_EPOCH)
+      localForkConfig.capellaEpoch, forkConfig.capellaEpoch)
     ? ConsensusFork.Deneb.validateForkEpochCompatibility(
-      localForkConfig.DENEB_FORK_EPOCH,
-      forkConfig.DENEB_FORK_EPOCH)
+      localForkConfig.denebEpoch, forkConfig.denebEpoch)
 
     # Save newly discovered forks.
-    if localForkConfig.ALTAIR_FORK_EPOCH == FAR_FUTURE_EPOCH:
-      localForkConfig.ALTAIR_FORK_EPOCH = forkConfig.ALTAIR_FORK_EPOCH
-    if localForkConfig.CAPELLA_FORK_VERSION.isNone():
-      localForkConfig.CAPELLA_FORK_VERSION = forkConfig.CAPELLA_FORK_VERSION
-    if localForkConfig.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH:
-      localForkConfig.CAPELLA_FORK_EPOCH = forkConfig.CAPELLA_FORK_EPOCH
-    if localForkConfig.DENEB_FORK_EPOCH == FAR_FUTURE_EPOCH:
-      localForkConfig.DENEB_FORK_EPOCH = forkConfig.DENEB_FORK_EPOCH
+    if localForkConfig.altairEpoch == FAR_FUTURE_EPOCH:
+      localForkConfig.altairEpoch = forkConfig.altairEpoch
+    if localForkConfig.capellaVersion.isNone():
+      localForkConfig.capellaVersion = forkConfig.capellaVersion
+    if localForkConfig.capellaEpoch == FAR_FUTURE_EPOCH:
+      localForkConfig.capellaEpoch = forkConfig.capellaEpoch
+    if localForkConfig.denebEpoch == FAR_FUTURE_EPOCH:
+      localForkConfig.denebEpoch = forkConfig.denebEpoch
 
   ok()
 

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import std/[sets, sequtils]
 import chronicles, metrics
 import "."/[common, api, block_service, selection_proofs]
@@ -210,7 +212,7 @@ proc pollForSyncCommitteeDuties*(
   let
     vc = service.client
     indices = toSeq(vc.attachedValidators[].indices())
-    altairEpoch = vc.runtimeConfig.forkConfig.get().ALTAIR_FORK_EPOCH
+    altairEpoch = vc.runtimeConfig.forkConfig.get().altairEpoch
     epoch = max(period.start_epoch(), altairEpoch)
     relevantDuties =
       block:
@@ -372,7 +374,7 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef) {.async.} =
     currentEpoch = currentSlot.epoch()
     altairEpoch =
       if vc.runtimeConfig.forkConfig.isSome():
-        vc.runtimeConfig.forkConfig.get().ALTAIR_FORK_EPOCH
+        vc.runtimeConfig.forkConfig.get().altairEpoch
       else:
         return
 

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -73,6 +73,10 @@ type
     proc (pubkey: ValidatorPubKey): Opt[ValidatorAndIndex]
          {.raises: [], gcsafe.}
 
+  GetCapellaForkVersionFn* =
+    proc (): Opt[Version] {.raises: [], gcsafe.}
+  GetDenebForkEpochFn* =
+    proc (): Opt[Epoch] {.raises: [], gcsafe.}
   GetForkFn* =
     proc (epoch: Epoch): Opt[Fork] {.raises: [], gcsafe.}
   GetGenesisFn* =
@@ -90,6 +94,8 @@ type
     defaultBuilderAddress*: Opt[string]
     getValidatorAndIdxFn*: ValidatorPubKeyToDataFn
     getBeaconTimeFn*: GetBeaconTimeFn
+    getCapellaForkVersionFn*: GetCapellaForkVersionFn
+    getDenebForkEpochFn*: GetDenebForkEpochFn
     getForkFn*: GetForkFn
     getGenesisFn*: GetGenesisFn
 
@@ -122,6 +128,8 @@ func init*(T: type KeymanagerHost,
            defaultBuilderAddress: Opt[string],
            getValidatorAndIdxFn: ValidatorPubKeyToDataFn,
            getBeaconTimeFn: GetBeaconTimeFn,
+           getCapellaForkVersionFn: GetCapellaForkVersionFn,
+           getDenebForkEpochFn: GetDenebForkEpochFn,
            getForkFn: GetForkFn,
            getGenesisFn: GetGenesisFn): T =
   T(validatorPool: validatorPool,
@@ -135,6 +143,8 @@ func init*(T: type KeymanagerHost,
     defaultBuilderAddress: defaultBuilderAddress,
     getValidatorAndIdxFn: getValidatorAndIdxFn,
     getBeaconTimeFn: getBeaconTimeFn,
+    getCapellaForkVersionFn: getCapellaForkVersionFn,
+    getDenebForkEpochFn: getDenebForkEpochFn,
     getForkFn: getForkFn,
     getGenesisFn: getGenesisFn)
 

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -22,6 +22,7 @@ import
 
 export
   streams, keystore, phase0, altair, tables, uri, crypto,
+  signatures.voluntary_exit_signature_fork,
   rest_types, eth2_rest_serialization, rest_remote_signer_calls,
   slashing_protection
 


### PR DESCRIPTION
When trying to sign `VoluntaryExit` via keymanager API, the logic is not yet aware of EIP-7044 (part of Deneb). This patch adds missing EIP-7044 support to the keymanager API as well.

As part of this, the VC needs to become aware about:

- `CAPELLA_FORK_VERSION`: To correctly form the EIP-7044 signing domain. The fork schedule does not indicate which of the results, if any, corresponds to Capella.
- `CAPELLA_FORK_EPOCH`: To detect whether Capella was scheduled. If a BN does not have it in its config while other BNs have it, this leads to a log if Capella has not activated yet, or marks the BN as incompatible if Capella already activated.
- `DENEB_FORK_EPOCH`: To check whether EIP-7044 logic should be used.

Related PRs:

- #5120 added support for processing EIP-7044 `VoluntaryExit` messages as part of the state transition functions (tested by EF spec tests).
- #5953 synced the support from #5120 to gossip validation.
- #5954 added support to the `nimbus_beacon_node deposits exit` command.
- #5956 contains an alternative generic version of `VCForkConfig`.