### PR TITLE
rank peers by their score instead of their memory address

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -456,15 +456,15 @@ func netKbps*(peer: Peer): float {.inline.} =
   ## Returns current network throughput average value in Kbps for peer ``peer``.
   round(((peer.netThroughput.average / 1024) * 10_000) / 10_000)
 
-func `<`(a, b: Peer): bool =
-  ## Comparison function, which first checks peer's scores, and if the peers'
-  ## score is equal it compares peers' network throughput.
-  if a.score < b.score:
-    true
-  elif a.score == b.score:
-    (a.netThroughput.average < b.netThroughput.average)
+# /!\ Must be exported to be seen by `peerCmp`
+func `<`*(a, b: Peer): bool =
+  ## Comparison function indicating `true` if peer `a` ranks worse than peer `b`
+  if a.score != b.score:
+    a.score < b.score
+  elif a.netThroughput.average != b.netThroughput.average:
+    a.netThroughput.average < b.netThroughput.average
   else:
-    false
+    system.`<`(a, b)
 
 const
   maxRequestQuota = 1000000

--- a/beacon_chain/networking/peer_pool.nim
+++ b/beacon_chain/networking/peer_pool.nim
@@ -502,7 +502,8 @@ proc acquireItemImpl[A, B](pool: PeerPool[A, B],
   let pindex =
     if filter == {PeerType.Incoming, PeerType.Outgoing}:
       if len(pool.outQueue) > 0 and len(pool.incQueue) > 0:
-        # Don't think `<` is actually `<` here.
+        # `<` here is the `PeerIndex` implementation (`HeapQueue` uses `<`),
+        # which then flips the arguments to rank `>` on `A` using `pool.cmp`
         if pool.incQueue[0] < pool.outQueue[0]:
           inc(pool.acqIncPeersCount)
           let item = pool.incQueue.pop()


### PR DESCRIPTION
The `<` function to compare peers was not exported, leading to the same peer be acquired over and over again until kick. `mixin` doesn't pull it into `peerCmp` without `*` export, and with the export no mixin needed.