### PR TITLE
rm Goerli remnant; add explanatory comment about opt sync validation

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1529,7 +1529,6 @@ proc exchangeConfigWithSingleEL(
         # https://chainid.network/
         expectedChain = case m.eth1Network.get
           of mainnet: 1.Quantity
-          of goerli:  5.Quantity
           of sepolia: 11155111.Quantity
           of holesky: 17000.Quantity
       if expectedChain != providerChain:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -545,11 +545,16 @@ proc storeBlock(
 
     # TODO run https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#blob-kzg-commitments
     # https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#specification
-    # "This validation MUST be instantly run in all cases even during active sync process."
+    # "This validation MUST be instantly run in all cases even during active
+    # sync process."
     #
     # Client software MUST validate `blockHash` value as being equivalent to
     # `Keccak256(RLP(ExecutionBlockHeader))`
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#specification
+    #
+    # This should simulate an unsynced EL, which still must perform these
+    # checks. This means it must be able to do so without context, beyond
+    # whatever data the block itself contains.
     when typeof(signedBlock).kind >= ConsensusFork.Bellatrix and typeof(signedBlock).kind <= ConsensusFork.Deneb:
       debugComment "electra can do this in principle"
       template payload(): auto = signedBlock.message.body.execution_payload
@@ -562,8 +567,6 @@ proc storeBlock(
         doAssert strictVerification notin dag.updateFlags
         self.consensusManager.quarantine[].addUnviable(signedBlock.root)
         return err((VerifierError.Invalid, ProcessingStatus.completed))
-    else:
-      discard
 
   let newPayloadTick = Moment.now()
 

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -47,7 +47,6 @@ type
 
   Eth1Network* = enum
     mainnet
-    goerli
     sepolia
     holesky
 

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -462,10 +462,6 @@ proc collectSignatureSets*(
               genesis_fork, genesis_validators_root, bls_change.message,
               validator_pubkey, sig)
 
-  block:
-    # 9. Consolidations
-    debugComment "check consolidations signatures"
-
   ok()
 
 proc batchVerify*(verifier: var BatchVerifier, sigs: openArray[SignatureSet]): bool =


### PR DESCRIPTION
The `debugComment` is not salient anymore with `v1.5.0-alpha.3`, which switched the consolidations to EL-triggered, and removed CL signature verification of them.