### PR TITLE
avoid blocking deep reorgs > 64 epochs

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1793,15 +1793,15 @@ proc updateState*(
         # eventually reach bs
         ancestors.add(cur.bid)
 
-      if cur.slot == GENESIS_SLOT or
-          (cur.slot.epoch +  uint64(EPOCHS_PER_STATE_SNAPSHOT) * 2 < startEpoch):
+      if cur.slot == GENESIS_SLOT or (cur.slot < dag.finalizedHead.slot and
+          cur.slot.epoch + uint64(EPOCHS_PER_STATE_SNAPSHOT) * 2 < startEpoch):
         # We've either walked two full state snapshot lengths or hit the tail
         # and still can't find a matching state: this can happen when
         # starting the node from an arbitrary finalized checkpoint and not
         # backfilling the states
         notice "Request for pruned historical state",
           request = shortLog(bsi), tail = shortLog(dag.tail),
-          cur = shortLog(cur)
+          cur = shortLog(cur), finalized = shortLog(dag.finalizedHead)
         return false
 
       # Move slot by slot to capture epoch boundary states


### PR DESCRIPTION
On Goerli there are some instances of long streaks of empty epochs due to different branches being built in parallel. They sometimes lead to `Request for pruned historical state` logs requiring a BN restart to resolve. Avoid that by trying to restore states from the entire non- finalized history, to avoid losing sync in such situtions.