### PR TITLE
implement `getBlobs` and bypass blob gossip validation on successful blob retrievals from EL

### DIFF
--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -389,6 +389,16 @@ func popBlobless*(
   else:
     Opt.none(ForkedSignedBeaconBlock)
 
+func getBlobless*(
+    quarantine: var Quarantine,
+    root: Eth2Digest): Opt[ForkedSignedBeaconBlock] =
+  if quarantine.blobless.hasKey(root):
+    Opt.some((quarantine.blobless.getOrDefault(
+              root,
+              default(ForkedSignedBeaconBlock))))
+  else:
+    Opt.none(ForkedSignedBeaconBlock)
+
 func popColumnless*(
     quarantine: var Quarantine,
     root: Eth2Digest): Opt[ForkedSignedBeaconBlock] =

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1001,7 +1001,7 @@ proc lazyWait(futures: seq[FutureBase]) {.async: (raises: []).} =
 
 proc sendGetBlobs*(
     m: ELManager,
-    blck: electra.SignedBeaconBlock | fulu.SignedBeaconBlock
+    blck: electra.SignedBeaconBlock | fulu.SignedBeaconBlock,
 ): Future[Opt[seq[BlobAndProofV1]]] {.async: (raises: [CancelledError]).} =
   if m.elConnections.len == 0:
     return err()
@@ -1042,7 +1042,7 @@ proc sendGetBlobs*(
     await noCancel allFutures(pending)
 
     if bestResponse.isSome():
-      return ok(requests[bestResponse.get()].value().blobsAndProofs)
+      return ok(requests[bestResponse.get()].value())
 
     if timeoutExceeded:
       break

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -57,6 +57,7 @@ type
     GetPayloadV3Response |
     GetPayloadV4Response
 
+
 contract(DepositContract):
   proc deposit(pubkey: PubKeyBytes,
                withdrawalCredentials: WithdrawalCredentialsBytes,
@@ -108,6 +109,8 @@ const
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#request-2
   GETPAYLOAD_TIMEOUT = 1.seconds
 
+  # https://github.com/ethereum/execution-apis/blob/ad9102b11212d51b736a0413c8655a8da93e55fc/src/engine/cancun.md#request-3
+  GETBLOBS_TIMEOUT = 1.seconds
   connectionStateChangeHysteresisThreshold = 15
     ## How many unsuccesful/successful requests we must see
     ## before declaring the connection as degraded/restored
@@ -862,6 +865,13 @@ proc sendNewPayloadToSingleEL(
     payload, versioned_hashes, Hash32 parent_beacon_block_root,
     executionRequests)
 
+proc sendGetBlobsToSingleEL(
+    connection: ELConnection,
+    versioned_hashes: seq[engine_api.VersionedHash]
+): Future[GetBlobsV1Response] {.async: (raises: [CatchableError]).} =
+  let rpcClient = await connection.connectedRpcClient()
+  await rpcClient.engine_getBlobsV1(versioned_hashes)
+
 type
   StatusRelation = enum
     newStatusIsPreferable
@@ -989,6 +999,61 @@ proc lazyWait(futures: seq[FutureBase]) {.async: (raises: []).} =
     let pending = futures.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
     if len(pending) > 0:
       await noCancel allFutures(pending)
+
+proc sendGetBlobs*(
+    m: ELManager,
+    blck: electra.SignedBeaconBlock | fulu.SignedBeaconBlock
+): Future[Opt[seq[BlobAndProofV1]]] {.async: (raises: [CancelledError]).} =
+  if m.elConnections.len == 0:
+    return err()
+  let
+    timeout = GETBLOBS_TIMEOUT
+    deadline = sleepAsync(timeout)
+
+  var bestResponse = Opt.none(int)
+
+  while true:
+    let
+      requests = m.elConnections.mapIt(
+        sendGetBlobsToSingleEL(it, mapIt(
+            blck.message.body.blob_kzg_commitments,
+            engine_api.VersionedHash(kzg_commitment_to_versioned_hash(it)))))
+      timeoutExceeded =
+        try:
+          await allFutures(requests).wait(deadline)
+          false
+        except AsyncTimeoutError:
+          true
+        except CancelledError as exc:
+          let pending =
+            requests.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
+          await noCancel allFutures(pending)
+          raise exc
+
+    for idx, req in requests:
+      if not(req.finished()):
+        warn "Timeout while getting blob and proof",
+             url = m.elConnections[idx].engineUrl.url,
+             reason = req.error.msg
+      else:
+        if bestResponse.isNone:
+          bestResponse = Opt.some(idx)
+
+    let pending =
+      requests.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
+    await noCancel allFutures(pending)
+
+    if bestResponse.isSome():
+      return ok(requests[bestResponse.get()].value().blobsAndProofs)
+
+    else:
+      # should not reach this case
+      discard
+
+    if timeoutExceeded:
+      break
+
+  err()
 
 proc sendNewPayload*(
     m: ELManager,

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -57,7 +57,6 @@ type
     GetPayloadV3Response |
     GetPayloadV4Response
 
-
 contract(DepositContract):
   proc deposit(pubkey: PubKeyBytes,
                withdrawalCredentials: WithdrawalCredentialsBytes,

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1007,8 +1007,7 @@ proc sendGetBlobs*(
   if m.elConnections.len == 0:
     return err()
   let
-    timeout = GETBLOBS_TIMEOUT
-    deadline = sleepAsync(timeout)
+    deadline = sleepAsync(GETBLOBS_TIMEOUT)
 
   var bestResponse = Opt.none(int)
 
@@ -1045,10 +1044,6 @@ proc sendGetBlobs*(
 
     if bestResponse.isSome():
       return ok(requests[bestResponse.get()].value().blobsAndProofs)
-
-    else:
-      # should not reach this case
-      discard
 
     if timeoutExceeded:
       break

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -12,6 +12,7 @@ import
   chronicles, chronos, metrics,
   taskpools,
   ../spec/[helpers, forks],
+  ../el/el_manager,
   ../consensus_object_pools/[
     blob_quarantine, block_clearance, block_quarantine, blockchain_dag,
     attestation_pool, light_client_pool, sync_committee_msg_pool,
@@ -138,6 +139,10 @@ type
     # ----------------------------------------------------------------
     batchCrypto*: ref BatchCrypto
 
+    # EL integration
+    # ----------------------------------------------------------------
+    elManager*: ELManager
+
     # Missing information
     # ----------------------------------------------------------------
     quarantine*: ref Quarantine
@@ -169,6 +174,7 @@ proc new*(T: type Eth2Processor,
           blobQuarantine: ref BlobQuarantine,
           rng: ref HmacDrbgContext,
           getBeaconTime: GetBeaconTimeFn,
+          elManager: ELManager,
           taskpool: Taskpool
          ): ref Eth2Processor =
   (ref Eth2Processor)(
@@ -186,6 +192,7 @@ proc new*(T: type Eth2Processor,
     quarantine: quarantine,
     blobQuarantine: blobQuarantine,
     getCurrentBeaconTime: getBeaconTime,
+    elManager: elManager,
     batchCrypto: BatchCrypto.new(
       rng = rng,
       # Only run eager attestation signature verification if we're not
@@ -267,9 +274,40 @@ proc processSignedBeaconBlock*(
   v
 
 proc processBlobSidecar*(
-    self: var Eth2Processor, src: MsgSource,
-    blobSidecar: deneb.BlobSidecar, subnet_id: BlobId): ValidationRes =
+    self: ref Eth2Processor, src: MsgSource,
+    blobSidecar: deneb.BlobSidecar, subnet_id: BlobId):
+    Future[ValidationRes] {.async: (raises: [CancelledError]).} =
   template block_header: untyped = blobSidecar.signed_block_header.message
+  let block_root = hash_tree_root(block_header)
+
+  if (let o = self.quarantine[].popBlobless(block_root); o.isSome):
+    let blobless = o.get()
+    withBlck(blobless):
+      when consensusFork >= ConsensusFork.Electra:
+        let blobsFromElOpt = await self.elManager.sendGetBlobs(forkyBlck)
+        debugEcho "pulled blobs from el"
+        debugEcho blobsFromElOpt.get.len
+        if blobsFromElOpt.get.len > 0 and blobsFromElOpt.isSome():
+          let blobsEl = blobsFromElOpt.get()
+          # check lengths of array[BlobAndProofV1] with blobs
+          # kzg commitments of the signed block
+          if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
+            var
+              kzgblbs: deneb.Blobs
+              kzgprfs: deneb.KzgProofs
+            for idx in 0..<blobsEl.len:
+              kzgblbs[idx] = blobsEl[idx].blob.data
+              kzgprfs[idx].bytes = blobsEl[idx].proof.data
+            let blob_sidecars_el =
+              create_blob_sidecars(forkyBlck, kzgprfs, kzgblbs)
+
+            for blb_el in blob_sidecars_el:
+              self.blobQuarantine[].put(newClone blb_el)
+
+            if self.blobQuarantine[].hasBlobs(forkyBlck):
+              self.blockProcessor[].enqueueBlock(
+                MsgSource.gossip, blobless,
+                Opt.some(self.blobQuarantine[].popBlobs(block_root, forkyBlck)))
 
   let
     wallTime = self.getCurrentBeaconTime()
@@ -295,9 +333,8 @@ proc processBlobSidecar*(
   debug "Blob validated, putting in blob quarantine"
   self.blobQuarantine[].put(newClone(blobSidecar))
 
-  let block_root = hash_tree_root(block_header)
   if (let o = self.quarantine[].popBlobless(block_root); o.isSome):
-    let blobless = o.unsafeGet()
+    let blobless = o.get()
     withBlck(blobless):
       when consensusFork >= ConsensusFork.Deneb:
         if self.blobQuarantine[].hasBlobs(forkyBlck):

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -277,7 +277,8 @@ proc processSignedBeaconBlock*(
 proc validateBlobSidecarFromEL(
     self: ref Eth2Processor,
     block_root: Eth2Digest):
-    Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
+    Future[Result[void, ValidationError]]
+    {.async: (raises: [CancelledError]).} =
 
   if (let o = self.quarantine[].popBlobless(block_root); o.isSome):
     let blobless = o.get()
@@ -287,13 +288,15 @@ proc validateBlobSidecarFromEL(
           await self.elManager.sendGetBlobs(forkyBlck)
         if blobsFromElOpt.get.len > 0 and blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
+
           # check lengths of array[BlobAndProofV1] with blobs
           # kzg commitments of the signed block
           if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
             let blob_sidecars_el =
               create_blob_sidecars(
                 forkyBlck,
-                deneb.KzgProofs.init(blobsEl.mapIt(kzg.KzgProof(bytes: it.proof.data))),
+                deneb.KzgProofs.init(blobsEl.mapIt(kzg.KzgProof(
+                                                   bytes: it.proof.data))),
                 deneb.Blobs.init(blobsEl.mapIt(it.blob.data)))
 
             for blb_el in blob_sidecars_el:
@@ -304,6 +307,8 @@ proc validateBlobSidecarFromEL(
                 MsgSource.gossip, blobless,
                 Opt.some(self.blobQuarantine[].popBlobs(block_root, forkyBlck)))
 
+            debug "Pulled blobs from EL, bypassing blob gossip validation",
+              blobs_from_el = blobsEl.len
             return ok()
 
   else:

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -76,6 +76,8 @@ declareCounter beacon_light_client_optimistic_update_received,
   "Number of valid light client optimistic update processed by this node"
 declareCounter beacon_light_client_optimistic_update_dropped,
   "Number of invalid light client optimistic update dropped by this node", labels = ["reason"]
+declareCounter el_blob_loss,
+  "Number of EL blob misses while calling `engine_getBlobsV1`"
 
 const delayBuckets = [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, Inf]
 
@@ -90,6 +92,10 @@ declareHistogram beacon_block_delay,
 
 declareHistogram blob_sidecar_delay,
   "Time(s) between slot start and blob sidecar reception", buckets = delayBuckets
+
+declareHistogram el_blob_loss,
+  "Misses of El blobs from slot start and getBlobs call", buckets = delayBuckets
+
 
 type
   DoppelgangerProtection = object
@@ -284,6 +290,9 @@ proc validateBlobSidecarFromEL(
     let blobless = o.get()
     withBlck(blobless):
       when consensusFork >= ConsensusFork.Electra:
+        let
+          start_time = Moment.now()
+          el_blob_loss = 0
         let blobsFromElOpt =
           await self.elManager.sendGetBlobs(forkyBlck)
         if blobsFromElOpt.get.len > 0 and blobsFromElOpt.isSome():
@@ -311,10 +320,26 @@ proc validateBlobSidecarFromEL(
               self.blockProcessor[].enqueueBlock(
                 MsgSource.gossip, blobless,
                 Opt.some(self.blobQuarantine[].popBlobs(block_root, forkyBlck)))
-
+            let end_time = Moment.now()
+            debug "Time taken to get 100% response from EL and bypass blob gossip validation",
+                  time_taken = end_time - start_time
             debug "Pulled blobs from EL, bypassing blob gossip validation",
               blobs_from_el = blobsEl.len
             return ok()
+
+          elif blobsEl.len < forkyBlck.message.body.blob_kzg_commitments.len and
+              blobsEl.len != 0:
+            let end_time = Moment.now()
+
+            el_blob_loss = forkyBlck.message.body.blob_kzg_commitments.len - blobsEl.len
+
+            debug "Time taken to receive partially response from EL",
+                  received_percent = float((blobsEl.len div forkyBlck.message.body.blob_kzg_commitments.len) * 100),
+                  time_taken = end_time - start_time
+          else:
+            let end_time = Moment.now()
+            debug "Empty response received from EL",
+                  time_elapsed = end_time - start_time
 
   else:
     return errIgnore("EL did not respond with blobs and proofs")

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -274,20 +274,17 @@ proc processSignedBeaconBlock*(
 
   v
 
-proc processBlobSidecar*(
-    self: ref Eth2Processor, src: MsgSource,
-    blobSidecar: deneb.BlobSidecar, subnet_id: BlobId):
-    Future[ValidationRes] {.async: (raises: [CancelledError]).} =
-  template block_header: untyped = blobSidecar.signed_block_header.message
-  let block_root = hash_tree_root(block_header)
+proc validateBlobSidecarFromEL(
+    self: ref Eth2Processor,
+    block_root: Eth2Digest):
+    Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
 
   if (let o = self.quarantine[].popBlobless(block_root); o.isSome):
     let blobless = o.get()
     withBlck(blobless):
       when consensusFork >= ConsensusFork.Electra:
-        let blobsFromElOpt = await self.elManager.sendGetBlobs(forkyBlck)
-        debugEcho "pulled blobs from el"
-        debugEcho blobsFromElOpt.get.len
+        let blobsFromElOpt =
+          await self.elManager.sendGetBlobs(forkyBlck)
         if blobsFromElOpt.get.len > 0 and blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
           # check lengths of array[BlobAndProofV1] with blobs
@@ -306,6 +303,24 @@ proc processBlobSidecar*(
               self.blockProcessor[].enqueueBlock(
                 MsgSource.gossip, blobless,
                 Opt.some(self.blobQuarantine[].popBlobs(block_root, forkyBlck)))
+
+            return ok()
+
+  else:
+    return errIgnore("EL did not respond with blobs and proofs")
+
+proc processBlobSidecar*(
+    self: ref Eth2Processor, src: MsgSource,
+    blobSidecar: deneb.BlobSidecar, subnet_id: BlobId):
+    Future[ValidationRes] {.async: (raises: [CancelledError]).} =
+  template block_header: untyped = blobSidecar.signed_block_header.message
+  let block_root = hash_tree_root(block_header)
+
+  let vEl =
+    await self.validateBlobSidecarFromEL(block_root)
+
+  if vEl.isOk():
+    return vEl
 
   let
     wallTime = self.getCurrentBeaconTime()

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -276,12 +276,13 @@ proc processSignedBeaconBlock*(
 
   v
 
-proc validateBlobSidecarFromEL(
+proc processBlobSidecarFromEL*(
     self: ref Eth2Processor,
-    block_root: Eth2Digest):
-    Future[Result[void, ValidationError]]
+    blobSidecar: deneb.BlobSidecar):
+    Future[ValidationRes]
     {.async: (raises: [CancelledError]).} =
-
+  template block_header: untyped = blobSidecar.signed_block_header.message
+  let block_root = hash_tree_root(block_header)
   if (let o = self.quarantine[].getBlobless(block_root); o.isSome):
     let blobless = o.get()
     withBlck(blobless):
@@ -346,12 +347,6 @@ proc processBlobSidecar*(
     Future[ValidationRes] {.async: (raises: [CancelledError]).} =
   template block_header: untyped = blobSidecar.signed_block_header.message
   let block_root = hash_tree_root(block_header)
-
-  let vEl =
-    await self.validateBlobSidecarFromEL(block_root)
-
-  if vEl.isOk():
-    return vEl
 
   let
     wallTime = self.getCurrentBeaconTime()

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -93,10 +93,6 @@ declareHistogram beacon_block_delay,
 declareHistogram blob_sidecar_delay,
   "Time(s) between slot start and blob sidecar reception", buckets = delayBuckets
 
-declareHistogram el_blob_loss,
-  "Misses of El blobs from slot start and getBlobs call", buckets = delayBuckets
-
-
 type
   DoppelgangerProtection = object
     broadcastStartEpoch*: Epoch  ##\

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -157,8 +157,40 @@ type
 
   ValidationRes* = Result[void, ValidationError]
 
+
 func toValidationResult*(res: ValidationRes): ValidationResult =
   if res.isOk(): ValidationResult.Accept else: res.error()[0]
+
+proc toValidationRace*(
+    f1, f2: Future[ValidationRes]
+): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+  let
+    f1b = noCancel(f1)
+    f2b = noCancel(f2)
+
+  var raced: FutureBase
+  try:
+    raced = await race([f1b, f2b])
+  except ValueError:
+    # This shouldn't normally happen with 2 futures
+    return ValidationResult.Ignore
+
+  let
+    first = if raced == f1b: f1 else: f2
+    second = if raced == f1b: f2 else: f1
+
+  try:
+    let res1 = await first
+    if res1.isOk():
+      return ValidationResult.Accept
+  except CatchableError:
+    discard
+
+  try:
+    let res2 = await second
+    return toValidationResult(res2)
+  except CatchableError:
+    return ValidationResult.Ignore
 
 # Initialization
 # ------------------------------------------------------------------------------

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -288,7 +288,7 @@ proc validateBlobSidecarFromEL(
       when consensusFork >= ConsensusFork.Electra:
         let
           start_time = Moment.now()
-          el_blob_loss = 0
+        var el_blob_loss = 0
         let blobsFromElOpt =
           await self.elManager.sendGetBlobs(forkyBlck)
         if blobsFromElOpt.get.len > 0 and blobsFromElOpt.isSome():

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -280,7 +280,7 @@ proc validateBlobSidecarFromEL(
     Future[Result[void, ValidationError]]
     {.async: (raises: [CancelledError]).} =
 
-  if (let o = self.quarantine[].popBlobless(block_root); o.isSome):
+  if (let o = self.quarantine[].getBlobless(block_root); o.isSome):
     let blobless = o.get()
     withBlck(blobless):
       when consensusFork >= ConsensusFork.Electra:
@@ -292,6 +292,11 @@ proc validateBlobSidecarFromEL(
           # check lengths of array[BlobAndProofV1] with blobs
           # kzg commitments of the signed block
           if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
+
+            # we have got all blobs from EL, now we can
+            # conveniently the blobless block from quarantine
+            discard self.quarantine[].popBlobless(block_root)
+
             let blob_sidecars_el =
               create_blob_sidecars(
                 forkyBlck,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -8,9 +8,10 @@
 {.push raises: [].}
 
 import
-  std/tables,
+  std/[tables, sequtils],
   chronicles, chronos, metrics,
   taskpools,
+  ssz_serialization/types,
   ../spec/[helpers, forks],
   ../el/el_manager,
   ../consensus_object_pools/[
@@ -292,14 +293,11 @@ proc processBlobSidecar*(
           # check lengths of array[BlobAndProofV1] with blobs
           # kzg commitments of the signed block
           if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
-            var
-              kzgblbs: deneb.Blobs
-              kzgprfs: deneb.KzgProofs
-            for idx in 0..<blobsEl.len:
-              kzgblbs[idx] = blobsEl[idx].blob.data
-              kzgprfs[idx].bytes = blobsEl[idx].proof.data
             let blob_sidecars_el =
-              create_blob_sidecars(forkyBlck, kzgprfs, kzgblbs)
+              create_blob_sidecars(
+                forkyBlck,
+                deneb.KzgProofs.init(blobsEl.mapIt(kzg.KzgProof(bytes: it.proof.data))),
+                deneb.Blobs.init(blobsEl.mapIt(it.blob.data)))
 
             for blb_el in blob_sidecars_el:
               self.blobQuarantine[].put(newClone blb_el)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2115,8 +2115,15 @@ proc installMessageValidators(node: BeaconNode) =
               getBlobSidecarTopic(digest, subnet_id), proc (
                 blobSidecar: deneb.BlobSidecar
               ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-                return toValidationResult(
-                  await node.processor.processBlobSidecarFromEL(blobSidecar)))
+                let
+                  fut1 =
+                    (node.processor.processBlobSidecarFromEL(blobSidecar))
+                  fut2 =
+                    (node.processor.processBlobSidecar(MsgSource.gossip,
+                                                       blobSidecar,
+                                                       subnet_id))
+
+                return waitFor toValidationRace(fut1, fut2))
 
       when consensusFork >= ConsensusFork.Deneb:
         # blob_sidecar_{subnet_id}

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -453,69 +453,23 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Electra:
-          # Pull blobs and proofs from the EL blob pool
-          let blobsFromElOpt = await node.elManager.sendGetBlobs(forkyBlck)
-          debugEcho "pulled blobs from el"
-          debugEcho blobsFromElOpt.get.len
-          if blobsFromElOpt.isSome():
-            let blobsEl = blobsFromElOpt.get()
-            # check lengths of array[BlobAndProofV1] with blob
-            # kzg commitments of the signed block
-            if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
-              # create blob sidecars from EL instead
-              var
-                kzgBlbs: deneb.Blobs
-                kzgPrfs: deneb.KzgProofs
-
-              for idx in 0..<blobsEl.len:
-                kzgBlbs[idx] = blobsEl[idx].blob.data
-                kzgPrfs[idx].bytes = blobsEl[idx].proof.data
-              let blob_sidecars_el =
-                 create_blob_sidecars(forkyBlck, kzgPrfs, kzgBlbs)
-
-              # populate blob quarantine to tackle blob loop
-              for blb_el in blob_sidecars_el:
-                blobQuarantine[].put(newClone blb_el)
-
-              # now pop blobQuarantine and make block available for attestation
-              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
-              return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                               Opt.some(blobs),
-                                               maybeFinalized = maybeFinalized)
-
-          # in case EL does not support `engine_getBlobsV1`
-          else:
-            if not blobQuarantine[].hasBlobs(forkyBlck):
-              # We don't have all the blobs for this block, so we have
-              # to put it in blobless quarantine.
-              if not quarantine[].addBlobless(dag.finalizedHead.slot, forkyBlck):
-                return err(VerifierError.UnviableFork)
-              else:
-                return err(VerifierError.MissingParent)
-            else:
-              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
-              return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                               Opt.some(blobs),
-                                               maybeFinalized = maybeFinalized)
-
-        elif consensusFork >= ConsensusFork.Deneb and
+        when consensusFork >= ConsensusFork.Deneb and
             consensusFork < ConsensusFork.Electra:
           if not blobQuarantine[].hasBlobs(forkyBlck):
             # We don't have all the blobs for this block, so we have
             # to put it in blobless quarantine.
             if not quarantine[].addBlobless(dag.finalizedHead.slot, forkyBlck):
-              return err(VerifierError.UnviableFork)
+              err(VerifierError.UnviableFork)
             else:
-              return err(VerifierError.MissingParent)
+              err(VerifierError.MissingParent)
           else:
             let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
-            return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+            await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
                                              Opt.some(blobs),
                                              maybeFinalized = maybeFinalized)
 
         else:
-          return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+          await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
                                     Opt.none(BlobSidecars),
                                     maybeFinalized = maybeFinalized)
     rmanBlockLoader = proc(
@@ -540,7 +494,8 @@ proc initFullNode(
       config.doppelgangerDetection,
       blockProcessor, node.validatorMonitor, dag, attestationPool,
       validatorChangePool, node.attachedValidators, syncCommitteeMsgPool,
-      lightClientPool, quarantine, blobQuarantine, rng, getBeaconTime, taskpool)
+      lightClientPool, quarantine, blobQuarantine, rng, getBeaconTime,
+      node.elManager, taskpool)
     syncManagerFlags =
       if node.config.longRangeSync != LongRangeSyncMode.Lenient:
         {SyncManagerFlag.NoGenesisSync}
@@ -2155,12 +2110,12 @@ proc installMessageValidators(node: BeaconNode) =
         for it in 0.BlobId ..< subnetCount.BlobId:
           closureScope:  # Needed for inner `proc`; don't lift it out of loop.
             let subnet_id = it
-            node.network.addValidator(
+            node.network.addAsyncValidator(
               getBlobSidecarTopic(digest, subnet_id), proc (
                 blobSidecar: deneb.BlobSidecar
-              ): ValidationResult =
-                toValidationResult(
-                  node.processor[].processBlobSidecar(
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processBlobSidecar(
                     MsgSource.gossip, blobSidecar, subnet_id)))
 
   node.installLightClientMessageValidators()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -464,8 +464,8 @@ proc initFullNode(
           else:
             let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
             await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                             Opt.some(blobs),
-                                             maybeFinalized = maybeFinalized)
+                                      Opt.some(blobs),
+                                      maybeFinalized = maybeFinalized)
 
         else:
           await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -481,7 +481,7 @@ proc initFullNode(
               # now pop blobQuarantine and make block available for attestation
               let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
               return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                               Opt.some(blob_sidecars_el),
+                                               Opt.some(blobs),
                                                maybeFinalized = maybeFinalized)
 
           # in case EL does not support `engine_getBlobsV1`

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -453,8 +453,7 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Deneb and
-            consensusFork < ConsensusFork.Electra:
+        when consensusFork >= ConsensusFork.Deneb:
           if not blobQuarantine[].hasBlobs(forkyBlck):
             # We don't have all the blobs for this block, so we have
             # to put it in blobless quarantine.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2098,6 +2098,26 @@ proc installMessageValidators(node: BeaconNode) =
               await node.processor.processBlsToExecutionChange(
                 MsgSource.gossip, msg)))
 
+      when consensusFork >= ConsensusFork.Electra:
+        # blob_sidecar_{subnet_id}
+        # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
+        let subnets =
+          when consensusFork >= ConsensusFork.Electra:
+            node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+          else:
+            node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT
+        # It's safe to try as many times to fetch EL blobs as
+        # there are blob subnets.
+        for it in 0.BlobId ..< subnets.BlobId:
+          closureScope:  # Needed for inner `proc`; don't lift it out of loop.
+            let subnet_id = it
+            node.network.addAsyncValidator(
+              getBlobSidecarTopic(digest, subnet_id), proc (
+                blobSidecar: deneb.BlobSidecar
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processBlobSidecarFromEL(blobSidecar)))
+
       when consensusFork >= ConsensusFork.Deneb:
         # blob_sidecar_{subnet_id}
         # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/[os, random, terminal, times, exitprocs, sequtils],
+  std/[os, random, terminal, times, exitprocs],
   chronos, chronicles,
   metrics, metrics/chronos_httpserver,
   ssz_serialization/types,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -8,9 +8,10 @@
 {.push raises: [].}
 
 import
-  std/[os, random, terminal, times, exitprocs],
+  std/[os, random, terminal, times, exitprocs, sequtils],
   chronos, chronicles,
   metrics, metrics/chronos_httpserver,
+  ssz_serialization/types,
   stew/[byteutils, io2],
   eth/p2p/discoveryv5/[enr, random2],
   ./consensus_object_pools/[
@@ -452,21 +453,67 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Deneb:
+        when consensusFork >= ConsensusFork.Electra:
+          # Pull blobs and proofs from the EL blob pool
+          let blobsFromElOpt = await node.elManager.sendGetBlobs(forkyBlck)
+          if blobsFromElOpt.isSome():
+            let blobsEl = blobsFromElOpt.get()
+            # check lengths of array[BlobAndProofV1] with blob
+            # kzg commitments of the signed block
+            if blobsEl.len == forkyBlck.message.body.blob_kzg_commitments.len:
+              # create blob sidecars from EL instead
+              var
+                kzgBlbs: deneb.Blobs
+                kzgPrfs: deneb.KzgProofs
+
+              for idx in 0..<blobsEl.len:
+                kzgBlbs[idx] = blobsEl[idx].blob.data
+                kzgPrfs[idx].bytes = blobsEl[idx].proof.data
+              let blob_sidecars_el =
+                 create_blob_sidecars(forkyBlck, kzgPrfs, kzgBlbs)
+
+              # populate blob quarantine to tackle blob loop
+              for blb_el in blob_sidecars_el:
+                blobQuarantine[].put(newClone blb_el)
+
+              # now pop blobQuarantine and make block available for attestation
+              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
+              return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+                                               Opt.some(blobs),
+                                               maybeFinalized = maybeFinalized)
+
+          # in case EL does not support `engine_getBlobsV1`
+          else:
+            if not blobQuarantine[].hasBlobs(forkyBlck):
+              # We don't have all the blobs for this block, so we have
+              # to put it in blobless quarantine.
+              if not quarantine[].addBlobless(dag.finalizedHead.slot, forkyBlck):
+                return err(VerifierError.UnviableFork)
+              else:
+                return err(VerifierError.MissingParent)
+            else:
+              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
+              return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+                                               Opt.some(blobs),
+                                               maybeFinalized = maybeFinalized)
+
+        elif consensusFork >= ConsensusFork.Deneb and
+            consensusFork < ConsensusFork.Electra:
           if not blobQuarantine[].hasBlobs(forkyBlck):
             # We don't have all the blobs for this block, so we have
             # to put it in blobless quarantine.
             if not quarantine[].addBlobless(dag.finalizedHead.slot, forkyBlck):
-              err(VerifierError.UnviableFork)
+              return err(VerifierError.UnviableFork)
             else:
-              err(VerifierError.MissingParent)
+              return err(VerifierError.MissingParent)
           else:
             let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
-            await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                      Opt.some(blobs),
-                                      maybeFinalized = maybeFinalized)
+            return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+                                             Opt.some(blobs),
+                                             maybeFinalized = maybeFinalized)
+
         else:
-          await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
+          return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
                                     Opt.none(BlobSidecars),
                                     maybeFinalized = maybeFinalized)
     rmanBlockLoader = proc(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -456,6 +456,8 @@ proc initFullNode(
         when consensusFork >= ConsensusFork.Electra:
           # Pull blobs and proofs from the EL blob pool
           let blobsFromElOpt = await node.elManager.sendGetBlobs(forkyBlck)
+          debugEcho "pulled blobs from el"
+          debugEcho blobsFromElOpt.get.len
           if blobsFromElOpt.isSome():
             let blobsEl = blobsFromElOpt.get()
             # check lengths of array[BlobAndProofV1] with blob
@@ -472,14 +474,14 @@ proc initFullNode(
               let blob_sidecars_el =
                  create_blob_sidecars(forkyBlck, kzgPrfs, kzgBlbs)
 
-              # populate blob quarantine to tackle blob loop
-              for blb_el in blob_sidecars_el:
-                blobQuarantine[].put(newClone blb_el)
+              # # populate blob quarantine to tackle blob loop
+              # for blb_el in blob_sidecars_el:
+              #   blobQuarantine[].put(newClone blb_el)
 
-              # now pop blobQuarantine and make block available for attestation
-              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
+              # # now pop blobQuarantine and make block available for attestation
+              # let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
               return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
-                                               Opt.some(blobs),
+                                               Opt.some(blob_sidecars_el),
                                                maybeFinalized = maybeFinalized)
 
           # in case EL does not support `engine_getBlobsV1`

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2123,7 +2123,7 @@ proc installMessageValidators(node: BeaconNode) =
                                                        blobSidecar,
                                                        subnet_id))
 
-                return waitFor toValidationRace(fut1, fut2))
+                return await toValidationRace(fut1, fut2))
 
       when consensusFork >= ConsensusFork.Deneb:
         # blob_sidecar_{subnet_id}

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -474,12 +474,12 @@ proc initFullNode(
               let blob_sidecars_el =
                  create_blob_sidecars(forkyBlck, kzgPrfs, kzgBlbs)
 
-              # # populate blob quarantine to tackle blob loop
-              # for blb_el in blob_sidecars_el:
-              #   blobQuarantine[].put(newClone blb_el)
+              # populate blob quarantine to tackle blob loop
+              for blb_el in blob_sidecars_el:
+                blobQuarantine[].put(newClone blb_el)
 
-              # # now pop blobQuarantine and make block available for attestation
-              # let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
+              # now pop blobQuarantine and make block available for attestation
+              let blobs = blobQuarantine[].popBlobs(forkyBlck.root, forkyBlck)
               return await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
                                                Opt.some(blob_sidecars_el),
                                                maybeFinalized = maybeFinalized)


### PR DESCRIPTION
https://github.com/ethereum/execution-apis/pull/559

if EL supports `engine_getBlobsV1`
- makes the block available as soon as the CL gets all the required blobs from the blob pool
- populates blob quarantine with that info (should probably verify proofs and inclusion once, like gossip?)
- pops from blob quarantine and add blobs to the block processor

else
- does everything the conventional way

Note: `getBlobs` in `nimbus-eth2` here is made to be backward compatible from Electra and NOT Deneb (Deneb is what the spec suggests)

Pros
- doesn't call kzg proof verification and inclusion proof verification for 9 blobs per slot (assuming the EL can be trusted)
- faster block import (in happy cases)

Cons
- relying heavily on the EL mempool can cause threats of various sorts, however, our block processor runs another kzg proof check before persisting the block and blobs, in case of a failure, the `RequestManager` should be able to fetch back the otherwise malicious blob/proof data sent by the bad EL, EL can be quickly swapped, Nimbus would rely on blob gossip that entire duration and switch back to optimistically pulling blobs from EL.

~~CI failing: because of some nim-web3 upstream incompatibilities~~