### PR TITLE
remove unnecessary exports in `eth2_discovery`

### DIFF
--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -24,10 +24,6 @@ type
   Eth2DiscoveryProtocol* = protocol.Protocol
   Eth2DiscoveryId* = NodeId
 
-export
-  Eth2DiscoveryProtocol, open, start, close, closeWait,
-    updateRecord, results
-
 func parseBootstrapAddress*(address: string):
     Result[enr.Record, cstring] =
   let lowerCaseAddress = toLowerAscii(string address)


### PR DESCRIPTION
The exports in `eth2_discovery` produce deprecation warnings as they refer to `close`, `closeWait` and so on. Turns out that they are not necessary at all. The `Eth2DiscoveryProtocol` is even already exported two lines above using `*` marker...