### PR TITLE
prevent VC from trying to use implemented Bellatrix and Capella builder APIs

### DIFF
--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -11,7 +11,6 @@ import
   chronos, presto/client, chronicles,
   ".."/".."/validators/slashing_protection_common,
   ".."/datatypes/[phase0, altair, bellatrix],
-  ".."/mev/[bellatrix_mev, capella_mev],
   ".."/[helpers, forks, keystore, eth2_ssz_serialization],
   "."/[rest_types, rest_common, eth2_rest_serialization]
 
@@ -205,18 +204,6 @@ proc publishBlindedBlock*(body: phase0.SignedBeaconBlock): RestPlainResponse {.
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
 
 proc publishBlindedBlock*(body: altair.SignedBeaconBlock): RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: bellatrix_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: capella_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/blinded_blocks",
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -2461,10 +2461,8 @@ proc publishBlindedBlock*(
           publishBlindedBlock(it, data.phase0Data)
         of ConsensusFork.Altair:
           publishBlindedBlock(it, data.altairData)
-        of ConsensusFork.Bellatrix:
-          publishBlindedBlock(it, data.bellatrixData)
-        of ConsensusFork.Capella:
-          publishBlindedBlock(it, data.capellaData)
+        of ConsensusFork.Bellatrix, ConsensusFork.Capella:
+          raise (ref ValidatorApiError)(msg: ResponseNotImplementedError)
         of ConsensusFork.Deneb:
           publishBlindedBlock(it, data.denebData)
         of ConsensusFork.Electra:
@@ -2509,10 +2507,8 @@ proc publishBlindedBlock*(
         publishBlindedBlock(it, data.phase0Data)
       of ConsensusFork.Altair:
         publishBlindedBlock(it, data.altairData)
-      of ConsensusFork.Bellatrix:
-        publishBlindedBlock(it, data.bellatrixData)
-      of ConsensusFork.Capella:
-        publishBlindedBlock(it, data.capellaData)
+      of ConsensusFork.Bellatrix, ConsensusFork.Capella:
+        raise (ref ValidatorApiError)(msg: ResponseNotImplementedError)
       of ConsensusFork.Deneb:
         publishBlindedBlock(it, data.denebData)
       of ConsensusFork.Electra:


### PR DESCRIPTION
Nimbus does not support either the Bellatrix or Capella builder APIs, but the VC pretends structurally they still exist and has types for these now-nonexistent-in-Nimbus protocols.