### PR TITLE
rename LC gindex constants to match spec

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -255,7 +255,7 @@ proc initLightClientBootstrapForPeriod(
             forkyBlck.toLightClientHeader(lcDataFork))
           dag.lcDataStore.db.putCurrentSyncCommitteeBranch(
             bid.slot, forkyState.data.build_proof(
-              lcDataFork.CURRENT_SYNC_COMMITTEE_GINDEX).get)
+              lcDataFork.current_sync_committee_gindex).get)
         else: raiseAssert "Unreachable"
   res
 
@@ -403,10 +403,10 @@ proc initLightClientUpdateForPeriod(
           attested_header: forkyBlck.toLightClientHeader(lcDataFork),
           next_sync_committee: forkyState.data.next_sync_committee,
           next_sync_committee_branch: forkyState.data.build_proof(
-            lcDataFork.NEXT_SYNC_COMMITTEE_GINDEX).get,
+            lcDataFork.next_sync_committee_gindex).get,
           finality_branch:
             if finalizedBid.slot != FAR_FUTURE_SLOT:
-              forkyState.data.build_proof(lcDataFork.FINALIZED_ROOT_GINDEX).get
+              forkyState.data.build_proof(lcDataFork.finalized_root_gindex).get
             else:
               default(lcDataFork.FinalityBranch)))
       else: raiseAssert "Unreachable"
@@ -478,16 +478,16 @@ proc cacheLightClientData(
     bid = blck.toBlockId()
     cachedData = CachedLightClientData(
       current_sync_committee_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.CURRENT_SYNC_COMMITTEE_GINDEX).get,
-        LightClientDataFork.high.CURRENT_SYNC_COMMITTEE_GINDEX),
+        state.data.build_proof(lcDataFork.current_sync_committee_gindex).get,
+        LightClientDataFork.high.current_sync_committee_gindex),
       next_sync_committee_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.NEXT_SYNC_COMMITTEE_GINDEX).get,
-        LightClientDataFork.high.NEXT_SYNC_COMMITTEE_GINDEX),
+        state.data.build_proof(lcDataFork.next_sync_committee_gindex).get,
+        LightClientDataFork.high.next_sync_committee_gindex),
       finalized_slot:
         state.data.finalized_checkpoint.epoch.start_slot,
       finality_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.FINALIZED_ROOT_GINDEX).get,
-        LightClientDataFork.high.FINALIZED_ROOT_GINDEX),
+        state.data.build_proof(lcDataFork.finalized_root_gindex).get,
+        LightClientDataFork.high.finalized_root_gindex),
       current_period_best_update:
         current_period_best_update,
       latest_signature_slot:
@@ -553,7 +553,7 @@ proc assignLightClientData(
             next_sync_committee.get
           forkyObject.next_sync_committee_branch = normalize_merkle_branch(
             attested_data.next_sync_committee_branch,
-            lcDataFork.NEXT_SYNC_COMMITTEE_GINDEX)
+            lcDataFork.next_sync_committee_gindex)
     else:
       doAssert next_sync_committee.isNone
     var finalized_slot = attested_data.finalized_slot
@@ -562,7 +562,7 @@ proc assignLightClientData(
         if finalized_slot == forkyObject.finalized_header.beacon.slot:
           forkyObject.finality_branch = normalize_merkle_branch(
             attested_data.finality_branch,
-            lcDataFork.FINALIZED_ROOT_GINDEX)
+            lcDataFork.finalized_root_gindex)
         elif finalized_slot < max(dag.tail.slot, dag.backfill.slot):
           forkyObject.finalized_header.reset()
           forkyObject.finality_branch.reset()
