### PR TITLE
fix: response checking from RequestManager for blobs

### DIFF
--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -10,6 +10,7 @@
 # Uncategorized helper functions from the spec
 
 import
+  std/sequtils,
   # Status libraries
   stew/[byteutils, endians2, objects],
   nimcrypto/sha2,
@@ -250,6 +251,24 @@ func create_blob_sidecars*(
       sidecar.kzg_commitment_inclusion_proof).expect("Valid gindex")
     res.add(sidecar)
   res
+
+func search_sidecar_identifier*(
+    data: seq[BlobIdentifier] | seq[DataColumnIdentifier], 
+    target: ref BlobSidecar | ref DataColumnSidecar): int =
+  var
+    low_pt = 0
+    high_pt = data.high
+
+  while low_pt <= high_pt:
+    let mid = (low_pt + high_pt) div 2
+    if data[mid].index == target.index:
+      return mid  # Target found at index `mid`
+    elif data[mid].index < target.index:
+      low_pt = mid + 1
+    else:
+      high_pt = mid - 1
+
+  -1  # Target not found
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/altair/light-client/sync-protocol.md#is_sync_committee_update
 template is_sync_committee_update*(update: SomeForkyLightClientUpdate): bool =

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -543,7 +543,6 @@ proc compute_execution_block_hash*(blck: ForkyBeaconBlock): Eth2Digest =
   rlpHash(blockToBlockHeader(blck)).to(Eth2Digest)
 
 from std/math import exp, ln
