### PR TITLE
increase blob quarantine capacity to match block quarantine capacity

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -15,7 +15,9 @@ from std/sequtils import mapIt
 from std/strutils import join
 
 const
-  MaxBlobs = SLOTS_PER_EPOCH * MAX_BLOBS_PER_BLOCK
+  MaxBlobs = 3 * SLOTS_PER_EPOCH * MAX_BLOBS_PER_BLOCK
+    ## Same limit as `MaxOrphans` in `block_quarantine`;
+    ## blobs may arrive before an orphan is tagged `blobless`
 
 type
   BlobQuarantine* = object


### PR DESCRIPTION
Blobs are cached from gossip and other sources for all orphans, not just those specifically tagged as `blobless`. `blobless` only means that they are actively fetched from the network. The `MaxBlobs` should be aligned to match `MaxOrphans`. Note that blobs are tiny compared to blocks, so this isn't a huge memory hog.