### PR TITLE
add function to import blobs to `ncli_db`

### DIFF
--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -468,7 +468,7 @@ proc cmdPutBlock(conf: DbConf, cfg: RuntimeConfig) =
         db.putGenesisBlock(forkyBlck.root)
 
 proc cmdPutBlob(conf: DbConf, cfg: RuntimeConfig) =
-  let db = BeaconChainDB.new(conf.databaseDir.string)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg)
   defer: db.close()
 
   for file in conf.blobFile:


### PR DESCRIPTION
`ncli_db` does not support importing blobs, making it impossible to complete the database solely from dumped files. Add the missing support.