### PR TITLE
Bump geth to `v1.14.12`

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -21,7 +21,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.14.11-f3c696fa"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.14.12-293a300d"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.14.12