### PR TITLE
Corrections of Spelling and Grammar Errors

### DIFF
--- a/docs/the_nimbus_book/src/audit.md
+++ b/docs/the_nimbus_book/src/audit.md
@@ -6,7 +6,7 @@ Nimbus has undergone an extensive multi-vendor ([ConsenSys Diligence](https://co
 During that process, we were notified of several issues within the codebase.
 These issues have been addressed, contributing significantly to the overall security of Nimbus and other applications that use its libraries.
 
-Additionally, as a result of the work done from our security vendors, we have incoroprated many new security processes and tooling to improve our ability to find security issues in the future.
+Additionally, as a result of the work done from our security vendors, we have incorporated many new security processes and tooling to improve our ability to find security issues in the future.
 
 For more information on the issues and how they were addressed, the interested reader should direct themselves to the [scoped repositories](https://github.com/status-im/nimbus-eth2/labels?q=audit); all reported issues and their mitigations are open to the public.
 

--- a/docs/the_nimbus_book/src/developers.md
+++ b/docs/the_nimbus_book/src/developers.md
@@ -53,7 +53,7 @@ The `stable` branch tracks the latest released version of Nimbus and is suitable
 mingw32-make # this first invocation will update the Git submodules
 ```
 
-You can now follow the instructions in this this book by replacing `make` with `mingw32-make` (you should run `mingw32` regardless of whether you're running 32-bit or 64-bit architecture):
+You can now follow the instructions in this book by replacing `make` with `mingw32-make` (you should run `mingw32` regardless of whether you're running 32-bit or 64-bit architecture):
 
 ```bash
 mingw32-make test # run the test suite

--- a/docs/the_nimbus_book/src/keep-an-eye.md
+++ b/docs/the_nimbus_book/src/keep-an-eye.md
@@ -19,7 +19,7 @@ To keep track of your sync progress, pay attention to the `Slot start` messages 
 
 ```
 INF 2022-06-16 13:23:11.008+02:00 Slot start
-  topics="beacnde"
+  topics="beacnode"
   slot=4046214
   epoch=126444
   sync="00h37m (99.38%) 11.0476slots/s (DDQQDDDPDD:4021215)"


### PR DESCRIPTION
1. docs/the_nimbus_book/src/audit.md
"incoroprated" виправлено на "incorporated".
2. docs/the_nimbus_book/src/developers.md
"this this" виправлено на "this".
3. docs/the_nimbus_book/src/keep-an-eye.md
"beacnde" виправлено на "beacnode".