### PR TITLE
chore: correct typos

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -37,7 +37,7 @@ type
     proc(data: electra.Attestation) {.gcsafe, raises: [].}
 
   Validation[CVBType] = object
-    ## Validations collect a set of signatures for a distict attestation - in
+    ## Validations collect a set of signatures for a distinct attestation - in
     ## eth2, a single bit is used to keep track of which signatures have been
     ## added to the aggregate meaning that only non-overlapping aggregates may
     ## be further combined.
@@ -1197,7 +1197,7 @@ proc selectOptimisticHead*(
 proc prune*(pool: var AttestationPool) =
   if (let v = pool.forkChoice.prune(); v.isErr):
     # If pruning fails, it's likely the result of a bug - this shouldn't happen
-    # but we'll keep running hoping that the fork chocie will recover eventually
+    # but we'll keep running hoping that the fork choice will recover eventually
     error "Couldn't prune fork choice, bug?", err = v.error()
 
 func validatorSeenAtEpoch*(pool: AttestationPool, epoch: Epoch,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -266,7 +266,7 @@ proc addHeadBlockWithParent*(
   var cache = StateCache()
 
   # We've verified that the slot of the new block is newer than that of the
-  # parent, so we should now be able to create an approriate clearance state
+  # parent, so we should now be able to create an appropriate clearance state
   # onto which we can apply the new block
   let clearanceBlock = BlockSlotId.init(parent.bid, signedBlock.message.slot)
   if not updateState(

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -224,7 +224,7 @@ func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): Opt[BlockSlotId] =
   template tryWithState(state: ForkedHashedBeaconState) =
     block:
       withState(state):
-        # State must be a descendent of the finalized chain to be viable
+        # State must be a descendant of the finalized chain to be viable
         let finBsi = forkyState.getBlockIdAtSlot(dag.finalizedHead.slot)
         if finBsi.isSome and  # DAG finalized bid slot wrong if CP not @ epoch
             finBsi.unsafeGet.bid.root == dag.finalizedHead.blck.bid.root:


### PR DESCRIPTION
###Description

This PR updates the wording in several README.md files for clarity:
- Fixed phrasing in `beacon_chain/consensus_object_pools/attestation_pool.nim`.
- Fixed phrasing in `beacon_chain/consensus_object_pools/block_clearance.nim`.
- Fixed phrasing in `beacon_chain/consensus_object_pools/blockchain_dag.nim`.
Only documentation improvements.Thanks