### PR TITLE
add: ssz consensus objs tests for peerdas

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -2396,6 +2396,61 @@ OK: 25/25 Fail: 0/25 Skip: 0/25
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
+## EF - EIP7594 - SSZ consensus objects  [Preset: mainnet]
+```diff
++   Testing    AggregateAndProof                                                             OK
++   Testing    Attestation                                                                   OK
++   Testing    AttestationData                                                               OK
++   Testing    AttesterSlashing                                                              OK
++   Testing    BLSToExecutionChange                                                          OK
++   Testing    BeaconBlock                                                                   OK
++   Testing    BeaconBlockBody                                                               OK
++   Testing    BeaconBlockHeader                                                             OK
++   Testing    BeaconState                                                                   OK
++   Testing    BlobIdentifier                                                                OK
++   Testing    BlobSidecar                                                                   OK
++   Testing    Checkpoint                                                                    OK
++   Testing    ContributionAndProof                                                          OK
++   Testing    DataColumnIdentifier                                                          OK
++   Testing    DataColumnSidecar                                                             OK
++   Testing    Deposit                                                                       OK
++   Testing    DepositData                                                                   OK
++   Testing    DepositMessage                                                                OK
++   Testing    Eth1Block                                                                     OK
++   Testing    Eth1Data                                                                      OK
++   Testing    ExecutionPayload                                                              OK
++   Testing    ExecutionPayloadHeader                                                        OK
++   Testing    Fork                                                                          OK
++   Testing    ForkData                                                                      OK
++   Testing    HistoricalBatch                                                               OK
++   Testing    HistoricalSummary                                                             OK
++   Testing    IndexedAttestation                                                            OK
++   Testing    LightClientBootstrap                                                          OK
++   Testing    LightClientFinalityUpdate                                                     OK
++   Testing    LightClientHeader                                                             OK
++   Testing    LightClientOptimisticUpdate                                                   OK
++   Testing    LightClientUpdate                                                             OK
++   Testing    MatrixEntry                                                                   OK
++   Testing    PendingAttestation                                                            OK
++   Testing    PowBlock                                                                      OK
++   Testing    ProposerSlashing                                                              OK
++   Testing    SignedAggregateAndProof                                                       OK
++   Testing    SignedBLSToExecutionChange                                                    OK
++   Testing    SignedBeaconBlock                                                             OK
++   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedContributionAndProof                                                    OK
++   Testing    SignedVoluntaryExit                                                           OK
++   Testing    SigningData                                                                   OK
++   Testing    SyncAggregate                                                                 OK
++   Testing    SyncAggregatorSelectionData                                                   OK
++   Testing    SyncCommittee                                                                 OK
++   Testing    SyncCommitteeContribution                                                     OK
++   Testing    SyncCommitteeMessage                                                          OK
++   Testing    Validator                                                                     OK
++   Testing    VoluntaryExit                                                                 OK
++   Testing    Withdrawal                                                                    OK
+```
+OK: 51/51 Fail: 0/51 Skip: 0/51
 ## EF - Electra - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
@@ -3706,4 +3761,4 @@ OK: 69/88 Fail: 0/88 Skip: 19/88
 OK: 3/3 Fail: 0/3 Skip: 0/3
 
 ---TOTAL---
