### PR TITLE
add: metadata-v3 for custody subnet count

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -69,7 +69,7 @@ type
     protocols: seq[ProtocolInfo]
       ## Protocols managed by the DSL and mounted on the switch
     protocolStates*: seq[RootRef]
-    metadata*: altair.MetaData
+    metadata*: eip7594.MetaData
     connectTimeout*: chronos.Duration
     seenThreshold*: chronos.Duration
     connQueue: AsyncQueue[PeerAddr]
@@ -106,7 +106,7 @@ type
     lastReqTime*: Moment
     connections*: int
     enr*: Opt[enr.Record]
-    metadata*: Opt[altair.MetaData]
+    metadata*: Opt[eip7594.MetaData]
     failedMetadataRequests: int
     lastMetadataTime*: Moment
     direction*: PeerType
@@ -1795,7 +1795,7 @@ proc new(T: type Eth2Node,
     let
       connectTimeout = chronos.seconds(10)
       seenThreshold = chronos.seconds(10)
-  type MetaData = altair.MetaData # Weird bug without this..
+  type MetaData = eip7594.MetaData # Weird bug without this..
 
   # Versions up to v22.3.0 would write an empty `MetaData` to
   #`data-dir/node-metadata.json` which would then be reloaded on startup - don't
@@ -2082,7 +2082,7 @@ proc updatePeerMetadata(node: Eth2Node, peerId: PeerId) {.async: (raises: [Cance
 
   let
     peer = node.getPeer(peerId)
-    newMetadataRes = await peer.getMetadata_v2()
+    newMetadataRes = await peer.getMetadata_v3()
     newMetadata = newMetadataRes.valueOr:
       debug "Failed to retrieve metadata from peer!", peerId, error = newMetadataRes.error
       peer.failedMetadataRequests.inc()

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -175,11 +175,11 @@ p2pProtocol PeerSync(version = 1,
     {.libp2pProtocol("metadata", 1).} =
     raise newException(InvalidInputsError, "GetMetaData v1 unsupported")
 
-  proc getMetadata_v2(peer: Peer): altair.MetaData
+  proc getMetadata_v2(peer: Peer): eip7594.MetaData
     {.libp2pProtocol("metadata", 2).} =
     peer.network.metadata
 
-  proc getMetadata_v3(peer:  ): eip7594.MetaData
+  proc getMetadata_v3(peer: Peer): eip7594.MetaData
     {.libp2pProtocol("metadata", 3).} =
     peer.network.metadata
 

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -181,7 +181,7 @@ p2pProtocol PeerSync(version = 1,
       seq_number: peer.network.metadata.seq_number,
       attnets: peer.network.metadata.attnets,
       syncnets: peer.network.metadata.syncnets)
-    return altair_metadata
+    altair_metadata
 
   proc getMetadata_v3(peer: Peer): eip7594.MetaData
     {.libp2pProtocol("metadata", 3).} =

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -179,6 +179,10 @@ p2pProtocol PeerSync(version = 1,
     {.libp2pProtocol("metadata", 2).} =
     peer.network.metadata
 
+  proc getMetadata_v3(peer:  ): eip7594.MetaData
+    {.libp2pProtocol("metadata", 3).} =
+    peer.network.metadata
+
   proc goodbye(peer: Peer, reason: uint64)
     {.async, libp2pProtocol("goodbye", 1).} =
     debug "Received Goodbye message", reason = disconnectReasonName(reason), peer

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -175,9 +175,13 @@ p2pProtocol PeerSync(version = 1,
     {.libp2pProtocol("metadata", 1).} =
     raise newException(InvalidInputsError, "GetMetaData v1 unsupported")
 
-  proc getMetadata_v2(peer: Peer): eip7594.MetaData
+  proc getMetadata_v2(peer: Peer): altair.MetaData
     {.libp2pProtocol("metadata", 2).} =
-    peer.network.metadata
+    let altair_metadata = altair.MetaData(
+      seq_number: peer.network.metadata.seq_number,
+      attnets: peer.network.metadata.attnets,
+      syncnets: peer.network.metadata.syncnets)
+    return altair_metadata
 
   proc getMetadata_v3(peer: Peer): eip7594.MetaData
     {.libp2pProtocol("metadata", 3).} =

--- a/beacon_chain/spec/datatypes/eip7594.nim
+++ b/beacon_chain/spec/datatypes/eip7594.nim
@@ -9,7 +9,7 @@
 
 import
   std/[sequtils],
-  "."/[base, deneb], 
+  "."/[base, deneb, altair], 
   kzg4844,
   stew/[byteutils]
 
@@ -78,6 +78,13 @@ type
     row_index*: RowIndex
 
   CscBits* = BitArray[DATA_COLUMN_SIDECAR_SUBNET_COUNT]
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/p2p-interface.md#metadata
+  MetaData* = object
+    seq_number*: uint64
+    attnets*: AttnetBits
+    syncnets*: SyncnetBits
+    custody_subnet_count*: uint64 
 
 # func serializeDataColumn(data_column: DataColumn): auto =
 #   var counter = 0

--- a/beacon_chain/spec/datatypes/eip7594.nim
+++ b/beacon_chain/spec/datatypes/eip7594.nim
@@ -9,7 +9,7 @@
 
 import
   std/[sequtils],
-  "."/[base, deneb, altair], 
+  "."/[altair, base, deneb], 
   kzg4844,
   stew/[byteutils]
 

--- a/beacon_chain/spec/datatypes/eip7594.nim
+++ b/beacon_chain/spec/datatypes/eip7594.nim
@@ -79,7 +79,7 @@ type
 
   CscBits* = BitArray[DATA_COLUMN_SIDECAR_SUBNET_COUNT]
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/p2p-interface.md#metadata
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.4/specs/_features/eip7594/p2p-interface.md#metadata
   MetaData* = object
     seq_number*: uint64
     attnets*: AttnetBits

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -60,6 +60,8 @@ type
     CAPELLA_FORK_EPOCH*: Epoch
     DENEB_FORK_VERSION*: Version
     DENEB_FORK_EPOCH*: Epoch
+    EIP7594_FORK_VERSION*: Version
+    EIP7594_FORK_EPOCH*: Epoch
     ELECTRA_FORK_VERSION*: Version
     ELECTRA_FORK_EPOCH*: Epoch
 


### PR DESCRIPTION
This PR adds metadata V3 for custody_subnet_count, keeping metadata V2 compatible.
