### PR TITLE
some simplifications

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1124,9 +1124,7 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   # The end-slot tracker might call this when it's theoretically applicable,
   # but more than SYNC_COMMITTEE_SUBNET_COUNT epochs from when the next sync
   # committee period begins, in which case `epochsToNextSyncPeriod` is none.
-  if  epochsToSyncPeriod.isNone or
-      node.dag.cfg.consensusForkAtEpoch(epoch + epochsToSyncPeriod.get) <
-        ConsensusFork.Altair:
+  if epochsToSyncPeriod.isNone:
     return subnets
 
   subnets + node.getNextSyncCommitteeSubnets(epoch)

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -160,11 +160,6 @@ func getTargetGossipState*(
   if isBehind:
     return {}
 
-  doAssert BELLATRIX_FORK_EPOCH >= ALTAIR_FORK_EPOCH
-  doAssert CAPELLA_FORK_EPOCH >= BELLATRIX_FORK_EPOCH
-  doAssert DENEB_FORK_EPOCH >= CAPELLA_FORK_EPOCH
-  doAssert ELECTRA_FORK_EPOCH >= DENEB_FORK_EPOCH
-
   # https://github.com/ethereum/consensus-specs/issues/2902
   # Don't care whether ALTAIR_FORK_EPOCH == BELLATRIX_FORK_EPOCH or
   # BELLATRIX_FORK_EPOCH == CAPELLA_FORK_EPOCH works, because those


### PR DESCRIPTION
- no need to optimize for phase0 gossip environment anymore
- `checkForkConsistency` already checks for the ordering of all the forks, and having those listed out multiple places just adds maintenance