### PR TITLE
Electra REST forked BeaconBlockBody reading support

### DIFF
--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -52,6 +52,8 @@ const
 static:
   doAssert(ClientMaximumValidatorIds <= ServerMaximumValidatorIds)
 
+debugComment "update RestExecutionPayload from https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#executionpayload then make sure block body reading changes follows"
+
 type
   # https://github.com/ethereum/beacon-APIs/blob/v2.4.2/apis/eventstream/index.yaml
   EventTopic* {.pure.} = enum
@@ -320,6 +322,14 @@ type
     blob_gas_used*: Option[uint64]   ## [New in Deneb]
     excess_blob_gas*: Option[uint64] ## [New in Deneb]
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/phase0/beacon-chain.md#attestation
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/electra/beacon-chain.md#attestation
+  RestAttestation* = object
+    aggregation_bits*:
+      BitList[Limit MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
+    data*: AttestationData
+    signature*: ValidatorSig
+    committee_bits*: Opt[AttestationCommitteeBits]
 
   PrepareBeaconProposer* = object
     validator_index*: ValidatorIndex


### PR DESCRIPTION
Won't be merged in September's release cycle, because it affects Deneb REST block reading and can't be readily isolated into future-forks-only codepaths aside from not very usefully disabling it by default.

It's not yet complete, either, because of the requests in `ExecutionPayload`, but those might be changing soon, so won't address them yet.