### PR TITLE
correctly build arm64 macos Nim compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
             builder: ['self-hosted','ubuntu-22.04']
           - target:
               os: macos
+              cpu: amd64
             builder: macos-13
+          - target:
+              os: macos
+              cpu: arm64
+            builder: macos-latest
           - target:
               os: windows
             builder: windows-2022


### PR DESCRIPTION
Trying to see if the correct version of Nim compiler will be built on arm64 macos.