### PR TITLE
explicitly scope AttesterSlashing and IndexedAttestation types to phase0

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -48,7 +48,7 @@ type
     exitQueue*: AsyncEventQueue[SignedVoluntaryExit]
     blsToExecQueue*: AsyncEventQueue[SignedBLSToExecutionChange]
     propSlashQueue*: AsyncEventQueue[ProposerSlashing]
-    attSlashQueue*: AsyncEventQueue[AttesterSlashing]
+    attSlashQueue*: AsyncEventQueue[phase0.AttesterSlashing]
     blobSidecarQueue*: AsyncEventQueue[BlobSidecarInfoObject]
     finalQueue*: AsyncEventQueue[FinalizationInfoObject]
     reorgQueue*: AsyncEventQueue[ReorgInfoObject]

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -493,7 +493,7 @@ proc processBlsToExecutionChange*(
 
 proc processAttesterSlashing*(
     self: var Eth2Processor, src: MsgSource,
-    attesterSlashing: AttesterSlashing): ValidationRes =
+    attesterSlashing: phase0.AttesterSlashing): ValidationRes =
   logScope:
     attesterSlashing = shortLog(attesterSlashing)
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1087,7 +1087,7 @@ proc validateBlsToExecutionChange*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#attester_slashing
 proc validateAttesterSlashing*(
-    pool: ValidatorChangePool, attester_slashing: AttesterSlashing):
+    pool: ValidatorChangePool, attester_slashing: phase0.AttesterSlashing):
     Result[void, ValidationError] =
   # [IGNORE] At least one index in the intersection of the attesting indices of
   # each attestation has not yet been seen in any prior attester_slashing (i.e.

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -837,7 +837,7 @@ template gossipMaxSize(T: untyped): uint32 =
     # Attestation, AttesterSlashing, and SignedAggregateAndProof, which all
     # have lists bounded at MAX_VALIDATORS_PER_COMMITTEE (2048) items, thus
     # having max sizes significantly smaller than GOSSIP_MAX_SIZE.
-    elif T is phase0.Attestation or T is AttesterSlashing or
+    elif T is phase0.Attestation or T is phase0.AttesterSlashing or
          T is SignedAggregateAndProof or T is phase0.SignedBeaconBlock or
          T is altair.SignedBeaconBlock or T is SomeForkyLightClientObject:
       GOSSIP_MAX_SIZE
