### PR TITLE
continue validator duties if chain does not progress for a long time

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -165,16 +165,15 @@ proc advanceClearanceState*(
 
     dag.advanceSlots(dag.clearanceState, next, true, cache, info)
 
+    logScope:
+      oldSlot = clearanceSlot
+      newSlot = next
+      updateStateDur = Moment.now() - startTick
     if not chainIsDegraded:
-      debug "Prepared clearance state for next block",
-        oldSlot = clearanceSlot, newSlot = next,
-        updateStateDur = Moment.now() - startTick
+      debug "Prepared clearance state for next block"
     else:
-      let activeBalance = withEpochInfo(info):
-        info.balances.current_epoch
-      info "Prepared clearance state for next block",
-        oldSlot = clearanceSlot, newSlot = next, activeBalance,
-        updateStateDur = Moment.now() - startTick
+      let activeBalance = withEpochInfo(info): info.balances.current_epoch
+      info "Prepared clearance state for next block", activeBalance
 
 proc checkHeadBlock*(
     dag: ChainDAGRef, signedBlock: ForkySignedBeaconBlock):

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -168,6 +168,7 @@ proc advanceClearanceState*(
     logScope:
       oldSlot = clearanceSlot
       newSlot = next
+      wallSlot
       updateStateDur = Moment.now() - startTick
     if not chainIsDegraded:
       debug "Prepared clearance state for next block"

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -206,6 +206,9 @@ type
 
     cfg*: RuntimeConfig
 
+    lastChainProgress*: Moment
+      ## Indicates the last wall time at which meaningful progress was made
+      
     shufflingRefs*: LRUCache[16, ShufflingRef]
 
     epochRefs*: LRUCache[32, EpochRef]

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -155,8 +155,10 @@ func setOptimisticHead*(
     bid: BlockId, execution_block_hash: Eth2Digest) =
   self.optimisticHead = (bid: bid, execution_block_hash: execution_block_hash)
 
-proc updateExecutionClientHead(self: ref ConsensusManager,
-                               newHead: BeaconHead): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
+proc updateExecutionClientHead*(
+    self: ref ConsensusManager,
+    newHead: BeaconHead
+): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
   let headExecutionBlockHash =
     self.dag.loadExecutionBlockHash(newHead.blck).valueOr:
       # `BlockRef` are only created for blocks that have passed

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1270,7 +1270,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
       if slot > head.slot: (slot - head.slot).uint64
       else: 0'u64
     isBehind =
-      headDistance > TOPIC_SUBSCRIBE_THRESHOLD_SLOTS + HYSTERESIS_BUFFER
+      headDistance > TOPIC_SUBSCRIBE_THRESHOLD_SLOTS + HYSTERESIS_BUFFER and
+      node.syncStatus(head) == ChainSyncStatus.Syncing
     targetGossipState =
       getTargetGossipState(
         slot.epoch,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1546,6 +1546,12 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     node.dag.advanceClearanceState(slot,
       chainIsDegraded = (node.syncStatus(head) == ChainSyncStatus.Degraded))
 
+    # If the chain has halted, we have to ensure that the EL gets synced
+    # so that we can perform validator duties again
+    if not dag.head.executionValid and not dag.chainIsProgressing():
+      let beaconHead = node.attestationPool[].getBeaconHead(head)
+      discard await node.consensusManager.updateExecutionClientHead(beaconHead)
+
   # Prepare action tracker for the next slot
   node.consensusManager[].actionTracker.updateSlot(slot + 1)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1548,7 +1548,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
     # If the chain has halted, we have to ensure that the EL gets synced
     # so that we can perform validator duties again
-    if not dag.head.executionValid and not dag.chainIsProgressing():
+    if not node.dag.head.executionValid and not node.dag.chainIsProgressing():
       let beaconHead = node.attestationPool[].getBeaconHead(head)
       discard await node.consensusManager.updateExecutionClientHead(beaconHead)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1542,7 +1542,8 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     # probability of being prepared for the block that will arrive and the
     # epoch processing that follows
     await sleepAsync(advanceCutoff.offset)
-    node.dag.advanceClearanceState()
+    node.dag.advanceClearanceState(slot,
+      chainIsDegraded = (node.syncStatus(head) == ChainSyncStatus.Degraded))
 
   # Prepare action tracker for the next slot
   node.consensusManager[].actionTracker.updateSlot(slot + 1)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -257,15 +257,15 @@ proc syncStatus*(node: BeaconNode, head: BlockRef): ChainSyncStatus =
     return ChainSyncStatus.Syncing
 
   let numPeers = len(node.network.peers)
-  if numPeers <= node.config.maxPeers div 2:
+  if numPeers <= node.config.maxPeers div 4:
     # We may have poor connectivity, wait until more peers are available
     warn "Chain appears to have stalled, but have low peers",
       numPeers, maxPeers = node.config.maxPeers
     node.dag.resetChainProgressWatchdog()
     return ChainSyncStatus.Syncing
 
-  let numPeersWithHigherProgress =
-    node.network.peerPool.peers.countIt(it.getHeadSlot() > head.slot)
+  let numPeersWithHigherProgress = node.network.peerPool.peers
+    .countIt(it != nil and it.getHeadSlot() > head.slot)
   if numPeersWithHigherProgress > node.config.maxPeers div 8:
     # A peer indicates that they are on a later slot, wait for sync manager
     # to progress, or for it to kick the peer if they are faking the status

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -227,29 +227,61 @@ proc getGraffitiBytes*(
   getGraffiti(node.config.validatorsDir, node.config.defaultGraffitiBytes(),
               validator.pubkey)
 
-proc isSynced*(node: BeaconNode, head: BlockRef): bool =
-  ## TODO This function is here as a placeholder for some better heurestics to
-  ##      determine if we're in sync and should be producing blocks and
-  ##      attestations. Generally, the problem is that slot time keeps advancing
-  ##      even when there are no blocks being produced, so there's no way to
-  ##      distinguish validators geniunely going missing from the node not being
-  ##      well connected (during a network split or an internet outage for
-  ##      example). It would generally be correct to simply keep running as if
-  ##      we were the only legit node left alive, but then we run into issues:
-  ##      with enough many empty slots, the validator pool is emptied leading
-  ##      to empty committees and lots of empty slot processing that will be
-  ##      thrown away as soon as we're synced again.
+type ChainSyncStatus* {.pure.} = enum
+  Syncing,
+  Synced,
+  Degraded
 
+proc syncStatus*(node: BeaconNode, head: BlockRef): ChainSyncStatus =
+  ## Generally, the problem is that slot time keeps advancing
+  ## even when there are no blocks being produced, so there's no way to
+  ## distinguish validators geniunely going missing from the node not being
+  ## well connected (during a network split or an internet outage for
+  ## example). It would generally be correct to simply keep running as if
+  ## we were the only legit node left alive, but then we run into issues:
+  ## with enough many empty slots, the validator pool is emptied leading
+  ## to empty committees and lots of empty slot processing that will be
+  ## thrown away as soon as we're synced again.
   let
     # The slot we should be at, according to the clock
     beaconTime = node.beaconClock.now()
     wallSlot = beaconTime.toSlot()
 
-  # TODO if everyone follows this logic, the network will not recover from a
-  #      halt: nobody will be producing blocks because everone expects someone
-  #      else to do it
-  not wallSlot.afterGenesis or
-    head.slot + node.config.syncHorizon >= wallSlot.slot
+  if not wallSlot.afterGenesis or
+      head.slot + node.config.syncHorizon >= wallSlot.slot:
+    node.dag.resetChainProgressWatchdog()
+    return ChainSyncStatus.Synced
+
+  if node.dag.chainIsProgressing():
+    # Chain is progressing, we are out of sync
+    return ChainSyncStatus.Syncing
+
+  let numPeers = len(node.network.peers)
+  if numPeers <= node.config.maxPeers div 2:
+    # We may have poor connectivity, wait until more peers are available
+    node.dag.resetChainProgressWatchdog()
+    return ChainSyncStatus.Syncing
+
+  for peer in node.network.peerPool.peers:
+    if peer.getHeadSlot() > head.slot:
+      # A peer indicates that they are on a later slot, wait for sync manager
+      # to progress, or for it to kick the peer if they are faking the status
+      node.dag.resetChainProgressWatchdog()
+      return ChainSyncStatus.Syncing
+
+  # We are on the latest slot among all of our peers, and there has been no
+  # chain progress for an extended period of time.
+  let clearanceSlot = getStateField(node.dag.clearanceState, slot)
+  if clearanceSlot + node.config.syncHorizon < wallSlot.slot:
+    # If we were to propose a block now, we would incur a large lag spike
+    # that makes our block be way too late to be gossiped
+    return ChainSyncStatus.Degraded
+
+  # It is reasonable safe to assume that the network has halted, resume duties
+  ChainSyncStatus.Synced
+
+proc isSynced*(node: BeaconNode, head: BlockRef): bool =
+  node.syncStatus(head) == ChainSyncStatus.Synced
 
 proc handleLightClientUpdates*(node: BeaconNode, slot: Slot)
     {.async: (raises: [CancelledError]).} =


### PR DESCRIPTION
Nimbus currently stops performing validator duties if the blockchain does not progress for `node.config.syncHorizon` slots. This means that the chain won't recover because no new blocks are proposed. To fix that, continue performing validator duties if no progress is registered for a long time, and none of our peers is indicating any progress.