@@ -582,12 +582,12 @@ proc assignLightClientData(
             if finalized_slot == forkyObject.finalized_header.beacon.slot:
               forkyObject.finality_branch = normalize_merkle_branch(
                 attested_data.finality_branch,
-                lcDataFork.FINALIZED_ROOT_GINDEX)
+                lcDataFork.finalized_root_gindex)
             elif finalized_slot == GENESIS_SLOT:
               forkyObject.finalized_header.reset()
               forkyObject.finality_branch = normalize_merkle_branch(
                 attested_data.finality_branch,
-                lcDataFork.FINALIZED_ROOT_GINDEX)
+                lcDataFork.finalized_root_gindex)
             else:
               var fin_header = dag.getExistingLightClientHeader(finalized_bid)
               if fin_header.kind == LightClientDataFork.None:
@@ -599,7 +599,7 @@ proc assignLightClientData(
                 forkyObject.finalized_header = fin_header.forky(lcDataFork)
                 forkyObject.finality_branch = normalize_merkle_branch(
                   attested_data.finality_branch,
-                  lcDataFork.FINALIZED_ROOT_GINDEX)
+                  lcDataFork.finalized_root_gindex)
   withForkyObject(obj):
     when lcDataFork > LightClientDataFork.None:
       forkyObject.sync_aggregate = sync_aggregate
@@ -726,7 +726,7 @@ proc createLightClientBootstrap(
       dag.lcDataStore.db.putCurrentSyncCommitteeBranch(
         bid.slot, normalize_merkle_branch(
           dag.getLightClientData(bid).current_sync_committee_branch,
-          lcDataFork.CURRENT_SYNC_COMMITTEE_GINDEX))
+          lcDataFork.current_sync_committee_gindex))
     else: raiseAssert "Unreachable"
   ok()
 
@@ -1053,7 +1053,7 @@ proc getLightClientBootstrap(
           dag.lcDataStore.db.putHeader(header)
           dag.lcDataStore.db.putCurrentSyncCommitteeBranch(
             slot, forkyState.data.build_proof(
-              lcDataFork.CURRENT_SYNC_COMMITTEE_GINDEX).get)
+              lcDataFork.current_sync_committee_gindex).get)
         else: raiseAssert "Unreachable"
     do: return default(ForkedLightClientBootstrap)
 

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -61,9 +61,12 @@ const
   # If there are ever more than 32 members in `BeaconState`, indices change!
   # `FINALIZED_ROOT_GINDEX` is one layer deeper, i.e., `52 * 2 + 1`.
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/ssz/merkle-proofs.md
-  FINALIZED_ROOT_GINDEX* = 105.GeneralizedIndex  # finalized_checkpoint > root
-  CURRENT_SYNC_COMMITTEE_GINDEX* = 54.GeneralizedIndex  # current_sync_committee
-  NEXT_SYNC_COMMITTEE_GINDEX* = 55.GeneralizedIndex  # next_sync_committee
+  # finalized_checkpoint > root
+  FINALIZED_ROOT_GINDEX* = 105.GeneralizedIndex
+  # current_sync_committee
+  CURRENT_SYNC_COMMITTEE_GINDEX* = 54.GeneralizedIndex
+  # next_sync_committee
+  NEXT_SYNC_COMMITTEE_GINDEX* = 55.GeneralizedIndex
 
   SYNC_SUBCOMMITTEE_SIZE* = SYNC_COMMITTEE_SIZE div SYNC_COMMITTEE_SUBNET_COUNT
 

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -33,7 +33,8 @@ const
   # The first member (`randao_reveal`) is 16, subsequent members +1 each.
   # If there are ever more than 16 members in `BeaconBlockBody`, indices change!
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/ssz/merkle-proofs.md
-  EXECUTION_PAYLOAD_GINDEX* = 25.GeneralizedIndex  # execution_payload
+  # execution_payload
+  EXECUTION_PAYLOAD_GINDEX* = 25.GeneralizedIndex
 
 type
   SignedBLSToExecutionChangeList* =

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -45,9 +45,12 @@ const
   # If there are ever more than 64 members in `BeaconState`, indices change!
   # `FINALIZED_ROOT_GINDEX` is one layer deeper, i.e., `84 * 2 + 1`.
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/ssz/merkle-proofs.md
-  FINALIZED_ROOT_GINDEX* = 169.GeneralizedIndex  # finalized_checkpoint > root
-  CURRENT_SYNC_COMMITTEE_GINDEX* = 86.GeneralizedIndex  # current_sync_committee
-  NEXT_SYNC_COMMITTEE_GINDEX* = 87.GeneralizedIndex  # next_sync_committee
+  # finalized_checkpoint > root
+  FINALIZED_ROOT_GINDEX_ELECTRA* = 169.GeneralizedIndex
+  # current_sync_committee
+  CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA* = 86.GeneralizedIndex
+  # next_sync_committee
+  NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA* = 87.GeneralizedIndex
 
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#depositrequest
@@ -195,13 +198,13 @@ type
     signature*: ValidatorSig
 
   FinalityBranch* =
