### PR TITLE
Corrected spelling and grammar mistakes

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -7,8 +7,8 @@ AllTests-mainnet
 OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Attestation pool electra processing [Preset: mainnet]
 ```diff
-+ Aggregated attestations with disjoint comittee bits into a single on-chain aggregate [Pres OK
-+ Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Pr OK
++ Aggregated attestations with disjoint committee bits into a single on-chain aggregate [Pres OK
++ Attestations with disjoint committee bits and equal data into single on-chain aggregate [Pr OK
 + Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
 + Working with electra aggregates [Preset: mainnet]                                          OK
 ```
@@ -693,7 +693,7 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
 OK: 4/4 Fail: 0/4 Skip: 0/4
-## Key spliting
+## Key splitting
 ```diff
 + k < n                                                                                      OK
 + k == n                                                                                     OK
@@ -848,7 +848,7 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Single remote                                                                              OK
 + Verifying Signer / Many remotes                                                            OK
 + Verifying Signer / Single remote                                                           OK
-+ vesion 1                                                                                   OK
++ version 1                                                                                   OK
 ```
 OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Serialization/deserialization [Beacon Node] [Preset: mainnet]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Nimbus `v24.12.0` is a `low-urgency` release.
 
 ### Improvements
 
-* Support `bootstrap_nodes.yaml` bootstrap node specificationn:
+* Support `bootstrap_nodes.yaml` bootstrap node specification:
   https://github.com/status-im/nimbus-eth2/pull/6751
 
 2024-11-29 v24.11.0

--- a/nfuzz/README.md
+++ b/nfuzz/README.md
@@ -19,7 +19,7 @@ make libnfuzz.a
 make libnfuzz.so
 ```
 
-Default, the library is build with the `minimal` config. To select a specific config you can instead run:
+Default, the library is built with the `minimal` config. To select a specific config you can instead run:
 ```bash
 # build with mainnet config
 make libnfuzz.a NIMFLAGS="-d:const_preset=mainnet"


### PR DESCRIPTION
This pull request addresses and corrects the following issues:

Corrected "comittee" to "committee."
Changed "spliting" to "splitting."
Fixed "vesion" to "version."
Corrected "specificationn" to "specification."
Changed "is build" to "is built."


I hope my corrections will be helpful and contribute to improving your work. Thank you for your dedication and effort.