### PR TITLE
support special characters in network metadata paths

### DIFF
--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -8,13 +8,18 @@
 {.push raises: [].}
 
 import
-  std/[sequtils, strutils, os],
+  std/os,
   stew/[byteutils, objects], stew/shims/macros, nimcrypto/hash,
   web3/[conversions],
   web3/primitives as web3types,
   chronicles,
   eth/common/eth_types_json_serialization,
   ../spec/[eth2_ssz_serialization, forks]
+
+from std/sequtils import deduplicate, filterIt, mapIt
+from std/strutils import
+  escape, parseBiggestUInt, replace, splitLines, startsWith, strip,
+  toLowerAscii
 
 # TODO(zah):
 # We can compress the embedded states with snappy before embedding them here.
@@ -236,7 +241,7 @@ when const_preset == "gnosis":
       chiadoGenesisSize* {.importc: "gnosis_chiado_genesis_size".}: int
 
     # let `.incbin` in assembly file find the binary file through search path
-    {.passc: "-I" & vendorDir.}
+    {.passc: "-I" & escape(vendorDir).}
     {.compile: "network_metadata_gnosis.S".}
 
   else:
@@ -263,9 +268,6 @@ when const_preset == "gnosis":
       checkForkConsistency(network.cfg)
 
     for network in [gnosisMetadata, chiadoMetadata]:
-      doAssert network.cfg.ALTAIR_FORK_EPOCH < FAR_FUTURE_EPOCH
-      doAssert network.cfg.BELLATRIX_FORK_EPOCH < FAR_FUTURE_EPOCH
-      doAssert network.cfg.CAPELLA_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.DENEB_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.ELECTRA_FORK_EPOCH == FAR_FUTURE_EPOCH
       static: doAssert ConsensusFork.high == ConsensusFork.Deneb
@@ -287,7 +289,7 @@ elif const_preset == "mainnet":
     {.pop.}
 
     # let `.incbin` in assembly file find the binary file through search path
-    {.passc: "-I" & vendorDir.}
+    {.passc: "-I" & escape(vendorDir).}
     {.compile: "network_metadata_mainnet.S".}
 
   else:
@@ -329,9 +331,6 @@ elif const_preset == "mainnet":
       checkForkConsistency(network.cfg)
 
     for network in [mainnetMetadata, praterMetadata, sepoliaMetadata, holeskyMetadata]:
-      doAssert network.cfg.ALTAIR_FORK_EPOCH < FAR_FUTURE_EPOCH
-      doAssert network.cfg.BELLATRIX_FORK_EPOCH < FAR_FUTURE_EPOCH
-      doAssert network.cfg.CAPELLA_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.DENEB_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.ELECTRA_FORK_EPOCH == FAR_FUTURE_EPOCH
       static: doAssert ConsensusFork.high == ConsensusFork.Deneb

--- a/env.sh
+++ b/env.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
+# beacon_chain
+# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # We use ${BASH_SOURCE[0]} instead of $0 to allow sourcing this file
 # and we fall back to a Zsh-specific special var to also support Zsh.
 REL_PATH="$(dirname ${BASH_SOURCE[0]:-${(%):-%x}})"
-ABS_PATH="$(cd ${REL_PATH}; pwd)"
+ABS_PATH="$(cd "${REL_PATH}"; pwd)"
 
 # Activate nvm only when this file is sourced without arguments:
 if [ -z "$*" ]; then
@@ -32,5 +38,4 @@ if [ -f "${USER_ENV_FILE}" ]; then
   set +o allexport
 fi
 
-source ${ABS_PATH}/vendor/nimbus-build-system/scripts/env.sh
-
+source "${ABS_PATH}/vendor/nimbus-build-system/scripts/env.sh"


### PR DESCRIPTION
- https://github.com/status-im/nimbus-eth2/issues/6093

- `doAssert network.cfg.DENEB_FORK_EPOCH < FAR_FUTURE_EPOCH` and `checkForkConsistency(network.cfg)` implies `doAssert network.cfg.ALTAIR_FORK_EPOCH < FAR_FUTURE_EPOCH`,  `doAssert network.cfg.BELLATRIX_FORK_EPOCH < FAR_FUTURE_EPOCH`, and `doAssert network.cfg.CAPELLA_FORK_EPOCH < FAR_FUTURE_EPOCH`

- `escape(foo)` handles mores cases than the `env.sh` changes, but at least spaces will be handled everywhere, once the other PRs in other repos land, the Nim code will be ready for the shell scripts to use more comprehensive quoting via, e.g., (shell) `printf`