### PR TITLE
avoid rejecting empty era file in verification

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1276,7 +1276,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
         fatal "Era summaries don't lead up to backfill, database or era files corrupt?",
-          bid
+          bid, backfillSlot
         quit 1
 
       # In BeaconState.block_roots, empty slots are filled with the root of
@@ -1299,7 +1299,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       blocks += 1
 
     if blocks > 0:
-      info "Front-filled blocks from era files", blocks
+      info "Front-filled blocks from era files", blocks, backfillSlot
 
   let frontfillTick = Moment.now()
 

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -257,7 +257,7 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
           if blck[].signature != default(type(blck[].signature)):
             return err("Genesis slot signature not empty")
 
-    if not batchVerify(verifier, sigs):
+    if sigs.len > 0 and not batchVerify(verifier, sigs):
       return err("Invalid block signature")
 
   ok(getStateRoot(state[]))


### PR DESCRIPTION
`batchVerify`'s precondition is a non-empty signature list:

```nim
  if input.len == 0:
    # Spec precondition
    return false
```

This means that in eras without any blocks (as has happened on Goerli), calling it leads to era files being reported as invalid.