### PR TITLE
rm Nimbus book reference to import --method=single-salt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ TOOLS_CORE := \
 	ncli_testnet \
 	$(TOOLS_CORE_CUSTOMCOMPILE)
 
-# This TOOLS/TOOLS_CORE decomposition is a workaroud so nimbus_beacon_node can
+# The TOOLS/TOOLS_CORE decomposition is a workaround so nimbus_beacon_node can
 # build on its own, and if/when that becomes a non-issue, it can be recombined
 # to a single TOOLS list.
 TOOLS := $(TOOLS_CORE) nimbus_beacon_node

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -448,7 +448,7 @@ proc publishAttestationsAndAggregates(
       raise exc
 
   let aggregateTime =
-    # chronos.Duration substraction could not return negative value, in such
+    # chronos.Duration subtraction could not return negative value, in such
     # case it will return `ZeroDuration`.
     vc.beaconClock.durationToNextSlot() - OneThirdDuration
   if aggregateTime != ZeroDuration:
@@ -693,7 +693,7 @@ proc publishAttestationsAndAggregatesV2(
       raise exc
 
   let aggregateTime =
-    # chronos.Duration substraction could not return negative value, in such
+    # chronos.Duration subtraction could not return negative value, in such
     # case it will return `ZeroDuration`.
     vc.beaconClock.durationToNextSlot() - OneThirdDuration
   if aggregateTime != ZeroDuration:

--- a/docs/the_nimbus_book/src/run-a-validator.md
+++ b/docs/the_nimbus_book/src/run-a-validator.md
@@ -153,14 +153,6 @@ If your `validator_keys` folder is stored elsewhere, you can pass its location t
 Replacing `/path/to/keys` with the full pathname of where the `validator_keys` directory is found.
 
 
-### Optimized import for a large number of validators
-
-If you plan to use a large number of validators (e.g. more than 100) on a single beacon node or a validator client, you might benefit from running the `deposits import` command with the option `--method=single-salt`.
-This will force Nimbus to use the same password and random salt value when encrypting all of the imported keystores which will later enable it to load the large number of validator keys almost instantly.
-The theoretical downside of using this approach is that it makes the brute-force cracking of all imported keystores computationally equivalent to cracking just one of them.
-Nevertheless, the security parameters used by Ethereum are such that cracking even a single keystore is considered computationally infeasible with current hardware.
-
-
 ### Troubleshooting
 
 If you come across an error, make sure that:

--- a/nfuzz/libnfuzz.nim
+++ b/nfuzz/libnfuzz.nim
@@ -167,7 +167,7 @@ proc nfuzz_voluntary_exit(input: openArray[byte], xoutput: ptr byte,
 
 # Note: Could also accept raw input pointer and access list_size + seed here.
 # However, list_size needs to be known also outside this proc to allocate xoutput.
-# TODO: rework to copy immediatly in an uint8 openArray, considering we have to
+# TODO: rework to copy immediately in an uint8 openArray, considering we have to
 # go over the list anyhow?
 func nfuzz_shuffle(input_seed: ptr byte, xoutput: var openArray[uint64]): bool
     {.exportc, raises: [].} =

--- a/scripts/signers/web3signer.sh
+++ b/scripts/signers/web3signer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-# Copyright (c) 2023 Status Research & Development GmbH.
+# Copyright (c) 2023-2024 Status Research & Development GmbH.
 # Licensed under either of:
 # - Apache License, version 2.0
 # - MIT license
@@ -12,7 +12,7 @@ if ! command javac > /dev/null || ! javac -version > /dev/null; then
   # Instead, macOS ships with a stub executable that displays a message that
   # Java is not installed (javac -version exits with an error code 1).
   # If the user is running under these default settings, but a homebrew
-  # installation is disovered, we are happy to use it just in this script:
+  # installation is discovered, we are happy to use it just in this script:
   if [[ -d /opt/homebrew/opt/openjdk/bin ]]; then
     export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
   fi


### PR DESCRIPTION
A Trail of Bits audit of `ethstaker-deposit-cli` determined that reuse was cryptographically unsafe:
- https://github.com/eth-educators/ethstaker-deposit-cli/issues/238
- https://github.com/eth-educators/ethstaker-deposit-cli/security/advisories/GHSA-c6rv-g6pj-r6qx
- https://github.com/eth-educators/ethstaker-deposit-cli/releases/tag/v0.6.0

The functionality in Nimbus works fine, as far as it goes, but it implements a method now known to be less than ideally secure and not worth recommending in the guide.