### PR TITLE
bump `nim-libp2p` to `89cad5a3ba9088cc721682469a10917903da25a0`

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2305,7 +2305,6 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
 
   let
     params = GossipSubParams.init(
-      explicit = true,
       pruneBackoff = chronos.minutes(1),
       unsubscribeBackoff = chronos.seconds(10),
       floodPublish = true,


### PR DESCRIPTION
- add support for setting protocol handlers with `{.raises.}` annotation
- fix: valueOr and withValue utilities
- fix: remove explicit param from GossipSubParams constructor