### PR TITLE
add trivial `{.push raises: [].}` to `research` and `test` folders

### DIFF
--- a/research/fakeee.nim
+++ b/research/fakeee.nim
@@ -1,13 +1,13 @@
-## Fake execution engine API implementation useful for testing beacon node without a running execution node
-
-# Nimbus
+# beacon_chain
 # Copyright (c) 2022-2024 Status Research & Development GmbH
-# Licensed under either of
-#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
-#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
-# at your option.
-# This file may not be copied, modified, or distributed except according to
-# those terms.
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+## Fake execution engine API implementation useful for testing beacon node without a running execution node
 
 import
   std/typetraits,

--- a/research/mev_mock.nim
+++ b/research/mev_mock.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   confutils, presto,
   ../beacon_chain/spec/datatypes/capella,

--- a/research/timing.nim
+++ b/research/timing.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import
   std/[times, stats]
 

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -5,11 +5,11 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 # `wss_sim` loads a state and a set of validator keys, then simulates a
 # beacon chain running with the given validators producing blocks
 # and attesting when they're supposed to.
-
-{.push raises: [].}
 
 import
   std/[strformat, sequtils, tables],

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 # All tests except scenarios, which as compiled separately for mainnet and minimal
 
 import

--- a/tests/consensus_spec/all_tests.nim
+++ b/tests/consensus_spec/all_tests.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 # BLS test vectors are covered by nim-blscurve:

--- a/tests/consensus_spec/altair/all_altair_fixtures.nim
+++ b/tests/consensus_spec/altair/all_altair_fixtures.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/altair/test_fixture_rewards.nim
+++ b/tests/consensus_spec/altair/test_fixture_rewards.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/altair/test_fixture_state_transition_epoch.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
+++ b/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
+++ b/tests/consensus_spec/bellatrix/all_bellatrix_fixtures.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_rewards.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_state_transition_epoch.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/consensus_spec_tests_preset.nim
+++ b/tests/consensus_spec/consensus_spec_tests_preset.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ../testutil
 
 # Tests that depend on `mainnet` vs `minimal` compile-time configuration

--- a/tests/consensus_spec/deneb/all_deneb_fixtures.nim
+++ b/tests/consensus_spec/deneb/all_deneb_fixtures.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/deneb/test_fixture_rewards.nim
+++ b/tests/consensus_spec/deneb/test_fixture_rewards.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/phase0/all_phase0_fixtures.nim
+++ b/tests/consensus_spec/phase0/all_phase0_fixtures.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2021-2022 Status Research & Development GmbH
+# Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/phase0/test_fixture_rewards.nim
+++ b/tests/consensus_spec/phase0/test_fixture_rewards.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/phase0/test_fixture_state_transition_epoch.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/test_fixture_fork.nim
+++ b/tests/consensus_spec/test_fixture_fork.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/fuzzing/beacon_node_cli/fuzz_beacon_node_cli.nim
+++ b/tests/fuzzing/beacon_node_cli/fuzz_beacon_node_cli.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import
   # TODO These imports shouldn't be necessary here
   #      (this is a variation of the sandwich problem)
@@ -7,4 +16,3 @@ import
   ../../../beacon_chain/conf, ../../../beacon_chain/spec/network
 
 fuzzCliParsing BeaconNodeConf
-

--- a/tests/fuzzing/ssz_decode_Attestation.nim
+++ b/tests/fuzzing/ssz_decode_Attestation.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest Attestation

--- a/tests/fuzzing/ssz_decode_AttesterSlashing.nim
+++ b/tests/fuzzing/ssz_decode_AttesterSlashing.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest AttesterSlashing

--- a/tests/fuzzing/ssz_decode_BeaconState.nim
+++ b/tests/fuzzing/ssz_decode_BeaconState.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest BeaconState

--- a/tests/fuzzing/ssz_decode_ProposerSlashing.nim
+++ b/tests/fuzzing/ssz_decode_ProposerSlashing.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest ProposerSlashing

--- a/tests/fuzzing/ssz_decode_SignedAggregateAndProof.nim
+++ b/tests/fuzzing/ssz_decode_SignedAggregateAndProof.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest SignedAggregateAndProof

--- a/tests/fuzzing/ssz_decode_SignedBeaconBlock.nim
+++ b/tests/fuzzing/ssz_decode_SignedBeaconBlock.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest SignedBeaconBlock

--- a/tests/fuzzing/ssz_decode_VoluntaryExit.nim
+++ b/tests/fuzzing/ssz_decode_VoluntaryExit.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import ./ssz_fuzzing
 
 sszFuzzingTest SignedVoluntaryExit

