### PR TITLE
bump `geth` to `v1.13.15`

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -21,7 +21,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.13.14-2bd6bd01"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.13.15-c5ba367e"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.13.15