### PR TITLE
bump geth to `v1.14.10`

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -21,7 +21,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.14.7-aa55f5ea"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.14.10-1015a42d"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.14.8
- https://github.com/ethereum/go-ethereum/releases/tag/v1.14.9
- https://github.com/ethereum/go-ethereum/releases/tag/v1.14.10