### PR TITLE
don't use {.noinit.} with case objects

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -170,7 +170,7 @@ proc updateLightClientFromDag*(node: BeaconNode) =
 
   let bdata = node.dag.getForkedBlock(dagHead.blck.bid).valueOr:
     return
-  var header {.noinit.}: ForkedLightClientHeader
+  var header: ForkedLightClientHeader
   withBlck(bdata):
     const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
     when lcDataFork > LightClientDataFork.None:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -388,7 +388,7 @@ proc initLightClientUpdateForPeriod(
       finalizedBid = finalizedBsi.bid # For fallback `break` at start of loop
 
   # Save best light client data for given period
-  var update {.noinit.}: ForkedLightClientUpdate
+  var update: ForkedLightClientUpdate
   let attestedBid = dag.existingParent(signatureBid).valueOr:
     dag.handleUnexpectedLightClientError(signatureBid.slot)
     return err()
@@ -456,7 +456,7 @@ proc initLightClientDataForPeriod(
     dag.lcDataStore.db.sealPeriod(period)
   ok()
 
-proc getLightClientData(
+func getLightClientData(
     dag: ChainDAGRef,
     bid: BlockId): CachedLightClientData =
   ## Fetch cached light client data about a given block.
@@ -464,7 +464,7 @@ proc getLightClientData(
   try: dag.lcDataStore.cache.data[bid]
   except KeyError: raiseAssert "Unreachable"
 
-proc cacheLightClientData(
+func cacheLightClientData(
     dag: ChainDAGRef,
     state: ForkyHashedBeaconState,
     blck: ForkyTrustedSignedBeaconBlock,
@@ -501,7 +501,7 @@ func shouldImportLcData(dag: ChainDAGRef): bool =
   dag.lcDataStore.importMode != LightClientDataImportMode.None and
   dag.cfg.ALTAIR_FORK_EPOCH != FAR_FUTURE_EPOCH
 
-proc deleteLightClientData*(dag: ChainDAGRef, bid: BlockId) =
+func deleteLightClientData*(dag: ChainDAGRef, bid: BlockId) =
   ## Delete cached light client data for a given block. This needs to be called
   ## when a block becomes unreachable due to finalization of a different fork.
   if not dag.shouldImportLcData:
@@ -1132,7 +1132,7 @@ proc getLightClientUpdateForPeriod*(
     return default(ForkedLightClientUpdate)
   update
 
-proc getLightClientFinalityUpdate*(
+func getLightClientFinalityUpdate*(
     dag: ChainDAGRef): ForkedLightClientFinalityUpdate =
   if not dag.lcDataStore.serve:
     return default(ForkedLightClientFinalityUpdate)
@@ -1148,7 +1148,7 @@ proc getLightClientFinalityUpdate*(
     return default(ForkedLightClientFinalityUpdate)
   finalityUpdate
 
-proc getLightClientOptimisticUpdate*(
+func getLightClientOptimisticUpdate*(
     dag: ChainDAGRef): ForkedLightClientOptimisticUpdate =
   if not dag.lcDataStore.serve:
     return default(ForkedLightClientOptimisticUpdate)

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -96,7 +96,7 @@ proc loadSteps(
             .expect("Unknown update fork " & $update_fork_digest)
         update_filename = s["update"].getStr()
 
-      var update {.noinit.}: ForkedLightClientUpdate
+      var update: ForkedLightClientUpdate
       withLcDataFork(lcDataForkAtConsensusFork(update_consensus_fork)):
         when lcDataFork > LightClientDataFork.None:
           update = ForkedLightClientUpdate.init(parseTest(
@@ -175,7 +175,7 @@ proc runTest(suiteName, path: string) =
       let bootstrap_consensus_fork =
         meta.fork_digests.consensusForkForDigest(meta.bootstrap_fork_digest)
           .expect("Unknown bootstrap fork " & $meta.bootstrap_fork_digest)
-      var bootstrap {.noinit.}: ForkedLightClientBootstrap
+      var bootstrap: ForkedLightClientBootstrap
       withLcDataFork(lcDataForkAtConsensusFork(bootstrap_consensus_fork)):
         when lcDataFork > LightClientDataFork.None:
           bootstrap = ForkedLightClientBootstrap.init(parseTest(
@@ -191,7 +191,7 @@ proc runTest(suiteName, path: string) =
       let store_consensus_fork =
         meta.fork_digests.consensusForkForDigest(meta.store_fork_digest)
           .expect("Unknown store fork " & $meta.store_fork_digest)
-      var store {.noinit.}: ForkedLightClientStore
+      var store: ForkedLightClientStore
       withLcDataFork(lcDataForkAtConsensusFork(store_consensus_fork)):
         when lcDataFork > LightClientDataFork.None:
           bootstrap[].migrateToDataFork(lcDataFork)

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -146,7 +146,7 @@ suite "Light client" & preset():
     # Initialize light client store
     var bootstrap = dag.getLightClientBootstrap(trusted_block_root)
     check bootstrap.kind > LightClientDataFork.None
-    var store {.noinit.}: ForkedLightClientStore
+    var store: ForkedLightClientStore
     withForkyBootstrap(bootstrap):
       when lcDataFork > LightClientDataFork.None:
         var storeRes = newClone(initialize_light_client_store(

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -289,7 +289,7 @@ suite "Light client processor" & preset():
               template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
               check forkyStore.finalized_header != forkyUpdate.attested_header
 
-      var oldFinalized {.noinit.}: ForkedLightClientHeader
+      var oldFinalized: ForkedLightClientHeader
       withForkyStore(store[]):
         when lcDataFork > LightClientDataFork.None:
           oldFinalized = ForkedLightClientHeader.init(


### PR DESCRIPTION
The semantics aren't compatible, because to then assign to the case objects, it needs to check the existing discriminators.