### PR TITLE
Set default localBlockValueBoost to 10

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -647,7 +647,7 @@ type
       # https://github.com/prysmaticlabs/prysm/pull/12227/files
       localBlockValueBoost* {.
         desc: "Increase execution layer block values for builder bid comparison by a percentage"
-        defaultValue: 0
+        defaultValue: 10
         name: "local-block-value-boost" .}: uint8
 
       historyMode* {.

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -137,7 +137,7 @@ The following options are available:
      --payload-builder         Enable external payload builder [=false].
      --payload-builder-url     Payload builder URL.
      --local-block-value-boost  Increase execution layer block values for builder bid comparison by a percentage
-                               [=0].
+                               [=10].
      --history                 Retention strategy for historical data (archive/prune) [=HistoryMode.Prune].
 
 ...


### PR DESCRIPTION
In order to help increase censorship resistance, I propose to change the default localBlockValueBoost to 10. This means validators will prioritize local block building unless the bid from the external block builder is 10% or higher than what the validator would receive when building locally.

Looking at ([stats](https://censorship.pics/)), it can be seen that currently 63.7% of external builders are censoring transactions compared to 8.53% of validators who do local block building, so setting a minimum 10% as default can help increase the overall censorship resistance of the network.

It is still easy for users to opt out of this by manually setting the flag to 0, but many are likely to use the default which could help with censorship resistance for the network.