### PR TITLE
stop testing with broken upstream/version-2-0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,8 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        branch: [~, upstream/version-2-0]
-        exclude:
-          - target:
-              os: macos
-            branch: upstream/version-2-0
-          - target:
-              os: windows
-            branch: upstream/version-2-0
+        branch: [~]
         include:
-          - branch: upstream/version-2-0
-            branch-short: version-2-0
-            nimflags-extra: --mm:refc
           - target:
               os: linux
             builder: ['self-hosted','ubuntu-22.04']


### PR DESCRIPTION
- https://github.com/nim-lang/Nim/issues/24239

For example, https://github.com/status-im/nimbus-eth2/actions/runs/11179855556/job/31080358216?pr=6596
```
2024-10-04T12:45:44.9229734Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(977, 23) template/generic instantiation of `state_transition` from here
2024-10-04T12:45:44.9232219Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(348, 25) template/generic instantiation of `state_transition_block` from here
2024-10-04T12:45:44.9234480Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(312, 22) template/generic instantiation of `withState` from here
2024-10-04T12:45:44.9236762Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(314, 33) template/generic instantiation of `state_transition_block_aux` from here
2024-10-04T12:45:44.9239043Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(283, 20) template/generic instantiation of `process_block` from here
2024-10-04T12:45:44.9241336Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition_block.nim(1106, 19) template/generic instantiation of `process_randao` from here
2024-10-04T12:45:44.9244330Z Error: fatal error: invalid kind for lastOrd(tyGenericParam)
2024-10-04T12:45:45.0791879Z make: *** [Makefile:447: ncli_db] Error 1
2024-10-04T12:45:45.0819246Z make: *** Waiting for unfinished jobs....
2024-10-04T12:45:58.4618270Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(977, 23) template/generic instantiation of `state_transition` from here
2024-10-04T12:45:58.4620843Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(348, 25) template/generic instantiation of `state_transition_block` from here
2024-10-04T12:45:58.4623097Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(312, 22) template/generic instantiation of `withState` from here
2024-10-04T12:45:58.4625366Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(314, 33) template/generic instantiation of `state_transition_block_aux` from here
2024-10-04T12:45:58.4627673Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(283, 20) template/generic instantiation of `process_block` from here
2024-10-04T12:45:58.4630033Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition_block.nim(1106, 19) template/generic instantiation of `process_randao` from here
2024-10-04T12:45:58.4631598Z Error: fatal error: invalid kind for lastOrd(tyGenericParam)
2024-10-04T12:45:58.6455229Z make: *** [Makefile:447: nimbus_light_client] Error 1
2024-10-04T12:46:10.2726118Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(977, 23) template/generic instantiation of `state_transition` from here
2024-10-04T12:46:10.2728489Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(348, 25) template/generic instantiation of `state_transition_block` from here
2024-10-04T12:46:10.2730732Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(312, 22) template/generic instantiation of `withState` from here
2024-10-04T12:46:10.2732939Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(314, 33) template/generic instantiation of `state_transition_block_aux` from here
2024-10-04T12:46:10.2735147Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(283, 20) template/generic instantiation of `process_block` from here
2024-10-04T12:46:10.2737271Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition_block.nim(1106, 19) template/generic instantiation of `process_randao` from here
2024-10-04T12:46:10.2738651Z Error: fatal error: invalid kind for lastOrd(tyGenericParam)
2024-10-04T12:46:10.4725543Z make: *** [Makefile:447: mev_mock] Error 1
2024-10-04T12:46:11.4243854Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(977, 23) template/generic instantiation of `state_transition` from here
2024-10-04T12:46:11.4247865Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(348, 25) template/generic instantiation of `state_transition_block` from here
2024-10-04T12:46:11.4251695Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(312, 22) template/generic instantiation of `withState` from here
2024-10-04T12:46:11.4255464Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(314, 33) template/generic instantiation of `state_transition_block_aux` from here
2024-10-04T12:46:11.4259256Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition.nim(283, 20) template/generic instantiation of `process_block` from here
2024-10-04T12:46:11.4263015Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/state_transition_block.nim(1106, 19) template/generic instantiation of `process_randao` from here
2024-10-04T12:46:11.4265742Z Error: fatal error: invalid kind for lastOrd(tyGenericParam)
2024-10-04T12:46:11.6195712Z make: *** [Makefile:447: wss_sim] Error 1
```