### PR TITLE
metrics for proposer and sync duties

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -52,7 +52,7 @@ declareGauge next_action_wait,
   "Seconds until the next attestation will be sent"
 
 declareGauge next_proposal_wait,
-  "Seconds until the next proposal will be sent, or -1 if no proposal scheduled"
+  "Seconds until the next proposal will be sent, or Inf if not known"
 
 declareGauge sync_committee_active,
   "1 if there are current sync committee duties, 0 otherwise"
@@ -1487,9 +1487,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
   next_proposal_wait.set(
     if nextProposalSlot != FAR_FUTURE_SLOT:
-      saturate(fromNow(node.beaconClock, nextProposalSlot))
+      saturate(fromNow(node.beaconClock, nextProposalSlot)).toFloatSeconds()
     else:
-      -1)
+      Inf)
 
   sync_committee_active.set(if inCurrentSyncCommittee: 1 else: 0)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -51,6 +51,12 @@ declareGauge ticks_delay,
 declareGauge next_action_wait,
   "Seconds until the next attestation will be sent"
 
+declareGauge next_proposal_wait,
+  "Seconds until the next proposal will be sent, or -1 if no proposal scheduled"
+
+declareGauge sync_committee_active,
+  "1 if there are current sync committee duties, 0 otherwise"
+
 declareCounter db_checkpoint_seconds,
   "Time spent checkpointing the database to clear the WAL file"
 
@@ -1444,19 +1450,21 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     else:
       toGaugeValue(x)
 
+  let
+    syncCommitteeSlot = slot + 1
+    syncCommitteeEpoch = syncCommitteeSlot.epoch
+    inCurrentSyncCommittee =
+      not node.getCurrentSyncCommiteeSubnets(syncCommitteeEpoch).isZeros()
+
   template formatSyncCommitteeStatus(): string =
-    let
-      syncCommitteeSlot = slot + 1
-      slotsToNextSyncCommitteePeriod =
+    if inCurrentSyncCommittee:
+      "current"
+    elif not node.getNextSyncCommitteeSubnets(syncCommitteeEpoch).isZeros():
+      let slotsToNextSyncCommitteePeriod =
         SLOTS_PER_SYNC_COMMITTEE_PERIOD -
         since_sync_committee_period_start(syncCommitteeSlot)
-
-    # int64 conversion is safe
-    doAssert slotsToNextSyncCommitteePeriod <= SLOTS_PER_SYNC_COMMITTEE_PERIOD
-
-    if not node.getCurrentSyncCommiteeSubnets(syncCommitteeSlot.epoch).isZeros:
-      "current"
-    elif not node.getNextSyncCommitteeSubnets(syncCommitteeSlot.epoch).isZeros:
+      # int64 conversion is safe
+      doAssert slotsToNextSyncCommitteePeriod <= SLOTS_PER_SYNC_COMMITTEE_PERIOD
       "in " & toTimeLeftString(
         SECONDS_PER_SLOT.int64.seconds * slotsToNextSyncCommitteePeriod.int64)
     else:
@@ -1476,6 +1484,14 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
   if nextAttestationSlot != FAR_FUTURE_SLOT:
     next_action_wait.set(nextActionWaitTime.toFloatSeconds)
+
+  next_proposal_wait.set(
+    if nextProposalSlot != FAR_FUTURE_SLOT:
+      saturate(fromNow(node.beaconClock, nextProposalSlot))
+    else:
+      -1)
+
+  sync_committee_active.set(if inCurrentSyncCommittee: 1 else: 0)
 
   let epoch = slot.epoch
   if epoch + 1 >= node.network.forkId.next_fork_epoch:


### PR DESCRIPTION
To avoid restarting with scheduled proposals or sync duties, which are rare but have high rewards, add metrics to simpify tracking them.