### PR TITLE
make blobs use less quota when other nodes sync from us

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -479,18 +479,19 @@ template awaitQuota*(peerParam: Peer, costParam: float, protocolIdParam: string)
 
   if not peer.quota.tryConsume(cost.int):
     let protocolId = protocolIdParam
-    debug "Awaiting peer quota", peer, cost, protocolId
+    debug "Awaiting peer quota", peer, cost = cost, protocolId = protocolId
     nbc_reqresp_messages_throttled.inc(1, [protocolId])
     await peer.quota.consume(cost.int)
 
-template awaitQuota*(networkParam: Eth2Node, costParam: float, protocolIdParam: string) =
+template awaitQuota*(
+    networkParam: Eth2Node, costParam: float, protocolIdParam: string) =
   let
     network = networkParam
     cost = int(costParam)
 
   if not network.quota.tryConsume(cost.int):
     let protocolId = protocolIdParam
-    debug "Awaiting network quota", peer, cost, protocolId
+    debug "Awaiting network quota", peer, cost = cost, protocolId = protocolId
     nbc_reqresp_messages_throttled.inc(1, [protocolId])
     await network.quota.consume(cost.int)
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -20,7 +20,10 @@ logScope:
   topics = "sync_proto"
 
 const
-  blockResponseCost = allowedOpsPerSecondCost(64) # Allow syncing ~64 blocks/sec (minus request costs)
+  blockResponseCost = allowedOpsPerSecondCost(64)
+    ## Allow syncing ~64 blocks/sec (minus request costs)
+  blobResponseCost = allowedOpsPerSecondCost(1000)
+    ## Multiple can exist per block, they are much smaller than blocks
 
 type
   BeaconSyncNetworkState* {.final.} = ref object of RootObj
@@ -275,8 +278,8 @@ p2pProtocol BeaconSync(version = 1,
             bytes = bytes.len(), blck = shortLog(blockRef), blobindex = index
           continue
 
-        peer.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
-        peer.network.awaitQuota(blockResponseCost, "blob_sidecars_by_root/1")
+        peer.awaitQuota(blobResponseCost, "blob_sidecars_by_root/1")
+        peer.network.awaitQuota(blobResponseCost, "blob_sidecars_by_root/1")
 
         await response.writeBytesSZ(
           uncompressedLen, bytes,
@@ -345,8 +348,8 @@ p2pProtocol BeaconSync(version = 1,
             continue
 
           # TODO extract from libp2pProtocol
-          peer.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
-          peer.network.awaitQuota(blockResponseCost, "blobs_sidecars_by_range/1")
+          peer.awaitQuota(blobResponseCost, "blobs_sidecars_by_range/1")
+          peer.network.awaitQuota(blobResponseCost, "blobs_sidecars_by_range/1")
 
           await response.writeBytesSZ(
             uncompressedLen, bytes,


### PR DESCRIPTION
Each individual blob currently uses as much quota from the network limit as an entire block does, 128 items per second shared across all peers. Blobs are 128 KB each instead of up to several MB and are simpler to encode. There can be multiple per block (6 currently), so allow 2000 blobs per second across all peers. That decreases the cost per block from `3125 + 3125 * blobs.len` quota (= `[3125, 21875]`) to a lower `3125 + 200 * blobs.len` quota (= `[3125, 4325]`), accounting for the slight increase in data transfer and encoding time.