### PR TITLE
start tracking Nim 2.2 as possible next Nim version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,17 @@ jobs:
             cpu: arm64
           - os: windows
             cpu: amd64
-        branch: [~, upstream/version-2-0]
+        branch: [~, upstream/version-2-2]
         exclude:
           - target:
               os: macos
-            branch: upstream/version-2-0
+            branch: upstream/version-2-2
           - target:
               os: windows
-            branch: upstream/version-2-0
+            branch: upstream/version-2-2
         include:
-          - branch: upstream/version-2-0
-            branch-short: version-2-0
+          - branch: upstream/version-2-2
+            branch-short: version-2-2
             nimflags-extra: --mm:refc
           - target:
               os: linux
@@ -212,7 +212,7 @@ jobs:
           # allowed to prevent potential problems with downloads on different
           # file systems". However, GitHub Actions workflows do not support a
           # usual assortment of string functions.
-          name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ matrix.branch == 'upstream/version-2-0' && 'version-2-0' || matrix.branch }}
+          name: Unit Test Results ${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ matrix.branch == 'upstream/version-2-2' && 'version-2-2' || matrix.branch }}
           path: build/*.xml
 
   devbuild:


### PR DESCRIPTION
Tentative, could be switched back to `version-2-0` readily enough if compelling, but by default at this point, anticipate targeting Nim 2.2 soon.