### PR TITLE
Update nimbus.guide color schemes to be closer to nimbus.team

### DIFF
--- a/docs/the_nimbus_book/mkdocs.yml
+++ b/docs/the_nimbus_book/mkdocs.yml
@@ -16,18 +16,19 @@ theme:
     - navigation.top
     - content.tabs.link
   palette:
-    - scheme: default
-      primary: orange
-      accent: amber
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
     - scheme: slate
       primary: black
       accent: light blue
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+    - scheme: default
+      primary: white
+      accent: light blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
 extra_css:
   - stylesheets/extra.css
 


### PR DESCRIPTION
The new nimbus.team website got launched with different color schemes than the previous.
This is a small attempt to get the color schemes (dark/light) closer to those used on nimbus.team.

There was already a dark scheme added before. This change just sets that dark scheme as default, as is also the case for nimbus.team.

It also removes orange/amber colors from the light scheme.

I've done this exact same change for Fluffy, you can see how it looks here: https://fluffy.guide/quick-start.html 

This is just a suggestion as I quickly did this for Fluffy and perhaps there is already something in the making to make it immediately much more consistent with [nimbus.team.](https://nimbus.team/).