### PR TITLE
ci: use clang 18 from Homebrew on aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -714,6 +714,7 @@ libnimbus_lc.a: | build deps
 		echo -e $(BUILD_END_MSG) "build/$@"
 
 # `-Wno-maybe-uninitialized` in Linux: https://github.com/nim-lang/Nim/issues/22246
+# `-Wno-unsafe-buffer-usage` Support llvm@18 on macOS: https://github.com/status-im/nimbus-eth2/pull/6153
 # `-Wl,--stack,0x0000000000800000` in Windows: MinGW default of 2 MB leads to `SIGSEGV` in `___chkstk_ms` in Nim 2.0
 test_libnimbus_lc: libnimbus_lc.a
 	+ echo -e $(BUILD_MSG) "build/$@" && \
@@ -723,19 +724,45 @@ test_libnimbus_lc: libnimbus_lc.a
 			if (( $${WITH_UBSAN:-0} )); then \
 				EXTRA_FLAGS+=('-fsanitize=undefined'); \
 			fi; \
-			clang -D__DIR__="\"beacon_chain/libnimbus_lc\"" --std=c17 -Weverything -Werror -Wno-declaration-after-statement -Wno-nullability-extension -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -o build/test_libnimbus_lc beacon_chain/libnimbus_lc/test_libnimbus_lc.c build/libnimbus_lc.a -framework Security "$${EXTRA_FLAGS[@]}"; \
+			clang -D__DIR__="\"beacon_chain/libnimbus_lc\"" \
+				--std=c17 \
+				-Weverything -Werror \
+				-Wno-declaration-after-statement -Wno-nullability-extension \
+				-Wno-unsafe-buffer-usage -Wno-unknown-warning-option \
+				-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk \
+				-o build/test_libnimbus_lc \
+				beacon_chain/libnimbus_lc/test_libnimbus_lc.c build/libnimbus_lc.a \
+				-framework Security "$${EXTRA_FLAGS[@]}"; \
 			;; \
 		MINGW64_*) \
 			if (( $${WITH_UBSAN:-0} )); then \
 				EXTRA_FLAGS+=('-fsanitize=undefined'); \
 			fi; \
-			gcc -D__DIR__="\"beacon_chain/libnimbus_lc\"" --std=c17 -Wall -Wextra -pedantic -Werror -pedantic-errors -flto -Wno-nullability-extension -Wl,--stack,0x0000000000800000 -o build/test_libnimbus_lc -D_CRT_SECURE_NO_WARNINGS beacon_chain/libnimbus_lc/test_libnimbus_lc.c build/libnimbus_lc.a "$${EXTRA_FLAGS[@]}"; \
+			gcc -D__DIR__="\"beacon_chain/libnimbus_lc\"" \
+				--std=c17 -flto \
+				-pedantic -pedantic-errors \
+				-Wall -Wextra -Werror -Wno-nullability-extension \
+				-Wno-unsafe-buffer-usage -Wno-unknown-warning-option \
+				-Wl,--stack,0x0000000000800000 \
+				-o build/test_libnimbus_lc \
+				-D_CRT_SECURE_NO_WARNINGS \
+				beacon_chain/libnimbus_lc/test_libnimbus_lc.c \
+				build/libnimbus_lc.a \
+				"$${EXTRA_FLAGS[@]}"; \
 			;; \
 		*) \
 			if (( $${WITH_UBSAN:-0} )); then \
 				EXTRA_FLAGS+=('-fsanitize=undefined'); \
 			fi; \
-			gcc -D__DIR__="\"beacon_chain/libnimbus_lc\"" --std=c17 -Wall -Wextra -pedantic -Werror -pedantic-errors -Wno-maybe-uninitialized -flto -o build/test_libnimbus_lc beacon_chain/libnimbus_lc/test_libnimbus_lc.c build/libnimbus_lc.a "$${EXTRA_FLAGS[@]}"; \
+			gcc -D__DIR__="\"beacon_chain/libnimbus_lc\"" \
+				--std=c17 -flto \
+				-pedantic -pedantic-errors \
+				-Wall -Wextra -Werror -Wno-maybe-uninitialized \
+				-Wno-unsafe-buffer-usage -Wno-unknown-warning-option \
+				-o build/test_libnimbus_lc \
+				beacon_chain/libnimbus_lc/test_libnimbus_lc.c \
+				build/libnimbus_lc.a \
+				"$${EXTRA_FLAGS[@]}"; \
 			;; \
 		esac && \
 		echo -e $(BUILD_END_MSG) "build/$@"

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,3 +1,4 @@
+#!/usr/bin/env groovy
 /* beacon_chain
  * Copyright (c) 2019-2024 Status Research & Development GmbH
  * Licensed and distributed under either of
@@ -5,6 +6,7 @@
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
+library 'status-jenkins-lib@v1.8.14'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
@@ -59,6 +61,22 @@ pipeline {
   }
 
   stages {
+    stage('Setup') {
+      when { expression { NODE_LABELS.contains("macos") } }
+      steps { script {
+        def brew_prefix = brew.prefix()
+        /* Explicit PATH to avoid using HomeBrew LLVM. */
+        env.PATH = "/usr/local/bin:/usr/sbin:/usr/bin:/bin:${brew_prefix}/bin"
+        /* Newer Clang 18.0 from Homebrew on macOS, XCode provides 15.0.
+         * Temp fix for BLST issue: https://github.com/supranational/blst/issues/209 */
+        if (utils.arch() == 'arm64') {
+          env.PATH     = "${brew_prefix}/opt/llvm/bin:$PATH"
+          env.LDFLAGS  = "-L${brew_prefix}/opt/llvm/lib"
+          env.CPPFLAGS = "-I${brew_prefix}/opt/llvm/include"
+        }
+      } }
+    }
+
     stage('Deps') {
       steps { timeout(20) {
         /* To allow the following parallel stages. */


### PR DESCRIPTION
Not sure if `LDFLAGS` and `CPPFLAGS` are absolutely necessary but Brew docs recommend it.

Depends on:
- [`infra-ci#67fafcb5`](https://github.com/status-im/infra-ci/commit/67fafcb5) - ci-slave-macos: install llvm 17 for newer clang
- https://github.com/status-im/status-jenkins-lib/pull/90