### PR TITLE
fix `Eth-Consensus-Block-Value` reading

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -4014,7 +4014,7 @@ proc decodeBytes*[T: ProduceBlockResponseV3](
           Opt.none(Uint256)
         else:
           try:
-            Opt.some parse(headerPayloadValue, UInt256, 10)
+            Opt.some parse(headerConsensusValue, UInt256, 10)
           except ValueError:
             return err("Incorrect `Eth-Consensus-Block-Value` header value")
     withConsensusFork(fork):


### PR DESCRIPTION
Fix regression from #5842 where `Eth-Execution-Payload-Value` is parsed into `consensusValue` instead of `Eth-consensus-Block-Value`. We don't use those values for now, but fixing avoids hard-to-debug bugs later.