### PR TITLE
avoid `--gc:arc` issue in validator key caching

### DIFF
--- a/beacon_chain/spec/eth2_merkleization.nim
+++ b/beacon_chain/spec/eth2_merkleization.nim
@@ -98,10 +98,10 @@ func init*(T: type HashedValidatorPubKey, key: ValidatorPubKey): HashedValidator
             # The interface of HashSet is such that we must construct a full
             # instance to check if it's in the set - then we can return that
             # instace and discard the one we just created temporarily
-            keys[tmp]
+            addr keys[tmp][]
           except KeyError:
             raiseAssert "just checked"
         else:
-          tmp
+          addr tmp[]
 
-  HashedValidatorPubKey(value: addr cached[])
+  HashedValidatorPubKey(value: cached)

--- a/beacon_chain/spec/eth2_merkleization.nim
+++ b/beacon_chain/spec/eth2_merkleization.nim
@@ -104,4 +104,4 @@ func init*(T: type HashedValidatorPubKey, key: ValidatorPubKey): HashedValidator
         else:
           addr tmp[]
 
-  HashedValidatorPubKey(value: cached)
+  HashedValidatorPubKey(value: cached)  # https://github.com/nim-lang/Nim/issues/23505


### PR DESCRIPTION
The current implementation of the validator key cache as introduced in #5883 leads to issues when compiling with `--gc:arc`. Namely, the assert in `injectdestructors.nim` > `destructiveMoveVar` is triggered:

```nim
assert n.kind != nkSym or not hasDestructor(c, n.sym.typ)
```

`cached == nkSym`, and `n.sym.typ == ref HashedValidatorPubKeyItem` with `hasDestructor(c, n.sym.typ) == true`.

Inlining the `addr ...[]` avoids the problem and allows `--gc:arc` compilation as part of LC wasm demo project.

Compilation command:

```sh
nim c \
    -d:disable_libbacktrace \
    -d:disableMarchNative \
    -d:disableLTO \
    -d:emscripten \
    -d:release \
    -d:useGcAssert \
    -d:useSysAssert \
    --debuginfo:off \
    --nimcache:nimcache \
    --os:linux \
    --cpu:wasm32 \
    --cc:clang \
    --clang.exe:emcc \
    --clang.linkerexe:emcc \
    --gc:arc \
    --exceptions:goto \
    --define:noSignalHandler \
    --define:danger \
    --panics:on \
    --passC:-fpic \
    --passL:-Os \
    --passL:-fpic \
    --passC:'-pthread' \
    --passL:'-pthread' \
    --passC:'-sASSERTIONS' \
    --passL:'-sASSERTIONS' \
    --passC:'-sINITIAL_MEMORY=256MB' \
    --passL:'-sINITIAL_MEMORY=256MB' \
    --passC:'-sSTACK_SIZE=128MB' \
    --passL:'-sSTACK_SIZE=128MB' \
    --passC:'-sUSE_PTHREADS=1' \
    --passL:'-sUSE_PTHREADS=1' \
    --passC:'-sPTHREAD_POOL_SIZE_STRICT=0' \
    --passL:'-sPTHREAD_POOL_SIZE_STRICT=0' \
    --passL:'-sEXPORTED_FUNCTIONS="[_free, _malloc, _NimMain, _ETHRandomNumberCreate, _ETHConsensusConfigCreateFromYaml, _ETHConsensusConfigGetConsensusVersionAtEpoch, _ETHBeaconStateCreateFromSsz, _ETHBeaconStateDestroy, _ETHBeaconStateCopyGenesisValidatorsRoot, _ETHRootDestroy, _ETHForkDigestsCreateFromState, _ETHBeaconClockCreateFromState, _ETHBeaconClockGetSlot, _ETHLightClientStoreCreateFromBootstrap, _ETHLightClientStoreDestroy, _kETHLcSyncKind_UpdatesByRange, _kETHLcSyncKind_FinalityUpdate, _kETHLcSyncKind_OptimisticUpdate, _ETHLightClientStoreGetNextSyncTask, _ETHLightClientStoreGetMillisecondsToNextSyncTask, _ETHLightClientStoreProcessUpdatesByRange, _ETHLightClientStoreProcessFinalityUpdate, _ETHLightClientStoreProcessOptimisticUpdate, _ETHLightClientStoreGetFinalizedHeader, _ETHLightClientStoreIsNextSyncCommitteeKnown, _ETHLightClientStoreGetOptimisticHeader, _ETHLightClientStoreGetSafetyThreshold, _ETHLightClientHeaderCreateCopy, _ETHLightClientHeaderDestroy, _ETHLightClientHeaderCopyBeaconRoot, _ETHLightClientHeaderGetBeacon, _ETHBeaconBlockHeaderGetSlot, _ETHBeaconBlockHeaderGetProposerIndex, _ETHBeaconBlockHeaderGetParentRoot, _ETHBeaconBlockHeaderGetStateRoot, _ETHBeaconBlockHeaderGetBodyRoot, _ETHLightClientHeaderCopyExecutionHash, _ETHLightClientHeaderGetExecution, _ETHExecutionPayloadHeaderGetParentHash, _ETHExecutionPayloadHeaderGetFeeRecipient, _ETHExecutionPayloadHeaderGetStateRoot, _ETHExecutionPayloadHeaderGetReceiptsRoot, _ETHExecutionPayloadHeaderGetLogsBloom, _ETHExecutionPayloadHeaderGetPrevRandao, _ETHExecutionPayloadHeaderGetBlockNumber, _ETHExecutionPayloadHeaderGetGasLimit, _ETHExecutionPayloadHeaderGetGasUsed, _ETHExecutionPayloadHeaderGetTimestamp, _ETHExecutionPayloadHeaderGetExtraDataBytes, _ETHExecutionPayloadHeaderGetBaseFeePerGas, _ETHExecutionPayloadHeaderGetBlobGasUsed, _ETHExecutionPayloadHeaderGetExcessBlobGas, _ETHExecutionBlockHeaderCreateFromJson, _ETHExecutionBlockHeaderDestroy, _ETHExecutionBlockHeaderGetTransactionsRoot, _ETHExecutionBlockHeaderGetWithdrawalsRoot, _ETHTransactionsCreateFromJson, _ETHTransactionsDestroy, _ETHTransactionsGetCount, _ETHTransactionsGet, _ETHTransactionGetHash, _ETHTransactionGetFrom, _ETHTransactionGetNonce, _ETHTransactionGetMaxPriorityFeePerGas, _ETHTransactionGetMaxFeePerGas, _ETHTransactionGetGas, _ETHTransactionIsCreatingContract, _ETHTransactionGetTo, _ETHTransactionGetValue, _ETHTransactionGetInputBytes, _ETHTransactionGetBytes, _ETHTransactionGetEip6493Root, _ETHTransactionGetEip6493Bytes, _ETHTransactionGetNumEip6493SnappyBytes, _ETHReceiptsCreateFromJson, _ETHReceiptsDestroy, _ETHReceiptsGet, _ETHReceiptHasStatus, _ETHReceiptGetBytes, _ETHReceiptGetEip6493Bytes, _ETHReceiptGetNumEip6493SnappyBytes]"' \
    --passL:'-sEXPORTED_RUNTIME_METHODS="[lengthBytesUTF8, stringToNewUTF8]"' \
    --passL:'-Wl,--no-entry' \
    --noMain:on \
    --passL:'-o libnimbus_lc.js' \
    nimbus-eth2/beacon_chain/libnimbus_lc/libnimbus_lc.nim
```