### PR TITLE
lower testnet base ports to avoid port clashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,10 +210,10 @@ libbacktrace:
 # - --base-el-rpc-port + --el-port-offset * [0, --nodes + --light-clients)
 # - --base-el-ws-port + --el-port-offset * [0, --nodes + --light-clients)
 # - --base-el-auth-rpc-port + --el-port-offset * [0, --nodes + --light-clients)
-UNIT_TEST_BASE_PORT := 39960
-REST_TEST_BASE_PORT := 40990
-MINIMAL_TESTNET_BASE_PORT := 35001
-MAINNET_TESTNET_BASE_PORT := 36501
+UNIT_TEST_BASE_PORT := 29960
+REST_TEST_BASE_PORT := 30990
+MINIMAL_TESTNET_BASE_PORT := 25001
+MAINNET_TESTNET_BASE_PORT := 26501
 
 restapi-test:
 	./tests/simulation/restapi.sh \


### PR DESCRIPTION
Hitting the same ports as `status-desktop` is using during end-to-end tests is more probably when our rage is higher.