-OK: 2984/3004 Fail: 0/3004 Skip: 20/3004
+OK: 3035/3055 Fail: 0/3055 Skip: 20/3055

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -2505,6 +2505,61 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + test_process_light_client_update_not_timeout                                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
+## EF - EIP7594 - SSZ consensus objects  [Preset: minimal]
+```diff
++   Testing    AggregateAndProof                                                             OK
++   Testing    Attestation                                                                   OK
++   Testing    AttestationData                                                               OK
++   Testing    AttesterSlashing                                                              OK
++   Testing    BLSToExecutionChange                                                          OK
++   Testing    BeaconBlock                                                                   OK
++   Testing    BeaconBlockBody                                                               OK
++   Testing    BeaconBlockHeader                                                             OK
++   Testing    BeaconState                                                                   OK
++   Testing    BlobIdentifier                                                                OK
++   Testing    BlobSidecar                                                                   OK
++   Testing    Checkpoint                                                                    OK
++   Testing    ContributionAndProof                                                          OK
++   Testing    DataColumnIdentifier                                                          OK
++   Testing    DataColumnSidecar                                                             OK
++   Testing    Deposit                                                                       OK
++   Testing    DepositData                                                                   OK
++   Testing    DepositMessage                                                                OK
++   Testing    Eth1Block                                                                     OK
++   Testing    Eth1Data                                                                      OK
++   Testing    ExecutionPayload                                                              OK
++   Testing    ExecutionPayloadHeader                                                        OK
++   Testing    Fork                                                                          OK
++   Testing    ForkData                                                                      OK
++   Testing    HistoricalBatch                                                               OK
++   Testing    HistoricalSummary                                                             OK
++   Testing    IndexedAttestation                                                            OK
++   Testing    LightClientBootstrap                                                          OK
++   Testing    LightClientFinalityUpdate                                                     OK
++   Testing    LightClientHeader                                                             OK
++   Testing    LightClientOptimisticUpdate                                                   OK
++   Testing    LightClientUpdate                                                             OK
++   Testing    MatrixEntry                                                                   OK
++   Testing    PendingAttestation                                                            OK
++   Testing    PowBlock                                                                      OK
++   Testing    ProposerSlashing                                                              OK
++   Testing    SignedAggregateAndProof                                                       OK
++   Testing    SignedBLSToExecutionChange                                                    OK
++   Testing    SignedBeaconBlock                                                             OK
++   Testing    SignedBeaconBlockHeader                                                       OK
++   Testing    SignedContributionAndProof                                                    OK
++   Testing    SignedVoluntaryExit                                                           OK
++   Testing    SigningData                                                                   OK
++   Testing    SyncAggregate                                                                 OK
++   Testing    SyncAggregatorSelectionData                                                   OK
++   Testing    SyncCommittee                                                                 OK
++   Testing    SyncCommitteeContribution                                                     OK
++   Testing    SyncCommitteeMessage                                                          OK
++   Testing    Validator                                                                     OK
++   Testing    VoluntaryExit                                                                 OK
++   Testing    Withdrawal                                                                    OK
+```
+OK: 51/51 Fail: 0/51 Skip: 0/51
 ## EF - Electra - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
@@ -4043,4 +4098,4 @@ OK: 185/207 Fail: 0/207 Skip: 22/207
 OK: 3/3 Fail: 0/3 Skip: 0/3
 
 ---TOTAL---
-OK: 3290/3313 Fail: 0/3313 Skip: 23/3313
+OK: 3341/3364 Fail: 0/3364 Skip: 23/3364

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -107,7 +107,7 @@ proc compute_matrix*(blobs: seq[KzgBlob]): Result[seq[MatrixEntry], cstring] =
 
   for blbIdx, blob in blobs.pairs:
     let cellsAndProofs = computeCellsAndKzgProofs(blob)
-    if not cellsAndProofs.isOk:
+    if cellsAndProofs.isErr:
       return err("Computing Extended Matrix: Issue computing cells and proofs")
 
     for i in 0..<eip7594.CELLS_PER_EXT_BLOB:
