### PR TITLE
chore: update copyright year for beacon node bash scripts

### DIFF
--- a/run-holesky-beacon-node.sh
+++ b/run-holesky-beacon-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2023 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2024 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license

--- a/run-mainnet-beacon-node.sh
+++ b/run-mainnet-beacon-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2020-2021 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2020-2024 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license

--- a/run-sepolia-beacon-node.sh
+++ b/run-sepolia-beacon-node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2022 Status Research & Development GmbH. Licensed under
+# Copyright (c) 2024 Status Research & Development GmbH. Licensed under
 # either of:
 # - Apache License, version 2.0
 # - MIT license


### PR DESCRIPTION
This updates the copyright years for the run-*-beacon-node.sh scripts.