### PR TITLE
Revert "stop testing with broken upstream/version-2-0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,18 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [~]
+        branch: [~, upstream/version-2-0]
+        exclude:
+          - target:
+              os: macos
+            branch: upstream/version-2-0
+          - target:
+              os: windows
+            branch: upstream/version-2-0
         include:
+          - branch: upstream/version-2-0
+            branch-short: version-2-0
+            nimflags-extra: --mm:refc
           - target:
               os: linux
             builder: ['self-hosted','ubuntu-22.04']

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -777,8 +777,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
       indices
     case info.kind
     of EpochInfoFork.Phase0:
-      template info: untyped = info.phase0Data
-      for i, s in info.validators:
+      for i, s in info.phase0Data.validators:
         let perf = addr perfs[i]
         if RewardFlags.isActiveInPreviousEpoch in s.flags:
           if s.is_previous_epoch_attester.isSome():


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#6554

If upstream Nim has been fixed, can test `version-2-0` again