### PR TITLE
make Nimbus Nim 2.2-compatible

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -994,7 +994,7 @@ proc init*(T: type BeaconNode,
     withState(dag.headState):
       getValidator(forkyState().data.validators.asSeq(), pubkey)
 
-  func getCapellaForkVersion(): Opt[Version] =
+  func getCapellaForkVersion(): Opt[presets.Version] =
     Opt.some(cfg.CAPELLA_FORK_VERSION)
 
   func getDenebForkEpoch(): Opt[Epoch] =

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -606,7 +606,7 @@ proc makeBeaconBlockForHeadAndSlot*(
       slot, head = shortLog(head), error
     $error
 
-  var blobsBundleOpt = Opt.none(BlobsBundle)
+  var blobsBundleOpt = Opt.none(deneb.BlobsBundle)
   when typeof(payload).kind >= ConsensusFork.Deneb:
     blobsBundleOpt = Opt.some(payload.blobsBundle)
 


### PR DESCRIPTION
`make test && make` works with:
```
Nim Compiler Version 2.2.1 [Linux: amd64]
Compiled at 2025-01-23
Copyright (c) 2006-2025 by Andreas Rumpf

git hash: 12347eae74dbaa0e4dd99691e3a4509e8fe8b265
active boot switches: -d:release
```