### PR TITLE
only request blobs if a sync response actually provided blocks

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -415,7 +415,7 @@ proc syncStep[A, B](man: SyncManager[A, B], index: int, peer: A)
       var hasBlobs = false
       for blck in blockData:
         withBlck(blck[]):
-          when consensusFork >= ConsensusForkDeneb:
+          when consensusFork >= ConsensusFork.Deneb:
             if forkyBlck.message.body.blob_kzg_commitments.len > 0:
               hasBlobs = true
               break


### PR DESCRIPTION
During sync, we can skip the `blobSidecarsByRange` request when there are no blocks with `kzg_commitments` in the blocks data. Avoids running into throttling from peers during long periods of non-finality.