### PR TITLE
increase TNS state downloading timeout to 120 seconds

### DIFF
--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -21,7 +21,7 @@ import
 from presto import RestDecodingError
 
 const
-  largeRequestsTimeout = 90.seconds # Downloading large items such as states.
+  largeRequestsTimeout = 120.seconds # Downloading large items such as states.
   smallRequestsTimeout = 30.seconds # Downloading smaller items such as blocks and deposit snapshots.
 
 proc fetchDepositSnapshot(


### PR DESCRIPTION
Over time, the natural ratio of `largeRequestsTimeout` to `smallRequestsTimeout` should increase, since the states (which contain both active and inactive validators) grow faster than the ongoing network traffic (which contain only active validators).

Reported the other day in #dev-helpdesk in Discord:
![2024-08-11T23:40:49,220543020+00:00](https://github.com/user-attachments/assets/c41e5538-890d-4efd-9d5b-b16f071f883b)