### PR TITLE
add: column support to ENR, Metadata and Request Manager

### DIFF
--- a/beacon_chain/consensus_object_pools/data_column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/data_column_quarantine.nim
@@ -78,7 +78,7 @@ func hasDataColumn*(
   false
 
 func peekColumnIndices*(quarantine: DataColumnQuarantine,
-                        blck: electra.SignedBeaconBlock):
+                        blck: fulu.SignedBeaconBlock):
                         seq[ColumnIndex] =
   # Peeks into the currently received column indices
   # from quarantine, necessary data availability checks
@@ -110,7 +110,7 @@ func gatherDataColumns*(quarantine: DataColumnQuarantine,
 
 func popDataColumns*(
     quarantine: var DataColumnQuarantine, digest: Eth2Digest,
-    blck: electra.SignedBeaconBlock):
+    blck: fulu.SignedBeaconBlock):
     seq[ref DataColumnSidecar] =
   var r: DataColumnSidecars
   for idx in quarantine.custody_columns:
@@ -123,7 +123,7 @@ func popDataColumns*(
   r
 
 func hasMissingDataColumns*(quarantine: DataColumnQuarantine,
-    blck: electra.SignedBeaconBlock): bool =
+    blck: fulu.SignedBeaconBlock): bool =
   # `hasMissingDataColumns` consists of the data columns that,
   # have been missed over gossip, also in case of a supernode,
   # the method would return missing columns when the supernode
@@ -149,7 +149,7 @@ func hasMissingDataColumns*(quarantine: DataColumnQuarantine,
     return true
 
 func hasEnoughDataColumns*(quarantine: DataColumnQuarantine,
-    blck: electra.SignedBeaconBlock): bool =
+    blck: fulu.SignedBeaconBlock): bool =
   # `hasEnoughDataColumns` dictates whether there is `enough`
   # data columns for a block to be enqueued, ideally for a supernode
   # if it receives atleast 50%+ gossip and RPC
@@ -175,7 +175,7 @@ func hasEnoughDataColumns*(quarantine: DataColumnQuarantine,
         return true
 
 func dataColumnFetchRecord*(quarantine: DataColumnQuarantine,
-                            blck: electra.SignedBeaconBlock):
+                            blck: fulu.SignedBeaconBlock):
                             DataColumnFetchRecord =
   var indices: seq[ColumnIndex]
   for i in quarantine.custody_columns:

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1647,6 +1647,15 @@ proc runDiscoveryLoop(node: Eth2Node) {.async: (raises: [CancelledError]).} =
     # Also, give some time to dial the discovered nodes and update stats etc
     await sleepAsync(5.seconds)
 
+proc fetchNodeIdFromPeerId*(peer: Peer): NodeId=
+  # Convert peer id to node id by extracting the peer's public key
+  let nodeId =
+    block:
+      var key: PublicKey
+      discard peer.peerId.extractPublicKey(key)
+      keys.PublicKey.fromRaw(key.skkey.getBytes()).get().toNodeId()
+  nodeId
+
 proc resolvePeer(peer: Peer) =
   # Resolve task which performs searching of peer's public key and recovery of
   # ENR using discovery5. We only resolve ENR for peers we know about to avoid

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2418,6 +2418,33 @@ func announcedENR*(node: Eth2Node): enr.Record =
   doAssert node.discovery != nil, "The Eth2Node must be initialized"
   node.discovery.localNode.record
 
+proc lookupCscFromPeer*(peer: Peer): uint64 =
+  # Fetches the custody column count from a remote peer.
+  # If the peer advertises their custody column count via the `csc` ENR field,
+  # that value is returned. Otherwise, the default value `CUSTODY_REQUIREMENT`
+  # is assumed.
+
+  let metadata = peer.metadata
+  if metadata.isOk:
+    return metadata.get.custody_subnet_count
+
+  # Try getting the custody count from ENR if metadata fetch fails.
+  debug "Could not get csc from metadata, trying from ENR", 
+        peer_id = peer.peerId
+  let enrOpt = peer.enr
+  if not enrOpt.isNone:
+    let enr = enrOpt.get
+    let enrFieldOpt = enr.get(enrCustodySubnetCountField, seq[byte])
+    if enrFieldOpt.isOk:
+      try:
+        let csc = SSZ.decode(enrFieldOpt.get, uint8)
+        return csc.uint64
+      except SszError, SerializationError:
+        discard  # Ignore decoding errors and fallback to default
+
+  # Return default value if no valid custody subnet count is found.
+  return CUSTODY_REQUIREMENT.uint64
+
 func shortForm*(id: NetKeyPair): string =
   $PeerId.init(id.pubkey)
 
@@ -2578,6 +2605,20 @@ proc updateStabilitySubnetMetadata*(node: Eth2Node, attnets: AttnetBits) =
     warn "Failed to update the ENR attnets field", error = res.error
   else:
     debug "Stability subnets changed; updated ENR attnets", attnets
