### PR TITLE
Rid result from `get_custody_column_subnets`

### DIFF
--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -92,7 +92,7 @@ func get_custody_column_list*(node_id: NodeId,
   # before sending, data_column_sidecars_by_range requests
   let
     subnet_ids =
-      get_custody_column_subnets(node_id, custody_subnet_count).get
+      get_custody_column_subnets(node_id, custody_subnet_count)
   const
     columns_per_subnet =
       NUMBER_OF_COLUMNS div DATA_COLUMN_SIDECAR_SUBNET_COUNT

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -40,14 +40,11 @@ func sortedColumnIndexList*(columnsPerSubnet: ColumnIndex,
 
 func get_custody_column_subnets*(node_id: NodeId,
                                  custody_subnet_count: uint64):
-                                 Result[HashSet[uint64], cstring] =
+                                 HashSet[uint64] =
 
   # Decouples the custody subnet computation part from
   # `get_custody_columns`, in order to later use this subnet list
   # in order to maintain subscription to specific column subnets.
-
-  if not (custody_subnet_count <= DATA_COLUMN_SIDECAR_SUBNET_COUNT):
-    return err("Eip7594: Custody subnet count exceeds the DATA_COLUMN_SIDECAR_SUBNET_COUNT")
 
   var
     subnet_ids: HashSet[uint64]
@@ -80,7 +77,7 @@ func get_custody_columns*(node_id: NodeId,
                           seq[ColumnIndex] =
   let
     subnet_ids =
-      get_custody_column_subnets(node_id, custody_subnet_count).get
+      get_custody_column_subnets(node_id, custody_subnet_count)
   const
     columns_per_subnet =
       NUMBER_OF_COLUMNS div DATA_COLUMN_SIDECAR_SUBNET_COUNT

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -69,7 +69,7 @@ func get_custody_column_subnets*(node_id: NodeId,
       current_id = NodeId(StUint[256].zero)
     current_id += NodeId(StUint[256].one)
 
-  ok(subnet_ids)
+  subnet_ids
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/das-core.md#get_custody_columns
 func get_custody_columns*(node_id: NodeId,


### PR DESCRIPTION
As discussed with @tersec , the scenario where `custody_subnet_count` would exceed `DATA_COLUMN_SIDECAR_SUBNET_COUNT`, would hardly appear, regardless the check's mention in specs: https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/das-core.md#get_custody_columns

The highest `custody_subnet_count` can be ever attainable in Nimbus' prod branch would be `=` to `DATA_COLUMN_SIDECAR_SUBNET_COUNT`, via the `--subscribe-all-subnets` flag, and no way else.

Hence, the usage of result and it's corresponding `get` was becoming unintentionally useless.

The check and potentially the result, would however be useful in the devnet branches, as it would get us a clear indication of data column reconstruction, it's timings and CPU utilizations.