### PR TITLE
fix check docs stage in jenkins

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,5 +1,5 @@
 /* beacon_chain
- * Copyright (c) 2019-2023 Status Research & Development GmbH
+ * Copyright (c) 2019-2024 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/scripts/check_docs_help_msg.sh
+++ b/scripts/check_docs_help_msg.sh
@@ -12,6 +12,7 @@ DOC_FILE='docs/the_nimbus_book/src/options.md'
 DOC_USAGE=$(sed -n '/Usage/,/^...$/ { /^...$/d; p; }' "${DOC_FILE}")
 BIN_USAGE=$(
   COLUMNS=200 build/nimbus_beacon_node --help | \
+    sed 's/\x1b\[[0-9;]*m//g' | \
     sed -n '/Usage/,/Available sub-commands/ { /Available sub-commands/d; p; }' | \
     sed 's/\\x1B\\[[0-9;]*[mG]//g' | \
     sed 's/[[:space:]]*$//'


### PR DESCRIPTION
Ignore color information when checking consistency of options.md with the built binary.