### PR TITLE
ci: bump archiving timeout, list artifacts

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -143,13 +143,17 @@ pipeline {
           } }
         }
       }
-      post { always { timeout(5) {
-        archiveArtifacts(
-          artifacts: '*.tar.gz',
-          excludes: '**/geth-*.tar.gz',  /* `scripts/geth_binaries.sh` */
-          allowEmptyArchive: true
-        )
-      } } }
+      post {
+        always { timeout(10) {
+          /* DEBUG: Show file sizes to catch too big ones. */
+          sh 'ls -hl *.tar.gz'
+          archiveArtifacts(
+            artifacts: '*.tar.gz',
+            excludes: '**/geth-*.tar.gz',  /* `scripts/geth_binaries.sh` */
+            allowEmptyArchive: true
+          )
+        } }
+      }
     }
   }
 


### PR DESCRIPTION
We suspect in some cases the archive is bigger than normally. I'm adding a listing of the file sizes to catch that.