### PR TITLE
more concise RLP decoding syntax in EL helpers

### DIFF
--- a/beacon_chain/spec/helpers_el.nim
+++ b/beacon_chain/spec/helpers_el.nim
@@ -14,13 +14,8 @@ import
 
 func readExecutionTransaction(
     txBytes: bellatrix.Transaction): Result[ExecutionTransaction, string] =
-  # Nim 2.0.8: `rlp.decode(distinctBase(txBytes), ExecutionTransaction)`
-  # uses the generic `read` from `rlp.nim` instead of the specific `read`
-  # from `eth_types_rlp.nim`, leading to compilation error.
-  # Doing this in two steps works around this resolution order issue.
-  var rlp = rlpFromBytes(distinctBase(txBytes))
   try:
-    ok rlp.read(ExecutionTransaction)
+    ok rlp.decode(distinctBase(txBytes), ExecutionTransaction)
   except RlpError as exc:
     err("Invalid transaction: " & exc.msg)
 


### PR DESCRIPTION
The comment in `readExecutionTransaction` is not actually relevant when the `rlp.decode` template is called from a non-generic function. The function still cannot be simply inlined; `is_valid_versioned_hashes` is itself generic and would require an `export eth_types_rlp` to work properly (generic sandwich issue). The non-generic function wrapper seems simpler and avoids injecting RLP into importing modules.