### PR TITLE
remove unused and redundant `PayloadID` type definition

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -333,8 +333,6 @@ proc getFeeRecipient*(
 proc getGasLimit*(self: ConsensusManager, pubkey: ValidatorPubKey): uint64 =
   getGasLimit(self.validatorsDir, self.defaultGasLimit, pubkey)
 
-from ../spec/datatypes/bellatrix import PayloadID
-
 proc runProposalForkchoiceUpdated*(
     self: ref ConsensusManager, wallSlot: Slot): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
   let

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -171,7 +171,7 @@ type
     depositContractSyncStatus: DepositContractSyncStatus
       ## Are we sure that this EL has synced the deposit contract?
 
-    lastPayloadId: Option[engine_api.PayloadID]
+    lastPayloadId: Option[PayloadID]
 
   FullBlockId* = object
     number: Eth1BlockNumber

--- a/beacon_chain/spec/datatypes/bellatrix.nim
+++ b/beacon_chain/spec/datatypes/bellatrix.nim
@@ -44,8 +44,6 @@ type
   BloomLogs* = object
     data*: array[BYTES_PER_LOGS_BLOOM, byte]
 
-  PayloadID* = array[8, byte]
-
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/bellatrix/beacon-chain.md#executionpayload
   ExecutionPayload* = object
     # Execution block header fields


### PR DESCRIPTION
`PayloadID` is defined in `nim-web3` and our own Bellatrix definition can be removed.