### PR TITLE
electra attestation updates

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -5,6 +5,11 @@ AllTests-mainnet
 + ancestorSlot                                                                               OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## Attestation pool electra processing [Preset: mainnet]
+```diff
++ Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Attestation pool processing [Preset: mainnet]
 ```diff
 + Attestation from different branch [Preset: mainnet]                                        OK
@@ -1020,4 +1025,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 685/690 Fail: 0/690 Skip: 5/690
+OK: 686/691 Fail: 0/691 Skip: 5/691

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -107,16 +107,14 @@ iterator get_attesting_indices*(shufflingRef: ShufflingRef,
                                 aggregation_bits: ElectraCommitteeValidatorsBits, on_chain: static bool):
                                   ValidatorIndex =
   when on_chain:
-    var committee_offset = 0'u64
+    var pos = 0
     for committee_index in get_committee_indices(committee_bits):
-      for index_in_committee, validator_index in get_beacon_committee(
+      for _, validator_index in get_beacon_committee(
           shufflingRef, slot, committee_index):
 
-        if aggregation_bits[int(committee_offset) + index_in_committee]:
+        if aggregation_bits[pos]:
           yield validator_index
-
-      committee_offset +=
-        get_beacon_committee_len(shufflingRef, slot, committee_index)
+          pos += 1
   else:
     let committee_index = get_committee_index_one(committee_bits)
     for validator_index in get_attesting_indices(

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -285,7 +285,7 @@ proc process_block*(self: var ForkChoice,
 
   for attestation in blck.body.attestations:
     if attestation.data.beacon_block_root in self.backend:
-      for validator_index in dag.get_attesting_indices(attestation):
+      for validator_index in dag.get_attesting_indices(attestation, true):
         self.backend.process_attestation(
           validator_index,
           attestation.data.beacon_block_root,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -602,7 +602,7 @@ proc storeBlock(
         src, wallTime, trustedBlock.message)
 
       for attestation in trustedBlock.message.body.attestations:
-        for validator_index in dag.get_attesting_indices(attestation):
+        for validator_index in dag.get_attesting_indices(attestation, true):
           vm[].registerAttestationInBlock(attestation.data, validator_index,
             trustedBlock.message.slot)
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -872,7 +872,8 @@ proc validateAttestation*(
   let
     fork = pool.dag.forkAtEpoch(attestation.data.slot.epoch)
     attesting_index = get_attesting_indices_one(
-      shufflingRef, slot, attestation.committee_bits, attestation.aggregation_bits)
+      shufflingRef, slot, attestation.committee_bits,
+      attestation.aggregation_bits, false)
 
   # The number of aggregation bits matches the committee size, which ensures
   # this condition holds.
@@ -1151,7 +1152,7 @@ proc validateAggregate*(
   let
     fork = pool.dag.forkAtEpoch(aggregate.data.slot.epoch)
     attesting_indices = get_attesting_indices(
-      shufflingRef, slot, committee_index, aggregate.aggregation_bits)
+      shufflingRef, slot, committee_index, aggregate.aggregation_bits, false)
 
   let
     sig =

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -598,16 +598,14 @@ iterator get_attesting_indices_iter*(
     cache: var StateCache): ValidatorIndex =
   ## Return the set of attesting indices corresponding to ``aggregation_bits``
   ## and ``committee_bits``.
-  var committee_offset = 0'u64
+  var pos = 0
   for committee_index in get_committee_indices(committee_bits):
-    for index_in_committee, validator_index in get_beacon_committee(
+    for _, validator_index in get_beacon_committee(
         state, data.slot, committee_index, cache):
 
-      if aggregation_bits[int(committee_offset) + index_in_committee]:
+      if aggregation_bits[pos]:
         yield validator_index
-
-    committee_offset +=
-      get_beacon_committee_len(state, data.slot, committee_index, cache)
+      pos += 1
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
 func get_attesting_indices*(

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -596,24 +596,18 @@ iterator get_attesting_indices_iter*(
     aggregation_bits: ElectraCommitteeValidatorsBits,
     committee_bits: auto,
     cache: var StateCache): ValidatorIndex =
-  debugComment "replace this implementation with actual iterator, after checking on conditions re repeat vals, ordering, etc; this is almost direct transcription of spec link algorithm in one of the places it doesn't make sense"
   ## Return the set of attesting indices corresponding to ``aggregation_bits``
   ## and ``committee_bits``.
-  var output: HashSet[ValidatorIndex]
-  let committee_indices = toSeq(committee_bits.oneIndices)
-  var committee_offset = 0
-  for index in committee_indices:
-    let committee = get_beacon_committee(state, data.slot, index.CommitteeIndex, cache)
-    var committee_attesters: HashSet[ValidatorIndex]
-    for i, index in committee:
-      if aggregation_bits[committee_offset + i]:
-        committee_attesters.incl index
-    output.incl committee_attesters
+  var committee_offset = 0'u64
+  for committee_index in get_committee_indices(committee_bits):
+    for index_in_committee, validator_index in get_beacon_committee(
+        state, data.slot, committee_index, cache):
 
-    committee_offset += len(committee)
+      if aggregation_bits[int(committee_offset) + index_in_committee]:
+        yield validator_index
 
-  for validatorIndex in output:
-    yield validatorIndex
+    committee_offset +=
+      get_beacon_committee_len(state, data.slot, committee_index, cache)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
 func get_attesting_indices*(
@@ -921,7 +915,7 @@ proc check_attestation*(
 proc check_attestation*(
     state: electra.BeaconState,
     attestation: electra.Attestation | electra.TrustedAttestation,
-    flags: UpdateFlags, cache: var StateCache): Result[void, cstring] =
+    flags: UpdateFlags, cache: var StateCache, on_chain: static bool): Result[void, cstring] =
   ## Check that an attestation follows the rules of being included in the state
   ## at the current slot. When acting as a proposer, the same rules need to
   ## be followed!
@@ -937,17 +931,26 @@ proc check_attestation*(
   if not (data.index == 0):
     return err("Electra attestation data index not 0")
 
-  var participants_count = 0
-  debugComment "cache doesn't know about forks"
-  for index in attestation.committee_bits.oneIndices:
-    if not (index.uint64 < get_committee_count_per_slot(
-        state, data.target.epoch, cache)):
-      return err("foo")
-    let committee = get_beacon_committee(state, data.slot, index.CommitteeIndex, cache)
-    participants_count += len(committee)
+  when on_chain:
+    var participants_count = 0'u64
+    debugComment "cache doesn't know about forks"
+    for index in attestation.committee_bits.oneIndices:
+      if not (index.uint64 < get_committee_count_per_slot(
+          state, data.target.epoch, cache)):
+        return err("attestation wrong committee index len")
+      participants_count +=
+        get_beacon_committee_len(state, data.slot, index.CommitteeIndex, cache)
 
-  if not (len(attestation.aggregation_bits) == participants_count):
-    return err("")
+    if not (lenu64(attestation.aggregation_bits) == participants_count):
+      return err("attestation wrong aggregation bit length")
+  else:
+    let
+      committee_index = get_committee_index_one(attestation.committee_bits).valueOr:
+        return err("Network attestation without single committee index")
+
+    if not (lenu64(attestation.aggregation_bits) ==
+        get_beacon_committee_len(state, data.slot, committee_index, cache)):
+      return err("attestation wrong aggregation bit length")
 
   if epoch == get_current_epoch(state):
     if not (data.source == state.current_justified_checkpoint):
@@ -1100,7 +1103,7 @@ proc process_attestation*(
     attestation: electra.Attestation | electra.TrustedAttestation,
     flags: UpdateFlags, base_reward_per_increment: Gwei,
     cache: var StateCache): Result[Gwei, cstring] =
-  ? check_attestation(state, attestation, flags, cache)
+  ? check_attestation(state, attestation, flags, cache, true)
 
   let proposer_index = get_beacon_proposer_index(state, cache).valueOr:
     return err("process_attestation: no beacon proposer index and probably no active validators")

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -878,7 +878,7 @@ func get_base_reward(
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
     state: ForkyBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
-    cache: var StateCache): Result[void, cstring] =
+    cache: var StateCache, on_chain: static bool = true): Result[void, cstring] =
   ## Check that an attestation follows the rules of being included in the state
   ## at the current slot. When acting as a proposer, the same rules need to
   ## be followed!

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -731,6 +731,7 @@ iterator getValidatorIndices*(attester_slashing: AttesterSlashing | TrustedAttes
 func shortLog*(v: electra.Attestation | electra.TrustedAttestation): auto =
   (
     aggregation_bits: v.aggregation_bits,
+    committee_bits: v.committee_bits,
     data: shortLog(v.data),
     signature: shortLog(v.signature)
   )

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -8,7 +8,9 @@
 
 # Helpers and functions pertaining to managing the validator set
 
-import "."/[algorithm, crypto, helpers]
+import
+  std/algorithm,
+  "."/[crypto, helpers]
 export helpers
 
 const

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -557,7 +557,6 @@ func get_committee_index_one*(bits: AttestationCommitteeBits): Opt[CommitteeInde
 
 proc compute_on_chain_aggregate*(
     network_aggregates: openArray[electra.Attestation]): Opt[electra.Attestation] =
-
   # aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
   let aggregates = @network_aggregates # assume already sorted
 
@@ -573,9 +572,10 @@ proc compute_on_chain_aggregate*(
   var aggregation_bits = ElectraCommitteeValidatorsBits.init(totalLen)
   var committee_offset = 0
   for i, a in aggregates:
-    let committee_index = ? get_committee_index_one(a.committee_bits)
+    let
+      committee_index = ? get_committee_index_one(a.committee_bits)
+      first = committee_offset == 0
 
-    let first = aggregation_bits.len == 0
     for idx, b in a.aggregation_bits:
       aggregation_bits[committee_offset + idx] = b
     committee_offset += a.aggregation_bits.len()

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -8,7 +8,7 @@
 
 # Helpers and functions pertaining to managing the validator set
 
-import ./helpers
+import "."/[crypto, helpers]
 export helpers
 
 const
@@ -541,3 +541,59 @@ func compute_subscribed_subnet(node_id: UInt256, epoch: Epoch, index: uint64):
 iterator compute_subscribed_subnets*(node_id: UInt256, epoch: Epoch): SubnetId =
   for index in 0'u64 ..< SUBNETS_PER_NODE:
     yield compute_subscribed_subnet(node_id, epoch, index)
+
+iterator get_committee_indices*(bits: AttestationCommitteeBits): CommitteeIndex =
+  for index, b in bits:
+    if b:
+      yield CommitteeIndex.init(uint64(index)).valueOr:
+        break # Too many bits! Shouldn't happen
+
+func get_committee_index_one*(bits: AttestationCommitteeBits): Opt[CommitteeIndex] =
+  var res = Opt.none(CommitteeIndex)
+  for committee_index in get_committee_indices(bits):
+    if res.isSome(): return Opt.none(CommitteeIndex)
+    res = Opt.some(committee_index)
+  res
+
+proc compute_on_chain_aggregate*(
+    network_aggregates: openArray[electra.Attestation]): Opt[electra.Attestation] =
+
+  # aggregates = sorted(network_aggregates, key=lambda a: get_committee_indices(a.committee_bits)[0])
+  let aggregates = @network_aggregates # assume already sorted
+
+  let data = aggregates[0].data
+
+  var agg: AggregateSignature
+  var committee_bits: AttestationCommitteeBits
+
+  var totalLen = 0
+  for i, a in aggregates:
+    totalLen += a.aggregation_bits.len
+
+  var aggregation_bits = ElectraCommitteeValidatorsBits.init(totalLen)
+  var committee_offset = 0
+  for i, a in aggregates:
+    let committee_index = ? get_committee_index_one(a.committee_bits)
+
+    let first = aggregation_bits.len == 0
+    for idx, b in a.aggregation_bits:
+      aggregation_bits[committee_offset + idx] = b
+    committee_offset += a.aggregation_bits.len()
+
+    if i == 0:
+      let sig = ? a.signature.load() # Expensive
+      if first:
+        agg = AggregateSignature.init(sig)
+      else:
+        agg.aggregate(sig)
+
+    committee_bits[int(committee_index)] = true
+
+  let signature = agg.finish()
+
+  ok electra.Attestation(
+      aggregation_bits: aggregation_bits,
+      data: data,
+      committee_bits: committee_bits,
+      signature: signature.toValidatorSig(),
+  )

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -501,7 +501,7 @@ proc makeBeaconBlockForHeadAndSlot*(
   let
     attestations =
       when PayloadType.kind == ConsensusFork.Electra:
-        default(seq[electra.Attestation])
+        node.attestationPool[].getElectraAttestationsForBlock(state[], cache)
       else:
         node.attestationPool[].getAttestationsForBlock(state[], cache)
     exits = withState(state[]):

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -381,7 +381,7 @@ func collectFromAttestations(
       doAssert base_reward_per_increment > 0.Gwei
       for attestation in forkyBlck.message.body.attestations:
         doAssert check_attestation(
-          forkyState.data, attestation, {}, cache).isOk
+          forkyState.data, attestation, {}, cache, true).isOk
         let proposerReward =
           if attestation.data.target.epoch == get_current_epoch(forkyState.data):
             get_proposer_reward(

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -23,7 +23,7 @@ import
   ../beacon_chain/spec/[beaconstate, helpers, state_transition, validator],
   ../beacon_chain/beacon_clock,
   # Test utilities
-  ./testutil, ./testdbutil, ./testblockutil
+  ./testutil, ./testdbutil, ./testblockutil, ./consensus_spec/fixtures_utils
 
 from std/sequtils import toSeq
 from ./testbcutil import addHeadBlock
@@ -48,6 +48,8 @@ func combine(tgt: var phase0.Attestation, src: phase0.Attestation) =
   tgt.signature = agg.finish().toValidatorSig()
 
 func loadSig(a: phase0.Attestation): CookedSig =
+  a.signature.load.get()
+func loadSig(a: electra.Attestation): CookedSig =
   a.signature.load.get()
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
@@ -730,3 +732,126 @@ suite "Attestation pool processing" & preset():
           blckRef.slot.start_beacon_time)
 
     doAssert: b10Add_clone.error == VerifierError.Duplicate
+
+suite "Attestation pool electra processing" & preset():
+  ## For now just test that we can compile and execute block processing with
+  ## mock data.
+
+  setup:
+    # Genesis state that results in 6 members per committee
+    let rng = HmacDrbgContext.new()
+    var
+      validatorMonitor = newClone(ValidatorMonitor.init())
+      cfg = genesisTestRuntimeConfig(ConsensusFork.Electra)
+      dag = init(
+        ChainDAGRef, cfg,
+        makeTestDB(SLOTS_PER_EPOCH * 6, cfg = cfg),
+        validatorMonitor, {})
+      taskpool = Taskpool.new()
+      verifier = BatchVerifier.init(rng, taskpool)
+      quarantine = newClone(Quarantine.init())
+      pool = newClone(AttestationPool.init(dag, quarantine))
+      state = newClone(dag.headState)
+      cache = StateCache()
+      info = ForkedEpochInfo()
+    # Slot 0 is a finalized slot - won't be making attestations for it..
+    check:
+      process_slots(
+        dag.cfg, state[], getStateField(state[], slot) + 1, cache, info,
+        {}).isOk()
+
+
+  test "Can add and retrieve simple electra attestations" & preset():
+    let
+      # Create an attestation for slot 1!
+      bc0 = get_beacon_committee(
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      attestation = makeElectraAttestation(
+        state[], state[].latest_block_root, bc0[0], cache)
+
+    pool[].addAttestation(
+      attestation, @[bc0[0]], attestation.loadSig,
+      attestation.data.slot.start_beacon_time)
+
+    check:
+      process_slots(
+        defaultRuntimeConfig, state[],
+        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        info, {}).isOk()
+
+    let attestations = pool[].getElectraAttestationsForBlock(state[], cache)
+
+    check:
+      attestations.len == 1
+
+    let
+      root1 = addTestBlock(
+        state[], cache, electraAttestations = attestations,
+        nextSlot = false).electraData.root
+      bc1 = get_beacon_committee(
+        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+      att1 = makeElectraAttestation(state[], root1, bc1[0], cache)
+
+    check:
+      withState(state[]): forkyState.latest_block_root == root1
+
+      process_slots(
+        defaultRuntimeConfig, state[],
+        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        info, {}).isOk()
+
+      withState(state[]): forkyState.latest_block_root == root1
+
+    check:
+      # shouldn't include already-included attestations
+      pool[].getElectraAttestationsForBlock(state[], cache) == []
+
+    pool[].addAttestation(
+      att1, @[bc1[0]], att1.loadSig, att1.data.slot.start_beacon_time)
+
+    check:
+      # but new ones should go in
+      pool[].getElectraAttestationsForBlock(state[], cache).len() == 1
+
+    let
+      att2 = makeElectraAttestation(state[], root1, bc1[1], cache)
+    pool[].addAttestation(
+      att2, @[bc1[1]], att2.loadSig, att2.data.slot.start_beacon_time)
+
+    let
+      combined = pool[].getElectraAttestationsForBlock(state[], cache)
+
+    check:
+      # New attestations should be combined with old attestations
+      combined.len() == 1
+      combined[0].aggregation_bits.countOnes() == 2
+
+    pool[].addAttestation(
+      combined[0], @[bc1[1], bc1[0]], combined[0].loadSig,
+      combined[0].data.slot.start_beacon_time)
+
+    check:
+      # readding the combined attestation shouldn't have an effect
+      pool[].getElectraAttestationsForBlock(state[], cache).len() == 1
+
+    let
+      # Someone votes for a different root
+      att3 = makeElectraAttestation(state[], ZERO_HASH, bc1[2], cache)
+    pool[].addAttestation(
+      att3, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
+
+    check:
+      # We should now get both attestations for the block, but the aggregate
+      # should be the one with the most votes
+      pool[].getElectraAttestationsForBlock(state[], cache).len() == 2
+      # pool[].getAggregatedAttestation(2.Slot, 0.CommitteeIndex).
+      #   get().aggregation_bits.countOnes() == 2
+      # pool[].getAggregatedAttestation(2.Slot, hash_tree_root(att2.data)).
+      #   get().aggregation_bits.countOnes() == 2
+
+    let
+      # Someone votes for a different root
+      att4 = makeElectraAttestation(state[], ZERO_HASH, bc1[2], cache)
+    pool[].addAttestation(
+      att4, @[bc1[2]], att3.loadSig, att3.data.slot.start_beacon_time)
+

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -158,6 +158,7 @@ proc addTestBlock*(
     cache: var StateCache,
     eth1_data: Eth1Data = Eth1Data(),
     attestations: seq[phase0.Attestation] = newSeq[phase0.Attestation](),
+    electraAttestations: seq[electra.Attestation] = newSeq[electra.Attestation](),
     deposits: seq[Deposit] = newSeq[Deposit](),
     sync_aggregate: SyncAggregate = SyncAggregate.init(),
     graffiti: GraffitiBytes = default(GraffitiBytes),
@@ -221,7 +222,7 @@ proc addTestBlock*(
         block_hash: eth1_data.block_hash),
       graffiti,
       when consensusFork == ConsensusFork.Electra:
-        default(seq[electra.Attestation])
+        electraAttestations
       else:
         attestations,
       deposits,
@@ -248,6 +249,7 @@ proc makeTestBlock*(
     cache: var StateCache,
     eth1_data = Eth1Data(),
     attestations = newSeq[phase0.Attestation](),
+    electraAttestations = newSeq[electra.Attestation](),
     deposits = newSeq[Deposit](),
     sync_aggregate = SyncAggregate.init(),
     graffiti = default(GraffitiBytes),
@@ -259,7 +261,8 @@ proc makeTestBlock*(
   let tmpState = assignClone(state)
   addTestBlock(
     tmpState[], cache, eth1_data,
-    attestations, deposits, sync_aggregate, graffiti, cfg = cfg)
+    attestations, electraAttestations, deposits, sync_aggregate, graffiti,
+    cfg = cfg)
 
 func makeAttestationData*(
     state: ForkyBeaconState, slot: Slot, committee_index: CommitteeIndex,
@@ -290,7 +293,7 @@ func makeAttestationData*(
 func makeAttestationSig(
     fork: Fork, genesis_validators_root: Eth2Digest, data: AttestationData,
     committee: openArray[ValidatorIndex],
-    bits: CommitteeValidatorsBits): ValidatorSig =
+    bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits): ValidatorSig =
   let signing_root = compute_attestation_signing_root(
     fork, genesis_validators_root, data)
 
@@ -391,6 +394,78 @@ func makeFullAttestations*(
     doAssert committee.len() >= 1
     var attestation = phase0.Attestation(
       aggregation_bits: CommitteeValidatorsBits.init(committee.len),
+      data: data)
+    for i in 0..<committee.len:
+      attestation.aggregation_bits.setBit(i)
+
+    attestation.signature = makeAttestationSig(
+        getStateField(state, fork),
+        getStateField(state, genesis_validators_root), data, committee,
+        attestation.aggregation_bits)
+
+    result.add attestation
+
+func makeElectraAttestation(
+    state: ForkedHashedBeaconState, beacon_block_root: Eth2Digest,
+    committee: seq[ValidatorIndex], slot: Slot, committee_index: CommitteeIndex,
+    validator_index: ValidatorIndex, cache: var StateCache,
+    flags: UpdateFlags = {}): electra.Attestation =
+  let
+    index_in_committee = committee.find(validator_index)
+    data = makeAttestationData(state, slot, CommitteeIndex(0), beacon_block_root)
+
+  doAssert index_in_committee != -1, "find_beacon_committee should guarantee this"
+
+  var aggregation_bits = ElectraCommitteeValidatorsBits.init(committee.len)
+  aggregation_bits.setBit index_in_committee
+
+  let sig = if skipBlsValidation in flags:
+    ValidatorSig()
+  else:
+    makeAttestationSig(
+      getStateField(state, fork),
+      getStateField(state, genesis_validators_root),
+      data, committee, aggregation_bits)
+
+  var committee_bits: AttestationCommitteeBits
+  committee_bits[int committee_index] = true
+
+  electra.Attestation(
+    data: data,
+    committee_bits: committee_bits,
+    aggregation_bits: aggregation_bits,
+    signature: sig
+  )
+
+func makeElectraAttestation*(
+    state: ForkedHashedBeaconState, beacon_block_root: Eth2Digest,
+    validator_index: ValidatorIndex, cache: var StateCache): electra.Attestation =
+  let (committee, slot, index) =
+    find_beacon_committee(state, validator_index, cache)
+  makeElectraAttestation(state, beacon_block_root, committee, slot, index,
+    validator_index, cache)
+
+func makeFullElectraAttestations*(
+    state: ForkedHashedBeaconState, beacon_block_root: Eth2Digest, slot: Slot,
+    cache: var StateCache,
+    flags: UpdateFlags = {}): seq[electra.Attestation] =
+  # Create attestations in which the full committee participates for each shard
+  # that should be attested to during a particular slot
+  let committees_per_slot = get_committee_count_per_slot(
+    state, slot.epoch, cache)
+  for committee_index in get_committee_indices(committees_per_slot):
+    let
+      committee = get_beacon_committee(state, slot, committee_index, cache)
+      data = makeAttestationData(state, slot, CommitteeIndex(0), beacon_block_root)
+    var
+      committee_bits: AttestationCommitteeBits
+
+    committee_bits[int committee_index] = true
+
+    doAssert committee.len() >= 1
+    var attestation = electra.Attestation(
+      aggregation_bits: ElectraCommitteeValidatorsBits.init(committee.len),
+      committee_bits: committee_bits,
       data: data)
     for i in 0..<committee.len:
       attestation.aggregation_bits.setBit(i)

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -27,8 +27,10 @@ proc makeTestDB*(
     cfg = defaultRuntimeConfig): BeaconChainDB =
   # Blob support requires DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH
   var cfg = cfg
-  cfg.CAPELLA_FORK_EPOCH = 90000.Epoch
-  cfg.DENEB_FORK_EPOCH = 100000.Epoch
+  if cfg.CAPELLA_FORK_EPOCH == FAR_FUTURE_EPOCH:
+    cfg.CAPELLA_FORK_EPOCH = 90000.Epoch
+  if cfg.DENEB_FORK_EPOCH == FAR_FUTURE_EPOCH:
+    cfg.DENEB_FORK_EPOCH = 100000.Epoch
 
   var genState = (ref ForkedHashedBeaconState)(
     kind: ConsensusFork.Phase0,


### PR DESCRIPTION
In Electra, we have two attestation formats: on-chain and on-network - the former combines all committees of a slot in a single committee bit list.

This PR makes a number of cleanups to move towards fixing this - attestation packing however still needs to be fixed as it currently creates attestations with a single committee only which is very inefficient.