### PR TITLE
fix Nim v2 builds by checking for correct job name

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -165,5 +165,5 @@ def getAgentLabel() {
 }
 
 def nimCommitForJob() {
-  return JOB_NAME.contains('-nimv2/') ? 'upstream/version-2-0' : ''
+  return JOB_NAME.contains('nimv2') ? 'upstream/version-2-0' : ''
 }


### PR DESCRIPTION
Since job folder structure has been changed we don't need the dash.