### PR TITLE
Implement latest EIP-7685 `requestsHash` method

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -533,9 +533,7 @@ proc storeBlock(
     # required checks on the CL instead and proceed as if the EL was syncing
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#verify_and_notify_new_payload
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/deneb/beacon-chain.md#modified-verify_and_notify_new_payload
-    debugComment "electra block hash has new/changed format"
-    when typeof(signedBlock).kind >= ConsensusFork.Bellatrix and
-         typeof(signedBlock).kind != ConsensusFork.Electra:
+    when typeof(signedBlock).kind >= ConsensusFork.Bellatrix:
       if signedBlock.message.is_execution_block:
         template payload(): auto = signedBlock.message.body.execution_payload
 

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -467,7 +467,7 @@ func append*(w: var RlpWriter, request: electra.ConsolidationRequest) =
     targetPubkey: Bytes48 request.target_pubkey.blob)
 
 # https://eips.ethereum.org/EIPS/eip-7685
-func computeRequestsTrieRoot(
+func computeRequestsHash(
     requests: electra.ExecutionRequests): EthHash32 =
   let requestsHash = computeDigest:
     template mixInRequests(requestType, requestList): untyped =
@@ -519,7 +519,7 @@ proc blockToBlockHeader*(blck: ForkyBeaconBlock): EthHeader =
         Opt.none(EthHash32)
     requestsHash =
       when typeof(payload).kind >= ConsensusFork.Electra:
-        Opt.some blck.body.execution_requests.computeRequestsTrieRoot()
+        Opt.some blck.body.execution_requests.computeRequestsHash()
       else:
         Opt.none(EthHash32)
 


### PR DESCRIPTION
It's now this weird one-off hashing method so that EL can partially forget in some modules what the data schema is.