-from std/sequtils import foldl
 
 func ln_binomial(n, k: int): float64 =
   if k > n:

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -252,24 +252,6 @@ func create_blob_sidecars*(
     res.add(sidecar)
   res
 
-func search_sidecar_identifier*(
-    data: seq[BlobIdentifier] | seq[DataColumnIdentifier], 
-    target: ref BlobSidecar | ref DataColumnSidecar): int =
-  var
-    low_pt = 0
-    high_pt = data.high
-
-  while low_pt <= high_pt:
-    let mid = (low_pt + high_pt) div 2
-    if data[mid].index == target.index:
-      return mid  # Target found at index `mid`
-    elif data[mid].index < target.index:
-      low_pt = mid + 1
-    else:
-      high_pt = mid - 1
-
-  -1  # Target not found
-
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/altair/light-client/sync-protocol.md#is_sync_committee_update
 template is_sync_committee_update*(update: SomeForkyLightClientUpdate): bool =
   when update is SomeForkyLightClientUpdateWithSyncCommittee:

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -119,8 +119,7 @@ proc checkResponse(idList: seq[BlobIdentifier],
 
     # Check if the blob response is a subset
     if binarySearch(idList, blobs[i], cmpSidecarIdentifier) == -1:
-      i = if i != blobs.len - 1: i + 2 else: i + 1
-      continue
+      return false
 
     # Verify block_root and index match
     if id.block_root != block_root or id.index != blobs[i].index:

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -18,7 +18,7 @@ import
   "."/sync_protocol, "."/sync_manager,
   ../gossip_processing/block_processor
 
-from std/algorithm import binarySearch
+from std/algorithm import binarySearch, sort
 from ../beacon_clock import GetBeaconTimeFn
 export block_quarantine, sync_manager
 
@@ -203,6 +203,9 @@ proc requestBlocksByRoot(rman: RequestManager, items: seq[Eth2Digest]) {.async: 
     if not(isNil(peer)):
       rman.network.peerPool.release(peer)
 
+func cmpBlobIndexes(x, y: ref BlobSidecar): int =
+  cmp(x.index, y.index)
+
 proc fetchBlobsFromNetwork(self: RequestManager,
                            idList: seq[BlobIdentifier])
                            {.async: (raises: [CancelledError]).} =
@@ -216,8 +219,9 @@ proc fetchBlobsFromNetwork(self: RequestManager,
     let blobs = await blobSidecarsByRoot(peer, BlobIdentifierList idList)
 
     if blobs.isOk:
-      let ublobs = blobs.get()
-      if not checkResponse(idList, ublobs.asSeq()):
+      var ublobs = blobs.get().asSeq()
+      ublobs.sort(cmpBlobIndexes)
+      if not checkResponse(idList, ublobs):
         debug "Mismatched response to blobs by root",
           peer = peer, blobs = shortLog(idList), ublobs = len(ublobs)
         peer.updateScore(PeerScoreBadResponse)

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -104,19 +104,29 @@ proc checkResponse(roots: openArray[Eth2Digest],
 
 proc checkResponse(idList: seq[BlobIdentifier],
                    blobs: openArray[ref BlobSidecar]): bool =
-  if len(blobs) > len(idList):
+  if blobs.len > idList.len:
     return false
-  for blob in blobs:
-    let block_root = hash_tree_root(blob.signed_block_header.message)
-    var found = false
-    for id in idList:
-      if id.block_root == block_root and id.index == blob.index:
-        found = true
-        break
-    if not found:
+  
+  var i = 0
+  while i < blobs.len:
+    let
+      block_root = hash_tree_root(blobs[i].signed_block_header.message)
+      id = idList[i]
+    
+    # Check if the blob response is a subset
+    if search_sidecar_identifier(idList, blobs[i]) == -1:
+      i = if i != blobs.len - 1: i + 2 else: i + 1
+      continue
+
+    # Verify block_root and index match
+    if id.block_root != block_root or id.index != blobs[i].index:
       return false
-    blob[].verify_blob_sidecar_inclusion_proof().isOkOr:
+
+    # Verify inclusion proof
+    blobs[i][].verify_blob_sidecar_inclusion_proof().isOkOr:
       return false
+
+    inc i
   true
 
 proc requestBlocksByRoot(rman: RequestManager, items: seq[Eth2Digest]) {.async: (raises: [CancelledError]).} =

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -106,13 +106,13 @@ proc checkResponse(idList: seq[BlobIdentifier],
                    blobs: openArray[ref BlobSidecar]): bool =
   if blobs.len > idList.len:
     return false
-  
+
   var i = 0
   while i < blobs.len:
     let
       block_root = hash_tree_root(blobs[i].signed_block_header.message)
       id = idList[i]
-    
+
     # Check if the blob response is a subset
     if search_sidecar_identifier(idList, blobs[i]) == -1:
       i = if i != blobs.len - 1: i + 2 else: i + 1

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -18,6 +18,7 @@ import
   "."/sync_protocol, "."/sync_manager,
   ../gossip_processing/block_processor
 
+from std/algorithm import binarySearch
 from ../beacon_clock import GetBeaconTimeFn
 export block_quarantine, sync_manager
 
@@ -102,11 +103,14 @@ proc checkResponse(roots: openArray[Eth2Digest],
       checks.del(res)
   true
 
+func cmpSidecarIdentifier(x: BlobIdentifier | DataColumnIdentifier,
+                          y: ref BlobSidecar | ref DataColumnSidecar): int =
+  cmp(x.index, y.index)
+
 proc checkResponse(idList: seq[BlobIdentifier],
                    blobs: openArray[ref BlobSidecar]): bool =
   if blobs.len > idList.len:
     return false
-
   var i = 0
   while i < blobs.len:
     let
@@ -114,7 +118,7 @@ proc checkResponse(idList: seq[BlobIdentifier],
       id = idList[i]
 
     # Check if the blob response is a subset
-    if search_sidecar_identifier(idList, blobs[i]) == -1:
+    if binarySearch(idList, blobs[i], cmpSidecarIdentifier) == -1:
       i = if i != blobs.len - 1: i + 2 else: i + 1
       continue
 
@@ -125,7 +129,6 @@ proc checkResponse(idList: seq[BlobIdentifier],
     # Verify inclusion proof
     blobs[i][].verify_blob_sidecar_inclusion_proof().isOkOr:
       return false
-
     inc i
   true
 


### PR DESCRIPTION
Previously `checkResponse` for blobs could potentially return some erroneous results for certain values of `idList`. The algo went like:

```nim
proc checkResponse(idList: seq[BlobIdentifier],
                   blobs: openArray[ref BlobSidecar]): bool =
  if len(blobs) > len(idList):
    return false
  for blob in blobs:
    let block_root = hash_tree_root(blob.signed_block_header.message)
    var found = false
    for id in idList:
      if id.block_root == block_root and id.index == blob.index:
        found = true
        break
    if not found:
      return false
    blob[].verify_blob_sidecar_inclusion_proof().isOkOr:
      return false
  true
```

here, initially `found` is `false`, say we check the first elem of `idList`, we see it passes correctly through the `if` statement, we may see `found` as `true` and exit the inner loop, thereby NOT checking the other elements of the `idList`, `else` we straightway return `false`. hence, in any case we DON'T correctly iterate through `idList` and check it.

one simple attack, could be a situation where the seq of `BlobSidecar` has the correct inclusion proof, but any of the non 1st response element(s) is/are missing/incorrect, `checkResponse` regardless should still respond as `true`.

looking at all of this, here's an updated algo, this iterates through the `idList` and the responded seq using a common loop control variable, and efficiently jumps if only a subset of the request has been responded correctly, it performs this check using a binary search.

thereby, the final time complexity of this response checker drops from `O(n^2)` (if `idList` was correctly iterated), to `O(n log n)`. this optimization should be more relevant for data columns later as well, as we would often ask for columns in the order of 50-60 of them, if we were a supernode.