### PR TITLE
add compounding withdrawal helpers

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -856,6 +856,23 @@ func is_partially_withdrawable_validator(
   has_eth1_withdrawal_credential(validator) and
     has_max_effective_balance and has_excess_balance
 
+# https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#new-is_compounding_withdrawal_credential
+func is_compounding_withdrawal_credential(
+    withdrawal_credentials: Eth2Digest): bool =
+  withdrawal_credentials.data[0] == COMPOUNDING_WITHDRAWAL_PREFIX
+
+# https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#new-has_compounding_withdrawal_credential
+func has_compounding_withdrawal_credential(validator: Validator): bool =
+  ## Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal
+  ## credential.
+  is_compounding_withdrawal_credential(validator.withdrawal_credentials)
+
+# https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#new-has_execution_withdrawal_credential
+func has_execution_withdrawal_credential(validator: Validator): bool =
+  ## Check if ``validator`` has a 0x01 or 0x02 prefixed withdrawal credential.
+  has_compounding_withdrawal_credential(validator) or
+    has_eth1_withdrawal_credential(validator)
+
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/capella/beacon-chain.md#new-get_expected_withdrawals
 func get_expected_withdrawals*(
     state: capella.BeaconState | deneb.BeaconState | electra.BeaconState):

--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -58,6 +58,9 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/capella/beacon-chain.md#domain-types
   DOMAIN_BLS_TO_EXECUTION_CHANGE* = DomainType([byte 0x0a, 0x00, 0x00, 0x00])
 
+  # https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#domains
+  DOMAIN_CONSOLIDATION* = DomainType([byte 0x0b, 0x00, 0x00, 0x00])
+
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/fork-choice.md#configuration
   PROPOSER_SCORE_BOOST*: uint64 = 40
   REORG_HEAD_WEIGHT_THRESHOLD*: uint64 = 20
@@ -79,3 +82,6 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS_DENEB*: uint64 = 128 # TODO Make use of in request code
+
+  # https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#withdrawal-prefixes
+  COMPOUNDING_WITHDRAWAL_PREFIX* = 0x02


### PR DESCRIPTION
`COMPOUNDING_WITHDRAWAL_PREFIX` is explicitly "non-configurable" (https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#constants), so placing it as an actual constant. But it might end up being like the other prefixes, in theory configurable by network presets.