### PR TITLE
rm unused code/type conversoins; re-enable Electra block gossip verification

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -559,9 +559,7 @@ proc new*(T: type BeaconChainDB,
       sealedPeriods: "lc_sealed_periods")).expectDb()
   static: doAssert LightClientDataFork.high == LightClientDataFork.Electra
 
-  var blobs : KvStoreRef
-  if cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
-    blobs = kvStore db.openKvStore("deneb_blobs").expectDb()
+  var blobs = kvStore db.openKvStore("deneb_blobs").expectDb()
 
   # Versions prior to 1.4.0 (altair) stored validators in `immutable_validators`
   # which stores validator keys in compressed format - this is

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -269,7 +269,7 @@ when const_preset == "gnosis":
     for network in [gnosisMetadata, chiadoMetadata]:
       doAssert network.cfg.DENEB_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.ELECTRA_FORK_EPOCH == FAR_FUTURE_EPOCH
-      static: doAssert ConsensusFork.high == ConsensusFork.Electra
+      doAssert ConsensusFork.high == ConsensusFork.Electra
 
 elif const_preset == "mainnet":
   when incbinEnabled:
@@ -321,7 +321,7 @@ elif const_preset == "mainnet":
     for network in [mainnetMetadata, sepoliaMetadata, holeskyMetadata]:
       doAssert network.cfg.DENEB_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.ELECTRA_FORK_EPOCH == FAR_FUTURE_EPOCH
-      static: doAssert ConsensusFork.high == ConsensusFork.Electra
+      doAssert ConsensusFork.high == ConsensusFork.Electra
 
 proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
   template loadRuntimeMetadata(): auto =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2271,7 +2271,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
       bnStatus = BeaconNodeStatus.Stopping
     c_signal(ansi_c.SIGTERM, SIGTERMHandler)
 
