### PR TITLE
stop using deprecated stew/results

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -8,7 +8,6 @@
 {.push raises: [].}
 
 import
-  stew/results,
   chronicles, chronos, metrics,
   ../spec/[forks, signatures, signatures_batch],
   ../sszdump

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -9,8 +9,8 @@
 
 import
   std/tables,
-  stew/results,
-  chronicles, chronos, metrics, taskpools,
+  chronicles, chronos, metrics,
+  taskpools,
   ../spec/[helpers, forks],
   ../spec/datatypes/[altair, phase0, deneb],
   ../consensus_object_pools/[

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -9,7 +9,7 @@
 
 import
   std/[algorithm, sequtils],
-  chronos, chronicles, stew/results,
+  chronos, chronicles,
   eth/p2p/discoveryv5/[enr, protocol, node, random2],
   ../spec/datatypes/altair,
   ../spec/eth2_ssz_serialization,

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -9,7 +9,7 @@
 
 import
   std/[typetraits, sequtils, sets],
-  stew/[results, base10],
+  stew/base10,
   chronicles, metrics,
   ./rest_utils,
   ./state_ttl_cache,

--- a/beacon_chain/rpc/rest_event_api.nim
+++ b/beacon_chain/rpc/rest_event_api.nim
@@ -9,7 +9,6 @@
 
 import
   std/sequtils,
-  stew/results,
   chronicles,
   chronos/apps/http/httpserver,
   ./rest_utils,

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   std/[sequtils],
   stew/base10,

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -7,7 +7,7 @@
 
 import
   std/[sequtils],
-  stew/[results, base10],
+  stew/base10,
   chronicles,
   chronos/apps/http/httpdebug,
   libp2p/[multiaddress, multicodec, peerstore],

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -5,7 +5,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 import
-  stew/[byteutils, results],
+  stew/byteutils,
   chronicles,
   eth/p2p/discoveryv5/enr,
   libp2p/[multiaddress, multicodec, peerstore],

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -4,6 +4,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   stew/byteutils,
   chronicles,

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -7,7 +7,7 @@
 {.push raises: [].}
 
 import std/[typetraits, sets, sequtils]
-import stew/[results, base10], chronicles
+import stew/base10, chronicles
 import ".."/[beacon_chain_db, beacon_node],
        ".."/networking/eth2_network,
        ".."/consensus_object_pools/[blockchain_dag, spec_cache,

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import std/[strutils, sequtils, algorithm]
-import stew/[results, base10], chronos, chronicles
+import stew/base10, chronos, chronicles
 import
   ../spec/datatypes/[phase0, altair],
   ../spec/eth2_apis/rest_types,

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import std/[heapqueue, tables, strutils, sequtils, math]
-import stew/[results, base10], chronos, chronicles
+import stew/base10, chronos, chronicles
 import
   ../spec/datatypes/[base, phase0, altair],
   ../spec/[helpers, forks],

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  stew/[base10, results],
+  stew/base10,
   chronicles, chronos, eth/async_utils,
   ./sync/[light_client_sync_helpers, sync_manager],
   ./consensus_object_pools/[block_clearance, blockchain_dag],

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -8,7 +8,6 @@
 {.push raises: [].}
 
 import
-  stew/results,
   std/sequtils,
   chronicles,
   metrics,

--- a/tests/consensus_spec/altair/test_fixture_operations.nim
+++ b/tests/consensus_spec/altair/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, state_transition_block],
   ../../../beacon_chain/spec/datatypes/altair,

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/bellatrix,

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/capella,

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/deneb,

--- a/tests/consensus_spec/electra/test_fixture_operations.nim
+++ b/tests/consensus_spec/electra/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/state_transition_block,
   ../../../beacon_chain/spec/datatypes/electra,

--- a/tests/consensus_spec/phase0/test_fixture_operations.nim
+++ b/tests/consensus_spec/phase0/test_fixture_operations.nim
@@ -12,7 +12,6 @@ import
   # Utilities
   chronicles,
   unittest2,
-  stew/results,
   # Beacon chain internals
   ../../../beacon_chain/spec/[beaconstate, state_transition_block],
   ../../../beacon_chain/spec/datatypes/phase0,

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -10,7 +10,7 @@
 
 import
   # Status libraries
-  stew/[byteutils, results], chronicles,
+  stew/byteutils, chronicles,
   taskpools,
   # Internals
   ../../beacon_chain/spec/[helpers, forks, state_transition_block],

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -12,7 +12,7 @@ import
   std/json,
   yaml,
   kzg4844/kzg_ex,
-  stew/[byteutils, results],
+  stew/byteutils,
   ../testutil,
   ./fixtures_utils, ./os_ops
 

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -10,7 +10,6 @@
 
 import
   # Status lib
-  stew/results,
   chronicles,
   # Internal
   ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -10,10 +10,10 @@
 
 import
   # Standard library
-  std/[os],
+  std/os,
   # Status lib
   eth/db/[kvstore, kvstore_sqlite3],
-  stew/[results, endians2],
+  stew/endians2,
   # Internal
   ../../beacon_chain/validators/slashing_protection,
   ../../beacon_chain/spec/[helpers],

--- a/tests/test_deposit_snapshots.nim
+++ b/tests/test_deposit_snapshots.nim
@@ -10,7 +10,8 @@
 
 import
   std/[json, os, random, sequtils, strutils, times],
-  chronos, stew/[base10, results], chronicles, unittest2,
+  chronos,
+  stew/base10, chronicles, unittest2,
   yaml,
   ../beacon_chain/beacon_chain_db,
   ../beacon_chain/spec/deposit_snapshots,

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -9,7 +9,7 @@
 {.used.}
 
 import
-  stew/results, presto/client,
+  presto/client,
   testutils/unittests, chronicles,
   ../beacon_chain/spec/eth2_apis/[eth2_rest_serialization, rest_types],
   ./testutil


### PR DESCRIPTION
The import/export network takes care of ensuring it's always around