### PR TITLE
use debug- prefix for Yamux experimental support

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -335,7 +335,7 @@ type
         hidden
         desc: "Enable the Yamux multiplexer"
         defaultValue: false
-        name: "enable-yamux" .}: bool
+        name: "debug-enable-yamux" .}: bool
 
       weakSubjectivityCheckpoint* {.
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"


### PR DESCRIPTION
Discussed in https://github.com/status-im/nimbus-eth2/pull/5080#issuecomment-1592988315

per https://nimbus.guide/options.html#available-options
> Any `debug`-prefixed flags are considered ephemeral and subject to removal without notice.

It's already not documented because it's hidden; this just makes the existing policy explicit.