### PR TITLE
fix: keeping `MAX_REQUEST_BLOB_SIDECARS` limit higher upto electra, so that deneb limits can also be sufficed under one version (v1)

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -89,7 +89,7 @@ type
   BeaconBlocksRes =
     NetRes[List[ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS]]
   BlobSidecarsRes =
-    NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)]]
+    NetRes[List[ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS_ELECTRA)]]
 
   SyncBlockData* = object
     blocks*: seq[ref ForkedSignedBeaconBlock]

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -338,7 +338,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       blobIds: BlobIdentifierList,
       response: MultipleChunksResponse[
-        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
+        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS_ELECTRA)])
       {.async, libp2pProtocol("blob_sidecars_by_root", 1).} =
     # TODO Semantically, this request should return a non-ref, but doing so
     #      runs into extreme inefficiency due to the compiler introducing
@@ -360,7 +360,7 @@ p2pProtocol BeaconSync(version = 1,
       startSlot: Slot,
       reqCount: uint64,
       response: MultipleChunksResponse[
-        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS)])
+        ref BlobSidecar, Limit(MAX_REQUEST_BLOB_SIDECARS_ELECTRA)])
       {.async, libp2pProtocol("blob_sidecars_by_range", 1).} =
     # TODO This code is more complicated than it needs to be, since the type
     #      of the multiple chunks response is not actually used in this server
@@ -372,7 +372,7 @@ p2pProtocol BeaconSync(version = 1,
     #      are `not-nil` in the implementation
     getBlobSidecarsByRange(
       "1", peer, peer.networkState.dag, response, startSlot, reqCount,
-      MAX_BLOBS_PER_BLOCK, MAX_REQUEST_BLOB_SIDECARS)
+      MAX_BLOBS_PER_BLOCK, MAX_REQUEST_BLOB_SIDECARS_ELECTRA)
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1
   proc dataColumnSidecarsByRoot(


### PR DESCRIPTION
This would avoid significant design complications which could have potentially involved baking in the `BeaconClock` in SyncProtocol to identify which fork do we currently lie on.