### PR TITLE
update beacon_validators to be more Nim 2.2-compatible

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -849,7 +849,6 @@ proc validateAttestation*(
     Future[Result[
       tuple[attesting_index: ValidatorIndex, sig: CookedSig],
       ValidationError]] {.async: (raises: [CancelledError]).} =
-  debugComment "should reject a bunch"
   # [REJECT] The attestation's epoch matches its target -- i.e.
   # attestation.data.target.epoch ==
   # compute_epoch_at_slot(attestation.data.slot)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -985,7 +985,6 @@ proc check_attestation*(
 
   when on_chain:
     var participants_count = 0'u64
-    debugComment "cache doesn't know about forks"
     for index in attestation.committee_bits.oneIndices:
       if not (index.uint64 < get_committee_count_per_slot(
           state, data.target.epoch, cache)):

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1941,8 +1941,6 @@ proc writeValue*(writer: var JsonWriter[RestJson],
 proc writeValue*(
     writer: var JsonWriter[RestJson], value: Web3SignerRequest
 ) {.raises: [IOError].} =
-  debugComment "electra web3signer needs some EIP-7549 changes"
-
   writer.beginRecord()
   case value.kind
   of Web3SignerRequestKind.AggregationSlot:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -487,7 +487,7 @@ proc makeBeaconBlockForHeadAndSlot*(
         withState(state[]):
           when  consensusFork >= ConsensusFork.Capella and
                 PayloadType.kind >= ConsensusFork.Capella:
-            let withdrawals = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
+            let withdrawals = List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
               get_expected_withdrawals(forkyState.data))
             if  withdrawals_root.isNone or
                 hash_tree_root(withdrawals) != withdrawals_root.get:


### PR DESCRIPTION
Otherwise Nim 2.2 seems to get confused between `capella.Withdrawal` and the `Withdrawal` from `eth/common/blocks.nim`.