--- a/tests/fuzzing/ssz_fuzzing.nim
+++ b/tests/fuzzing/ssz_fuzzing.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import
   testutils/fuzzing, faststreams/inputs, serialization/testing/tracing,
   ../../beacon_chain/spec/datatypes/base

--- a/tests/fuzzing/validator_client_cli/fuzz_validator_client_cli.nim
+++ b/tests/fuzzing/validator_client_cli/fuzz_validator_client_cli.nim
@@ -1,3 +1,12 @@
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
 import
   # TODO These imports shouldn't be necessary here
   #      (this is a variation of the sandwich problem)
@@ -7,4 +16,3 @@ import
   ../../../beacon_chain/conf
 
 fuzzCliParsing ValidatorClientConf
-

--- a/tests/helpers/debug_state.nim
+++ b/tests/helpers/debug_state.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   std/macros,
   ssz_serialization/types,

--- a/tests/helpers/digest_helpers.nim
+++ b/tests/helpers/digest_helpers.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 import
   ../../beacon_chain/spec/digest

--- a/tests/helpers/math_helpers.nim
+++ b/tests/helpers/math_helpers.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2020 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 func round_multiple_down*(x: uint64, n: uint64): uint64 =
   ## Round the input to the previous multiple of "n"

--- a/tests/mocking/mock_deposits.nim
+++ b/tests/mocking/mock_deposits.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 # Mocking deposits and genesis deposits
 # ---------------------------------------------------------------
 

--- a/tests/mocking/mock_genesis.nim
+++ b/tests/mocking/mock_genesis.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 # Mocking a genesis state
 # ---------------------------------------------------------------
 

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -33,9 +33,11 @@ func fakeValidator(index: SomeInteger): ValidatorPubKey =
   result.blob[0 ..< 8] = (1'u64 shl 48 + index.uint64).toBytesBE()
 
 proc sqlite3db_delete(basepath, dbname: string) =
-  removeFile(basepath / dbname&".sqlite3-shm")
-  removeFile(basepath / dbname&".sqlite3-wal")
-  removeFile(basepath / dbname&".sqlite3")
+  for extension in [".sqlite3-shm", ".sqlite3-wal", ".sqlite3"]:
+    try:
+      removeFile(basepath / dbname&extension)
+    except OSError:
+      discard
 
 const TestDir = ""
 const TestDbName = "test_slashprot"

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -1,10 +1,11 @@
-# Nimbus
+# beacon_chain
 # Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -1,10 +1,11 @@
-# Nimbus
+# beacon_chain
 # Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_beacon_time.nim
+++ b/tests/test_beacon_time.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_datatypes.nim
+++ b/tests/test_datatypes.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_deposit_snapshots.nim
+++ b/tests/test_deposit_snapshots.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_engine_authentication.nim
+++ b/tests/test_engine_authentication.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2022 Status Research & Development GmbH
+# Copyright (c) 2022-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_eth2_ssz_serialization.nim
+++ b/tests/test_eth2_ssz_serialization.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2022 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_forks.nim
+++ b/tests/test_forks.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_gossip_transition.nim
+++ b/tests/test_gossip_transition.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -5,7 +5,6 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -31,12 +31,13 @@ proc directoryItemsCount(dir: string): int {.raises: [OSError].} =
   for el in walkDir(dir):
     result += 1
 
-proc validatorPubKeysInDir(dir: string): seq[string] =
+proc validatorPubKeysInDir(dir: string): seq[string] {.raises: [OSError].} =
   for kind, file in walkDir(dir):
     if kind == pcDir:
       result.add(splitFile(file).name)
 
-proc contentEquals(filePath, expectedContent: string): bool =
+proc contentEquals(
+    filePath, expectedContent: string): bool {.raises: [IOError].} =
   var file: File
 
   discard open(file, filePath)
@@ -55,7 +56,7 @@ proc namesEqual(a, b: openArray[string]): bool =
   sorted(a) == sorted(b)
 
 when not defined(windows):
-  proc isEmptyDir(dir: string): bool =
+  proc isEmptyDir(dir: string): bool {.raises: [OSError].} =
     directoryItemsCount(dir) == 0
 
 if validatorDirRes.isErr():

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_message_signatures.nim
+++ b/tests/test_message_signatures.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_network_metadata.nim
+++ b/tests/test_network_metadata.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 import
   unittest2,

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 # Test for spec functions and helpers outside of the EF test vectors - mainly

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_validator_pool.nim
+++ b/tests/test_validator_pool.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/test_zero_signature.nim
+++ b/tests/test_zero_signature.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   chronicles,
   ../beacon_chain/beacon_chain_db,

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -1,4 +1,4 @@
-# Nimbus
+# beacon_chain
 # Copyright (c) 2021-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
Annotate the `research` and `test` files for which no further changes are needed to successfully compile them, to not interfere with periodic tasks such as spec reference bumps.