### PR TITLE
Bump libp2p to 458b0885dd276afeb81b9a6d431dde79e99f2b01

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2295,14 +2295,11 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
   let phase0Prefix = "/eth2/" & $forkDigests.phase0
 
   func msgIdProvider(m: messages.Message): Result[seq[byte], ValidationResult] =
-    template topic: untyped =
-      if m.topicIds.len > 0: m.topicIds[0] else: ""
-
     try:
       # This doesn't have to be a tight bound, just enough to avoid denial of
       # service attacks.
       let decoded = snappy.decode(m.data, static(GOSSIP_MAX_SIZE.uint32))
-      ok(gossipId(decoded, phase0Prefix, topic))
+      ok(gossipId(decoded, phase0Prefix, m.topic))
     except CatchableError:
       err(ValidationResult.Reject)
 


### PR DESCRIPTION
The most significant change is https://github.com/vacp2p/nim-libp2p/pull/1051 as it changes previous behavior. More info can be found in the respective PR's descriptions. 

https://github.com/vacp2p/nim-libp2p/pull/1061 was also a big change, but only a refactoring. The risk is an unintentional behavior change not caught during review.

This also fixes a compilation issue with topic renaming in `Message`.