-  if metadata.cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
+  block:
     let res =
       if config.trustedSetupFile.isNone:
         conf.loadKzgTrustedSetup()

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -122,7 +122,7 @@ proc publishBlockV3(vc: ValidatorClientRef, currentSlot, slot: Slot,
   let
     maybeBlock =
       try:
-        await vc.produceBlockV3(slot, randao_reveal, graffiti,
+        await vc.produceBlockV3(slot, randaoReveal, graffiti,
                                 vc.config.builderBoostFactor,
                                 ApiStrategyKind.Best)
       except ValidatorApiError as exc:

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -150,7 +150,6 @@ proc serveContributionAndProof*(service: SyncCommitteeServiceRef,
     vc = service.client
     startTime = Moment.now()
     slot = proof.contribution.slot
-    validatorIdx = validator.index.get()
     genesisRoot = vc.beaconGenesis.genesis_validators_root
     fork = vc.forkAtEpoch(slot.epoch)
 

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -22,16 +22,10 @@ import
   ./logtrace
 
 from std/os import changeFileExt, fileExists
-from std/sequtils import mapIt, toSeq
 from std/times import toUnix
 from ../beacon_chain/el/engine_api_conversions import asEth2Digest
 from ../beacon_chain/spec/beaconstate import initialize_beacon_state_from_eth1
 from ../tests/mocking/mock_genesis import mockEth1BlockHash
-
-# Compiled version of /scripts/depositContract.v.py in this repo
-# The contract was compiled in Remix (https://remix.ethereum.org/) with vyper (remote) compiler.
-const depositContractCode =
-  hexToSeqByte staticRead "../beacon_chain/el/deposit_contract_code.txt"
 
 # For nim-confutils, which uses this kind of init(Type, value) pattern
 func init(T: type IpAddress, ip: IpAddress): T = ip
@@ -389,19 +383,6 @@ proc createEnr(rng: var HmacDrbgContext,
       ])
   bootstrapEnr.tryGet()
 
-proc doCreateTestnetEnr(config: CliConfig,
-                        rng: var HmacDrbgContext)
-                       {.raises: [CatchableError].} =
-  let
-    cfg = getRuntimeConfig(config.eth2Network)
-    bootstrapEnr = parseBootstrapAddress(toSeq(lines(string config.inputBootstrapEnr))[0]).get()
-    forkIdField = bootstrapEnr.tryGet(enrForkIdField, seq[byte]).get()
-    enr =
-      createEnr(rng, string config.enrDataDir, string config.enrNetKeyFile,
-        config.enrNetKeyInsecurePassword, cfg, forkIdField,
-        config.enrAddress, config.enrPort)
-  stderr.writeLine(enr.toURI)
-
 proc doCreateTestnet*(config: CliConfig,
                       rng: var HmacDrbgContext)
                      {.raises: [CatchableError].} =
@@ -504,29 +485,6 @@ proc doCreateTestnet*(config: CliConfig,
     writeFile(bootstrapFile, enr.toURI)
     echo "Wrote ", bootstrapFile
 
-proc deployContract(web3: Web3, code: seq[byte]): Future[ReceiptObject] {.async.} =
-  let tr = TransactionArgs(
-    `from`: Opt.some web3.defaultAccount,
-    data: Opt.some code,
-    gas: Opt.some Quantity(3000000),
-    gasPrice: Opt.some Quantity(1))
-
-  let r = await web3.send(tr)
-  result = await web3.getMinedTransactionReceipt(r)
-
-proc sendEth(web3: Web3, to: Eth1Address, valueEth: int): Future[TxHash] =
-  let tr = TransactionArgs(
-    `from`: Opt.some web3.defaultAccount,
-    # TODO: Force json-rpc to generate 'data' field
-    # should not be needed anymore, new execution-api schema
-    # is using `input` field
-    data: Opt.some(newSeq[byte]()),
-    gas: Opt.some Quantity(3000000),
-    gasPrice: Opt.some Quantity(1),
-    value: Opt.some(valueEth.u256 * 1000000000000000000.u256),
-    to: Opt.some(to))
-  web3.send(tr)
-
 type
   DelayGenerator = proc(): chronos.Duration {.gcsafe, raises: [].}
 
@@ -542,43 +500,6 @@ proc initWeb3(web3Url, privateKey: string): Future[Web3] {.async.} =
     doAssert(accounts.len > 0)
     result.defaultAccount = accounts[0]
 
-# TODO: async functions should note take `seq` inputs because
-#       this leads to full copies.
-proc sendDeposits(deposits: seq[LaunchPadDeposit],
-                  web3Url, privateKey: string,
-                  depositContractAddress: Eth1Address,
-                  delayGenerator: DelayGenerator = nil) {.async.} =
-  notice "Sending deposits",
-    web3 = web3Url,
-    depositContract = depositContractAddress
-
-  var web3 = await initWeb3(web3Url, privateKey)
-  let gasPrice = int(await web3.provider.eth_gasPrice()) * 2
-  let depositContract = web3.contractSender(
-    DepositContract, depositContractAddress)
-  for i in 4200 ..< deposits.len:
-    let dp = deposits[i] as DepositData
-
-    while true:
-      try:
-        let tx = depositContract.deposit(
-          PubKeyBytes(@(dp.pubkey.toRaw())),
-          WithdrawalCredentialsBytes(@(dp.withdrawal_credentials.data)),
-          SignatureBytes(@(dp.signature.toRaw())),
-          FixedBytes[32](hash_tree_root(dp).data))
-
-        let status = await tx.send(value = 32.u256.ethToWei, gasPrice = gasPrice)
-
-        info "Deposit sent", tx = $status
-
-        if delayGenerator != nil:
-          await sleepAsync(delayGenerator())
-
-        break
-      except CatchableError:
-        await sleepAsync(chronos.seconds 60)
-        web3 = await initWeb3(web3Url, privateKey)
-
 {.pop.} # TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 
 when isMainModule:
@@ -586,7 +507,87 @@ when isMainModule:
     web3/confutils_defs,
     ../beacon_chain/filepath
 
+  from std/sequtils import mapIt, toSeq
   from std/terminal import readPasswordFromStdin
+
+  # Compiled version of /scripts/depositContract.v.py in this repo
+  # The contract was compiled in Remix (https://remix.ethereum.org/) with vyper (remote) compiler.
+  const depositContractCode =
+    hexToSeqByte staticRead "../beacon_chain/el/deposit_contract_code.txt"
+
+  proc doCreateTestnetEnr(config: CliConfig,
+                          rng: var HmacDrbgContext)
+                         {.raises: [CatchableError].} =
+    let
+      cfg = getRuntimeConfig(config.eth2Network)
+      bootstrapEnr = parseBootstrapAddress(toSeq(lines(string config.inputBootstrapEnr))[0]).get()
+      forkIdField = bootstrapEnr.tryGet(enrForkIdField, seq[byte]).get()
+      enr =
+        createEnr(rng, string config.enrDataDir, string config.enrNetKeyFile,
+          config.enrNetKeyInsecurePassword, cfg, forkIdField,
+          config.enrAddress, config.enrPort)
+    stderr.writeLine(enr.toURI)
+
+  proc deployContract(web3: Web3, code: seq[byte]): Future[ReceiptObject] {.async.} =
+    let tr = TransactionArgs(
+      `from`: Opt.some web3.defaultAccount,
+      data: Opt.some code,
+      gas: Opt.some Quantity(3000000),
+      gasPrice: Opt.some Quantity(1))
+
+    let r = await web3.send(tr)
+    result = await web3.getMinedTransactionReceipt(r)
+
+  proc sendEth(web3: Web3, to: Eth1Address, valueEth: int): Future[TxHash] =
+    let tr = TransactionArgs(
+      `from`: Opt.some web3.defaultAccount,
+      # TODO: Force json-rpc to generate 'data' field
+      # should not be needed anymore, new execution-api schema
+      # is using `input` field
+      data: Opt.some(newSeq[byte]()),
+      gas: Opt.some Quantity(3000000),
+      gasPrice: Opt.some Quantity(1),
+      value: Opt.some(valueEth.u256 * 1000000000000000000.u256),
+      to: Opt.some(to))
+    web3.send(tr)
+
+  # TODO: async functions should note take `seq` inputs because
+  #       this leads to full copies.
+  proc sendDeposits(deposits: seq[LaunchPadDeposit],
+                    web3Url, privateKey: string,
+                    depositContractAddress: Eth1Address,
+                    delayGenerator: DelayGenerator = nil) {.async.} =
+    notice "Sending deposits",
+      web3 = web3Url,
+      depositContract = depositContractAddress
+
+    var web3 = await initWeb3(web3Url, privateKey)
+    let gasPrice = int(await web3.provider.eth_gasPrice()) * 2
+    let depositContract = web3.contractSender(
+      DepositContract, depositContractAddress)
+    for i in 4200 ..< deposits.len:
+      let dp = deposits[i] as DepositData
+
+      while true:
+        try:
+          let tx = depositContract.deposit(
+            PubKeyBytes(@(dp.pubkey.toRaw())),
+            WithdrawalCredentialsBytes(@(dp.withdrawal_credentials.data)),
+            SignatureBytes(@(dp.signature.toRaw())),
+            FixedBytes[32](hash_tree_root(dp).data))
+
+          let status = await tx.send(
+            value = 32.u256.ethToWei, gasPrice = gasPrice)
+
+          info "Deposit sent", tx = $status
+
+          if delayGenerator != nil:
+            await sleepAsync(delayGenerator())
+
+          break
+        except CatchableError:
+          await sleepAsync(chronos.seconds 60)
+          web3 = await initWeb3(web3Url, privateKey)
 
   proc main() {.async.} =
     var conf = try: CliConfig.load()

--- a/tests/test_sync_committee_pool.nim
+++ b/tests/test_sync_committee_pool.nim
@@ -67,7 +67,7 @@ suite "Sync committee pool":
       nextPeriod = cfg.BELLATRIX_FORK_EPOCH.sync_committee_period + 1
 
       bid1 = BlockId(
-        slot: Slot(nextPeriod.start_slot - 2),  # Committee based on `slot + 1`
+        slot: nextPeriod.start_slot - 2,  # Committee based on `slot + 1`
         root: eth2digest(@[1.byte]))
 
       sig1 = get_sync_committee_message_signature(

--- a/tests/test_validator_bucket_sort.nim
+++ b/tests/test_validator_bucket_sort.nim
@@ -226,7 +226,7 @@ func findValidatorIndexBruteforce(
     h2: ValidatorPubKey): Opt[ValidatorIndex] =
   for validatorIndex in bsv.extraItems:
     if validators[validatorIndex.distinctBase].pubkey == h2:
-      return Opt.some validatorIndex.ValidatorIndex
+      return Opt.some validatorIndex
   for validatorIndex in bsv.bucketSorted:
     if validators[validatorIndex].pubkey == h2:
       return Opt.some validatorIndex.ValidatorIndex


### PR DESCRIPTION
The `ncli_testnet` changes move some code only used `when isMainModule` into that part of the module to avoid several `XDeclaredButNotUsed` hints when it's not the main module.