### PR TITLE
Fix typos and grammar in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Nimbus `v24.12.0` is a `low-urgency` release.
 
 ### Improvements
 
-* Support `bootstrap_nodes.yaml` bootstrap node specificationn:
+* Support `bootstrap_nodes.yaml` bootstrap node specification:
   https://github.com/status-im/nimbus-eth2/pull/6751
 
 2024-11-29 v24.11.0
@@ -2407,7 +2407,7 @@ It also brings further performance optimizations.
 * A new `slashingdb` sub-command with `import` and `export` options. This allows for
   safely migrating to Nimbus from another client (as per the [EIP-3076](https://eips.ethereum.org/EIPS/eip-3076)
   slashing protection interchange format).
-  Please see the the newly prepared [migration guides](https://nimbus.guide/migration.html) for the details.
+  Please see the newly prepared [migration guides](https://nimbus.guide/migration.html) for the details.
 
 * A new `ncli_db validatorPerf` command. This can be used to perform a textual
   report for the attestation performance of a particular validator

--- a/docs/the_nimbus_book/src/keep-an-eye.md
+++ b/docs/the_nimbus_book/src/keep-an-eye.md
@@ -53,4 +53,4 @@ The string of letters -- what we call the `sync worker map` (in the above case r
 ```
 
 !!! tip
-    You can also use you calls outlined in the [REST API page](./rest-api.md) to retrieve similar information.
+    You can also use the calls outlined in the [REST API page](./rest-api.md) to retrieve similar information.


### PR DESCRIPTION


Fixed several typos and grammatical issues in documentation to improve readability:

CHANGELOG.md:
- Support `bootstrap_nodes.yaml` bootstrap node specificationn:
+ Support `bootstrap_nodes.yaml` bootstrap node specification:
- Please see the the newly prepared [migration guides]
+ Please see the newly prepared [migration guides]

docs/the_nimbus_book/src/keep-an-eye.md:
- You can also use you calls outlined in the [REST API page]
+ You can also use the calls outlined in the [REST API page]


