### PR TITLE
use correct `INACTIVITY_SCORE_RECOVERY_RATE` if overridden from default

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -65,10 +65,6 @@ const
   CURRENT_SYNC_COMMITTEE_GINDEX* = 54.GeneralizedIndex  # current_sync_committee
   NEXT_SYNC_COMMITTEE_GINDEX* = 55.GeneralizedIndex  # next_sync_committee
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#inactivity-penalties
-  INACTIVITY_SCORE_BIAS* = 4
-  INACTIVITY_SCORE_RECOVERY_RATE* = 16
-
   SYNC_SUBCOMMITTEE_SIZE* = SYNC_COMMITTEE_SIZE div SYNC_COMMITTEE_SUBNET_COUNT
 
 # "Note: The sum of the weights equal WEIGHT_DENOMINATOR."

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1077,9 +1077,11 @@ func process_sync_committee_updates*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#inactivity-scores
 template compute_inactivity_update(
+    cfg: RuntimeConfig,
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState,
-    info: altair.EpochInfo, pre_inactivity_score: Gwei): Gwei =
+    info: altair.EpochInfo,
+    pre_inactivity_score: Gwei): Gwei =
   let previous_epoch = get_previous_epoch(state)  # get_eligible_validator_indices()
 
   # Increase the inactivity score of inactive validators
@@ -1094,7 +1096,8 @@ template compute_inactivity_update(
   # Decrease the inactivity score of all eligible validators during a
   # leak-free epoch
   if not_in_inactivity_leak:
-    inactivity_score -= min(INACTIVITY_SCORE_RECOVERY_RATE.uint64, inactivity_score)
+    inactivity_score -=
+      min(cfg.INACTIVITY_SCORE_RECOVERY_RATE, inactivity_score)
   inactivity_score
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#inactivity-scores
@@ -1118,7 +1121,7 @@ func process_inactivity_updates*(
     let
       pre_inactivity_score = state.inactivity_scores.asSeq()[index]
       inactivity_score =
-        compute_inactivity_update(state, info, pre_inactivity_score)
+        compute_inactivity_update(cfg, state, info, pre_inactivity_score)
 
     # Most inactivity scores remain at 0 - avoid invalidating cache
     if pre_inactivity_score != inactivity_score:


### PR DESCRIPTION
When a config defines a different `INACTIVITY_SCORE_RECOVERY_RATE` than the default, `process_inactivity_updates` uses an incorrect rate ever since #2710 when `INACTIVITY_SCORE_RECOVERY_RATE` became configurable.