### PR TITLE
use PR-3431 style fork choice on all networks

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2156,12 +2156,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
   if config.forkChoiceVersion.isNone:
-    config.forkChoiceVersion =
-      if metadata.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
-        # https://github.com/ethereum/pm/issues/844#issuecomment-1673359012
-        some(ForkChoiceVersion.Pr3431)
-      else:
-        some(ForkChoiceVersion.Stable)
+    config.forkChoiceVersion = some(ForkChoiceVersion.Pr3431)
 
   ## Ctrl+C handling
   proc controlCHandler() {.noconv.} =


### PR DESCRIPTION
To start phasing out Capella fork choice logic, set default to PR 3431. A subsequent release can remove the fallback option.