### PR TITLE
ci: move help docs check script to its own file

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -68,20 +68,13 @@ pipeline {
     stage('Build') {
       steps { timeout(50) {
         sh 'make LOG_LEVEL=TRACE'
-        /* Check documentation reflects `nimbus_beacon_node --help`. */
-        sh '''#!/usr/bin/env bash
-          if ! diff -u \\
-              <(sed -n '/Usage/,/^...$/ { /^...$/d; p; }' \\
-                docs/the_nimbus_book/src/options.md) \\
-              <(COLUMNS=200 build/nimbus_beacon_node --help | \\
-                sed -n '/Usage/,/Available sub-commands/ { /Available sub-commands/d; p; }' | \\
-                sed 's/\\x1B\\[[0-9;]*[mG]//g' | \\
-                sed 's/[[:space:]]*$//'); then \\
-            echo "Please update 'docs/the_nimbus_book/src/options.md' to match 'COLUMNS=200 nimbus_beacon_node --help'"; \\
-            false; \\
-          fi
-        '''
       } }
+    }
+
+    stage('Check Docs') {
+      steps {
+        sh './scripts/check_docs_help_msg.sh'
+      }
     }
 
     stage('Tests') {

--- a/scripts/check_docs_help_msg.sh
+++ b/scripts/check_docs_help_msg.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023-2024 Status Research & Development GmbH.
+# Licensed under either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+set -euo pipefail
+DOC_FILE='docs/the_nimbus_book/src/options.md'
+DOC_USAGE=$(sed -n '/Usage/,/^...$/ { /^...$/d; p; }' "${DOC_FILE}")
+BIN_USAGE=$(
+  COLUMNS=200 build/nimbus_beacon_node --help | \
+    sed -n '/Usage/,/Available sub-commands/ { /Available sub-commands/d; p; }' | \
+    sed 's/\\x1B\\[[0-9;]*[mG]//g' | \
+    sed 's/[[:space:]]*$//'
+)
+if ! diff -u <(echo "${DOC_USAGE}") <(echo "${BIN_USAGE}"); then
+  echo "Please update '${DOC_FILE}' to match 'COLUMNS=200 nimbus_beacon_node --help'"
+  exit 1
+fi


### PR DESCRIPTION
@etan-status please don't squeeze unreadable blobs like that into Jenkinsfiles.

And please don't squish a check/test into a build stage. Stages have names for a reason. Make use of them.