### PR TITLE
fix some UnusedImport warnings

### DIFF
--- a/beacon_chain/networking/eth2_agents.nim
+++ b/beacon_chain/networking/eth2_agents.nim
@@ -9,7 +9,6 @@
 
 import stew/base10
 import std/tables
-import libp2p/[multiaddress, multicodec, peerstore]
 
 type
   Eth2Agent* {.pure.} = enum


### PR DESCRIPTION
```
2024-07-25T02:05:59.6045279Z ......................................................................................................................../github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/networking/eth2_agents.nim(12, 30) Warning: imported and not used: 'multicodec' [UnusedImport]
2024-07-25T02:05:59.6047673Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/networking/eth2_agents.nim(12, 42) Warning: imported and not used: 'peerstore' [UnusedImport]
2024-07-25T02:05:59.6049952Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/networking/eth2_agents.nim(12, 16) Warning: imported and not used: 'multiaddress' [UnusedImport]
```