### PR TITLE
fix: typos in documentation files

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -40,7 +40,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_amd64_archive
@@ -49,14 +49,14 @@ jobs:
             ./dist/nimbus-eth2_Linux_amd64_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_amd64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_amd64_checksum
@@ -94,7 +94,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm64_archive
@@ -103,14 +103,14 @@ jobs:
             ./dist/nimbus-eth2_Linux_arm64v8_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm64_checksum
@@ -148,7 +148,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm_archive
@@ -157,14 +157,14 @@ jobs:
             ./dist/nimbus-eth2_Linux_arm32v7_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Linux_arm_checksum
@@ -194,7 +194,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: Windows_amd64_archive
@@ -203,14 +203,14 @@ jobs:
             ./dist/nimbus-eth2_Windows_amd64_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Windows_amd64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: Windows_amd64_checksum
@@ -240,7 +240,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_amd64_archive
@@ -249,14 +249,14 @@ jobs:
             ./dist/nimbus-eth2_macOS_amd64_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_amd64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_amd64_checksum
@@ -286,7 +286,7 @@ jobs:
           echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
           echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
 
-      - name: Upload archive artefact
+      - name: Upload archive artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_arm64_archive
@@ -295,14 +295,14 @@ jobs:
             ./dist/nimbus-eth2_macOS_arm64_nightly_latest.tar.gz
           retention-days: 2
 
-      - name: Upload BN checksum artefact
+      - name: Upload BN checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_arm64_checksum
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
-      - name: Upload VC checksum artefact
+      - name: Upload VC checksum artifact
         uses: actions/upload-artifact@v3
         with:
           name: macOS_arm64_checksum
@@ -319,7 +319,7 @@ jobs:
         with:
           ref: unstable
 
-      - name: Download artefacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4.1.7
 
       - name: Create release notes
@@ -364,7 +364,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Delete artefacts
+      - name: Delete artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           failOnError: false

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -37,7 +37,7 @@ type
     proc(data: electra.Attestation) {.gcsafe, raises: [].}
 
   Validation[CVBType] = object
-    ## Validations collect a set of signatures for a distict attestation - in
+    ## Validations collect a set of signatures for a distinct attestation - in
     ## eth2, a single bit is used to keep track of which signatures have been
     ## added to the aggregate meaning that only non-overlapping aggregates may
     ## be further combined.
