### PR TITLE
add KZG commitment to first-blob-found check in blobs gossip validation

### DIFF
--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -61,12 +61,14 @@ func hasBlob*(
     quarantine: BlobQuarantine,
     slot: Slot,
     proposer_index: uint64,
-    index: BlobIndex): bool =
+    index: BlobIndex,
+    kzg_commitment: KzgCommitment): bool =
   for blob_sidecar in quarantine.blobs.values:
     template block_header: untyped = blob_sidecar.signed_block_header.message
     if block_header.slot == slot and
         block_header.proposer_index == proposer_index and
-        blob_sidecar.index == index:
+        blob_sidecar.index == index and
+        blob_sidecar.kzg_commitment == kzg_commitment:
       return true
   false
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -423,8 +423,20 @@ proc validateBlobSidecar*(
   let block_root = hash_tree_root(block_header)
   if dag.getBlockRef(block_root).isSome():
     return errIgnore("BlobSidecar: already have block")
+
+  # This adds KZG commitment matching to the spec gossip validation. It's an
+  # IGNORE condition, so it shouldn't affect Nimbus's scoring, and when some
+  # (slashable) double proposals happen with blobs present, without this one
+  # or the other block, or potentially both, won't get its full set of blobs
+  # through gossip validation and have to backfill them later. There is some
+  # cost in slightly more outgoing bandwidth on such double-proposals but it
+  # remains insignificant compared with other bandwidth usage.
+  #
+  # It would be good to fix this more properly, but this has come up often on
+  # Pectra devnet-6.
   if blobQuarantine[].hasBlob(
-      block_header.slot, block_header.proposer_index, blob_sidecar.index):
+      block_header.slot, block_header.proposer_index, blob_sidecar.index,
+      blob_sidecar.kzg_commitment):
     return errIgnore("BlobSidecar: already have valid blob from same proposer")
 
   # [REJECT] The sidecar's inclusion proof is valid as verified by


### PR DESCRIPTION
https://dora.pectra-devnet-6.ethpandaops.io/slot/0xb95c84976c7742cfc297481babef50f6069b6b4d670beb6b64adb0521b82f43c

Example proposer slashing from Pectra devnet-6:
![2025-02-10T10:14:10,939458116+00:00](https://github.com/user-attachments/assets/b7e0ee86-95f5-4ac7-84fa-574a39f0273c)
