### PR TITLE
increase TNS state download timeout to 90s

### DIFF
--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -21,7 +21,7 @@ import
 from presto import RestDecodingError
 
 const
-  largeRequestsTimeout = 60.seconds # Downloading large items such as states.
+  largeRequestsTimeout = 90.seconds # Downloading large items such as states.
   smallRequestsTimeout = 30.seconds # Downloading smaller items such as blocks and deposit snapshots.
 
 proc fetchDepositSnapshot(


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/issues/6333

Any timeout will be somewhat arbitrary, but at least some evidence that 90s might be a better tradeoff than 60s.