### PR TITLE
move Attestation-related types/logging from base to phase0 types

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -250,20 +250,6 @@ type
 
   CommitteeValidatorsBits* = BitList[Limit MAX_VALIDATORS_PER_COMMITTEE]
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#attestation
-  Attestation* = object
-    aggregation_bits*: CommitteeValidatorsBits
-    data*: AttestationData
-    signature*: ValidatorSig
-
-  TrustedAttestation* = object
-    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
-    # It DOES NOT imply that the state transition was verified.
-    # Currently the code MUST verify the state transition as soon as the signature is verified
-    aggregation_bits*: CommitteeValidatorsBits
-    data*: AttestationData
-    signature*: TrustedSig
-
   ForkDigest* = distinct array[4, byte]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#forkdata
@@ -318,7 +304,6 @@ type
       ## Earliest epoch when voluntary exit can be processed
     validator_index*: uint64 # `ValidatorIndex` after validation
 
-  SomeAttestation* = Attestation | TrustedAttestation
   SomeIndexedAttestation* = IndexedAttestation | TrustedIndexedAttestation
   SomeProposerSlashing* = ProposerSlashing | TrustedProposerSlashing
   SomeAttesterSlashing* = AttesterSlashing | TrustedAttesterSlashing
@@ -429,17 +414,6 @@ type
   TrustedSignedBeaconBlockHeader* = object
     message*: BeaconBlockHeader
     signature*: TrustedSig
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/validator.md#aggregateandproof
-  AggregateAndProof* = object
-    aggregator_index*: uint64 # `ValidatorIndex` after validation
-    aggregate*: Attestation
-    selection_proof*: ValidatorSig
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/validator.md#signedaggregateandproof
-  SignedAggregateAndProof* = object
-    message*: AggregateAndProof
-    signature*: ValidatorSig
 
   SyncCommitteeCache* = object
     current_sync_committee*: array[SYNC_COMMITTEE_SIZE, ValidatorIndex]
@@ -842,16 +816,6 @@ func shortLog*(v: PendingAttestation): auto =
     proposer_index: v.proposer_index
   )
 
-func shortLog*(v: SomeAttestation): auto =
-  (
-    aggregation_bits: v.aggregation_bits,
-    data: shortLog(v.data),
-    signature: shortLog(v.signature)
-  )
-
-template asTrusted*(x: Attestation): TrustedAttestation =
-  isomorphicCast[TrustedAttestation](x)
-
 func shortLog*(v: SomeIndexedAttestation): auto =
   (
     attestating_indices: v.attesting_indices,
@@ -894,7 +858,6 @@ func shortLog*(v: SomeSignedVoluntaryExit): auto =
   )
 
 chronicles.formatIt AttestationData: it.shortLog
-chronicles.formatIt Attestation: it.shortLog
 chronicles.formatIt Checkpoint: it.shortLog
 
 const
@@ -925,23 +888,6 @@ func init*(T: type GraffitiBytes, input: string): GraffitiBytes
     if input.len > MAX_GRAFFITI_SIZE:
       raise newException(ValueError, "The graffiti value should be 32 characters or less")
     distinctBase(result)[0 ..< input.len] = toBytes(input)
-
-func init*(
-    T: type Attestation,
-    indices_in_committee: openArray[uint64],
-    committee_len: int,
-    data: AttestationData,
-    signature: ValidatorSig): Result[T, cstring] =
-  var bits = CommitteeValidatorsBits.init(committee_len)
-  for index_in_committee in indices_in_committee:
-    if index_in_committee >= committee_len.uint64: return err("Invalid index for committee")
-    bits.setBit index_in_committee
-
-  ok Attestation(
-    aggregation_bits: bits,
-    data: data,
-    signature: signature
-  )
 
 func defaultGraffitiBytes*(): GraffitiBytes =
   const graffitiBytes =

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -8,6 +8,7 @@
 {.push raises: [].}
 
 import ".."/datatypes/altair
+from ".."/datatypes/phase0 import Attestation
 from ".."/datatypes/bellatrix import ExecutionPayloadHeader
 from ".."/eth2_merkleization import hash_tree_root
 

--- a/beacon_chain/spec/mev/capella_mev.nim
+++ b/beacon_chain/spec/mev/capella_mev.nim
@@ -8,6 +8,7 @@
 {.push raises: [].}
 
 import ".."/datatypes/[altair, capella]
+from ".."/datatypes/phase0 import Attestation
 from stew/byteutils import to0xHex
 
 from ../eth2_merkleization import fromSszBytes, hash_tree_root, toSszType

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -10,6 +10,7 @@
 import ".."/datatypes/[altair, deneb]
 
 from stew/byteutils import to0xHex
+from ".."/datatypes/phase0 import Attestation
 from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/eth2_merkleization import hash_tree_root

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -10,6 +10,7 @@
 import ".."/datatypes/[altair, electra]
 
 from stew/byteutils import to0xHex
+from ".."/datatypes/phase0 import Attestation
 from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/datatypes/deneb import BlobsBundle, KzgCommitments


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-7549 means that there won't be only one kind of `Attestation`/`TrustedAttestation` but two, pre-Pectra and post-Pectra. This means that it should not be in `base` anymore. Furthermore, https://github.com/nim-lang/Nim/issues/23497 triggers if one tries to add another `Attestation` type to the Electra datatypes without first moving them out of `base`, so this PR comes first.