### PR TITLE
assert submodules are available to Nix derivation

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,6 +16,10 @@
   ],
 }:
 
+# The 'or' is to handle src fallback to ../. which lack submodules attribue.
+assert pkgs.lib.assertMsg ((src.submodules or true) == true)
+  "Unable to build without submodules. Append '?submodules=1#' to the URI.";
+
 let
   inherit (pkgs) stdenv lib writeScriptBin callPackage;
 


### PR DESCRIPTION
This should result in a human-readable error when `?submodules=1#` is not appended to the project URL as the README explains:
```
 > nix build '.'
       error: Unable to build without submodules. Append '?submodules=1#' to the URL.

 > nix build '.?submodules=1#'
```