### PR TITLE
add: data column reconstruction and broadcast

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -445,63 +445,6 @@ proc checkForPotentialDoppelganger(
         attestation = shortLog(attestation)
       quitDoppelganger()
 
-#TODO: need to revamp `recover_blobs` and rewrite this 
-proc processDataColumnReconstruction*(
-    self: ref Eth2Processor,
-    node: Eth2Node,
-    signed_block: deneb.SignedBeaconBlock |
-    electra.SignedBeaconBlock):
-    Future[ValidationRes] {.async: (raises: [CancelledError]).} =
-  
-  let
-    dag = self.dag
-    root = signed_block.root
-    custodiedColumnIndices = get_custody_columns(
-        node.nodeId,
-        CUSTODY_REQUIREMENT)
-  
-  var
-    data_column_sidecars: seq[DataColumnSidecar]
-    columnsOk = true
-    storedColumns: seq[ColumnIndex]
-  
-  # Loading the data columns from the database
-  for custody_column in custodiedColumnIndices.get:
-    let data_column = DataColumnSidecar.new()
-    if not dag.db.getDataColumnSidecar(root, custody_column, data_column[]):
-      columnsOk = false
-      break
-    data_column_sidecars.add data_column[]
-    storedColumns.add data_column.index
-
-    if columnsOk:
-      debug "Loaded data column for reconstruction"
-
-  # storedColumn number is less than the NUMBER_OF_COLUMNS
-  # then reconstruction is not possible, and if all the data columns
-  # are already stored then we do not need to reconstruct at all
-  if storedColumns.len < NUMBER_OF_COLUMNS or storedColumns.len == NUMBER_OF_COLUMNS:
-    return ok()
-  else:
-    return errIgnore ("DataColumnSidecar: Reconstruction error!")
-
-  # Recover blobs from saved data column sidecars
-  let recovered_cps = recover_cells_and_proofs(data_column_sidecars, storedColumns.len, signed_block)
-  if not recovered_cps.isOk:
-    return errIgnore ("Error recovering cells and proofs from data columns")
-
-  # Reconstruct data column sidecars from recovered blobs
-  let reconstructedDataColumns = get_data_column_sidecars(signed_block, recovered_cps.get)
-
-  for data_column in data_column_sidecars:
-    if data_column.index notin custodiedColumnIndices.get:
-      continue
-    
-    dag.db.putDataColumnSidecar(data_column)
-    notice "Data Column Reconstructed and Saved Successfully"
-
-  ok()
-
 proc processAttestation*(
     self: ref Eth2Processor, src: MsgSource,
     attestation: phase0.Attestation | electra.Attestation, subnet_id: SubnetId,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -19,7 +19,7 @@ import
   ./networking/[topic_params, network_metadata_downloads, eth2_network],
   ./rpc/[rest_api, state_ttl_cache],
   ./spec/datatypes/[altair, bellatrix, phase0],
-  ./spec/[deposit_snapshots, engine_authentication, weak_subjectivity],
+  ./spec/[deposit_snapshots, eip7594_helpers, engine_authentication, weak_subjectivity],
   ./sync/[sync_protocol, light_client_protocol],
   ./validators/[keystore_management, beacon_validators],
   "."/[
@@ -30,6 +30,7 @@ when defined(posix):
   import system/ansi_c
 
 from ./spec/datatypes/deneb import SignedBeaconBlock
+from ./spec/datatypes/electra import SignedBeaconBlock
 
 from
   libp2p/protocols/pubsub/gossipsub
@@ -1471,9 +1472,111 @@ proc pruneDataColumns(node: BeaconNode, slot: Slot) =
               count = count + 1
     debug "pruned data columns", count, dataColumnPruneEpoch
 
+proc tryReconstructingDataColumns* (self: BeaconNode,
+                                    signed_block: deneb.SignedBeaconBlock |
+                                    electra.SignedBeaconBlock): Result[void, string] =
+  # Checks whether the data columns can be reconstructed
+  # or not from the recovery matrix
+
+  let localCustodySubnetCount =
+    if self.config.subscribeAllSubnets:
+      DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64
+    else:
+      CUSTODY_REQUIREMENT
+
+  let
+    db = self.db
+    root = signed_block.root
+    custodiedColumnIndices = get_custody_columns(
+        self.network.nodeId,
+        localCustodySubnetCount)
+
+  var
+    data_column_sidecars: seq[DataColumnSidecar]
+    columnsOk = true
+    storedColumns: seq[ColumnIndex]
+
+  # Loading the data columns from the database
+  for custody_column in custodiedColumnIndices.get:
+    let data_column = DataColumnSidecar.new()
+    if not db.getDataColumnSidecar(root, custody_column, data_column[]):
+      columnsOk = false
+      break
+    data_column_sidecars.add data_column[]
+    storedColumns.add data_column.index
+
+    if columnsOk:
+      debug "Loaded data column for reconstruction"
+
+  # storedColumn number is less than the NUMBER_OF_COLUMNS
+  # then reconstruction is not possible, and if all the data columns
+  # are already stored then we do not need to reconstruct at all
+  if storedColumns.len < NUMBER_OF_COLUMNS or storedColumns.len == NUMBER_OF_COLUMNS:
+    return ok()
+  else:
+    return errIgnore ("DataColumnSidecar: Reconstruction error!")
+
+  # Recover blobs from saved data column sidecars
+  let recovered_cps = recover_cells_and_proofs(data_column_sidecars, storedColumns.len, signed_block)
+  if not recovered_cps.isOk:
+    return errIgnore ("Error recovering cells and proofs from data columns")
+
+  # Reconstruct data column sidecars from recovered blobs
+  let reconstructedDataColumns = get_data_column_sidecars(signed_block, recovered_cps.get)
+
+  for data_column in data_column_sidecars:
+    if data_column.index notin custodiedColumnIndices.get:
+      continue
+    
+    db.putDataColumnSidecar(data_column)
+    notice "Data Column Reconstructed and Saved Successfully"
+
+  ok()
+
+proc reconstructAndSendDataColumns*(node: BeaconNode, slot: Slot) {.async.} =
+  let db = node.db
+  var blckid: BlockId
+  let blck = node.dag.getForkedBlock(blckid).valueOr: return
+  when typeof(blck).kind < ConsensusFork.Deneb: return
+  else:
+    let res = node.tryReconstructingDataColumns(blck)
+    let custody_columns = get_custody_columns(
+          router.network.nodeId,
+          CUSTODY_REQUIREMENT)
+    var
+      data_column_sidecars: DataColumnSidecars
+      columnsOk = true
+    
+    for custody_column in custody_columns.get:
+      let data_column = DataColumnSidecar.new()
+      if not db.getDataColumnSidecar(
+              blck.root, custody_column, data_column[]):
+        columnsOk = false
+        debug "Issue with loading reconstructed data columns"
+        break
+      data_column_sidecars.add data_column
+
+    var das_workers = newSeq[Future[SendResult]](len(data_column_sidecars))
+    for i in 0..<data_column_sidecars.lenu64:
+      let subnet_id = compute_subnet_for_data_column_sidecar(i)
+      das_workers[i] =
+          router[].network.broadcastDataColumnSidecar(subnet_id, data_column_sidecars[i][])
+    let allres = await allFinished(das_workers)
+    for i in 0..<allres.len:
+      let res = allres[i]
+      doAssert res.finished()
+      if res.failed():
+        notice "Reconstructed data columns not sent",
+          data_column = shortLog(data_column_sidecars[i][]), error = res.error[]
+      else:
+        notice "Reconstructed data columns sent",
+          data_column = shortLog(data_column_sidecars[i][])
+
 proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # Things we do when slot processing has ended and we're about to wait for the
   # next slot
+
+  await node.reconstructAndSendDataColumns(slot)
 
   # By waiting until close before slot end, ensure that preparation for next
   # slot does not interfere with propagation of messages and with VC duties.

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -75,7 +75,7 @@ type
 
   BlsCurveType* = ValidatorPrivKey | ValidatorPubKey | ValidatorSig
 
-  BlsResult*[T] = Result[T, cstring]
+  BlsResult*[T] = Result[T, cstring] 
 
   TrustedSig* = object
     data* {.align: 16.}: array[RawSigSize, byte]
@@ -413,6 +413,9 @@ func toHex*(x: CookedPubKey): string =
 
 func `$`*(x: CookedPubKey): string =
   $(x.toPubKey())
+
+func toValidatorSig*(x: TrustedSig): ValidatorSig =
+  ValidatorSig(blob: x.data)
 
 func toValidatorSig*(x: CookedSig): ValidatorSig =
   ValidatorSig(blob: blscurve.Signature(x).exportRaw())

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -140,9 +140,9 @@ proc recover_matrix*(partial_matrix: seq[MatrixEntry],
 proc recover_cells_and_proofs*(
     data_columns: seq[DataColumnSidecar],
     columnCount: int,
-    blck: deneb.SignedBeaconBlock | 
-    electra.SignedBeaconBlock |
-    ForkySignedBeaconBlock):
+    blck: deneb.TrustedSignedBeaconBlock | 
+    electra.TrustedSignedBeaconBlock |
+    ForkedTrustedSignedBeaconBlock):
     Result[seq[CellsAndProofs], cstring] =
 
   # This helper recovers blobs from the data column sidecars

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -232,11 +232,6 @@ iterator blobSidecarTopics*(forkDigest: ForkDigest): string =
     yield getBlobSidecarTopic(forkDigest, subnet_id)
 
 
-const
-  KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH* = 32
-  MAX_REQUEST_DATA_COLUMN_SIDECARS* = MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS
-  MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS* = 4096
-
 func getDataColumnSidecarTopic*(forkDigest: ForkDigest,
                              subnet_id: uint64): string =
   eth2Prefix(forkDigest) & "data_column_sidecar_" & $subnet_id & "/ssz_snappy"

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -442,7 +442,7 @@ p2pProtocol BeaconSync(version = 1,
       reqCount: uint64,
       reqColumns: List[ColumnIndex, NUMBER_OF_COLUMNS],
       response: MultipleChunksResponse[
-        ref DataColumnSidecar, Limit(MAX_REQUEST_DATA_COLUMN_SIDECARS)])
+        ref DataColumnSidecar, Limit(MAX_REQUEST_DATA_COLUMNS)])
       {.async, libp2pProtocol("data_column_sidecars_by_range", 1).} =
     
     trace "got data columns range request", peer, startSlot, 


### PR DESCRIPTION
This PR adds data column reconstruction's computation logic, and broadcasting strategy, which in turn is called `onSlotEnd`

note: nix jenkins build is supposed to fail, as this network of branches haven't been rebased lately.