@@ -2585,7 +2585,7 @@ proc broadcastVoluntaryExit*(
   node.broadcast(topic, exit)
 
 proc broadcastAttesterSlashing*(
-    node: Eth2Node, slashing: AttesterSlashing):
+    node: Eth2Node, slashing: phase0.AttesterSlashing):
     Future[SendResult] {.async: (raises: [CancelledError], raw: true).} =
   let topic = getAttesterSlashingsTopic(
     node.forkDigestAtEpoch(node.getWallEpoch))

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -287,7 +287,7 @@ proc initFullNode(
     node.eventBus.blsToExecQueue.emit(data)
   proc onProposerSlashingAdded(data: ProposerSlashing) =
     node.eventBus.propSlashQueue.emit(data)
-  proc onAttesterSlashingAdded(data: AttesterSlashing) =
+  proc onAttesterSlashingAdded(data: phase0.AttesterSlashing) =
     node.eventBus.attSlashQueue.emit(data)
   proc onBlobSidecarAdded(data: BlobSidecar) =
     node.eventBus.blobSidecarQueue.emit(
@@ -1773,7 +1773,7 @@ proc installMessageValidators(node: BeaconNode) =
       # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/p2p-interface.md#attester_slashing
       node.network.addValidator(
         getAttesterSlashingsTopic(digest), proc (
-          attesterSlashing: AttesterSlashing
+          attesterSlashing: phase0.AttesterSlashing
         ): ValidationResult =
           toValidationResult(
             node.processor[].processAttesterSlashing(

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1257,7 +1257,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       block:
         if contentBody.isNone():
           return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
-        let dres = decodeBody(AttesterSlashing, contentBody.get())
+        let dres = decodeBody(phase0.AttesterSlashing, contentBody.get())
         if dres.isErr():
           return RestApiResponse.jsonError(Http400,
                                            InvalidAttesterSlashingObjectError,

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -368,7 +368,8 @@ type
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
@@ -405,7 +406,8 @@ type
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
@@ -429,7 +431,8 @@ type
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
@@ -497,7 +500,8 @@ type
   BeaconBlockValidatorChanges* = object
     # Collection of exits that are suitable for block production
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
     bls_to_execution_changes*:
       List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -393,7 +393,8 @@ type
 
     # Operations
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[Attestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
@@ -428,7 +429,8 @@ type
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
@@ -451,7 +453,8 @@ type
 
     # Operations
     proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    attester_slashings*: List[TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
+    attester_slashings*:
+      List[phase0.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     attestations*: List[TrustedAttestation, Limit MAX_ATTESTATIONS]
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -46,7 +46,6 @@ createJsonFlavor RestJson
 RestJson.useDefaultSerializationFor(
   AggregateAndProof,
   AttestationData,
-  AttesterSlashing,
   BLSToExecutionChange,
   BeaconBlockHeader,
   BlobSidecar,
@@ -107,7 +106,6 @@ RestJson.useDefaultSerializationFor(
   HistoricalSummary,
   ImportDistributedKeystoresBody,
   ImportRemoteKeystoresBody,
-  IndexedAttestation,
   KeymanagerGenericError,
   KeystoreInfo,
   ListFeeRecipientResponse,
@@ -262,9 +260,11 @@ RestJson.useDefaultSerializationFor(
   electra_mev.SignedBlindedBeaconBlock,
   electra_mev.SignedBuilderBid,
   phase0.Attestation,
+  phase0.AttesterSlashing,
   phase0.BeaconBlock,
   phase0.BeaconBlockBody,
   phase0.BeaconState,
+  phase0.IndexedAttestation,
   phase0.SignedBeaconBlock,
   phase0.TrustedAttestation
 )
@@ -323,7 +323,6 @@ const
 
 type
   EncodeTypes* =
-    AttesterSlashing |
     BlobSidecarInfoObject |
     DeleteKeystoresBody |
     EmptyBody |
@@ -338,6 +337,7 @@ type
     capella_mev.SignedBlindedBeaconBlock |
     deneb_mev.SignedBlindedBeaconBlock |
     electra_mev.SignedBlindedBeaconBlock |
+    phase0.AttesterSlashing |
     SignedValidatorRegistrationV1 |
     SignedVoluntaryExit |
     Web3SignerRequest |
@@ -1709,7 +1709,7 @@ proc readValue*(reader: var JsonReader[RestJson],
     proposer_slashings:
       Opt[List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]]
     attester_slashings:
-      Opt[List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]]
+      Opt[List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]]
     attestations: Opt[List[phase0.Attestation, Limit MAX_ATTESTATIONS]]
     deposits: Opt[List[Deposit, Limit MAX_DEPOSITS]]
     voluntary_exits: Opt[List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]]
@@ -1748,7 +1748,8 @@ proc readValue*(reader: var JsonReader[RestJson],
           "Multiple `attester_slashings` fields found",
           "RestPublishedBeaconBlockBody")
       attester_slashings = Opt.some(
-        reader.readValue(List[AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]))
+        reader.readValue(
+          List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]))
     of "attestations":
       if attestations.isSome():
         reader.raiseUnexpectedField("Multiple `attestations` fields found",

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -332,7 +332,8 @@ proc getPoolAttesterSlashings*(): RestResponse[GetPoolAttesterSlashingsResponse]
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttesterSlashings
 
-proc submitPoolAttesterSlashings*(body: AttesterSlashing): RestPlainResponse {.
+proc submitPoolAttesterSlashings*(body: phase0.AttesterSlashing):
+     RestPlainResponse {.
      rest, endpoint: "/eth/v1/beacon/pool/attester_slashings",
      meth: MethodPost.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolAttesterSlashings

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -554,7 +554,8 @@ type
   GetPeerResponse* = DataMetaEnclosedObject[RestNodePeer]
   GetPeersResponse* = DataMetaEnclosedObject[seq[RestNodePeer]]
   GetPoolAttestationsResponse* = DataEnclosedObject[seq[phase0.Attestation]]
-  GetPoolAttesterSlashingsResponse* = DataEnclosedObject[seq[AttesterSlashing]]
+  GetPoolAttesterSlashingsResponse* =
+    DataEnclosedObject[seq[phase0.AttesterSlashing]]
   GetPoolProposerSlashingsResponse* = DataEnclosedObject[seq[ProposerSlashing]]
   GetPoolVoluntaryExitsResponse* = DataEnclosedObject[seq[SignedVoluntaryExit]]
   GetProposerDutiesResponse* = DataRootEnclosedObject[seq[RestProposerDuty]]

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -468,7 +468,7 @@ proc routeSignedVoluntaryExit*(
   return ok()
 
 proc routeAttesterSlashing*(
-    router: ref MessageRouter, slashing: AttesterSlashing):
+    router: ref MessageRouter, slashing: phase0.AttesterSlashing):
     Future[SendResult] {.async: (raises: [CancelledError]).} =
   block:
     let res =

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -884,7 +884,8 @@ proc registerProposerSlashing*(
       epochSummary.proposer_slashings += 1
 
 proc registerAttesterSlashing*(
-    self: var ValidatorMonitor, src: MsgSource, slashing: AttesterSlashing) =
+    self: var ValidatorMonitor, src: MsgSource,
+    slashing: phase0.AttesterSlashing) =
   let data = slashing.attestation_1.data
 
   for idx in slashing.attestation_2.attesting_indices:

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -232,7 +232,7 @@ proc doSSZ(conf: NcliConf) =
       printTimers(false, timers)
 
   case kind
-  of "attester_slashing": printit(AttesterSlashing)
+  of "attester_slashing": printit(phase0.AttesterSlashing)
   of "attestation": printit(phase0.Attestation)
   of "phase0_signed_block": printit(phase0.SignedBeaconBlock)
   of "altair_signed_block": printit(altair.SignedBeaconBlock)

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -24,7 +24,7 @@ type
     attestation: phase0.Attestation
   AttesterSlashingInput = object
     state: phase0.BeaconState
-    attesterSlashing: AttesterSlashing
+    attesterSlashing: phase0.AttesterSlashing
   BlockInput = object
     state: phase0.BeaconState
     beaconBlock: phase0.SignedBeaconBlock

--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -91,8 +91,8 @@ suite baseDescription & "Attestation " & preset():
 
 suite baseDescription & "Attester Slashing " & preset():
   proc applyAttesterSlashing(
-      preState: var altair.BeaconState, attesterSlashing: AttesterSlashing):
-      Result[void, cstring] =
+      preState: var altair.BeaconState,
+      attesterSlashing: phase0.AttesterSlashing): Result[void, cstring] =
     var cache: StateCache
     doAssert (? process_attester_slashing(
       defaultRuntimeConfig, preState, attesterSlashing, {strictVerification},
@@ -100,7 +100,7 @@ suite baseDescription & "Attester Slashing " & preset():
     ok()
 
   for path in walkTests(OpAttSlashingDir):
-    runTest[AttesterSlashing, typeof applyAttesterSlashing](
+    runTest[phase0.AttesterSlashing, typeof applyAttesterSlashing](
       OpAttSlashingDir, suiteName, "Attester Slashing", "attester_slashing",
       applyAttesterSlashing, path)
 

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -97,8 +97,8 @@ suite baseDescription & "Attestation " & preset():
 
 suite baseDescription & "Attester Slashing " & preset():
   proc applyAttesterSlashing(
-      preState: var bellatrix.BeaconState, attesterSlashing: AttesterSlashing):
-      Result[void, cstring] =
+      preState: var bellatrix.BeaconState,
+      attesterSlashing: phase0.AttesterSlashing): Result[void, cstring] =
     var cache: StateCache
     doAssert (? process_attester_slashing(
       defaultRuntimeConfig, preState, attesterSlashing, {strictVerification},
@@ -106,7 +106,7 @@ suite baseDescription & "Attester Slashing " & preset():
     ok()
 
   for path in walkTests(OpAttSlashingDir):
-    runTest[AttesterSlashing, typeof applyAttesterSlashing](
+    runTest[phase0.AttesterSlashing, typeof applyAttesterSlashing](
       OpAttSlashingDir, suiteName, "Attester Slashing", "attester_slashing",
       applyAttesterSlashing, path)
 

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -111,7 +111,7 @@ suite "EF - Bellatrix - SSZ consensus objects " & preset():
           of "AggregateAndProof": checkSSZ(AggregateAndProof, path, hash)
           of "Attestation": checkSSZ(Attestation, path, hash)
           of "AttestationData": checkSSZ(AttestationData, path, hash)
-          of "AttesterSlashing": checkSSZ(AttesterSlashing, path, hash)
+          of "AttesterSlashing": checkSSZ(phase0.AttesterSlashing, path, hash)
           of "BeaconBlock": checkSSZ(bellatrix.BeaconBlock, path, hash)
           of "BeaconBlockBody": checkSSZ(bellatrix.BeaconBlockBody, path, hash)
           of "BeaconBlockHeader": checkSSZ(BeaconBlockHeader, path, hash)
@@ -129,7 +129,8 @@ suite "EF - Bellatrix - SSZ consensus objects " & preset():
           of "Fork": checkSSZ(Fork, path, hash)
           of "ForkData": checkSSZ(ForkData, path, hash)
           of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
-          of "IndexedAttestation": checkSSZ(IndexedAttestation, path, hash)
+          of "IndexedAttestation":
+            checkSSZ(phase0.IndexedAttestation, path, hash)
           of "LightClientBootstrap":
             checkSSZ(altair.LightClientBootstrap, path, hash)
           of "LightClientHeader":

--- a/tests/consensus_spec/phase0/test_fixture_operations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations.nim
@@ -82,8 +82,8 @@ suite baseDescription & "Attestation " & preset():
 
 suite baseDescription & "Attester Slashing " & preset():
   proc applyAttesterSlashing(
-      preState: var phase0.BeaconState, attesterSlashing: AttesterSlashing):
-      Result[void, cstring] =
+      preState: var phase0.BeaconState,
+      attesterSlashing: phase0.AttesterSlashing): Result[void, cstring] =
     var cache: StateCache
     doAssert (? process_attester_slashing(
       defaultRuntimeConfig, preState, attesterSlashing, {strictVerification},
@@ -91,7 +91,7 @@ suite baseDescription & "Attester Slashing " & preset():
     ok()
 
   for path in walkTests(OpAttSlashingDir):
-    runTest[AttesterSlashing, typeof applyAttesterSlashing](
+    runTest[phase0.AttesterSlashing, typeof applyAttesterSlashing](
       OpAttSlashingDir, suiteName, "Attester Slashing", "attester_slashing",
       applyAttesterSlashing, path)
 

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -62,7 +62,7 @@ type
     of opOnMergeBlock:
       powBlock: PowBlock
     of opOnAttesterSlashing:
-      attesterSlashing: AttesterSlashing
+      attesterSlashing: phase0.AttesterSlashing
     of opInvalidateHash:
       invalidatedHash: Eth2Digest
       latestValidHash: Eth2Digest
@@ -151,7 +151,7 @@ proc loadOps(
       let filename = step["attester_slashing"].getStr()
       let attesterSlashing = parseTest(
         path/filename & ".ssz_snappy",
-        SSZ, AttesterSlashing
+        SSZ, phase0.AttesterSlashing
       )
       result.add Operation(kind: opOnAttesterSlashing,
         attesterSlashing: attesterSlashing)

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -53,7 +53,8 @@ template bellatrix_steps() =
   do_check
   check: b.message.body.proposer_slashings.add(default(ProposerSlashing))
   do_check
-  check: b.message.body.attester_slashings.add(default(AttesterSlashing))
+  check:
+    b.message.body.attester_slashings.add(default(phase0.AttesterSlashing))
   do_check
   check: b.message.body.attestations.add(
     phase0.Attestation(aggregation_bits: CommitteeValidatorsBits.init(1)))

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -29,12 +29,14 @@ func makeSignedBeaconBlockHeader(
 
 func makeIndexedAttestation(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    validator_index: uint64, beacon_block_root: Eth2Digest): IndexedAttestation =
+    validator_index: uint64, beacon_block_root: Eth2Digest):
+    phase0.IndexedAttestation =
   let tmp = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
 
-  IndexedAttestation(
+  phase0.IndexedAttestation(
     data: tmp,
-    attesting_indices: List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE](@[validator_index]),
+    attesting_indices:
+      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE](@[validator_index]),
     signature: get_attestation_signature(
       fork, genesis_validators_root, tmp,
       MockPrivKeys[validator_index]).toValidatorSig)
@@ -97,7 +99,7 @@ suite "Validator change pool testing suite":
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS + 5:
       for j in 0'u64 .. i:
         let
-          msg = AttesterSlashing(
+          msg = phase0.AttesterSlashing(
             attestation_1: makeIndexedAttestation(
               fork, genesis_validators_root, Slot(1), j, makeFakeHash(0)),
             attestation_2: makeIndexedAttestation(


### PR DESCRIPTION
No semantic changes, deliberately so since it spams lots of single-line changes across 23 files.

Follow-up to https://github.com/status-im/nimbus-eth2/pull/6223

Without this PR, introducing the Electra `AttesterSlashing`/`TrustedAttesterSlashing` and `IndexedAttestation`/`TrustedIndexedAttestation` types would trigger `ambiguous identifier` cascades, which this rather triggers in a safe, controlled way first, before making any nontrivial changes.

For example, because of https://github.com/nim-lang/Nim/issues/23510 it's possible in general for such ambiguities in generic functions not to be detected, but to be automatically resolved to an essentially arbitrary type determined by import order. Diagnosing this on top of, and potentially reverting/reapplying a PR of this sort, would be disruptive and risky.

Therefore, split out this no-op of a PR, and build on top of it.