### PR TITLE
make Eth2Digest isZero 8x faster

### DIFF
--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -145,12 +145,12 @@ func `==`*(a, b: Eth2Digest): bool =
 
 func isZero*(x: Eth2Digest): bool =
   var tmp {.noinit.}: uint64
+  var tmp2 = 0'u64
   static: doAssert sizeof(x.data) mod sizeof(tmp) == 0
   staticFor i, 0 ..< sizeof(x.data) div sizeof(tmp):
     copyMem(addr tmp, addr x.data[i*sizeof(tmp)], sizeof(tmp))
-    if tmp != 0:
-      return false
-  true
+    tmp2 = tmp2 or tmp
+  tmp2 == 0
 
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -143,7 +143,16 @@ func `==`*(a, b: Eth2Digest): bool =
     equalMem(unsafeAddr a.data[0], unsafeAddr b.data[0], sizeof(a.data))
 
 func isZero*(x: Eth2Digest): bool =
-  x.isZeroMemory
+  # `MDigest` always 4-byte or more aligns `data` so checking in `uint32`-sized
+  # chunks keeps alignment-compatibility.
+  static:
+    doAssert sizeof(x.data) == 32
+    doAssert sizeof(uint) == sizeof(pointer)
+  let base = cast[uint](addr x.data[0])
+  template chunkZero(offset: uint): bool =
+    cast[ptr uint32](base + offset)[] == 0'u32
+  chunkZero(0) and chunkZero(4) and chunkZero(8) and chunkZero(12) and
+    chunkZero(16) and chunkZero(20) and chunkZero(24) and chunkZero(28)
 
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -32,6 +32,7 @@ import
   json_serialization
 
 from nimcrypto/utils import burnMem
+from stew/staticfor import staticFor
 
 export
   # Exports from sha2 / hash are explicit to avoid exporting upper-case `$` and
@@ -143,16 +144,13 @@ func `==`*(a, b: Eth2Digest): bool =
     equalMem(unsafeAddr a.data[0], unsafeAddr b.data[0], sizeof(a.data))
 
 func isZero*(x: Eth2Digest): bool =
-  # `MDigest` always 4-byte or more aligns `data` so checking in `uint32`-sized
-  # chunks keeps alignment-compatibility.
-  static:
-    doAssert sizeof(x.data) == 32
-    doAssert sizeof(uint) == sizeof(pointer)
-  let base = cast[uint](addr x.data[0])
-  template chunkZero(offset: uint): bool =
-    cast[ptr uint32](base + offset)[] == 0'u32
-  chunkZero(0) and chunkZero(4) and chunkZero(8) and chunkZero(12) and
-    chunkZero(16) and chunkZero(20) and chunkZero(24) and chunkZero(28)
+  var tmp {.noinit.}: uint64
+  static: doAssert sizeof(x.data) mod sizeof(tmp) == 0
+  staticFor i, 0 ..< sizeof(x.data) div sizeof(tmp):
+    copyMem(addr tmp, addr x.data[i*sizeof(tmp)], sizeof(tmp))
+    if tmp != 0:
+      return false
+  true
 
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a


### PR DESCRIPTION
Via profiling by @etan-status 
![iszeromemory_holesky_syncing](https://github.com/user-attachments/assets/012d1deb-c7e5-4d1a-a6f8-e986c8c4fb4f)

During Holesky syncing, Nimbus is spending 25% of its time in `isZeroMemory`. This PR improves this.

```
test 1:
  PR: 2.94 microseconds/10k zero Eth2Digest comparisons
prev: 18.6 microseconds/10k zero Eth2Digest comparisons

test 2:
  PR: 2.60 microseconds/10k zero Eth2Digest comparisons
prev: 18.6 microseconds/10k zero Eth2Digest comparisons

test 3:
  PR: 1.29 microseconds/10k zero Eth2Digest comparisons
prev: 8.33 microseconds/10k zero Eth2Digest comparisons

test 4:
  PR: 1.27 microseconds/10k zero Eth2Digest comparisons
prev: 8.29 microseconds/10k zero Eth2Digest comparisons

test 5:
  PR: 1.21 microseconds/10k zero Eth2Digest comparisons
prev: 8.29 microseconds/10k zero Eth2Digest comparisons

test 6:
  PR: 2.79 microseconds/10k zero Eth2Digest comparisons
prev: 18.7 microseconds/10k zero Eth2Digest comparisons

test 7:
  PR: 2.82 microseconds/10k zero Eth2Digest comparisons
prev: 18.7 microseconds/10k zero Eth2Digest comparisons

test 8:
  PR: 2.85 microseconds/10k zero Eth2Digest comparisons
prev: 18.7 microseconds/10k zero Eth2Digest comparisons

test 9:
  PR: 1.28 microseconds/10k zero Eth2Digest comparisons
prev: 8.28 microseconds/10k zero Eth2Digest comparisons

test 10:
  PR: 1.27 microseconds/10k zero Eth2Digest comparisons
prev: 8.32 microseconds/10k zero Eth2Digest comparisons
```
using
```nim
import "."/beacon_chain/spec/digest
import std/[strformat, times]
var aZeroHash = default(Eth2Digest)

func f(d: float): string =
  fmt"{d:.3}"

template measure(s: static string, code: untyped): bool =
  let t1 = cpuTime()
  var res: bool
  for _ in 0.uint ..< 1000.uint:
    res = code
  block:
    let duration = (cpuTime() - t1)*1_000_000
    echo s, ": ", f(duration), " microseconds/10k zero Eth2Digest comparisons"
  res

let _ = measure("  PR") do:
  isZero(aZeroHash)

let _ = measure("prev") do:
  isZeroSlow(aZeroHash)
```

It would arguably be better to use [cmpMem](https://nim-lang.org/docs/system.html#cmpMem%2Cpointer%2Cpointer%2CNatural) (i.e. `memcmp()` in thin disguise) to
- avoid assuming 4-byte alignment, not readily statically checkable;
- allow exploiting the more usual case of its being 16-byte aligned; and
- reduce the pointer arithmetic.

However, attempting to do this in a safe and efficient way triggers various combinations of:
- https://github.com/nim-lang/Nim/issues/24357
- https://github.com/nim-lang/Nim/issues/24359
- https://github.com/nim-lang/Nim/issues/24361

So this can function as a stopgap approach.