### PR TITLE
align default `syncHorizon` computation logic across networks

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -103,9 +103,6 @@ type
     processingDelay*: Opt[Duration]
     lastValidAttestedBlock*: Opt[BlockSlot]
 
-const
-  MaxEmptySlotCount* = uint64(10*60) div SECONDS_PER_SLOT
-
 # TODO stew/sequtils2
 template findIt*(s: openArray, predicate: untyped): int =
   var res = -1

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 # Everything needed to run a full Beacon Node
 
 import

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -586,9 +586,9 @@ type
 
       syncHorizon* {.
         hidden
-        desc: "Number of empty slots to process before considering the client out of sync"
-        defaultValue: MaxEmptySlotCount
-        defaultValueDesc: "50"
+        desc: "Number of empty slots to process before considering the client out of sync. Defaults to the number of slots in 10 minutes"
+        defaultValue: defaultSyncHorizon
+        defaultValueDesc: $defaultSyncHorizon
         name: "sync-horizon" .}: uint64
 
       terminalTotalDifficultyOverride* {.

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -278,8 +278,6 @@ func isSynced(dag: ChainDAGRef, wallSlot: Slot): bool =
   # the defaultSyncHorizon, it will start triggering in time so that potential
   # discrepancies between the head here, and the head the DAG has (which might
   # not yet be updated) won't be visible.
-  const defaultSyncHorizon = 50
-
   if dag.head.slot + defaultSyncHorizon < wallSlot:
     false
   else:

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -278,3 +278,6 @@ chronicles.formatIt TimeDiff: it.shortLog
 chronicles.formatIt Slot: it.shortLog
 chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt SyncCommitteePeriod: it.shortLog
+
+const defaultSyncHorizon* =
+  (uint64(10*60) + SECONDS_PER_SLOT - 1) div SECONDS_PER_SLOT


### PR DESCRIPTION
The `syncHorizon` describes the number of empty slots before the beacon node considers itself to be out of sync. There are two places where we currently set this to 50 slots, but it makes more sense to base it on wall time, e.g., the 10 minutes that the default 50 are derived from.