### PR TITLE
Adopt latest changes to request hash computation

### DIFF
--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -462,7 +462,7 @@ func computeRequestsHash(
 
   let requestsHash = computeDigest:
     template mixInRequests(requestType, requestList): untyped =
-      block:
+      if requestList.len > 0:
         let hash = computeDigest:
           bind h
           h.update([requestType.byte])

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -460,15 +460,16 @@ func computeRequestsHash(
     WITHDRAWAL_REQUEST_TYPE = 0x01'u8  # EIP-7002
     CONSOLIDATION_REQUEST_TYPE = 0x02'u8  # EIP-7251
 
+  template individualHash(requestType, requestList): Digest =
+    computeDigest:
+      h.update([requestType.byte])
+      for request in requestList:
+        h.update SSZ.encode(request)
+
   let requestsHash = computeDigest:
     template mixInRequests(requestType, requestList): untyped =
       if requestList.len > 0:
-        let hash = computeDigest:
-          bind h
-          h.update([requestType.byte])
-          for request in requestList:
-            h.update SSZ.encode(request)
-        h.update(hash.data)
+        h.update(individualHash(requestType, requestList).data)
 
     static:
       doAssert DEPOSIT_REQUEST_TYPE < WITHDRAWAL_REQUEST_TYPE


### PR DESCRIPTION
The `requestType` of empty lists is no longer part of the requests hash.

- https://github.com/ethereum/EIPs/pull/8989