### PR TITLE
explicitly mention `{.raises.}` in `tests` folder

### DIFF
--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -40,7 +41,11 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type altair.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type altair.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -58,7 +63,11 @@ proc checkSSZ(T: type altair.SignedBeaconBlock, dir: string, expectedHash: SSZHa
 
   # TODO check the value (requires YAML loader)
 
-proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -71,7 +80,10 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -40,7 +41,11 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type bellatrix.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type bellatrix.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
    # Deserialize into a ref object to not fill Nim stack
    let encoded = snappy.decode(
      readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -58,7 +63,11 @@ proc checkSSZ(T: type bellatrix.SignedBeaconBlock, dir: string, expectedHash: SS
 
    # TODO check the value (requires YAML loader)
 
-proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -71,7 +80,10 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -42,7 +42,11 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type capella.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type capella.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
    # Deserialize into a ref object to not fill Nim stack
    let encoded = snappy.decode(
      readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -60,7 +64,11 @@ proc checkSSZ(T: type capella.SignedBeaconBlock, dir: string, expectedHash: SSZH
 
    # TODO check the value (requires YAML loader)
 
-proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -73,7 +81,10 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -45,7 +46,11 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type deneb.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type deneb.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
    # Deserialize into a ref object to not fill Nim stack
    let encoded = snappy.decode(
      readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -63,7 +68,11 @@ proc checkSSZ(T: type deneb.SignedBeaconBlock, dir: string, expectedHash: SSZHas
 
    # TODO check the value (requires YAML loader)
 
-proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -76,7 +85,10 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -40,7 +41,11 @@ type
 # Note this only tracks HashTreeRoot
 # Checking the values against the yaml file is TODO (require more flexible Yaml parser)
 
-proc checkSSZ(T: type phase0.SignedBeaconBlock, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type phase0.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -58,7 +63,11 @@ proc checkSSZ(T: type phase0.SignedBeaconBlock, dir: string, expectedHash: SSZHa
 
   # TODO check the value (requires YAML loader)
 
-proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
   # Deserialize into a ref object to not fill Nim stack
   let encoded = snappy.decode(
     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
@@ -71,7 +80,10 @@ proc checkSSZ(T: type, dir: string, expectedHash: SSZHashTreeRoot) =
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot =
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -96,10 +96,11 @@ proc initialLoad(
   (dag, fkChoice)
 
 proc loadOps(
-    path: string, fork: ConsensusFork
+    path: string,
+    fork: ConsensusFork
 ): seq[Operation] {.raises: [
     IOError, KeyError, UnconsumedInput, ValueError,
-    YamlParserError, YamlConstructionError].} =
+    YamlConstructionError, YamlParserError].} =
   let stepsYAML = os_ops.readFile(path/"steps.yaml")
   let steps = yaml.loadToJson(stepsYAML)
 
@@ -290,10 +291,11 @@ proc stepChecks(
       raiseAssert "Unsupported check '" & $check & "'"
 
 proc doRunTest(
-    path: string, fork: ConsensusFork
+    path: string,
+    fork: ConsensusFork
 ) {.raises: [
     IOError, KeyError, UnconsumedInput, ValueError,
-    YamlParserError, YamlConstructionError].} =
+    YamlConstructionError, YamlParserError].} =
   let db = BeaconChainDB.new("", inMemory = true)
   defer:
     db.close()

--- a/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_light_client_single_merkle_proof.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -21,7 +22,8 @@ import
   ./fixtures_utils, ./os_ops
 
 proc runTest[T](suiteName, path: string, objType: typedesc[T]) =
-  test "Light client - Single merkle proof - " & path.relativePath(SszTestsDir):
+  let relativePathComponent = path.relativeTestPathComponent()
+  test "Light client - Single merkle proof - " & relativePathComponent:
     type
       TestProof = object
         leaf: string

--- a/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
+++ b/tests/consensus_spec/test_fixture_light_client_update_ranking.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -25,7 +26,8 @@ type
     updates_count: uint64
 
 proc runTest(suiteName, path: string, lcDataFork: static LightClientDataFork) =
-  test "Light client - Update ranking - " & path.relativePath(SszTestsDir):
+  let relativePathComponent = path.relativeTestPathComponent()
+  test "Light client - Update ranking - " & relativePathComponent:
     let meta = block:
       var s = openFileStream(path/"meta.yaml")
       defer: close(s)

--- a/tests/consensus_spec/test_fixture_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_merkle_proof.nim
@@ -1,10 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -21,7 +22,8 @@ import
   ./fixtures_utils, ./os_ops
 
 proc runTest[T](suiteName, path: string, objType: typedesc[T]) =
-  test "Merkle proof - Single merkle proof - " & path.relativePath(SszTestsDir):
+  let relativePathComponent = path.relativeTestPathComponent()
+  test "Merkle proof - Single merkle proof - " & relativePathComponent:
     type
       TestProof = object
         leaf: string

--- a/tests/consensus_spec/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/test_fixture_sanity_slots.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import ../../beacon_chain/spec/forks
@@ -15,7 +16,10 @@ from ../testutil import check, preset, suite, test
 from ../../beacon_chain/spec/state_transition import process_slots
 from ../helpers/debug_state import reportDiff
 
-proc runTest(T: type, testDir, forkName: static[string], suiteName, identifier: string) =
+proc runTest(
+    T: type,
+    testDir, forkName: static[string],
+    suiteName, identifier: string) {.raises: [IOError, ValueError].} =
   let
     testDir = testDir / identifier
     num_slots = readLines(testDir / "slots.yaml", 2)[0].parseInt.uint64

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -25,7 +26,8 @@ type
     fork_block {.defaultVal: -1.}: int
     bls_setting {.defaultVal: 1.}: int
 
-proc getTransitionInfo(testPath: string): TransitionInfo =
+proc getTransitionInfo(
+    testPath: string): TransitionInfo {.raises: [Exception, IOError].} =
   var transitionInfo: TransitionInfo
   let s = openFileStream(testPath/"meta.yaml")
   defer: close(s)

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
 {.used.}
 
 import
@@ -18,12 +19,15 @@ type
     dataDir* {.name: "data-dir".}: string
     el* {.name: "el".}: seq[EngineApiUrlConfigValue]
 
-proc loadExampleConfig(content: string, cmdLine = newSeq[string]()): ExampleConfigFile =
+proc loadExampleConfig(
+    content: string,
+    cmdLine = newSeq[string]()
+): ExampleConfigFile {.raises: [ConfigurationError, OSError].} =
   ExampleConfigFile.load(
     cmdLine = cmdLine,
     secondarySources = proc (
-        config: ExampleConfigFile, sources: ref SecondarySources
-    ) {.raises: [ConfigurationError].} =
+        config: ExampleConfigFile,
+        sources: ref SecondarySources) {.raises: [ConfigurationError].} =
       sources.addConfigFileContent(Toml, content))
 
 const


### PR DESCRIPTION
Add `{.raises.}` annotations to `tests` files where needed to enable `{.push raises: [].}`. Avoids interfering with periodic changes such as spec version bumps, and avoids special casing folders when editing. The effort to maintain `{.raises.}` is trivial after the initial round.