### PR TITLE
fix missing space in `block_sim` output

### DIFF
--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -490,7 +490,7 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
     verifyConsensus(dag.headState, attesterRatio * blockRatio)
 
     if t == tEpoch:
-      echo ". slot: ", shortLog(slot), "epoch: ", shortLog(slot.epoch)
+      echo ". slot: ", shortLog(slot), " epoch: ", shortLog(slot.epoch)
     else:
       try:
         write(stdout, ".")


### PR DESCRIPTION
In #5906, the `strformat` use was replaced with simply passing the parts of the string as `varargs` to `echo`. A space got lost from output as part of the transformation. Re-add it.