### PR TITLE
Fix errors in documentation files

### DIFF
--- a/beacon_chain/networking/README.md
+++ b/beacon_chain/networking/README.md
@@ -4,7 +4,7 @@ This folders hold a collection of modules to:
 - configure the Eth2 P2P network
 - discover, connect, and maintain quality Eth2 peers
 
-Data received is handed other to the `../gossip_processing` modules for validation.
+Data received is handed over to the `../gossip_processing` modules for validation.
 
 ## Security concerns
 

--- a/beacon_chain/validators/README.md
+++ b/beacon_chain/validators/README.md
@@ -1,6 +1,6 @@
 # Validators
 
-This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_cliant and nimbus_signing_process):
+This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_client and nimbus_signing_process):
 - Validator keystore
 - Validator slashing protection
 - Validator duties

--- a/beacon_chain/validators/README.md
+++ b/beacon_chain/validators/README.md
@@ -1,6 +1,6 @@
 # Validators
 
-This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_client and nimbus_signing_process):
+This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_cliant and nimbus_signing_process):
 - Validator keystore
 - Validator slashing protection
 - Validator duties

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,7 +6,7 @@ than suggested in the guideline for example at beacon node start or stop.
 
 The main objectives are:
 - INFO log level or higher should be suitable for long-term use, i.e. running for months or weeks. Logs are the users' main interface their beacon node and validators. In particular it should not be a denial-of-service vector, either by leading to high CPU usage of the console or filling disk space at an unsustainable rate.
-- INFO logs or higher should be target at users, logs only relevant to devs should be relegated to DEBUG or TRACE or commented out.
+- INFO logs or higher should be targeted at users, logs only relevant to devs should be relegated to DEBUG or TRACE or commented out.
 - DEBUG log level should still be readable by visual inspection during a slot time (6 seconds).
 
 Here is the suggestion of content per log level
@@ -36,7 +36,7 @@ Here is the suggestion of content per log level
   - "spammy" tasks that clutter debugging (attestations received, status/control messages)
 
 Logs done at high frequency should be summarized even at trace level to avoid drowning other subsystems.
-For example they can use an uint8 counter with
+For example they can use a uint8 counter with
 ```
 proc myHighFreqProc() =
   var counter {.threadvar.}: uint8

--- a/docs/the_nimbus_book/src/audit.md
+++ b/docs/the_nimbus_book/src/audit.md
@@ -6,7 +6,7 @@ Nimbus has undergone an extensive multi-vendor ([ConsenSys Diligence](https://co
 During that process, we were notified of several issues within the codebase.
 These issues have been addressed, contributing significantly to the overall security of Nimbus and other applications that use its libraries.
 
-Additionally, as a result of the work done from our security vendors, we have incoroprated many new security processes and tooling to improve our ability to find security issues in the future.
+Additionally, as a result of the work done from our security vendors, we have incorporated many new security processes and tooling to improve our ability to find security issues in the future.
 
 For more information on the issues and how they were addressed, the interested reader should direct themselves to the [scoped repositories](https://github.com/status-im/nimbus-eth2/labels?q=audit); all reported issues and their mitigations are open to the public.
 

--- a/nfuzz/README.md
+++ b/nfuzz/README.md
@@ -19,7 +19,7 @@ make libnfuzz.a
 make libnfuzz.so
 ```
 
-Default, the library is build with the `minimal` config. To select a specific config you can instead run:
+Default, the library is built with the `minimal` config. To select a specific config you can instead run:
 ```bash
 # build with mainnet config
 make libnfuzz.a NIMFLAGS="-d:const_preset=mainnet"


### PR DESCRIPTION
**beacon_chain/networking/README.md**
- `other ` → `over `

**beacon_chain/validators/README.md**
- `nimbus_validator_cliant ` → `nimbus_validator_client `

**docs/logging.md**
- `target ` → `targeted `
- `an uint8 ` → `a uint8 `

**docs/the_nimbus_book/src/audit.md**
- `incoroprated ` → `incorporated `

**nfuzz/README.md**
- `build ` → `built `
