### PR TITLE
Bump nim-eth module and add async raises for eth2 discovery

### DIFF
--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -127,7 +127,7 @@ proc queryRandom*(
     forkId: ENRForkID,
     wantedAttnets: AttnetBits,
     wantedSyncnets: SyncnetBits,
-    minScore: int): Future[seq[Node]] {.async.} =
+    minScore: int): Future[seq[Node]] {.async: (raises: [CancelledError]).} =
   ## Perform a discovery query for a random target
   ## (forkId) and matching at least one of the attestation subnets.
 
@@ -143,7 +143,7 @@ proc queryRandom*(
       peerForkId =
         try:
           SSZ.decode(eth2FieldBytes, ENRForkID)
-        except SszError as e:
+        except SerializationError as e:
           debug "Could not decode the eth2 field of peer",
             peer = n.record.toURI(), exception = e.name, msg = e.msg
           continue
@@ -156,7 +156,7 @@ proc queryRandom*(
       let attnetsNode =
         try:
           SSZ.decode(attnetsBytes.get(), AttnetBits)
-        except SszError as e:
+        except SerializationError as e:
           debug "Could not decode the attnets ERN bitfield of peer",
             peer = n.record.toURI(), exception = e.name, msg = e.msg
           continue
@@ -170,7 +170,7 @@ proc queryRandom*(
       let syncnetsNode =
         try:
           SSZ.decode(syncnetsBytes.get(), SyncnetBits)
-        except SszError as e:
+        except SerializationError as e:
           debug "Could not decode the syncnets ENR bitfield of peer",
             peer = n.record.toURI(), exception = e.name, msg = e.msg
           continue

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1550,7 +1550,7 @@ proc getLowSubnets(node: Eth2Node, epoch: Epoch): (AttnetBits, SyncnetBits) =
       default(SyncnetBits)
   )
 
-proc runDiscoveryLoop(node: Eth2Node) {.async.} =
+proc runDiscoveryLoop(node: Eth2Node) {.async: (raises: [CancelledError]).} =
   debug "Starting discovery loop"
 
   while true:


### PR DESCRIPTION
The nim-eth bump has more changes than just the async raises:

c3f9160 Add async raises annotations for uTP code (status-im/nim-eth#692)
3d66c5b Fix ImplicitDefaultValue warnings + replace some obsolete inits (status-im/nim-eth#697)
50e71b2 Add async raises annotations for discv5 (status-im/nim-eth#690)
c9b545b No sink (status-im/nim-eth#695)
5599435 ethblock: txs -> transactions (status-im/nim-eth#694)
b9b522f keccak doesn't need `init` (status-im/nim-eth#693)
c02e050 avoid `burnMem` for `keccakHash` (status-im/nim-eth#691)
d935c0d rlp: avoid or make faster seq copies (status-im/nim-eth#689)
68bd675 faster `hash` for `Address` (status-im/nim-eth#688)
0e83cfd results: use standalone repo (status-im/nim-eth#687)
50b3d01 Revert missing hexary trie node work (status-im/nim-eth#686)
2587988 eth_types: remove unused ref types (status-im/nim-eth#685)
bb5cb6a rlp: refresh code (status-im/nim-eth#683)
0addffc binary tries: remove (status-im/nim-eth#684)

The affecting ones for nimbus-eth2 would be status-im/nim-eth#692, status-im/nim-eth#689 and status-im/nim-eth#683