-    array[log2trunc(FINALIZED_ROOT_GINDEX), Eth2Digest]
+    array[log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA), Eth2Digest]
 
   CurrentSyncCommitteeBranch* =
-    array[log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX), Eth2Digest]
+    array[log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA), Eth2Digest]
 
   NextSyncCommitteeBranch* =
-    array[log2trunc(NEXT_SYNC_COMMITTEE_GINDEX), Eth2Digest]
+    array[log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA), Eth2Digest]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/capella/light-client/sync-protocol.md#modified-lightclientheader
   LightClientHeader* = object
@@ -808,7 +811,7 @@ func upgrade_lc_bootstrap_to_electra*(
     header: upgrade_lc_header_to_electra(pre.header),
     current_sync_committee: pre.current_sync_committee,
     current_sync_committee_branch: normalize_merkle_branch(
-      pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX))
+      pre.current_sync_committee_branch, CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/light-client/fork.md#upgrading-light-client-data
 func upgrade_lc_update_to_electra*(
@@ -817,10 +820,10 @@ func upgrade_lc_update_to_electra*(
     attested_header: upgrade_lc_header_to_electra(pre.attested_header),
     next_sync_committee: pre.next_sync_committee,
     next_sync_committee_branch: normalize_merkle_branch(
-      pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX),
+      pre.next_sync_committee_branch, NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA),
     finalized_header: upgrade_lc_header_to_electra(pre.finalized_header),
     finality_branch: normalize_merkle_branch(
-      pre.finality_branch, FINALIZED_ROOT_GINDEX),
+      pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
     sync_aggregate: pre.sync_aggregate,
     signature_slot: pre.signature_slot)
 
