### PR TITLE
avoid code repetition across forks for signed block contents

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -944,6 +944,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               return RestApiResponse.jsonError(error)
 
         withForkyBlck(restBlock):
+          # TODO (henridf): handle broadcast_validation flag
           if restBlock.kind != node.dag.cfg.consensusForkAtEpoch(
               forkyBlck.message.slot.epoch):
             doAssert strictVerification notin node.dag.updateFlags

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2020,44 +2020,8 @@ proc readValue*(reader: var JsonReader[RestJson],
     reader.raiseUnexpectedValue("Field `message` is missing")
 
   let blck = ForkedBeaconBlock(message.get())
-  value = RestPublishedSignedBeaconBlock(
-    case blck.kind
-    of ConsensusFork.Phase0:
-      ForkedSignedBeaconBlock.init(
-        phase0.SignedBeaconBlock(
-          message: blck.phase0Data,
-          signature: signature.get()
-        )
-      )
-    of ConsensusFork.Altair:
-      ForkedSignedBeaconBlock.init(
-        altair.SignedBeaconBlock(
-          message: blck.altairData,
-          signature: signature.get()
-        )
-      )
-    of ConsensusFork.Bellatrix:
-      ForkedSignedBeaconBlock.init(
-        bellatrix.SignedBeaconBlock(
-          message: blck.bellatrixData,
-          signature: signature.get()
-        )
-      )
-    of ConsensusFork.Capella:
-      ForkedSignedBeaconBlock.init(
-        capella.SignedBeaconBlock(
-          message: blck.capellaData,
-          signature: signature.get()
-        )
-      )
-    of ConsensusFork.Deneb:
-      ForkedSignedBeaconBlock.init(
-        deneb.SignedBeaconBlock(
-          message: blck.denebData,
-          signature: signature.get()
-        )
-      )
-  )
+  value = RestPublishedSignedBeaconBlock ForkedSignedBeaconBlock.init(
+    blck, blck.hash_tree_root(), signature.get())
 
 proc readValue*(reader: var JsonReader[RestJson],
                 value: var RestPublishedSignedBlockContents) {.

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -612,20 +612,31 @@ type
 func `==`*(a, b: RestValidatorIndex): bool =
   uint64(a) == uint64(b)
 
-func init*(T: type ForkedSignedBeaconBlock,
-           contents: RestPublishedSignedBlockContents): T =
-  return
-    case contents.kind
-    of ConsensusFork.Phase0:
-      ForkedSignedBeaconBlock.init(contents.phase0Data)
-    of ConsensusFork.Altair:
-      ForkedSignedBeaconBlock.init(contents.altairData)
-    of ConsensusFork.Bellatrix:
-      ForkedSignedBeaconBlock.init(contents.bellatrixData)
-    of ConsensusFork.Capella:
-      ForkedSignedBeaconBlock.init(contents.capellaData)
-    of ConsensusFork.Deneb:
-      ForkedSignedBeaconBlock.init(contents.denebData.signed_block)
+template withForkyBlck*(
+    x: RestPublishedSignedBlockContents, body: untyped): untyped =
+  case x.kind
+  of ConsensusFork.Deneb:
+    const consensusFork {.inject, used.} = ConsensusFork.Deneb
+    template forkyBlck: untyped {.inject, used.} = x.denebData.signed_block
+    template kzg_proofs: untyped {.inject, used.} = x.denebData.kzg_proofs
+    template blobs: untyped {.inject, used.} = x.denebData.blobs
+    body
+  of ConsensusFork.Capella:
+    const consensusFork {.inject, used.} = ConsensusFork.Capella
+    template forkyBlck: untyped {.inject, used.} = x.capellaData
+    body
+  of ConsensusFork.Bellatrix:
+    const consensusFork {.inject, used.} = ConsensusFork.Bellatrix
+    template forkyBlck: untyped {.inject, used.} = x.bellatrixData
+    body
+  of ConsensusFork.Altair:
+    const consensusFork {.inject, used.} = ConsensusFork.Altair
+    template forkyBlck: untyped {.inject, used.} = x.altairData
+    body
+  of ConsensusFork.Phase0:
+    const consensusFork {.inject, used.} = ConsensusFork.Phase0
+    template forkyBlck: untyped {.inject, used.} = x.phase0Data
+    body
 
 func init*(t: typedesc[RestPublishedSignedBlockContents],
            blck: phase0.BeaconBlock, root: Eth2Digest,

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -638,6 +638,21 @@ template withForkyBlck*(
     template forkyBlck: untyped {.inject, used.} = x.phase0Data
     body
 
+func init*(T: type ForkedSignedBeaconBlock,
+           contents: RestPublishedSignedBlockContents): T =
+  return
+    case contents.kind
+    of ConsensusFork.Phase0:
+      ForkedSignedBeaconBlock.init(contents.phase0Data)
+    of ConsensusFork.Altair:
+      ForkedSignedBeaconBlock.init(contents.altairData)
+    of ConsensusFork.Bellatrix:
+      ForkedSignedBeaconBlock.init(contents.bellatrixData)
+    of ConsensusFork.Capella:
+      ForkedSignedBeaconBlock.init(contents.capellaData)
+    of ConsensusFork.Deneb:
+      ForkedSignedBeaconBlock.init(contents.denebData.signed_block)
+
 func init*(t: typedesc[RestPublishedSignedBlockContents],
            blck: phase0.BeaconBlock, root: Eth2Digest,
            signature: ValidatorSig): RestPublishedSignedBlockContents =


### PR DESCRIPTION
Use forks sugar to make `RestPublishedSignedBlockContents` more concise.