### PR TITLE
allow syncing from peers that are behind us (but after finalized head)

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -362,6 +362,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A)
           local_safe_slot = man.getSafeSlot(),
           local_last_slot = man.getLastSlot(),
           local_first_slot = man.getFirstSlot()
+    await sleepAsync(RESP_TIMEOUT_DUR)
     peer.updateScore(PeerScoreUseless)
     return
 


### PR DESCRIPTION
Currently, sync manager refuses to sync from peers that report a lower head slot than our own. While this seems reasonable in a finalizing chain, it makes discovering alternate branches of non-finalizing chains more difficult. The criteria to make a peer ineligible can be set to the safe slot instead; finalized on forward, backfill on backward direction.

If sync manager discovers an alternate branch, block verifier reports `MissingParent`. Sync manager then rewinds to an earlier slot to try and discover the parent block. This parent block may be earlier than our own head. Peers with lower head slot than our own may still assist us in obtaining those blocks, as indicated by whether `req` is `empty`. While requests are non-`empty`, we also can skip the peer status update, which typically triggers 1-minute `sleepAsync` wait times if hit. Such a long wait should only be performed if there is a chance that a peer becomes eligible to handle a request if it made more progress - if it already can provide a useful response, we can ask it right away.

If the sync queue wants to sync newer slots, the logic doesn't change from before; the peer will still end up with a slight `Useless` descore.