### PR TITLE
bump to c-kzg-4844 `v2.0.0`

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -22,7 +22,7 @@ import
   eth/p2p/discoveryv5/enr,
   json_serialization, web3/[primitives, confutils_defs],
   chronos/transports/common,
-  kzg4844/kzg_ex,
+  kzg4844/kzg,
   ./spec/[engine_authentication, keystore, network, crypto],
   ./spec/datatypes/base,
   ./networking/network_metadata,
@@ -1500,11 +1500,11 @@ proc loadKzgTrustedSetup*(): Result[void, string] =
       vendorDir & "/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt")
 
   static: doAssert const_preset in ["mainnet", "gnosis", "minimal"]
-  Kzg.loadTrustedSetupFromString(trustedSetup)
+  loadTrustedSetupFromString(trustedSetup, 0)
 
 proc loadKzgTrustedSetup*(trustedSetupPath: string): Result[void, string] =
   try:
-    Kzg.loadTrustedSetupFromString(readFile(trustedSetupPath))
+    loadTrustedSetupFromString(readFile(trustedSetupPath), 0)
   except IOError as err:
     err(err.msg)
 

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -15,6 +15,7 @@ import
   web3, web3/[engine_api, primitives, conversions],
   eth/common/eth_types,
   results,
+  kzg4844/[kzg_abi, kzg],
   stew/[assign2, byteutils, objects],
   # Local modules:
   ../spec/[eth2_merkleization, forks],

--- a/beacon_chain/el/engine_api_conversions.nim
+++ b/beacon_chain/el/engine_api_conversions.nim
@@ -8,6 +8,7 @@
 {.push raises: [].}
 
 import
+  kzg4844/[kzg_abi, kzg],
   ../spec/datatypes/[bellatrix, capella, deneb, electra],
   web3/[engine_api, engine_api_types]
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -11,6 +11,7 @@ import
   # Status
   chronicles, chronos, metrics,
   results,
+  kzg4844/[kzg, kzg_abi],
   stew/byteutils,
   # Internals
   ../spec/[
@@ -458,7 +459,7 @@ proc validateBlobSidecar*(
   # [REJECT] The sidecar's blob is valid as verified by `verify_blob_kzg_proof(
   # blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
   block:
-    let ok = verifyProof(
+    let ok = verifyBlobKzgProof(
         KzgBlob(bytes: blob_sidecar.blob),
         blob_sidecar.kzg_commitment,
         blob_sidecar.kzg_proof).valueOr:

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -29,7 +29,7 @@ import
   ../extras,
   ./datatypes/[phase0, altair, bellatrix, deneb],
   "."/[beaconstate, eth2_merkleization, helpers, validator, signatures],
-  kzg4844/kzg_abi, kzg4844/kzg_ex
+  kzg4844/kzg_abi, kzg4844/kzg
 
 from std/algorithm import fill, sorted
 from std/sequtils import count, filterIt, mapIt
@@ -1083,7 +1083,7 @@ func kzg_commitment_to_versioned_hash*(
 proc validate_blobs*(
     expected_kzg_commitments: seq[KzgCommitment], blobs: seq[KzgBlob],
     proofs: seq[KzgProof]): Result[void, string] =
-  let res = verifyProofs(blobs, expected_kzg_commitments, proofs).valueOr:
+  let res = verifyBlobKzgProofBatch(blobs, expected_kzg_commitments, proofs).valueOr:
     return err("validate_blobs proof verification error: " & error())
 
   if not res:

--- a/beacon_chain/validators/message_router_mev.nim
+++ b/beacon_chain/validators/message_router_mev.nim
@@ -128,7 +128,7 @@ proc unblindAndRouteBlockMEV*(
       if blindedBlock.message.body.blob_kzg_commitments !=
           bundle.data.blobs_bundle.commitments:
         return err("unblinded blobs bundle has unexpected commitments")
-      let ok = verifyProofs(
+      let ok = verifyBlobKzgProofBatch(
           blobs_bundle.blobs.mapIt(KzgBlob(bytes: it)),
           asSeq blobs_bundle.commitments,
           asSeq blobs_bundle.proofs).valueOr:

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -11,7 +11,7 @@
 import
   std/json,
   yaml/tojson,
-  kzg4844/kzg_ex,
+  kzg4844/kzg,
   stew/byteutils,
   ../testutil,
   ./fixtures_utils, ./os_ops
@@ -31,9 +31,9 @@ func fromHex[N: static int](s: string): Opt[array[N, byte]] =
 
 block:
   template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
-  doAssert Kzg.loadTrustedSetup(
+  doAssert loadTrustedSetup(
     sourceDir &
-      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt").isOk
+      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
 
 proc runBlobToKzgCommitmentTest(suiteName, suitePath, path: string) =
   let relativePathComponent = path.relativeTestPathComponent(suitePath)
@@ -75,7 +75,7 @@ proc runVerifyKzgProofTest(suiteName, suitePath, path: string) =
     if commitment.isNone or z.isNone or y.isNone or proof.isNone:
       check output.kind == JNull
     else:
-      let v = verifyProof(
+      let v = verifyKzgProof(
         KzgCommitment(bytes: commitment.get),
         KzgBytes32(bytes: z.get), KzgBytes32(bytes: y.get),
         KzgBytes48(bytes: proof.get))
@@ -237,4 +237,4 @@ suite suiteName:
     for kind, path in walkDir(testsDir, relative = true, checkDir = true):
       runComputeBlobKzgProofTest(suiteName, testsDir, testsDir / path)
 
-doAssert Kzg.freeTrustedSetup().isOk
+doAssert freeTrustedSetup().isOk


### PR DESCRIPTION
This PR merges the newest release of c-kzg-4844 `v2.0.0`, which for the first time include peerDAS functions in it, this PR would eventually allow us to merge peerDAS crypto and it's other core specs into `unstable`

ref PR: https://github.com/ethereum/c-kzg-4844/pull/482

Gist of changes, as per Justin:
```
- Remove the "zero overhead aliases" which I find pretty confusing.
- I think one could argue that these are over-complicated & prone to issues.
- When adding EIP-7594 support, I made several mistakes.
- Remove duplicate tests, only use reference tests.
- The tests for each API (kzg, kzg_abi, kzg_ex) were too much.
- It's okay to only run through the reference tests.
- Use a global KzgCtx like the other bindings do.
- This is simpler & also less prone to mistakes.
- Requires that free_trusted_setup is called on exit.
```

All the necessary fixes in `nimbus-eth2` are made by me in this PR.