### PR TITLE
ensure passing unsigned integer to `rlp.encode`

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1322,7 +1322,7 @@ proc ETHExecutionBlockHeaderCreateFromJson(
     var tr = initHexaryTrie(newMemoryDB())
     for i, wd in wds:
       try:
-        tr.put(rlp.encode(i), wd.bytes)
+        tr.put(rlp.encode(i.uint), wd.bytes)
       except RlpError:
         raiseAssert "Unreachable"
     if tr.rootHash() != data.withdrawalsRoot.get.asEth2Digest:
@@ -1632,7 +1632,7 @@ proc ETHTransactionsCreateFromJson(
   var tr = initHexaryTrie(newMemoryDB())
   for i, transaction in txs:
     try:
-      tr.put(rlp.encode(i), distinctBase(transaction.bytes))
+      tr.put(rlp.encode(i.uint), distinctBase(transaction.bytes))
     except RlpError:
       raiseAssert "Unreachable"
   if tr.rootHash() != transactionsRoot[]:
@@ -2208,7 +2208,7 @@ proc ETHReceiptsCreateFromJson(
   var tr = initHexaryTrie(newMemoryDB())
   for i, rec in recs:
     try:
-      tr.put(rlp.encode(i), rec.bytes)
+      tr.put(rlp.encode(i.uint), rec.bytes)
     except RlpError:
       raiseAssert "Unreachable"
   if tr.rootHash() != receiptsRoot[]:

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -445,9 +445,10 @@ proc computeTransactionsTrieRoot*(
   var tr = initHexaryTrie(newMemoryDB())
   for i, transaction in payload.transactions:
     try:
-      tr.put(rlp.encode(i), distinctBase(transaction))  # Already RLP encoded
+      # Transactions are already RLP encoded
+      tr.put(rlp.encode(i.uint), distinctBase(transaction))
     except RlpError as exc:
-      doAssert false, "HexaryTrie.put failed: " & $exc.msg
+      raiseAssert "HexaryTrie.put failed: " & $exc.msg
   tr.rootHash()
 
 func toExecutionWithdrawal*(
@@ -468,9 +469,9 @@ proc computeWithdrawalsTrieRoot*(
   var tr = initHexaryTrie(newMemoryDB())
   for i, withdrawal in payload.withdrawals:
     try:
-      tr.put(rlp.encode(i), rlp.encode(toExecutionWithdrawal(withdrawal)))
+      tr.put(rlp.encode(i.uint), rlp.encode(toExecutionWithdrawal(withdrawal)))
     except RlpError as exc:
-      doAssert false, "HexaryTrie.put failed: " & $exc.msg
+      raiseAssert "HexaryTrie.put failed: " & $exc.msg
   tr.rootHash()
 
 proc blockToBlockHeader*(blck: ForkyBeaconBlock): ExecutionBlockHeader =


### PR DESCRIPTION
RLP encoding is not defined for signed integers. Make sure to use unsigned integers when encoding RLP for EL block hash computation.