### PR TITLE
make EL light client disk usage table consistent with hardware table

### DIFF
--- a/docs/the_nimbus_book/src/el-light-client.md
+++ b/docs/the_nimbus_book/src/el-light-client.md
@@ -14,7 +14,7 @@ Compared to a full beacon node, a light client has several advantages and disadv
 
 | Feature | Beacon Node | Light Client |
 | -- | -- | -- |
-| Disk usage | ~70GB | **<1MB** |
+| Disk usage | ~200GB | **<1MB** |
 | Bandwidth | *TBD* | **TBD (low)** |
 | Sync time | Hours | **Seconds** |
 | Head delay | **None** | 4/3 slot (15 s) |


### PR DESCRIPTION
Make https://nimbus.guide/hardware.html and https://nimbus.guide/el-light-client.html consistent

Whether 200GB is the best number or not, it's more correct than 70GB.