### PR TITLE
add: EF test vectors as per alpha 5 for peerdas

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -432,6 +432,66 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_proof_length_differen OK
 ```
 OK: 253/253 Fail: 0/253 Skip: 0/253
+## EF - KZG - EIP7594
+```diff
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_invalid_blob_26555bdcbf OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_invalid_blob_79fb3cb1ef OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_invalid_blob_7e99dea889 OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_invalid_blob_9d88c33852 OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_419245fbfe69f145  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_4aedd1a2a3933c3e  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_6e773f256383918c  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_b0731ef77b166ca8  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_b81d309b22788820  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_ed8b5001151417d5  OK
++ KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_valid_edeb8500a6507818  OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_all_cells_a OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_cell_047ee7 OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_cell_76ab46 OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_cell_77b669 OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_cell_c8e2ca OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_cell_index_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_duplicate_c OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_cell_i OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_cells_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_cells_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_than_h OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK
++ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_no_missing_a1 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_incorrect_cell_48bcbf OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_incorrect_commitment_ OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_incorrect_proof_ba29f OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_cell_bcb1b35c OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_cell_d89304ce OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_cell_d939faf6 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_cell_ef6ac828 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_cell_index_5d OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_commitment_4b OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_commitment_53 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_commitment_68 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_commitment_d3 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_missing_cell_ OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_missing_cell_ OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_missing_commi OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_missing_proof OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_proof_0424858 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_proof_48fa9d1 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_proof_8feaf47 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_invalid_proof_a9d14f0 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_0cfba0f22152206 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_3073caf43016db4 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_5211d9e9ff34c00 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_92c0b5242fa34ae OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_9fb9bff6fe1fb6b OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_d3f60d6d484ddb6 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_fd341ee5517e590 OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_multiple_blobs_ OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_same_cell_multi OK
++ KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_zero_cells_fbbd OK
+```
+OK: 56/56 Fail: 0/56 Skip: 0/56
 ## EF - SSZ generic types
 ```diff
   Testing basic_vector inputs - invalid                                                      Skip
@@ -1040,4 +1100,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 693/698 Fail: 0/698 Skip: 5/698
+OK: 749/754 Fail: 0/754 Skip: 5/754

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -11,13 +11,21 @@
 import
   std/json,
   yaml/tojson,
-  kzg4844/kzg,
+  kzg4844/[kzg, kzg_abi],
   stew/byteutils,
   ../testutil,
   ./fixtures_utils, ./os_ops
 
 from std/sequtils import anyIt, mapIt, toSeq
 from std/strutils import rsplit
+
+func toUInt64(s: int): Opt[uint64] =
+  if s < 0:
+    return Opt.none uint64
+  try:
+    Opt.some uint64(s)
+  except ValueError:
+    Opt.none uint64
 
 func fromHex[N: static int](s: string): Opt[array[N, byte]] =
   if s.len != 2*(N+1):
@@ -193,9 +201,93 @@ proc runComputeBlobKzgProofTest(suiteName, suitePath, path: string) =
       else:
         check p.get.bytes == fromHex[48](output.getStr).get
 
+proc runComputeCellsAndKzgProofsTest(suiteName, suitePath, path: string) =
+  let relativePathComponent = path.relativeTestPathComponent(suitePath)
+  test "KZG - Compute Cells And Proofs - " & relativePathComponent:
+    let 
+      data = loadToJson(os_ops.readFile(path/"data.yaml"))[0]
+      output = data["output"]
+      blob = fromHex[131072](data["input"]["blob"].getStr)
+
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/verify_cell_kzg_proof.md#condition
+    # If the blob is invalid (e.g. incorrect length or one of the 32-byte
+    # blocks does not represent a BLS field element) it should error, i.e. the
+    # the output should be `null`.
+    if blob.isNone:
+      check output.kind == JNull
+    else:
+      let p = newClone computeCellsAndKzgProofs(KzgBlob(bytes: blob.get))
+      if p[].isErr:
+        check output.kind == JNull
+      else:
+        let p_val = p[].get
+        for i in 0..<CELLS_PER_EXT_BLOB:
+          check p_val.cells[i].bytes == fromHex[2048](output[0][i].getStr).get
+          check p_val.proofs[i].bytes == fromHex[48](output[1][i].getStr).get
+
+proc runVerifyCellKzgProofBatchTest(suiteName, suitePath, path: string) =
+  let relativePathCompnent = path.relativeTestPathComponent(suitePath)
+  test "KZG - Verify Cell Kzg Proof Batch - " & relativePathCompnent:
+    let
+      data = loadToJson(os_ops.readFile(path/"data.yaml"))[0]
+      output = data["output"]
+      commitments = data["input"]["commitments"].mapIt(fromHex[48](it.getStr))
+      cell_indices = data["input"]["cell_indices"].mapIt(toUInt64(it.getInt))
+      cells = data["input"]["cells"].mapIt(fromHex[2048](it.getStr))
+      proofs = data["input"]["proofs"].mapIt(fromHex[48](it.getStr))
+
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md#condition
+    # If the blob is invalid (e.g. incorrect length or one of the 32-byte
+    # blocks does not represent a BLS field element) it should error, i.e. the
+    # the output should be `null`.
+    if commitments.anyIt(it.isNone) or 
+        cell_indices.anyIt(it.isNone) or 
+        proofs.anyIt(it.isNone) or
+        cells.anyIt(it.isNone):
+      check output.kind == JNull
+    else:
+      let v = newClone verifyCellKzgProofBatch(
+            commitments.mapIt(KzgCommitment(bytes: it.get)),
+            cell_indices.mapIt(it.get),
+            cells.mapIt(KzgCell(bytes: it.get)),
+            proofs.mapIt(KzgBytes48(bytes: it.get))
+          )
+      check:
+        if v[].isErr:
+          output.kind == JNull
+        else:
+          v[].get == output.getBool
+
+proc runRecoverCellsAndKzgProofsTest(suiteName, suitePath, path: string) =
+  let relativePathComponent = path.relativeTestPathComponent(suitePath)
+  test "KZG - Recover Cells And Kzg Proofs - " & relativePathComponent:
+    let
+      data = loadToJson(os_ops.readFile(path/"data.yaml"))[0]
+      output = data["output"]
+      cell_ids = data["input"]["cell_indices"].mapIt(toUInt64(it.getInt))
+      cells = data["input"]["cells"].mapIt(fromHex[2048](it.getStr))
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/recover_all_cells.md#condition
+    # If the blob is invalid (e.g. incorrect length or one of the 32-byte
+    # blocks does not represent a BLS field element) it should error, i.e. the
+    # the output should be `null`.
+    if cell_ids.anyIt(it.isNone) or 
+        cells.anyIt(it.isNone):
+      check output.kind == JNull
+    else:
+      let v = newClone recoverCellsAndKzgProofs(
+            cell_ids.mapIt(it.get),
+            cells.mapIt(KzgCell(bytes: it.get)))
+      if v[].isErr:
+        check output.kind == JNull
+      else:
+        let val = v[].get
+        for i in 0..<CELLS_PER_EXT_BLOB:
+          check val.cells[i].bytes == fromHex[2048](output[0][i].getStr).get
+          check val.proofs[i].bytes == fromHex[48](output[1][i].getStr).get
+
 from std/algorithm import sorted
 
