### PR TITLE
REST: Fix empty statuses array handling in POST to /eth/v1/beacon/states/{state_id}/validators

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -425,7 +425,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                 Http400, InvalidRequestBodyError, $error)
           let
             ids = request.ids.valueOr: @[]
-            filter = request.status.valueOr: AllValidatorFilterKinds
+            filter =
+              if request.status.isNone() or len(request.status.get) == 0:
+                AllValidatorFilterKinds
+              else:
+                request.status.get
           (ids, filter)
       sid = state_id.valueOr:
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,


### PR DESCRIPTION
Address #6175.