### PR TITLE
ensure blobs are quarantined when block is quarantined

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -29,7 +29,7 @@ from ../consensus_object_pools/block_pools_types import
 from ../consensus_object_pools/block_quarantine import
   addBlobless, addOrphan, addUnviable, pop, removeOrphan
 from ../consensus_object_pools/blob_quarantine import
-  BlobQuarantine, hasBlobs, popBlobs
+  BlobQuarantine, hasBlobs, popBlobs, put
 from ../validators/validator_monitor import
   MsgSource, ValidatorMonitor, registerAttestationInBlock, registerBeaconBlock,
   registerSyncAggregateInBlock
@@ -454,7 +454,7 @@ proc storeBlock(
       else:
         if blobsOpt.isSome:
           for blobSidecar in blobsOpt.get:
-            self.blobQuarantine.put(blobSidecar)
+            self.blobQuarantine[].put(blobSidecar)
         debug "Block quarantined",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -452,6 +452,9 @@ proc storeBlock(
           signature = shortLog(signedBlock.signature),
           err = r.error()
       else:
+        if blobsOpt.isSome:
+          for blobSidecar in blobsOpt.get:
+            self.blobQuarantine[].put(blobSidecar)
         debug "Block quarantined",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -454,7 +454,7 @@ proc storeBlock(
       else:
         if blobsOpt.isSome:
           for blobSidecar in blobsOpt.get:
-            self.blobQuarantine[].put(blobSidecar)
+            self.blobQuarantine.put(blobSidecar)
         debug "Block quarantined",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),


### PR DESCRIPTION
When quarantining a block from block processor, we should also keep a copy of its blobs. Otherwise, this involves more network roundtrips to obtain information we already have. This is in line with how blobs arrive from gossip and request manager sources. The existing flow does not work when applying blocks from quarantine, which is addressed here.