### PR TITLE
specifically use upstream Nim v2.0.4 for 2.0.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [~, upstream/version-1-6, upstream/version-2-0]
+        branch: [~, upstream/version-1-6, upstream/v2.0.4]
         exclude:
           - target:
               os: macos
@@ -47,7 +47,7 @@ jobs:
         include:
           - branch: upstream/version-1-6
             branch-short: version-1-6
-          - branch: upstream/version-2-0
+          - branch: upstream/v2.0.4
             branch-short: version-2-0
             nimflags-extra: --mm:refc
           - target:


### PR DESCRIPTION
try working around https://github.com/nim-lang/Nim/issues/23519 until that's resolved either in `nimbus-eth2` or Nim