### PR TITLE
update ShufflingRef version of get_attesting_indices to Electra v1.5.0-alpha.10

### DIFF
--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -162,7 +162,7 @@ programMain:
         db.putSyncCommittee(period, syncCommittee)
         db.putLatestFinalizedHeader(finalizedHeader)
 
-  var optimisticFcuFut: Future[(PayloadExecutionStatus, Opt[BlockHash])]
+  var optimisticFcuFut: Future[(PayloadExecutionStatus, Opt[Hash32])]
     .Raising([CancelledError])
   proc onOptimisticHeader(
       lightClient: LightClient, optimisticHeader: ForkedLightClientHeader) =

--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -7,10 +7,6 @@
 
 {.push raises: [].}
 
-# At the time of writing, the exact definitions of what should be used for
-# cryptography in the spec is in flux, with sizes and test vectors still being
-# hashed out. This layer helps isolate those chagnes.
-
 # BLS signatures can be combined such that multiple signatures are aggregated.
 # Each time a new signature is added, the corresponding public key must be
 # added to the verification key as well - if a key signs twice, it must be added

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -164,7 +164,7 @@ proc checkResponse(idList: seq[DataColumnIdentifier],
       block_root = hash_tree_root(columns[i].signed_block_header.message)
       id = idList[i]
 
-    # Check if the column reponse is a subset
+    # Check if the column response is a subset
     if binarySearch(idList, columns[i], cmpSidecarIdentifier) == -1:
       return false
 

--- a/docs/the_nimbus_book/src/validator-client-options.md
+++ b/docs/the_nimbus_book/src/validator-client-options.md
@@ -1,8 +1,8 @@
 # Validator client
 
-In the most simple setup, a single beacon node paired with an execution client is all that is needed to run a successful validator setup.
+In the simplest setup, a single beacon node paired with an execution client is all that is needed to run a successful validator setup.
 
-Nimbus however also provides options for running advanded setups that provide additional security and redundancy.
+Nimbus however also provides options for running advanced setups that provide additional security and redundancy.
 
 See the [validator client page](./validator-client.md) to get started!
 

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 import
   std/os,
   confutils,
@@ -45,9 +47,14 @@ type
       name: "out-dir" }: OutDir
 
 proc main =
-  let conf = load Config
+  let conf =
+    try:
+      load Config
+    except ConfigurationError:
+      error "Configuration error"
+      quit 1
   if conf.threshold == 0:
-    error "The specified treshold must be greater than zero"
+    error "The specified threshold must be greater than zero"
     quit 1
 
   if conf.remoteSignersUrls.len == 0:
@@ -55,7 +62,7 @@ proc main =
     quit 1
 
   if conf.threshold > conf.remoteSignersUrls.len.uint32:
-    error "The specified treshold must be lower or equal to the number of signers"
+    error "The specified threshold must be lower or equal to the number of signers"
     quit 1
 
   let rng = HmacDrbgContext.new()


### PR DESCRIPTION
`s/BlockHash/Hash32/` fixes a deprecation warning.