### PR TITLE
speed up electra attestation tests by 5x

### DIFF
--- a/beacon_chain/rpc/rest_rewards_api.nim
+++ b/beacon_chain/rpc/rest_rewards_api.nim
@@ -8,11 +8,10 @@
 {.push raises: [].}
 
 import
-  std/[typetraits, sequtils, sets],
+  std/[typetraits, sets],
   stew/base10,
   chronicles, metrics,
   ./rest_utils,
-  ./state_ttl_cache,
   ../beacon_node,
   ../consensus_object_pools/[blockchain_dag, spec_cache, validator_change_pool],
   ../spec/[forks, state_transition]

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -747,7 +747,8 @@ suite "Attestation pool electra processing" & preset():
       cfg = genesisTestRuntimeConfig(ConsensusFork.Electra)
       dag = init(
         ChainDAGRef, cfg,
-        makeTestDB(TOTAL_COMMITTEES * TARGET_COMMITTEE_SIZE*SLOTS_PER_EPOCH * 6, cfg = cfg),
+        makeTestDB(
+          TOTAL_COMMITTEES * TARGET_COMMITTEE_SIZE * SLOTS_PER_EPOCH, cfg = cfg),
         validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
@@ -765,7 +766,6 @@ suite "Attestation pool electra processing" & preset():
         cache,
         info,
         {}).isOk()
-
 
   test "Can add and retrieve simple electra attestations" & preset():
     let


### PR DESCRIPTION
Otherwise they take a long time simply to generate their test databases:
```
[2024-09-18T10:21:57.296Z] 10 longest individual test durations
[2024-09-18T10:21:57.296Z] ------------------------------------
[2024-09-18T10:21:57.296Z]  76.48s for Can add and retrieve simple electra attestations [Preset: mainnet]
[2024-09-18T10:21:57.296Z]  73.19s for Working with electra aggregates [Preset: mainnet]
[2024-09-18T10:21:57.296Z]  72.85s for Aggregated attestations with disjoint comittee bits into a single on-chain aggregate [Preset: mainnet]
[2024-09-18T10:21:57.296Z]  72.82s for Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Preset: mainnet]
```
or
```
Attestation pool electra processing [Preset: mainnet] .... (294.4s)
```
due to the number of validators they generate.

To some extent, this is necessary, because there need to be enough validators to generate at least two committees, to have meaningful tests. But the non-electra attestation tests have some overkill in how many validators/deposits they create, which becomes several cumulative minutes per `make test` in the Electra attestation pool tests.

This PR brings the total time for `test_attestation_pool` down to about a minute, from around 5-6 minutes.

Rewards API imports removals are to address some build warnings:
```
nimbus-eth2/beacon_chain/rpc/rest_rewards_api.nim(15, 3) Warning: imported and not used: 'state_ttl_cache' [UnusedImport]
nimbus-eth2/beacon_chain/rpc/rest_rewards_api.nim(11, 20) Warning: imported and not used: 'sequtils' [UnusedImport]
```