### PR TITLE
bump nimbus-build-system to use Nim 2.0.6 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [~, upstream/version-1-6, v2.0.6]
+        branch: [~, v2.0.6]
         exclude:
           - target:
               os: macos


### PR DESCRIPTION
- https://github.com/status-im/nimbus-build-system/commit/03bfa4c6acaf67e1e2e7c855ddd95b52de5a6cad