### PR TITLE
reduce code repetition in `test_toblindedblock`

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -88,10 +88,10 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Blinded block conversions
 ```diff
-+ Bellatrix toSignedBlindedBlock                                                             OK
-+ Capella toSignedBlindedBlock                                                               OK
-+ Deneb toSignedBlindedBlock                                                                 OK
-+ Electra toSignedBlindedBlock                                                               OK
++ Bellatrix toSignedBlindedBeaconBlock                                                       OK
++ Capella toSignedBlindedBeaconBlock                                                         OK
++ Deneb toSignedBlindedBeaconBlock                                                           OK
++ Electra toSignedBlindedBeaconBlock                                                         OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Block pool altair processing [Preset: mainnet]

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -116,28 +116,16 @@ template deneb_steps() =
   do_check
 
 suite "Blinded block conversions":
-  test "Bellatrix toSignedBlindedBlock":
-    var b = default(bellatrix.SignedBeaconBlock)
-    do_check
-    bellatrix_steps
-
-  test "Capella toSignedBlindedBlock":
-    var b = default(capella.SignedBeaconBlock)
-    do_check
-    bellatrix_steps
-    capella_steps
-
-  test "Deneb toSignedBlindedBlock":
-    var b = default(deneb.SignedBeaconBlock)
-    do_check
-    bellatrix_steps
-    capella_steps
-    deneb_steps
-
-  test "Electra toSignedBlindedBlock":
-    var b = default(electra.SignedBeaconBlock)
-    do_check
-    bellatrix_steps
-    capella_steps
-    deneb_steps
-    debugComment "add electra_steps"
+  withAll(ConsensusFork):
+    when consensusFork >= ConsensusFork.Bellatrix:
+      test $consensusFork & " toSignedBlindedBeaconBlock":
+        var b = default(consensusFork.SignedBeaconBlock)
+        do_check
+        bellatrix_steps
+        when consensusFork >= ConsensusFork.Capella:
+          capella_steps
+        when consensusFork >= ConsensusFork.Deneb:
+          deneb_steps
+        when consensusFork >= ConsensusFork.Electra:
+          debugComment "add electra_steps"
+        static: doAssert consensusFork.high == ConsensusFork.Electra


### PR DESCRIPTION
Use `withAll` to generate the tests for various blinded block types instead of copy pasting them for every fork.