### PR TITLE
adds peerdas-supernode flag

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -254,9 +254,10 @@ type
       name: "subscribe-all-subnets" .}: bool
 
     peerdasSupernode* {.
+      hidden
       defaultValue: false,
       desc: "Subscribe to all column subnets, thereby becoming a peerdas supernode"
-      name: "peerdas-supernode" .}: bool
+      name: "debug-peerdas-supernode" .}: bool
 
     slashingDbKind* {.
       hidden

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -253,6 +253,11 @@ type
       desc: "Subscribe to all subnet topics when gossiping"
       name: "subscribe-all-subnets" .}: bool
 
+    peerdasSupernode* {.
+      defaultValue: false,
+      desc: "Subscribe to all column subnets, thereby becoming a peerdas supernode"
+      name: "peerdas-supernode" .}: bool
+
     slashingDbKind* {.
       hidden
       defaultValue: SlashingDbKind.v2

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -416,7 +416,7 @@ proc initFullNode(
       onElectraAttesterSlashingAdded))
     blobQuarantine = newClone(BlobQuarantine.init(onBlobSidecarAdded))
     dataColumnQuarantine = newClone(DataColumnQuarantine.init())
-    supernode = node.config.subscribeAllSubnets
+    supernode = node.config.peerdasSupernode
     localCustodySubnets =
       if supernode:
         DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint64
@@ -564,7 +564,7 @@ proc initFullNode(
     node.network.nodeId.get_custody_columns(max(SAMPLES_PER_SLOT.uint64,
                                                 localCustodySubnets))
 
-  if node.config.subscribeAllSubnets:
+  if node.config.peerdasSupernode:
     node.network.loadCscnetMetadataAndEnr(DATA_COLUMN_SIDECAR_SUBNET_COUNT.uint8)
   else:
     node.network.loadCscnetMetadataAndEnr(CUSTODY_REQUIREMENT.uint8)

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -25,8 +25,8 @@ type
   ProofBytes = array[fulu.CELLS_PER_EXT_BLOB, KzgProof]
 
 func sortedColumnIndices(columnsPerSubnet: ColumnIndex,
-                          subnetIds: HashSet[uint64]):
-                          seq[ColumnIndex] =
+                         subnetIds: HashSet[uint64]):
+                         seq[ColumnIndex] =
   var res: seq[ColumnIndex] = @[]
   for i in 0'u64 ..< columnsPerSubnet:
     for subnetId in subnetIds:
@@ -36,8 +36,8 @@ func sortedColumnIndices(columnsPerSubnet: ColumnIndex,
   res
 
 func sortedColumnIndexList(columnsPerSubnet: ColumnIndex,
-                            subnetIds: HashSet[uint64]):
-                            List[ColumnIndex, NUMBER_OF_COLUMNS] =
+                           subnetIds: HashSet[uint64]):
+                           List[ColumnIndex, NUMBER_OF_COLUMNS] =
   var
     res: seq[ColumnIndex]
   for i in 0'u64 ..< columnsPerSubnet:

--- a/beacon_chain/spec/eip7594_helpers.nim
+++ b/beacon_chain/spec/eip7594_helpers.nim
@@ -24,7 +24,7 @@ type
   CellBytes = array[fulu.CELLS_PER_EXT_BLOB, Cell]
   ProofBytes = array[fulu.CELLS_PER_EXT_BLOB, KzgProof]
 
-func sortedColumnIndices*(columnsPerSubnet: ColumnIndex,
+func sortedColumnIndices(columnsPerSubnet: ColumnIndex,
                           subnetIds: HashSet[uint64]):
                           seq[ColumnIndex] =
   var res: seq[ColumnIndex] = @[]
@@ -35,7 +35,7 @@ func sortedColumnIndices*(columnsPerSubnet: ColumnIndex,
   res.sort
   res
 
-func sortedColumnIndexList*(columnsPerSubnet: ColumnIndex,
+func sortedColumnIndexList(columnsPerSubnet: ColumnIndex,
                             subnetIds: HashSet[uint64]):
                             List[ColumnIndex, NUMBER_OF_COLUMNS] =
   var

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -10,7 +10,6 @@
 # Uncategorized helper functions from the spec
 
 import
-  std/sequtils,
   # Status libraries
   stew/[byteutils, endians2, objects],
   nimcrypto/sha2,
@@ -543,6 +542,7 @@ proc compute_execution_block_hash*(blck: ForkyBeaconBlock): Eth2Digest =
   rlpHash(blockToBlockHeader(blck)).to(Eth2Digest)
 
 from std/math import exp, ln
+from std/sequtils import foldl
 
 func ln_binomial(n, k: int): float64 =
   if k > n:


### PR DESCRIPTION
In order to measure resources efficiently it's beneficial to have a separate peerdas supernode flag, this is because if we launch a peerdas supernode on `subscribe-all-subnets`, then we also end up subscribing to all attnets and syncnets, which would thereby use of more resources to run the peerdas supernode.

