### PR TITLE
bump `nim-eth` to `c482b4c5b658a77cc96b49d4a397aa6d98472ac7`

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -543,7 +543,7 @@ func asConsensusType*(payload: engine_api.GetPayloadV4Response):
     # The `mapIt` calls below are necessary only because we use different distinct
     # types for KZG commitments and Blobs in the `web3` and the `deneb` spec types.
     # Both are defined as `array[N, byte]` under the hood.
-    blobsBundle: BlobsBundle(
+    blobsBundle: deneb.BlobsBundle(
       commitments: KzgCommitments.init(
         payload.blobsBundle.commitments.mapIt(it.bytes)),
       proofs: KzgProofs.init(

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -477,7 +477,7 @@ func asConsensusType*(payload: engine_api.GetPayloadV3Response):
     # The `mapIt` calls below are necessary only because we use different distinct
     # types for KZG commitments and Blobs in the `web3` and the `deneb` spec types.
     # Both are defined as `array[N, byte]` under the hood.
-    blobsBundle: BlobsBundle(
+    blobsBundle: deneb.BlobsBundle(
       commitments: KzgCommitments.init(
         payload.blobsBundle.commitments.mapIt(it.bytes)),
       proofs: KzgProofs.init(


### PR DESCRIPTION
- Introduce wrapper type for EIP-4844 transactions