### PR TITLE
when adding duplicates to quarantine, schedule deepest missing parent

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -103,9 +103,10 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block quarantine
 ```diff
++ Recursive missing parent                                                                   OK
 + Unviable smoke test                                                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
+OK: 2/2 Fail: 0/2 Skip: 0/2
 ## BlockId and helpers
 ```diff
 + atSlot sanity                                                                              OK
@@ -1017,4 +1018,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 682/687 Fail: 0/687 Skip: 5/687
+OK: 683/688 Fail: 0/688 Skip: 5/688

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -105,7 +105,7 @@ func addMissing*(quarantine: var Quarantine, root: Eth2Digest) =
     return
 
   var r = root
-  while true:
+  for i in 0 .. MaxOrphans:  # Blocks are not trusted, avoid endless loops
     if r in quarantine.unviable:
       # Won't get anywhere with this block
       return
@@ -122,7 +122,7 @@ func addMissing*(quarantine: var Quarantine, root: Eth2Digest) =
     # Add if it's not there, but don't update missing counter
     if not found:
       discard quarantine.missing.hasKeyOrPut(r, MissingBlock())
-      break
+      return
 
 func removeOrphan*(
     quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -77,3 +77,44 @@ suite "Block quarantine":
 
       b5.root notin quarantine.blobless
       b6.root notin quarantine.blobless
+
+  test "Recursive missing parent":
+    let
+      b0 = makeBlock(Slot 0, ZERO_HASH)
+      b1 = makeBlock(Slot 1, b0.root)
+      b2 = makeBlock(Slot 2, b1.root)
+
+    var quarantine: Quarantine
+    check:
+      b0.root notin quarantine.missing
+      b1.root notin quarantine.missing
+      b2.root notin quarantine.missing
+
+      # Add b2
+      quarantine.addOrphan(Slot 0, b2).isOk
+      b0.root notin quarantine.missing
+      b1.root in quarantine.missing
+      b2.root notin quarantine.missing
+
+      # Add b1
+      quarantine.addOrphan(Slot 0, b1).isOk
+      b0.root in quarantine.missing
+      b1.root notin quarantine.missing
+      b2.root notin quarantine.missing
+
+      # Re-add b2
+      quarantine.addOrphan(Slot 0, b2).isOk
+      b0.root in quarantine.missing
+      b1.root notin quarantine.missing
+      b2.root notin quarantine.missing
+
+    # Empty missing
+    while quarantine.missing.len > 0:
+      discard quarantine.checkMissing(max = 5)
+
+    check:
+      # Re-add b2
+      quarantine.addOrphan(Slot 0, b2).isOk
+      b0.root in quarantine.missing
+      b1.root notin quarantine.missing
+      b2.root notin quarantine.missing


### PR DESCRIPTION
During sync, sometimes the same block gets encountered and added to quarantine multiple times. If its parent is already known, quarantine incorrectly registers it as missing, leading to re-download. This can be fixed by registering the parent's deepest missing parent recursively.

Also increase the stickiness of `missing`. We only perform 4 attempts within ~16 seconds before giving up. Very frequently, this is not enough and there is no progress until sync manager kicks in even on holesky.