### PR TITLE
Uses `nimbus-eth2` 24.3 stable release, joining Kaustinen Devnet (Verkle Readiness)

### DIFF
--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -549,16 +549,16 @@ type
   #   bls_to_execution_changes*:
   #     List[SignedBLSToExecutionChange, Limit MAX_BLS_TO_EXECUTION_CHANGES]
 
-  BeaconStateDiffPreSnapshot* = object
-    eth1_data_votes_recent*: seq[Eth1Data]
-    eth1_data_votes_len*: int
-    slot*: Slot
-    historical_summaries_len*: int
-    eth1_withdrawal_credential*: seq[bool]
+  # BeaconStateDiffPreSnapshot* = object
+  #   eth1_data_votes_recent*: seq[Eth1Data]
+  #   eth1_data_votes_len*: int
+  #   slot*: Slot
+  #   historical_summaries_len*: int
+  #   eth1_withdrawal_credential*: seq[bool]
 
-  IndexedWithdrawalCredentials* = object
-    validator_index*: uint64
-    withdrawal_credentials*: Eth2Digest
+  # IndexedWithdrawalCredentials* = object
+  #   validator_index*: uint64
+  #   withdrawal_credentials*: Eth2Digest
 
   # BeaconStateDiff* = object
   #   # Small and/or static; always include

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -61,8 +61,8 @@ type
     altair.HashedBeaconState |
     bellatrix.HashedBeaconState |
     capella.HashedBeaconState |
-    deneb.HashedBeaconState #|
-    # electra.HashedBeaconState
+    deneb.HashedBeaconState |
+    electra.HashedBeaconState
 
   ForkedHashedBeaconState* = object
     case kind*: ConsensusFork
@@ -117,24 +117,24 @@ type
     altair.BeaconBlock |
     bellatrix.BeaconBlock |
     capella.BeaconBlock |
-    deneb.BeaconBlock #|
-    # electra.BeaconBlock
+    deneb.BeaconBlock |
+    electra.BeaconBlock
 
   ForkySigVerifiedBeaconBlock* =
     phase0.SigVerifiedBeaconBlock |
     altair.SigVerifiedBeaconBlock |
     bellatrix.SigVerifiedBeaconBlock |
     capella.SigVerifiedBeaconBlock |
-    deneb.SigVerifiedBeaconBlock #|
-    # electra.SigVerifiedBeaconBlock
+    deneb.SigVerifiedBeaconBlock |
+    electra.SigVerifiedBeaconBlock
 
   ForkyTrustedBeaconBlock* =
     phase0.TrustedBeaconBlock |
     altair.TrustedBeaconBlock |
     bellatrix.TrustedBeaconBlock |
     capella.TrustedBeaconBlock |
-    deneb.TrustedBeaconBlock #|
-    # electra.TrustedBeaconBlock
+    deneb.TrustedBeaconBlock |
+    electra.TrustedBeaconBlock
 
   SomeForkyBeaconBlock* =
     ForkyBeaconBlock |
@@ -189,8 +189,8 @@ type
     altair.SignedBeaconBlock |
     bellatrix.SignedBeaconBlock |
     capella.SignedBeaconBlock |
-    deneb.SignedBeaconBlock #|
-    # electra.SignedBeaconBlock
+    deneb.SignedBeaconBlock |
+    electra.SignedBeaconBlock
 
   ForkedSignedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -220,24 +220,24 @@ type
     altair.SigVerifiedSignedBeaconBlock |
     bellatrix.SigVerifiedSignedBeaconBlock |
     capella.SigVerifiedSignedBeaconBlock |
-    deneb.SigVerifiedSignedBeaconBlock #|
-    # electra.SigVerifiedSignedBeaconBlock
+    deneb.SigVerifiedSignedBeaconBlock |
+    electra.SigVerifiedSignedBeaconBlock
 
   ForkyMsgTrustedSignedBeaconBlock* =
     phase0.MsgTrustedSignedBeaconBlock |
     altair.MsgTrustedSignedBeaconBlock |
     bellatrix.MsgTrustedSignedBeaconBlock |
     capella.MsgTrustedSignedBeaconBlock |
-    deneb.MsgTrustedSignedBeaconBlock #|
-    # electra.MsgTrustedSignedBeaconBlock
+    deneb.MsgTrustedSignedBeaconBlock |
+    electra.MsgTrustedSignedBeaconBlock
 
   ForkyTrustedSignedBeaconBlock* =
     phase0.TrustedSignedBeaconBlock |
     altair.TrustedSignedBeaconBlock |
     bellatrix.TrustedSignedBeaconBlock |
     capella.TrustedSignedBeaconBlock |
-    deneb.TrustedSignedBeaconBlock #|
-    # electra.TrustedSignedBeaconBlock
+    deneb.TrustedSignedBeaconBlock |
+    electra.TrustedSignedBeaconBlock
 
   ForkedMsgTrustedSignedBeaconBlock* = object
     case kind*: ConsensusFork


### PR DESCRIPTION
Adds support for Verkle-enabled Execution Clients following a hard fork. 2 such examples are:
- [Geth](https://github.com/gballet/go-ethereum)
- [Nethermind](https://github.com/NethermindEth/nethermind/tree/verkle-devnet-7)

References for spec and other implementations:
- https://github.com/sigp/lighthouse/issues/4042
- https://github.com/ethereum/consensus-specs/pull/3230
- https://github.com/ethereum/EIPs/pull/6800

NOTE: For the devnet, Kaustinen is rebased on top of Capella, skipping Deneb, for some reason this fork name has been renamed from `Verge` to `Electra`.

The plan to make this work is to set DENEB_FORK_EPOCH to FAR_FUTURE_EPOCH and make Capella, Altair, Bellatrix to 0, as the devnet starts from genesis.