### PR TITLE
allow frontfilling finalized CP block from era file

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1272,7 +1272,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     # blocks from genesis to backfill, if possible.
     for bid in dag.era.getBlockIds(
         historical_roots, historical_summaries, Slot(0), Eth2Digest()):
-      if bid.slot >= backfillSlot:
+      # If backfill has not yet started, the backfill slot itself also needs
+      # to be served from era files. Checkpoint sync starts from state only
+      if bid.slot > backfillSlot or
+          (bid.slot == backfillSlot and bid.root != dag.tail.root):
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
         fatal "Era summaries don't lead up to backfill, database or era files corrupt?",


### PR DESCRIPTION
Add support for using era file for the initial checkpoint block. This should also avoid an error when the beacon node is restarted before the backfill process has made any progress (#6059).