### PR TITLE
switch Builder API validator registration error to warning

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1789,7 +1789,7 @@ proc registerValidatorsPerBuilder(
           error "Timeout when registering validator with builder"
           continue  # Try next batch regardless
       except RestError as exc:
-        error "Error when registering validator(s) with builder", err = exc.msg
+        warn "Error when registering validator(s) with builder", err = exc.msg
         continue
 
     if HttpOk != registerValidatorResult.status:


### PR DESCRIPTION
It's not quite important enough to qualify as an error, though it should be shown and something is going unexpectedly wrong. Downgrade it slightly.