### PR TITLE
add: `get_extended_sample_count` with test

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -531,6 +531,11 @@ OK: 10/12 Fail: 0/12 Skip: 2/12
 + snapshot_cases                                                                             OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
+## EIP-7594 Sampling Tests
+```diff
++ EIP7594: Extended Sample Count                                                             OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EL Configuration
 ```diff
 + Empty config file                                                                          OK
@@ -1114,4 +1119,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 759/764 Fail: 0/764 Skip: 5/764
+OK: 760/765 Fail: 0/765 Skip: 5/765

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -111,7 +111,7 @@ func get_extended_sample_count*(samples_per_slot: int,
   const columnsCount = NUMBER_OF_COLUMNS.int
 
   # If 50% of the columns are missing, we are able to reconstruct the data
-  # If 50% + 1 columns are missing, we are NO MORE able to reconstruct the data
+  # If 50% + 1 columns are missing, we are become unable to reconstruct the data
   let worstCaseConditionCount = (columnsCount div 2) + 1
 
   # Compute the false positive threshold

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -100,12 +100,12 @@ func get_custody_column_list*(node_id: NodeId,
   sortedColumnIndexList(ColumnIndex(columns_per_subnet), subnet_ids)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/peer-sampling.md#get_extended_sample_count
-proc get_extended_sample_count*(samples_per_slot: int,
+func get_extended_sample_count*(samples_per_slot: int,
                                 allowed_failures: int):
                                 int =
-  # `get_extended_sample_count` computes the number of samples we
-  # should query from peers, given the SAMPLES_PER_SLOT and 
-  # the number of allowed failures
+  ## `get_extended_sample_count` computes the number of samples we
+  ## should query from peers, given the SAMPLES_PER_SLOT and 
+  ## the number of allowed failures
 
   # Retrieving the column count
   const columnsCount = NUMBER_OF_COLUMNS.int
@@ -122,9 +122,10 @@ proc get_extended_sample_count*(samples_per_slot: int,
 
   # Finally, compute the extended sample count
   for i in samples_per_slot .. columnsCount + 1:
-    if hypergeom_cdf(allowed_failures,
-                     columnsCount, 
-                     worstCaseConditionCount, i) <= falsePositiveThreshold:
+    if hypergeom_cdf(
+        allowed_failures,
+        columnsCount, 
+        worstCaseConditionCount, i) <= falsePositiveThreshold:
       sampleCount = i
       break
     sampleCount = i

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -126,4 +126,4 @@ proc get_extended_sample_count*(samples_per_slot: int,
       break
     sampleCount = i
   
-  return sampleCount
+  sampleCount

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -108,7 +108,7 @@ func get_extended_sample_count*(samples_per_slot: int,
   ## the number of allowed failures
 
   # Retrieving the column count
-  const columnsCount = NUMBER_OF_COLUMNS.int
+  const columnsCount = NUMBER_OF_COLUMNS
 
   # If 50% of the columns are missing, we are able to reconstruct the data
   # If 50% + 1 columns are missing, we cannot reconstruct the data
@@ -119,11 +119,11 @@ func get_extended_sample_count*(samples_per_slot: int,
     hypergeom_cdf(0, columnsCount, worstCaseConditionCount, samples_per_slot)
 
   # Finally, compute the extended sample count
-  for i in samples_per_slot .. columnsCount + 1:
+  for i in samples_per_slot .. columnsCount:
     if hypergeom_cdf(
         allowed_failures,
         columnsCount, 
         worstCaseConditionCount, i) <= falsePositiveThreshold:
       return i
 
-  return -999
+  columnsCount

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -108,20 +108,23 @@ proc get_extended_sample_count*(samples_per_slot: int,
   # the number of allowed failures
 
   # Retrieving the column count
-  let columnsCount = NUMBER_OF_COLUMNS.int
+  const columnsCount = NUMBER_OF_COLUMNS.int
 
   # If 50% of the columns are missing, we are able to reconstruct the data
   # If 50% + 1 columns are missing, we are NO MORE able to reconstruct the data
   let worstCaseConditionCount = (columnsCount div 2) + 1
 
   # Compute the false positive threshold
-  let falsePositiveThreshold = hypergeom_cdf(0, columnsCount, worstCaseConditionCount, samples_per_slot)
+  let falsePositiveThreshold = 
+    hypergeom_cdf(0, columnsCount, worstCaseConditionCount, samples_per_slot)
 
   var sampleCount: int
 
   # Finally, compute the extended sample count
   for i in samples_per_slot .. columnsCount + 1:
-    if hypergeom_cdf(allowed_failures, columnsCount, worstCaseConditionCount, i) <= falsePositiveThreshold:
+    if hypergeom_cdf(allowed_failures,
+                     columnsCount, 
+                     worstCaseConditionCount, i) <= falsePositiveThreshold:
       sampleCount = i
       break
     sampleCount = i

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -107,23 +107,20 @@ func get_extended_sample_count*(samples_per_slot: int,
   ## should query from peers, given the SAMPLES_PER_SLOT and 
   ## the number of allowed failures
 
-  # Retrieving the column count
-  const columnsCount = NUMBER_OF_COLUMNS
-
   # If 50% of the columns are missing, we are able to reconstruct the data
   # If 50% + 1 columns are missing, we cannot reconstruct the data
-  const worstCaseConditionCount = (columnsCount div 2) + 1
+  const worstCaseConditionCount = (NUMBER_OF_COLUMNS div 2) + 1
 
   # Compute the false positive threshold
   let falsePositiveThreshold = 
-    hypergeom_cdf(0, columnsCount, worstCaseConditionCount, samples_per_slot)
+    hypergeom_cdf(0, NUMBER_OF_COLUMNS, worstCaseConditionCount, samples_per_slot)
 
   # Finally, compute the extended sample count
-  for i in samples_per_slot .. columnsCount:
+  for i in samples_per_slot .. NUMBER_OF_COLUMNS:
     if hypergeom_cdf(
         allowed_failures,
-        columnsCount, 
+        NUMBER_OF_COLUMNS, 
         worstCaseConditionCount, i) <= falsePositiveThreshold:
       return i
 
-  columnsCount
+  NUMBER_OF_COLUMNS

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -111,14 +111,12 @@ func get_extended_sample_count*(samples_per_slot: int,
   const columnsCount = NUMBER_OF_COLUMNS.int
 
   # If 50% of the columns are missing, we are able to reconstruct the data
-  # If 50% + 1 columns are missing, we are become unable to reconstruct the data
-  let worstCaseConditionCount = (columnsCount div 2) + 1
+  # If 50% + 1 columns are missing, we cannot reconstruct the data
+  const worstCaseConditionCount = (columnsCount div 2) + 1
 
   # Compute the false positive threshold
   let falsePositiveThreshold = 
     hypergeom_cdf(0, columnsCount, worstCaseConditionCount, samples_per_slot)
-
-  var sampleCount: int
 
   # Finally, compute the extended sample count
   for i in samples_per_slot .. columnsCount + 1:
@@ -126,8 +124,6 @@ func get_extended_sample_count*(samples_per_slot: int,
         allowed_failures,
         columnsCount, 
         worstCaseConditionCount, i) <= falsePositiveThreshold:
-      sampleCount = i
-      break
-    sampleCount = i
-  
-  sampleCount
+      return i
+
+  return -999

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -27,6 +27,7 @@ import # Unit test
   ./test_discovery,
   ./test_engine_api_conversions,
   ./test_engine_authentication,
+  ./test_eip7594_helpers,
   ./test_el_manager,
   ./test_el_conf,
   ./test_eth2_ssz_serialization,

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -41,5 +41,6 @@ suite "EIP-7594 Sampling Tests":
       ]
 
       for (allowed_failures, extendedSampleCount) in tests:
-        check: get_extended_sample_count(samplesPerSlot, allowed_failures) == extendedSampleCount
+        check: get_extended_sample_count(
+            samplesPerSlot, allowed_failures) == extendedSampleCount
     testExtendedSampleCount()

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -1,0 +1,45 @@
+# beacon_chain
+# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+{.used.}
+
+import
+  unittest2,
+  ../beacon_chain/spec/[helpers, eip7594_helpers]
+
+suite "EIP-7594 Sampling Tests":
+  test "EIP7594: Extended Sample Count":
+    proc testExtendedSampleCount() =
+      let samplesPerSlot = 16
+      const tests = [
+        (0, 16),
+        (1, 20),
+        (2, 24),
+        (3, 27),
+        (4, 29),
+        (5, 32),
+        (6, 35),
+        (7, 37),
+        (8, 40),
+        (9, 42),
+        (10, 44),
+        (11, 47),
+        (12, 49),
+        (13, 51),
+        (14, 53),
+        (15, 55),
+        (16, 57),
+        (17, 59),
+        (18, 61),
+        (19, 63),
+        (20, 65)
+      ]
+
+      for (allowed_failures, extendedSampleCount) in tests:
+        check: get_extended_sample_count(samplesPerSlot, allowed_failures) == extendedSampleCount
+    testExtendedSampleCount()


### PR DESCRIPTION
Adds https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/peer-sampling.md#get_extended_sample_count with test to facilitate Lossy Sampling

Prequel: https://github.com/status-im/nimbus-eth2/pull/6447