### PR TITLE
add: compute matrix

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -536,6 +536,11 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EIP7594: Extended Sample Count                                                             OK
 ```
 OK: 1/1 Fail: 0/1 Skip: 0/1
+## EIP-7594 Unit Tests
+```diff
++ EIP-7594: Compute Matrix                                                                   OK
+```
+OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EL Configuration
 ```diff
 + Empty config file                                                                          OK
@@ -1119,4 +1124,4 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 OK: 9/9 Fail: 0/9 Skip: 0/9
 
 ---TOTAL---
-OK: 760/765 Fail: 0/765 Skip: 5/765
+OK: 761/766 Fail: 0/766 Skip: 5/766

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -119,7 +119,6 @@ proc compute_matrix* (blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
 
   ok(extended_matrix)
 
-
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/peer-sampling.md#get_extended_sample_count
 func get_extended_sample_count*(samples_per_slot: int,
                                 allowed_failures: int):

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -101,7 +101,7 @@ func get_custody_column_list*(node_id: NodeId,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/das-core.md#compute_matrix
 proc compute_matrix* (blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
-  # This helper demonstrates the relationship between blobs and the `MatrixEntries`
+  ## `compute_matrix` helper demonstrates the relationship between blobs and the `MatrixEntries`
   var extended_matrix: seq[MatrixEntry]
 
   for blbIdx, blob in blobs.pairs:

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -101,7 +101,8 @@ func get_custody_column_list*(node_id: NodeId,
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/das-core.md#compute_matrix
 proc compute_matrix*(blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
-  ## `compute_matrix` helper demonstrates the relationship between blobs and the `MatrixEntries`
+  ## `compute_matrix` helper demonstrates the relationship
+  ## between blobs and the `MatrixEntries`
   var extended_matrix: seq[MatrixEntry]
 
   for blbIdx, blob in blobs.pairs:

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -100,7 +100,7 @@ func get_custody_column_list*(node_id: NodeId,
   sortedColumnIndexList(ColumnIndex(columns_per_subnet), subnet_ids)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/das-core.md#compute_matrix
-proc compute_matrix* (blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
+proc compute_matrix*(blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
   ## `compute_matrix` helper demonstrates the relationship between blobs and the `MatrixEntries`
   var extended_matrix: seq[MatrixEntry]
 

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -9,7 +9,7 @@
 {.used.}
 
 import
-  random,
+  std/random,
   unittest2,
   results,
   kzg4844/[kzg_abi, kzg],

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -14,10 +14,6 @@ import
   results,
   stint,
   kzg4844/[kzg_abi, kzg],
-  ssz_serialization/proofs,
-  chronicles,
-  ../beacon_chain/spec/beacon_time,
-  eth/p2p/discoveryv5/[node],
   ./consensus_spec/[os_ops, fixtures_utils],
   ../beacon_chain/spec/[helpers, eip7594_helpers],
   ../beacon_chain/spec/datatypes/[eip7594, deneb]

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -9,10 +9,9 @@
 {.used.}
 
 import
+  std/sysrand,
   unittest2,
-  std/[macros, tables, sysrand],
   results,
-  stint,
   kzg4844/[kzg_abi, kzg],
   ./consensus_spec/[os_ops, fixtures_utils],
   ../beacon_chain/spec/[helpers, eip7594_helpers],

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -55,16 +55,16 @@ iterator chunks[T](lst: seq[T], n: int): seq[T] =
 suite "EIP-7594 Unit Tests":
   test "EIP-7594: Compute Matrix":
     proc testComputeExtendedMatrix() =
-      const 
-        blob_count = 2
+      var
+        rng = initRand(126)
+        blob_count = rng.rand(1..(deneb.MAX_BLOB_COMMITMENTS_PER_BLOCK.int))
       let
-        input_blobs = createSampleKzgBlobs(blob_count, 123456)
+        input_blobs = createSampleKzgBlobs(blob_count, rng.rand(int))
         extended_matrix = compute_matrix(input_blobs)
       doAssert extended_matrix.get.len == kzg_abi.CELLS_PER_EXT_BLOB * blob_count
       for row in chunks(extended_matrix.get, kzg_abi.CELLS_PER_EXT_BLOB):
         doAssert len(row) == kzg_abi.CELLS_PER_EXT_BLOB
     testComputeExtendedMatrix()
-
 
 suite "EIP-7594 Sampling Tests":
   test "EIP7594: Extended Sample Count":

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -40,11 +40,10 @@ proc createSampleKzgBlobs(n: int): seq[KzgBlob] =
 
   blobs
 
-proc chunks[T](lst: seq[T], n: int): seq[seq[T]] =
-    ## Helper that splits a list into N sized chunks.
-    result = @[]
-    for i in countup(0, len(lst) - 1, n):
-        result.add(lst[i..min(i + n - 1, len(lst) - 1)])
+iterator chunks[T](lst: seq[T], n: int): seq[T] =
+  ## Iterator that yields N-sized chunks from the list.
+  for i in countup(0, len(lst) - 1, n):
+    yield lst[i..min(i + n - 1, len(lst) - 1)]
 
 suite "EIP-7594 Unit Tests":
   test "EIP-7594: Compute Matrix":
@@ -55,8 +54,7 @@ suite "EIP-7594 Unit Tests":
         input_blobs = createSampleKzgBlobs(blob_count)
         extended_matrix = compute_matrix(input_blobs)
       doAssert extended_matrix.get.len == kzg_abi.CELLS_PER_EXT_BLOB * blob_count
-      let rows = chunks(extended_matrix.get, kzg_abi.CELLS_PER_EXT_BLOB)
-      for row in rows:
+      for row in chunks(extended_matrix.get, kzg_abi.CELLS_PER_EXT_BLOB):
         doAssert len(row) == kzg_abi.CELLS_PER_EXT_BLOB
     testComputeExtendedMatrix()
 

--- a/tests/test_eip7594_helpers.nim
+++ b/tests/test_eip7594_helpers.nim
@@ -10,7 +10,61 @@
 
 import
   unittest2,
-  ../beacon_chain/spec/[helpers, eip7594_helpers]
+  std/[macros, tables, sysrand],
+  results,
+  stint,
+  kzg4844/[kzg_abi, kzg],
+  ssz_serialization/proofs,
+  chronicles,
+  ../beacon_chain/spec/beacon_time,
+  eth/p2p/discoveryv5/[node],
+  ./consensus_spec/[os_ops, fixtures_utils],
+  ../beacon_chain/spec/[helpers, eip7594_helpers],
+  ../beacon_chain/spec/datatypes/[eip7594, deneb]
+
+from std/strutils import rsplit
+
+block:
+  template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
+  doAssert loadTrustedSetup(
+    sourceDir &
+      "/../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
+
+const MAX_TOP_BYTE = 114
+
+proc createSampleKzgBlobs(n: int): seq[KzgBlob] =
+  var
+    blob: array[BYTES_PER_BLOB, byte]
+    blobs: seq[KzgBlob]
+  for i in 0..<n:
+    discard urandom(blob)
+    for i in 0..<BYTES_PER_BLOB.int:
+      if blob[i] > MAX_TOP_BYTE and i %% kzg_abi.BYTES_PER_FIELD_ELEMENT == 0:
+        blob[i] = MAX_TOP_BYTE
+    blobs.add(KzgBlob(bytes: blob))
+
+  blobs
+
+proc chunks[T](lst: seq[T], n: int): seq[seq[T]] =
+    ## Helper that splits a list into N sized chunks.
+    result = @[]
+    for i in countup(0, len(lst) - 1, n):
+        result.add(lst[i..min(i + n - 1, len(lst) - 1)])
+
+suite "EIP-7594 Unit Tests":
+  test "EIP-7594: Compute Matrix":
+    proc testComputeExtendedMatrix() =
+      const 
+        blob_count = 2
+      let
+        input_blobs = createSampleKzgBlobs(blob_count)
+        extended_matrix = compute_matrix(input_blobs)
+      doAssert extended_matrix.get.len == kzg_abi.CELLS_PER_EXT_BLOB * blob_count
+      let rows = chunks(extended_matrix.get, kzg_abi.CELLS_PER_EXT_BLOB)
+      for row in rows:
+        doAssert len(row) == kzg_abi.CELLS_PER_EXT_BLOB
+    testComputeExtendedMatrix()
+
 
 suite "EIP-7594 Sampling Tests":
   test "EIP7594: Extended Sample Count":
@@ -44,3 +98,5 @@ suite "EIP-7594 Sampling Tests":
         check: get_extended_sample_count(
             samplesPerSlot, allowed_failures) == extendedSampleCount
     testExtendedSampleCount()
+
+doAssert freeTrustedSetup().isOk


### PR DESCRIPTION
Ref: https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/_features/eip7594/das-core.md#compute_matrix

This PR adds the `compute_matrix` function for peerDAS, it enables the BN to take a decision on when can rest of the data columns be reconstructed by obtaining a `MatrixEntry` like view.