### PR TITLE
avoid resetting chain stall detection on lag spike

### DIFF
--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -258,10 +258,11 @@ proc syncStatus*(node: BeaconNode, head: BlockRef): ChainSyncStatus =
 
   let numPeers = len(node.network.peerPool)
   if numPeers <= node.config.maxPeers div 4:
-    # We may have poor connectivity, wait until more peers are available
-    warn "Chain appears to have stalled, but have low peers",
+    # We may have poor connectivity, wait until more peers are available.
+    # This could also be intermittent, as state replays while chain is degraded
+    # may take significant amounts of time, during which many peers are lost
+    debug "Chain appears to have stalled, but have low peers",
       numPeers, maxPeers = node.config.maxPeers
-    node.dag.resetChainProgressWatchdog()
     return ChainSyncStatus.Syncing
 
   let

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -261,8 +261,6 @@ proc syncStatus*(node: BeaconNode, head: BlockRef): ChainSyncStatus =
     # We may have poor connectivity, wait until more peers are available.
     # This could also be intermittent, as state replays while chain is degraded
     # may take significant amounts of time, during which many peers are lost
-    trace "Chain appears to have stalled, but have low peers",
-      numPeers, maxPeers = node.config.maxPeers
     return ChainSyncStatus.Syncing
 
   let

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -261,7 +261,7 @@ proc syncStatus*(node: BeaconNode, head: BlockRef): ChainSyncStatus =
     # We may have poor connectivity, wait until more peers are available.
     # This could also be intermittent, as state replays while chain is degraded
     # may take significant amounts of time, during which many peers are lost
-    debug "Chain appears to have stalled, but have low peers",
+    trace "Chain appears to have stalled, but have low peers",
       numPeers, maxPeers = node.config.maxPeers
     return ChainSyncStatus.Syncing
 


### PR DESCRIPTION
During lag spike, e.g., from state replays, peer count can temporarily drop significantly. Should not have to wait another 60 minutes in that situation just to be back where one started.