@@ -139,7 +139,7 @@ proc recover_matrix*(partial_matrix: seq[MatrixEntry],
 
     let recoveredCellsAndKzgProofs = 
       recoverCellsAndKzgProofs(cell_indices, cells)
-    if not recoveredCellsAndKzgProofs.isOk:
+    if recoveredCellsAndKzgProofs.isErr:
       return err("Issue in recovering cells and proofs")
 
     for i in 0..<recoveredCellsAndKzgProofs.get.cells.len:

--- a/tests/consensus_spec/consensus_spec_tests_preset.nim
+++ b/tests/consensus_spec/consensus_spec_tests_preset.nim
@@ -17,6 +17,7 @@ import
   ./bellatrix/all_bellatrix_fixtures,
   ./capella/all_capella_fixtures,
   ./deneb/all_deneb_fixtures,
+  ./eip7594/all_eip7594_fixtures,
   ./electra/all_electra_fixtures,
   ./test_fixture_fork,
   ./test_fixture_fork_choice,

--- a/tests/consensus_spec/eip7594/all_eip7594_fixtures.nim
+++ b/tests/consensus_spec/eip7594/all_eip7594_fixtures.nim
@@ -1,0 +1,12 @@
+# beacon_chain
+# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+{.used.}
+
+import
+  ./test_fixture_ssz_consensus_objects

--- a/tests/consensus_spec/eip7594/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/eip7594/test_fixture_ssz_consensus_objects.nim
@@ -1,0 +1,188 @@
+# beacon_chain
+# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+{.used.}
+
+import
+  # Standard library
+  std/[
+    strutils, streams, strformat,
+    macros, sets],
+  # Third-party
+  yaml,
+  # Beacon chain internals
+  ../../../beacon_chain/spec/datatypes/[
+    altair, 
+    deneb, 
+    eip7594],
+  # Status libraries
+  snappy,
+  # Test utilities
+  ../../testutil, ../fixtures_utils, ../os_ops
+
+from ../../../beacon_chain/spec/datatypes/bellatrix import PowBlock
+from ../../../beacon_chain/spec/datatypes/capella import
+  BLSToExecutionChange, SignedBLSToExecutionChange, HistoricalSummary,
+  Withdrawal
+
+
+# SSZ tests of consensus objects (minimal/mainnet preset specific)
+
+# Parsing definitions
+# ----------------------------------------------------------------
+
+const
+  SSZDir = SszTestsDir/const_preset/"eip7594"/"ssz_static"
+
+type
+  SSZHashTreeRoot = object
+    # The test files have the values at the "root"
+    # so we **must** use "root" as a field name
+    root: string
+    # Some have a signing_root field
+    signing_root {.defaultVal: "".}: string
+
+# Note this only tracks HashTreeRoot
+# Checking the values against the yaml file is TODO (require more flexible Yaml parser)
+
+proc checkSSZ(
+    T: type deneb.SignedBeaconBlock,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
+   # Deserialize into a ref object to not fill Nim stack
+   let encoded = snappy.decode(
+     readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
+   let deserialized = newClone(sszDecodeEntireInput(encoded, T))
+
+   # SignedBeaconBlocks usually not hashed because they're identified by
+   # htr(BeaconBlock), so do it manually
+   check: expectedHash.root == "0x" & toLowerAscii($hash_tree_root(
+     [hash_tree_root(deserialized.message),
+     hash_tree_root(deserialized.signature)]))
+
+   check deserialized.root == hash_tree_root(deserialized.message)
+   check SSZ.encode(deserialized[]) == encoded
+   check sszSize(deserialized[]) == encoded.len
+
+   # TODO check the value (requires YAML loader)
+
+proc checkSSZ(
+    T: type,
+    dir: string,
+    expectedHash: SSZHashTreeRoot
+) {.raises: [IOError, SerializationError, UnconsumedInput].} =
+  # Deserialize into a ref object to not fill Nim stack
+  let encoded = snappy.decode(
+    readFileBytes(dir/"serialized.ssz_snappy"), MaxObjectSize)
+  let deserialized = newClone(sszDecodeEntireInput(encoded, T))
+
+  check: expectedHash.root == "0x" & toLowerAscii($hash_tree_root(deserialized[]))
+
+  check SSZ.encode(deserialized[]) == encoded
+  check sszSize(deserialized[]) == encoded.len
+
+  # TODO check the value (requires YAML loader)
+
+proc loadExpectedHashTreeRoot(
+    dir: string
+): SSZHashTreeRoot {.raises: [
+    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+  let s = openFileStream(dir/"roots.yaml")
+  yaml.load(s, result)
+  s.close()
+
+# Test runner
+# ----------------------------------------------------------------
+
+suite "EF - EIP7594 - SSZ consensus objects " & preset():
+  doAssert dirExists(SSZDir), "You need to run the \"download_test_vectors.sh\" script to retrieve the consensus spec test vectors."
+  for pathKind, sszType in walkDir(SSZDir, relative = true, checkDir = true):
+    doAssert pathKind == pcDir
+
+    test &"  Testing    {sszType}":
+      let path = SSZDir/sszType
+      for pathKind, sszTestKind in walkDir(
+          path, relative = true, checkDir = true):
+        doAssert pathKind == pcDir
+        let path = SSZDir/sszType/sszTestKind
+        for pathKind, sszTestCase in walkDir(
+            path, relative = true, checkDir = true):
+          let path = SSZDir/sszType/sszTestKind/sszTestCase
+          let hash = loadExpectedHashTreeRoot(path)
+
+          case sszType:
+          of "AggregateAndProof": checkSSZ(phase0.AggregateAndProof, path, hash)
+          of "Attestation": checkSSZ(phase0.Attestation, path, hash)
+          of "AttestationData": checkSSZ(AttestationData, path, hash)
+          of "AttesterSlashing": checkSSZ(phase0.AttesterSlashing, path, hash)
+          of "BeaconBlock": checkSSZ(deneb.BeaconBlock, path, hash)
+          of "BeaconBlockBody": checkSSZ(deneb.BeaconBlockBody, path, hash)
+          of "BeaconBlockHeader": checkSSZ(BeaconBlockHeader, path, hash)
+          of "BeaconState": checkSSZ(deneb.BeaconState, path, hash)
+          of "BlobIdentifier": checkSSZ(BlobIdentifier, path, hash)
+          of "BlobSidecar": checkSSZ(BlobSidecar, path, hash)
+          of "BLSToExecutionChange": checkSSZ(BLSToExecutionChange, path, hash)
+          of "Checkpoint": checkSSZ(Checkpoint, path, hash)
+          of "ContributionAndProof": checkSSZ(ContributionAndProof, path, hash)
+          of "DataColumnSidecar": checkSSZ(DataColumnSidecar, path, hash)
+          of "DataColumnIdentifier": checkSSZ(DataColumnIdentifier, path, hash)
+          of "Deposit": checkSSZ(Deposit, path, hash)
+          of "DepositData": checkSSZ(DepositData, path, hash)
+          of "DepositMessage": checkSSZ(DepositMessage, path, hash)
+          of "Eth1Block": checkSSZ(Eth1Block, path, hash)
+          of "Eth1Data": checkSSZ(Eth1Data, path, hash)
+          of "ExecutionPayload":
+            checkSSZ(deneb.ExecutionPayload, path, hash)
+          of "ExecutionPayloadHeader":
+            checkSSZ(deneb.ExecutionPayloadHeader, path, hash)
+          of "Fork": checkSSZ(Fork, path, hash)
+          of "ForkData": checkSSZ(ForkData, path, hash)
+          of "HistoricalBatch": checkSSZ(HistoricalBatch, path, hash)
+          of "HistoricalSummary": checkSSZ(HistoricalSummary, path, hash)
+          of "IndexedAttestation":
+            checkSSZ(phase0.IndexedAttestation, path, hash)
+          of "LightClientBootstrap":
+            checkSSZ(deneb.LightClientBootstrap, path, hash)
+          of "LightClientHeader":
+            checkSSZ(deneb.LightClientHeader, path, hash)
+          of "LightClientUpdate":
+            checkSSZ(deneb.LightClientUpdate, path, hash)
+          of "LightClientFinalityUpdate":
+            checkSSZ(deneb.LightClientFinalityUpdate, path, hash)
+          of "LightClientOptimisticUpdate":
+            checkSSZ(deneb.LightClientOptimisticUpdate, path, hash)
+          of "MatrixEntry":
+            checkSSZ(MatrixEntry, path, hash)
+          of "PendingAttestation": checkSSZ(PendingAttestation, path, hash)
+          of "PowBlock": checkSSZ(PowBlock, path, hash)
+          of "ProposerSlashing": checkSSZ(ProposerSlashing, path, hash)
+          of "SignedAggregateAndProof":
+            checkSSZ(phase0.SignedAggregateAndProof, path, hash)
+          of "SignedBeaconBlock":
+            checkSSZ(deneb.SignedBeaconBlock, path, hash)
+          of "SignedBeaconBlockHeader":
+            checkSSZ(SignedBeaconBlockHeader, path, hash)
+          of "SignedBLSToExecutionChange":
+            checkSSZ(SignedBLSToExecutionChange, path, hash)
+          of "SignedContributionAndProof":
+            checkSSZ(SignedContributionAndProof, path, hash)
+          of "SignedVoluntaryExit": checkSSZ(SignedVoluntaryExit, path, hash)
+          of "SigningData": checkSSZ(SigningData, path, hash)
+          of "SyncAggregate": checkSSZ(SyncAggregate, path, hash)
+          of "SyncAggregatorSelectionData":
+            checkSSZ(SyncAggregatorSelectionData, path, hash)
+          of "SyncCommittee": checkSSZ(SyncCommittee, path, hash)
+          of "SyncCommitteeContribution":
+            checkSSZ(SyncCommitteeContribution, path, hash)
+          of "SyncCommitteeMessage": checkSSZ(SyncCommitteeMessage, path, hash)
+          of "Withdrawal": checkSSZ(Withdrawal, path, hash)
+          of "Validator": checkSSZ(Validator, path, hash)
+          of "VoluntaryExit": checkSSZ(VoluntaryExit, path, hash)
+          else:
+            raise newException(ValueError, "Unsupported test: " & sszType)


### PR DESCRIPTION
this PR adds ssz consensus objects tests for peerDAS, can be merged with Electra consensus objects, once there is a finalisation on rebasing peerDAS to Electra by EF.