### PR TITLE
use v1.4.0 consensus spec test vectors

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, endians2, json_serialization, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.4.0-beta.7-hotfix"
+const SPEC_VERSION* = "1.4.0"
 ## Spec version we're aiming to be compatible with, right now
 
 const


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.4.0

https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.4.0