### PR TITLE
Eliminate sporadic quit() calls.

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -19,7 +19,8 @@ import
           eth2_merkleization,
           forks,
           presets,
-          state_transition],
+          state_transition,
+          defects],
   "."/[beacon_chain_db_light_client, filepath]
 
 from ./spec/datatypes/capella import BeaconState
@@ -648,11 +649,10 @@ proc new*(T: type BeaconChainDB,
       SqStoreRef.init("", "test", readOnly = readOnly, inMemory = true).expect(
         "working database (out of memory?)")
     else:
-      if (let res = secureCreatePath(dir); res.isErr):
-        let msg =
-          "Failed to create create database directory, reason: " &
-          ioErrorMsg(res.error)
-        raise (ref ResultDefect)(msg: msg)
+      secureCreatePath(dir).isOkOr:
+        const msg = "Failed to create create database directory"
+        fatal msg, path = dir, err = ioErrorMsg(error)
+        raiseDatabaseDefect(msg)
 
       SqStoreRef.init(
         dir, "nbc", readOnly = readOnly, manualCheckpoint = true).expectDb()

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -650,9 +650,9 @@ proc new*(T: type BeaconChainDB,
         "working database (out of memory?)")
     else:
       secureCreatePath(dir).isOkOr:
-        const msg = "Failed to create create database directory"
-        fatal msg, path = dir, err = ioErrorMsg(error)
-        raiseDatabaseDefect(msg)
+        fatal "Failed to create create database directory", path = dir,
+              reason = ioErrorMsg(error)
+        raiseDatabaseDefect()
 
       SqStoreRef.init(
         dir, "nbc", readOnly = readOnly, manualCheckpoint = true).expectDb()

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -649,9 +649,10 @@ proc new*(T: type BeaconChainDB,
         "working database (out of memory?)")
     else:
       if (let res = secureCreatePath(dir); res.isErr):
-        fatal "Failed to create create database directory",
-          path = dir, err = ioErrorMsg(res.error)
-        quit 1
+        let msg =
+          "Failed to create create database directory, reason: " &
+          ioErrorMsg(res.error)
+        raise (ref ResultDefect)(msg: msg)
 
       SqStoreRef.init(
         dir, "nbc", readOnly = readOnly, manualCheckpoint = true).expectDb()

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1414,7 +1414,9 @@ proc readValue*(r: var TomlReader, a: var Address)
   except CatchableError:
     r.raiseUnexpectedValue("string expected")
 
-proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
+proc loadEth2Network*(
+    eth2Network: Option[string]
+): Result[Eth2NetworkMetadata, string] =
   const defaultName =
     when const_preset == "gnosis":
       "gnosis"
@@ -1422,22 +1424,24 @@ proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
       "mainnet"
     else:
       "(unspecified)"
+
   network_name.set(2, labelValues = [eth2Network.get(otherwise = defaultName)])
 
   if eth2Network.isSome:
-    getMetadataForNetwork(eth2Network.get)
+    ok(getMetadataForNetwork(eth2Network.get))
   else:
     when const_preset == "gnosis":
-      getMetadataForNetwork("gnosis")
+      ok(getMetadataForNetwork("gnosis"))
     elif const_preset == "mainnet":
-      getMetadataForNetwork("mainnet")
+      ok(getMetadataForNetwork("mainnet"))
     else:
       # Presumably other configurations can have other defaults, but for now
       # this simplifies the flow
-      fatal "Must specify network on non-mainnet node"
-      quit 1
+      err("Must specify network on non-mainnet node")
 
-template loadEth2Network*(config: BeaconNodeConf): Eth2NetworkMetadata =
+template loadEth2Network*(
+    config: BeaconNodeConf
+): Result[Eth2NetworkMetadata, string] =
   loadEth2Network(config.eth2Network)
 
 func defaultFeeRecipient*(conf: AnyConf): Opt[Eth1Address] =
@@ -1457,19 +1461,15 @@ proc loadJwtSecret(
     rng: var HmacDrbgContext,
     dataDir: string,
     jwtSecret: Opt[InputFile],
-    allowCreate: bool): Opt[seq[byte]] =
+    allowCreate: bool
+): Result[seq[byte], string] =
   # Some Web3 endpoints aren't compatible with JWT, but if explicitly chosen,
   # use it regardless.
   if jwtSecret.isSome or allowCreate:
-    let secret = rng.checkJwtSecret(dataDir, jwtSecret)
-    if secret.isErr:
-      fatal "Specified a JWT secret file which couldn't be loaded",
-        err = secret.error
-      quit 1
-
-    Opt.some secret.get
+    let secret = ? rng.checkJwtSecret(dataDir, jwtSecret)
+    ok(secret)
   else:
-    Opt.none seq[byte]
+    ok(default(seq[byte]))
 
 func configJwtSecretOpt*(jwtSecret: Option[InputFile]): Opt[InputFile] =
   if jwtSecret.isSome:
@@ -1480,20 +1480,24 @@ func configJwtSecretOpt*(jwtSecret: Option[InputFile]): Opt[InputFile] =
 proc loadJwtSecret*(
     rng: var HmacDrbgContext,
     config: BeaconNodeConf,
-    allowCreate: bool): Opt[seq[byte]] =
+    allowCreate: bool
+): Result[seq[byte], string] =
   rng.loadJwtSecret(
     string(config.dataDir), config.jwtSecret.configJwtSecretOpt, allowCreate)
 
-proc engineApiUrls*(config: BeaconNodeConf): seq[EngineApiUrl] =
-  let elUrls = if config.noEl:
-    return newSeq[EngineApiUrl]()
-  elif config.elUrls.len == 0 and config.web3Urls.len == 0:
-    @[getDefaultEngineApiUrl(config.jwtSecret)]
-  else:
-    config.elUrls
+proc engineApiUrls*(
+    config: BeaconNodeConf
+): Result[seq[EngineApiUrl], string] =
+  let elUrls =
+    if config.noEl:
+      return ok(default(seq[EngineApiUrl]))
+    elif config.elUrls.len == 0 and config.web3Urls.len == 0:
+      @[getDefaultEngineApiUrl(config.jwtSecret)]
+    else:
+      config.elUrls
 
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(
-    config.jwtSecret.configJwtSecretOpt)
+  toFinalEngineApiUrls(elUrls & config.web3Urls,
+                       config.jwtSecret.configJwtSecretOpt)
 
 proc loadKzgTrustedSetup*(): Result[void, string] =
   static: doAssert const_preset in ["mainnet", "gnosis", "minimal"]

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -155,16 +155,20 @@ template databaseDir*(config: LightClientConf): string =
 template loadJwtSecret*(
     rng: var HmacDrbgContext,
     config: LightClientConf,
-    allowCreate: bool): Option[seq[byte]] =
+    allowCreate: bool
+): Result[seq[byte], string] =
   rng.loadJwtSecret(string(config.dataDir), config.jwtSecret, allowCreate)
 
-proc engineApiUrls*(config: LightClientConf): seq[EngineApiUrl] =
-  let elUrls = if config.noEl:
-    return newSeq[EngineApiUrl]()
-  elif config.elUrls.len == 0 and config.web3Urls.len == 0:
-    @[getDefaultEngineApiUrl(config.jwtSecret)]
-  else:
-    config.elUrls
+proc engineApiUrls*(
+    config: LightClientConf
+): Result[seq[EngineApiUrl], string] =
+  let elUrls =
+    if config.noEl:
+      return ok(default(seq[EngineApiUrl]))
+    elif config.elUrls.len == 0 and config.web3Urls.len == 0:
+      @[getDefaultEngineApiUrl(config.jwtSecret)]
+    else:
+      config.elUrls
 
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(
-    config.jwtSecret.configJwtSecretOpt)
+  toFinalEngineApiUrls(elUrls & config.web3Urls,
+                       config.jwtSecret.configJwtSecretOpt)

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -14,7 +14,7 @@ import
   stew/assign2,
   ../spec/[
     beaconstate, forks, signatures, signatures_batch,
-    state_transition, state_transition_epoch],
+    state_transition, state_transition_epoch, defects],
   "."/[block_pools_types, block_dag, blockchain_dag,
        blockchain_dag_light_client]
 
