### PR TITLE
config.nims: fix build/makefile_generation for riscv64

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -120,9 +120,10 @@ elif defined(macosx) and defined(arm64):
   # Apple's Clang can't handle "-march=native" on M1: https://github.com/status-im/nimbus-eth2/issues/2758
   switch("passC", "-mcpu=apple-m1")
   switch("passL", "-mcpu=apple-m1")
+elif defined(linux) and defined(riscv64):
+  switch("passC", "-march=rv64gc")
+  switch("passL", "-march=rv64gc")
 else:
-  switch("passC", "-march=native")
-  switch("passL", "-march=native")
   if defined(windows):
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
     # ("-fno-asynchronous-unwind-tables" breaks Nim's exception raising, sometimes)


### PR DESCRIPTION
I'm currently trying to build nimbus for my riscv64 laptop. Just like macosx, the `-march=native` command doesn't work for this gcc (abi version: `riscv64-linux-gnu`) and so the target needs to be set manually.