### PR TITLE
chore(vendor): update nim-libp2p path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,7 +22,7 @@
 	branch = master
 [submodule "vendor/nim-libp2p"]
 	path = vendor/nim-libp2p
-	url = https://github.com/status-im/nim-libp2p.git
+	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = untracked
 	branch = unstable
 [submodule "vendor/nimbus-build-system"]


### PR DESCRIPTION
The nim-libp2p repo has been moved from the status github org to the vacp2p org.