### PR TITLE
use consensus spec v1.5.0-alpha.0 test vectors; use Nim v2.0.4 specifically for 2.0.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [~, upstream/version-1-6, upstream/version-2-0]
+        branch: [~, upstream/version-1-6, v2.0.4]
         exclude:
           - target:
               os: macos
@@ -47,7 +47,7 @@ jobs:
         include:
           - branch: upstream/version-1-6
             branch-short: version-1-6
-          - branch: upstream/version-2-0
+          - branch: v2.0.4
             branch-short: version-2-0
             nimflags-extra: --mm:refc
           - target:

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -74,7 +74,7 @@ export
   tables, results, endians2, json_serialization, sszTypes, beacon_time, crypto,
   digest, presets
 
-const SPEC_VERSION* = "1.4.0"
+const SPEC_VERSION* = "1.5.0-alpha.0"
 ## Spec version we're aiming to be compatible with, right now
 
 const

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -393,7 +393,7 @@ template fcSuite(suiteName: static[string], testPathElem: static[string]) =
       let testsPath = presetPath/path/testPathElem
       if kind != pcDir or not os_ops.dirExists(testsPath):
         continue
-      if testsPath.contains("/eip6110/") or testsPath.contains("\\eip6110\\"):
+      if testsPath.contains("/electra/") or testsPath.contains("\\electra\\"):
         continue
       let fork = forkForPathComponent(path).valueOr:
         raiseAssert "Unknown test fork: " & testsPath


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-alpha.0
https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.5.0-alpha.0
towards https://notes.ethereum.org/@ethpandaops/pectra-devnet-0

Incorporate https://github.com/status-im/nimbus-eth2/pull/6220 but without the `upstream/` prefix which in this case was counterproductive