### PR TITLE
Fix: Update Nimble hash for new Nim version

### DIFF
--- a/.github/workflows/check-nim-hash.yml
+++ b/.github/workflows/check-nim-hash.yml
@@ -1,0 +1,19 @@
+name: Check Nim Hash
+on: 
+  pull_request:
+    paths:
+      - 'nix/nimble.nix'
+  push:
+    branches:
+      - stable
+      - testing
+
+jobs:
+  verify-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v20
+      - name: Verify Nim hash
+        run: |
+          nix-build nix/nimble.nix 

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -8,5 +8,5 @@ in pkgs.fetchFromGitHub {
   repo = "nimble";
   rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
-  hash = "sha256-sa0irAZjQRZLduEMBPf7sHlY1FigBJTR/vIH4ihii/w=";
+  hash = "sha256-MVHf19UbOWk8Zba2scj06PxdYYOJA6OXrVyDQ9Ku6Us=";
 }


### PR DESCRIPTION
## Changes
- Updated Nimble hash in `nix/nimble.nix` to match current Nim version
- Added CI workflow to automatically verify hash when `nimble.nix` is modified

## Details
- Fixed incorrect hash in `nix/nimble.nix`:
  ```diff
  -   hash = "sha256-sa0irAZjQRZLduEMBPf7sHlY1FigBJTR/vIH4ihii/w=";
  +   hash = "sha256-MVHf19UbOWk8Zba2scj06PxdYYOJA6OXrVyDQ9Ku6Us=";
  ```
- Added new workflow `.github/workflows/check-nim-hash.yml` for automatic hash verification on future updates

## Related issues
Fixes #6765

## Testing
- Verified locally using `nix-build nix/nimble.nix`
- CI workflow successfully verifies hash correctness