### PR TITLE
Fix REST /eth/v1/node/identity should return proper MultiAddresses (version 2).

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -83,6 +83,7 @@ type
     rng*: ref HmacDrbgContext
     peers*: Table[PeerId, Peer]
     directPeers*: DirectPeers
+    announcedAddresses*: seq[MultiAddress]
     validTopics: HashSet[string]
     peerPingerHeartbeatFut: Future[void].Raising([CancelledError])
     peerTrimmerHeartbeatFut: Future[void].Raising([CancelledError])
@@ -1769,7 +1770,7 @@ proc new(T: type Eth2Node,
          switch: Switch, pubsub: GossipSub,
          ip: Opt[IpAddress], tcpPort, udpPort: Opt[Port],
          privKey: keys.PrivateKey, discovery: bool,
-         directPeers: DirectPeers,
+         directPeers: DirectPeers, announcedAddresses: openArray[MultiAddress],
          rng: ref HmacDrbgContext): T {.raises: [CatchableError].} =
   when not defined(local_testnet):
     let
@@ -1813,6 +1814,7 @@ proc new(T: type Eth2Node,
     connectTimeout: connectTimeout,
     seenThreshold: seenThreshold,
     directPeers: directPeers,
+    announcedAddresses: @announcedAddresses,
     quota: TokenBucket.new(maxGlobalQuota, fullReplenishTime)
   )
 
@@ -2364,7 +2366,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
   let node = Eth2Node.new(
     config, cfg, enrForkId, discoveryForkId, forkDigests, getBeaconTime, switch, pubsub, extIp,
     extTcpPort, extUdpPort, netKeys.seckey.asEthKey,
-    discovery = config.discv5Enabled, directPeers, rng = rng)
+    discovery = config.discv5Enabled, directPeers, announcedAddresses,
+    rng = rng)
 
   node.pubsub.subscriptionValidator =
     proc(topic: string): bool {.gcsafe, raises: [].} =

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -106,35 +106,38 @@ proc getLastSeenAddress(node: BeaconNode, id: PeerId): string =
     $addrs[len(addrs) - 1]
   else:
     ""
-proc getDiscoveryAddresses(node: BeaconNode): Option[seq[string]] =
-  let restr = node.network.enrRecord().toTypedRecord()
-  if restr.isErr():
-    return none[seq[string]]()
-  let respa = restr.get().toPeerAddr(udpProtocol)
-  if respa.isErr():
-    return none[seq[string]]()
-  let pa = respa.get()
-  let mpa = MultiAddress.init(multiCodec("p2p"), pa.peerId)
-  if mpa.isErr():
-    return none[seq[string]]()
-  var addresses = newSeqOfCap[string](len(pa.addrs))
-  for item in pa.addrs:
-    let resa = concat(item, mpa.get())
-    if resa.isOk():
-      addresses.add($(resa.get()))
-  return some(addresses)
+proc getDiscoveryAddresses(node: BeaconNode): seq[string] =
+  let
+    typedRec = node.network.enrRecord().toTypedRecord().valueOr:
+      return default(seq[string])
+    peerAddr = typedRec.toPeerAddr(udpProtocol).valueOr:
+      return default(seq[string])
+    maddress = MultiAddress.init(multiCodec("p2p"), peerAddr.peerId).valueOr:
+      return default(seq[string])
 
-proc getP2PAddresses(node: BeaconNode): Option[seq[string]] =
-  let pinfo = node.network.switch.peerInfo
-  let mpa = MultiAddress.init(multiCodec("p2p"), pinfo.peerId)
-  if mpa.isErr():
-    return none[seq[string]]()
-  var addresses = newSeqOfCap[string](len(pinfo.addrs))
+  var addresses: seq[string]
+  for item in peerAddr.addrs:
+    let res = concat(item, maddress)
+    if res.isOk():
+      addresses.add($(res.get()))
+  addresses
+
+proc getP2PAddresses(node: BeaconNode): seq[string] =
+  let
+    pinfo = node.network.switch.peerInfo
+    maddress = MultiAddress.init(multiCodec("p2p"), pinfo.peerId).valueOr:
+      return default(seq[string])
+
+  var addresses: seq[string]
+  for item in node.network.announcedAddresses:
+    let res = concat(item, maddress)
+    if res.isOk():
+      addresses.add($(res.get()))
   for item in pinfo.addrs:
-    let resa = concat(item, mpa.get())
-    if resa.isOk():
-      addresses.add($(resa.get()))
-  return some(addresses)
+    let res = concat(item, maddress)
+    if res.isOk():
+      addresses.add($(res.get()))
+  addresses
 
 proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
   let
@@ -143,28 +146,12 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Node/getNetworkIdentity
   router.api2(MethodGet, "/eth/v1/node/identity") do () -> RestApiResponse:
-    let discoveryAddresses =
-      block:
-        let res = node.getDiscoveryAddresses()
-        if res.isSome():
-          res.get()
-        else:
-          newSeq[string](0)
-
-    let p2pAddresses =
-      block:
-        let res = node.getP2PAddresses()
-        if res.isSome():
-          res.get()
-        else:
-          newSeq[string]()
-
     RestApiResponse.jsonResponse(
       (
         peer_id: $node.network.peerId(),
         enr: node.network.enrRecord().toURI(),
-        p2p_addresses: p2pAddresses,
-        discovery_addresses: discoveryAddresses,
+        p2p_addresses: node.getP2PAddresses(),
+        discovery_addresses: node.getDiscoveryAddresses(),
         metadata: (
           seq_number: node.network.metadata.seq_number,
           syncnets: to0xHex(node.network.metadata.syncnets.bytes),


### PR DESCRIPTION
Note, this PR bumps `libp2p` with other changes, so it needs some time for testing.