### PR TITLE
Use Nimbus specific agent string instead of nim-presto defaults.

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -826,6 +826,7 @@ proc init*(T: type BeaconNode,
     RestServerRef.init(config.restAddress, config.restPort,
                        config.restAllowedOrigin,
                        validateBeaconApiQueries,
+                       nimbusAgentStr,
                        config)
   else:
     nil

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -357,6 +357,7 @@ proc init*(T: type RestServerRef,
            port: Port,
            allowedOrigin: Option[string],
            validateFn: PatternCallback,
+           ident: string,
            config: AnyConf): T =
   let
     address = initTAddress(ip, port)
@@ -375,6 +376,7 @@ proc init*(T: type RestServerRef,
 
   let res = RestServerRef.new(RestRouter.init(validateFn, allowedOrigin),
                               address, serverFlags = serverFlags,
+                              serverIdent = ident,
                               httpHeadersTimeout = headersTimeout,
                               maxHeadersSize = maxHeadersSize,
                               maxRequestBodySize = maxRequestBodySize,
@@ -428,11 +430,13 @@ proc initKeymanagerServer*(
         RestServerRef.init(config.keymanagerAddress, config.keymanagerPort,
                            config.keymanagerAllowedOrigin,
                            validateKeymanagerApiQueries,
+                           nimbusAgentStr,
                            config)
     else:
       RestServerRef.init(config.keymanagerAddress, config.keymanagerPort,
                          config.keymanagerAllowedOrigin,
                          validateKeymanagerApiQueries,
+                         nimbusAgentStr,
                          config)
   else:
     nil

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -142,7 +142,7 @@ proc getP2PAddresses(node: BeaconNode): seq[string] =
 proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
   let
     cachedVersion =
-      RestApiResponse.prepareJsonResponse((version: "Nimbus/" & fullVersionStr))
+      RestApiResponse.prepareJsonResponse((version: nimbusAgentStr))
 
   # https://ethereum.github.io/beacon-APIs/#/Node/getNetworkIdentity
   router.api2(MethodGet, "/eth/v1/node/identity") do () -> RestApiResponse:
@@ -284,4 +284,4 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
         Http206
       else:
         Http200
-    RestApiResponse.response("", status, contentType = "")
+    RestApiResponse.response(status)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -1102,7 +1102,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       numUpdatedFeeRecipients = numUpdated,
       numRefreshedFeeRecipients = numRefreshed
 
-    RestApiResponse.response("", Http200, "text/plain")
+    RestApiResponse.response(Http200)
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/registerValidator
   # https://github.com/ethereum/beacon-APIs/blob/v2.3.0/apis/validator/register_validator.yaml
@@ -1129,7 +1129,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       node.externalBuilderRegistrations[signedValidatorRegistration.message.pubkey] =
         signedValidatorRegistration
 
-    RestApiResponse.response("", Http200, "text/plain")
+    RestApiResponse.response(Http200)
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/getLiveness
   router.api2(MethodPost, "/eth/v1/validator/liveness/{epoch}") do (

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -51,6 +51,8 @@ const
 
   fullVersionStr* = "v" & versionAsStr & "-" & gitRevision & "-" & versionBlob
 
+  nimbusAgentStr* = "Nimbus/" & fullVersionStr
+
 func getNimGitHash*(): string =
   const gitPrefix = "git hash: "
   let tmp = splitLines(nimFullBanner)

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -4748,8 +4748,7 @@
       "body": {"content-type": "application/json", "data": "[{\"message\":{\"fee_recipient\":\"0xb943c2c22b1b186a34f47c4dbe2fe367de9ec180\",\"gas_limit\":\"40000000\",\"timestamp\":\"1661879190\",\"pubkey\":\"0xa37b7bb9c412b8cc318fabf7b1fec33eb9634680687f07b977393180ce99889dbcfda81900f3afb9f2281930cf49f5d8\"},\"signature\":\"0xa493085fab365d13bea2376434abc3dbfba00a576276c853acabd7b9cb2f2b4b0a90738dd9baeaef75d0f42fa94119a70a09b0ed38fbebb6dde92c9ca062447018821f36c19d6fe34eb8c357d62e5d33e5c1d35035472ef7dd22a7425cdba0c5\"}]"}
     },
     "response": {
-      "status": {"operator": "equals", "value": "200"},
-      "headers": [{"key": "Content-Type", "value": "text/plain", "operator": "equals"}]
+      "status": {"operator": "equals", "value": "200"}
     }
   },
   {


### PR DESCRIPTION
This PR changes agent string which we report via REST server API from `nim-presto/0.0.3` to `Nimbus` specific.
Use response(code) overload procedures.