### PR TITLE
styleCheck tweaks

### DIFF
--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1417,8 +1417,8 @@ template prepareForkedBlockReading(blockType: typedesc,
                                    version: var Opt[ConsensusFork],
                                    data: var Opt[JsonString],
                                    blinded: var Opt[bool],
-                                   payloadValue: var Opt[Uint256],
-                                   blockValue: var Opt[Uint256]) =
+                                   payloadValue: var Opt[UInt256],
+                                   blockValue: var Opt[UInt256]) =
   for fieldName {.inject.} in readObjectFields(reader):
     case fieldName
     of "version":
@@ -1459,7 +1459,7 @@ template prepareForkedBlockReading(blockType: typedesc,
         if payloadValue.isSome():
           reader.raiseUnexpectedField(
             "Multiple `execution_payload_value` fields found", blockType.name)
-        payloadValue = Opt.some(reader.readValue(Uint256))
+        payloadValue = Opt.some(reader.readValue(UInt256))
       else:
         unrecognizedFieldWarning(fieldName, blockType.name)
     of "consensus_block_value":
@@ -1467,7 +1467,7 @@ template prepareForkedBlockReading(blockType: typedesc,
         if blockValue.isSome():
           reader.raiseUnexpectedField(
             "Multiple `consensus_block_value` fields found", blockType.name)
-        blockValue = Opt.some(reader.readValue(Uint256))
+        blockValue = Opt.some(reader.readValue(UInt256))
       else:
         unrecognizedFieldWarning(fieldName, blockType.name)
     else:
@@ -1486,8 +1486,8 @@ proc readValue*[BlockType: ForkedBlindedBeaconBlock](
     version: Opt[ConsensusFork]
     data: Opt[JsonString]
     blinded: Opt[bool]
-    payloadValue: Opt[Uint256]
-    blockValue: Opt[Uint256]
+    payloadValue: Opt[UInt256]
+    blockValue: Opt[UInt256]
 
   prepareForkedBlockReading(BlockType, reader, version, data, blinded,
                             payloadValue, blockValue)
@@ -1552,8 +1552,8 @@ proc readValue*[BlockType: Web3SignerForkedBeaconBlock](
     version: Opt[ConsensusFork]
     data: Opt[JsonString]
     blinded: Opt[bool]
-    payloadValue: Opt[Uint256]
-    blockValue: Opt[Uint256]
+    payloadValue: Opt[UInt256]
+    blockValue: Opt[UInt256]
 
   prepareForkedBlockReading(BlockType, reader, version, data, blinded,
                             payloadValue, blockValue)
@@ -3360,7 +3360,7 @@ proc decodeBytes*[T: ProduceBlockResponseV3](
       consensusValue =
         if len(headerConsensusValue) == 0:
           # TODO (cheatfate): We should not allow empty `consensus-value`.
-          Opt.none(Uint256)
+          Opt.none(UInt256)
         else:
           try:
             Opt.some parse(headerConsensusValue, UInt256, 10)

--- a/ncli/nim.cfg
+++ b/ncli/nim.cfg
@@ -10,5 +10,5 @@
 -d:"libp2p_pki_schemes=secp256k1"
 
 --styleCheck:usages
---styleCheck:error
+--styleCheck:hint
 --hint[Processing]:off

--- a/research/nim.cfg
+++ b/research/nim.cfg
@@ -10,5 +10,5 @@
 -d:"libp2p_pki_schemes=secp256k1"
 
 --styleCheck:usages
---styleCheck:error
+--styleCheck:hint
 --hint[Processing]:off


### PR DESCRIPTION
`version-2-0` today got [a fix](https://github.com/nim-lang/Nim/pull/24270) for `--styleCheck:error` not having worked since Nim 1.6.12, which has started triggering on
```
2024-10-11T13:44:53.8027919Z /github-runner/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/spec/helpers.nim(323, 43) Error: 'None' should be: 'NONE' [enumField declared in /github-runner/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-chronicles/chronicles/options.nim(40, 5)]
```
in several `ncli/` and `research/` modules.