### PR TITLE
fix light client topic subscriptions

### DIFF
--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -342,25 +342,26 @@ proc installMessageValidators*(
   for consensusFork in ConsensusFork:
     withLcDataFork(lcDataForkAtConsensusFork(consensusFork)):
       when lcDataFork > LightClientDataFork.None:
-        let
-          contextFork = consensusFork  # Avoid capturing `Deneb` (Nim 1.6)
-          digest = forkDigests[].atConsensusFork(contextFork)
+        closureScope:
+          let
+            contextFork = consensusFork
+            digest = forkDigests[].atConsensusFork(contextFork)
 
-        # light_client_optimistic_update
-        # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_finality_update
-        lightClient.network.addValidator(
-          getLightClientFinalityUpdateTopic(digest), proc (
-            msg: lcDataFork.LightClientFinalityUpdate
-          ): ValidationResult =
-            validate(msg, contextFork, processLightClientFinalityUpdate))
+          # light_client_optimistic_update
+          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_finality_update
+          lightClient.network.addValidator(
+            getLightClientFinalityUpdateTopic(digest), proc (
+              msg: lcDataFork.LightClientFinalityUpdate
+            ): ValidationResult =
+              validate(msg, contextFork, processLightClientFinalityUpdate))
 
-        # light_client_optimistic_update
-        # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
-        lightClient.network.addValidator(
-          getLightClientOptimisticUpdateTopic(digest), proc (
-            msg: lcDataFork.LightClientOptimisticUpdate
-          ): ValidationResult =
-            validate(msg, contextFork, processLightClientOptimisticUpdate))
+          # light_client_optimistic_update
+          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
+          lightClient.network.addValidator(
+            getLightClientOptimisticUpdateTopic(digest), proc (
+              msg: lcDataFork.LightClientOptimisticUpdate
+            ): ValidationResult =
+              validate(msg, contextFork, processLightClientOptimisticUpdate))
 
 proc updateGossipStatus*(
     lightClient: LightClient, slot: Slot, dagIsBehind = default(Option[bool])) =


### PR DESCRIPTION
Using `let contextFork = consensusFork` no longer seems to work to avoid capturing the `var` loop variable; it ends up being `Electra` for all handlers. Use `closureScope` as a more sustainable fix.