### PR TITLE
Fix typos and improve spelling.

### DIFF
--- a/beacon_chain/validators/README.md
+++ b/beacon_chain/validators/README.md
@@ -1,6 +1,6 @@
 # Validators
 
-This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_cliant and nimbus_signing_process):
+This folder holds all modules related to a Beacon Chain Validator besides the binaries they interact directly with (nimbus_validator_client and nimbus_signing_process):
 - Validator keystore
 - Validator slashing protection
 - Validator duties


### PR DESCRIPTION
Fixes the spelling error: "cliant" corrected to "client".