### PR TITLE
pass `cfg` to `ETHBeaconClockCreateFromState` LC API

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -211,7 +211,7 @@ typedef struct ETHForkDigests ETHForkDigests;
  * Creates a fork digests cache for a given beacon state.
  *
  * - The fork digests cache must be destroyed with `ETHForkDigestsDestroy`
- *    once no longer needed, to release memory.
+ *   once no longer needed, to release memory.
  *
  * @param      cfg                  Ethereum Consensus Layer network configuration.
  * @param      state                Beacon state.
@@ -244,13 +244,15 @@ typedef struct ETHBeaconClock ETHBeaconClock;
  * - The beacon clock must be destroyed with `ETHBeaconClockDestroy`
  *   once no longer needed, to release memory.
  *
+ * @param      cfg                  Ethereum Consensus Layer network configuration.
  * @param      state                Beacon state.
  *
  * @return Pointer to an initialized beacon clock based on the beacon state or
  *         NULL if the state contained an invalid time.
  */
 ETH_RESULT_USE_CHECK
-ETHBeaconClock *ETHBeaconClockCreateFromState(const ETHBeaconState *state);
+ETHBeaconClock *ETHBeaconClockCreateFromState(
+    const ETHConsensusConfig *cfg, const ETHBeaconState *state);
 
 /**
  * Destroys a beacon clock.

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -230,6 +230,7 @@ proc ETHForkDigestsDestroy(forkDigests: ptr ForkDigests) {.exported.} =
   forkDigests.destroy()
 
 proc ETHBeaconClockCreateFromState(
+    cfg: ptr RuntimeConfig,
     state: ptr ForkedHashedBeaconState): ptr BeaconClock {.exported.} =
   ## Creates a beacon clock for a given beacon state's `genesis_time` field.
   ##
@@ -237,11 +238,12 @@ proc ETHBeaconClockCreateFromState(
   ##   once no longer needed, to release memory.
   ##
   ## Parameters:
+  ## * `cfg` - Ethereum Consensus Layer network configuration.
   ## * `state` - Beacon state.
   ##
   ## Returns:
-  ## * Pointer to an initialized beacon clock based on the beacon state or NULL
-  ##   if the state contained an invalid time.
+  ## * Pointer to an initialized beacon clock based on the beacon state or
+  ##   NULL if the state contained an invalid time.
   let beaconClock = BeaconClock.new()
   beaconClock[] =
     BeaconClock.init(getStateField(state[], genesis_time)).valueOr:

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -1,6 +1,6 @@
 /**
  * beacon_chain
- * Copyright (c) 2023 Status Research & Development GmbH
+ * Copyright (c) 2023-2024 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -268,7 +268,7 @@ int main(void)
     ETHBeaconState *genesisState = loadGenesis(cfg, __DIR__ "/test_files/genesis.ssz");
     ETHRoot *genesisValRoot = ETHBeaconStateCopyGenesisValidatorsRoot(genesisState);
     ETHForkDigests *forkDigests = ETHForkDigestsCreateFromState(cfg, genesisState);
-    ETHBeaconClock *beaconClock = ETHBeaconClockCreateFromState(genesisState);
+    ETHBeaconClock *beaconClock = ETHBeaconClockCreateFromState(cfg, genesisState);
     ETHBeaconStateDestroy(genesisState);
     printf("Current slot: %d\n", ETHBeaconClockGetSlot(beaconClock));
     printf("\n");


### PR DESCRIPTION
We don't need the `cfg` right now, but it makes sense to have the object passed to the clock so that the API doesn't break if we want to support configurable `SECONDS_PER_SLOT`. As the `libnimbus_lc` library is not yet widely used, better to add the argument now than later.