### PR TITLE
turn on `request_manager` while chain is stalled

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -443,7 +443,9 @@ proc initFullNode(
       network: node.network)
     requestManager = RequestManager.init(
       node.network, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
-      (proc(): bool = node.syncStatus(dag.head) == ChainSyncStatus.Syncing),
+      (proc(): bool =
+        syncManager.inProgress and
+        node.syncStatus(dag.head) == ChainSyncStatus.Syncing),
       quarantine, blobQuarantine, rmanBlockVerifier)
 
   if node.config.lightClientDataServe:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -443,7 +443,7 @@ proc initFullNode(
       network: node.network)
     requestManager = RequestManager.init(
       node.network, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
-      (proc(): bool = syncManager.inProgress),
+      (proc(): bool = node.syncStatus(dag.head) == ChainSyncStatus.Syncing),
       quarantine, blobQuarantine, rmanBlockVerifier)
 
   if node.config.lightClientDataServe:


### PR DESCRIPTION
While chain is stalled, both sync manager and request manager could be useful to discover additional branches. `request_manager` should only be inhibited while syncing on a regularly operating chain.