### PR TITLE
BN: User agent recognition and error codes decoding.

### DIFF
--- a/beacon_chain/networking/eth2_agents.nim
+++ b/beacon_chain/networking/eth2_agents.nim
@@ -24,7 +24,7 @@ type
 func `$`*(a: Eth2Agent): string =
   case a
   of Eth2Agent.Unknown:
-    "unrecognized"
+    "pending/unknown"
   of Eth2Agent.Nimbus:
     "nimbus"
   of Eth2Agent.Lighthouse:

--- a/beacon_chain/networking/eth2_agents.nim
+++ b/beacon_chain/networking/eth2_agents.nim
@@ -91,9 +91,23 @@ const
     (252'u64, "The IP address the peer is using is banned"),
   ].toTable()
 
-func disconnectReasonName*(a: Eth2Agent, code: uint64): string =
+  # This is combination of all the errors, we need it when remote agent is not
+  # identified yet.
+  UnknownErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (130'u64, "Too many requests from the peer"),
+    (237'u64, "Peer score is too low"),
+    (250'u64, "Peer score is too low"),
+    (251'u64, "The peer is banned"),
+    (252'u64, "The IP address the peer is using is banned"),
+  ].toTable()
+
+func disconnectReasonName*(agent: Eth2Agent, code: uint64): string =
   if code < 128'u64:
     case code
+    of 0'u64:
+      "Unknown error (0)"
     of 1'u64:
       "Client shutdown (1)"
     of 2'u64:
@@ -111,9 +125,9 @@ func disconnectReasonName*(a: Eth2Agent, code: uint64): string =
       scode = " (" & Base10.toString(code) & ")"
       defaultMessage = "Disconnected"
 
-    case a
+    case agent
     of Eth2Agent.Unknown:
-      "Disconnected" & scode
+      UnknownErrors.getOrDefault(code, defaultMessage) & scode
     of Eth2Agent.Nimbus:
       NimbusErrors.getOrDefault(code, defaultMessage) & scode
     of Eth2Agent.Lighthouse:

--- a/beacon_chain/networking/eth2_agents.nim
+++ b/beacon_chain/networking/eth2_agents.nim
@@ -40,7 +40,7 @@ func `$`*(a: Eth2Agent): string =
 
 const
   # Lighthouse errors could be found here
-  # https://github.com/sigp/lighthouse/blob/stable/beacon_node/lighthouse_network/src/rpc/methods.rs
+  # https://github.com/sigp/lighthouse/blob/5fdd3b39bb8150d1ea8622e42e0166ed46af7693/beacon_node/lighthouse_network/src/rpc/methods.rs#L171
   LighthouseErrors = [
     (128'u64, "Unable to verify network"),
     (129'u64, "The node has too many connected peers"),
@@ -50,7 +50,7 @@ const
   ].toTable()
 
   # Prysm errors could be found here
-  # https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/p2p/types/rpc_goodbye_codes.go
+  # https://github.com/prysmaticlabs/prysm/blob/7a394062e1054d73014e793819cb9cf0d20ff2e3/beacon-chain/p2p/types/rpc_goodbye_codes.go#L12
   PrysmErrors = [
     (128'u64, "Unable to verify network"),
     (129'u64, "The node has too many connected peers"),
@@ -59,7 +59,7 @@ const
   ].toTable()
 
   # Lodestar errors could be found here
-  # https://github.com/ChainSafe/lodestar/blob/unstable/packages/beacon-node/src/constants/network.ts
+  # https://github.com/ChainSafe/lodestar/blob/7280234bea66b49da3900b916a1b54c4666e4173/packages/beacon-node/src/constants/network.ts#L20
   LodestarErrors = [
     (128'u64, "Unable to verify network"),
     (129'u64, "The node has too many connected peers"),
@@ -68,7 +68,7 @@ const
   ].toTable()
 
   # Teku errors could be found here
-  # https://github.com/Consensys/teku/blob/master/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
+  # https://github.com/Consensys/teku/blob/a3f7ebc75f24ec942286b0c1ae192e411f84aa7e/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/GoodbyeMessage.java#L42
   TekuErrors = [
     (128'u64, "Unable to verify network"),
     (129'u64, "The node has too many connected peers"),
@@ -76,13 +76,13 @@ const
   ].toTable()
 
   # Nimbus errors could be found here
-  # https://github.com/status-im/nimbus-eth2/blob/unstable/beacon_chain/networking/eth2_network.nim
+  # https://github.com/status-im/nimbus-eth2/blob/9b6b42c8f9792e657397bb3669a80b57da470c04/beacon_chain/networking/eth2_network.nim#L176
   NimbusErrors = [
     (237'u64, "Peer score is too low")
   ].toTable()
 
   # Grandine errors could be found here
-  # https://github.com/grandinetech/eth2_libp2p/blob/main/src/rpc/methods.rs
+  # https://github.com/grandinetech/eth2_libp2p/blob/63a0c5e662847b86b1d5617478e39bccd39df0a9/src/rpc/methods.rs#L246
   GrandineErrors = [
     (128'u64, "Unable to verify network"),
     (129'u64, "The node has too many connected peers"),

--- a/beacon_chain/networking/eth2_agents.nim
+++ b/beacon_chain/networking/eth2_agents.nim
@@ -1,0 +1,128 @@
+# beacon_chain
+# Copyright (c) 2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+import stew/base10
+import std/tables
+import libp2p/[multiaddress, multicodec, peerstore]
+
+type
+  Eth2Agent* {.pure.} = enum
+    Unknown,
+    Nimbus,
+    Lighthouse,
+    Prysm,
+    Teku,
+    Lodestar,
+    Grandine
+
+func `$`*(a: Eth2Agent): string =
+  case a
+  of Eth2Agent.Unknown:
+    "unrecognized"
+  of Eth2Agent.Nimbus:
+    "nimbus"
+  of Eth2Agent.Lighthouse:
+    "lighthouse"
+  of Eth2Agent.Prysm:
+    "prysm"
+  of Eth2Agent.Teku:
+    "teku"
+  of Eth2Agent.Lodestar:
+    "lodestar"
+  of Eth2Agent.Grandine:
+    "grandine"
+
+const
+  # Lighthouse errors could be found here
+  # https://github.com/sigp/lighthouse/blob/stable/beacon_node/lighthouse_network/src/rpc/methods.rs
+  LighthouseErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (250'u64, "Peer score is too low"),
+    (251'u64, "The peer is banned"),
+    (252'u64, "The IP address the peer is using is banned"),
+  ].toTable()
+
+  # Prysm errors could be found here
+  # https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/p2p/types/rpc_goodbye_codes.go
+  PrysmErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (250'u64, "Peer score is too low"),
+    (251'u64, "The peer is banned")
+  ].toTable()
+
+  # Lodestar errors could be found here
+  # https://github.com/ChainSafe/lodestar/blob/unstable/packages/beacon-node/src/constants/network.ts
+  LodestarErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (250'u64, "Peer score is too low"),
+    (251'u64, "The peer is banned")
+  ].toTable()
+
+  # Teku errors could be found here
+  # https://github.com/Consensys/teku/blob/master/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/networking/libp2p/rpc/GoodbyeMessage.java
+  TekuErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (130'u64, "Too many requests from the peer")
+  ].toTable()
+
+  # Nimbus errors could be found here
+  # https://github.com/status-im/nimbus-eth2/blob/unstable/beacon_chain/networking/eth2_network.nim
+  NimbusErrors = [
+    (237'u64, "Peer score is too low")
+  ].toTable()
+
+  # Grandine errors could be found here
+  # https://github.com/grandinetech/eth2_libp2p/blob/main/src/rpc/methods.rs
+  GrandineErrors = [
+    (128'u64, "Unable to verify network"),
+    (129'u64, "The node has too many connected peers"),
+    (250'u64, "Peer score is too low"),
+    (251'u64, "The peer is banned"),
+    (252'u64, "The IP address the peer is using is banned"),
+  ].toTable()
+
+func disconnectReasonName*(a: Eth2Agent, code: uint64): string =
+  if code < 128'u64:
+    case code
+    of 1'u64:
+      "Client shutdown (1)"
+    of 2'u64:
+      "Irrelevant network (2)"
+    of 3'u64:
+      "Fault or error (3)"
+    else:
+      let
+        scode = " (" & Base10.toString(code) & ")"
+        defaultMessage = "Disconnected"
+
+      defaultMessage & scode
+  else:
+    let
+      scode = " (" & Base10.toString(code) & ")"
+      defaultMessage = "Disconnected"
+
+    case a
+    of Eth2Agent.Unknown:
+      "Disconnected" & scode
+    of Eth2Agent.Nimbus:
+      NimbusErrors.getOrDefault(code, defaultMessage) & scode
+    of Eth2Agent.Lighthouse:
+      LighthouseErrors.getOrDefault(code, defaultMessage) & scode
+    of Eth2Agent.Prysm:
+      PrysmErrors.getOrDefault(code, defaultMessage) & scode
+    of Eth2Agent.Teku:
+      TekuErrors.getOrDefault(code, defaultMessage) & scode
+    of Eth2Agent.Lodestar:
+      LodestarErrors.getOrDefault(code, defaultMessage) & scode
+    of Eth2Agent.Grandine:
+      GrandineErrors.getOrDefault(code, defaultMessage) & scode

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -30,13 +30,13 @@ import
   ../spec/datatypes/[phase0, altair, bellatrix],
   ../spec/[eth2_ssz_serialization, network, helpers, forks],
   ../validators/keystore_management,
-  "."/[eth2_discovery, eth2_protocol_dsl, libp2p_json_serialization, peer_pool,
-       peer_scores]
+  "."/[eth2_discovery, eth2_protocol_dsl, eth2_agents,
+       libp2p_json_serialization, peer_pool, peer_scores]
 
 export
   tables, chronos, ratelimit, version, multiaddress, peerinfo, p2pProtocol,
   connection, libp2p_json_serialization, eth2_ssz_serialization, results,
-  eth2_discovery, peer_pool, peer_scores
+  eth2_discovery, peer_pool, peer_scores, eth2_agents
 
 logScope:
   topics = "networking"
@@ -99,6 +99,7 @@ type
   Peer* = ref object
     network*: Eth2Node
     peerId*: PeerId
+    remoteAgent*: Eth2Agent
     discoveryId*: Eth2DiscoveryId
     connectionState*: ConnectionState
     protocolStates*: seq[RootRef]
@@ -338,6 +339,26 @@ func shortProtocolId(protocolId: string): string =
     else:
       protocolId.high
   protocolId[start..ends]
+
+proc updateAgent*(peer: Peer) =
+  let
+    agent = toLowerAscii(peer.network.switch.peerStore[AgentBook][peer.peerId])
+    # proto = peer.network.switch.peerStore[ProtoVersionBook][peer.peerId]
+
+  if "nimbus" in agent:
+    peer.remoteAgent = Eth2Agent.Nimbus
+  elif "lighthouse" in agent:
+    peer.remoteAgent = Eth2Agent.Lighthouse
+  elif "teku" in agent:
+    peer.remoteAgent = Eth2Agent.Teku
+  elif "lodestar" in agent:
+    peer.remoteAgent = Eth2Agent.Lodestar
+  elif "prysm" in agent:
+    peer.remoteAgent = Eth2Agent.Prysm
+  elif "grandine" in agent:
+    peer.remoteAgent = Eth2Agent.Grandine
+  else:
+    peer.remoteAgent = Eth2Agent.Unknown
 
 proc openStream(node: Eth2Node,
                 peer: Peer,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -360,6 +360,11 @@ proc updateAgent*(peer: Peer) =
   else:
     peer.remoteAgent = Eth2Agent.Unknown
 
+proc getRemoteAgent*(peer: Peer): Eth2Agent =
+  if peer.remoteAgent == Eth2Agent.Unknown:
+    peer.updateAgent()
+  peer.remoteAgent
+
 proc openStream(node: Eth2Node,
                 peer: Peer,
                 protocolId: string): Future[NetRes[Connection]]


### PR DESCRIPTION
This PR adds, detection of remote peers via libp2p user agent string.
Using this we could properly decode application-defined error codes.
Also one more metric was added `nbc_disconnects_count` which indicates number of disconnects from specific CL nodes.