### PR TITLE
fix broken discord link in docs

### DIFF
--- a/docs/the_nimbus_book/src/migration.md
+++ b/docs/the_nimbus_book/src/migration.md
@@ -188,6 +188,6 @@ For a quick guide on how to set up a systemd service, see [our systemd guide](./
 
 ## Final thoughts
 
-If you are unsure of the safety of a step, please get in touch with us directly on [discord](https://discord.gg/nnNEBvHu3m).
+If you are unsure of the safety of a step, please get in touch with us directly on [discord](https://discord.gg/XRxWahP).
 Additionally, we recommend testing the migration works correctly on a testnet before going ahead on mainnet.
 


### PR DESCRIPTION
Fixed a broken discord link (https://discord.gg/nnNEBvHu3m) in the migrating page of the docs and replaced it with [the discord link from the README](https://github.com/status-im/nimbus-eth2/blob/stable/README.md?plain=1#L7)