### PR TITLE
use correct Nim version in daily job, and `--mm:refc` on `devel`

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -26,8 +26,13 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [version-1-6, devel]
+        branch: [upstream/version-1-6, upstream/devel]
         include:
+          - branch: upstream/version-1-6
+            branch-short: version-1-6
+          - branch: upstream/devel
+            branch-short: devel
+            nimflags-extra: --mm:refc
           - target:
               os: linux
             builder: ubuntu-20.04
@@ -45,7 +50,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch-short }})'
     runs-on: ${{ matrix.builder }}
     continue-on-error: ${{ matrix.branch == 'devel' }}
     steps:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -137,7 +137,6 @@ jobs:
           # Stack usage test on recent enough gcc:
           if [[ '${{ runner.os }}' == 'Linux' && '${{ matrix.target.cpu }}' == 'amd64' ]]; then
             export NIMFLAGS="${NIMFLAGS} -d:limitStackUsage"
-            echo "NIMFLAGS=${NIMFLAGS}" >> $GITHUB_ENV
           fi
 
           # libminiupnp / natpmp
@@ -145,6 +144,9 @@ jobs:
             export CFLAGS="${CFLAGS} -m32 -mno-adx"
             echo "CFLAGS=${CFLAGS}" >> $GITHUB_ENV
           fi
+
+          export NIMFLAGS="${NIMFLAGS} ${{ matrix.nimflags-extra }}"
+          echo "NIMFLAGS=${NIMFLAGS}" >> $GITHUB_ENV
 
           ncpu=""
           make_cmd="make"

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -52,7 +52,7 @@ jobs:
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch-short }})'
     runs-on: ${{ matrix.builder }}
-    continue-on-error: ${{ matrix.branch == 'devel' }}
+    continue-on-error: ${{ matrix.branch-short == 'devel' }}
     steps:
       - name: Checkout
         if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Daily CI uses an outdated Nim 1.6 because it uses `origin/version-1-6` which is not maintained very regularly. Pull from `upstream/version-1-6` instead, same as in `ci.yml`, and also make sure that `--mm:refc` is turned on for `upstream/devel`.