### PR TITLE
fix blinded block conversion for Deneb and Electra

### DIFF
--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -166,7 +166,9 @@ func toSignedBlindedBeaconBlock*(blck: deneb.SignedBeaconBlock):
           transactions_root:
             hash_tree_root(blck.message.body.execution_payload.transactions),
           withdrawals_root:
-            hash_tree_root(blck.message.body.execution_payload.withdrawals)),
+            hash_tree_root(blck.message.body.execution_payload.withdrawals),
+          blob_gas_used: blck.message.body.execution_payload.blob_gas_used,
+          excess_blob_gas: blck.message.body.execution_payload.excess_blob_gas),
         bls_to_execution_changes: blck.message.body.bls_to_execution_changes,
         blob_kzg_commitments: blck.message.body.blob_kzg_commitments)),
     signature: blck.signature)

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -141,6 +141,8 @@ func toSignedBlindedBeaconBlock*(blck: electra.SignedBeaconBlock):
             hash_tree_root(blck.message.body.execution_payload.transactions),
           withdrawals_root:
             hash_tree_root(blck.message.body.execution_payload.withdrawals),
+          blob_gas_used: blck.message.body.execution_payload.blob_gas_used,
+          excess_blob_gas: blck.message.body.execution_payload.excess_blob_gas,
           deposit_requests_root: hash_tree_root(
             blck.message.body.execution_payload.deposit_requests),
           withdrawal_requests_root: hash_tree_root(

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -112,6 +112,10 @@ template capella_steps() =
   do_check
 
 template deneb_steps() =
+  b.message.body.execution_payload.blob_gas_used = 8
+  do_check
+  b.message.body.execution_payload.excess_blob_gas = 9
+  do_check
   check: b.message.body.blob_kzg_commitments.add(default(KzgCommitment))
   do_check
 


### PR DESCRIPTION
`blob_gas_used` and `excess_blob_gas` were not copied on blinding signed beacon block.