### PR TITLE
move AttesterSlashing and IndexedAttestation from base to phase0

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -222,32 +222,6 @@ type
     signed_header_1*: TrustedSignedBeaconBlockHeader
     signed_header_2*: TrustedSignedBeaconBlockHeader
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.7/specs/phase0/beacon-chain.md#attesterslashing
-  AttesterSlashing* = object
-    attestation_1*: IndexedAttestation
-    attestation_2*: IndexedAttestation
-
-  TrustedAttesterSlashing* = object
-    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
-    # It DOES NOT imply that the state transition was verified.
-    # Currently the code MUST verify the state transition as soon as the signature is verified
-    attestation_1*: TrustedIndexedAttestation
-    attestation_2*: TrustedIndexedAttestation
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#indexedattestation
-  IndexedAttestation* = object
-    attesting_indices*: List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE]
-    data*: AttestationData
-    signature*: ValidatorSig
-
-  TrustedIndexedAttestation* = object
-    # The Trusted version, at the moment, implies that the cryptographic signature was checked.
-    # It DOES NOT imply that the state transition was verified.
-    # Currently the code MUST verify the state transition as soon as the signature is verified
-    attesting_indices*: List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE]
-    data*: AttestationData
-    signature*: TrustedSig
-
   CommitteeValidatorsBits* = BitList[Limit MAX_VALIDATORS_PER_COMMITTEE]
 
   ForkDigest* = distinct array[4, byte]
@@ -304,9 +278,7 @@ type
       ## Earliest epoch when voluntary exit can be processed
     validator_index*: uint64 # `ValidatorIndex` after validation
 
-  SomeIndexedAttestation* = IndexedAttestation | TrustedIndexedAttestation
   SomeProposerSlashing* = ProposerSlashing | TrustedProposerSlashing
-  SomeAttesterSlashing* = AttesterSlashing | TrustedAttesterSlashing
   SomeSignedBeaconBlockHeader* = SignedBeaconBlockHeader | TrustedSignedBeaconBlockHeader
   SomeSignedVoluntaryExit* = SignedVoluntaryExit | TrustedSignedVoluntaryExit
 
@@ -814,29 +786,6 @@ func shortLog*(v: PendingAttestation): auto =
     data: shortLog(v.data),
     inclusion_delay: v.inclusion_delay,
     proposer_index: v.proposer_index
-  )
-
-func shortLog*(v: SomeIndexedAttestation): auto =
-  (
-    attestating_indices: v.attesting_indices,
-    data: shortLog(v.data),
-    signature: shortLog(v.signature)
-  )
-
-iterator getValidatorIndices*(attester_slashing: SomeAttesterSlashing): uint64 =
-  template attestation_1(): auto = attester_slashing.attestation_1
-  template attestation_2(): auto = attester_slashing.attestation_2
-
-  let attestation_2_indices = toHashSet(attestation_2.attesting_indices.asSeq)
-  for validator_index in attestation_1.attesting_indices.asSeq:
-    if validator_index notin attestation_2_indices:
-      continue
-    yield validator_index
-
-func shortLog*(v: SomeAttesterSlashing): auto =
-  (
-    attestation_1: shortLog(v.attestation_1),
-    attestation_2: shortLog(v.attestation_2),
   )
 
 func shortLog*(v: SomeProposerSlashing): auto =

--- a/beacon_chain/spec/mev/bellatrix_mev.nim
+++ b/beacon_chain/spec/mev/bellatrix_mev.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import ".."/datatypes/altair
-from ".."/datatypes/phase0 import Attestation
+from ".."/datatypes/phase0 import Attestation, AttesterSlashing
 from ".."/datatypes/bellatrix import ExecutionPayloadHeader
 from ".."/eth2_merkleization import hash_tree_root
 

--- a/beacon_chain/spec/mev/capella_mev.nim
+++ b/beacon_chain/spec/mev/capella_mev.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import ".."/datatypes/[altair, capella]
-from ".."/datatypes/phase0 import Attestation
+from ".."/datatypes/phase0 import Attestation, AttesterSlashing
 from stew/byteutils import to0xHex
 
 from ../eth2_merkleization import fromSszBytes, hash_tree_root, toSszType

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -10,7 +10,7 @@
 import ".."/datatypes/[altair, deneb]
 
 from stew/byteutils import to0xHex
-from ".."/datatypes/phase0 import Attestation
+from ".."/datatypes/phase0 import Attestation, AttesterSlashing
 from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/eth2_merkleization import hash_tree_root

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -10,7 +10,7 @@
 import ".."/datatypes/[altair, electra]
 
 from stew/byteutils import to0xHex
-from ".."/datatypes/phase0 import Attestation
+from ".."/datatypes/phase0 import Attestation, AttesterSlashing
 from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/datatypes/deneb import BlobsBundle, KzgCommitments


### PR DESCRIPTION
https://eips.ethereum.org/EIPS/eip-7549 means that there won't be only one kind of `AttesterSlashing` and `IndexedAttestation` but two each, pre-Pectra and post-Pectra.

This means that they should not be in base anymore. Furthermore, https://github.com/nim-lang/Nim/issues/23497 triggers if one tries to add other versions of these types to the Electra `datatypes` without first moving them out of base, so this PR comes first.