### PR TITLE
rename `DepositTreeSnapshot` -> `DepositContractSnapshot`

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -141,7 +141,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
-## DepositTreeSnapshot
+## DepositContractSnapshot
 ```diff
 + Migration                                                                                  OK
 + SSZ                                                                                        OK

--- a/beacon_chain/el/eth1_chain.nim
+++ b/beacon_chain/el/eth1_chain.nim
@@ -166,7 +166,7 @@ proc pruneOldBlocks(chain: var Eth1Chain, depositIndex: uint64) =
 
   if chain.finalizedDepositsMerkleizer.getChunkCount > initialChunks:
     chain.finalizedBlockHash = lastBlock.hash
-    chain.db.putDepositTreeSnapshot DepositTreeSnapshot(
+    chain.db.putDepositContractSnapshot DepositContractSnapshot(
       eth1Block: lastBlock.hash,
       depositContractState: chain.finalizedDepositsMerkleizer.toDepositContractState,
       blockHeight: lastBlock.number)
@@ -370,7 +370,7 @@ proc init*(T: type Eth1Chain,
   let
     (finalizedBlockHash, depositContractState) =
       if db != nil:
-        let treeSnapshot = db.getDepositTreeSnapshot()
+        let treeSnapshot = db.getDepositContractSnapshot()
         if treeSnapshot.isSome:
           (treeSnapshot.get.eth1Block, treeSnapshot.get.depositContractState)
         else:
@@ -378,7 +378,7 @@ proc init*(T: type Eth1Chain,
           if oldSnapshot.isSome:
             (oldSnapshot.get.eth1Block, oldSnapshot.get.depositContractState)
           else:
-            db.putDepositTreeSnapshot DepositTreeSnapshot(
+            db.putDepositContractSnapshot DepositContractSnapshot(
               eth1Block: depositContractBlockHash,
               blockHeight: depositContractBlockNumber)
             (depositContractBlockHash, default(DepositContractState))

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -640,8 +640,8 @@ proc init*(T: type BeaconNode,
   if config.finalizedDepositTreeSnapshot.isSome:
     let
       depositTreeSnapshotPath = config.finalizedDepositTreeSnapshot.get.string
-      depositTreeSnapshot = try:
-        SSZ.loadFile(depositTreeSnapshotPath, DepositTreeSnapshot)
+      depositContractSnapshot = try:
+        SSZ.loadFile(depositTreeSnapshotPath, DepositContractSnapshot)
       except SszError as err:
         fatal "Deposit tree snapshot loading failed",
               err = formatMsg(err, depositTreeSnapshotPath)
@@ -649,7 +649,7 @@ proc init*(T: type BeaconNode,
       except CatchableError as err:
         fatal "Failed to read deposit tree snapshot file", err = err.msg
         quit 1
-    db.putDepositTreeSnapshot(depositTreeSnapshot)
+    db.putDepositContractSnapshot(depositContractSnapshot)
 
   let engineApiUrls = config.engineApiUrls
 

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -133,7 +133,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4881.md
   router.api2(MethodGet, "/eth/v1/beacon/deposit_snapshot") do (
     ) -> RestApiResponse:
-    let snapshot = node.db.getDepositTreeSnapshot().valueOr:
+    let snapshot = node.db.getDepositContractSnapshot().valueOr:
       # This can happen in a very short window after the client is started,
       # but the snapshot record still haven't been upgraded in the database.
       # Returning 404 should be easy to handle for the clients - they just need

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -24,8 +24,9 @@ const
   largeRequestsTimeout = 60.seconds # Downloading large items such as states.
   smallRequestsTimeout = 30.seconds # Downloading smaller items such as blocks and deposit snapshots.
 
-proc fetchDepositSnapshot(client: RestClientRef):
-                          Future[Result[DepositTreeSnapshot, string]] {.async.} =
+proc fetchDepositSnapshot(
+    client: RestClientRef
+): Future[Result[DepositContractSnapshot, string]] {.async.} =
   let resp = try:
     awaitWithTimeout(client.getDepositSnapshot(), smallRequestsTimeout):
       return err "Fetching /eth/v1/beacon/deposit_snapshot timed out"
@@ -33,7 +34,7 @@ proc fetchDepositSnapshot(client: RestClientRef):
     return err("The trusted node likely does not support the /eth/v1/beacon/deposit_snapshot end-point:" & e.msg)
 
   let data = resp.data.data
-  let snapshot = DepositTreeSnapshot(
+  let snapshot = DepositContractSnapshot(
     eth1Block: data.execution_block_hash,
     depositContractState: DepositContractState(
       branch: data.finalized,
@@ -393,7 +394,7 @@ proc doTrustedNodeSync*(
           info "Writing deposit contracts snapshot",
                depositRoot = depositSnapshot.get.getDepositRoot(),
                depositCount = depositSnapshot.get.getDepositCountU64
-          db.putDepositTreeSnapshot(depositSnapshot.get)
+          db.putDepositContractSnapshot(depositSnapshot.get)
         else:
           warn "The downloaded deposit snapshot does not agree with the downloaded state"
       else:

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -347,15 +347,16 @@ func `as`(blk: BlockObject, T: type deneb.ExecutionPayloadHeader): T =
     blob_gas_used: uint64 blk.blobGasUsed.getOrDefault(),
     excess_blob_gas: uint64 blk.excessBlobGas.getOrDefault())
 
-func createDepositTreeSnapshot(deposits: seq[DepositData],
-                               blockHash: Eth2Digest,
-                               blockHeight: uint64): DepositTreeSnapshot =
+func createDepositContractSnapshot(
+    deposits: seq[DepositData],
+    blockHash: Eth2Digest,
+    blockHeight: uint64): DepositContractSnapshot =
   var merkleizer = DepositsMerkleizer.init()
   for i, deposit in deposits:
     let htr = hash_tree_root(deposit)
     merkleizer.addChunk(htr.data)
 
-  DepositTreeSnapshot(
+  DepositContractSnapshot(
     eth1Block: blockHash,
     depositContractState: merkleizer.toDepositContractState,
     blockHeight: blockHeight)
@@ -473,7 +474,7 @@ proc doCreateTestnet*(config: CliConfig,
 
     SSZ.saveFile(
       config.outputDepositTreeSnapshot.string,
-      createDepositTreeSnapshot(
+      createDepositContractSnapshot(
         deposits,
         genesisExecutionPayloadHeader.block_hash,
         genesisExecutionPayloadHeader.block_number))

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -160,7 +160,7 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
   defer: db.close()
 
   ChainDAGRef.preInit(db, genesisState[])
-  db.putDepositTreeSnapshot(depositTreeSnapshot)
+  db.putDepositContractSnapshot(depositTreeSnapshot)
 
   let rng = HmacDrbgContext.new()
   var

--- a/scripts/test_merge_node.nim
+++ b/scripts/test_merge_node.nim
@@ -55,7 +55,7 @@ proc run() {.async.} =
   let
     elManager = newClone ELManager.init(
       defaultRuntimeConfig, db = nil, nil, @[paramStr(1)],
-      none(DepositTreeSnapshot), none(Eth1Network), false,
+      none(DepositContractSnapshot), none(Eth1Network), false,
       some readJwtSecret(paramStr(2)).get)
 
   try:


### PR DESCRIPTION
EIP-4881 was never correctly implemented, the `DepositTreeSnapshot` structure has nothing to do with its actual definition. Reflect that by renaming the type to a Nimbus-specific `DepositContractSnapshot`, so that an actual EIP-4881 implementation can use the correct names.

- https://eips.ethereum.org/EIPS/eip-4881#specification

Notably, `DepositTreeSnapshot` contains a compressed sequence in `finalized`, only containing the minimally required intermediate roots.

That also explains the incorrect REST response reported in #5508.

The non-canonical representation was introduced in #4303 and is also persisted in the database. We'll have to maintain it for a while.