### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,10 +1,10 @@
 beacon_chain is licensed under the MIT License
-Copyright (c) 2018 Status Research & Development GmbH
+Copyright (c) 2025 Status Research & Development GmbH
 -----------------------------------------------------
 
 The MIT License (MIT)
 
-Copyright (c) 2018 Status Research & Development GmbH
+Copyright (c) 2025 Status Research & Development GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2018 to 2025 in the LICENSE file.