### PR TITLE
`getMetaData_v3`

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2086,11 +2086,11 @@ proc updateMetadataV2ToV3(metadataRes: NetRes[altair.MetaData]):
                           NetRes[fulu.MetaData] =
   if metadataRes.isOk:
     let metadata = metadataRes.get
-    return ok(fulu.MetaData(seq_number: metadata.seq_number,
+    ok(fulu.MetaData(seq_number: metadata.seq_number,
                             attnets: metadata.attnets,
                             syncnets: metadata.syncnets))
   else:
-    return err(metadataRes.error)
+    err(metadataRes.error)
 
 proc getMetadata_vx(node: Eth2Node, peer: Peer): 
                     Future[NetRes[fulu.MetaData]]

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -69,7 +69,7 @@ type
     protocols: seq[ProtocolInfo]
       ## Protocols managed by the DSL and mounted on the switch
     protocolStates*: seq[RootRef]
-    metadata*: altair.MetaData
+    metadata*: fulu.MetaData
     connectTimeout*: chronos.Duration
     seenThreshold*: chronos.Duration
     connQueue: AsyncQueue[PeerAddr]
@@ -108,7 +108,7 @@ type
     lastReqTime*: Moment
     connections*: int
     enr*: Opt[enr.Record]
-    metadata*: Opt[altair.MetaData]
+    metadata*: Opt[fulu.MetaData]
     failedMetadataRequests: int
     lastMetadataTime*: Moment
     direction*: PeerType
@@ -1803,7 +1803,7 @@ proc new(T: type Eth2Node,
     let
       connectTimeout = chronos.seconds(10)
       seenThreshold = chronos.seconds(10)
-  type MetaData = altair.MetaData # Weird bug without this..
+  type MetaData = fulu.MetaData # Weird bug without this..
 
   # Versions up to v22.3.0 would write an empty `MetaData` to
   #`data-dir/node-metadata.json` which would then be reloaded on startup - don't
@@ -2082,12 +2082,32 @@ proc p2pProtocolBackendImpl*(p: P2PProtocol): Backend =
 import ./peer_protocol
 export peer_protocol
 
+proc updateMetadataV2ToV3(metadata: altair.MetaData): fulu.MetaData =
+  fulu.MetaData(
+    seq_number: metadata.seq_number,
+    attnets: metadata.attnets,
+    syncnets: metadata.syncnets)
+
+proc getMetadata_vx(node: Eth2Node, peer: Peer): 
+                    Future[NetRes[fulu.MetaData]]
+                   {.async: (raises: [CancelledError]).} =
+  let
+    res = 
+      if node.cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        # Directly fetch fulu metadata if available
+        await getMetadata_v3(peer)
+      else:
+        let metadata_v2_result = await getMetadata_v2(peer)
+        metadata_v2_result.map(proc (altairData: altair.MetaData): 
+                                     fulu.MetaData {.closure.} =
+          updateMetadataV2ToV3(altairData))
+  return res
+
 proc updatePeerMetadata(node: Eth2Node, peerId: PeerId) {.async: (raises: [CancelledError]).} =
   trace "updating peer metadata", peerId
-
   let
     peer = node.getPeer(peerId)
-    newMetadataRes = await peer.getMetadata_v2()
+    newMetadataRes = await node.getMetadata_vx(peer)
     newMetadata = newMetadataRes.valueOr:
       debug "Failed to retrieve metadata from peer!", peerId, error = newMetadataRes.error
       peer.failedMetadataRequests.inc()

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2082,11 +2082,15 @@ proc p2pProtocolBackendImpl*(p: P2PProtocol): Backend =
 import ./peer_protocol
 export peer_protocol
 
-proc updateMetadataV2ToV3(metadata: altair.MetaData): fulu.MetaData =
-  fulu.MetaData(
-    seq_number: metadata.seq_number,
-    attnets: metadata.attnets,
-    syncnets: metadata.syncnets)
+proc updateMetadataV2ToV3(metadataRes: NetRes[altair.MetaData]): 
+                          NetRes[fulu.MetaData] =
+  if metadataRes.isOk:
+    let metadata = metadataRes.get
+    return ok(fulu.MetaData(seq_number: metadata.seq_number,
+                            attnets: metadata.attnets,
+                            syncnets: metadata.syncnets))
+  else:
+    return err(metadataRes.error)
 
 proc getMetadata_vx(node: Eth2Node, peer: Peer): 
                     Future[NetRes[fulu.MetaData]]
@@ -2097,10 +2101,7 @@ proc getMetadata_vx(node: Eth2Node, peer: Peer):
         # Directly fetch fulu metadata if available
         await getMetadata_v3(peer)
       else:
-        let metadata_v2_result = await getMetadata_v2(peer)
-        metadata_v2_result.map(proc (altairData: altair.MetaData): 
-                                     fulu.MetaData {.closure.} =
-          updateMetadataV2ToV3(altairData))
+        updateMetadataV2ToV3(await getMetadata_v2(peer))
   return res
 
 proc updatePeerMetadata(node: Eth2Node, peerId: PeerId) {.async: (raises: [CancelledError]).} =

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -169,6 +169,14 @@ p2pProtocol PeerSync(version = 1,
 
   proc getMetadata_v2(peer: Peer): altair.MetaData
     {.libp2pProtocol("metadata", 2).} =
+    let altair_metadata = altair.MetaData(
+      seq_number: peer.network.metadata.seq_number,
+      attnets: peer.network.metadata.attnets,
+      syncnets: peer.network.metadata.syncnets)
+    altair_metadata
+
+  proc getMetadata_v3(peer: Peer): fulu.MetaData
+    {. libp2pProtocol("metadata", 3).} =
     peer.network.metadata
 
   proc goodbye(peer: Peer, reason: uint64) {.


### PR DESCRIPTION
implements https://github.com/ethereum/consensus-specs/blob/dev/specs/_features/eip7594/p2p-interface.md#metadata

conditionally calls getMetaData v2 or v3 by checking if `FULU_FORK_EPOCH` is scheduled or not.