### PR TITLE
add `{.raises.}` annotations to `test_fixture_operations`

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -129,7 +130,7 @@ suite baseDescription & "Execution Payload " & preset():
   proc makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var bellatrix.BeaconState, body: bellatrix.BeaconBlockBody):
-        Result[void, cstring] =
+        Result[void, cstring] {.raises: [IOError].} =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -146,7 +147,7 @@ suite baseDescription & "Execution Payload " & preset():
   proc makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var capella.BeaconState, body: capella.BeaconBlockBody):
-        Result[void, cstring] =
+        Result[void, cstring] {.raises: [IOError].} =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [IOError].}
 {.used.}
 
 import
@@ -149,7 +150,7 @@ suite baseDescription & "Execution Payload " & preset():
   proc makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var deneb.BeaconState, body: deneb.BeaconBlockBody):
-        Result[void, cstring] =
+        Result[void, cstring] {.raises: [IOError].} =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [IOError].}
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/phase0/test_fixture_operations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import


### PR DESCRIPTION
Some more progress in making exception flow explicit.