@@ -831,7 +834,7 @@ func upgrade_lc_finality_update_to_electra*(
     attested_header: upgrade_lc_header_to_electra(pre.attested_header),
     finalized_header: upgrade_lc_header_to_electra(pre.finalized_header),
     finality_branch: normalize_merkle_branch(
-      pre.finality_branch, FINALIZED_ROOT_GINDEX),
+      pre.finality_branch, FINALIZED_ROOT_GINDEX_ELECTRA),
     sync_aggregate: pre.sync_aggregate,
     signature_slot: pre.signature_slot)
 

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -227,12 +227,12 @@ template kind*(
       electra.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Electra
 
-template FINALIZED_ROOT_GINDEX*(
+template finalized_root_gindex*(
     kind: static LightClientDataFork): GeneralizedIndex =
   when kind >= LightClientDataFork.Electra:
-    electra.FINALIZED_ROOT_GINDEX
+    FINALIZED_ROOT_GINDEX_ELECTRA
   elif kind >= LightClientDataFork.Altair:
-    altair.FINALIZED_ROOT_GINDEX
+    FINALIZED_ROOT_GINDEX
   else:
     static: raiseAssert "Unreachable"
 
@@ -244,12 +244,12 @@ template FinalityBranch*(kind: static LightClientDataFork): auto =
   else:
     static: raiseAssert "Unreachable"
 
-template CURRENT_SYNC_COMMITTEE_GINDEX*(
+template current_sync_committee_gindex*(
     kind: static LightClientDataFork): GeneralizedIndex =
   when kind >= LightClientDataFork.Electra:
-    electra.CURRENT_SYNC_COMMITTEE_GINDEX
+    CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA
   elif kind >= LightClientDataFork.Altair:
-    altair.CURRENT_SYNC_COMMITTEE_GINDEX
+    CURRENT_SYNC_COMMITTEE_GINDEX
   else:
     static: raiseAssert "Unreachable"
 
@@ -261,12 +261,12 @@ template CurrentSyncCommitteeBranch*(kind: static LightClientDataFork): auto =
   else:
     static: raiseAssert "Unreachable"
 
-template NEXT_SYNC_COMMITTEE_GINDEX*(
+template next_sync_committee_gindex*(
     kind: static LightClientDataFork): GeneralizedIndex =
   when kind >= LightClientDataFork.Electra:
-    electra.NEXT_SYNC_COMMITTEE_GINDEX
+    NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA
   elif kind >= LightClientDataFork.Altair:
-    altair.NEXT_SYNC_COMMITTEE_GINDEX
+    NEXT_SYNC_COMMITTEE_GINDEX
   else:
     static: raiseAssert "Unreachable"
 

--- a/beacon_chain/spec/light_client_sync.nim
+++ b/beacon_chain/spec/light_client_sync.nim
@@ -50,7 +50,7 @@ func initialize_light_client_store*(
       if not is_valid_normalized_merkle_branch(
           hash_tree_root(bootstrap.current_sync_committee),
           bootstrap.current_sync_committee_branch,
-          lcDataFork.CURRENT_SYNC_COMMITTEE_GINDEX,
+          lcDataFork.current_sync_committee_gindex,
           bootstrap.header.beacon.state_root):
         return ResultType.err(VerifierError.Invalid)
 
@@ -132,7 +132,7 @@ proc validate_light_client_update*(
           if not is_valid_normalized_merkle_branch(
               finalized_root,
               update.finality_branch,
-              lcDataFork.FINALIZED_ROOT_GINDEX,
+              lcDataFork.finalized_root_gindex,
               update.attested_header.beacon.state_root):
             return err(VerifierError.Invalid)
 
@@ -153,7 +153,7 @@ proc validate_light_client_update*(
           if not is_valid_normalized_merkle_branch(
               hash_tree_root(update.next_sync_committee),
               update.next_sync_committee_branch,
-              lcDataFork.NEXT_SYNC_COMMITTEE_GINDEX,
+              lcDataFork.next_sync_committee_gindex,
               update.attested_header.beacon.state_root):
             return err(VerifierError.Invalid)
 

--- a/tests/consensus_spec/altair/test_fixture_light_client_sync_protocol.nim
+++ b/tests/consensus_spec/altair/test_fixture_light_client_sync_protocol.nim
@@ -286,8 +286,8 @@ proc runTest(storeDataFork: static LightClientDataFork) =
       template next_sync_committee(): auto = state.next_sync_committee
       let
         next_sync_committee_branch = normalize_merkle_branch(
-          state.build_proof(altair.NEXT_SYNC_COMMITTEE_GINDEX).get,
-          storeDataFork.NEXT_SYNC_COMMITTEE_GINDEX)
+          state.build_proof(NEXT_SYNC_COMMITTEE_GINDEX).get,
+          storeDataFork.next_sync_committee_gindex)
 
       # Finality is unchanged
         finality_header = default(storeDataFork.LightClientHeader)
@@ -359,8 +359,8 @@ proc runTest(storeDataFork: static LightClientDataFork) =
           state.finalized_checkpoint.root
       let
         finality_branch = normalize_merkle_branch(
-          state.build_proof(altair.FINALIZED_ROOT_GINDEX).get,
-          storeDataFork.FINALIZED_ROOT_GINDEX)
+          state.build_proof(FINALIZED_ROOT_GINDEX).get,
+          storeDataFork.finalized_root_gindex)
 
         update = storeDataFork.LightClientUpdate(
           attested_header: attested_header,


### PR DESCRIPTION
Use `_ELECTRA` suffix for gindex constants to match consensus-specs.