### PR TITLE
add --electra-fork-epoch to launch_local_testnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
       # The upload creates a combined report that gets posted as a comment on the PR
       # https://github.com/EnricoMi/publish-unit-test-result-action
       - name: Upload combined results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}
           path: build/*.xml
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event File
           path: ${{ github.event_path }}

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1592,7 +1592,7 @@ proc signAndSendAggregate(
   if not is_aggregator(shufflingRef, slot, committee_index, selectionProof):
     return
 
-  template signAndSendAggregate() =
+  template signAndSendAggregatedAttestations() =
     msg.signature = block:
       let res = await validator.getAggregateAndProofSignature(
         fork, genesis_validators_root, msg.message)
@@ -1622,7 +1622,7 @@ proc signAndSendAggregate(
       slot, default(Eth2Digest), committee_index).valueOr:
         return
 
-    signAndSendAggregate()
+    signAndSendAggregatedAttestations()
   else:
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/validator.md#construct-aggregate
     # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/validator.md#aggregateandproof
@@ -1636,7 +1636,7 @@ proc signAndSendAggregate(
       slot, committee_index).valueOr:
         return
 
-    signAndSendAggregate()
+    signAndSendAggregatedAttestations()
 
 proc sendAggregatedAttestations(
     node: BeaconNode, head: BlockRef, slot: Slot) =

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -216,6 +216,10 @@ while true; do
       DENEB_FORK_EPOCH="$2"
       shift 2
       ;;
+    --electra-fork-epoch)
+      ELECTRA_FORK_EPOCH="$2"
+      shift 2
+      ;;
     --stop-at-epoch)
       STOP_AT_EPOCH=$2
       STOP_AT_EPOCH_FLAG="--debug-stop-at-epoch=$2"


### PR DESCRIPTION
The `upload-artifact@v3` to `@v4` changes respond to a GitHub Actions message:
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/upload-artifact@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/