### PR TITLE
Some VC tunings

### DIFF
--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -14,7 +14,11 @@ import "."/[common, api, block_service, selection_proofs]
 const
   ServiceName = "duties_service"
   SUBSCRIPTION_LOOKAHEAD_EPOCHS* = 4'u64
-  AGGREGATION_PRE_COMPUTE_EPOCHS* = 1'u64
+  AGGREGATION_PRE_COMPUTE_SLOTS* = 1'u64
+    # We do pre-computation for current and next slot only. Pre-computation
+    # is good for low number of validators, but with big count of validators
+    # number of remote signature requests could overload remote signature
+    # service.
 
 logScope: service = ServiceName
 
@@ -319,7 +323,7 @@ proc pollForAttesterDuties*(service: DutiesServiceRef) {.async.} =
         moment = Moment.now()
         sigres =
           await vc.fillAttestationSelectionProofs(currentSlot,
-            currentSlot + Epoch(AGGREGATION_PRE_COMPUTE_EPOCHS))
+            currentSlot + AGGREGATION_PRE_COMPUTE_SLOTS)
 
       if vc.config.distributedEnabled:
         debug "Attestation selection proofs have been received",
@@ -412,7 +416,7 @@ proc pollForSyncCommitteeDuties*(service: DutiesServiceRef) {.async.} =
         moment = Moment.now()
         sigres =
           await vc.fillSyncCommitteeSelectionProofs(currentSlot,
-            currentSlot + Epoch(AGGREGATION_PRE_COMPUTE_EPOCHS))
+            currentSlot + AGGREGATION_PRE_COMPUTE_SLOTS)
 
       if vc.config.distributedEnabled:
         debug "Sync committee selection proofs have been received",

--- a/beacon_chain/validator_client/selection_proofs.nim
+++ b/beacon_chain/validator_client/selection_proofs.nim
@@ -129,7 +129,8 @@ proc fillAttestationSelectionProofs*(
                   if sres.isErr():
                     warn "Unable to create slot signature using remote signer",
                          reason = sres.error(), epoch = mreq.slot.epoch(),
-                         slot = mreq.slot
+                         slot = mreq.slot,
+                         validator = validatorLog(mreq.validator)
                     Opt.none(ValidatorSig)
                   else:
                     inc(sigres.signaturesReceived)
@@ -396,9 +397,10 @@ proc fillSyncCommitteeSelectionProofs*(
                 if mreq.future.completed():
                   let sres = Future[SignatureResult](mreq.future).read()
                   if sres.isErr():
-                    warn "Unable to create slot signature using remote signer",
+                    warn "Unable to create selection proof using remote signer",
                          reason = sres.error(), epoch = mreq.slot.epoch(),
-                         slot = mreq.slot
+                         slot = mreq.slot,
+                         validator = validatorLog(mreq.validator)
                     Opt.none(ValidatorSig)
                   else:
                     inc(sigres.signaturesReceived)

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -28,6 +28,7 @@ export
 
 const
   WEB3_SIGNER_DELAY_TOLERANCE = 3.seconds
+  WEB3_SIGNER_ATTEMPTS_COUNT = 4
 
 declareGauge validators,
   "Number of validators attached to the beacon node"
@@ -469,8 +470,9 @@ proc signWithDistributedKey(v: AttachedValidator,
 
   let
     deadline = sleepAsync(WEB3_SIGNER_DELAY_TOLERANCE)
-    signatureReqs = mapIt(v.clients, it[0].signData(it[1].pubkey, deadline,
-                                                    2, request))
+    signatureReqs = mapIt(v.clients,
+      it[0].signData(it[1].pubkey, deadline, WEB3_SIGNER_ATTEMPTS_COUNT,
+                     request))
 
   await allFutures(signatureReqs)
 
@@ -504,7 +506,8 @@ proc signWithSingleKey(v: AttachedValidator,
   let
     deadline = sleepAsync(WEB3_SIGNER_DELAY_TOLERANCE)
     (client, info) = v.clients[0]
-    res = await client.signData(info.pubkey, deadline, 2, request)
+    res = await client.signData(
+      info.pubkey, deadline, WEB3_SIGNER_ATTEMPTS_COUNT, request)
 
   if not(deadline.finished()): await cancelAndWait(deadline)
   if res.isErr():


### PR DESCRIPTION
* Increase number of failed web3 signer requests before signaling failure from 2 to 4.
* Decrease number of aggregated pre-computed slots from 32 to 2.
* Add validator field to some log statements.