+
+proc loadCscnetMetadataAndEnr*(node: Eth2Node, cscnets: CscCount) =
+  node.metadata.custody_subnet_count = cscnets.uint64
+  let res =
+    node.discovery.updateRecord({
+      enrCustodySubnetCountField: SSZ.encode(cscnets)
+    })
+
+  if res.isErr:
+    # This should not occur in this scenario as the private key would always
+    # be the correct one and the ENR will not increase in size
+    warn "Failed to update the ENR csc field", error = res.error
+  else:
+    debug "Updated ENR csc", cscnets
 
 proc updateSyncnetsMetadata*(node: Eth2Node, syncnets: SyncnetBits) =
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/altair/validator.md#sync-committee-subnet-stability

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -478,6 +478,13 @@ proc initFullNode(
         Opt.some blob_sidecar
       else:
         Opt.none(ref BlobSidecar)
+    rmanDataColumnLoader = proc(
+        columnId: DataColumnIdentifier): Opt[ref DataColumnSidecar] =
+      var data_column_sidecar = DataColumnSidecar.new()
+      if dag.db.getDataColumnSidecar(columnId.block_root, columnId.index, data_column_sidecar[]):
+        Opt.some data_column_sidecar
+      else:
+        Opt.none(ref DataColumnSidecar)
 
     processor = Eth2Processor.new(
       config.doppelgangerDetection,
@@ -525,10 +532,10 @@ proc initFullNode(
       processor: processor,
       network: node.network)
     requestManager = RequestManager.init(
-      node.network, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
+      node.network, supernode, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
       (proc(): bool = syncManager.inProgress),
-      quarantine, blobQuarantine, rmanBlockVerifier,
-      rmanBlockLoader, rmanBlobLoader)
+      quarantine, blobQuarantine, dataColumnQuarantine, rmanBlockVerifier,
+      rmanBlockLoader, rmanBlobLoader, rmanDataColumnLoader)
   
   # As per EIP 7594, the BN is now categorised into a 
   # `Fullnode` and a `Supernode`, the fullnodes custodies a

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -553,6 +553,12 @@ proc initFullNode(
   dataColumnQuarantine[].custody_columns = 
     node.network.nodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
                                             localCustodySubnets))
+
+  if node.config.subscribeAllSubnets:
+    node.network.loadCscnetMetadataAndEnr(DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint8)
+  else:
+    node.network.loadCscnetMetadataAndEnr(CUSTODY_REQUIREMENT.uint8)
+
   if node.config.lightClientDataServe:
     proc scheduleSendingLightClientUpdates(slot: Slot) =
       if node.lightClientPool[].broadcastGossipFut != nil:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -535,10 +535,10 @@ proc initFullNode(
       processor: processor,
       network: node.network)
     requestManager = RequestManager.init(
-      node.network, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
-      (proc(): bool = syncManager.inProgress),
-      quarantine, blobQuarantine, rmanBlockVerifier,
-      rmanBlockLoader, rmanBlobLoader)
+      node.network, supernode, custody_columns_set, dag.cfg.DENEB_FORK_EPOCH, 
+      getBeaconTime, (proc(): bool = syncManager.inProgress),
+      quarantine, blobQuarantine, dataColumnQuarantine, rmanBlockVerifier,
+      rmanBlockLoader, rmanBlobLoader, rmanDataColumnLoader)
 
   # As per EIP 7594, the BN is now categorised into a
   # `Fullnode` and a `Supernode`, the fullnodes custodies a

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -422,6 +422,9 @@ proc initFullNode(
         DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64
       else:
         CUSTODY_REQUIREMENT.uint64
+    custody_columns_set =
+      node.network.nodeId.get_custody_columns_set(max(SAMPLES_PER_SLOT.uint64,
+                                                      localCustodySubnets))
     consensusManager = ConsensusManager.new(
       dag, attestationPool, quarantine, node.elManager,
       ActionTracker.init(node.network.nodeId, config.subscribeAllSubnets),
@@ -532,8 +535,8 @@ proc initFullNode(
       processor: processor,
       network: node.network)
     requestManager = RequestManager.init(
-      node.network, supernode, dag.cfg.DENEB_FORK_EPOCH, getBeaconTime,
-      (proc(): bool = syncManager.inProgress),
+      node.network, supernode, custody_columns_set, dag.cfg.DENEB_FORK_EPOCH, 
+      getBeaconTime, (proc(): bool = syncManager.inProgress),
       quarantine, blobQuarantine, dataColumnQuarantine, rmanBlockVerifier,
       rmanBlockLoader, rmanBlobLoader, rmanDataColumnLoader)
   
@@ -559,7 +562,7 @@ proc initFullNode(
   dataColumnQuarantine[].supernode = supernode
   dataColumnQuarantine[].custody_columns = 
     node.network.nodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                            localCustodySubnets))
+                                                localCustodySubnets))
 
   if node.config.subscribeAllSubnets:
     node.network.loadCscnetMetadataAndEnr(DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint8)