@@ -357,7 +357,7 @@ proc addBackfillBlock*(
           fatal "Invalid proposer in backfill block - checkpoint state corrupt?",
             head = shortLog(dag.head), tail = shortLog(dag.tail)
 
-          quit 1
+          raiseClearanceDefect("Checkpoint state corruption")
 
         if not verify_block_signature(
             dag.forkAtEpoch(blck.slot.epoch),
@@ -413,7 +413,7 @@ proc addBackfillBlock*(
         # swapped or something?).
         fatal "Checkpoint given during initial startup inconsistent with genesis block - wrong network used when starting the node?",
           tail = shortLog(dag.tail), head = shortLog(dag.head)
-        quit 1
+        raiseClearanceDefect("Wrong network used")
 
       # Signal that we're done by resetting backfill
       reset(dag.backfill)

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -12,7 +12,7 @@ import
   stew/[arrayops, assign2, byteutils],
   chronos, metrics, results, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
-    state_transition, validator],
+    state_transition, validator, defects],
   ../spec/forks,
   ".."/[beacon_chain_db, beacon_clock, era_db],
   "."/[block_pools_types, block_quarantine]
@@ -1123,9 +1123,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
           headBlocks.add curRef
         else:
           if headBlocks.len > 0:
-            fatal "Missing block needed to create head state, database corrupt?",
-              curRef = shortLog(curRef)
-            quit 1
+            const msg =
+              "Missing block needed to create head state, database corrupt?"
+            fatal msg, curRef = shortLog(curRef)
+            raiseDagDefect(msg)
           # Without the block data we can't form a state for this root, so
           # we'll need to move the head back
           headRef = nil
@@ -1139,9 +1140,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   if not foundHeadState:
     if not dag.getStateByParent(curRef.bid, dag.headState):
-      fatal "Could not load head state, database corrupt?",
-        head = shortLog(head), tail = shortLog(dag.tail)
-      quit 1
+      const msg = "Could not load head state, database corrupt?"
+      fatal msg, head = shortLog(head), tail = shortLog(dag.tail)
+      raiseDagDefect(msg)
 
   block:
     # EpochRef needs an epoch boundary state
@@ -1190,9 +1191,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # regular hard-fork upgrades. See for example:
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#testing
   if stateFork.current_version != configFork.current_version:
-    error "State from database does not match network, check --network parameter",
-      tail = dag.tail, headRef, stateFork, configFork
-    quit 1
+    const msg =
+      "State from database does not match network, check --network parameter"
+    fatal msg, tail = dag.tail, headRef, stateFork, configFork
+    raiseDagDefect(msg)
 
   # Need to load state to find genesis validators root, before loading era db
   dag.era = EraDB.new(
@@ -1242,10 +1244,11 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     let finalized = db.finalizedBlocks.get(db.finalizedBlocks.high.get()).expect(
       "tail at least")
     if finalized != dag.finalizedHead.blck.root:
-      error "Head does not lead to finalized block, database corrupt?",
-        head = shortLog(head), finalizedHead = shortLog(dag.finalizedHead),
-        tail = shortLog(dag.tail), finalized = shortLog(finalized)
-      quit 1
+      const msg = "Head does not lead to finalized block, database corrupt?"
+      fatal msg, head = shortLog(head),
+            finalizedHead = shortLog(dag.finalizedHead),
+            tail = shortLog(dag.tail), finalized = shortLog(finalized)
+      raiseDagDefect(msg)
 
   dag.backfill = block:
     let backfillSlot = db.finalizedBlocks.low.expect("tail at least")
@@ -1298,9 +1301,11 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
           (bid.slot == backfillSlot and bid.root != dag.tail.root):
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
-        fatal "Era summaries don't lead up to backfill, database or era files corrupt?",
-          bid, backfillSlot
-        quit 1
+        const msg =
+          "Era summaries don't lead up to backfill, database or era files " &
+          "corrupt?"
+        fatal msg, bid, backfillSlot
+        raiseDagDefect(msg)
 
       # In BeaconState.block_roots, empty slots are filled with the root of
       # the previous block - in our data structure, we use a zero hash instead
@@ -2405,9 +2410,10 @@ proc updateHead*(
     # implicitly finalised, the head is an ancestor of the tail and we always
     # store the tail state in the database, as well as every epoch slot state in
     # between
-    fatal "Unable to load head state during head update, database corrupt?",
-      lastHead = shortLog(lastHead)
-    quit 1
+    const msg =
+      "Unable to load head state during head update, database corrupt?"
+    fatal msg, lastHead = shortLog(lastHead)
+    raiseDagDefect(msg)
 
   dag.head = newHead
 
@@ -2819,9 +2825,11 @@ proc rebuildIndex*(dag: ChainDAGRef) =
         if not dag.db.getState(
             dag.cfg.consensusForkAtEpoch(slot.epoch), state_root, state[],
             noRollback):
-          fatal "Cannot load state, database corrupt or created for a different network?",
-            state_root, slot
-          quit 1
+          const msg =
+            "Cannot load state, database corrupt or created for a different " &
+            "network?"
+          fatal msg, state_root, slot
+          raiseDagDefect(msg)
         tailBid = Opt.some state[].latest_block_id()
 
       continue

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1123,10 +1123,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
           headBlocks.add curRef
         else:
           if headBlocks.len > 0:
-            const msg =
-              "Missing block needed to create head state, database corrupt?"
-            fatal msg, curRef = shortLog(curRef)
-            raiseDagDefect(msg)
+            fatal "Missing block needed to create head state, database corrupt?",
+                  curRef = shortLog(curRef)
+            raiseDagDefect()
           # Without the block data we can't form a state for this root, so
           # we'll need to move the head back
           headRef = nil
@@ -1140,9 +1139,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   if not foundHeadState:
     if not dag.getStateByParent(curRef.bid, dag.headState):
-      const msg = "Could not load head state, database corrupt?"
-      fatal msg, head = shortLog(head), tail = shortLog(dag.tail)
-      raiseDagDefect(msg)
+      fatal "Could not load head state, database corrupt?",
+            head = shortLog(head), tail = shortLog(dag.tail)
+      raiseDagDefect()
 
   block:
     # EpochRef needs an epoch boundary state
@@ -1191,10 +1190,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # regular hard-fork upgrades. See for example:
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#testing
   if stateFork.current_version != configFork.current_version:
-    const msg =
-      "State from database does not match network, check --network parameter"
-    fatal msg, tail = dag.tail, headRef, stateFork, configFork
-    raiseDagDefect(msg)
+    fatal "State from database does not match network, check --network parameter",
+          tail = dag.tail, headRef, stateFork, configFork
+    raiseDagDefect()
 
   # Need to load state to find genesis validators root, before loading era db
   dag.era = EraDB.new(
@@ -1244,11 +1242,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     let finalized = db.finalizedBlocks.get(db.finalizedBlocks.high.get()).expect(
       "tail at least")
     if finalized != dag.finalizedHead.blck.root:
-      const msg = "Head does not lead to finalized block, database corrupt?"
-      fatal msg, head = shortLog(head),
-            finalizedHead = shortLog(dag.finalizedHead),
+      fatal "Head does not lead to finalized block, database corrupt?",
+            head = shortLog(head), finalizedHead = shortLog(dag.finalizedHead),
             tail = shortLog(dag.tail), finalized = shortLog(finalized)
-      raiseDagDefect(msg)
+      raiseDagDefect()
 
   dag.backfill = block:
     let backfillSlot = db.finalizedBlocks.low.expect("tail at least")
@@ -1301,11 +1298,9 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
           (bid.slot == backfillSlot and bid.root != dag.tail.root):
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
-        const msg =
-          "Era summaries don't lead up to backfill, database or era files " &
-          "corrupt?"
-        fatal msg, bid, backfillSlot
-        raiseDagDefect(msg)
+        fatal "Era summaries don't lead up to backfill, database or era files corrupt?",
+              bid, backfillSlot
+        raiseDagDefect()
 
       # In BeaconState.block_roots, empty slots are filled with the root of
       # the previous block - in our data structure, we use a zero hash instead
@@ -2410,10 +2405,9 @@ proc updateHead*(
     # implicitly finalised, the head is an ancestor of the tail and we always
     # store the tail state in the database, as well as every epoch slot state in
     # between
-    const msg =
-      "Unable to load head state during head update, database corrupt?"
-    fatal msg, lastHead = shortLog(lastHead)
-    raiseDagDefect(msg)
+    fatal "Unable to load head state during head update, database corrupt?",
+          lastHead = shortLog(lastHead)
+    raiseDagDefect()
 
   dag.head = newHead
 
@@ -2825,11 +2819,9 @@ proc rebuildIndex*(dag: ChainDAGRef) =
         if not dag.db.getState(
             dag.cfg.consensusForkAtEpoch(slot.epoch), state_root, state[],
             noRollback):
-          const msg =
-            "Cannot load state, database corrupt or created for a different " &
-            "network?"
-          fatal msg, state_root, slot
-          raiseDagDefect(msg)
+          fatal "Cannot load state, database corrupt or created for a different network?",
+                state_root, slot
+          raiseDagDefect()
         tailBid = Opt.some state[].latest_block_id()
 
       continue

--- a/beacon_chain/consensus_object_pools/blockchain_list.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_list.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/blockchain_list.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_list.nim
@@ -42,9 +42,9 @@ proc init*(T: type ChainListRef, directory: string): ChainListRef =
         let
           flags = {ChainFileFlag.Repair}
           res = ChainFileHandle.init(filename, flags).valueOr:
-            const msg = "Unexpected failure while loading backfill data"
-            fatal msg, filename = filename, reason = error
-            raiseChainListDefect(msg)
+            fatal "Unexpected failure while loading backfill data",
+                  filename = filename, reason = error
+            raiseChainListDefect()
         Opt.some(res)
   ChainListRef(path: directory, handle: handle)
 
@@ -185,9 +185,9 @@ proc addBackfillBlockData*(
     let storeBlockTick = Moment.now()
 
     store(clist, signedBlock, blobsOpt).isOkOr:
-      const msg = "Unexpected failure while trying to store data"
-      fatal msg, filename = chainFilePath(clist.path), reason = error
-      raiseChainListDefect(msg)
+      fatal "Unexpected failure while trying to store data",
+            filename = chainFilePath(clist.path), reason = error
+      raiseChainListDefect()
 
     let bdata = BlockData(blck: signedBlock, blob: blobsOpt)
     clist.setTail(bdata)
@@ -222,9 +222,9 @@ proc addBackfillBlockData*(
   let storeBlockTick = Moment.now()
 
   store(clist, signedBlock, blobsOpt).isOkOr:
-    const msg = "Unexpected failure while trying to store data"
-    fatal msg, filename = chainFilePath(clist.path), reason = error
-    raiseChainListDefect(msg)
+    fatal "Unexpected failure while trying to store data",
+          filename = chainFilePath(clist.path), reason = error
+    raiseChainListDefect()
 
   debug "Block backfilled",
         verify_block_duration = shortLog(storeBlockTick - verifyBlockTick),

--- a/beacon_chain/consensus_object_pools/blockchain_list.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_list.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import std/sequtils, stew/io2, chronicles, chronos, metrics,
-       ../spec/forks,
+       ../spec/[forks, defects],
        ../[beacon_chain_file, beacon_clock],
        ../sszdump
 
@@ -41,12 +41,11 @@ proc init*(T: type ChainListRef, directory: string): ChainListRef =
       else:
         let
           flags = {ChainFileFlag.Repair}
-          res = ChainFileHandle.init(filename, flags)
-        if res.isErr():
-          fatal "Unexpected failure while loading backfill data",
-                filename = filename, reason = res.error
-          quit 1
-        Opt.some(res.get())
+          res = ChainFileHandle.init(filename, flags).valueOr:
+            const msg = "Unexpected failure while loading backfill data"
+            fatal msg, filename = filename, reason = error
+            raiseChainListDefect(msg)
+        Opt.some(res)
   ChainListRef(path: directory, handle: handle)
 
 proc init*(T: type ChainListRef, directory: string,
@@ -186,9 +185,9 @@ proc addBackfillBlockData*(
     let storeBlockTick = Moment.now()
 
     store(clist, signedBlock, blobsOpt).isOkOr:
-      fatal "Unexpected failure while trying to store data",
-            filename = chainFilePath(clist.path), reason = error
-      quit 1
+      const msg = "Unexpected failure while trying to store data"
+      fatal msg, filename = chainFilePath(clist.path), reason = error
+      raiseChainListDefect(msg)
 
     let bdata = BlockData(blck: signedBlock, blob: blobsOpt)
     clist.setTail(bdata)
@@ -223,9 +222,9 @@ proc addBackfillBlockData*(
   let storeBlockTick = Moment.now()
 
   store(clist, signedBlock, blobsOpt).isOkOr:
-    fatal "Unexpected failure while trying to store data",
-           filename = chainFilePath(clist.path), reason = error
-    quit 1
+    const msg = "Unexpected failure while trying to store data"
+    fatal msg, filename = chainFilePath(clist.path), reason = error
+    raiseChainListDefect(msg)
 
   debug "Block backfilled",
         verify_block_duration = shortLog(storeBlockTick - verifyBlockTick),

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -12,7 +12,7 @@ import
   stew/[byteutils, base10],
   chronicles,
   ./spec/eth2_apis/rest_beacon_client,
-  ./spec/signatures,
+  ./spec/[signatures, defects],
   ./validators/keystore_management,
   "."/[conf, beacon_clock, filepath]
 
@@ -58,7 +58,7 @@ proc getSignedExitMessage(
         echo "The validator keystores directory '" & validatorsDir &
              "' does not contain a keystore for the selected validator " &
              "with public key '" & validatorKeyAsStr & "'."
-        quit 1
+        raiseDepositsDefect()
 
       let signingItem = loadKeystore(
         validatorsDir,
@@ -69,7 +69,7 @@ proc getSignedExitMessage(
 
       if signingItem.isNone:
         fatal "Unable to continue without decrypted signing key"
-        quit 1
+        raiseDepositsDefect()
 
       signingItem.get().privateKey
 
@@ -101,7 +101,7 @@ proc askForExitConfirmation(): ClientExitAction =
       stdin.readLine()
     except IOError:
       fatal "Failed to read user input from stdin"
-      quit 1
+      raiseDepositsDefect()
 
   echoP "PLEASE BEWARE!"
 
@@ -188,7 +188,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
       let validatorStorage = decryptor.getValidator(pubkey).valueOr:
         fatal "Incorrect validator index, key or keystore path specified",
               value = pubkey, reason = error
-        quit 1
+        raiseDepositsDefect()
       validators.add validatorStorage
 
   let genesis = try:
@@ -205,13 +205,13 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   except CatchableError as exc:
     fatal "Failed to obtain the genesis validators root of the network",
            reason = exc.msg
-    quit 1
+    raiseDepositsDefect()
 
   let currentEpoch = block:
     let
       beaconClock = BeaconClock.init(genesis.genesis_time).valueOr:
-        error "Server returned invalid genesis time", genesis
-        quit 1
+        fatal "Server returned invalid genesis time", genesis
+        raiseDepositsDefect()
 
       time = getTime()
       slot = beaconClock.toSlot(time).slot
@@ -236,7 +236,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   except CatchableError as exc:
     fatal "Failed to obtain the fork id of the head state",
            reason = exc.msg
-    quit 1
+    raiseDepositsDefect()
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/beacon-chain.md#voluntary-exits
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.0/specs/deneb/beacon-chain.md#modified-process_voluntary_exit
@@ -267,7 +267,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   except CatchableError as exc:
     fatal "Failed to obtain the config spec of the beacon node",
            reason = exc.msg
-    quit 1
+    raiseDepositsDefect()
 
   debug "Signing fork obtained", fork, signingFork
 
@@ -293,7 +293,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
         raiseGenericError(response)
     except CatchableError as exc:
       fatal "Failed to obtain information for validator", reason = exc.msg
-      quit 1
+      raiseDepositsDefect()
 
     let
       validatorIdx = restValidator.index.uint64
@@ -360,7 +360,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
         hadErrors = true
 
   if hadErrors:
-    quit 1
+    raiseDepositsDefect()
 
 proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
   await restValidatorExit(config)
@@ -371,10 +371,10 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
   of DepositsCmd.createTestnetDeposits:
     if config.eth2Network.isNone:
       fatal "Please specify the intended testnet for the deposits"
-      quit 1
+      raiseDepositsDefect()
     let metadata = config.loadEth2Network().valueOr:
       fatal "Unable to get network metadata", reason = error
-      quit 1
+      raiseDepositsDefect()
     var seed: KeySeed
     defer: burnMem(seed)
     var walletPath: WalletPathPair
@@ -384,27 +384,27 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
         id = config.existingWalletId.get
         found = findWallet(config, id).valueOr:
           fatal "Failed to locate wallet", error = error
-          quit 1
+          raiseDepositsDefect()
 
       if found.isSome:
         walletPath = found.get
       else:
         fatal "Unable to find wallet with the specified name/uuid", id
-        quit 1
+        raiseDepositsDefect()
 
       var unlocked = unlockWalletInteractively(walletPath.wallet)
       if unlocked.isOk:
         swap(seed, unlocked.get)
       else:
         # The failure will be reported in `unlockWalletInteractively`.
-        quit 1
+        raiseDepositsDefect()
     else:
       let walletOpt = createWalletInteractively(rng, config).valueOr:
         fatal "Unable to create wallet", reason = error
-        quit 1
+        raiseDepositsDefect()
       var wallet = walletOpt.valueOr:
         fatal "Process interrupted by user"
-        quit 1
+        raiseDepositsDefect()
       swap(seed, wallet.seed)
       walletPath = wallet.walletPath
 
@@ -431,7 +431,7 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
 
     if deposits.isErr:
       fatal "Failed to generate deposits", err = deposits.error
-      quit 1
+      raiseDepositsDefect()
 
     try:
       let depositDataPath = if config.outDepositsFile.isSome:
@@ -451,14 +451,14 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
         fatal "Failed to update wallet file after generating deposits",
                 wallet = walletPath.path,
                 error = status.error
-        quit 1
+        raiseDepositsDefect()
     except CatchableError as err:
       fatal "Failed to create launchpad deposit data file", err = err.msg
-      quit 1
+      raiseDepositsDefect()
   #[
   of DepositsCmd.status:
     echo "The status command is not implemented yet"
-    quit 1
+    raiseDepositsDefect()
   ]#
 
   of DepositsCmd.`import`:
@@ -474,7 +474,7 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
               " Since no such directory exists, please either provide the " &
               "correct path as an argument or copy the imported keys in the " &
               "expected location."
-        quit 1
+        raiseDepositsDefect()
 
     importKeystoresFromDir(
       rng, config.importMethod,

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -157,7 +157,7 @@ func getIdent*(storage: ValidatorStorage): ValidatorIdent =
   of ValidatorStorageKind.Identifier:
     storage.ident
 
-proc restValidatorExit(config: BeaconNodeConf) {.async.} =
+proc restValidatorExit(config: BeaconNodeConf) {.async: (raises: []).} =
   let
     client =
       block:
@@ -168,7 +168,8 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
 
         RestClientRef.new(config.restUrlForExit, flags = flags,
                           socketFlags = socketFlags).valueOr:
-          raise (ref RestError)(msg: $error)
+          fatal "Unable to initialize REST client", reason = error
+          raiseDepositsDefect()
 
     stateIdHead = StateIdent(kind: StateQueryKind.Named,
                              value: StateIdentType.Head)
@@ -202,9 +203,11 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
       genesis.get().data
     else:
       raiseGenericError(response)
-  except CatchableError as exc:
+  except CancelledError:
+    return
+  except RestError as exc:
     fatal "Failed to obtain the genesis validators root of the network",
-           reason = exc.msg
+          reason = exc.msg
     raiseDepositsDefect()
 
   let currentEpoch = block:
@@ -233,7 +236,9 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
       fork.get().data
     else:
       raiseGenericError(response)
-  except CatchableError as exc:
+  except CancelledError:
+    return
+  except RestError as exc:
     fatal "Failed to obtain the fork id of the head state",
            reason = exc.msg
     raiseDepositsDefect()
@@ -264,7 +269,9 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
         fork, capellaForkVersion, currentEpoch, denebForkEpoch)
     else:
       raise newException(RestError, "Error response (" & $response.status & ")")
-  except CatchableError as exc:
+  except CancelledError:
+    return
+  except RestError as exc:
     fatal "Failed to obtain the config spec of the beacon node",
            reason = exc.msg
     raiseDepositsDefect()
@@ -291,7 +298,9 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
         validatorInfo.get().data
       else:
         raiseGenericError(response)
-    except CatchableError as exc:
+    except CancelledError:
+      return
+    except RestError as exc:
       fatal "Failed to obtain information for validator", reason = exc.msg
       raiseDepositsDefect()
 
@@ -354,19 +363,17 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
           for el in responseStacktraces.get():
             echo el
           echoP "Please try again."
-      except CatchableError as err:
+      except CancelledError:
+        return
+      except RestError as exc:
         fatal "Failed to send the signed exit message",
-              signedExit, reason = err.msg
+              signedExit, reason = exc.msg
         hadErrors = true
 
   if hadErrors:
     raiseDepositsDefect()
 
-proc handleValidatorExitCommand(config: BeaconNodeConf) {.async.} =
-  await restValidatorExit(config)
-
-proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
-    raises: [CatchableError].} =
+proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) =
   case config.depositsCmd
   of DepositsCmd.createTestnetDeposits:
     if config.eth2Network.isNone:
@@ -465,8 +472,12 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     let validatorKeysDir = if config.importedDepositsDir.isSome:
       config.importedDepositsDir.get
     else:
-      let cwd = os.getCurrentDir()
-      if dirExists(cwd / "validator_keys"):
+      let cwd = io2.getCurrentDir().valueOr:
+        fatal "Unable to obtain current working directory",
+              reason = ioErrorMsg(error)
+        raiseDepositsDefect()
+
+      if isDir(cwd / "validator_keys"):
         InputDir(cwd / "validator_keys")
       else:
         echo "The default search path for validator keys is a sub-directory " &
@@ -482,4 +493,4 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
       config.validatorsDir, config.secretsDir)
 
   of DepositsCmd.exit:
-    waitFor handleValidatorExitCommand(config)
+    waitFor restValidatorExit(config)

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -274,7 +274,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
   if not config.printData:
     case askForExitConfirmation()
     of ClientExitAction.abort:
-      quit 0
+      raiseSuccessDefect()
     of ClientExitAction.confirm:
       discard
 
@@ -325,7 +325,7 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
       echo "  -H 'Accept: */*' \\"
       echo "  -H 'Content-Type: application/json' \\"
       echo "  -d '" & string.fromBytes(bytes) & "'"
-      quit 0
+      raiseSuccessDefect()
     else:
       try:
         let
@@ -411,12 +411,12 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     secureCreatePath(config.outValidatorsDir).isOkOr:
       fatal "Could not create directory",
             path = config.outValidatorsDir, reason = ioErrorMsg(error)
-      quit QuitFailure
+      raiseDepositsDefect()
 
     secureCreatePath(config.outSecretsDir).isOkOr:
       fatal "Could not create directory",
             path = config.outSecretsDir, reason = ioErrorMsg(error)
-      quit QuitFailure
+      raiseDepositsDefect()
 
     let deposits = generateDeposits(
       metadata.cfg,

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -372,7 +372,9 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     if config.eth2Network.isNone:
       fatal "Please specify the intended testnet for the deposits"
       quit 1
-    let metadata = config.loadEth2Network()
+    let metadata = config.loadEth2Network().valueOr:
+      fatal "Unable to get network metadata", reason = error
+      quit 1
     var seed: KeySeed
     defer: burnMem(seed)
     var walletPath: WalletPathPair
@@ -397,22 +399,23 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
         # The failure will be reported in `unlockWalletInteractively`.
         quit 1
     else:
-      var walletRes = createWalletInteractively(rng, config)
-      if walletRes.isErr:
-        fatal "Unable to create wallet", err = walletRes.error
+      let walletOpt = createWalletInteractively(rng, config).valueOr:
+        fatal "Unable to create wallet", reason = error
         quit 1
-      else:
-        swap(seed, walletRes.get.seed)
-        walletPath = walletRes.get.walletPath
+      var wallet = walletOpt.valueOr:
+        fatal "Process interrupted by user"
+        quit 1
+      swap(seed, wallet.seed)
+      walletPath = wallet.walletPath
 
-    if (let res = secureCreatePath(config.outValidatorsDir); res.isErr):
+    secureCreatePath(config.outValidatorsDir).isOkOr:
       fatal "Could not create directory",
-        path = config.outValidatorsDir, err = ioErrorMsg(res.error)
+            path = config.outValidatorsDir, reason = ioErrorMsg(error)
       quit QuitFailure
 
-    if (let res = secureCreatePath(config.outSecretsDir); res.isErr):
+    secureCreatePath(config.outSecretsDir).isOkOr:
       fatal "Could not create directory",
-        path = config.outSecretsDir, err = ioErrorMsg(res.error)
+            path = config.outSecretsDir, reason = ioErrorMsg(error)
       quit QuitFailure
 
     let deposits = generateDeposits(

--- a/beacon_chain/el/deposit_contract.nim
+++ b/beacon_chain/el/deposit_contract.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/el/deposit_contract.nim
+++ b/beacon_chain/el/deposit_contract.nim
@@ -14,7 +14,7 @@ import
   ../networking/network_metadata,
   web3, web3/confutils_defs, eth/common/keys, eth/p2p/discoveryv5/random2,
   stew/[io2, byteutils],
-  ../spec/eth2_merkleization,
+  ../spec/[eth2_merkleization, defects],
   ../spec/datatypes/base,
   ../validators/keystore_management
 
@@ -217,7 +217,7 @@ proc main() {.async.} =
     if conf.remoteValidatorsCount > 0 and
        conf.remoteSignersUrls.len == 0:
       fatal "Please specify at least one remote signer URL"
-      quit 1
+      raiseDepositContractDefect()
 
     if (let res = secureCreatePath(string conf.outValidatorsDir); res.isErr):
       warn "Could not create validators folder",
@@ -241,14 +241,14 @@ proc main() {.async.} =
 
     if deposits.isErr:
       fatal "Failed to generate deposits", err = deposits.error
-      quit 1
+      raiseDepositContractDefect()
 
     let launchPadDeposits =
       mapIt(deposits.value, LaunchPadDeposit.init(cfg, it))
 
     Json.saveFile(string conf.outDepositsFile, launchPadDeposits)
     notice "Deposit data written", filename = conf.outDepositsFile
-    quit 0
+    raiseSuccessDefect()
 
   var deposits: seq[LaunchPadDeposit]
   if conf.cmd == StartUpCommand.sendDeposits:
@@ -291,7 +291,7 @@ proc main() {.async.} =
       conf.maxDelay = conf.minDelay
     elif conf.minDelay > conf.maxDelay:
       echo "The minimum delay should not be larger than the maximum delay"
-      quit 1
+      raiseDepositContractDefect()
 
     if conf.maxDelay > 0.0:
       delayGenerator = proc (): chronos.Duration =
@@ -307,4 +307,6 @@ proc main() {.async.} =
     # This is handled above before the case statement
     discard
 
-when isMainModule: waitFor main()
+when isMainModule:
+  withDefectsHandlers():
+    waitFor main()

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 import
   std/[options, uri],

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -168,7 +168,7 @@ func getDefaultEngineApiUrl*(x: Option[InputFile]): EngineApiUrlConfigValue =
         some defaultJwtSecret)
 
 proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
-                 confJwtSecret: Opt[seq[byte]]): Result[EngineApiUrl, cstring] =
+                 confJwtSecret: Opt[seq[byte]]): Result[EngineApiUrl, string] =
   if confValue.jwtSecret.isSome and confValue.jwtSecretFile.isSome:
     return err "The options `jwtSecret` and `jwtSecretFile` should not be specified together"
 
@@ -187,23 +187,21 @@ proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
     jwtSecret = jwtSecret,
     roles = confValue.roles.get(defaultEngineApiRoles))
 
-proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[seq[byte]] =
+proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Result[Opt[seq[byte]], string] =
   if jwtSecret.isSome:
-    let res = loadJwtSecretFile(jwtSecret.get)
-    if res.isOk:
-      Opt.some res.value
-    else:
-      fatal "Failed to load JWT secret file", err = res.error
-      quit 1
+    let res = ? loadJwtSecretFile(jwtSecret.get)
+    ok(Opt.some(res))
   else:
-    Opt.none seq[byte]
+    ok(Opt.none(seq[byte]))
 
-proc toFinalEngineApiUrls*(elUrls: seq[EngineApiUrlConfigValue],
-                           confJwtSecret: Opt[InputFile]): seq[EngineApiUrl] =
-  let jwtSecret = loadJwtSecret confJwtSecret
+proc toFinalEngineApiUrls*(
+    elUrls: seq[EngineApiUrlConfigValue],
+    confJwtSecret: Opt[InputFile]
+): Result[seq[EngineApiUrl], string] =
+  var res: seq[EngineApiUrl]
 
+  let jwtSecret = ? loadJwtSecret(confJwtSecret)
   for elUrl in elUrls:
-    let engineApiUrl = elUrl.toFinalUrl(jwtSecret).valueOr:
-      fatal "Invalid EL configuration", err = error
-      quit 1
-    result.add engineApiUrl
+    let engineApiUrl = ? elUrl.toFinalUrl(jwtSecret)
+    res.add(engineApiUrl)
+  ok(res)

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1991,7 +1991,7 @@ proc testWeb3Provider*(
     web3Url: Uri,
     depositContractAddress: Eth1Address,
     jwtSecret: Opt[seq[byte]]
-) {.async: (raises: [CatchableError]).} =
+): Future[int] {.async: (raises: [CatchableError]).} =
 
   stdout.write "Establishing web3 connection..."
   let web3 =
@@ -2000,7 +2000,7 @@ proc testWeb3Provider*(
                     getJsonRpcRequestHeaders(jwtSecret)).wait(5.seconds)
     except CatchableError as exc:
       stdout.write "\rEstablishing web3 connection: Failure(" & exc.msg & ")\n"
-      quit 1
+      return 1
 
   stdout.write "\rEstablishing web3 connection: Connected\n"
 
@@ -2034,3 +2034,5 @@ proc testWeb3Provider*(
 
   discard request "Deposit root":
     ns.get_deposit_root.call(blockNumber = latestBlock.number)
+
+  0

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1987,26 +1987,34 @@ func `$`(x: Quantity): string =
 func `$`(x: BlockObject): string =
   $(x.number) & " [" & $(x.hash) & "]"
 
+proc writeOut*(s: string) =
+  try:
+    stdout.write s
+  except IOError:
+    discard
+
 proc testWeb3Provider*(
     web3Url: Uri,
     depositContractAddress: Eth1Address,
     jwtSecret: Opt[seq[byte]]
-): Future[int] {.async: (raises: [CatchableError]).} =
+): Future[int] {.async: (raises: [CancelledError]).} =
 
-  stdout.write "Establishing web3 connection..."
+  writeOut "Establishing web3 connection..."
   let web3 =
     try:
       await newWeb3($web3Url,
                     getJsonRpcRequestHeaders(jwtSecret)).wait(5.seconds)
+    except CancelledError as exc:
+      raise exc
     except CatchableError as exc:
-      stdout.write "\rEstablishing web3 connection: Failure(" & exc.msg & ")\n"
+      writeOut "\rEstablishing web3 connection: Failure(" & exc.msg & ")\n"
       return 1
 
-  stdout.write "\rEstablishing web3 connection: Connected\n"
+  writeOut "\rEstablishing web3 connection: Connected\n"
 
   template request(actionDesc: static string,
                    action: untyped): untyped =
-    stdout.write actionDesc & "..."
+    writeOut actionDesc & "..."
     stdout.flushFile()
     var res: typeof(read action)
     try:
@@ -2014,10 +2022,12 @@ proc testWeb3Provider*(
       res = await fut.wait(web3RequestsTimeout)
       when res is BlockObject:
         res = raiseIfNil res
-      stdout.write "\r" & actionDesc & ": " & $res
-    except CatchableError as err:
-      stdout.write "\r" & actionDesc & ": Error(" & err.msg & ")"
-    stdout.write "\n"
+      writeOut "\r" & actionDesc & ": " & $res
+    except CancelledError as exc:
+      raise exc
+    except CatchableError as exc:
+      writeOut "\r" & actionDesc & ": Error(" & exc.msg & ")"
+    writeOut "\n"
     res
 
   discard request "Chain ID":

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -9,7 +9,7 @@
 
 import
   chronicles, chronos, metrics,
-  ../spec/[forks, helpers_el, signatures, signatures_batch],
+  ../spec/[forks, helpers_el, signatures, signatures_batch, defects],
   ../sszdump
 
 from std/deques import Deque, addLast, contains, initDeque, items, len, shrink
@@ -884,8 +884,9 @@ proc processBlock(
     (afterGenesis, _) = wallTime.toSlot()
 
   if not afterGenesis:
-    error "Processing block before genesis, clock turned back?"
-    quit 1
+    const msg = "Processing block before genesis, clock turned back?"
+    fatal msg
+    raiseProcessorDefect(msg)
 
   let res = withBlck(entry.blck):
     await self.storeBlock(

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -884,9 +884,8 @@ proc processBlock(
     (afterGenesis, _) = wallTime.toSlot()
 
   if not afterGenesis:
-    const msg = "Processing block before genesis, clock turned back?"
-    fatal msg
-    raiseProcessorDefect(msg)
+    fatal "Processing block before genesis, clock turned back?"
+    raiseProcessorDefect()
 
   let res = withBlck(entry.blck):
     await self.storeBlock(

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -9,7 +9,7 @@
 
 import
   chronos, metrics,
-  ../spec/light_client_sync,
+  ../spec/[light_client_sync, defects],
   ../consensus_object_pools/block_pools_types,
   ".."/[beacon_clock, sszdump],
   "."/[eth2_processor, gossip_validation]
@@ -485,8 +485,9 @@ proc addObject*(
       else:
         false
     if not mayProcessBeforeGenesis:
-      error "Processing LC object before genesis, clock turned back?"
-      quit 1
+      const msg = "Processing LC object before genesis, clock turned back?"
+      fatal msg
+      raiseProcessorDefect(msg)
 
   let res = self.storeObject(src, wallTime, obj)
 

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -485,9 +485,8 @@ proc addObject*(
       else:
         false
     if not mayProcessBeforeGenesis:
-      const msg = "Processing LC object before genesis, clock turned back?"
-      fatal msg
-      raiseProcessorDefect(msg)
+      fatal "Processing LC object before genesis, clock turned back?"
+      raiseProcessorDefect()
 
   let res = self.storeObject(src, wallTime, obj)
 

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -12,7 +12,7 @@ import
   chronos, chronicles,
   eth/p2p/discoveryv5/[enr, protocol, node, random2],
   ../spec/datatypes/[altair, fulu],
-  ../spec/eth2_ssz_serialization,
+  ../spec/[eth2_ssz_serialization, defects],
   ".."/[conf, conf_light_client]
 
 from std/os import splitFile
@@ -70,11 +70,13 @@ proc loadBootstrapFile*(bootstrapFile: string,
       for ln in strippedLines(bootstrapFile):
         addBootstrapNode(ln, bootstrapEnrs)
     except IOError as e:
-      error "Could not read bootstrap file", msg = e.msg
-      quit 1
+      const msg = "Could not read bootstrap file"
+      fatal msg, reason = e.msg
+      raiseNetworkDefect(msg)
   else:
-    error "Unknown bootstrap file format", ext
-    quit 1
+    const msg = "Unknown bootstrap file format"
+    fatal msg, ext
+    raiseNetworkDefect(msg)
 
 proc new*(T: type Eth2DiscoveryProtocol,
           config: BeaconNodeConf | LightClientConf,

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -70,13 +70,11 @@ proc loadBootstrapFile*(bootstrapFile: string,
       for ln in strippedLines(bootstrapFile):
         addBootstrapNode(ln, bootstrapEnrs)
     except IOError as e:
-      const msg = "Could not read bootstrap file"
-      fatal msg, reason = e.msg
-      raiseNetworkDefect(msg)
+      fatal "Could not read bootstrap file", reason = e.msg
+      raiseNetworkDefect()
   else:
-    const msg = "Unknown bootstrap file format"
-    fatal msg, ext
-    raiseNetworkDefect(msg)
+    fatal "Unknown bootstrap file format", ext
+    raiseNetworkDefect()
 
 proc new*(T: type Eth2DiscoveryProtocol,
           config: BeaconNodeConf | LightClientConf,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1892,18 +1892,16 @@ proc startListening*(node: Eth2Node) {.async.} =
     try:
        node.discovery.open()
     except CatchableError as exc:
-      const msg =
-        "Failed to start discovery service. UDP port may be already in use"
-      fatal msg, reason = exc.msg
-      raiseNetworkDefect(msg)
+      fatal "Failed to start discovery service. UDP port may be already in use",
+            reason = exc.msg
+      raiseNetworkDefect()
 
   try:
     await node.switch.start()
   except CatchableError as exc:
-    const msg =
-      "Failed to start LibP2P transport. TCP port may be already in use"
-    fatal msg, reason = exc.msg
-    raiseNetworkDefect(msg)
+    fatal "Failed to start LibP2P transport. TCP port may be already in use",
+          reason = exc.msg
+    raiseNetworkDefect()
 
 proc peerPingerHeartbeat(node: Eth2Node): Future[void] {.async: (raises: [CancelledError]).}
 proc peerTrimmerHeartbeat(node: Eth2Node): Future[void] {.async: (raises: [CancelledError]).}
@@ -2335,19 +2333,17 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
           if s.startsWith("enr:"):
             let
               enr = parseBootstrapAddress(s).valueOr:
-                const msg = "Failed to parse bootstrap address"
-                fatal msg, enr = s
-                raiseNetworkDefect(msg)
+                fatal "Failed to parse bootstrap address", enr = s
+                raiseNetworkDefect()
               typedEnr = TypedRecord.fromRecord(enr)
               peerAddress = toPeerAddr(typedEnr, tcpProtocol).get()
             (peerAddress.peerId, peerAddress.addrs[0])
           elif s.startsWith("/"):
             parseFullAddress(s).tryGet()
           else:
-            const msg =
-              "Direct peers address should start with / (multiaddress) or enr"
-            fatal msg, conf = s
-            raiseNetworkDefect(msg)
+            fatal "Direct peers address should start with / (multiaddress) or enr",
+                  conf = s
+            raiseNetworkDefect()
         res.mgetOrPut(peerId, @[]).add(address)
         info "Adding privileged direct peer", peerId, address
       res

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -27,7 +27,7 @@ import
   eth/[common/keys, async_utils],
   eth/net/nat, eth/p2p/discoveryv5/[enr, node, random2],
   ".."/[version, conf, beacon_clock, conf_light_client],
-  ../spec/[eth2_ssz_serialization, network, helpers, forks],
+  ../spec/[eth2_ssz_serialization, network, helpers, forks, defects],
   ../validators/keystore_management,
   "."/[eth2_discovery, eth2_protocol_dsl, eth2_agents,
        libp2p_json_serialization, peer_pool, peer_scores]
@@ -1892,16 +1892,18 @@ proc startListening*(node: Eth2Node) {.async.} =
     try:
        node.discovery.open()
     except CatchableError as exc:
-      fatal "Failed to start discovery service. UDP port may be already in use",
-            exc = exc.msg
-      quit 1
+      const msg =
+        "Failed to start discovery service. UDP port may be already in use"
+      fatal msg, reason = exc.msg
+      raiseNetworkDefect(msg)
 
   try:
     await node.switch.start()
   except CatchableError as exc:
-    fatal "Failed to start LibP2P transport. TCP port may be already in use",
-          exc = exc.msg
-    quit 1
+    const msg =
+      "Failed to start LibP2P transport. TCP port may be already in use"
+    fatal msg, reason = exc.msg
+    raiseNetworkDefect(msg)
 
 proc peerPingerHeartbeat(node: Eth2Node): Future[void] {.async: (raises: [CancelledError]).}
 proc peerTrimmerHeartbeat(node: Eth2Node): Future[void] {.async: (raises: [CancelledError]).}
@@ -2333,16 +2335,19 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
           if s.startsWith("enr:"):
             let
               enr = parseBootstrapAddress(s).valueOr:
-                fatal "Failed to parse bootstrap address", enr=s
-                quit 1
+                const msg = "Failed to parse bootstrap address"
+                fatal msg, enr = s
+                raiseNetworkDefect(msg)
               typedEnr = TypedRecord.fromRecord(enr)
               peerAddress = toPeerAddr(typedEnr, tcpProtocol).get()
             (peerAddress.peerId, peerAddress.addrs[0])
           elif s.startsWith("/"):
             parseFullAddress(s).tryGet()
           else:
-            fatal "direct peers address should start with / (multiaddress) or enr:", conf=s
-            quit 1
+            const msg =
+              "Direct peers address should start with / (multiaddress) or enr"
+            fatal msg, conf = s
+            raiseNetworkDefect(msg)
         res.mgetOrPut(peerId, @[]).add(address)
         info "Adding privileged direct peer", peerId, address
       res

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2195,7 +2195,7 @@ func initNetKeys(privKey: PrivateKey): NetKeyPair =
 proc getRandomNetKeys*(rng: var HmacDrbgContext): NetKeyPair =
   let privKey = PrivateKey.random(Secp256k1, rng).valueOr:
     fatal "Could not generate random network key file"
-    quit QuitFailure
+    raiseNetworkDefect()
   initNetKeys(privKey)
 
 proc getPersistentNetKeys*(
@@ -2208,7 +2208,7 @@ proc getPersistentNetKeys*(
       keys = rng.getRandomNetKeys()
       pres = PeerId.init(keys.pubkey).valueOr:
         fatal "Could not obtain PeerId from network key", error
-        quit QuitFailure
+        raiseNetworkDefect()
     info "Generating new networking key",
       network_public_key = keys.pubkey, network_peer_id = $pres
     keys
@@ -2234,7 +2234,7 @@ proc getPersistentNetKeys*(
       let
         privKey = loadNetKeystore(keyPath, insecurePassword).valueOr:
           fatal "Could not load network key file"
-          quit QuitFailure
+          raiseNetworkDefect()
         keys = initNetKeys(privKey)
       info "Network key storage was successfully unlocked",
         network_public_key = keys.pubkey
@@ -2248,7 +2248,7 @@ proc getPersistentNetKeys*(
         sres = saveNetKeystore(rng, keyPath, keys.seckey, insecurePassword)
       if sres.isErr():
         fatal "Could not create network key file"
-        quit QuitFailure
+        raiseNetworkDefect()
 
       info "New network key storage was created",
         network_public_key = keys.pubkey

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -14,7 +14,7 @@ import
   web3/primitives as web3types,
   chronicles,
   eth/common/eth_types_json_serialization,
-  ../spec/[eth2_ssz_serialization, forks]
+  ../spec/[eth2_ssz_serialization, forks, defects]
 
 from std/sequtils import deduplicate, filterIt, mapIt
 from std/strutils import
@@ -353,17 +353,18 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
         let res = loadEth2NetworkMetadata(networkName)
         res.valueOr:
           fatal "The selected network is not compatible with the current build",
-            reason = res.error
-          quit 1
+                reason = res.error
+          raiseMetadataDefect()
       except IOError as exc:
-        fatal "Cannot load network: IOError", msg = exc.msg, networkName
-        quit 1
+        fatal "Cannot load network: IOError", reason = exc.msg, networkName
+        raiseMetadataDefect()
       except PresetFileError as exc:
-        fatal "Cannot load network: PresetFileError", msg = exc.msg, networkName
-        quit 1
+        fatal "Cannot load network: PresetFileError", reason = exc.msg,
+              networkName
+        raiseMetadataDefect()
     else:
       fatal "config.yaml not found for network", networkName
-      quit 1
+      raiseMetadataDefect()
 
   if networkName in ["goerli", "prater"]:
     warn "Goerli is deprecated and unsupported; https://blog.ethereum.org/2023/11/30/goerli-lts-update suggests migrating to Holesky or Sepolia"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -21,7 +21,7 @@ import
   ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/[
     deposit_snapshots, engine_authentication, weak_subjectivity,
-    peerdas_helpers],
+    peerdas_helpers, defects],
   ./sync/[sync_protocol, light_client_protocol, sync_overseer],
   ./validators/[keystore_management, beacon_validators],
   "."/[
@@ -256,7 +256,7 @@ proc loadChainDag(
             networkGenesisValidatorsRoot = networkGenesisValidatorsRoot.get,
             databaseGenesisValidatorsRoot,
             dataDir = config.dataDir
-      quit 1
+      raiseBeaconNodeDefect()
 
   # The first pruning after restart may take a while..
   if config.historyMode == HistoryMode.Prune:
@@ -274,10 +274,10 @@ proc checkWeakSubjectivityCheckpoint(
       dag.cfg, currentSlot, dag.headState, wsCheckpoint)
 
   if isCheckpointStale:
-    error "Weak subjectivity checkpoint is stale",
+    fatal "Weak subjectivity checkpoint is stale",
           currentSlot, checkpoint = wsCheckpoint,
           headStateSlot = getStateField(dag.headState, slot)
-    quit 1
+    raiseBeaconNodeDefect()
 
 from ./spec/state_transition_block import kzg_commitment_to_versioned_hash
 
@@ -689,12 +689,12 @@ proc init*(T: type BeaconNode,
     genesisState =
       (await fetchGenesisState(
         metadata, config.genesisState, config.genesisStateUrl)).valueOr:
-      quit 1
+        raiseBeaconNodeDefect()
     let
       genesisTime = getStateField(genesisState[], genesis_time)
       beaconClock = BeaconClock.init(genesisTime).valueOr:
         fatal "Invalid genesis time in genesis state", genesisTime
-        quit 1
+        raiseBeaconNodeDefect()
       currentSlot = beaconClock.now().slotOrZero()
       checkpoint = Checkpoint(
         epoch: epoch(getStateField(genesisState[], slot)),
@@ -710,24 +710,24 @@ proc init*(T: type BeaconNode,
         # We do support any network which starts from Altair or later fork.
         let metadata = config.loadEth2Network().valueOr:
           fatal "Unable to get network metadata", reason = error
-          quit 1
+          raiseBeaconNodeDefect()
         if metadata.cfg.ALTAIR_FORK_EPOCH != GENESIS_EPOCH:
           fatal WeakSubjectivityLogMessage, current_slot = currentSlot,
                 altair_fork_epoch = metadata.cfg.ALTAIR_FORK_EPOCH
-          quit 1
+          raiseBeaconNodeDefect()
 
   let taskpool =
     try:
       if config.numThreads < 0:
         fatal "The number of threads --num-threads cannot be negative."
-        quit 1
+        raiseBeaconNodeDefect()
       elif config.numThreads == 0:
         Taskpool.new(numThreads = min(countProcessors(), 16))
       else:
         Taskpool.new(numThreads = config.numThreads)
     except CatchableError as e:
       fatal "Cannot start taskpool", err = e.msg
-      quit 1
+      raiseBeaconNodeDefect()
 
   info "Threadpool started", numThreads = taskpool.numThreads
 
@@ -768,7 +768,7 @@ proc init*(T: type BeaconNode,
         if genesisState.isNil:
           genesisState = (await fetchGenesisState(
             metadata, config.genesisState, config.genesisStateUrl)).valueOr:
-              quit 1
+              raiseBeaconNodeDefect()
         if not genesisState.isNil:
           let genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
           notice "Neither `--trusted-block-root` nor `--trusted-state-root` " &
@@ -793,7 +793,7 @@ proc init*(T: type BeaconNode,
       if genesisState.isNil:
         genesisState = (await fetchGenesisState(
           metadata, config.genesisState, config.genesisStateUrl)).valueOr:
-            quit 1
+            raiseBeaconNodeDefect()
       await db.doRunTrustedNodeSync(
         metadata,
         config.databaseDir,
@@ -818,15 +818,15 @@ proc init*(T: type BeaconNode,
     except SszError as err:
       fatal "Checkpoint state loading failed",
             err = formatMsg(err, checkpointStatePath)
-      quit 1
+      raiseBeaconNodeDefect()
     except CatchableError as err:
       fatal "Failed to read checkpoint state file", err = err.msg
-      quit 1
+      raiseBeaconNodeDefect()
 
     if not getStateField(tmp[], slot).is_epoch:
       fatal "--finalized-checkpoint-state must point to a state for an epoch slot",
         slot = getStateField(tmp[], slot)
-      quit 1
+      raiseBeaconNodeDefect()
     tmp
   else:
     nil
@@ -840,18 +840,18 @@ proc init*(T: type BeaconNode,
         except SszError as err:
           fatal "Deposit tree snapshot loading failed",
                 err = formatMsg(err, depositTreeSnapshotPath)
-          quit 1
+          raiseBeaconNodeDefect()
         except CatchableError as err:
           fatal "Failed to read deposit tree snapshot file", err = err.msg
-          quit 1
+          raiseBeaconNodeDefect()
       depositContractSnapshot = DepositContractSnapshot.init(snapshot).valueOr:
         fatal "Invalid deposit tree snapshot file"
-        quit 1
+        raiseBeaconNodeDefect()
     db.putDepositContractSnapshot(depositContractSnapshot)
 
   let engineApiUrls = config.engineApiUrls().valueOr:
     fatal "Unable to get Engine API locations", reason = error
-    quit 1
+    raiseBeaconNodeDefect()
 
   if engineApiUrls.len == 0:
     notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
@@ -867,14 +867,14 @@ proc init*(T: type BeaconNode,
         if genesisState.isNil:
           (await fetchGenesisState(
             metadata, config.genesisState, config.genesisStateUrl)).valueOr:
-              quit 1
+              raiseBeaconNodeDefect()
         else:
           genesisState
 
     if genesisState.isNil and checkpointState.isNil:
       fatal "No database and no genesis snapshot found. Please supply a genesis.ssz " &
             "with the network configuration"
-      quit 1
+      raiseBeaconNodeDefect()
 
     if not genesisState.isNil and not checkpointState.isNil:
       if getStateField(genesisState[], genesis_validators_root) !=
@@ -884,7 +884,7 @@ proc init*(T: type BeaconNode,
             genesisState[], genesis_validators_root),
           rootFromCheckpoint = getStateField(
             checkpointState[], genesis_validators_root)
-        quit 1
+        raiseBeaconNodeDefect()
 
     try:
       # Always store genesis state if we have it - this allows reindexing and
@@ -902,12 +902,12 @@ proc init*(T: type BeaconNode,
       doAssert ChainDAGRef.isInitialized(db).isOk(), "preInit should have initialized db"
     except CatchableError as exc:
       error "Failed to initialize database", err = exc.msg
-      quit 1
+      raiseBeaconNodeDefect()
   else:
     if not checkpointState.isNil:
       fatal "A database already exists, cannot start from given checkpoint",
         dataDir = config.dataDir
-      quit 1
+      raiseBeaconNodeDefect()
 
   # Doesn't use std/random directly, but dependencies might
   randomize(rng[].rand(high(int)))
@@ -931,7 +931,7 @@ proc init*(T: type BeaconNode,
     genesisTime = getStateField(dag.headState, genesis_time)
     beaconClock = BeaconClock.init(genesisTime).valueOr:
       fatal "Invalid genesis time in state", genesisTime
-      quit 1
+      raiseBeaconNodeDefect()
 
     getBeaconTime = beaconClock.getBeaconTimeFn()
 
@@ -951,7 +951,7 @@ proc init*(T: type BeaconNode,
           res.clear().isOkOr:
             fatal "Unable to reset backfill database",
                   path = config.databaseDir(), reason = error
-            quit 1
+            raiseBeaconNodeDefect()
       res
 
   info "Backfill database initialized", path = config.databaseDir(),
@@ -994,7 +994,7 @@ proc init*(T: type BeaconNode,
     discard
   of SlashingDbKind.v1:
     error "Slashing DB v1 is no longer supported for writing"
-    quit 1
+    raiseBeaconNodeDefect()
   of SlashingDbKind.both:
     warn "Slashing DB v1 deprecated, writing only v2"
 
@@ -1477,7 +1477,8 @@ proc maybeUpdateActionTrackerNextEpoch(
       else:
         epochRefFallback()
 
-proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
+proc updateGossipStatus(node: BeaconNode, slot: Slot) {.
+  async: (raises: [CancelledError]).} =
   ## Subscribe to subnets that we are providing stability for or aggregating
   ## and unsubscribe from the ones that are no longer relevant.
 
@@ -1870,7 +1871,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
 
   # Check before any re-scheduling of onSlotStart()
   if checkIfShouldStopAtEpoch(wallSlot, node.config.stopAtEpoch):
-    quit(0)
+    raiseSuccessDefect()
 
   when defined(windows):
     if node.config.runAsService:
@@ -2123,7 +2124,7 @@ proc stop(node: BeaconNode) =
   node.db.close()
   notice "Databases closed"
 
-proc run(node: BeaconNode) {.raises: [CatchableError].} =
+proc run(node: BeaconNode) =
   bnStatus = BeaconNodeStatus.Running
 
   if not isNil(node.restServer):
@@ -2144,7 +2145,10 @@ proc run(node: BeaconNode) {.raises: [CatchableError].} =
   node.requestManager.start()
   node.syncOverseer.start()
 
-  waitFor node.updateGossipStatus(wallSlot)
+  try:
+    waitFor node.updateGossipStatus(wallSlot)
+  except CancelledError as exc:
+    return
 
   for web3signerUrl in node.config.web3SignerUrls:
     # TODO
@@ -2169,11 +2173,14 @@ proc run(node: BeaconNode) {.raises: [CatchableError].} =
   # time to say goodbye
   node.stop()
 
-var gPidFile: string
-proc createPidFile(filename: string) {.raises: [IOError].} =
-  writeFile filename, $os.getCurrentProcessId()
-  gPidFile = filename
-  addQuitProc proc {.noconv.} = discard io2.removeFile(gPidFile)
+var gPidFile: Opt[string]
+proc createPidFile(filename: string) =
+  io2.writeFile(filename, $os.getCurrentProcessId()).isOkOr:
+    gPidFile = Opt.some(filename)
+
+proc removePidFile() =
+  if gPidFile.isSome():
+    discard io2.removeFile(gPidFile.get())
 
 proc initializeNetworking(node: BeaconNode) {.async.} =
   node.installMessageValidators()
@@ -2186,7 +2193,7 @@ proc initializeNetworking(node: BeaconNode) {.async.} =
 
   await node.network.start()
 
-proc start*(node: BeaconNode) {.raises: [CatchableError].} =
+proc start*(node: BeaconNode) =
   let
     head = node.dag.head
     finalizedHead = node.dag.finalizedHead
@@ -2214,7 +2221,11 @@ proc start*(node: BeaconNode) {.raises: [CatchableError].} =
   if genesisTime.inFuture:
     notice "Waiting for genesis", genesisIn = genesisTime.offset
 
-  waitFor node.initializeNetworking()
+  try:
+    waitFor node.initializeNetworking()
+  except CatchableError as exc:
+    fatal "Unable to initialize networking", reason = exc.msg
+    raiseBeaconNodeDefect()
 
   node.elManager.start()
   node.run()
@@ -2362,7 +2373,7 @@ when not defined(windows):
 
     asyncSpawn statusBarUpdatesPollingLoop()
 
-proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.raises: [CatchableError].} =
+proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) =
   info "Launching beacon node",
       version = fullVersionStr,
       bls_backend = $BLS_BACKEND,
@@ -2391,10 +2402,9 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
       url = "http://" & $metricsAddress & ":" & $config.metricsPort & "/metrics"
     try:
       startMetricsHttpServer($metricsAddress, config.metricsPort)
-    except CatchableError as exc:
-      raise exc
     except Exception as exc:
-      raiseAssert exc.msg # TODO fix metrics
+      fatal "Could not start metrics HTTP server", reason = exc.msg
+      raiseBeaconNodeDefect()
 
   # Nim GC metrics (for the main thread) will be collected in onSecond(), but
   # we disable piggy-backing on other metrics here.
@@ -2405,7 +2415,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   # the db.
   let metadata = config.loadEth2Network().valueOr:
     fatal "Unable to get network metadata", reason = error
-    quit 1
+    raiseBeaconNodeDefect()
 
   # Updating the config based on the metadata certainly is not beautiful but it
   # works
@@ -2442,7 +2452,12 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
     if res.isErr():
       raiseAssert res.error()
 
-  let node = waitFor BeaconNode.init(rng, config, metadata)
+  let node =
+    try:
+      waitFor BeaconNode.init(rng, config, metadata)
+    except CatchableError as exc:
+      fatal "Beacon node initialization unexpectedly fails", reason = exc.msg
+      raiseBeaconNodeDefect()
 
   if bnStatus == BeaconNodeStatus.Stopping:
     return
@@ -2457,8 +2472,7 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   else:
     node.start()
 
-proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
-    raises: [CatchableError].} =
+proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) =
   case config.recordCmd:
   of RecordCmd.create:
     let netKeys = getPersistentNetKeys(rng, config)
@@ -2467,10 +2481,16 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     for field in config.fields:
       let fieldPair = field.split(":")
       if fieldPair.len > 1:
-        fieldPairs.add(toFieldPair(fieldPair[0], hexToSeqByte(fieldPair[1])))
+        let data =
+          try:
+            hexToSeqByte(fieldPair[1])
+          except ValueError as exc:
+            fatal "Invalid hexadecimal encoding", reason = exc.msg
+            raiseRecordDefect()
+        fieldPairs.add(toFieldPair(fieldPair[0], data))
       else:
         fatal "Invalid field pair"
-        quit QuitFailure
+        raiseRecordDefect()
 
     let record = enr.Record.init(
       config.seqNumber,
@@ -2485,34 +2505,51 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
   of RecordCmd.print:
     echo $config.recordPrint
 
-proc doWeb3Cmd(config: BeaconNodeConf, rng: var HmacDrbgContext)
-    {.raises: [CatchableError].} =
+proc doWeb3Cmd(config: BeaconNodeConf, rng: var HmacDrbgContext) =
   case config.web3Cmd:
   of Web3Cmd.test:
     let
       metadata = config.loadEth2Network().valueOr:
         fatal "Unable to get network metadata", reason = error
-        quit 1
+        raiseWeb3CmdDefect()
       secret = rng.loadJwtSecret(config, allowCreate = true).valueOr:
         fatal "Unable to get JWT secret", reason = error
-        quit 1
-      res = waitFor testWeb3Provider(
-        config.web3TestUrl, metadata.cfg.DEPOSIT_CONTRACT_ADDRESS,
-        Opt.some(secret))
-    quit res
+        raiseWeb3CmdDefect()
+      res =
+        try:
+          waitFor testWeb3Provider(
+            config.web3TestUrl, metadata.cfg.DEPOSIT_CONTRACT_ADDRESS,
+            Opt.some(secret))
+        except CancelledError:
+          raiseWeb3CmdDefect()
+    if res == 0:
+      raiseSuccessDefect()
+    else:
+      raiseWeb3CmdDefect()
 
-proc doSlashingExport(conf: BeaconNodeConf) {.raises: [IOError].}=
+proc doSlashingExport(conf: BeaconNodeConf) =
   let
     dir = conf.validatorsDir()
     filetrunc = SlashingDbName
   # TODO: Make it read-only https://github.com/status-im/nim-eth/issues/312
-  let db = SlashingProtectionDB.loadUnchecked(dir, filetrunc, readOnly = false)
+  let db =
+    try:
+      SlashingProtectionDB.loadUnchecked(dir, filetrunc, readOnly = false)
+    except IOError as exc:
+      fatal "Failed to load the slashing protection database", reason = exc.msg
+      raiseSlashInterDefect()
 
   let interchange = conf.exportedInterchangeFile.string
-  db.exportSlashingInterchange(interchange, conf.exportedValidators)
-  echo "Export finished: '", dir/filetrunc & ".sqlite3" , "' into '", interchange, "'"
+  try:
+    db.exportSlashingInterchange(interchange, conf.exportedValidators)
+  except IOError as exc:
+    fatal "Export failed", reason = exc.msg
+    raiseSlashInterDefect()
 
-proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOError].} =
+  echo "Export finished: '", dir/filetrunc & ".sqlite3" , "' into '",
+       interchange, "'"
+
+proc doSlashingImport(conf: BeaconNodeConf) =
   let
     dir = conf.validatorsDir()
     filetrunc = SlashingDbName
@@ -2524,11 +2561,17 @@ proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOErr
   try:
     spdir = Json.loadFile(interchange, SPDIR,
                           requireAllFields = true)
-  except SerializationError as err:
+  except IOError as exc:
+    fatal $Json & " load issue for file",
+          file_path = interchange,
+          reason = exc.msg
+    raiseSlashInterDefect()
+  except SerializationError as exc:
+    fatal $Json & " load issue for file",
+          file_path = interchange,
+          reason = exc.formatMsg(interchange)
     writeStackTrace()
-    stderr.write $Json & " load issue for file \"", interchange, "\"\n"
-    stderr.write err.formatMsg(interchange), "\n"
-    quit 1
+    raiseSlashInterDefect()
 
   # Open DB and handle migration from v1 to v2 if needed
   let db = SlashingProtectionDB.init(
@@ -2542,54 +2585,81 @@ proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOErr
   # Failures mode:
   # - siError can only happen with invalid genesis_validators_root which would be caught above
   # - siPartial can happen for invalid public keys, slashable blocks, slashable votes
-  let status = db.inclSPDIR(spdir)
+  let status =
+    try:
+      db.inclSPDIR(spdir)
+    except IOError as exc:
+      fatal "Slashing directory check failed",
+            path = dir,
+            reason = exc.msg
+      raiseSlashInterDefect()
+    except SerializationError as exc:
+      fatal "Slashing directory check failed",
+            path = dir,
+            reason = exc.formatMsg(dir)
+      raiseSlashInterDefect()
+
   doAssert status in {siSuccess, siPartial}
 
-  echo "Import finished: '", interchange, "' into '", dir/filetrunc & ".sqlite3", "'"
+  echo "Import finished: '", interchange, "' into '",
+       dir/filetrunc & ".sqlite3", "'"
 
-proc doSlashingInterchange(conf: BeaconNodeConf) {.raises: [CatchableError].} =
+proc doSlashingInterchange(conf: BeaconNodeConf) =
   case conf.slashingdbCmd
   of SlashProtCmd.`export`:
     conf.doSlashingExport()
   of SlashProtCmd.`import`:
     conf.doSlashingImport()
 
-proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
+proc handleStartUpCmd(config: var BeaconNodeConf) =
   # Single RNG instance for the application - will be seeded on construction
   # and avoid using system resources (such as urandom) after that
   let rng = HmacDrbgContext.new()
 
-  case config.cmd
-  of BNStartUpCmd.noCommand: doRunBeaconNode(config, rng)
-  of BNStartUpCmd.deposits: doDeposits(config, rng[])
-  of BNStartUpCmd.wallets: doWallets(config, rng[])
-  of BNStartUpCmd.record: doRecord(config, rng[])
-  of BNStartUpCmd.web3: doWeb3Cmd(config, rng[])
-  of BNStartUpCmd.slashingdb: doSlashingInterchange(config)
-  of BNStartUpCmd.trustedNodeSync:
-    if config.blockId.isSome():
-      error "--blockId option has been removed - use --state-id instead!"
-      quit 1
+  withDefectsHandlers:
+    case config.cmd
+    of BNStartUpCmd.noCommand: doRunBeaconNode(config, rng)
+    of BNStartUpCmd.deposits: doDeposits(config, rng[])
+    of BNStartUpCmd.wallets: doWallets(config, rng[])
+    of BNStartUpCmd.record: doRecord(config, rng[])
+    of BNStartUpCmd.web3: doWeb3Cmd(config, rng[])
+    of BNStartUpCmd.slashingdb: doSlashingInterchange(config)
+    of BNStartUpCmd.trustedNodeSync:
+      if config.blockId.isSome():
+        fatal "--blockId option has been removed - use --state-id instead!"
+        raiseTrustedSyncDefect()
 
-    let
-      metadata = loadEth2Network(config).valueOr:
-        fatal "Unable to get network metadata", reason = error
-        quit 1
-      db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
-      genesisState = (waitFor fetchGenesisState(metadata)).valueOr:
-        quit 1
-    waitFor db.doRunTrustedNodeSync(
-      metadata,
-      config.databaseDir,
-      config.eraDir,
-      config.trustedNodeUrl,
-      config.stateId,
-      config.lcTrustedBlockRoot,
-      config.backfillBlocks,
-      config.reindex,
-      config.downloadDepositSnapshot,
-      genesisState)
-    db.close()
+      let
+        metadata = loadEth2Network(config).valueOr:
+          fatal "Unable to get network metadata", reason = error
+          raiseTrustedSyncDefect()
+        db = BeaconChainDB.new(config.databaseDir, metadata.cfg,
+                               inMemory = false)
+        genesisState =
+          try:
+            (waitFor fetchGenesisState(metadata)).valueOr:
+              raiseTrustedSyncDefect()
+          except CancelledError:
+            raiseTrustedSyncDefect()
+      try:
+        waitFor db.doRunTrustedNodeSync(
+          metadata,
+          config.databaseDir,
+          config.eraDir,
+          config.trustedNodeUrl,
+          config.stateId,
+          config.lcTrustedBlockRoot,
+          config.backfillBlocks,
+          config.reindex,
+          config.downloadDepositSnapshot,
+          genesisState)
+        db.close()
+      except CatchableError:
+        raiseTrustedSyncDefect()
+  do:
+    # This is addQuitProc() replacement which will be called even in case of
+    # defects.
+    removePidFile()
 
 {.pop.} # TODO moduletests exceptions
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -67,13 +67,13 @@ proc fetchGenesisState(
     metadata: Eth2NetworkMetadata,
     genesisState = none(InputFile),
     genesisStateUrl = none(Uri)
-): Future[ref ForkedHashedBeaconState] {.async: (raises: []).} =
+): Future[Opt[ref ForkedHashedBeaconState]] {.
+  async: (raises: [CancelledError]).} =
   let genesisBytes =
     if metadata.genesis.kind != BakedIn and genesisState.isSome:
-      let res = io2.readAllBytes(genesisState.get.string)
-      res.valueOr:
-        error "Failed to read genesis state file", err = res.error.ioErrorMsg
-        quit 1
+      io2.readAllBytes(genesisState.get.string).valueOr:
+        fatal "Failed to read genesis state file", reason = ioErrorMsg(error)
+        return Opt.none(ref ForkedHashedBeaconState)
     elif metadata.hasGenesis:
       try:
         if metadata.genesis.kind == BakedInUrl:
@@ -81,25 +81,28 @@ proc fetchGenesisState(
                sourceUrl = $genesisStateUrl
                  .get(parseUri metadata.genesis.url)
         await metadata.fetchGenesisBytes(genesisStateUrl)
-      except CatchableError as err:
-        error "Failed to obtain genesis state",
+      except CancelledError as exc:
+        raise exc
+      except CatchableError as exc:
+        fatal "Failed to obtain genesis state",
               source = metadata.genesis.sourceDesc,
-              err = err.msg
-        quit 1
+              reason = exc.msg
+        return Opt.none(ref ForkedHashedBeaconState)
     else:
       @[]
 
   if genesisBytes.len > 0:
     try:
-      newClone readSszForkedHashedBeaconState(metadata.cfg, genesisBytes)
-    except CatchableError as err:
-      error "Invalid genesis state",
+      Opt.some(
+        newClone readSszForkedHashedBeaconState(metadata.cfg, genesisBytes))
+    except CatchableError as exc:
+      fatal "Invalid genesis state",
             size = genesisBytes.len,
             digest = eth2digest(genesisBytes),
-            err = err.msg
-      quit 1
+            reason = exc.msg
+      return Opt.none(ref ForkedHashedBeaconState)
   else:
-    nil
+    Opt.none(ref ForkedHashedBeaconState)
 
 proc doRunTrustedNodeSync(
     db: BeaconChainDB,
@@ -684,8 +687,9 @@ proc init*(T: type BeaconNode,
     # If database directory missing, we going to use genesis state to check
     # for weak_subjectivity_period.
     genesisState =
-      await fetchGenesisState(
-        metadata, config.genesisState, config.genesisStateUrl)
+      (await fetchGenesisState(
+        metadata, config.genesisState, config.genesisStateUrl)).valueOr:
+      quit 1
     let
       genesisTime = getStateField(genesisState[], genesis_time)
       beaconClock = BeaconClock.init(genesisTime).valueOr:
@@ -762,8 +766,9 @@ proc init*(T: type BeaconNode,
       elif cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH:
         # Sync can be bootstrapped from the genesis block root
         if genesisState.isNil:
-          genesisState = await fetchGenesisState(
-            metadata, config.genesisState, config.genesisStateUrl)
+          genesisState = (await fetchGenesisState(
+            metadata, config.genesisState, config.genesisStateUrl)).valueOr:
+              quit 1
         if not genesisState.isNil:
           let genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
           notice "Neither `--trusted-block-root` nor `--trusted-state-root` " &
@@ -786,8 +791,9 @@ proc init*(T: type BeaconNode,
         trustedStateRoot = config.trustedStateRoot
     else:
       if genesisState.isNil:
-        genesisState = await fetchGenesisState(
-          metadata, config.genesisState, config.genesisStateUrl)
+        genesisState = (await fetchGenesisState(
+          metadata, config.genesisState, config.genesisStateUrl)).valueOr:
+            quit 1
       await db.doRunTrustedNodeSync(
         metadata,
         config.databaseDir,
@@ -859,8 +865,9 @@ proc init*(T: type BeaconNode,
         checkpointState
       else:
         if genesisState.isNil:
-          await fetchGenesisState(
-            metadata, config.genesisState, config.genesisStateUrl)
+          (await fetchGenesisState(
+            metadata, config.genesisState, config.genesisStateUrl)).valueOr:
+              quit 1
         else:
           genesisState
 
@@ -2569,7 +2576,8 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
         fatal "Unable to get network metadata", reason = error
         quit 1
       db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
-      genesisState = waitFor fetchGenesisState(metadata)
+      genesisState = (waitFor fetchGenesisState(metadata)).valueOr:
+        quit 1
     waitFor db.doRunTrustedNodeSync(
       metadata,
       config.databaseDir,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2342,9 +2342,14 @@ when not defined(windows):
         # an error message to the user.
         "$" & expr
 
-    var statusBar = StatusBarView.init(
-      node.config.statusBarContents,
-      dataResolver)
+    var statusBar =
+      try:
+        StatusBarView.init(
+        node.config.statusBarContents,
+        dataResolver)
+      except ValueError as exc:
+        warn "Unable to initalize status bar", reason = exc.msg
+        return
 
     when compiles(defaultChroniclesStream.outputs[0].writer):
       let tmp = defaultChroniclesStream.outputs[0].writer

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -704,7 +704,9 @@ proc init*(T: type BeaconNode,
       if not is_within_weak_subjectivity_period(metadata.cfg, currentSlot,
                                                 genesisState[], checkpoint):
         # We do support any network which starts from Altair or later fork.
-        let metadata = config.loadEth2Network()
+        let metadata = config.loadEth2Network().valueOr:
+          fatal "Unable to get network metadata", reason = error
+          quit 1
         if metadata.cfg.ALTAIR_FORK_EPOCH != GENESIS_EPOCH:
           fatal WeakSubjectivityLogMessage, current_slot = currentSlot,
                 altair_fork_epoch = metadata.cfg.ALTAIR_FORK_EPOCH
@@ -841,7 +843,9 @@ proc init*(T: type BeaconNode,
         quit 1
     db.putDepositContractSnapshot(depositContractSnapshot)
 
-  let engineApiUrls = config.engineApiUrls
+  let engineApiUrls = config.engineApiUrls().valueOr:
+    fatal "Unable to get Engine API locations", reason = error
+    quit 1
 
   if engineApiUrls.len == 0:
     notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
@@ -2392,7 +2396,9 @@ proc doRunBeaconNode(config: var BeaconNodeConf, rng: ref HmacDrbgContext) {.rai
   # There are no managed event loops in here, to do a graceful shutdown, but
   # letting the default Ctrl+C handler exit is safe, since we only read from
   # the db.
-  let metadata = config.loadEth2Network()
+  let metadata = config.loadEth2Network().valueOr:
+    fatal "Unable to get network metadata", reason = error
+    quit 1
 
   # Updating the config based on the metadata certainly is not beautiful but it
   # works
@@ -2476,11 +2482,17 @@ proc doWeb3Cmd(config: BeaconNodeConf, rng: var HmacDrbgContext)
     {.raises: [CatchableError].} =
   case config.web3Cmd:
   of Web3Cmd.test:
-    let metadata = config.loadEth2Network()
-
-    waitFor testWeb3Provider(config.web3TestUrl,
-                             metadata.cfg.DEPOSIT_CONTRACT_ADDRESS,
-                             rng.loadJwtSecret(config, allowCreate = true))
+    let
+      metadata = config.loadEth2Network().valueOr:
+        fatal "Unable to get network metadata", reason = error
+        quit 1
+      secret = rng.loadJwtSecret(config, allowCreate = true).valueOr:
+        fatal "Unable to get JWT secret", reason = error
+        quit 1
+      res = waitFor testWeb3Provider(
+        config.web3TestUrl, metadata.cfg.DEPOSIT_CONTRACT_ADDRESS,
+        Opt.some(secret))
+    quit res
 
 proc doSlashingExport(conf: BeaconNodeConf) {.raises: [IOError].}=
   let
@@ -2553,7 +2565,9 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
       quit 1
 
     let
-      metadata = loadEth2Network(config)
+      metadata = loadEth2Network(config).valueOr:
+        fatal "Unable to get network metadata", reason = error
+        quit 1
       db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
       genesisState = waitFor fetchGenesisState(metadata)
     waitFor db.doRunTrustedNodeSync(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2249,7 +2249,7 @@ func formatGwei(amount: Gwei): string =
       result.setLen(result.len - 1)
 
 when not defined(windows):
-  proc initStatusBar(node: BeaconNode) {.raises: [ValueError].} =
+  proc initStatusBar(node: BeaconNode) =
     if not isatty(stdout): return
     if not node.config.statusBarEnabled: return
 

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -19,7 +19,7 @@ import
   stew/io2,
 
   # Local modules
-  ./spec/[helpers, keystore],
+  ./spec/[helpers, keystore, defects],
   ./spec/datatypes/base,
   "."/[beacon_clock, beacon_node_status, conf, conf_common, version]
 
@@ -199,7 +199,7 @@ proc setupLogging*(
       stderr.write "Invalid value for --log-level. " & err.msg
     except IOError:
       echo "Invalid value for --log-level. " & err.msg
-    quit 1
+    raiseLogDefect()
 
 template makeBannerAndConfig*(clientId: string, ConfType: type): untyped =
   let
@@ -237,7 +237,7 @@ template makeBannerAndConfig*(clientId: string, ConfType: type): untyped =
                        "a properly formatted TOML array\n"
     except IOError:
       discard
-    quit 1
+    raiseConfigDefect()
   {.pop.}
   config
 
@@ -410,7 +410,7 @@ proc initKeymanagerServer*(
     if config.keymanagerTokenFile.isNone:
       echo "To enable the Keymanager API, you must also specify " &
            "the --keymanager-token-file option."
-      quit 1
+      raiseKeymanagerDefect()
 
     let
       tokenFilePath = config.keymanagerTokenFile.get.string
@@ -419,12 +419,12 @@ proc initKeymanagerServer*(
     if tokenFileReadRes.isErr:
       fatal "Failed to read the keymanager token file",
             error = $tokenFileReadRes.error
-      quit 1
+      raiseKeymanagerDefect()
 
     token = tokenFileReadRes.value.strip
     if token.len == 0:
       fatal "The keymanager token should not be empty", tokenFilePath
-      quit 1
+      raiseKeymanagerDefect()
 
     when config is BeaconNodeConf:
       if existingRestServer != nil and

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -59,7 +59,9 @@ programMain:
     altairSyncCommittees: "altair_sync_committees")).expect("Database OK")
   defer: db.close()
 
-  let metadata = loadEth2Network(config.eth2Network)
+  let metadata = loadEth2Network(config.eth2Network).valueOr:
+    fatal "Unable to get network metadata", reason = error
+    quit 1
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
   template cfg(): auto = metadata.cfg
@@ -94,7 +96,9 @@ programMain:
     network = createEth2Node(
       rng, config, netKeys, cfg,
       forkDigests, getBeaconTime, genesis_validators_root)
-    engineApiUrls = config.engineApiUrls
+    engineApiUrls = config.engineApiUrls().valueOr:
+      fatal "Unable to get Engine API locations", reason = error
+      quit 1
     elManager =
       if engineApiUrls.len > 0:
         ELManager.new(

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -14,7 +14,7 @@ import
   ./el/el_manager,
   ./gossip_processing/optimistic_processor,
   ./networking/[topic_params, network_metadata_downloads],
-  ./spec/beaconstate,
+  ./spec/[beaconstate, defects],
   ./spec/datatypes/[phase0, altair, bellatrix, capella, deneb],
   "."/[filepath, light_client, light_client_db, nimbus_binary_common, version]
 
@@ -354,12 +354,14 @@ programMain:
       let processingTime = finished - afterSleep
       trace "onSecond task completed", sleepTime, processingTime
 
-  onSecond(Moment.now())
-  lightClient.start()
+  withDefectsHandlers():
+    onSecond(Moment.now())
+    lightClient.start()
 
-  asyncSpawn runOnSlotLoop()
-  asyncSpawn runOnSecondLoop()
-  while globalRunning:
-    poll()
+    asyncSpawn runOnSlotLoop()
+    asyncSpawn runOnSecondLoop()
+
+    while globalRunning:
+      poll()
 
   notice "Exiting light client"

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -13,7 +13,7 @@ import serialization, json_serialization,
        chronos, presto, presto/secureserver, chronicles, confutils,
        results, stew/[base10, byteutils, io2, bitops2]
 import "."/spec/datatypes/[base, altair, phase0],
-       "."/spec/[crypto, digest, network, signatures, forks],
+       "."/spec/[crypto, digest, network, signatures, forks, defects],
        "."/spec/eth2_apis/[rest_types, eth2_rest_serialization],
        "."/rpc/rest_constants,
        "."/[conf, version, nimbus_binary_common],
@@ -414,7 +414,7 @@ proc asyncInit(sn: SigningNodeRef) {.async: (raises: [SigningNodeError]).} =
         raise newException(SigningNodeError, "")
       SigningNodeServer(kind: SigningNodeKind.NonSecure, nserver: res.get())
 
-proc asyncRun*(sn: SigningNodeRef) {.async: (raises: []).} =
+proc asyncRun*(sn: SigningNodeRef) {.async: (raises: [SigningNodeError]).} =
   sn.runKeystoreCachePruningLoopFut =
     runKeystoreCachePruningLoop(sn.keystoreCache)
   sn.installApiHandlers()
@@ -428,6 +428,11 @@ proc asyncRun*(sn: SigningNodeRef) {.async: (raises: []).} =
   except CatchableError as exc:
     warn "Main loop failed with unexpected error", err_name = $exc.name,
          reason = $exc.msg
+
+  # This is trick to fool asyncraises from generating warning:
+  # No exceptions possible with this operation, `error` always returns nil.
+  if false:
+    raise newException(SigningNodeError, "")
 
   debug "Stopping main processing loop"
   var pending: seq[Future[void]]
@@ -483,4 +488,6 @@ programMain:
     makeBannerAndConfig("Nimbus signing node " & fullVersionStr,
                         SigningNodeConf)
   setupLogging(config.logLevel, config.logStdout, config.logFile)
-  waitFor runSigningNode(config)
+
+  withDefectsHandlers():
+    waitFor runSigningNode(config)

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -1,5 +1,5 @@
 # nimbus_signing_node
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -9,6 +9,7 @@
 
 import
   stew/io2, presto, metrics, metrics/chronos_httpserver,
+  ./spec/defects,
   ./rpc/rest_key_management_api,
   ./validator_client/[
     common, fallback_service, duties_service, fork_service, block_service,
@@ -289,11 +290,11 @@ proc new*(
         if len(servers) == 0:
           fatal "Not enough beacon nodes available",
                 nodes_count = len(servers)
-          quit 1
+          raiseValidatorClientDefect()
         else:
           fatal "Beacon nodes do not cover all required roles",
                 missing_roles = $missingRoles, nodes_count = len(servers)
-          quit 1
+          raiseValidatorClientDefect()
       servers
 
   when declared(waitSignal):
@@ -605,4 +606,5 @@ programMain:
 
   setupFileLimits()
   setupLogging(config.logLevel, config.logStdout, config.logFile)
-  waitFor runValidatorClient(config, rng)
+  withDefectsHandlers():
+    waitFor runValidatorClient(config, rng)

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -7,7 +7,7 @@
 
 type
   ExitProcessDefect* = object of Defect
-    exitCode*: int16
+    exitCode*: int8
 
   SuccessDefect* = object of ExitProcessDefect
   DatabaseDefect* = object of ExitProcessDefect
@@ -30,6 +30,9 @@ type
   TrustedSyncDefect* = object of ExitProcessDefect
   WalletsDefect* = object of ExitProcessDefect
   BeaconNodeDefect* = object of ExitProcessDefect
+  RecordDefect* = object of ExitProcessDefect
+  Web3CmdDefect* = object of ExitProcessDefect
+  SlashInterDefect* = object of ExitProcessDefect
 
 template declareExitHelpers(defect, code: untyped): untyped =
   template `raise defect`*() =
@@ -59,3 +62,15 @@ declareExitHelpers(DepositsDefect, 30)
 declareExitHelpers(TrustedSyncDefect, 31)
 declareExitHelpers(WalletsDefect, 32)
 declareExitHelpers(BeaconNodeDefect, 33)
+declareExitHelpers(RecordDefect, 34)
+declareExitHelpers(Web3CmdDefect, 35)
+declareExitHelpers(SlashInterDefect, 36)
+
+template withDefectsHandlers*(pbody, fbody: untyped) =
+  try:
+    pbody
+  except ExitProcessDefect as exc:
+    # This defects are already logged, so we just quit.
+    quit(exc.exitCode)
+  finally:
+    fbody

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -38,6 +38,7 @@ type
 
   ValidatorClientDefect* = object of ExitProcessDefect
   LightClientDefect* = object of ExitProcessDefect
+  DepositContractDefect* = object of ExitProcessDefect
 
 template declareExitHelpers(defect, code: untyped): untyped =
   template `raise defect`*() =
@@ -72,6 +73,7 @@ declareExitHelpers(Web3CmdDefect, 35)
 declareExitHelpers(SlashInterDefect, 36)
 declareExitHelpers(ValidatorClientDefect, 37)
 declareExitHelpers(LightClientDefect, 38)
+declareExitHelpers(DepositContractDefect, 39)
 
 template withDefectsHandlers*(pbody, fbody: untyped) =
   try:

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -6,44 +6,50 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 type
-  DatabaseDefect* = object of Defect
-  SlashingDefect* = object of Defect
-  ClearanceDefect* = object of Defect
-  StrictDefect* = object of Defect
-  NetworkDefect* = object of Defect
-  DagDefect* = object of Defect
-  KeystoreDefect* = object of Defect
-  ProcessorDefect* = object of Defect
-  DiscoveryDefect* = object of Defect
-  ChainListDefect* = object of Defect
-  OverseerDefect* = object of Defect
+  ExitProcessDefect* = object of Defect
+    exitCode*: int16
+
+  DatabaseDefect* = object of ExitProcessDefect
+  SlashingDefect* = object of ExitProcessDefect
+  NetworkDefect* = object of ExitProcessDefect
+  ClearanceDefect* = object of ExitProcessDefect
+  StrictDefect* = object of ExitProcessDefect
+  DagDefect* = object of ExitProcessDefect
+  KeystoreDefect* = object of ExitProcessDefect
+  ProcessorDefect* = object of ExitProcessDefect
+  DiscoveryDefect* = object of ExitProcessDefect
+  ChainListDefect* = object of ExitProcessDefect
+  OverseerDefect* = object of ExitProcessDefect
 
 template raiseDatabaseDefect*(message: string) =
-  raise (ref DatabaseDefect)(msg: message)
+  raise (ref DatabaseDefect)(exitCode: 12, msg: message)
 
 template raiseSlashingDefect*(message: string) =
-  raise (ref SlashingDefect)(msg: message)
+  raise (ref SlashingDefect)(exitCode: 13, msg: message)
 
 template raiseClearanceDefect*(message: string) =
-  raise (ref ClearanceDefect)(msg: message)
+  raise (ref ClearanceDefect)(exitCode: 14, msg: message)
 
 template raiseStrictDefect*(message: string) =
-  raise (ref StrictDefect)(msg: message)
+  raise (ref StrictDefect)(exitCode: 15, msg: message)
 
 template raiseDagDefect*(message: string) =
-  raise (ref DagDefect)(msg: message)
+  raise (ref DagDefect)(exitCode: 16, msg: message)
 
 template raiseKeystoreDefect*(message: string) =
-  raise (ref KeystoreDefect)(msg: message)
+  raise (ref KeystoreDefect)(exitCode: 17, msg: message)
 
 template raiseProcessorDefect*(message: string) =
-  raise (ref ProcessorDefect)(msg: message)
+  raise (ref ProcessorDefect)(exitCode: 18, msg: message)
 
 template raiseDiscoveryDefect*(message: string) =
-  raise (ref DiscoveryDefect)(msg: message)
+  raise (ref DiscoveryDefect)(exitCode: 19, msg: message)
 
 template raiseChainListDefect*(message: string) =
-  raise (ref ChainListDefect)(msg: message)
+  raise (ref ChainListDefect)(exitCode: 20, msg: message)
 
 template raiseOverseerDefect*(message: string) =
-  raise (ref OverseerDefect)(msg: message)
+  raise (ref OverseerDefect)(exitCode: 21, msg: message)
+
+template raiseNetworkDefect*(message: string) =
+  raise (ref NetworkDefect)(exitCode: 22, msg: message)

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -5,6 +5,8 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [].}
+
 type
   ExitProcessDefect* = object of Defect
     exitCode*: int8

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -1,0 +1,49 @@
+# beacon_chain
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+type
+  DatabaseDefect* = object of Defect
+  SlashingDefect* = object of Defect
+  ClearanceDefect* = object of Defect
+  StrictDefect* = object of Defect
+  NetworkDefect* = object of Defect
+  DagDefect* = object of Defect
+  KeystoreDefect* = object of Defect
+  ProcessorDefect* = object of Defect
+  DiscoveryDefect* = object of Defect
+  ChainListDefect* = object of Defect
+  OverseerDefect* = object of Defect
+
+template raiseDatabaseDefect*(message: string) =
+  raise (ref DatabaseDefect)(msg: message)
+
+template raiseSlashingDefect*(message: string) =
+  raise (ref SlashingDefect)(msg: message)
+
+template raiseClearanceDefect*(message: string) =
+  raise (ref ClearanceDefect)(msg: message)
+
+template raiseStrictDefect*(message: string) =
+  raise (ref StrictDefect)(msg: message)
+
+template raiseDagDefect*(message: string) =
+  raise (ref DagDefect)(msg: message)
+
+template raiseKeystoreDefect*(message: string) =
+  raise (ref KeystoreDefect)(msg: message)
+
+template raiseProcessorDefect*(message: string) =
+  raise (ref ProcessorDefect)(msg: message)
+
+template raiseDiscoveryDefect*(message: string) =
+  raise (ref DiscoveryDefect)(msg: message)
+
+template raiseChainListDefect*(message: string) =
+  raise (ref ChainListDefect)(msg: message)
+
+template raiseOverseerDefect*(message: string) =
+  raise (ref OverseerDefect)(msg: message)

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -20,36 +20,38 @@ type
   DiscoveryDefect* = object of ExitProcessDefect
   ChainListDefect* = object of ExitProcessDefect
   OverseerDefect* = object of ExitProcessDefect
+  MetadataDefect* = object of ExitProcessDefect
+  LogDefect* = object of ExitProcessDefect
+  ConfigDefect* = object of ExitProcessDefect
+  KeymanagerDefect* = object of ExitProcessDefect
 
-template raiseDatabaseDefect*(message: string) =
-  raise (ref DatabaseDefect)(exitCode: 12, msg: message)
+  DepositsDefect* = object of ExitProcessDefect
+  TrustedSyncDefect* = object of ExitProcessDefect
+  WalletsDefect* = object of ExitProcessDefect
 
-template raiseSlashingDefect*(message: string) =
-  raise (ref SlashingDefect)(exitCode: 13, msg: message)
+template declareExitHelpers(defect, code: untyped): untyped =
+  template `raise defect`*() =
+    raise (ref defect)(exitCode: code, msg: "")
+  template `raise defect`*(message: string) =
+    raise (ref defect)(exitCode: code, msg: message)
 
-template raiseClearanceDefect*(message: string) =
-  raise (ref ClearanceDefect)(exitCode: 14, msg: message)
-
-template raiseStrictDefect*(message: string) =
-  raise (ref StrictDefect)(exitCode: 15, msg: message)
-
-template raiseDagDefect*(message: string) =
-  raise (ref DagDefect)(exitCode: 16, msg: message)
-
-template raiseKeystoreDefect*(message: string) =
-  raise (ref KeystoreDefect)(exitCode: 17, msg: message)
-
-template raiseProcessorDefect*(message: string) =
-  raise (ref ProcessorDefect)(exitCode: 18, msg: message)
-
-template raiseDiscoveryDefect*(message: string) =
-  raise (ref DiscoveryDefect)(exitCode: 19, msg: message)
-
-template raiseChainListDefect*(message: string) =
-  raise (ref ChainListDefect)(exitCode: 20, msg: message)
-
-template raiseOverseerDefect*(message: string) =
-  raise (ref OverseerDefect)(exitCode: 21, msg: message)
-
-template raiseNetworkDefect*(message: string) =
-  raise (ref NetworkDefect)(exitCode: 22, msg: message)
+# Submodules exits
+declareExitHelpers(DatabaseDefect, 12)
+declareExitHelpers(SlashingDefect, 13)
+declareExitHelpers(NetworkDefect, 14)
+declareExitHelpers(ClearanceDefect, 15)
+declareExitHelpers(StrictDefect, 16)
+declareExitHelpers(DagDefect, 17)
+declareExitHelpers(KeystoreDefect, 18)
+declareExitHelpers(ProcessorDefect, 19)
+declareExitHelpers(DiscoveryDefect, 20)
+declareExitHelpers(ChainListDefect, 21)
+declareExitHelpers(OverseerDefect, 22)
+declareExitHelpers(LogDefect, 23)
+declareExitHelpers(ConfigDefect, 24)
+declareExitHelpers(KeymanagerDefect, 25)
+declareExitHelpers(MetadataDefect, 26)
+# Modules exits
+declareExitHelpers(DepositsDefect, 30)
+declareExitHelpers(TrustedSyncDefect, 31)
+declareExitHelpers(WalletsDefect, 32)

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -9,6 +9,7 @@ type
   ExitProcessDefect* = object of Defect
     exitCode*: int16
 
+  SuccessDefect* = object of ExitProcessDefect
   DatabaseDefect* = object of ExitProcessDefect
   SlashingDefect* = object of ExitProcessDefect
   NetworkDefect* = object of ExitProcessDefect
@@ -28,6 +29,7 @@ type
   DepositsDefect* = object of ExitProcessDefect
   TrustedSyncDefect* = object of ExitProcessDefect
   WalletsDefect* = object of ExitProcessDefect
+  BeaconNodeDefect* = object of ExitProcessDefect
 
 template declareExitHelpers(defect, code: untyped): untyped =
   template `raise defect`*() =
@@ -36,6 +38,7 @@ template declareExitHelpers(defect, code: untyped): untyped =
     raise (ref defect)(exitCode: code, msg: message)
 
 # Submodules exits
+declareExitHelpers(SuccessDefect, 0)
 declareExitHelpers(DatabaseDefect, 12)
 declareExitHelpers(SlashingDefect, 13)
 declareExitHelpers(NetworkDefect, 14)
@@ -55,3 +58,4 @@ declareExitHelpers(MetadataDefect, 26)
 declareExitHelpers(DepositsDefect, 30)
 declareExitHelpers(TrustedSyncDefect, 31)
 declareExitHelpers(WalletsDefect, 32)
+declareExitHelpers(BeaconNodeDefect, 33)

--- a/beacon_chain/spec/defects.nim
+++ b/beacon_chain/spec/defects.nim
@@ -36,6 +36,9 @@ type
   Web3CmdDefect* = object of ExitProcessDefect
   SlashInterDefect* = object of ExitProcessDefect
 
+  ValidatorClientDefect* = object of ExitProcessDefect
+  LightClientDefect* = object of ExitProcessDefect
+
 template declareExitHelpers(defect, code: untyped): untyped =
   template `raise defect`*() =
     raise (ref defect)(exitCode: code, msg: "")
@@ -67,6 +70,8 @@ declareExitHelpers(BeaconNodeDefect, 33)
 declareExitHelpers(RecordDefect, 34)
 declareExitHelpers(Web3CmdDefect, 35)
 declareExitHelpers(SlashInterDefect, 36)
+declareExitHelpers(ValidatorClientDefect, 37)
+declareExitHelpers(LightClientDefect, 38)
 
 template withDefectsHandlers*(pbody, fbody: untyped) =
   try:
@@ -76,3 +81,10 @@ template withDefectsHandlers*(pbody, fbody: untyped) =
     quit(exc.exitCode)
   finally:
     fbody
+
+template withDefectsHandlers*(pbody: untyped) =
+  try:
+    pbody
+  except ExitProcessDefect as exc:
+    # This defects are already logged, so we just quit.
+    quit(exc.exitCode)

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -12,7 +12,7 @@ import
   bearssl/rand,
   nimcrypto/[hmac, utils, sha2],
   results,
-  stew/byteutils
+  stew/[io2, byteutils]
 
 from std/base64 import encode
 from std/json import JsonNode, `$`, `%*`
@@ -61,7 +61,7 @@ func getSignedToken*(key: openArray[byte], payload: string): string =
 func getSignedIatToken*(key: openArray[byte], time: int64): string =
   getSignedToken(key, $getIatToken(time))
 
-func parseJwtTokenValue*(input: string): Result[seq[byte], cstring] =
+func parseJwtTokenValue*(input: string): Result[seq[byte], string] =
   # Secret JWT key is parsed in constant time using nimcrypto:
   # https://github.com/cheatfate/nimcrypto/pull/44
   let secret = utils.fromHex(input)
@@ -70,21 +70,23 @@ func parseJwtTokenValue*(input: string): Result[seq[byte], cstring] =
   else:
     err("The JWT secret should be 256 bits and hex-encoded")
 
-proc loadJwtSecretFile*(jwtSecretFile: InputFile): Result[seq[byte], cstring] =
+proc loadJwtSecretFile*(jwtSecretFile: InputFile): Result[seq[byte], string] =
   try:
     let lines = readLines(string jwtSecretFile, 1)
     if lines.len > 0:
       parseJwtTokenValue(lines[0])
     else:
       err("The JWT token file should not be empty")
-  except IOError:
-    err("couldn't open specified JWT secret file")
+  except IOError as exc:
+    err("couldn't open specified JWT secret file, reason: " & $exc.msg)
   except ValueError:
     err("invalid JWT hex string")
 
 proc checkJwtSecret*(
-    rng: var HmacDrbgContext, dataDir: string, jwtSecret: Opt[InputFile]):
-    Result[seq[byte], cstring] =
+    rng: var HmacDrbgContext,
+    dataDir: string,
+    jwtSecret: Opt[InputFile]
+): Result[seq[byte], string] =
   # If such a parameter is given, but the file cannot be read, or does not
   # contain a hex-encoded key of 256 bits, the client should treat this as an
   # error: either abort the startup, or show error and continue without
@@ -100,14 +102,9 @@ proc checkJwtSecret*(
     let jwtSecretPath = dataDir / jwtSecretFilename
 
     let newSecret = rng.generateBytes(JWT_SECRET_LEN)
-    try:
-      writeFile(jwtSecretPath, newSecret.to0xHex())
-    except IOError as exc:
-      # Allow continuing to run, though this is effectively fatal for a merge
-      # client using authentication. This keeps it lower-risk initially.
-      warn "Could not write JWT secret to data directory",
-        jwtSecretPath,
-        err = exc.msg
+    io2.writeFile(jwtSecretPath, newSecret.to0xHex()).isOkOr:
+      return err(
+        "Could not write JWT secret to data directory, reason: " & $error)
     return ok(newSecret)
 
   loadJwtSecretFile(jwtSecret.get)

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  chronicles, confutils/defs,
+  confutils/defs,
   bearssl/rand,
   nimcrypto/[hmac, utils, sha2],
   results,

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -813,9 +813,9 @@ proc process_sync_aggregate*(
     template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
     let num_active_participants = countOnes(sync_committee_bits).uint64
     if num_active_participants * 3 < static(sync_committee_bits.len * 2):
-      const msg = "Low sync committee participation"
-      fatal msg, slot = state.slot, num_active_participants
-      raiseStrictDefect(msg)
+      fatal "Low sync committee participation", slot = state.slot,
+            num_active_participants
+      raiseStrictDefect()
 
   # Verify sync committee aggregate signature signing over the previous slot
   # block root

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -28,7 +28,8 @@ import
   chronicles, metrics,
   ../extras,
   ./datatypes/[phase0, altair, bellatrix, deneb],
-  "."/[beaconstate, eth2_merkleization, helpers, validator, signatures],
+  "."/[beaconstate, eth2_merkleization, helpers, validator, signatures,
+       defects],
   kzg4844/kzg_abi, kzg4844/kzg
 
 from std/algorithm import fill, sorted
@@ -812,9 +813,9 @@ proc process_sync_aggregate*(
     template sync_committee_bits(): auto = sync_aggregate.sync_committee_bits
     let num_active_participants = countOnes(sync_committee_bits).uint64
     if num_active_participants * 3 < static(sync_committee_bits.len * 2):
-      fatal "Low sync committee participation",
-        slot = state.slot, num_active_participants
-      quit 1
+      const msg = "Low sync committee participation"
+      fatal msg, slot = state.slot, num_active_participants
+      raiseStrictDefect(msg)
 
   # Verify sync committee aggregate signature signing over the previous slot
   # block root

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -336,10 +336,10 @@ proc weigh_justification_and_finalization(
       epoch: previous_epoch, root: get_block_root(state, previous_epoch))
     uint8(res.justification_bits).setBit 1
   elif strictVerification in flags:
-    const msg = "Low attestation participation in previous epoch"
-    fatal msg, total_active_balance, previous_epoch_target_balance,
+    fatal "Low attestation participation in previous epoch",
+          total_active_balance, previous_epoch_target_balance,
           current_epoch_target_balance, epoch = get_current_epoch(state)
-    raiseStrictDefect(msg)
+    raiseStrictDefect()
 
   if current_epoch_target_balance * 3 >= total_active_balance * 2:
     res.current_justified_checkpoint = Checkpoint(
@@ -1510,9 +1510,9 @@ proc process_epoch*(
     # the finalization rules triggered.
     if (epoch >= 2 and state.current_justified_checkpoint.epoch + 2 < epoch) or
        (epoch >= 3 and state.finalized_checkpoint.epoch + 3 < epoch):
-      const msg = "The network did not finalize"
-      fatal msg, epoch, finalizedEpoch = state.finalized_checkpoint.epoch
-      raiseStrictDefect(msg)
+      fatal "The network did not finalize", epoch,
+            finalizedEpoch = state.finalized_checkpoint.epoch
+      raiseStrictDefect()
 
   process_inactivity_updates(cfg, state, info)
 
@@ -1553,9 +1553,9 @@ proc process_epoch*(
     # the finalization rules triggered.
     if (epoch >= 2 and state.current_justified_checkpoint.epoch + 2 < epoch) or
        (epoch >= 3 and state.finalized_checkpoint.epoch + 3 < epoch):
-      const msg = "The network did not finalize"
-      fatal msg, epoch, finalizedEpoch = state.finalized_checkpoint.epoch
-      raiseStrictDefect(msg)
+      fatal "The network did not finalize", epoch,
+            finalizedEpoch = state.finalized_checkpoint.epoch
+      raiseStrictDefect()
 
   process_inactivity_updates(cfg, state, info)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -25,7 +25,7 @@
 import
   stew/assign2, chronicles,
   ../extras,
-  "."/[beaconstate, eth2_merkleization, validator]
+  "."/[beaconstate, eth2_merkleization, validator, defects]
 
 from std/math import sum, `^`
 from stew/bitops2 import setBit
@@ -336,12 +336,10 @@ proc weigh_justification_and_finalization(
       epoch: previous_epoch, root: get_block_root(state, previous_epoch))
     uint8(res.justification_bits).setBit 1
   elif strictVerification in flags:
-    fatal "Low attestation participation in previous epoch",
-      total_active_balance,
-      previous_epoch_target_balance,
-      current_epoch_target_balance,
-      epoch = get_current_epoch(state)
-    quit 1
+    const msg = "Low attestation participation in previous epoch"
+    fatal msg, total_active_balance, previous_epoch_target_balance,
+          current_epoch_target_balance, epoch = get_current_epoch(state)
+    raiseStrictDefect(msg)
 
   if current_epoch_target_balance * 3 >= total_active_balance * 2:
     res.current_justified_checkpoint = Checkpoint(
@@ -1512,9 +1510,9 @@ proc process_epoch*(
     # the finalization rules triggered.
     if (epoch >= 2 and state.current_justified_checkpoint.epoch + 2 < epoch) or
        (epoch >= 3 and state.finalized_checkpoint.epoch + 3 < epoch):
-      fatal "The network did not finalize",
-             epoch, finalizedEpoch = state.finalized_checkpoint.epoch
-      quit 1
+      const msg = "The network did not finalize"
+      fatal msg, epoch, finalizedEpoch = state.finalized_checkpoint.epoch
+      raiseStrictDefect(msg)
 
   process_inactivity_updates(cfg, state, info)
 
@@ -1555,9 +1553,9 @@ proc process_epoch*(
     # the finalization rules triggered.
     if (epoch >= 2 and state.current_justified_checkpoint.epoch + 2 < epoch) or
        (epoch >= 3 and state.finalized_checkpoint.epoch + 3 < epoch):
-      fatal "The network did not finalize",
-             epoch, finalizedEpoch = state.finalized_checkpoint.epoch
-      quit 1
+      const msg = "The network did not finalize"
+      fatal msg, epoch, finalizedEpoch = state.finalized_checkpoint.epoch
+      raiseStrictDefect(msg)
 
   process_inactivity_updates(cfg, state, info)
 

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -12,7 +12,8 @@ import stew/base10, chronos, chronicles, results
 import
   ../consensus_object_pools/blockchain_list,
   ../spec/eth2_apis/rest_types,
-  ../spec/[helpers, forks, network, forks_light_client, weak_subjectivity],
+  ../spec/[helpers, forks, network, forks_light_client, weak_subjectivity,
+           defects],
   ../networking/[peer_pool, peer_scores, eth2_network],
   ../gossip_processing/block_processor,
   ../[beacon_clock, beacon_node],
@@ -289,9 +290,9 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
     clist =
       block:
         overseer.clist.seekForSlot(dag.head.slot).isOkOr:
-          fatal "Unable to find slot in backfill data", reason = error,
-                path = overseer.clist.path
-          quit 1
+          const msg = "Unable to find slot in backfill data"
+          fatal msg, reason = error, path = overseer.clist.path
+          raiseOverseerDefect(msg)
         overseer.clist
 
   var
@@ -308,16 +309,15 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
 
   block mainLoop:
     while true:
-      let res = getChainFileTail(handle.handle)
-      if res.isErr():
-        fatal "Unable to read backfill data", reason = res.error
-        quit 1
-      let bres = res.get()
-      if bres.isNone():
+      let res = getChainFileTail(handle.handle).valueOr:
+        const msg = "Unable to read backfill data"
+        fatal msg, reason = error
+        raiseOverseerDefect(msg)
+      if res.isNone():
         return
 
       let
-        data = bres.get()
+        data = res.get()
         blockEpoch = data.blck.slot.epoch()
 
       if blockEpoch != currentEpoch:
@@ -359,8 +359,9 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
               raiseAssert "Should not happen with unbounded AsyncQueue"
             let res = await bchunk.resfut
             if res.isErr():
-              fatal "Unable to add block data to database", reason = res.error
-              quit 1
+              const msg = "Unable to add block data to database"
+              fatal msg, reason = res.error
+              raiseOverseerDefect(msg)
 
           let updateTick = Moment.now()
           debug "Number of blocks injected",
@@ -453,8 +454,13 @@ proc mainLoop*(
   else:
     if dag.needsBackfill():
       # Checkpoint/Trusted state we have is too old.
-      error "Trusted node sync started too long time ago"
-      quit 1
+      const msg =
+        "Last attempt to perform trusted node sync was made long time " &
+        "ago (outside of weak subjectivity period)"
+      fatal msg, current_slot = currentSlot,
+            dag_backfill_slot = dag.backfill.slot,
+            retention_period_slot = overseer.getLastBlockRetentionPeriodSlot()
+      raiseOverseerDefect(msg)
 
     if not(isUntrustedBackfillEmpty(clist)):
       let headSlot = clist.head.get().slot
@@ -473,17 +479,17 @@ proc mainLoop*(
     if overseer.config.longRangeSync == LongRangeSyncMode.Light:
       let dagHead = dag.finalizedHead
       if dagHead.slot < dag.cfg.ALTAIR_FORK_EPOCH.start_slot:
-        fatal "Light forward syncing requires a post-Altair state",
-              head_slot = dagHead.slot,
+        const msg = "Light forward syncing requires a post-Altair state"
+        fatal msg, head_slot = dagHead.slot,
               altair_start_slot = dag.cfg.ALTAIR_FORK_EPOCH.start_slot
-        quit 1
+        raiseOverseerDefect(msg)
 
       if overseer.isWithinBlockRetentionPeriod(dagHead.slot):
-        fatal "Current database head slot is not in the block retention " &
-              "period range",
-              head_slot = dagHead.slot,
+        const msg = "Current database head slot is not in the block " &
+                    "retention period range"
+        fatal msg, head_slot = dagHead.slot,
               retention_period_slot = overseer.getLastBlockRetentionPeriodSlot()
-        quit 1
+        raiseOverseerDefect(msg)
 
       if isUntrustedBackfillEmpty(clist):
         overseer.untrustedInProgress = true
@@ -516,9 +522,9 @@ proc mainLoop*(
         return
 
       clist.clear().isOkOr:
-        warn "Unable to remove backfill data file",
-             path = clist.path.chainFilePath(), reason = error
-        quit 1
+        const msg = "Unable to remove backfill data file"
+        warn msg, path = clist.path.chainFilePath(), reason = error
+        raiseOverseerDefect(msg)
 
       overseer.untrustedInProgress = false
       # Reset status bar
@@ -532,7 +538,6 @@ proc start*(overseer: SyncOverseerRef) =
   overseer.loopFuture = overseer.mainLoop()
 
 proc stop*(overseer: SyncOverseerRef) {.async: (raises: []).} =
-  doAssert(not(isNil(overseer.loopFuture)),
-           "SyncOverseer was not started yet")
+  doAssert(not(isNil(overseer.loopFuture)), "SyncOverseer is not started yet")
   if not(overseer.loopFuture.finished()):
     await cancelAndWait(overseer.loopFuture)

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -290,9 +290,9 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
     clist =
       block:
         overseer.clist.seekForSlot(dag.head.slot).isOkOr:
-          const msg = "Unable to find slot in backfill data"
-          fatal msg, reason = error, path = overseer.clist.path
-          raiseOverseerDefect(msg)
+          fatal "Unable to find slot in backfill data", reason = error,
+                path = overseer.clist.path
+          raiseOverseerDefect()
         overseer.clist
 
   var
@@ -310,9 +310,8 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
   block mainLoop:
     while true:
       let res = getChainFileTail(handle.handle).valueOr:
-        const msg = "Unable to read backfill data"
-        fatal msg, reason = error
-        raiseOverseerDefect(msg)
+        fatal "Unable to read backfill data", reason = error
+        raiseOverseerDefect()
       if res.isNone():
         return
 
@@ -359,9 +358,8 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
               raiseAssert "Should not happen with unbounded AsyncQueue"
             let res = await bchunk.resfut
             if res.isErr():
-              const msg = "Unable to add block data to database"
-              fatal msg, reason = res.error
-              raiseOverseerDefect(msg)
+              fatal "Unable to add block data to database", reason = res.error
+              raiseOverseerDefect()
 
           let updateTick = Moment.now()
           debug "Number of blocks injected",
@@ -454,13 +452,11 @@ proc mainLoop*(
   else:
     if dag.needsBackfill():
       # Checkpoint/Trusted state we have is too old.
-      const msg =
-        "Last attempt to perform trusted node sync was made long time " &
-        "ago (outside of weak subjectivity period)"
-      fatal msg, current_slot = currentSlot,
-            dag_backfill_slot = dag.backfill.slot,
+      fatal "Last attempt to perform trusted node sync was made long time " &
+            "ago (outside of weak subjectivity period)",
+            current_slot = currentSlot, dag_backfill_slot = dag.backfill.slot,
             retention_period_slot = overseer.getLastBlockRetentionPeriodSlot()
-      raiseOverseerDefect(msg)
+      raiseOverseerDefect()
 
     if not(isUntrustedBackfillEmpty(clist)):
       let headSlot = clist.head.get().slot
@@ -479,17 +475,16 @@ proc mainLoop*(
     if overseer.config.longRangeSync == LongRangeSyncMode.Light:
       let dagHead = dag.finalizedHead
       if dagHead.slot < dag.cfg.ALTAIR_FORK_EPOCH.start_slot:
-        const msg = "Light forward syncing requires a post-Altair state"
-        fatal msg, head_slot = dagHead.slot,
+        fatal "Light forward syncing requires a post-Altair state",
+              head_slot = dagHead.slot,
               altair_start_slot = dag.cfg.ALTAIR_FORK_EPOCH.start_slot
-        raiseOverseerDefect(msg)
+        raiseOverseerDefect()
 
       if overseer.isWithinBlockRetentionPeriod(dagHead.slot):
-        const msg = "Current database head slot is not in the block " &
-                    "retention period range"
-        fatal msg, head_slot = dagHead.slot,
+        fatal "Current database head slot is not in the block " &
+              "retention period range", head_slot = dagHead.slot,
               retention_period_slot = overseer.getLastBlockRetentionPeriodSlot()
-        raiseOverseerDefect(msg)
+        raiseOverseerDefect()
 
       if isUntrustedBackfillEmpty(clist):
         overseer.untrustedInProgress = true
@@ -522,9 +517,9 @@ proc mainLoop*(
         return
 
       clist.clear().isOkOr:
-        const msg = "Unable to remove backfill data file"
-        warn msg, path = clist.path.chainFilePath(), reason = error
-        raiseOverseerDefect(msg)
+        fatal "Unable to remove backfill data file",
+             path = clist.path.chainFilePath(), reason = error
+        raiseOverseerDefect()
 
       overseer.untrustedInProgress = false
       # Reset status bar

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -14,8 +14,7 @@ import
   ./consensus_object_pools/[block_clearance, blockchain_dag],
   ./spec/eth2_apis/rest_beacon_client,
   ./spec/[beaconstate, eth2_merkleization, forks, light_client_sync,
-          network, presets,
-          state_transition, deposit_snapshots],
+          network, presets, state_transition, deposit_snapshots, defects],
   "."/[beacon_clock, beacon_chain_db, era_db]
 
 from presto import RestDecodingError
@@ -88,8 +87,8 @@ proc doTrustedNodeSync*(
 
   var
     client = createNewRestClient(restUrl).valueOr:
-      error "Cannot connect to server", reason = error
-      quit 1
+      fatal "Cannot connect to server", reason = error
+      raiseTrustedSyncDefect()
 
   # If possible, we'll store the genesis state in the database - this is not
   # strictly necessary but renders the resulting database compatible with
@@ -98,24 +97,24 @@ proc doTrustedNodeSync*(
     if (let genesisRoot = db.getGenesisBlock(); genesisRoot.isSome()):
       let
         genesisBlock = db.getForkedBlock(genesisRoot.get()).valueOr:
-          error "Cannot load genesis block from database",
-            genesisRoot = genesisRoot.get()
-          quit 1
+          fatal "Cannot load genesis block from database",
+                genesisRoot = genesisRoot.get()
+          raiseTrustedSyncDefect()
         genesisStateRoot = getForkedBlockField(genesisBlock, state_root)
         consensusFork = cfg.consensusForkAtEpoch(GENESIS_EPOCH)
 
         tmp = (ref ForkedHashedBeaconState)(kind: consensusFork)
       if not db.getState(consensusFork, genesisStateRoot, tmp[], noRollback):
-        error "Cannot load genesis state from database",
-          genesisStateRoot
-        quit 1
+        fatal "Cannot load genesis state from database",
+              genesisStateRoot
+        raiseTrustedSyncDefect()
 
       if (genesisState != nil) and
           (getStateRoot(tmp[]) != getStateRoot(genesisState[])):
-        error "Unexpected genesis state in database, is this the same network?",
-          databaseRoot = getStateRoot(tmp[]),
-          genesisRoot = getStateRoot(genesisState[])
-        quit 1
+        fatal "Unexpected genesis state in database, is this the same network?",
+              databaseRoot = getStateRoot(tmp[]),
+              genesisRoot = getStateRoot(genesisState[])
+        raiseTrustedSyncDefect()
       tmp
     else:
       let tmp = if genesisState != nil:
@@ -123,8 +122,8 @@ proc doTrustedNodeSync*(
       else:
         case syncTarget.kind
         of TrustedNodeSyncKind.TrustedBlockRoot:
-          error "Genesis state is required when using `trustedBlockRoot`",
-            missingNetworkMetadataFile = "genesis.ssz"
+          fatal "Genesis state is required when using `trustedBlockRoot`",
+                missingNetworkMetadataFile = "genesis.ssz"
           # `genesis_time` and `genesis_validators_root` are required to check
           # light client data signatures. They are not part of `config.yaml`.
           # We could download the initial state based on `LightClientBootstrap`
@@ -139,7 +138,7 @@ proc doTrustedNodeSync*(
           # prove correctness of a particular genesis state. However, there is
           # currently no endpoint to obtain proofs, and they change for every
           # slot, making it tricky to actually provide them.
-          quit 1
+          raiseTrustedSyncDefect()
         of TrustedNodeSyncKind.StateId:
           notice "Downloading genesis state", restUrl
           try:
@@ -164,9 +163,9 @@ proc doTrustedNodeSync*(
     head = if dbHead.isSome():
       let
         bid = db.getBlockId(dbHead.get()).valueOr:
-          error "Database missing head block summary - database too old or corrupt",
-            headRoot = dbHead.get()
-          quit 1
+          fatal "Database missing head block summary - database too old or corrupt",
+                headRoot = dbHead.get()
+          raiseTrustedSyncDefect()
 
       Opt.some bid
     else:
@@ -191,8 +190,8 @@ proc doTrustedNodeSync*(
         let
           genesisTime = getStateField(genesisState[], genesis_time)
           beaconClock = BeaconClock.init(genesisTime).valueOr:
-            error "Invalid genesis time in state", genesisTime
-            quit 1
+            fatal "Invalid genesis time in state", genesisTime
+            raiseTrustedSyncDefect()
           getBeaconTime = beaconClock.getBeaconTimeFn()
 
           genesis_validators_root =
@@ -209,21 +208,22 @@ proc doTrustedNodeSync*(
                 trustedBlockRoot, cfg, forkDigests),
               smallRequestsTimeout
             ):
-              error "Attempt to download LC bootstrap timed out"
-              quit 1
+              fatal "Attempt to download LC bootstrap timed out"
+              raiseTrustedSyncDefect()
           except CatchableError as exc:
-            error "Unable to download LC bootstrap", error = exc.msg
-            quit 1
+            fatal "Unable to download LC bootstrap", error = exc.msg
+            raiseTrustedSyncDefect()
         if bootstrap.kind == LightClientDataFork.None:
-          error "LC bootstrap unavailable on server"
-          quit 1
+          fatal "LC bootstrap unavailable on server"
+          raiseTrustedSyncDefect()
         bootstrap.migrateToDataFork(lcDataFork)
 
         var storeRes = initialize_light_client_store(
           trustedBlockRoot, bootstrap.forky(lcDataFork), cfg)
         if storeRes.isErr:
-          error "`initialize_light_client_store` failed", err = storeRes.error
-          quit 1
+          fatal "`initialize_light_client_store` failed",
+                reason = storeRes.error
+          raiseTrustedSyncDefect()
         template store: auto = storeRes.get
         store.trackBestViableCheckpoint()
 
@@ -260,15 +260,15 @@ proc doTrustedNodeSync*(
                   startPeriod, count, cfg, forkDigests),
                 smallRequestsTimeout
               ):
-                error "Attempt to download LC updates timed out"
-                quit 1
+                fatal "Attempt to download LC updates timed out"
+                raiseTrustedSyncDefect()
             except CatchableError as exc:
-              error "Unable to download LC updates", error = exc.msg
-              quit 1
+              fatal "Unable to download LC updates", reason = exc.msg
+              raiseTrustedSyncDefect()
           let e = updates.checkLightClientUpdates(startPeriod, count)
           if e.isErr:
-            error "Malformed LC updates response", resError = e.error
-            quit 1
+            fatal "Malformed LC updates response", reason = e.error
+            raiseTrustedSyncDefect()
           if updates.len == 0:
             warn "Server does not appear to be fully synced"
             break
@@ -279,8 +279,8 @@ proc doTrustedNodeSync*(
               store, updates[i].forky(lcDataFork),
               getBeaconTime().slotOrZero(), cfg, genesis_validators_root)
             if not res.isOk:
-              error "`process_light_client_update` failed", resError = res.error
-              quit 1
+              fatal "`process_light_client_update` failed", reason = res.error
+              raiseTrustedSyncDefect()
             store.trackBestViableCheckpoint()
 
         var finalityUpdate =
@@ -290,28 +290,28 @@ proc doTrustedNodeSync*(
               client.getLightClientFinalityUpdate(cfg, forkDigests),
               smallRequestsTimeout
             ):
-              error "Attempt to download LC finality update timed out"
-              quit 1
+              fatal "Attempt to download LC finality update timed out"
+              raiseTrustedSyncDefect()
           except CatchableError as exc:
-            error "Unable to download LC finality update", error = exc.msg
-            quit 1
+            fatal "Unable to download LC finality update", reason = exc.msg
+            raiseTrustedSyncDefect()
         if bootstrap.kind == LightClientDataFork.None:
-          error "LC finality update unavailable on server"
-          quit 1
+          fatal "LC finality update unavailable on server"
+          raiseTrustedSyncDefect()
         finalityUpdate.migrateToDataFork(lcDataFork)
 
         let res = process_light_client_update(
           store, finalityUpdate.forky(lcDataFork),
           getBeaconTime().slotOrZero(), cfg, genesis_validators_root)
         if not res.isOk:
-          error "`process_light_client_update` failed", resError = res.error
-          quit 1
+          fatal "`process_light_client_update` failed", reason = res.error
+          raiseTrustedSyncDefect()
         store.trackBestViableCheckpoint()
 
         if bestViableCheckpoint.isErr:
-          error "CP not on epoch boundary. Retry later",
-            latestCheckpointSlot = store.finalized_header.beacon.slot
-          quit 1
+          fatal "CP not on epoch boundary. Retry later",
+                latestCheckpointSlot = store.finalized_header.beacon.slot
+          raiseTrustedSyncDefect()
         if not store.finalized_header.beacon.slot.is_epoch:
           warn "CP not on epoch boundary. Using older one",
             latestCheckpointSlot = store.finalized_header.beacon.slot,
@@ -329,54 +329,53 @@ proc doTrustedNodeSync*(
       state = try:
         let id = block:
           let tmp = StateIdent.decodeString(stateId).valueOr:
-            error "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
-            quit 1
+            fatal "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
+            raiseTrustedSyncDefect()
           if tmp.kind == StateQueryKind.Slot and not tmp.slot.is_epoch():
             notice "Rounding given slot to epoch"
             StateIdent.init(tmp.slot.epoch().start_slot)
           else:
             tmp
         awaitWithTimeout(client.getStateV2(id, cfg), largeRequestsTimeout):
-          error "Attempt to download checkpoint state timed out"
-          quit 1
+          fatal "Attempt to download checkpoint state timed out"
+          raiseTrustedSyncDefect()
       except CatchableError as exc:
-        error "Unable to download checkpoint state",
-          error = exc.msg
-        quit 1
+        fatal "Unable to download checkpoint state", reason = exc.msg
+        raiseTrustedSyncDefect()
 
     if state == nil:
-      error "No state found a given checkpoint"
-      quit 1
+      fatal "No state found a given checkpoint"
+      raiseTrustedSyncDefect()
 
     if stateRoot.isSome:
       if state[].getStateRoot() != stateRoot.get:
-        error "Checkpoint state has incorrect root!",
-          expectedStateRoot = stateRoot.get,
-          actualStateRoot = state[].getStateRoot()
-        quit 1
+        fatal "Checkpoint state has incorrect root!",
+              expectedStateRoot = stateRoot.get,
+              actualStateRoot = state[].getStateRoot()
+        raiseTrustedSyncDefect()
       info "Checkpoint state validated against LC data",
         stateRoot = stateRoot.get
 
     if not getStateField(state[], slot).is_epoch():
-      error "State slot must fall on an epoch boundary",
-        slot = getStateField(state[], slot),
-        offset = getStateField(state[], slot) -
-          getStateField(state[], slot).epoch.start_slot
-      quit 1
+      fatal "State slot must fall on an epoch boundary",
+            slot = getStateField(state[], slot),
+            offset = getStateField(state[], slot) -
+            getStateField(state[], slot).epoch.start_slot
+      raiseTrustedSyncDefect()
 
     if genesisState != nil:
       if getStateField(state[], genesis_time) !=
           getStateField(genesisState[], genesis_time):
-        error "Checkpoint state does not match genesis",
-          timeInCheckpoint = getStateField(state[], genesis_time),
-          timeInGenesis = getStateField(genesisState[], genesis_time)
-        quit 1
+        fatal "Checkpoint state does not match genesis",
+              timeInCheckpoint = getStateField(state[], genesis_time),
+              timeInGenesis = getStateField(genesisState[], genesis_time)
+        raiseTrustedSyncDefect()
       if getStateField(state[], genesis_validators_root) !=
           getStateField(genesisState[], genesis_validators_root):
-        error "Checkpoint state does not match genesis",
+        fatal "Checkpoint state does not match genesis",
           rootInCheckpoint = getStateField(state[], genesis_validators_root),
           rootInGenesis = getStateField(genesisState[], genesis_validators_root)
-        quit 1
+        raiseTrustedSyncDefect()
 
       ChainDAGRef.preInit(db, genesisState[])
 
@@ -448,8 +447,8 @@ proc doTrustedNodeSync*(
 
           warn "Retrying download of block", slot, err = exc.msg
           client = createNewRestClient(restUrl).valueOr:
-            error "Cannot connect to server", url = restUrl, reason = error
-            quit 1
+            fatal "Cannot connect to server", url = restUrl, reason = error
+            raiseTrustedSyncDefect()
 
       raise lastError
 
@@ -494,9 +493,9 @@ proc doTrustedNodeSync*(
             of VerifierError.Invalid,
                 VerifierError.MissingParent,
                 VerifierError.UnviableFork:
-              error "Got invalid block from trusted node - is it on the right network?",
-                blck = shortLog(forkyBlck), err = res.error()
-              quit 1
+              fatal "Got invalid block from trusted node - is it on the right network?",
+                    blck = shortLog(forkyBlck), reason = res.error()
+              raiseTrustedSyncDefect()
             of VerifierError.Duplicate:
               discard
 

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -760,9 +760,9 @@ iterator listLoadableKeys*(validatorsDir, secretsDir: string,
         yield cres
 
   except OSError as err:
-    const msg = "Validator keystores directory is not accessible"
-    fatal msg, path = validatorsDir, err = err.msg
-    raiseKeystoreDefect(msg)
+    fatal "Validator keystores directory is not accessible",
+          path = validatorsDir, reason = err.msg
+    raiseKeystoreDefect()
 
 iterator listLoadableKeystores*(validatorsDir, secretsDir: string,
                                 nonInteractive: bool,
@@ -793,16 +793,15 @@ iterator listLoadableKeystores*(validatorsDir, secretsDir: string,
         let
           keystore = loadKeystore(validatorsDir, secretsDir, keyName,
                                   nonInteractive, cache).valueOr:
-            const msg = "Unable to load keystore"
-            fatal msg, keystore = file
-            raiseKeystoreDefect(msg)
+            fatal "Unable to load keystore", keystore = file
+            raiseKeystoreDefect()
 
         yield keystore
 
   except OSError as err:
-    const msg = "Validator keystores directory is not accessible"
-    fatal msg, path = validatorsDir, err = err.msg
-    raiseKeystoreDefect(msg)
+    fatal "Validator keystores directory is not accessible",
+          path = validatorsDir, reason = err.msg
+    raiseKeystoreDefect()
 
 iterator listLoadableKeystores*(config: AnyConf,
                                 cache: KeystoreCacheRef): KeystoreData =
@@ -1904,9 +1903,8 @@ proc importKeystoresFromDir*(rng: var HmacDrbgContext, meth: ImportMethod,
           if password.len == 0:
             break
   except OSError:
-    const msg = "Failed to access the imported deposits directory"
-    fatal msg
-    raiseKeystoreDefect(msg)
+    fatal "Failed to access the imported deposits directory"
+    raiseKeystoreDefect()
 
 template ask(prompt: string): string =
   try:
@@ -2029,9 +2027,8 @@ proc createWalletInteractively*(
   try:
     discard getch()
   except IOError as err:
-    const msg = "Failed to read a key from stdin"
-    fatal msg, reason = err.msg
-    raiseKeystoreDefect(msg)
+    fatal "Failed to read a key from stdin", reason = err.msg
+    raiseKeystoreDefect()
 
   clearScreen()
 

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -13,7 +13,7 @@ import
   bearssl/rand,
   serialization, blscurve, eth/common/eth_types, confutils,
   nimbus_security_resources,
-  ".."/spec/[eth2_merkleization, keystore, crypto],
+  ".."/spec/[eth2_merkleization, keystore, crypto, defects],
   ".."/spec/datatypes/base,
   stew/[io2, byteutils], libp2p/crypto/crypto as lcrypto,
   nimcrypto/utils as ncrutils,
@@ -44,6 +44,7 @@ const
   BuilderConfigPath = "payload_builder.json"
   KeyNameSize = 98 # 0x + hexadecimal key representation 96 characters.
   MaxKeystoreFileSize = 65536
+  StdinReadFailureMessage = "Failed to read password from stdin"
 
 type
   WalletPathPair* = object
@@ -759,9 +760,9 @@ iterator listLoadableKeys*(validatorsDir, secretsDir: string,
         yield cres
 
   except OSError as err:
-    error "Validator keystores directory is not accessible",
-          path = validatorsDir, err = err.msg
-    quit 1
+    const msg = "Validator keystores directory is not accessible"
+    fatal msg, path = validatorsDir, err = err.msg
+    raiseKeystoreDefect(msg)
 
 iterator listLoadableKeystores*(validatorsDir, secretsDir: string,
                                 nonInteractive: bool,
@@ -792,15 +793,16 @@ iterator listLoadableKeystores*(validatorsDir, secretsDir: string,
         let
           keystore = loadKeystore(validatorsDir, secretsDir, keyName,
                                   nonInteractive, cache).valueOr:
-            fatal "Unable to load keystore", keystore = file
-            quit 1
+            const msg = "Unable to load keystore"
+            fatal msg, keystore = file
+            raiseKeystoreDefect(msg)
 
         yield keystore
 
   except OSError as err:
-    error "Validator keystores directory is not accessible",
-          path = validatorsDir, err = err.msg
-    quit 1
+    const msg = "Validator keystores directory is not accessible"
+    fatal msg, path = validatorsDir, err = err.msg
+    raiseKeystoreDefect(msg)
 
 iterator listLoadableKeystores*(config: AnyConf,
                                 cache: KeystoreCacheRef): KeystoreData =
@@ -1902,8 +1904,9 @@ proc importKeystoresFromDir*(rng: var HmacDrbgContext, meth: ImportMethod,
           if password.len == 0:
             break
   except OSError:
-    fatal "Failed to access the imported deposits directory"
-    quit 1
+    const msg = "Failed to access the imported deposits directory"
+    fatal msg
+    raiseKeystoreDefect(msg)
 
 template ask(prompt: string): string =
   try:
@@ -1983,7 +1986,7 @@ else:
 
 proc createWalletInteractively*(
     rng: var HmacDrbgContext,
-    config: BeaconNodeConf): Result[CreatedWallet, string] =
+    config: BeaconNodeConf): Result[Opt[CreatedWallet], string] =
 
   if config.nonInteractive:
     return err "not running in interactive mode"
@@ -2004,7 +2007,7 @@ proc createWalletInteractively*(
 
   while true:
     let answer = ask "Action"
-    if answer.len > 0 and answer[0] == 'q': quit 1
+    if answer.len > 0 and answer[0] == 'q': return ok(Opt.none(CreatedWallet))
     if answer == "continue": break
     echoP "To proceed to your seed phrase, please type 'continue' (without the quotes). " &
           "Type 'q' to exit now."
@@ -2026,8 +2029,9 @@ proc createWalletInteractively*(
   try:
     discard getch()
   except IOError as err:
-    fatal "Failed to read a key from stdin", err = err.msg
-    quit 1
+    const msg = "Failed to read a key from stdin"
+    fatal msg, reason = err.msg
+    raiseKeystoreDefect(msg)
 
   clearScreen()
 
@@ -2054,7 +2058,7 @@ proc createWalletInteractively*(
             "(the first word from the seed phrase, followed by the last 3)"
       echo ""
     else:
-      quit 1
+      return ok(Opt.none(CreatedWallet))
 
   clearScreen()
 
@@ -2075,8 +2079,8 @@ proc createWalletInteractively*(
       burnMem(recoveryPassword.get)
 
   if recoveryPassword.isErr:
-    fatal "Failed to read password from stdin: "
-    quit 1
+    fatal StdinReadFailureMessage
+    raiseKeystoreDefect(StdinReadFailureMessage)
 
   var keystorePass = KeystorePass.init recoveryPassword.get
   defer: burnMem(keystorePass)
@@ -2085,7 +2089,7 @@ proc createWalletInteractively*(
   defer: burnMem(seed)
 
   let walletPath = ? pickPasswordAndSaveWallet(rng, config, seed)
-  return ok CreatedWallet(walletPath: walletPath, seed: seed)
+  ok(Opt.some(CreatedWallet(walletPath: walletPath, seed: seed)))
 
 proc restoreWalletInteractively*(rng: var HmacDrbgContext,
                                  config: BeaconNodeConf) =
@@ -2100,8 +2104,8 @@ proc restoreWalletInteractively*(rng: var HmacDrbgContext,
   echo "To restore your wallet, please enter your backed-up seed phrase."
   while true:
     if not readPasswordInput("Seedphrase: ", enteredMnemonic):
-      fatal "failure to read password from stdin"
-      quit 1
+      fatal StdinReadFailureMessage
+      raiseKeystoreDefect(StdinReadFailureMessage)
 
     if validateMnemonic(enteredMnemonic, validatedMnemonic):
       break
@@ -2119,8 +2123,8 @@ proc restoreWalletInteractively*(rng: var HmacDrbgContext,
       burnMem(recoveryPassword.get)
 
   if recoveryPassword.isErr:
-    fatal "Failed to read password from stdin"
-    quit 1
+    fatal StdinReadFailureMessage
+    raiseKeystoreDefect(StdinReadFailureMessage)
 
   var keystorePass = KeystorePass.init recoveryPassword.get
   defer: burnMem(keystorePass)

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -17,6 +17,7 @@ import
   chronicles, chronicles/timings,
   # Internal
   ../spec/datatypes/base,
+  ../spec/defects,
   ./slashing_protection_common,
   ./slashing_protection_v2
 
@@ -95,8 +96,7 @@ proc init*(
       " for a few minutes at https://github.com/status-im/nimbus-eth2/releases/tag/v1.6.0" &
       " until the messages \"Migrating local validators slashing DB from v1 to v2\"" &
       " and \"Slashing DB migration successful.\""
-
-    quit 1
+    raiseSlashingDefect("Slashing protection database requires migration")
 
 proc init*(
        T: type SlashingProtectionDB,
@@ -131,8 +131,9 @@ proc loadUnchecked*(
     )
     result.modes.incl(kCompleteArchive)
   except CatchableError as err:
-    error "Failed to load the Slashing protection database", err = err.msg
-    quit 1
+    const msg = "Failed to load the slashing protection database"
+    fatal msg, reason = err.msg
+    raiseSlashingDefect(msg)
 
 proc close*(db: SlashingProtectionDB) =
   ## Close a slashing protection database
@@ -230,7 +231,7 @@ proc pruneBlocks*(
 
   # {.error: "This is a backend specific proc".}
   fatal "This is a backend specific proc"
-  quit 1
+  raiseSlashingDefect("Backend specific procedure")
 
 proc pruneAttestations*(
        db: SlashingProtectionDB,
@@ -245,7 +246,7 @@ proc pruneAttestations*(
 
   # {.error: "This is a backend specific proc".}
   fatal "This is a backend specific proc"
-  quit 1
+  raiseSlashingDefect("Backend specific procedure")
 
 proc pruneAfterFinalization*(
        db: SlashingProtectionDB,

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -131,9 +131,8 @@ proc loadUnchecked*(
     )
     result.modes.incl(kCompleteArchive)
   except CatchableError as err:
-    const msg = "Failed to load the slashing protection database"
-    fatal msg, reason = err.msg
-    raiseSlashingDefect(msg)
+    fatal "Failed to load the slashing protection database", reason = err.msg
+    raiseSlashingDefect()
 
 proc close*(db: SlashingProtectionDB) =
   ## Close a slashing protection database

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -653,9 +653,9 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Opt[Eth2Digest] =
   if status.isOk():
     # Privacy, don't display the user private path
     if version != db.typeof.version():
-      const msg = "Incorrect DB version"
-      fatal msg, found = version, expected = db.typeof.version()
-      raiseSlashingDefect(msg)
+      fatal "Incorrect DB version", found = version,
+            expected = db.typeof.version()
+      raiseSlashingDefect()
     return Opt.some(root)
   else:
     return Opt.none(Eth2Digest)
@@ -676,17 +676,15 @@ proc initCompatV1*(
   let
     alreadyExists = fileExists(databasePath / databaseName & ".sqlite3")
     backend = SqStoreRef.init(databasePath, databaseName).valueOr:
-      const msg = "Failed to open slashing protection database"
-      fatal msg, reason = error
-      raiseSlashingDefect(msg)
+      fatal "Failed to open slashing protection database", reason = error
+      raiseSlashingDefect()
 
   var res: tuple[db: SlashingProtectionDB_v2, requiresMigration: bool]
   res.db = T(backend: backend)
   if alreadyExists and res.db.getMetadataTable_DbV2().isSome():
     res.db.checkDB(genesis_validators_root).isOkOr:
-      const msg = "Incompatible slashing protection database"
-      fatal msg, reason = error
-      raiseSlashingDefect(msg)
+      fatal "Incompatible slashing protection database", reason = error
+      raiseSlashingDefect()
 
     res.requiresMigration = false
   elif alreadyExists:
@@ -723,16 +721,14 @@ proc init*(T: type SlashingProtectionDB_v2,
     alreadyExists = fileExists(databasePath / databaseName & ".sqlite3")
     backend = SqStoreRef.init(databasePath, databaseName,
                               keyspaces = []).valueOr:
-      const msg = "Failed to open slashing protection database"
-      fatal msg, reason = error
-      raiseSlashingDefect(msg)
+      fatal "Failed to open slashing protection database", reason = error
+      raiseSlashingDefect()
 
   var res = T(backend: backend)
   if alreadyExists:
     res.checkDB(genesis_validators_root).isOkOr:
-      const msg = "Slashing protection database check error"
-      fatal msg, reason = error
-      raiseSlashingDefect(msg)
+      fatal "Slashing protection database check error", reason = error
+      raiseSlashingDefect()
   else:
     res.setupDB(genesis_validators_root)
   # Cached queries

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -18,7 +18,7 @@ import
   sqlite3_abi,
   # Internal
   ../spec/datatypes/base,
-  ../spec/helpers,
+  ../spec/[helpers, defects],
   ./slashing_protection_common
 
 export results
@@ -653,10 +653,9 @@ proc getMetadataTable_DbV2*(db: SlashingProtectionDB_v2): Opt[Eth2Digest] =
   if status.isOk():
     # Privacy, don't display the user private path
     if version != db.typeof.version():
-      fatal "Incorrect DB version",
-        found = version,
-        expected = db.typeof.version()
-      quit 1
+      const msg = "Incorrect DB version"
+      fatal msg, found = version, expected = db.typeof.version()
+      raiseSlashingDefect(msg)
     return Opt.some(root)
   else:
     return Opt.none(Eth2Digest)
@@ -676,32 +675,35 @@ proc initCompatV1*(
 
   let
     alreadyExists = fileExists(databasePath / databaseName & ".sqlite3")
-    backendRes = SqStoreRef.init(databasePath, databaseName)
-    backend = backendRes.valueOr: # TODO https://github.com/nim-lang/Nim/issues/22605
-      fatal "Failed to open slashing protection database", err = backendRes.error
-      quit 1
+    backend = SqStoreRef.init(databasePath, databaseName).valueOr:
+      const msg = "Failed to open slashing protection database"
+      fatal msg, reason = error
+      raiseSlashingDefect(msg)
 
-  result.db = T(backend: backend)
-  if alreadyExists and result.db.getMetadataTable_DbV2().isSome():
-    let status = result.db.checkDB(genesis_validators_root)
-    if status.isErr:
-      fatal "Incompatible slashing protection database",
-             reason = status.error
-      quit 1
-    result.requiresMigration = false
+  var res: tuple[db: SlashingProtectionDB_v2, requiresMigration: bool]
+  res.db = T(backend: backend)
+  if alreadyExists and res.db.getMetadataTable_DbV2().isSome():
+    res.db.checkDB(genesis_validators_root).isOkOr:
+      const msg = "Incompatible slashing protection database"
+      fatal msg, reason = error
+      raiseSlashingDefect(msg)
+
+    res.requiresMigration = false
   elif alreadyExists:
-    result.db.setupDB(genesis_validators_root)
-    result.requiresMigration = true
+    res.db.setupDB(genesis_validators_root)
+    res.requiresMigration = true
   else:
-    result.db.setupDB(genesis_validators_root)
-    result.requiresMigration = false
+    res.db.setupDB(genesis_validators_root)
+    res.requiresMigration = false
 
   # Cached queries
-  result.db.setupCachedQueries()
+  res.db.setupCachedQueries()
 
   debug "Loaded slashing protection (v2)",
     genesis_validators_root = shortLog(genesis_validators_root),
-    requiresMigration = result.requiresMigration
+    requiresMigration = res.requiresMigration
+
+  res
 
 # Resource Management
 # -------------------------------------------------------------
@@ -719,42 +721,45 @@ proc init*(T: type SlashingProtectionDB_v2,
 
   let
     alreadyExists = fileExists(databasePath / databaseName & ".sqlite3")
-    backendRes = SqStoreRef.init(databasePath, databaseName,
-                                 keyspaces = [])
-    backend = backendRes.valueOr: # TODO https://github.com/nim-lang/Nim/issues/22605
-      fatal "Failed to open slashing protection database", err = backendRes.error
-      quit 1
+    backend = SqStoreRef.init(databasePath, databaseName,
+                              keyspaces = []).valueOr:
+      const msg = "Failed to open slashing protection database"
+      fatal msg, reason = error
+      raiseSlashingDefect(msg)
 
-  result = T(backend: backend)
+  var res = T(backend: backend)
   if alreadyExists:
-    let status = result.checkDB(genesis_validators_root)
-    if status.isErr:
-      fatal "Slashing protection database check error",
-             reason = status.error
-      quit 1
+    res.checkDB(genesis_validators_root).isOkOr:
+      const msg = "Slashing protection database check error"
+      fatal msg, reason = error
+      raiseSlashingDefect(msg)
   else:
-    result.setupDB(genesis_validators_root)
-
+    res.setupDB(genesis_validators_root)
   # Cached queries
-  result.setupCachedQueries()
+  res.setupCachedQueries()
+  res
 
 proc loadUnchecked*(
-       T: type SlashingProtectionDB_v2,
-       basePath, dbname: string, readOnly: bool
-     ): SlashingProtectionDB_v2 {.raises:[IOError].}=
+    T: type SlashingProtectionDB_v2,
+    basePath, dbname: string, readOnly: bool
+): SlashingProtectionDB_v2 {.raises:[IOError].}=
   ## Load a slashing protection DB
   ## Note: This is for conversion usage in ncli_slashing
   ##       this doesn't check the genesis validator root
   ##
   ## Privacy: This leaks user folder hierarchy in case the file does not exist
-  let path = basePath/dbname&".sqlite3"
-  let alreadyExists = fileExists(path)
+  let
+    path = basePath/dbname&".sqlite3"
+    alreadyExists = fileExists(path)
+
   if not alreadyExists:
     raise newException(IOError, "DB '" & path & "' does not exist.")
-  result = T(backend: SqStoreRef.init(basePath, dbname, readOnly = readOnly).get())
 
+  var res =
+    T(backend: SqStoreRef.init(basePath, dbname, readOnly = readOnly).get())
   # Cached queries
-  result.setupCachedQueries()
+  res.setupCachedQueries()
+  res
 
 proc close*(db: SlashingProtectionDB_v2) =
   ## Close a slashing protection database

--- a/beacon_chain/wallets.nim
+++ b/beacon_chain/wallets.nim
@@ -9,6 +9,7 @@
 
 import
   std/os,
+  ./spec/defects,
   ./validators/keystore_management,
   ./conf
 
@@ -20,18 +21,18 @@ proc doWallets*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
       let
         name = config.createdWalletNameFlag.get
         existingWallet = findWallet(config, name).valueOr:
-          fatal "Failed to locate wallet", error = error
-          quit 1
+          fatal "Failed to locate wallet", reason = error
+          raiseWalletsDefect()
       if existingWallet.isSome:
         echo "The Wallet '" & name.string & "' already exists."
-        quit 1
+        raiseWalletsDefect()
 
     let walletOpt = createWalletInteractively(rng, config).valueOr:
-      fatal "Unable to create wallet", err = error
-      quit 1
+      fatal "Unable to create wallet", reason = error
+      raiseWalletsDefect()
     var wallet = walletOpt.valueOr:
       fatal "Process interrupted by user"
-      quit 1
+      raiseWalletsDefect()
     burnMem(wallet.seed)
 
   of WalletsCmd.list:

--- a/beacon_chain/wallets.nim
+++ b/beacon_chain/wallets.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,8 +13,7 @@ import
   ./validators/keystore_management,
   ./conf
 
-proc doWallets*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
-    raises: [CatchableError].} =
+proc doWallets*(config: BeaconNodeConf, rng: var HmacDrbgContext) =
   case config.walletsCmd:
   of WalletsCmd.create:
     if config.createdWalletNameFlag.isSome:
@@ -36,18 +35,22 @@ proc doWallets*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
     burnMem(wallet.seed)
 
   of WalletsCmd.list:
-    for kind, walletFile in walkDir(config.walletsDir):
-      if kind != pcFile: continue
-      if checkSensitiveFilePermissions(walletFile):
-        let walletRes = loadWallet(walletFile)
-        if walletRes.isOk:
-          echo walletRes.get.longName
+    try:
+      for kind, walletFile in walkDir(config.walletsDir):
+        if kind != pcFile: continue
+        if checkSensitiveFilePermissions(walletFile):
+          let walletRes = loadWallet(walletFile)
+          if walletRes.isOk:
+            echo walletRes.get.longName
+          else:
+            warn "Found corrupt wallet file",
+                  wallet = walletFile, error = walletRes.error
         else:
-          warn "Found corrupt wallet file",
-                wallet = walletFile, error = walletRes.error
-      else:
-        warn "Found wallet file with insecure permissions",
-              wallet = walletFile
+          warn "Found wallet file with insecure permissions",
+                wallet = walletFile
+    except OSError as exc:
+      fatal "Unable to create wallets list", reason = exc.msg
+      raiseWalletsDefect()
 
   of WalletsCmd.restore:
     restoreWalletInteractively(rng, config)

--- a/beacon_chain/wallets.nim
+++ b/beacon_chain/wallets.nim
@@ -26,8 +26,11 @@ proc doWallets*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
         echo "The Wallet '" & name.string & "' already exists."
         quit 1
 
-    var wallet = createWalletInteractively(rng, config).valueOr:
+    let walletOpt = createWalletInteractively(rng, config).valueOr:
       fatal "Unable to create wallet", err = error
+      quit 1
+    var wallet = walletOpt.valueOr:
+      fatal "Process interrupted by user"
       quit 1
     burnMem(wallet.seed)
 


### PR DESCRIPTION
This PR converts all the established `quit` calls into `raiseDefect` statements and also establishes place where all this specific `Defects` being handled and appropriate exit code returned.

The only `quit()` left is Doppelganger one, i make it available for 2 reasons.
1. Is it ok to convert it to Defect?
2. `129` is invalid exit code number because it falls into the signals range. For Linux `SIGHUP` signal sent to process could also return exit code `129`.
