### PR TITLE
descore when opening connection fails, same as when reading fails

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -978,7 +978,7 @@ proc makeEth2Request(peer: Peer, protocolId: string, requestBytes: seq[byte],
         peer.updateScore(PeerScoreInvalidRequest)
       else:
         peer.updateScore(PeerScorePoorRequest)
-      return streamRes.error()
+      return err streamRes.error()
 
   try:
     # Send the request

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -971,8 +971,14 @@ proc makeEth2Request(peer: Peer, protocolId: string, requestBytes: seq[byte],
     deadline = sleepAsync timeout
     streamRes =
       awaitWithTimeout(peer.network.openStream(peer, protocolId), deadline):
+        peer.updateScore(PeerScorePoorRequest)
         return neterr StreamOpenTimeout
-    stream = ?streamRes
+    stream = streamRes.valueOr:
+      if streamRes.error().kind in ProtocolViolations:
+        peer.updateScore(PeerScoreInvalidRequest)
+      else:
+        peer.updateScore(PeerScorePoorRequest)
+      return streamRes.error()
 
   try:
     # Send the request


### PR DESCRIPTION
`eth2_network` forgets to descore peers when opening connection times out. It only descores when opening the connection succeeds and then there is a subsequent error. The caller cannot distinguish the cases, so ensure that the descore is also applied if the request fails during its initial portion.