### PR TITLE
cache head block eligibility for fork choice

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -109,6 +109,7 @@ type
     bid*: BlockId
     parent*: Option[Index]
     checkpoints*: FinalityCheckpoints
+    sharedFinalizedEpoch*: Epoch
     weight*: int64
     invalid*: bool
     bestChild*: Option[Index]


### PR DESCRIPTION
When there are long periods of non-finality, `nodeIsViableForHead` has been observed to consume significant time as it repeatedly walks the non-finalized check graph as part of determining what heads are eligible for fork choice. Caching the result resolves that.

Overall, it may still be better to prune fork choice more aggressively when finality advances, to fully avoid the case specced out using the linear scan. The current implementation is very close to spec, though, so such a change should not be introduced without thorough testing.

The simple cache should allow significantly better performance on Goerli while the network is still supported (Mid April).