### PR TITLE
construct info object for `BlobSidecar` earlier

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -29,7 +29,8 @@ type
     block_root*: Eth2Digest
     indices*: seq[BlobIndex]
 
-  OnBlobSidecarCallback = proc(data: BlobSidecar) {.gcsafe, raises: [].}
+  OnBlobSidecarCallback = proc(
+      data: BlobSidecarInfoObject) {.gcsafe, raises: [].}
 
 func shortLog*(x: seq[BlobIndex]): string =
   "<" & x.mapIt($it).join(", ") & ">"

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -11,6 +11,7 @@ import
   # Status
   chronicles, chronos, metrics,
   results,
+  stew/byteutils,
   # Internals
   ../spec/[
     beaconstate, state_transition_block, forks, helpers, network, signatures],
@@ -467,7 +468,13 @@ proc validateBlobSidecar*(
 
   # Send notification about new blob sidecar via callback
   if not(isNil(blobQuarantine.onBlobSidecarCallback)):
-    blobQuarantine.onBlobSidecarCallback(blob_sidecar)
+    blobQuarantine.onBlobSidecarCallback BlobSidecarInfoObject(
+      block_root: hash_tree_root(blob_sidecar.signed_block_header.message),
+      index: blob_sidecar.index,
+      slot: blob_sidecar.signed_block_header.message.slot,
+      kzg_commitment: blob_sidecar.kzg_commitment,
+      versioned_hash:
+        blob_sidecar.kzg_commitment.kzg_commitment_to_versioned_hash.to0xHex())
 
   ok()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -293,15 +293,8 @@ proc initFullNode(
     node.eventBus.propSlashQueue.emit(data)
   proc onAttesterSlashingAdded(data: phase0.AttesterSlashing) =
     node.eventBus.attSlashQueue.emit(data)
-  proc onBlobSidecarAdded(data: BlobSidecar) =
-    node.eventBus.blobSidecarQueue.emit(
-      BlobSidecarInfoObject(
-        block_root: hash_tree_root(data.signed_block_header.message),
-        index: data.index,
-        slot: data.signed_block_header.message.slot,
-        kzg_commitment: data.kzg_commitment,
-        versioned_hash:
-          data.kzg_commitment.kzg_commitment_to_versioned_hash.to0xHex))
+  proc onBlobSidecarAdded(data: BlobSidecarInfoObject) =
+    node.eventBus.blobSidecarQueue.emit(data)
   proc onBlockAdded(data: ForkedTrustedSignedBeaconBlock) =
     let optimistic =
       if node.currentSlot().epoch() >= dag.cfg.BELLATRIX_FORK_EPOCH:


### PR DESCRIPTION
To avoid "forked" types creeping into `BlobSidecar`, move the reduction to `BlobSidecarInfoObject` to the sole caller. The info object is fork agnostic, so does not need "forked" if `BlobSidecar` ever updates.