### PR TITLE
use SingleAttestation for submitPoolAttestationsV2

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1450,32 +1450,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       # Since our validation logic supports batch processing, we will submit all
       # attestations for validation.
       for attestation in dres.get():
-        when AttestationType is electra.Attestation:
-          let attester_indices = toSeq(
-            get_attesting_indices(node.dag, attestation, true))
-          if len(attester_indices) != 1:
-            return RestApiResponse.jsonError(Http400,
-                                             InvalidAttestationObjectError,
-                                             $dres.error)
-          let committee_index = get_committee_index_one(
-              attestation.committee_bits).valueOr:
-              return RestApiResponse.jsonError(Http400,
-                                               InvalidAttestationObjectError,
-                                               $dres.error)
-          pendingAttestations.add(node.router.routeAttestation(
-            SingleAttestation(
-              committee_index: committee_index.distinctBase,
-              attester_index: attester_indices[0].uint64,
-              data: attestation.data,
-              signature: attestation.signature)))
-        else:
-          pendingAttestations.add(node.router.routeAttestation(attestation))
+        pendingAttestations.add(node.router.routeAttestation(attestation))
 
     case consensusVersion.get():
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
         decodeAttestations(phase0.Attestation)
       of ConsensusFork.Electra .. ConsensusFork.Fulu:
-        decodeAttestations(electra.Attestation)
+        decodeAttestations(electra.SingleAttestation)
 
     let failures =
       block:

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -257,6 +257,7 @@ RestJson.useDefaultSerializationFor(
   electra.LightClientUpdate,
   electra.SignedAggregateAndProof,
   electra.SignedBeaconBlock,
+  electra.SingleAttestation,
   electra.TrustedAttestation,
   electra_mev.BlindedBeaconBlock,
   electra_mev.BlindedBeaconBlockBody,


### PR DESCRIPTION
https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttestationsV2 doesn't clarify but https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/pool/attestations.v2.yaml does