### PR TITLE
pause deployment of long-range sync option default

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -562,9 +562,10 @@ type
         name: "light-client-data-max-periods" .}: Option[uint64]
 
       longRangeSync* {.
+        hidden
         desc: "Enable long-range syncing (genesis sync)",
-        defaultValue: LongRangeSyncMode.Light,
-        name: "long-range-sync".}: LongRangeSyncMode
+        defaultValue: LongRangeSyncMode.Lenient,
+        name: "debug-long-range-sync".}: LongRangeSyncMode
 
       inProcessValidators* {.
         desc: "Disable the push model (the beacon node tells a signing process with the private keys of the validators what to sign and when) and load the validators in the beacon node itself"

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -112,7 +112,6 @@ The following options are available:
      --light-client-data-import-mode  Which classes of light client data to import. Must be one of: none, only-new,
                                full (slow startup), on-demand (may miss validator duties) [=only-new].
      --light-client-data-max-periods  Maximum number of sync committee periods to retain light client data.
-     --long-range-sync         Enable long-range syncing (genesis sync) [=LongRangeSyncMode.Light].
      --in-process-validators   Disable the push model (the beacon node tells a signing process with the private
                                keys of the validators what to sign and when) and load the validators in the
                                beacon node itself [=true].


### PR DESCRIPTION
Inspired by https://github.com/status-im/nimbus-eth2/issues/6433

They were offline long enough they're outside the WSP.

The change has (correctly, as far as it goes) prevented them from restarting, because the "light client sync" part is still to come. Once it does, they'd catch up automatically with the new setting.

The tradeoff is, people who change the setting to avoid that in the transition period often/likely won't bother changing it back, so for the sake of increasing adoption of the setting in the medium-to-long-term, delay deployment for the next release.

This is not a revert -- all the code stays in place, it's fine, just a default change and therefore leaving the option not-yet-documented. It hasn't been in any releases yet.