### PR TITLE
remove option to select Capella fork choice algo

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -32,8 +32,6 @@ import
 
 from std/os import getHomeDir, parentDir, `/`
 from std/strutils import parseBiggestUInt, replace
-from fork_choice/fork_choice_types
-  import ForkChoiceVersion
 from consensus_object_pools/block_pools_types_light_client
   import LightClientDataImportMode
 
@@ -675,12 +673,6 @@ type
         hidden
         desc: "Bandwidth estimate for the node (bits per second)"
         name: "debug-bandwidth-estimate" .}: Option[Natural]
-
-      forkChoiceVersion* {.
-        hidden
-        desc: "Forkchoice version to use. " &
-              "Must be one of: stable"
-        name: "debug-forkchoice-version" .}: Option[ForkChoiceVersion]
 
     of BNStartUpCmd.wallets:
       case walletsCmd* {.command.}: WalletsCmd

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -104,7 +104,6 @@ declareGauge attestation_pool_block_attestation_packing_time,
 
 proc init*(T: type AttestationPool, dag: ChainDAGRef,
            quarantine: ref Quarantine,
-           forkChoiceVersion = ForkChoiceVersion.Stable,
            onAttestation: OnPhase0AttestationCallback = nil,
            onElectraAttestation: OnElectraAttestationCallback = nil): T =
   ## Initialize an AttestationPool from the dag `headState`
@@ -113,7 +112,7 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
   let finalizedEpochRef = dag.getFinalizedEpochRef()
 
   var forkChoice = ForkChoice.init(
-    finalizedEpochRef, dag.finalizedHead.blck, forkChoiceVersion)
+    finalizedEpochRef, dag.finalizedHead.blck)
 
   # Feed fork choice with unfinalized history - during startup, block pool only
   # keeps track of a single history so we just need to follow it

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -49,13 +49,11 @@ func compute_deltas(
 logScope: topics = "fork_choice"
 
 func init*(
-    T: type ForkChoiceBackend, checkpoints: FinalityCheckpoints,
-    version: ForkChoiceVersion): T =
-  T(proto_array: ProtoArray.init(checkpoints, version))
+    T: type ForkChoiceBackend, checkpoints: FinalityCheckpoints): T =
+  T(proto_array: ProtoArray.init(checkpoints))
 
 proc init*(
-    T: type ForkChoice, epochRef: EpochRef, blck: BlockRef,
-    version: ForkChoiceVersion): T =
+    T: type ForkChoice, epochRef: EpochRef, blck: BlockRef): T =
   ## Initialize a fork choice context for a finalized state - in the finalized
   ## state, the justified and finalized checkpoints are the same, so only one
   ## is used here
@@ -67,10 +65,8 @@ proc init*(
     backend: ForkChoiceBackend.init(
       FinalityCheckpoints(
         justified: checkpoint,
-        finalized: checkpoint),
-      version),
+        finalized: checkpoint)),
     checkpoints: Checkpoints(
-      version: version,
       justified: BalanceCheckpoint(
         checkpoint: checkpoint,
         total_active_balance: epochRef.total_active_balance,

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -29,14 +29,6 @@ import
 # ----------------------------------------------------------------------
 
 type
-  ForkChoiceVersion* {.pure.} = enum
-    ## Controls which version of fork choice to run.
-    Stable = "stable"
-      ## Use current version from stable Ethereum consensus specifications
-    Pr3431 = "pr3431"
-      ## https://github.com/ethereum/consensus-specs/pull/3431
-      ## https://github.com/ethereum/consensus-specs/issues/3466
-
   fcKind* = enum
     ## Fork Choice Error Kinds
     fcFinalizedNodeUnknown
@@ -96,7 +88,6 @@ type
     ## Subtracted from logical index to get the physical index
 
   ProtoArray* = object
-    version*: ForkChoiceVersion
     currentEpoch*: Epoch
     checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
@@ -121,7 +112,6 @@ type
     balances*: seq[Gwei]
 
   Checkpoints* = object
-    version*: ForkChoiceVersion
     time*: BeaconTime
     justified*: BalanceCheckpoint
     finalized*: Checkpoint

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -385,7 +385,7 @@ proc initFullNode(
     quarantine = newClone(
       Quarantine.init())
     attestationPool = newClone(AttestationPool.init(
-      dag, quarantine, config.forkChoiceVersion.get, onAttestationReceived))
+      dag, quarantine, onAttestationReceived))
     syncCommitteeMsgPool = newClone(
       SyncCommitteeMsgPool.init(rng, dag.cfg, onSyncContribution))
     lightClientPool = newClone(
@@ -2249,8 +2249,6 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
-  if config.forkChoiceVersion.isNone:
-    config.forkChoiceVersion = some(ForkChoiceVersion.Pr3431)
 
   ## Ctrl+C handling
   proc controlCHandler() {.noconv.} =

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -90,8 +90,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
     var response = GetForkChoiceResponse(
       justified_checkpoint: forkChoice.checkpoints.justified.checkpoint,
       finalized_checkpoint: forkChoice.checkpoints.finalized,
-      extra_data: RestExtraData(
-        version: some($forkChoice.backend.proto_array.version)))
+      extra_data: RestExtraData())
 
     for item in forkChoice.backend.proto_array:
       let

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -601,7 +601,7 @@ type
     extra_data*: Option[RestNodeExtraData]
 
   RestExtraData* = object
-    version*: Option[string]
+    discard
 
   GetForkChoiceResponse* = object
     justified_checkpoint*: Checkpoint

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -90,8 +90,7 @@ proc initialLoad(
     dag = ChainDAGRef.init(
       forkedState[].kind.genesisTestRuntimeConfig, db, validatorMonitor, {})
     fkChoice = newClone(ForkChoice.init(
-      dag.getFinalizedEpochRef(), dag.finalizedHead.blck,
-      ForkChoiceVersion.Pr3431))
+      dag.getFinalizedEpochRef(), dag.finalizedHead.blck))
 
   (dag, fkChoice)
 

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -298,8 +298,7 @@ proc startBeaconNode(basePort: int) {.raises: [CatchableError].} =
     "--keymanager-port=" & $(basePort + PortKind.KeymanagerBN.ord),
     "--keymanager-token-file=" & tokenFilePath,
     "--suggested-fee-recipient=" & $defaultFeeRecipient,
-    "--doppelganger-detection=off",
-    "--debug-forkchoice-version=stable"], it))
+    "--doppelganger-detection=off"], it))
   except Exception as exc: # TODO fix confutils exceptions
     raiseAssert exc.msg
 


### PR DESCRIPTION
With Deneb having run stable for quite a while now, it's time to remove the option to select the prior fork choice algo from Capella.