### PR TITLE
avoid forgetting to quit in `os_ops` tools if log fails

### DIFF
--- a/tests/consensus_spec/os_ops.nim
+++ b/tests/consensus_spec/os_ops.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import std/os
 import stew/io2
 
@@ -13,8 +22,11 @@ proc readFile*(filename: string): string =
   let res = io2.readAllChars(filename)
   if res.isErr():
     writeStackTrace()
-    stderr.write "Could not load data from file \"", filename, "\"\n"
-    stderr.write "(" & $int(res.error()) & ") " & ioErrorMsg(res.error()), "\n"
+    try:
+      stderr.write "Could not load data from file \"", filename, "\"\n"
+      stderr.write "(" & $int(res.error()) & ") ", ioErrorMsg(res.error()), "\n"
+    except IOError:
+      discard
     quit 1
   res.get()
 
@@ -25,7 +37,10 @@ proc readFileBytes*(path: string): seq[byte] =
   let res = io2.readAllBytes(path)
   if res.isErr():
     writeStackTrace()
-    stderr.write "Could not load data from file \"", path, "\"\n"
-    stderr.write "(" & $int(res.error()) & ") " & ioErrorMsg(res.error()), "\n"
+    try:
+      stderr.write "Could not load data from file \"", path, "\"\n"
+      stderr.write "(" & $int(res.error()) & ") ", ioErrorMsg(res.error()), "\n"
+    except IOError:
+      discard
     quit 1
   res.get()


### PR DESCRIPTION
`stderr.write` may fail, e.g., if no tty is connected, which may happen in some CI configurations. Discard such failures and continue quitting instead of raising the error.