### PR TITLE
VC: Enable block monitoring by default

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1047,7 +1047,7 @@ type
 
     monitoringType* {.
       desc: "Enable block monitoring which are seen by beacon node (BETA)"
-      defaultValue: BlockMonitoringType.Disabled
+      defaultValue: BlockMonitoringType.Event
       name: "block-monitor-type".}: BlockMonitoringType
 
   SigningNodeConf* = object


### PR DESCRIPTION
This feature should address issue https://github.com/status-im/nimbus-eth2/issues/4111