-const suiteName = "EF - KZG"
+var suiteName = "EF - KZG"
 
 suite suiteName:
   const suitePath = SszTestsDir/"general"/"deneb"/"kzg"
@@ -236,5 +328,31 @@ suite suiteName:
     let testsDir = suitePath/"compute_blob_kzg_proof"/"kzg-mainnet"
     for kind, path in walkDir(testsDir, relative = true, checkDir = true):
       runComputeBlobKzgProofTest(suiteName, testsDir, testsDir / path)
+
+suiteName = "EF - KZG - EIP7594"
+
+suite suiteName:
+  const suitePath = SszTestsDir/"general"/"eip7594"/"kzg"
+
+  # TODO also check that the only direct subdirectory of each is kzg-mainnet
+  doAssert sorted(mapIt(
+      toSeq(walkDir(suitePath, relative = true, checkDir = true)), it.path)) ==
+    ["compute_cells_and_kzg_proofs", "recover_cells_and_kzg_proofs",
+     "verify_cell_kzg_proof_batch"]
+
+  block:
+    let testsDir = suitePath/"compute_cells_and_kzg_proofs"/"kzg-mainnet"
+    for kind, path in walkDir(testsDir, relative = true, checkDir = true):
+      runComputeCellsAndKzgProofsTest(suiteName, testsDir, testsDir/path)
+
+  block:
+    let testsDir = suitePath/"recover_cells_and_kzg_proofs"/"kzg-mainnet"
+    for kind, path in walkDir(testsDir, relative = true, checkDir = true):
+      runRecoverCellsAndKzgProofsTest(suiteName, testsDir, testsDir/path)
+
+  block:
+    let testsDir = suitePath/"verify_cell_kzg_proof_batch"/"kzg-mainnet"
+    for kind, path in walkDir(testsDir, relative = true, checkDir = true):
+      runVerifyCellKzgProofBatchTest(suiteName, testsDir, testsDir/path)
 
 doAssert freeTrustedSetup().isOk

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -209,7 +209,7 @@ proc runComputeCellsAndKzgProofsTest(suiteName, suitePath, path: string) =
       output = data["output"]
       blob = fromHex[131072](data["input"]["blob"].getStr)
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/verify_cell_kzg_proof.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/tests/formats/kzg_7594/verify_cell_kzg_proof.md#condition
     # If the blob is invalid (e.g. incorrect length or one of the 32-byte
     # blocks does not represent a BLS field element) it should error, i.e. the
     # the output should be `null`.
@@ -236,7 +236,7 @@ proc runVerifyCellKzgProofBatchTest(suiteName, suitePath, path: string) =
       cells = data["input"]["cells"].mapIt(fromHex[2048](it.getStr))
       proofs = data["input"]["proofs"].mapIt(fromHex[48](it.getStr))
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md#condition
     # If the blob is invalid (e.g. incorrect length or one of the 32-byte
     # blocks does not represent a BLS field element) it should error, i.e. the
     # the output should be `null`.
@@ -266,7 +266,7 @@ proc runRecoverCellsAndKzgProofsTest(suiteName, suitePath, path: string) =
       output = data["output"]
       cell_ids = data["input"]["cell_indices"].mapIt(toUInt64(it.getInt))
       cells = data["input"]["cells"].mapIt(fromHex[2048](it.getStr))
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.2/tests/formats/kzg_7594/recover_all_cells.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5 /tests/formats/kzg_7594/recover_all_cells.md#condition
     # If the blob is invalid (e.g. incorrect length or one of the 32-byte
     # blocks does not represent a BLS field element) it should error, i.e. the
     # the output should be `null`.


### PR DESCRIPTION
This pr adds the tests for the test vectors provided by EF for peerdas cryptography. Ref: https://github.com/ethereum/consensus-spec-tests/tree/v1.5.0-alpha.5/tests/general/eip7594/kzg