--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -117,7 +117,7 @@ type
     seq_number*: uint64
     attnets*: AttnetBits
     syncnets*: SyncnetBits
-    custody_subnet_count*: CscCount
+    custody_subnet_count*: uint64
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/deneb/beacon-chain.md#executionpayload
   ExecutionPayload* = object

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -35,16 +35,6 @@ func sortedColumnIndices*(columnsPerSubnet: ColumnIndex,
   res.sort
   res
 
-func sortedColumnIndicesToHashSet*(columnsPerSubnet: ColumnIndex,
-                                   subnetIds: HashSet[uint64]):
-                                   HashSet[ColumnIndex] =
-  var res: HashSet[ColumnIndex] = initHashSet[ColumnIndex]()
-  for i in 0'u64 ..< columnsPerSubnet:
-    for subnetId in subnetIds:
-      let index = DATA_COLUMN_SIDECAR_SUBNET_COUNT * i + subnetId
-      res.incl(ColumnIndex(index))  # Add to HashSet
-  res
-
 func sortedColumnIndexList*(columnsPerSubnet: ColumnIndex,
                             subnetIds: HashSet[uint64]):
                             List[ColumnIndex, NUMBER_OF_COLUMNS] =
@@ -115,7 +105,7 @@ func get_custody_columns_set*(node_id: NodeId,
     columns_per_subnet =
       NUMBER_OF_COLUMNS div DATA_COLUMN_SIDECAR_SUBNET_COUNT
 
-  sortedColumnIndicesToHashSet(ColumnIndex(columns_per_subnet), subnet_ids)
+  sortedColumnIndices(ColumnIndex(columns_per_subnet), subnet_ids).toHashSet()
 
 func get_custody_column_list*(node_id: NodeId,
                               custody_subnet_count: uint64):

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -35,6 +35,16 @@ func sortedColumnIndices*(columnsPerSubnet: ColumnIndex,
   res.sort
   res
 
+func sortedColumnIndicesToHashSet*(columnsPerSubnet: ColumnIndex,
+                                   subnetIds: HashSet[uint64]):
+                                   HashSet[ColumnIndex] =
+  var res: HashSet[ColumnIndex] = initHashSet[ColumnIndex]()
+  for i in 0'u64 ..< columnsPerSubnet:
+    for subnetId in subnetIds:
+      let index = DATA_COLUMN_SIDECAR_SUBNET_COUNT * i + subnetId
+      res.incl(ColumnIndex(index))  # Add to HashSet
+  res
+
 func sortedColumnIndexList*(columnsPerSubnet: ColumnIndex,
                             subnetIds: HashSet[uint64]):
                             List[ColumnIndex, NUMBER_OF_COLUMNS] =
@@ -92,6 +102,20 @@ func get_custody_columns*(node_id: NodeId,
       NUMBER_OF_COLUMNS div DATA_COLUMN_SIDECAR_SUBNET_COUNT
 
   sortedColumnIndices(ColumnIndex(columns_per_subnet), subnet_ids)
+
+func get_custody_columns_set*(node_id: NodeId,
+                              custody_subnet_count: uint64):
+                              HashSet[ColumnIndex] =
+  # This method returns a HashSet of column indices, 
+  # the method is specifically relevant while peer filtering
+  let
+    subnet_ids =
+      get_custody_column_subnets(node_id, custody_subnet_count)
+  const
+    columns_per_subnet =
+      NUMBER_OF_COLUMNS div DATA_COLUMN_SIDECAR_SUBNET_COUNT
+
+  sortedColumnIndicesToHashSet(ColumnIndex(columns_per_subnet), subnet_ids)
 
 func get_custody_column_list*(node_id: NodeId,
                               custody_subnet_count: uint64):

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -47,6 +47,7 @@ const
 
   enrAttestationSubnetsField* = "attnets"
   enrSyncSubnetsField* = "syncnets"
+  enrCustodySubnetCountField* = "csc"
   enrForkIdField* = "eth2"
 
 template eth2Prefix(forkDigest: ForkDigest): string =

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -155,22 +155,27 @@ proc checkResponse(idList: seq[BlobIdentifier],
   true
 
 proc checkResponse(idList: seq[DataColumnIdentifier],
-                   columns: openArray[ref DataColumnSidecar]):
-                   bool =
+                   columns: openArray[ref DataColumnSidecar]): bool =
   if columns.len > idList.len:
     return false
-  for column in columns:
-    let block_root =
-      hash_tree_root(column.signed_block_header.message)
-    var found = false
-    for id in idList:
-      if id.block_root == block_root and id.index == column.index:
-        found = true
-        break
-      if not found:
-        return false
-    column[].verify_data_column_sidecar_inclusion_proof().isOkOr:
+  var i = 0
+  while i < columns.len:
+    let
+      block_root = hash_tree_root(columns[i].signed_block_header.message)
+      id = idList[i]
+
+    # Check if the column reponse is a subset
+    if binarySearch(idList, columns[i], cmpSidecarIdentifier) == -1:
       return false
+
+    # Verify block root and index match
+    if id.block_root != block_root or id.index != columns[i].index:
+      return false
+
+    # Verify inclusion proof
+    columns[i][].verify_data_column_sidecar_inclusion_proof().isOkOr:
+      return false
+    inc i
   true
 
 proc requestBlocksByRoot(rman: RequestManager, items: seq[Eth2Digest]) {.async: (raises: [CancelledError]).} =
@@ -244,7 +249,7 @@ proc requestBlocksByRoot(rman: RequestManager, items: seq[Eth2Digest]) {.async: 
     if not(isNil(peer)):
       rman.network.peerPool.release(peer)
 
-func cmpBlobIndexes(x, y: ref BlobSidecar): int =
+func cmpSidecarIndexes(x, y: ref BlobSidecar | ref DataColumnSidecar): int =
   cmp(x.index, y.index)
 
 proc fetchBlobsFromNetwork(self: RequestManager,
@@ -261,7 +266,7 @@ proc fetchBlobsFromNetwork(self: RequestManager,
 
     if blobs.isOk:
       var ublobs = blobs.get().asSeq()
-      ublobs.sort(cmpBlobIndexes)
+      ublobs.sort(cmpSidecarIndexes)
       if not checkResponse(idList, ublobs):
         debug "Mismatched response to blobs by root",
           peer = peer, blobs = shortLog(idList), ublobs = len(ublobs)
@@ -337,9 +342,8 @@ proc checkPeerCustody*(rman: RequestManager,
 proc fetchDataColumnsFromNetwork(rman: RequestManager,
                                  colIdList: seq[DataColumnIdentifier])
                                  {.async: (raises: [CancelledError]).} =
-  var peer: Peer
+  var peer = await rman.network.peerPool.acquire()
   try:
-    peer = await rman.network.peerPool.acquire()
 
     if rman.checkPeerCustody(peer):
       debug "Requesting data columns by root", peer = peer, columns = shortLog(colIdList),
@@ -347,8 +351,9 @@ proc fetchDataColumnsFromNetwork(rman: RequestManager,
       let columns = await dataColumnSidecarsByRoot(peer, DataColumnIdentifierList colIdList)
 
       if columns.isOk:
-        let ucolumns = columns.get()
-        if not checkResponse(colIdList, ucolumns.asSeq()):
+        var ucolumns = columns.get().asSeq()
+        ucolumns.sort(cmpSidecarIndexes)
+        if not checkResponse(colIdList, ucolumns):
           debug "Mismatched response to data columns by root",
             peer = peer, columns = shortLog(colIdList), ucolumns = len(ucolumns)
           peer.updateScore(PeerScoreBadResponse)

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -274,10 +274,14 @@ proc fetchBlobsFromNetwork(self: RequestManager,
 proc checkPeerCustody*(rman: RequestManager,
                        peer: Peer):
                        bool =
-  ## Returns true if the peer custodies atleast
-  ## ONE of the common custody columns, straight 
-  ## away returns true if the peer is a supernode.
+  # Returns true if the peer custodies atleast
+  # ONE of the common custody columns, straight 
+  # away returns true if the peer is a supernode.
   if rman.supernode:
+    # For a supernode, it is always best/optimistic
+    # to filter other supernodes, rather than filter
+    # too many full nodes that have a subset of the custody
+    # columns
     if peer.lookupCscFromPeer() == 
         DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64:
       return true

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -525,7 +525,7 @@ proc requestManagerBlobLoop(
             blobs_count = len(blobIds),
             sync_speed = speed(start, finish)
 
-proc getMissingDataColumns(rman: RequestManager): seq[DataColumnIdentifier] =
+proc getMissingDataColumns(rman: RequestManager): HashSet[DataColumnIdentifier] =
   let
     wallTime = rman.getBeaconTime()
     wallSlot = wallTime.slotOrZero()
@@ -534,7 +534,7 @@ proc getMissingDataColumns(rman: RequestManager): seq[DataColumnIdentifier] =
   const waitDur = TimeDiff(nanoseconds: DATA_COLUMN_GOSSIP_WAIT_TIME_NS)
 
   var
-    fetches: seq[DataColumnIdentifier]
+    fetches: HashSet[DataColumnIdentifier]
     ready: seq[Eth2Digest]
 
   for columnless in rman.quarantine[].peekColumnless():
@@ -555,12 +555,12 @@ proc getMissingDataColumns(rman: RequestManager): seq[DataColumnIdentifier] =
             let id = DataColumnIdentifier(block_root: columnless.root, index: idx)
             if id.index in rman.custody_columns_set and id notin fetches and 
                 len(forkyBlck.message.body.blob_kzg_commitments) != 0:
-              fetches.add(id)
+              fetches.incl(id)
         else:
           # this is a programming error and it not should occur
           warn "missing column handler found columnless block with all data columns",
              blk = columnless.root,
-             commitments=len(forkyBlck.message.body.blob_kzg_commitments)
+             commitments = len(forkyBlck.message.body.blob_kzg_commitments)
           ready.add(columnless.root)
   
   for root in ready:
@@ -583,7 +583,8 @@ proc requestManagerDataColumnLoop(
 
     var columnIds: seq[DataColumnIdentifier]
     if rman.dataColumnLoader == nil:
-      columnIds = missingColumnIds
+      for item in missingColumnIds:
+        columnIds.add item
     else:
       var
         blockRoots: seq[Eth2Digest]

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -290,10 +290,11 @@ proc checkPeerCustody*(rman: RequestManager,
     elif peer.lookupCscFromPeer() == 
         CUSTODY_REQUIREMENT.uint64:
       # Fetch local custody column
-      let localNodeId = rman.network.nodeId
-      let localCustodyColumns =
-        localNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                            CUSTODY_REQUIREMENT.uint64))
+      let
+        localNodeId = rman.network.nodeId
+        localCustodyColumns =
+          localNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
+                                          CUSTODY_REQUIREMENT.uint64))
 
       # Fetch the remote custody count
       let remoteCustodySubnetCount =
@@ -310,8 +311,8 @@ proc checkPeerCustody*(rman: RequestManager,
       for local_column in localCustodyColumns:
         if local_column notin remoteCustodyColumns:
           return false
-        else:
-          return true
+      
+      return true
     
     else:
       return false

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -64,6 +64,7 @@ type
   RequestManager* = object
     network*: Eth2Node
     supernode*: bool
+    custody_columns_set: HashSet[ColumnIndex]
     getBeaconTime: GetBeaconTimeFn
     inhibit: InhibitFn
     quarantine: ref Quarantine
@@ -85,6 +86,7 @@ func shortLog*(x: seq[FetchRecord]): string =
 
 proc init*(T: type RequestManager, network: Eth2Node,
               supernode: bool,
+              custody_columns_set: HashSet[ColumnIndex],
               denebEpoch: Epoch,
               getBeaconTime: GetBeaconTimeFn,
               inhibit: InhibitFn,
@@ -98,6 +100,7 @@ proc init*(T: type RequestManager, network: Eth2Node,
   RequestManager(
     network: network,
     supernode: supernode,
+    custody_columns_set: custody_columns_set,
     getBeaconTime: getBeaconTime,
     inhibit: inhibit,
     quarantine: quarantine,
@@ -293,12 +296,6 @@ proc checkPeerCustody*(rman: RequestManager,
 
     elif peer.lookupCscFromPeer() == 
         CUSTODY_REQUIREMENT.uint64:
-      # Fetch local custody column
-      let
-        localNodeId = rman.network.nodeId
-        localCustodyColumns =
-          localNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                              CUSTODY_REQUIREMENT.uint64))
 
       # Fetch the remote custody count
       let remoteCustodySubnetCount =
@@ -309,10 +306,10 @@ proc checkPeerCustody*(rman: RequestManager,
       let
         remoteNodeId = fetchNodeIdFromPeerId(peer)
         remoteCustodyColumns =
-          remoteNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
+          remoteNodeId.get_custody_columns_set(max(SAMPLES_PER_SLOT.uint64,
                                                remoteCustodySubnetCount))
 
-      for local_column in localCustodyColumns:
+      for local_column in rman.custody_columns_set:
         if local_column notin remoteCustodyColumns:
           return false
       
@@ -556,15 +553,7 @@ proc getMissingDataColumns(rman: RequestManager): seq[DataColumnIdentifier] =
              commitments = len(forkyBlck.message.body.blob_kzg_commitments)
           for idx in missing.indices:
             let id = DataColumnIdentifier(block_root: columnless.root, index: idx)
-            let local_csc = 
-              if rman.supernode:
-                DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64
-              else:
-                CUSTODY_REQUIREMENT.uint64
-            let local_custody =
-              rman.network.nodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                                          local_csc))
-            if id.index in local_custody and id notin fetches and 
+            if id.index in rman.custody_columns_set and id notin fetches and 
                 len(forkyBlck.message.body.blob_kzg_commitments) != 0:
               fetches.add(id)
         else:

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -11,10 +11,11 @@ import std/[sequtils, strutils]
 import chronos, chronicles
 import
   ../spec/datatypes/[phase0, deneb, fulu],
-  ../spec/[forks, network],
+  ../spec/[forks, network, eip7594_helpers],
   ../networking/eth2_network,
   ../consensus_object_pools/block_quarantine,
   ../consensus_object_pools/blob_quarantine,
+  ../consensus_object_pools/data_column_quarantine,
   "."/sync_protocol, "."/sync_manager,
   ../gossip_processing/block_processor
 
@@ -31,8 +32,13 @@ const
   PARALLEL_REQUESTS* = 2
     ## Number of peers we using to resolve our request.
 
+  PARALLEL_REQUESTS_DATA_COLUMNS* = 32
+
   BLOB_GOSSIP_WAIT_TIME_NS* = 2 * 1_000_000_000
-    ## How long to wait for blobs to arrive over gossip before fetching.
+    ## How long to wait for blobs to arri ve over gossip before fetching.
+
+  DATA_COLUMN_GOSSIP_WAIT_TIME_NS* = 2 * 1_000_000_000
+    ## How long to wait for blobs to arri ve over gossip before fetching.
 
   POLL_INTERVAL = 1.seconds
 
@@ -49,19 +55,27 @@ type
   BlobLoaderFn* = proc(
       blobId: BlobIdentifier): Opt[ref BlobSidecar] {.gcsafe, raises: [].}
 
+  DataColumnLoaderFn* = proc(
+      columnId: DataColumnIdentifier):
+      Opt[ref DataColumnSidecar] {.gcsafe, raises: [].}
+
   InhibitFn* = proc: bool {.gcsafe, raises: [].}
 
   RequestManager* = object
     network*: Eth2Node
+    supernode*: bool
     getBeaconTime: GetBeaconTimeFn
     inhibit: InhibitFn
     quarantine: ref Quarantine
     blobQuarantine: ref BlobQuarantine
+    dataColumnQuarantine: ref DataColumnQuarantine
     blockVerifier: BlockVerifierFn
     blockLoader: BlockLoaderFn
     blobLoader: BlobLoaderFn
+    dataColumnLoader: DataColumnLoaderFn
     blockLoopFuture: Future[void].Raising([CancelledError])
     blobLoopFuture: Future[void].Raising([CancelledError])
+    dataColumnLoopFuture: Future[void].Raising([CancelledError])
 
 func shortLog*(x: seq[Eth2Digest]): string =
   "[" & x.mapIt(shortLog(it)).join(", ") & "]"
@@ -70,23 +84,29 @@ func shortLog*(x: seq[FetchRecord]): string =
   "[" & x.mapIt(shortLog(it.root)).join(", ") & "]"
 
 proc init*(T: type RequestManager, network: Eth2Node,
+              supernode: bool,
               denebEpoch: Epoch,
               getBeaconTime: GetBeaconTimeFn,
               inhibit: InhibitFn,
               quarantine: ref Quarantine,
               blobQuarantine: ref BlobQuarantine,
+              dataColumnQuarantine: ref DataColumnQuarantine,
               blockVerifier: BlockVerifierFn,
               blockLoader: BlockLoaderFn = nil,
-              blobLoader: BlobLoaderFn = nil): RequestManager =
+              blobLoader: BlobLoaderFn = nil,
+              dataColumnLoader: DataColumnLoaderFn = nil): RequestManager =
   RequestManager(
     network: network,
+    supernode: supernode,
     getBeaconTime: getBeaconTime,
     inhibit: inhibit,
     quarantine: quarantine,
     blobQuarantine: blobQuarantine,
+    dataColumnQuarantine: dataColumnQuarantine,
     blockVerifier: blockVerifier,
     blockLoader: blockLoader,
-    blobLoader: blobLoader)
+    blobLoader: blobLoader,
+    dataColumnLoader: dataColumnLoader)
 
 proc checkResponse(roots: openArray[Eth2Digest],
                    blocks: openArray[ref ForkedSignedBeaconBlock]): bool =
@@ -116,6 +136,25 @@ proc checkResponse(idList: seq[BlobIdentifier],
     if not found:
       return false
     blob[].verify_blob_sidecar_inclusion_proof().isOkOr:
+      return false
+  true
+
+proc checkResponse(idList: seq[DataColumnIdentifier],
+                   columns: openArray[ref DataColumnSidecar]):
+                   bool =
+  if columns.len > idList.len:
+    return false
+  for column in columns:
+    let block_root =
+      hash_tree_root(column.signed_block_header.message)
+    var found = false
+    for id in idList:
+      if id.block_root == block_root and id.index == column.index:
+        found = true
+        break
+      if not found:
+        return false
+    column[].verify_data_column_sidecar_inclusion_proof().isOkOr:
       return false
   true
 
@@ -231,6 +270,90 @@ proc fetchBlobsFromNetwork(self: RequestManager,
   finally:
     if not(isNil(peer)):
       self.network.peerPool.release(peer)
+
+proc checkPeerCustody*(rman: RequestManager,
+                       peer: Peer):
+                       bool =
+  ## Returns true if the peer custodies atleast
+  ## ONE of the common custody columns, straight 
+  ## away returns true if the peer is a supernode.
+  if rman.supernode:
+    if peer.lookupCscFromPeer() == 
+        DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64:
+      return true
+  
+  else:
+    if peer.lookupCscFromPeer() == 
+        DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64:
+      return true
+
+    elif peer.lookupCscFromPeer() == 
+        CUSTODY_REQUIREMENT.uint64:
+      # Fetch local custody column
+      let localNodeId = rman.network.nodeId
+      let localCustodyColumns =
+        localNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
+                                            CUSTODY_REQUIREMENT.uint64))
+
+      # Fetch the remote custody count
+      let remoteCustodySubnetCount =
+        peer.lookupCscFromPeer()
+
+      # Extract remote peer's nodeID from peerID
+      # Fetch custody columns from remote peer
+      let
+        remoteNodeId = fetchNodeIdFromPeerId(peer)
+        remoteCustodyColumns =
+          remoteNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
+                                              remoteCustodySubnetCount))
+
+      for local_column in localCustodyColumns:
+        if local_column notin remoteCustodyColumns:
+          return false
+        else:
+          return true
+    
+    else:
+      return false
+
+proc fetchDataColumnsFromNetwork(rman: RequestManager,
+                                 colIdList: seq[DataColumnIdentifier])
+                                 {.async: (raises: [CancelledError]).} =
+  var peer: Peer
+  try:
+    peer = await rman.network.peerPool.acquire()
+
+    if rman.checkPeerCustody(peer):
+      debug "Requesting data columns by root", peer = peer, columns = shortLog(colIdList),
+                                                      peer_score = peer.getScore()
+      let columns = await dataColumnSidecarsByRoot(peer, DataColumnIdentifierList colIdList)
+
+      if columns.isOk:
+        let ucolumns = columns.get()
+        if not checkResponse(colIdList, ucolumns.asSeq()):
+          debug "Mismatched response to data columns by root",
+            peer = peer, columns = shortLog(colIdList), ucolumns = len(ucolumns)
+          peer.updateScore(PeerScoreBadResponse)
+          return
+
+        for col in ucolumns:
+          rman.dataColumnQuarantine[].put(col)
+        var curRoot: Eth2Digest
+        for col in ucolumns:
+          let block_root = hash_tree_root(col.signed_block_header.message)
+          if block_root != curRoot:
+            curRoot = block_root
+            if (let o = rman.quarantine[].popColumnless(curRoot); o.isSome):
+              let col = o.unsafeGet()
+              discard await rman.blockVerifier(col, false)
+      else:
+        debug "Data columns by root request not done, peer doesn't have custody column",
+          peer = peer, columns = shortLog(colIdList), err = columns.error()
+        peer.updateScore(PeerScoreNoValues)
+
+  finally:
+    if not(isNil(peer)):
+      rman.network.peerPool.release(peer)
 
 proc requestManagerBlockLoop(
     rman: RequestManager) {.async: (raises: [CancelledError]).} =
@@ -400,10 +523,124 @@ proc requestManagerBlobLoop(
             blobs_count = len(blobIds),
             sync_speed = speed(start, finish)
 
+proc getMissingDataColumns(rman: RequestManager): seq[DataColumnIdentifier] =
+  let
+    wallTime = rman.getBeaconTime()
+    wallSlot = wallTime.slotOrZero()
+    delay = wallTime - wallSlot.start_beacon_time()
+  
+  const waitDur = TimeDiff(nanoseconds: DATA_COLUMN_GOSSIP_WAIT_TIME_NS)
+
+  var
+    fetches: seq[DataColumnIdentifier]
+    ready: seq[Eth2Digest]
+
+  for columnless in rman.quarantine[].peekColumnless():
+    withBlck(columnless):
+      when consensusFork >= ConsensusFork.Fulu:
+        # granting data columns a chance to arrive over gossip
+        if forkyBlck.message.slot == wallSlot and delay < waitDur:
+          debug "Not handling missing data columns early in slot"
+          continue
+
+        if not rman.dataColumnQuarantine[].hasMissingDataColumns(forkyBlck):
+          let missing = rman.dataColumnQuarantine[].dataColumnFetchRecord(forkyBlck)
+          if len(missing.indices) == 0:
+            warn "quarantine is missing data columns, but missing indices are empty",
+             blk = columnless.root,
+             commitments = len(forkyBlck.message.body.blob_kzg_commitments)
+          for idx in missing.indices:
+            let id = DataColumnIdentifier(block_root: columnless.root, index: idx)
+            let local_csc = 
+              if rman.supernode:
+                DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64
+              else:
+                CUSTODY_REQUIREMENT.uint64
+            let local_custody =
+              rman.network.nodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
+                                                          local_csc))
+            if id.index in local_custody and id notin fetches and 
+                len(forkyBlck.message.body.blob_kzg_commitments) != 0:
+              fetches.add(id)
+        else:
+          # this is a programming error and it not should occur
+          warn "missing column handler found columnless block with all data columns",
+             blk = columnless.root,
+             commitments=len(forkyBlck.message.body.blob_kzg_commitments)
+          ready.add(columnless.root)
+  
+  for root in ready:
+    let columnless = rman.quarantine[].popColumnless(root).valueOr:
+      continue
+    discard rman.blockVerifier(columnless, false)
+  fetches
+
+proc requestManagerDataColumnLoop(
+    rman: RequestManager) {.async: (raises: [CancelledError]).} =
+  while true:
+    
+    await sleepAsync(POLL_INTERVAL)
+    if rman.inhibit():
+      continue
+
+    let missingColumnIds = rman.getMissingDataColumns()
+    if missingColumnIds.len == 0:
+      continue
+
+    var columnIds: seq[DataColumnIdentifier]
+    if rman.dataColumnLoader == nil:
+      columnIds = missingColumnIds
+    else:
+      var
+        blockRoots: seq[Eth2Digest]
+        curRoot: Eth2Digest
+      for columnId in missingColumnIds:
+        if columnId.block_root != curRoot:
+          curRoot = columnId.block_root
+          blockRoots.add curRoot
+        let data_column_sidecar = rman.dataColumnLoader(columnId).valueOr:
+          columnIds.add columnId
+          if blockRoots.len > 0 and blockRoots[^1] == curRoot:
+            # A data column is missing, remove from list of fully available data columns
+            discard blockRoots.pop()
+          continue
+        debug "Loaded orphaned data columns from storage", columnId
+        rman.dataColumnQuarantine[].put(data_column_sidecar)
+      var verifiers = newSeqOfCap[
+        Future[Result[void, VerifierError]]  
+          .Raising([CancelledError])](blockRoots.len)
+      for blockRoot in blockRoots:
+        let blck = rman.quarantine[].popColumnless(blockRoot).valueOr:
+          continue
+        verifiers.add rman.blockVerifier(blck, maybeFinalized = false)
+      try:
+        await allFutures(verifiers)
+      except CancelledError as exc:
+        var futs = newSeqOfCap[Future[void].Raising([])](verifiers.len)
+        for verifier in verifiers:
+          futs.add verifier.cancelAndWait()
+        await noCancel allFutures(futs)
+        raise exc
+    if columnIds.len > 0:
+      debug "Requesting detected missing data columns", columns = shortLog(columnIds)
+      let start = SyncMoment.now(0)
+      var workers:
+        array[PARALLEL_REQUESTS_DATA_COLUMNS, Future[void].Raising([CancelledError])]
+      for i in 0..<PARALLEL_REQUESTS_DATA_COLUMNS:
+        workers[i] = rman.fetchDataColumnsFromNetwork(columnIds)
+      
+      await allFutures(workers)
+      let finish = SyncMoment.now(uint64(len(columnIds)))
+
+      debug "Request manager data column tick",
+            data_columns_count = len(columnIds),
+            sync_speed = speed(start, finish)
+
 proc start*(rman: var RequestManager) =
   ## Start Request Manager's loops.
   rman.blockLoopFuture = rman.requestManagerBlockLoop()
   rman.blobLoopFuture = rman.requestManagerBlobLoop()
+  rman.dataColumnLoopFuture = rman.requestManagerDataColumnLoop()
 
 proc stop*(rman: RequestManager) =
   ## Stop Request Manager's loop.
@@ -411,3 +648,5 @@ proc stop*(rman: RequestManager) =
     rman.blockLoopFuture.cancelSoon()
   if not(isNil(rman.blobLoopFuture)):
     rman.blobLoopFuture.cancelSoon()
+  if not(isNil(rman.dataColumnLoopFuture)):
+    rman.dataColumnLoopFuture.cancelSoon()

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -298,7 +298,7 @@ proc checkPeerCustody*(rman: RequestManager,
         localNodeId = rman.network.nodeId
         localCustodyColumns =
           localNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                          CUSTODY_REQUIREMENT.uint64))
+                                              CUSTODY_REQUIREMENT.uint64))
 
       # Fetch the remote custody count
       let remoteCustodySubnetCount =
@@ -310,7 +310,7 @@ proc checkPeerCustody*(rman: RequestManager,
         remoteNodeId = fetchNodeIdFromPeerId(peer)
         remoteCustodyColumns =
           remoteNodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
-                                              remoteCustodySubnetCount))
+                                               remoteCustodySubnetCount))
 
       for local_column in localCustodyColumns:
         if local_column notin remoteCustodyColumns:


### PR DESCRIPTION
This PR adds `custody_subent_count` to both ENR and Metadata as corresponding field, in peerDAS, it helps peers to filer other peers from the peer pool as `full nodes` and `supernodes`.