### PR TITLE
Add log parameters to sync manager debug message

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -226,7 +226,7 @@ proc getBlobSidecars[A, B](man: SyncManager[A, B], peer: A,
   mixin getScore, `==`
 
   doAssert(not(req.isEmpty()), "Request must not be empty!")
-  debug "Requesting blobs sidecars from peer",
+  debug "Requesting blob sidecars from peer",
         request = req,
         peer_score = req.item.getScore(),
         peer_speed = req.item.netKbps(),
@@ -350,7 +350,12 @@ proc getSyncBlockData*[T](
     if shouldGetBlob:
       let blobData =
         block:
-          debug "Requesting blobs sidecars from peer"
+          debug "Requesting blob sidecars from peer",
+                slot = slot,
+                peer = peer,
+                peer_score = peer.getScore(),
+                peer_speed = peer.netKbps(),
+                topics = "syncman"
           let res = await blobSidecarsByRange(peer, slot, 1'u64)
           if res.isErr():
             peer.updateScore(PeerScoreNoValues)


### PR DESCRIPTION
There is a single debug message emitted by `sync_manager` that does not include log parameters. Add them, so that `topics` filtering works.