### PR TITLE
Chore/update libp2p branch master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,7 +24,7 @@
 	path = vendor/nim-libp2p
 	url = https://github.com/vacp2p/nim-libp2p.git
 	ignore = untracked
-	branch = unstable
+	branch = master
 [submodule "vendor/nimbus-build-system"]
 	path = vendor/nimbus-build-system
 	url = https://github.com/status-im/nimbus-build-system.git


### PR DESCRIPTION
changes the default branch of libp2p from unstable to master.
See https://github.com/vacp2p/nim-libp2p/issues/1088