### PR TITLE
BN: Fix el_manager timeouts issue in block processing.

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -251,8 +251,8 @@ proc variedSleep*(
 ): Future[void] {.async: (raises: [CancelledError], raw: true).} =
   doAssert(len(durations) > 0, "Empty durations array!")
   let index =
-    if (counter < 0) or (counter > len(durations)):
-      len(durations) - 1
+    if (counter < 0) or (counter > high(durations)):
+      high(durations)
     else:
       counter
   inc(counter)
@@ -1073,7 +1073,7 @@ proc sendNewPayload*(
     blck: SomeForkyBeaconBlock
 ): Future[PayloadExecutionStatus] {.
     async: (raises: [CancelledError], raw: true).} =
-  sendNewPayload(m, blck, DeadlineObject.init(FORKCHOICEUPDATED_TIMEOUT))
+  sendNewPayload(m, blck, DeadlineObject.init(NEWPAYLOAD_TIMEOUT))
 
 proc forkchoiceUpdatedForSingleEL(
     connection: ELConnection,
@@ -1262,7 +1262,7 @@ proc forkchoiceUpdated*(
                        Opt[PayloadAttributesV2] |
                        Opt[PayloadAttributesV3]
 ): Future[(PayloadExecutionStatus, Opt[BlockHash])] {.
-   async: (raises: [CancelledError], raw: true).} =
+    async: (raises: [CancelledError], raw: true).} =
   forkchoiceUpdated(
     m, headBlockHash, safeBlockHash, finalizedBlockHash,
     payloadAttributes, DeadlineObject.init(FORKCHOICEUPDATED_TIMEOUT))

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -439,10 +439,14 @@ proc storeBlock(
     vm = self.validatorMonitor
     dag = self.consensusManager.dag
     wallSlot = wallTime.slotOrZero
-    deadlineObj =
-      DeadlineObject.init(
-        chronos.nanoseconds(attestationSlotOffset.nanoseconds))
-      # This should be `4.seconds` for `mainnet` preset.
+    deadlineTime =
+      block:
+        let slotTime = (wallSlot + 1).start_beacon_time() - 1.seconds
+        if slotTime <= wallTime:
+          0.seconds
+        else:
+          chronos.nanoseconds((slotTime - wallTime).nanoseconds)
+    deadlineObj = DeadlineObject.init(deadlineTime)
 
   # If the block is missing its parent, it will be re-orphaned below
   self.consensusManager.quarantine[].removeOrphan(signedBlock)


### PR DESCRIPTION
Use predefined array of exponential timeouts when all the requests to EL has been failed.

So now both operations `newPayload` and `updateHead` sharing single timeout of `4.seconds` on `mainnet` preset.