@@ -696,7 +696,7 @@ func score(
     doAssert aggregation_bits.len() == xxx[].len(),
       "check_attestation ensures committee length"
 
-    # How many votes were in the attestation minues the votes that are the same
+    # How many votes were in the attestation minus the votes that are the same
     return bitsScore - aggregation_bits.countOverlap(xxx[])
 
   # Not found in cache - fresh vote meaning all attestations count
@@ -958,7 +958,7 @@ proc getElectraAttestationsForBlock*(
 
       #TODO: Merge candidates per block structure with the candidates one
       # and score possible on-chain attestations while collecting candidates
-      # (previous loop) and reavaluate cache key definition
+      # (previous loop) and reevaluate cache key definition
       let
         entry2 = block:
           var e2 = entry.data
@@ -1197,7 +1197,7 @@ proc selectOptimisticHead*(
 proc prune*(pool: var AttestationPool) =
   if (let v = pool.forkChoice.prune(); v.isErr):
     # If pruning fails, it's likely the result of a bug - this shouldn't happen
-    # but we'll keep running hoping that the fork chocie will recover eventually
+    # but we'll keep running hoping that the fork choice will recover eventually
     error "Couldn't prune fork choice, bug?", err = v.error()
 
 func validatorSeenAtEpoch*(pool: AttestationPool, epoch: Epoch,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -266,7 +266,7 @@ proc addHeadBlockWithParent*(
   var cache = StateCache()
 
   # We've verified that the slot of the new block is newer than that of the
-  # parent, so we should now be able to create an approriate clearance state
+  # parent, so we should now be able to create an appropriate clearance state
   # onto which we can apply the new block
   let clearanceBlock = BlockSlotId.init(parent.bid, signedBlock.message.slot)
   if not updateState(

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -89,7 +89,7 @@ type
     ## instantiated: sync from genesis or checkpoint, and therefore, what
     ## features we can offer in terms of historical replay.
     ##
-    ## Beacuse the state transition is forwards-only, checkpoint sync generally
+    ## Because the state transition is forwards-only, checkpoint sync generally
     ## allows replaying states from that point onwards - anything earlier
     ## would require a backfill of blocks and a subsequent replay from genesis.
     ##

--- a/beacon_chain/gossip_processing/optimistic_processor.nim
+++ b/beacon_chain/gossip_processing/optimistic_processor.nim
@@ -94,7 +94,7 @@ proc processSignedBeaconBlock*(
   # Block validation is delegated to the sync committee and is done with delay.
   # If we forward invalid spam blocks, we may be disconnected + IP banned,
   # so we avoid accepting any blocks. Since we don't meaningfully contribute
-  # to the blocks gossip, we may also accummulate negative peer score over time.
+  # to the blocks gossip, we may also accumulate negative peer score over time.
   # However, we are actively contributing to other topics, so some of the
   # negative peer score may be offset through those different topics.
   # The practical impact depends on the actually deployed scoring heuristics.

--- a/beacon_chain/networking/network_metadata_downloads.nim
+++ b/beacon_chain/networking/network_metadata_downloads.nim
@@ -41,7 +41,7 @@ proc fetchGenesisBytes*(
     result = await downloadFile(genesisStateUrlOverride.get(parseUri metadata.genesis.url))
     # Under the built-in default URL, we serve a snappy-encoded BeaconState in order
     # to reduce the size of the downloaded file with roughly 50% (this precise ratio
-    # depends on the number of validator recors). The user is still free to provide
+    # depends on the number of validator records). The user is still free to provide
     # any URL which may serve an uncompressed state (e.g. a Beacon API endpoint)
     #
     # Since a SSZ-encoded BeaconState will start with a LittleEndian genesis time

--- a/docs/the_nimbus_book/src/audit.md
+++ b/docs/the_nimbus_book/src/audit.md
@@ -6,7 +6,7 @@ Nimbus has undergone an extensive multi-vendor ([ConsenSys Diligence](https://co
 During that process, we were notified of several issues within the codebase.
 These issues have been addressed, contributing significantly to the overall security of Nimbus and other applications that use its libraries.
 
-Additionally, as a result of the work done from our security vendors, we have incoroprated many new security processes and tooling to improve our ability to find security issues in the future.
+Additionally, as a result of the work done from our security vendors, we have incorporated many new security processes and tooling to improve our ability to find security issues in the future.
 
 For more information on the issues and how they were addressed, the interested reader should direct themselves to the [scoped repositories](https://github.com/status-im/nimbus-eth2/labels?q=audit); all reported issues and their mitigations are open to the public.
 

--- a/docs/the_nimbus_book/src/developers.md
+++ b/docs/the_nimbus_book/src/developers.md
@@ -51,7 +51,7 @@ The `stable` branch tracks the latest released version of Nimbus and is suitable
 mingw32-make # this first invocation will update the Git submodules
 ```
 
-You can now follow the instructions in this this book by replacing `make` with `mingw32-make` (you should run `mingw32` regardless of whether you're running 32-bit or 64-bit architecture):
+You can now follow the instructions in this book by replacing `make` with `mingw32-make` (you should run `mingw32` regardless of whether you're running 32-bit or 64-bit architecture):
 
 ```bash
 mingw32-make test # run the test suite


### PR DESCRIPTION
Corrected `artefact` to `artifact` x20
Corrected `distict` to `distinct`
Corrected `minues` to `minus`
Corrected `reavaluate` to `reevaluate`
Corrected `chocie` to `choice`
Corrected `approriate` to `appropriate`
Corrected `Beacuse` to `Because`
Corrected `accummulate` to `accumulate`
Corrected `recors` to `records`
Corrected `incoroprated` to `incorporated`
Corrected `instructions in this this book` to `instructions in this book`