### PR TITLE
Disable totals summary in Markdown test reports

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -4,7 +4,6 @@ AllTests-mainnet
 ```diff
 + ancestorSlot                                                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Attestation pool electra processing [Preset: mainnet]
 ```diff
 + Aggregated attestations with disjoint comittee bits into a single on-chain aggregate [Pres OK
@@ -13,7 +12,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
 + Working with electra aggregates [Preset: mainnet]                                          OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Attestation pool processing [Preset: mainnet]
 ```diff
 + Attestation from different branch [Preset: mainnet]                                        OK
@@ -29,7 +27,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK
 + Working with aggregates [Preset: mainnet]                                                  OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Backfill
 ```diff
 + Backfill to genesis                                                                        OK
@@ -37,7 +34,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + Reload backfill position                                                                   OK
 + Restart after each block                                                                   OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Beacon chain DB [Preset: mainnet]
 ```diff
 + empty database [Preset: mainnet]                                                           OK
@@ -75,7 +71,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + sanity check phase 0 states, reusing buffers [Preset: mainnet]                             OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## Beacon chain file test suite
 ```diff
 + Auto check/repair test (missing data)                                                      OK
@@ -84,7 +79,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 + Auto check/repair test (only header)                                                       OK
 + Fixture file validation                                                                    OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Beacon state [Preset: mainnet]
 ```diff
 + Smoke test initialize_beacon_state_from_eth1 [Preset: mainnet]                             OK
@@ -95,18 +89,15 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + merklizer state roundtrip                                                                  OK
 + process_slots                                                                              OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Beacon time
 ```diff
 + Dependent slots                                                                            OK
 + basics                                                                                     OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Beacon validators test suite
 ```diff
 + builderBetterBid(builderBoostFactor) test                                                  OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Blinded block conversions
 ```diff
 + Bellatrix toSignedBlindedBeaconBlock                                                       OK
@@ -115,12 +106,10 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Electra toSignedBlindedBeaconBlock                                                         OK
 + Fulu toSignedBlindedBeaconBlock                                                            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Block pool altair processing [Preset: mainnet]
 ```diff
 + Invalid signatures [Preset: mainnet]                                                       OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block pool processing [Preset: mainnet]
 ```diff
 + Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
@@ -129,36 +118,30 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + updateHead updates head and headState [Preset: mainnet]                                    OK
 + updateState sanity [Preset: mainnet]                                                       OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Block processor [Preset: mainnet]
 ```diff
 + Reverse order block add & get [Preset: mainnet]                                            OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Block quarantine
 ```diff
 + Recursive missing parent                                                                   OK
 + Unviable smoke test                                                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## BlockId and helpers
 ```diff
 + atSlot sanity                                                                              OK
 + parent sanity                                                                              OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## BlockRef and helpers
 ```diff
 + get_ancestor sanity                                                                        OK
 + isAncestorOf sanity                                                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## BlockSlot and helpers
 ```diff
 + atSlot sanity                                                                              OK
 + parent sanity                                                                              OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Combined scenarios [Beacon Node] [Preset: mainnet]
 ```diff
 + ImportKeystores should not be blocked by fee recipient setting [Beacon Node] [Preset: main OK
@@ -166,7 +149,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + ImportRemoteKeys should not be blocked by fee recipient setting [Beacon Node] [Preset: mai OK
 + ImportRemoteKeys should not be blocked by gas limit setting [Beacon Node] [Preset: mainnet OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## DeleteKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Deleting not existing key [Beacon Node] [Preset: mainnet]                                  OK
@@ -174,7 +156,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## DeleteRemoteKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Deleting existing local key and remote key [Beacon Node] [Preset: mainnet]                 OK
@@ -183,7 +164,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## DepositContractSnapshot
 ```diff
 + Migration                                                                                  OK
@@ -191,18 +171,15 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + depositCount                                                                               OK
 + isValid                                                                                    OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Discovery fork ID
 ```diff
 + Expected fork IDs                                                                          OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Diverging hardforks
 ```diff
 + Non-tail block in common                                                                   OK
 + Tail block only in common                                                                  OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - KZG
 ```diff
 + KZG - Blob to KZG commitment - blob_to_kzg_commitment_case_invalid_blob_59d64ff6b4648fad   OK
@@ -459,7 +436,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_invalid_proof_d070689 OK
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_proof_length_differen OK
 ```
-OK: 253/253 Fail: 0/253 Skip: 0/253
 ## EF - KZG - PeerDAS
 ```diff
 + KZG - Compute Cells And Proofs - compute_cells_and_kzg_proofs_case_invalid_blob_26555bdcbf OK
@@ -519,7 +495,6 @@ OK: 253/253 Fail: 0/253 Skip: 0/253
 + KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_same_cell_multi OK
 + KZG - Verify Cell Kzg Proof Batch - verify_cell_kzg_proof_batch_case_valid_zero_cells_fbbd OK
 ```
-OK: 56/56 Fail: 0/56 Skip: 0/56
 ## EF - PeerDAS - Networking [Preset: mainnet]
 ```diff
 + Networking - Compute Columns for Custody Group - mainnet/fulu/networking/compute_columns_f OK
@@ -537,7 +512,6 @@ OK: 56/56 Fail: 0/56 Skip: 0/56
 + Networking - Get Custody Groups - mainnet/fulu/networking/get_custody_groups/pyspec_tests/ OK
 + Networking - Get Custody Groups - mainnet/fulu/networking/get_custody_groups/pyspec_tests/ OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - SSZ generic types
 ```diff
   Testing basic_vector inputs - invalid                                                      Skip
@@ -553,7 +527,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + Testing uints        inputs - invalid                                                      OK
 + Testing uints        inputs - valid                                                        OK
 ```
-OK: 10/12 Fail: 0/12 Skip: 2/12
 ## EIP-4881
 ```diff
 + deposit_cases                                                                              OK
@@ -562,13 +535,11 @@ OK: 10/12 Fail: 0/12 Skip: 2/12
 + invalid_snapshot                                                                           OK
 + snapshot_cases                                                                             OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EIP-7594 Unit Tests
 ```diff
 + EIP-7594: Compute Matrix                                                                   OK
 + EIP:7594: Recover Matrix                                                                   OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EL Configuration
 ```diff
 + Empty config file                                                                          OK
@@ -577,27 +548,23 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Old style config files                                                                     OK
 + URL parsing                                                                                OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Engine API conversions
 ```diff
 + Roundtrip engine RPC V1 and bellatrix ExecutionPayload representations                     OK
 + Roundtrip engine RPC V2 and capella ExecutionPayload representations                       OK
 + Roundtrip engine RPC V3 and deneb ExecutionPayload representations                         OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Eth1 monitor
 ```diff
 + Deposits chain                                                                             OK
 + Rewrite URLs                                                                               OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Eth2 specific discovery tests
 ```diff
 + Invalid attnets field                                                                      OK
 + Subnet query                                                                               OK
 + Subnet query after ENR update                                                              OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Fee recipient management [Beacon Node] [Preset: mainnet]
 ```diff
 + Configuring the fee recipient [Beacon Node] [Preset: mainnet]                              OK
@@ -610,19 +577,16 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Obtaining the fee recipient of an unconfigured validator returns the suggested default [Be OK
 + Setting the fee recipient on a missing validator creates a record for it [Beacon Node] [Pr OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
 ## FinalizedBlocks [Preset: mainnet]
 ```diff
 + Basic ops [Preset: mainnet]                                                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Fork id compatibility test
 ```diff
 + Digest check                                                                               OK
 + Fork check                                                                                 OK
 + Next fork epoch check                                                                      OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Forked SSZ readers
 ```diff
 + load altair block                                                                          OK
@@ -637,7 +601,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + load phase0 state                                                                          OK
 + should raise on unknown data                                                               OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## Gas limit management [Beacon Node] [Preset: mainnet]
 ```diff
 + Configuring the gas limit [Beacon Node] [Preset: mainnet]                                  OK
@@ -650,24 +613,20 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Obtaining the gas limit of an unconfigured validator returns the suggested default [Beacon OK
 + Setting the gas limit on a missing validator creates a record for it [Beacon Node] [Preset OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
 ## Gossip fork transition
 ```diff
 + Gossip fork transition                                                                     OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Gossip validation  [Preset: mainnet]
 ```diff
 + Empty committee when no committee for slot                                                 OK
 + validateAttestation                                                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Gossip validation - Altair
 ```diff
 + Period boundary                                                                            OK
 + validateSyncCommitteeMessage - Duplicate pubkey                                            OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Graffiti management [Beacon Node] [Preset: mainnet]
 ```diff
 + Configuring the graffiti [Beacon Node] [Preset: mainnet]                                   OK
@@ -678,7 +637,6 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + Obtaining the graffiti of an unconfigured validator returns the suggested default [Beacon  OK
 + Setting the graffiti on a missing validator creates a record for it [Beacon Node] [Preset: OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Honest validator
 ```diff
 + General pubsub topics                                                                      OK
@@ -689,7 +647,6 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + isNearSyncCommitteePeriod                                                                  OK
 + is_aggregator                                                                              OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
 ## ImportKeystores requests [Beacon Node] [Preset: mainnet]
 ```diff
 + ImportKeystores/ListKeystores/DeleteKeystores [Beacon Node] [Preset: mainnet]              OK
@@ -697,7 +654,6 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## ImportRemoteKeys/ListRemoteKeys/DeleteRemoteKeys [Beacon Node] [Preset: mainnet]
 ```diff
 + Importing list of remote keys [Beacon Node] [Preset: mainnet]                              OK
@@ -705,7 +661,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Key spliting
 ```diff
 + k < n                                                                                      OK
@@ -713,7 +668,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + k == n == 100                                                                              OK
 + single share                                                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## KeyStorage testing suite
 ```diff
 + Load Prysm keystore                                                                        OK
@@ -729,19 +683,16 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + [SCRYPT] Network Keystore decryption                                                       OK
 + [SCRYPT] Network Keystore encryption                                                       OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Latest valid hash [Preset: mainnet]
 ```diff
 + LVH searching                                                                              OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Light client [Preset: mainnet]
 ```diff
 + Init from checkpoint                                                                       OK
 + Light client sync                                                                          OK
 + Pre-Altair                                                                                 OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Light client processor [Preset: mainnet]
 ```diff
 + Duplicate bootstrap (Optimistic) [Preset: mainnet]                                         OK
@@ -757,7 +708,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Sync (Optimistic) [Preset: mainnet]                                                        OK
 + Sync (Strict) [Preset: mainnet]                                                            OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## ListKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Correct token provided [Beacon Node] [Preset: mainnet]                                     OK
@@ -765,7 +715,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## ListRemoteKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Correct token provided [Beacon Node] [Preset: mainnet]                                     OK
@@ -773,7 +722,6 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## Message signatures
 ```diff
 + Aggregate and proof signatures                                                             OK
@@ -785,20 +733,17 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + Sync committee signed contribution and proof signatures                                    OK
 + Voluntary exit signatures                                                                  OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## Network metadata
 ```diff
 + mainnet                                                                                    OK
 + sepolia                                                                                    OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Nimbus remote signer/signing test (verifying-web3signer)
 ```diff
 + Signing BeaconBlock (getBlockSignature(capella))                                           OK
 + Signing BeaconBlock (getBlockSignature(deneb))                                             OK
 + Waiting for signing node (/upcheck) test                                                   OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Nimbus remote signer/signing test (web3signer)
 ```diff
 + Connection timeout test                                                                    OK
@@ -819,17 +764,14 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Signing voluntary exit (getValidatorExitSignature())                                       OK
 + Waiting for signing node (/upcheck) test                                                   OK
 ```
-OK: 17/17 Fail: 0/17 Skip: 0/17
 ## Old database versions [Preset: mainnet]
 ```diff
 + pre-1.1.0                                                                                  OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## PeerDAS Sampling Tests
 ```diff
 + PeerDAS: Extended Sample Count                                                             OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## PeerPool testing suite
 ```diff
 + Access peers by key test                                                                   OK
@@ -845,12 +787,10 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + addPeerNoWait() test                                                                       OK
 + deletePeer() test                                                                          OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Pruning
 ```diff
 + prune states                                                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## REST JSON encoding and decoding
 ```diff
 + Blob                                                                                       OK
@@ -859,7 +799,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + KzgProof                                                                                   OK
 + Validator pubkey hack                                                                      OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Remove keystore testing suite
 ```diff
 + Many remotes                                                                               OK
@@ -868,36 +807,30 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Verifying Signer / Single remote                                                           OK
 + vesion 1                                                                                   OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## Serialization/deserialization [Beacon Node] [Preset: mainnet]
 ```diff
 + Deserialization test vectors                                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Serialization/deserialization test suite
 ```diff
 + RestErrorMessage parser tests                                                              OK
 + RestErrorMessage writer tests                                                              OK
 + strictParse(Stuint) tests                                                                  OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Shufflings
 ```diff
 + Accelerated shuffling computation                                                          OK
 + Accelerated shuffling computation (with epochRefState jump)                                OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Shufflings (merged)
 ```diff
 + Accelerated shuffling computation                                                          OK
 + Accelerated shuffling computation (with epochRefState jump)                                OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Size bounds
 ```diff
 + SignedBeaconBlockDeneb                                                                     OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Slashing Interchange tests  [Preset: mainnet]
 ```diff
 + Slashing test: duplicate_pubkey_not_slashable.json                                         OK
@@ -939,7 +872,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Slashing test: single_validator_two_blocks_no_signing_root.json                            OK
 + Slashing test: wrong_genesis_validators_root.json                                          OK
 ```
-OK: 35/38 Fail: 0/38 Skip: 3/38
 ## Slashing Protection DB [Preset: mainnet]
 ```diff
 + Attestation ordering #1698                                                                 OK
@@ -955,35 +887,29 @@ OK: 35/38 Fail: 0/38 Skip: 3/38
 + SP for surrounding attestations                                                            OK
 + Test valid attestation #1699                                                               OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## Spec datatypes
 ```diff
 + Graffiti bytes                                                                             OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Spec helpers
 ```diff
 + build_proof - BeaconState                                                                  OK
 + hypergeom_cdf                                                                              OK
 + integer_squareroot                                                                         OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## Specific field types
 ```diff
 + root update                                                                                OK
 + roundtrip                                                                                  OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Starting states
 ```diff
 + Starting state without block                                                               OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## State history
 ```diff
 + getBlockIdAtSlot                                                                           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Sync committee pool
 ```diff
 + Aggregating votes                                                                          OK
@@ -994,7 +920,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Missed slots across sync committee period boundary                                         OK
 + isSeen                                                                                     OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
 ## SyncManager test suite
 ```diff
 + [SyncManager] groupBlobs() test                                                            OK
@@ -1018,12 +943,10 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + [SyncQueue] checkResponse() test                                                           OK
 + [SyncQueue] hasEndGap() test                                                               OK
 ```
-OK: 20/20 Fail: 0/20 Skip: 0/20
 ## Type helpers
 ```diff
 + BeaconBlock                                                                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## Validator Client test suite
 ```diff
 + /eth/v1/validator/beacon_committee_selections serialization/deserialization test           OK
@@ -1041,7 +964,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + getUniqueVotes() test vectors                                                              OK
 + normalizeUri() test vectors                                                                OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## Validator change pool testing suite
 ```diff
 + addValidatorChangeMessage/getAttesterSlashingMessage (Electra)                             OK
@@ -1052,7 +974,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + addValidatorChangeMessage/getVoluntaryExitMessage                                          OK
 + pre-pre-fork voluntary exit                                                                OK
 ```
-OK: 7/7 Fail: 0/7 Skip: 0/7
 ## Validator pool
 ```diff
 + Doppelganger for genesis validator                                                         OK
@@ -1060,20 +981,17 @@ OK: 7/7 Fail: 0/7 Skip: 0/7
 + Dynamic validator set: queryValidatorsSource() test                                        OK
 + Dynamic validator set: updateDynamicValidators() test                                      OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## ValidatorPubKey bucket sort
 ```diff
 + incremental construction                                                                   OK
 + one-shot construction                                                                      OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## Zero signature sanity checks
 ```diff
 + SSZ serialization roundtrip of SignedBeaconBlockHeader                                     OK
 + Zero signatures cannot be loaded into a BLS signature object                               OK
 + default initialization of signatures                                                       OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## chain DAG finalization tests [Preset: mainnet]
 ```diff
 + init with gaps [Preset: mainnet]                                                           OK
@@ -1081,7 +999,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + prune heads on finalization [Preset: mainnet]                                              OK
 + shutdown during finalization [Preset: mainnet]                                             OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## createValidatorFiles()
 ```diff
 + Add keystore files [LOCAL]                                                                 OK
@@ -1093,27 +1010,23 @@ OK: 4/4 Fail: 0/4 Skip: 0/4
 + `createLocalValidatorFiles` with `validatorsDir` without permissions                       OK
 + `createValidatorFiles` with already existing dirs and any error                            OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## engine API authentication
 ```diff
 + HS256 JWS iat token signing                                                                OK
 + HS256 JWS signing                                                                          OK
 + getIatToken                                                                                OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## eth2.0-deposits-cli compatibility
 ```diff
 + restoring mnemonic with password                                                           OK
 + restoring mnemonic without password                                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## removeValidatorFiles()
 ```diff
 + Remove nonexistent validator                                                               OK
 + Remove validator files                                                                     OK
 + Remove validator files twice                                                               OK
 ```
-OK: 3/3 Fail: 0/3 Skip: 0/3
 ## removeValidatorFiles() multiple keystore types
 ```diff
 + Remove [LOCAL] when [LOCAL] is missing                                                     OK
@@ -1123,7 +1036,6 @@ OK: 3/3 Fail: 0/3 Skip: 0/3
 + Remove [REMOTE] when [REMOTE] is missing                                                   OK
 + Remove [REMOTE] when [REMOTE] is present                                                   OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## saveKeystore()
 ```diff
 + Save [LOCAL] keystore after [LOCAL] keystore with different id                             OK
@@ -1135,18 +1047,15 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + Save [REMOTE] keystore after [REMOTE] keystore with different id                           OK
 + Save [REMOTE] keystore after [REMOTE] keystore with same id                                OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## state diff tests [Preset: mainnet]
 ```diff
 + random slot differences [Preset: mainnet]                                                  OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## subnet tracker
 ```diff
 + should register stability subnets on attester duties                                       OK
 + should register sync committee duties                                                      OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## weak-subjectivity-checkpoint
 ```diff
 + Correct values                                                                             OK
@@ -1159,7 +1068,3 @@ OK: 2/2 Fail: 0/2 Skip: 0/2
 + non-number epoch                                                                           OK
 + shorter root                                                                               OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
-
----TOTAL---
-OK: 787/792 Fail: 0/792 Skip: 5/792

--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -4,18 +4,15 @@ ConsensusSpecPreset-mainnet
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Altair - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -40,7 +37,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Altair - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -54,7 +50,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Altair - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -68,12 +63,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Altair - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -88,7 +81,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Altair - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -107,7 +99,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -116,12 +107,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Altair - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Altair - Finality - finality_no_updates_at_genesis [Preset: mainnet]        OK
@@ -130,7 +119,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Altair - Finality - finality_rule_3 [Preset: mainnet]                       OK
 + [Valid]   EF - Altair - Finality - finality_rule_4 [Preset: mainnet]                       OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Altair - Fork  [Preset: mainnet]
 ```diff
 + EF - Altair - Fork - altair_fork_random_0 [Preset: mainnet]                                OK
@@ -148,7 +136,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Altair - Fork - fork_random_low_balances [Preset: mainnet]                            OK
 + EF - Altair - Fork - fork_random_misc_balances [Preset: mainnet]                           OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Altair - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_max_inclusion_slot        OK
@@ -193,7 +180,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Valid]   EF - Altair - Operations - Attestation - one_basic_attestation                   OK
 + [Valid]   EF - Altair - Operations - Attestation - previous_epoch                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Altair - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Attester Slashing - invalid_all_empty_indices         OK
@@ -227,7 +213,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Altair - Operations - Attester Slashing - proposer_index_slashed            OK
 + [Valid]   EF - Altair - Operations - Attester Slashing - with_effective_balance_disparity  OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Altair - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Block Header - invalid_multiple_blocks_single_slot    OK
@@ -237,7 +222,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Altair - Operations - Block Header - invalid_slot_block_header              OK
 + [Valid]   EF - Altair - Operations - Block Header - basic_block_header                     OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Altair - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Deposit - invalid_bad_merkle_proof                    OK
@@ -260,7 +244,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Altair - Operations - Deposit - top_up__max_effective_balance               OK
 + [Valid]   EF - Altair - Operations - Deposit - top_up__zero_balance                        OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Altair - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_different_proposer_indice OK
@@ -279,7 +262,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + [Valid]   EF - Altair - Operations - Proposer Slashing - block_header_from_future          OK
 + [Valid]   EF - Altair - Operations - Proposer Slashing - slashed_and_proposer_index_the_sa OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_bad_domain         OK
@@ -309,7 +291,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_ex OK
 + [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_wi OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Altair - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Operations - Voluntary Exit - invalid_incorrect_signature          OK
@@ -322,7 +303,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Altair - Operations - Voluntary Exit - default_exit_epoch_subsequent_exit   OK
 + [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__min_churn        OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
 ## EF - Altair - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Altair - Random - randomized_0 [Preset: mainnet]                            OK
@@ -342,7 +322,6 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + [Valid]   EF - Altair - Random - randomized_8 [Preset: mainnet]                            OK
 + [Valid]   EF - Altair - Random - randomized_9 [Preset: mainnet]                            OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Altair - Rewards  [Preset: mainnet]
 ```diff
 + EF - Altair - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                  OK
@@ -380,7 +359,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Altair - Rewards - with_slashed_validators [Preset: mainnet]                          OK
 + EF - Altair - Rewards - with_slashed_validators_leak [Preset: mainnet]                     OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Altair - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -423,7 +401,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 39/39 Fail: 0/39 Skip: 0/39
 ## EF - Altair - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]         OK
@@ -474,7 +451,6 @@ OK: 39/39 Fail: 0/39 Skip: 0/39
 + [Valid]   EF - Altair - Sanity - Blocks - sync_committee_committee_genesis__half [Preset:  OK
 + [Valid]   EF - Altair - Sanity - Blocks - voluntary_exit [Preset: mainnet]                 OK
 ```
-OK: 47/47 Fail: 0/47 Skip: 0/47
 ## EF - Altair - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Altair - Slots - double_empty_epoch [Preset: mainnet]                                 OK
@@ -484,7 +460,6 @@ OK: 47/47 Fail: 0/47 Skip: 0/47
 + EF - Altair - Slots - slots_1 [Preset: mainnet]                                            OK
 + EF - Altair - Slots - slots_2 [Preset: mainnet]                                            OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Altair - Transition  [Preset: mainnet]
 ```diff
 + EF - Altair - Transition - non_empty_historical_roots [Preset: mainnet]                    OK
@@ -510,7 +485,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Altair - Transition - transition_with_random_half_participation [Preset: mainnet]     OK
 + EF - Altair - Transition - transition_with_random_three_quarters_participation [Preset: ma OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
 ## EF - Altair - Unittests - Light client - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -518,23 +492,19 @@ OK: 22/22 Fail: 0/22 Skip: 0/22
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Bellatrix - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -559,7 +529,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Bellatrix - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -573,7 +542,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Bellatrix - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -587,12 +555,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -607,7 +573,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Bellatrix - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -626,7 +591,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -635,12 +599,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Bellatrix - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Bellatrix - Finality - finality_no_updates_at_genesis [Preset: mainnet]     OK
@@ -649,7 +611,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: mainnet]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: mainnet]                    OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Bellatrix - Fork  [Preset: mainnet]
 ```diff
 + EF - Bellatrix - Fork - bellatrix_fork_random_0 [Preset: mainnet]                          OK
@@ -665,7 +626,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Bellatrix - Fork - fork_random_low_balances [Preset: mainnet]                         OK
 + EF - Bellatrix - Fork - fork_random_misc_balances [Preset: mainnet]                        OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Bellatrix - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Attestation - invalid_after_max_inclusion_slot     OK
@@ -710,7 +670,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + [Valid]   EF - Bellatrix - Operations - Attestation - one_basic_attestation                OK
 + [Valid]   EF - Bellatrix - Operations - Attestation - previous_epoch                       OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Bellatrix - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_all_empty_indices      OK
@@ -744,7 +703,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Bellatrix - Operations - Attester Slashing - proposer_index_slashed         OK
 + [Valid]   EF - Bellatrix - Operations - Attester Slashing - with_effective_balance_dispari OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Bellatrix - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Block Header - invalid_multiple_blocks_single_slot OK
@@ -754,7 +712,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Bellatrix - Operations - Block Header - invalid_slot_block_header           OK
 + [Valid]   EF - Bellatrix - Operations - Block Header - basic_block_header                  OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Bellatrix - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Deposit - invalid_bad_merkle_proof                 OK
@@ -778,7 +735,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Bellatrix - Operations - Deposit - top_up__max_effective_balance            OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - top_up__zero_balance                     OK
 ```
-OK: 20/20 Fail: 0/20 Skip: 0/20
 ## EF - Bellatrix - Operations - Execution Payload  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - invalid_bad_everything_first_p OK
@@ -808,7 +764,6 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - zero_length_transaction_first_ OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - zero_length_transaction_regula OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Bellatrix - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_different_proposer_ind OK
@@ -827,7 +782,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Bellatrix - Operations - Proposer Slashing - block_header_from_future       OK
 + [Valid]   EF - Bellatrix - Operations - Proposer Slashing - slashed_and_proposer_index_the OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_bad_domain      OK
@@ -857,7 +811,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
 + [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Bellatrix - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Voluntary Exit - invalid_incorrect_signature       OK
@@ -876,7 +829,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Bellatrix - Operations - Voluntary Exit - voluntary_exit_with_current_fork_ OK
 + [Valid]   EF - Bellatrix - Operations - Voluntary Exit - voluntary_exit_with_previous_fork OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Bellatrix - Random - randomized_0 [Preset: mainnet]                         OK
@@ -896,7 +848,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Bellatrix - Random - randomized_8 [Preset: mainnet]                         OK
 + [Valid]   EF - Bellatrix - Random - randomized_9 [Preset: mainnet]                         OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Bellatrix - Rewards  [Preset: mainnet]
 ```diff
 + EF - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: mainnet]               OK
@@ -934,7 +885,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Bellatrix - Rewards - with_slashed_validators [Preset: mainnet]                       OK
 + EF - Bellatrix - Rewards - with_slashed_validators_leak [Preset: mainnet]                  OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Bellatrix - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -980,7 +930,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 42/42 Fail: 0/42 Skip: 0/42
 ## EF - Bellatrix - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]      OK
@@ -1034,7 +983,6 @@ OK: 42/42 Fail: 0/42 Skip: 0/42
 + [Valid]   EF - Bellatrix - Sanity - Blocks - sync_committee_committee_genesis__half [Prese OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: mainnet]              OK
 ```
-OK: 50/50 Fail: 0/50 Skip: 0/50
 ## EF - Bellatrix - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Bellatrix - Slots - double_empty_epoch [Preset: mainnet]                              OK
@@ -1044,7 +992,6 @@ OK: 50/50 Fail: 0/50 Skip: 0/50
 + EF - Bellatrix - Slots - slots_1 [Preset: mainnet]                                         OK
 + EF - Bellatrix - Slots - slots_2 [Preset: mainnet]                                         OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Bellatrix - Transition  [Preset: mainnet]
 ```diff
 + EF - Bellatrix - Transition - non_empty_historical_roots [Preset: mainnet]                 OK
@@ -1070,23 +1017,19 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Bellatrix - Transition - transition_with_random_half_participation [Preset: mainnet]  OK
 + EF - Bellatrix - Transition - transition_with_random_three_quarters_participation [Preset: OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
 ## EF - Capella - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Capella - Epoch Processing - Historical summaries update [Preset: mainnet]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: mainnet]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -1111,7 +1054,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Capella - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -1125,7 +1067,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Capella - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -1139,12 +1080,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Capella - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -1159,7 +1098,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Capella - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -1178,7 +1116,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -1187,12 +1124,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Capella - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Capella - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -1201,7 +1136,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Capella - Finality - finality_rule_3 [Preset: mainnet]                      OK
 + [Valid]   EF - Capella - Finality - finality_rule_4 [Preset: mainnet]                      OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Capella - Fork  [Preset: mainnet]
 ```diff
 + EF - Capella - Fork - capella_fork_random_0 [Preset: mainnet]                              OK
@@ -1217,7 +1151,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Capella - Fork - fork_random_low_balances [Preset: mainnet]                           OK
 + EF - Capella - Fork - fork_random_misc_balances [Preset: mainnet]                          OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Capella - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Attestation - invalid_after_max_inclusion_slot       OK
@@ -1262,7 +1195,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + [Valid]   EF - Capella - Operations - Attestation - one_basic_attestation                  OK
 + [Valid]   EF - Capella - Operations - Attestation - previous_epoch                         OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Capella - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Attester Slashing - invalid_all_empty_indices        OK
@@ -1296,7 +1228,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Capella - Operations - Attester Slashing - proposer_index_slashed           OK
 + [Valid]   EF - Capella - Operations - Attester Slashing - with_effective_balance_disparity OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Capella - Operations - BLS to execution change  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - BLS to execution change - invalid_already_0x01       OK
@@ -1315,7 +1246,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Capella - Operations - BLS to execution change - success_withdrawable       OK
 + [Valid]   EF - Capella - Operations - BLS to execution change - valid_signature_from_staki OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
@@ -1325,7 +1255,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Invalid] EF - Capella - Operations - Block Header - invalid_slot_block_header             OK
 + [Valid]   EF - Capella - Operations - Block Header - basic_block_header                    OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Capella - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Deposit - invalid_bad_merkle_proof                   OK
@@ -1350,7 +1279,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Capella - Operations - Deposit - top_up__max_effective_balance              OK
 + [Valid]   EF - Capella - Operations - Deposit - top_up__zero_balance                       OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Capella - Operations - Execution Payload  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Execution Payload - invalid_bad_everything_first_pay OK
@@ -1380,7 +1308,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Capella - Operations - Execution Payload - zero_length_transaction_first_pa OK
 + [Valid]   EF - Capella - Operations - Execution Payload - zero_length_transaction_regular_ OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Capella - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Proposer Slashing - invalid_different_proposer_indic OK
@@ -1399,7 +1326,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Capella - Operations - Proposer Slashing - block_header_from_future         OK
 + [Valid]   EF - Capella - Operations - Proposer Slashing - slashed_and_proposer_index_the_s OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Sync Aggregate - invalid_signature_bad_domain        OK
@@ -1429,7 +1355,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Capella - Operations - Sync Aggregate - sync_committee_with_participating_e OK
 + [Valid]   EF - Capella - Operations - Sync Aggregate - sync_committee_with_participating_w OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Capella - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Voluntary Exit - invalid_incorrect_signature         OK
@@ -1448,7 +1373,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Capella - Operations - Voluntary Exit - voluntary_exit_with_current_fork_ve OK
 + [Valid]   EF - Capella - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_v OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Operations - Withdrawals  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_f OK
@@ -1505,7 +1429,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Capella - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 + [Valid]   EF - Capella - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 ```
-OK: 53/53 Fail: 0/53 Skip: 0/53
 ## EF - Capella - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Capella - Random - randomized_0 [Preset: mainnet]                           OK
@@ -1525,7 +1448,6 @@ OK: 53/53 Fail: 0/53 Skip: 0/53
 + [Valid]   EF - Capella - Random - randomized_8 [Preset: mainnet]                           OK
 + [Valid]   EF - Capella - Random - randomized_9 [Preset: mainnet]                           OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Capella - Rewards  [Preset: mainnet]
 ```diff
 + EF - Capella - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                 OK
@@ -1563,7 +1485,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Capella - Rewards - with_slashed_validators [Preset: mainnet]                         OK
 + EF - Capella - Rewards - with_slashed_validators_leak [Preset: mainnet]                    OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Capella - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -1613,7 +1534,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 46/46 Fail: 0/46 Skip: 0/46
 ## EF - Capella - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Capella - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]        OK
@@ -1679,7 +1599,6 @@ OK: 46/46 Fail: 0/46 Skip: 0/46
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: mainnet]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 ```
-OK: 62/62 Fail: 0/62 Skip: 0/62
 ## EF - Capella - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Capella - Slots - double_empty_epoch [Preset: mainnet]                                OK
@@ -1689,7 +1608,6 @@ OK: 62/62 Fail: 0/62 Skip: 0/62
 + EF - Capella - Slots - slots_1 [Preset: mainnet]                                           OK
 + EF - Capella - Slots - slots_2 [Preset: mainnet]                                           OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Capella - Transition  [Preset: mainnet]
 ```diff
 + EF - Capella - Transition - non_empty_historical_roots [Preset: mainnet]                   OK
@@ -1715,7 +1633,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Capella - Transition - transition_with_random_half_participation [Preset: mainnet]    OK
 + EF - Capella - Transition - transition_with_random_three_quarters_participation [Preset: m OK
 ```
-OK: 22/22 Fail: 0/22 Skip: 0/22
 ## EF - Capella - Unittests - Light client - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -1723,23 +1640,19 @@ OK: 22/22 Fail: 0/22 Skip: 0/22
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Deneb - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Deneb - Epoch Processing - Historical summaries update [Preset: mainnet]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: mainnet]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -1764,7 +1677,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Deneb - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -1778,7 +1690,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Deneb - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -1792,12 +1703,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Deneb - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -1812,7 +1721,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Deneb - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -1831,7 +1739,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Deneb - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -1840,12 +1747,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Deneb - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Deneb - Finality - finality_no_updates_at_genesis [Preset: mainnet]         OK
@@ -1854,7 +1759,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Deneb - Finality - finality_rule_3 [Preset: mainnet]                        OK
 + [Valid]   EF - Deneb - Finality - finality_rule_4 [Preset: mainnet]                        OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Deneb - Fork  [Preset: mainnet]
 ```diff
 + EF - Deneb - Fork - deneb_fork_random_0 [Preset: mainnet]                                  OK
@@ -1870,7 +1774,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Deneb - Fork - fork_random_low_balances [Preset: mainnet]                             OK
 + EF - Deneb - Fork - fork_random_misc_balances [Preset: mainnet]                            OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Deneb - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Attestation - invalid_after_max_inclusion_slot         OK
@@ -1915,7 +1818,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + [Valid]   EF - Deneb - Operations - Attestation - one_basic_attestation                    OK
 + [Valid]   EF - Deneb - Operations - Attestation - previous_epoch                           OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Deneb - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Attester Slashing - invalid_all_empty_indices          OK
@@ -1949,7 +1851,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Deneb - Operations - Attester Slashing - proposer_index_slashed             OK
 + [Valid]   EF - Deneb - Operations - Attester Slashing - with_effective_balance_disparity   OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Deneb - Operations - BLS to execution change  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - BLS to execution change - invalid_already_0x01         OK
@@ -1967,7 +1868,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Deneb - Operations - BLS to execution change - success_not_activated        OK
 + [Valid]   EF - Deneb - Operations - BLS to execution change - success_withdrawable         OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Deneb - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Block Header - invalid_multiple_blocks_single_slot     OK
@@ -1977,7 +1877,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Deneb - Operations - Block Header - invalid_slot_block_header               OK
 + [Valid]   EF - Deneb - Operations - Block Header - basic_block_header                      OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Deneb - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Deposit - invalid_bad_merkle_proof                     OK
@@ -2002,7 +1901,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Deneb - Operations - Deposit - top_up__max_effective_balance                OK
 + [Valid]   EF - Deneb - Operations - Deposit - top_up__zero_balance                         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Deneb - Operations - Execution Payload  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Execution Payload - invalid_bad_everything_first_paylo OK
@@ -2046,7 +1944,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Deneb - Operations - Execution Payload - zero_length_transaction_regular_pa OK
 + [Valid]   EF - Deneb - Operations - Execution Payload - zeroed_commitment                  OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Deneb - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Proposer Slashing - invalid_different_proposer_indices OK
@@ -2065,7 +1962,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Deneb - Operations - Proposer Slashing - block_header_from_future           OK
 + [Valid]   EF - Deneb - Operations - Proposer Slashing - slashed_and_proposer_index_the_sam OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Deneb - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Sync Aggregate - invalid_signature_bad_domain          OK
@@ -2095,7 +1991,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Deneb - Operations - Sync Aggregate - sync_committee_with_participating_exi OK
 + [Valid]   EF - Deneb - Operations - Sync Aggregate - sync_committee_with_participating_wit OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Deneb - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Voluntary Exit - invalid_incorrect_signature           OK
@@ -2114,7 +2009,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Deneb - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_ver OK
 + [Valid]   EF - Deneb - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_ver OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Deneb - Operations - Withdrawals  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_few OK
@@ -2171,7 +2065,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Deneb - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balan OK
 + [Valid]   EF - Deneb - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balan OK
 ```
-OK: 53/53 Fail: 0/53 Skip: 0/53
 ## EF - Deneb - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Deneb - Random - randomized_0 [Preset: mainnet]                             OK
@@ -2191,7 +2084,6 @@ OK: 53/53 Fail: 0/53 Skip: 0/53
 + [Valid]   EF - Deneb - Random - randomized_8 [Preset: mainnet]                             OK
 + [Valid]   EF - Deneb - Random - randomized_9 [Preset: mainnet]                             OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Deneb - Rewards  [Preset: mainnet]
 ```diff
 + EF - Deneb - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                   OK
@@ -2229,7 +2121,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Deneb - Rewards - with_slashed_validators [Preset: mainnet]                           OK
 + EF - Deneb - Rewards - with_slashed_validators_leak [Preset: mainnet]                      OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Deneb - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -2281,7 +2172,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
 ## EF - Deneb - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Deneb - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]          OK
@@ -2356,7 +2246,6 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 + [Valid]   EF - Deneb - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet]   OK
 + [Valid]   EF - Deneb - Sanity - Blocks - zero_blob [Preset: mainnet]                       OK
 ```
-OK: 71/71 Fail: 0/71 Skip: 0/71
 ## EF - Deneb - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Deneb - Slots - double_empty_epoch [Preset: mainnet]                                  OK
@@ -2366,7 +2255,6 @@ OK: 71/71 Fail: 0/71 Skip: 0/71
 + EF - Deneb - Slots - slots_1 [Preset: mainnet]                                             OK
 + EF - Deneb - Slots - slots_2 [Preset: mainnet]                                             OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Deneb - Transition  [Preset: mainnet]
 ```diff
 + EF - Deneb - Transition - non_empty_historical_roots [Preset: mainnet]                     OK
@@ -2395,7 +2283,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Deneb - Transition - transition_with_random_half_participation [Preset: mainnet]      OK
 + EF - Deneb - Transition - transition_with_random_three_quarters_participation [Preset: mai OK
 ```
-OK: 25/25 Fail: 0/25 Skip: 0/25
 ## EF - Deneb - Unittests - Light client - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -2403,24 +2290,20 @@ OK: 25/25 Fail: 0/25 Skip: 0/25
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Electra - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 + Effective balance updates - effective_balance_hysteresis_with_compounding_credentials [Pre OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Electra - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Electra - Epoch Processing - Historical summaries update [Preset: mainnet]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: mainnet]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -2445,7 +2328,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Electra - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -2459,7 +2341,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Electra - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -2473,7 +2354,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Electra - Epoch Processing - Pending consolidations [Preset: mainnet]
 ```diff
 + Pending consolidations - all_consolidation_cases_together [Preset: mainnet]                OK
@@ -2490,7 +2370,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Pending consolidations - pending_consolidation_with_pending_deposit [Preset: mainnet]      OK
 + Pending consolidations - skip_consolidation_when_source_slashed [Preset: mainnet]          OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
 ## EF - Electra - Epoch Processing - Pending deposits [Preset: mainnet]
 ```diff
 + Pending deposits - apply_pending_deposit_compounding_withdrawal_credentials_max [Preset: m OK
@@ -2538,12 +2417,10 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + Pending deposits - process_pending_deposits_withdrawable_validator [Preset: mainnet]       OK
 + Pending deposits - process_pending_deposits_withdrawable_validator_not_churned [Preset: ma OK
 ```
-OK: 44/44 Fail: 0/44 Skip: 0/44
 ## EF - Electra - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -2563,7 +2440,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Electra - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -2582,7 +2458,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Electra - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -2591,12 +2466,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Electra - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Electra - Finality - finality_no_updates_at_genesis [Preset: mainnet]       OK
@@ -2605,7 +2478,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Electra - Finality - finality_rule_3 [Preset: mainnet]                      OK
 + [Valid]   EF - Electra - Finality - finality_rule_4 [Preset: mainnet]                      OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Electra - Fork  [Preset: mainnet]
 ```diff
 + EF - Electra - Fork - electra_fork_random_0 [Preset: mainnet]                              OK
@@ -2628,7 +2500,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Electra - Fork - fork_random_low_balances [Preset: mainnet]                           OK
 + EF - Electra - Fork - fork_random_misc_balances [Preset: mainnet]                          OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Electra - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Attestation - invalid_after_max_inclusion_slot       OK
@@ -2677,7 +2548,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + [Valid]   EF - Electra - Operations - Attestation - one_basic_attestation                  OK
 + [Valid]   EF - Electra - Operations - Attestation - previous_epoch                         OK
 ```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## EF - Electra - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Attester Slashing - invalid_all_empty_indices        OK
@@ -2711,7 +2581,6 @@ OK: 45/45 Fail: 0/45 Skip: 0/45
 + [Valid]   EF - Electra - Operations - Attester Slashing - proposer_index_slashed           OK
 + [Valid]   EF - Electra - Operations - Attester Slashing - with_effective_balance_disparity OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Electra - Operations - BLS to execution change  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - BLS to execution change - invalid_already_0x01       OK
@@ -2729,7 +2598,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Electra - Operations - BLS to execution change - success_not_activated      OK
 + [Valid]   EF - Electra - Operations - BLS to execution change - success_withdrawable       OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Electra - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
@@ -2739,7 +2607,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Electra - Operations - Block Header - invalid_slot_block_header             OK
 + [Valid]   EF - Electra - Operations - Block Header - basic_block_header                    OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Electra - Operations - Consolidation Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Electra - Operations - Consolidation Request - basic_switch_to_compounding  OK
@@ -2753,7 +2620,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Electra - Operations - Consolidation Request - switch_to_compounding_with_e OK
 + [Valid]   EF - Electra - Operations - Consolidation Request - switch_to_compounding_with_p OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Electra - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Deposit - invalid_bad_merkle_proof                   OK
@@ -2778,7 +2644,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + [Valid]   EF - Electra - Operations - Deposit - top_up__max_effective_balance              OK
 + [Valid]   EF - Electra - Operations - Deposit - top_up__zero_balance                       OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Electra - Operations - Deposit Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_invalid_si OK
@@ -2790,7 +2655,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_top_up_max OK
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_top_up_min OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## EF - Electra - Operations - Execution Payload  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Execution Payload - invalid_bad_everything_first_pay OK
@@ -2834,7 +2698,6 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + [Valid]   EF - Electra - Operations - Execution Payload - zero_length_transaction_regular_ OK
 + [Valid]   EF - Electra - Operations - Execution Payload - zeroed_commitment                OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Electra - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Proposer Slashing - invalid_different_proposer_indic OK
@@ -2853,7 +2716,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Electra - Operations - Proposer Slashing - block_header_from_future         OK
 + [Valid]   EF - Electra - Operations - Proposer Slashing - slashed_and_proposer_index_the_s OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Electra - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Sync Aggregate - invalid_signature_bad_domain        OK
@@ -2883,7 +2745,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Electra - Operations - Sync Aggregate - sync_committee_with_participating_e OK
 + [Valid]   EF - Electra - Operations - Sync Aggregate - sync_committee_with_participating_w OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Electra - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Voluntary Exit - invalid_incorrect_signature         OK
@@ -2911,7 +2772,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Electra - Operations - Voluntary Exit - min_balance_exits_up_to_churn       OK
 + [Valid]   EF - Electra - Operations - Voluntary Exit - success_exit_queue__min_churn       OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Electra - Operations - Withdrawal Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Electra - Operations - Withdrawal Request - activation_epoch_less_than_shar OK
@@ -2934,7 +2794,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Electra - Operations - Withdrawal Request - pending_withdrawals_consume_all OK
 + [Valid]   EF - Electra - Operations - Withdrawal Request - unknown_pubkey                  OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Electra - Operations - Withdrawals  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_f OK
@@ -3013,7 +2872,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + [Valid]   EF - Electra - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 + [Valid]   EF - Electra - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 ```
-OK: 75/75 Fail: 0/75 Skip: 0/75
 ## EF - Electra - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Electra - Random - randomized_0 [Preset: mainnet]                           OK
@@ -3033,7 +2891,6 @@ OK: 75/75 Fail: 0/75 Skip: 0/75
 + [Valid]   EF - Electra - Random - randomized_8 [Preset: mainnet]                           OK
 + [Valid]   EF - Electra - Random - randomized_9 [Preset: mainnet]                           OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Electra - Rewards  [Preset: mainnet]
 ```diff
 + EF - Electra - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                 OK
@@ -3071,7 +2928,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Electra - Rewards - with_slashed_validators [Preset: mainnet]                         OK
 + EF - Electra - Rewards - with_slashed_validators_leak [Preset: mainnet]                    OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Electra - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -3131,7 +2987,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Withdrawal                                                                    OK
 +   Testing    WithdrawalRequest                                                             OK
 ```
-OK: 56/56 Fail: 0/56 Skip: 0/56
 ## EF - Electra - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Electra - Sanity - Blocks - deposit_transition__invalid_eth1_deposits_overl OK
@@ -3221,7 +3076,6 @@ OK: 56/56 Fail: 0/56 Skip: 0/56
 + [Valid]   EF - Electra - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet] OK
 + [Valid]   EF - Electra - Sanity - Blocks - zero_blob [Preset: mainnet]                     OK
 ```
-OK: 86/86 Fail: 0/86 Skip: 0/86
 ## EF - Electra - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Electra - Slots - double_empty_epoch [Preset: mainnet]                                OK
@@ -3236,7 +3090,6 @@ OK: 86/86 Fail: 0/86 Skip: 0/86
 + EF - Electra - Slots - slots_1 [Preset: mainnet]                                           OK
 + EF - Electra - Slots - slots_2 [Preset: mainnet]                                           OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Electra - Transition  [Preset: mainnet]
 ```diff
 + EF - Electra - Transition - non_empty_historical_roots [Preset: mainnet]                   OK
@@ -3267,7 +3120,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + EF - Electra - Transition - transition_with_random_half_participation [Preset: mainnet]    OK
 + EF - Electra - Transition - transition_with_random_three_quarters_participation [Preset: m OK
 ```
-OK: 27/27 Fail: 0/27 Skip: 0/27
 ## EF - Electra - Unittests - Light client - Sync protocol [Preset: mainnet]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -3275,24 +3127,20 @@ OK: 27/27 Fail: 0/27 Skip: 0/27
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Fulu - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 + Effective balance updates - effective_balance_hysteresis_with_compounding_credentials [Pre OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Fulu - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Fulu - Epoch Processing - Historical summaries update [Preset: mainnet]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: mainnet]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Epoch Processing - Inactivity [Preset: mainnet]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: mainnet]              OK
@@ -3317,7 +3165,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: mainnet]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: mainnet]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Fulu - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -3331,7 +3178,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Fulu - Epoch Processing - Participation flag updates [Preset: mainnet]
 ```diff
 + Participation flag updates - all_zeroed [Preset: mainnet]                                  OK
@@ -3345,7 +3191,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_2 [Preset: mainnet]                                    OK
 + Participation flag updates - random_genesis [Preset: mainnet]                              OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Fulu - Epoch Processing - Pending consolidations [Preset: mainnet]
 ```diff
 + Pending consolidations - all_consolidation_cases_together [Preset: mainnet]                OK
@@ -3362,7 +3207,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Pending consolidations - pending_consolidation_with_pending_deposit [Preset: mainnet]      OK
 + Pending consolidations - skip_consolidation_when_source_slashed [Preset: mainnet]          OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
 ## EF - Fulu - Epoch Processing - Pending deposits [Preset: mainnet]
 ```diff
 + Pending deposits - apply_pending_deposit_compounding_withdrawal_credentials_max [Preset: m OK
@@ -3410,12 +3254,10 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + Pending deposits - process_pending_deposits_withdrawable_validator [Preset: mainnet]       OK
 + Pending deposits - process_pending_deposits_withdrawable_validator_not_churned [Preset: ma OK
 ```
-OK: 44/44 Fail: 0/44 Skip: 0/44
 ## EF - Fulu - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -3435,7 +3277,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Fulu - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -3454,7 +3295,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Fulu - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -3463,12 +3303,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Fulu - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Fulu - Finality - finality_no_updates_at_genesis [Preset: mainnet]          OK
@@ -3477,7 +3315,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Fulu - Finality - finality_rule_3 [Preset: mainnet]                         OK
 + [Valid]   EF - Fulu - Finality - finality_rule_4 [Preset: mainnet]                         OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Fulu - Fork  [Preset: mainnet]
 ```diff
 + EF - Fulu - Fork - fork_base_state [Preset: mainnet]                                       OK
@@ -3493,7 +3330,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Fulu - Fork - fulu_fork_random_low_balances [Preset: mainnet]                         OK
 + EF - Fulu - Fork - fulu_fork_random_misc_balances [Preset: mainnet]                        OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Fulu - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Attestation - invalid_after_max_inclusion_slot          OK
@@ -3542,7 +3378,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + [Valid]   EF - Fulu - Operations - Attestation - one_basic_attestation                     OK
 + [Valid]   EF - Fulu - Operations - Attestation - previous_epoch                            OK
 ```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## EF - Fulu - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Attester Slashing - invalid_all_empty_indices           OK
@@ -3576,7 +3411,6 @@ OK: 45/45 Fail: 0/45 Skip: 0/45
 + [Valid]   EF - Fulu - Operations - Attester Slashing - proposer_index_slashed              OK
 + [Valid]   EF - Fulu - Operations - Attester Slashing - with_effective_balance_disparity    OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Fulu - Operations - BLS to execution change  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - BLS to execution change - invalid_already_0x01          OK
@@ -3594,7 +3428,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Fulu - Operations - BLS to execution change - success_not_activated         OK
 + [Valid]   EF - Fulu - Operations - BLS to execution change - success_withdrawable          OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Fulu - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Block Header - invalid_multiple_blocks_single_slot      OK
@@ -3604,7 +3437,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Fulu - Operations - Block Header - invalid_slot_block_header                OK
 + [Valid]   EF - Fulu - Operations - Block Header - basic_block_header                       OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Fulu - Operations - Consolidation Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Fulu - Operations - Consolidation Request - basic_switch_to_compounding     OK
@@ -3618,7 +3450,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Fulu - Operations - Consolidation Request - switch_to_compounding_with_exce OK
 + [Valid]   EF - Fulu - Operations - Consolidation Request - switch_to_compounding_with_pend OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Fulu - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Deposit - invalid_bad_merkle_proof                      OK
@@ -3643,7 +3474,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + [Valid]   EF - Fulu - Operations - Deposit - top_up__max_effective_balance                 OK
 + [Valid]   EF - Fulu - Operations - Deposit - top_up__zero_balance                          OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Fulu - Operations - Deposit Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_invalid_sig   OK
@@ -3655,7 +3485,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_top_up_max_ef OK
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_top_up_min_ac OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## EF - Fulu - Operations - Execution Payload  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Execution Payload - invalid_bad_everything_first_payloa OK
@@ -3699,7 +3528,6 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + [Valid]   EF - Fulu - Operations - Execution Payload - zero_length_transaction_regular_pay OK
 + [Valid]   EF - Fulu - Operations - Execution Payload - zeroed_commitment                   OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Fulu - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Proposer Slashing - invalid_different_proposer_indices  OK
@@ -3718,7 +3546,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Fulu - Operations - Proposer Slashing - block_header_from_future            OK
 + [Valid]   EF - Fulu - Operations - Proposer Slashing - slashed_and_proposer_index_the_same OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Fulu - Operations - Sync Aggregate  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Sync Aggregate - invalid_signature_bad_domain           OK
@@ -3748,7 +3575,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Fulu - Operations - Sync Aggregate - sync_committee_with_participating_exit OK
 + [Valid]   EF - Fulu - Operations - Sync Aggregate - sync_committee_with_participating_with OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Fulu - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Voluntary Exit - invalid_incorrect_signature            OK
@@ -3776,7 +3602,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Fulu - Operations - Voluntary Exit - min_balance_exits_up_to_churn          OK
 + [Valid]   EF - Fulu - Operations - Voluntary Exit - success_exit_queue__min_churn          OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Fulu - Operations - Withdrawal Request  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - activation_epoch_less_than_shard_c OK
@@ -3799,7 +3624,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - pending_withdrawals_consume_all_ex OK
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - unknown_pubkey                     OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Fulu - Operations - Withdrawals  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_few_ OK
@@ -3878,7 +3702,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + [Valid]   EF - Fulu - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balanc OK
 + [Valid]   EF - Fulu - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balanc OK
 ```
-OK: 75/75 Fail: 0/75 Skip: 0/75
 ## EF - Fulu - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Fulu - Random - randomized_0 [Preset: mainnet]                              OK
@@ -3898,7 +3721,6 @@ OK: 75/75 Fail: 0/75 Skip: 0/75
 + [Valid]   EF - Fulu - Random - randomized_8 [Preset: mainnet]                              OK
 + [Valid]   EF - Fulu - Random - randomized_9 [Preset: mainnet]                              OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Fulu - Rewards  [Preset: mainnet]
 ```diff
 + EF - Fulu - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                    OK
@@ -3936,7 +3758,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Fulu - Rewards - with_slashed_validators [Preset: mainnet]                            OK
 + EF - Fulu - Rewards - with_slashed_validators_leak [Preset: mainnet]                       OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Fulu - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -3999,7 +3820,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Withdrawal                                                                    OK
 +   Testing    WithdrawalRequest                                                             OK
 ```
-OK: 59/59 Fail: 0/59 Skip: 0/59
 ## EF - Fulu - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Fulu - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]           OK
@@ -4076,7 +3896,6 @@ OK: 59/59 Fail: 0/59 Skip: 0/59
 + [Valid]   EF - Fulu - Sanity - Blocks - withdrawal_success_two_blocks [Preset: mainnet]    OK
 + [Valid]   EF - Fulu - Sanity - Blocks - zero_blob [Preset: mainnet]                        OK
 ```
-OK: 73/73 Fail: 0/73 Skip: 0/73
 ## EF - Fulu - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Fulu - Slots - double_empty_epoch [Preset: mainnet]                                   OK
@@ -4091,7 +3910,6 @@ OK: 73/73 Fail: 0/73 Skip: 0/73
 + EF - Fulu - Slots - slots_1 [Preset: mainnet]                                              OK
 + EF - Fulu - Slots - slots_2 [Preset: mainnet]                                              OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Light client - Single merkle proof [Preset: mainnet]
 ```diff
 + Light client - Single merkle proof - mainnet/altair/light_client/single_merkle_proof/Beaco OK
@@ -4114,7 +3932,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Light client - Single merkle proof - mainnet/electra/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - mainnet/fulu/light_client/single_merkle_proof/BeaconB OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Merkle proof [Preset: mainnet]
 ```diff
 + Merkle proof - Single merkle proof - mainnet/deneb/merkle_proof/single_merkle_proof/Beacon OK
@@ -4132,23 +3949,19 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Merkle proof - Single merkle proof - mainnet/fulu/merkle_proof/single_merkle_proof/BeaconB OK
 + Merkle proof - Single merkle proof - mainnet/fulu/merkle_proof/single_merkle_proof/BeaconB OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: mainnet]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: mainnet]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Eth1 data reset [Preset: mainnet]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: mainnet]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: mainnet]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Phase 0 - Epoch Processing - Historical roots update [Preset: mainnet]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: mainnet]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Justification & Finalization [Preset: mainnet]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: mainnet]                            OK
@@ -4162,17 +3975,14 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Justification & Finalization - 23_poor_support [Preset: mainnet]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: mainnet]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Phase 0 - Epoch Processing - Participation record updates [Preset: mainnet]
 ```diff
 + Participation record updates - updated_participation_record [Preset: mainnet]              OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: mainnet]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: mainnet]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Registry updates [Preset: mainnet]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: mainnet]           OK
@@ -4187,7 +3997,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_min [Preset: mainnet]                         OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: mainnet]                      OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Phase 0 - Epoch Processing - Rewards and penalties [Preset: mainnet]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: mainnet]                        OK
@@ -4210,7 +4019,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Rewards and penalties - random_fill_attestations [Preset: mainnet]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: mainnet]               OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Phase 0 - Epoch Processing - Slashings [Preset: mainnet]
 ```diff
 + Slashings - low_penalty [Preset: mainnet]                                                  OK
@@ -4219,12 +4027,10 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Slashings - scaled_penalties [Preset: mainnet]                                             OK
 + Slashings - slashings_with_random_state [Preset: mainnet]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase 0 - Epoch Processing - Slashings reset [Preset: mainnet]
 ```diff
 + Slashings reset - flush_slashings [Preset: mainnet]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Operations - Attestation  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: ma OK
@@ -4269,7 +4075,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: ma OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: ma OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Phase 0 - Operations - Attester Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
@@ -4303,7 +4108,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Phase 0 - Operations - Block Header  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
@@ -4313,7 +4117,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Phase 0 - Operations - Deposit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: mainne OK
@@ -4334,7 +4137,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: mainne OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: mainne OK
 ```
-OK: 17/17 Fail: 0/17 Skip: 0/17
 ## EF - Phase 0 - Operations - Proposer Slashing  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
@@ -4353,7 +4155,6 @@ OK: 17/17 Fail: 0/17 Skip: 0/17
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Phase 0 - Operations - Voluntary Exit  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
@@ -4366,7 +4167,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
 ## EF - Phase 0 - Rewards  [Preset: mainnet]
 ```diff
 + EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: mainnet]                 OK
@@ -4419,7 +4219,6 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + EF - Phase 0 - Rewards - with_slashed_validators [Preset: mainnet]                         OK
 + EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: mainnet]                    OK
 ```
-OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - Phase 0 - SSZ consensus objects  [Preset: mainnet]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -4450,7 +4249,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 27/27 Fail: 0/27 Skip: 0/27
 ## EF - Phase 0 - Sanity - Slots  [Preset: mainnet]
 ```diff
 + EF - Phase 0 - Slots - double_empty_epoch [Preset: mainnet]                                OK
@@ -4460,7 +4258,6 @@ OK: 27/27 Fail: 0/27 Skip: 0/27
 + EF - Phase 0 - Slots - slots_1 [Preset: mainnet]                                           OK
 + EF - Phase 0 - Slots - slots_2 [Preset: mainnet]                                           OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Phase0 - Finality  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Phase0 - Finality - finality_no_updates_at_genesis [Preset: mainnet]        OK
@@ -4469,7 +4266,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Phase0 - Finality - finality_rule_3 [Preset: mainnet]                       OK
 + [Valid]   EF - Phase0 - Finality - finality_rule_4 [Preset: mainnet]                       OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase0 - Random  [Preset: mainnet]
 ```diff
 + [Valid]   EF - Phase0 - Random - randomized_0 [Preset: mainnet]                            OK
@@ -4489,7 +4285,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Phase0 - Random - randomized_8 [Preset: mainnet]                            OK
 + [Valid]   EF - Phase0 - Random - randomized_9 [Preset: mainnet]                            OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Phase0 - Sanity - Blocks  [Preset: mainnet]
 ```diff
 + [Invalid] EF - Phase0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: mainnet]         OK
@@ -4533,7 +4328,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Phase0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: mainnet]      OK
 + [Valid]   EF - Phase0 - Sanity - Blocks - voluntary_exit [Preset: mainnet]                 OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## ForkChoice
 ```diff
 + ForkChoice - mainnet/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_attestations_is_great OK
@@ -4670,7 +4464,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + ForkChoice - mainnet/fulu/fork_choice/on_block/pyspec_tests/proposer_boost_root_same_slot_ OK
   ForkChoice - mainnet/fulu/fork_choice/should_override_forkchoice_update/pyspec_tests/shoul Skip
 ```
-OK: 106/133 Fail: 0/133 Skip: 27/133
 ## Sync
 ```diff
 + Sync - mainnet/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
@@ -4679,7 +4472,3 @@ OK: 106/133 Fail: 0/133 Skip: 27/133
 + Sync - mainnet/electra/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + Sync - mainnet/fulu/sync/optimistic/pyspec_tests/from_syncing_to_invalid                   OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
-
----TOTAL---
-OK: 3821/3848 Fail: 0/3848 Skip: 27/3848

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -4,18 +4,15 @@ ConsensusSpecPreset-minimal
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Altair - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -40,7 +37,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Altair - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -54,7 +50,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Altair - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -70,12 +65,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Altair - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
@@ -94,7 +87,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -113,7 +105,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -122,12 +113,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Altair - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Altair - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -136,7 +125,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Altair - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Altair - Finality - finality_no_updates_at_genesis [Preset: minimal]        OK
@@ -145,7 +133,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Altair - Finality - finality_rule_3 [Preset: minimal]                       OK
 + [Valid]   EF - Altair - Finality - finality_rule_4 [Preset: minimal]                       OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Altair - Fork  [Preset: minimal]
 ```diff
 + EF - Altair - Fork - altair_fork_random_0 [Preset: minimal]                                OK
@@ -165,7 +152,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Altair - Fork - fork_random_low_balances [Preset: minimal]                            OK
 + EF - Altair - Fork - fork_random_misc_balances [Preset: minimal]                           OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Altair - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Attestation - invalid_after_max_inclusion_slot        OK
@@ -210,7 +196,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Altair - Operations - Attestation - one_basic_attestation                   OK
 + [Valid]   EF - Altair - Operations - Attestation - previous_epoch                          OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Altair - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Attester Slashing - invalid_all_empty_indices         OK
@@ -244,7 +229,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Altair - Operations - Attester Slashing - proposer_index_slashed            OK
 + [Valid]   EF - Altair - Operations - Attester Slashing - with_effective_balance_disparity  OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Altair - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Block Header - invalid_multiple_blocks_single_slot    OK
@@ -254,7 +238,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Altair - Operations - Block Header - invalid_slot_block_header              OK
 + [Valid]   EF - Altair - Operations - Block Header - basic_block_header                     OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Altair - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Deposit - invalid_bad_merkle_proof                    OK
@@ -277,7 +260,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Altair - Operations - Deposit - top_up__max_effective_balance               OK
 + [Valid]   EF - Altair - Operations - Deposit - top_up__zero_balance                        OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Altair - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Proposer Slashing - invalid_different_proposer_indice OK
@@ -296,7 +278,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + [Valid]   EF - Altair - Operations - Proposer Slashing - block_header_from_future          OK
 + [Valid]   EF - Altair - Operations - Proposer Slashing - slashed_and_proposer_index_the_sa OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Altair - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Sync Aggregate - invalid_signature_bad_domain         OK
@@ -324,7 +305,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Altair - Operations - Sync Aggregate - sync_committee_with_participating_wi OK
 + [Valid]   EF - Altair - Operations - Sync Aggregate - valid_signature_future_committee     OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Altair - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Operations - Voluntary Exit - invalid_incorrect_signature          OK
@@ -338,7 +318,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__min_churn        OK
 + [Valid]   EF - Altair - Operations - Voluntary Exit - success_exit_queue__scaled_churn     OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Altair - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Altair - Random - randomized_0 [Preset: minimal]                            OK
@@ -358,7 +337,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + [Valid]   EF - Altair - Random - randomized_8 [Preset: minimal]                            OK
 + [Valid]   EF - Altair - Random - randomized_9 [Preset: minimal]                            OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Altair - Rewards  [Preset: minimal]
 ```diff
 + EF - Altair - Rewards - all_balances_too_low_for_reward [Preset: minimal]                  OK
@@ -396,7 +374,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Altair - Rewards - with_slashed_validators [Preset: minimal]                          OK
 + EF - Altair - Rewards - with_slashed_validators_leak [Preset: minimal]                     OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Altair - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -439,7 +416,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 39/39 Fail: 0/39 Skip: 0/39
 ## EF - Altair - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Altair - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]         OK
@@ -495,7 +471,6 @@ OK: 39/39 Fail: 0/39 Skip: 0/39
 + [Valid]   EF - Altair - Sanity - Blocks - sync_committee_committee_genesis__half [Preset:  OK
 + [Valid]   EF - Altair - Sanity - Blocks - voluntary_exit [Preset: minimal]                 OK
 ```
-OK: 52/52 Fail: 0/52 Skip: 0/52
 ## EF - Altair - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Altair - Slots - double_empty_epoch [Preset: minimal]                                 OK
@@ -505,7 +480,6 @@ OK: 52/52 Fail: 0/52 Skip: 0/52
 + EF - Altair - Slots - slots_1 [Preset: minimal]                                            OK
 + EF - Altair - Slots - slots_2 [Preset: minimal]                                            OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Altair - Transition  [Preset: minimal]
 ```diff
 + EF - Altair - Transition - non_empty_historical_roots [Preset: minimal]                    OK
@@ -535,7 +509,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Altair - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minima OK
 + EF - Altair - Transition - transition_with_voluntary_exit_right_before_fork [Preset: minim OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Altair - Unittests - Light client - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -543,23 +516,19 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Bellatrix - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Bellatrix - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -584,7 +553,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Bellatrix - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -598,7 +566,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Bellatrix - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -614,12 +581,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Bellatrix - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
@@ -638,7 +603,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -657,7 +621,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -666,12 +629,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Bellatrix - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Bellatrix - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -680,7 +641,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Bellatrix - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Bellatrix - Finality - finality_no_updates_at_genesis [Preset: minimal]     OK
@@ -689,7 +649,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Bellatrix - Finality - finality_rule_3 [Preset: minimal]                    OK
 + [Valid]   EF - Bellatrix - Finality - finality_rule_4 [Preset: minimal]                    OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Bellatrix - Fork  [Preset: minimal]
 ```diff
 + EF - Bellatrix - Fork - bellatrix_fork_random_0 [Preset: minimal]                          OK
@@ -707,7 +666,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Bellatrix - Fork - fork_random_low_balances [Preset: minimal]                         OK
 + EF - Bellatrix - Fork - fork_random_misc_balances [Preset: minimal]                        OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Bellatrix - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Attestation - invalid_after_max_inclusion_slot     OK
@@ -752,7 +710,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Valid]   EF - Bellatrix - Operations - Attestation - one_basic_attestation                OK
 + [Valid]   EF - Bellatrix - Operations - Attestation - previous_epoch                       OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Bellatrix - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Attester Slashing - invalid_all_empty_indices      OK
@@ -786,7 +743,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Bellatrix - Operations - Attester Slashing - proposer_index_slashed         OK
 + [Valid]   EF - Bellatrix - Operations - Attester Slashing - with_effective_balance_dispari OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Bellatrix - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Block Header - invalid_multiple_blocks_single_slot OK
@@ -796,7 +752,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Bellatrix - Operations - Block Header - invalid_slot_block_header           OK
 + [Valid]   EF - Bellatrix - Operations - Block Header - basic_block_header                  OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Bellatrix - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Deposit - invalid_bad_merkle_proof                 OK
@@ -820,7 +775,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Bellatrix - Operations - Deposit - top_up__max_effective_balance            OK
 + [Valid]   EF - Bellatrix - Operations - Deposit - top_up__zero_balance                     OK
 ```
-OK: 20/20 Fail: 0/20 Skip: 0/20
 ## EF - Bellatrix - Operations - Execution Payload  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Execution Payload - invalid_bad_everything_first_p OK
@@ -850,7 +804,6 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - zero_length_transaction_first_ OK
 + [Valid]   EF - Bellatrix - Operations - Execution Payload - zero_length_transaction_regula OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Bellatrix - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Proposer Slashing - invalid_different_proposer_ind OK
@@ -869,7 +822,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Bellatrix - Operations - Proposer Slashing - block_header_from_future       OK
 + [Valid]   EF - Bellatrix - Operations - Proposer Slashing - slashed_and_proposer_index_the OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Bellatrix - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Sync Aggregate - invalid_signature_bad_domain      OK
@@ -897,7 +849,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Bellatrix - Operations - Sync Aggregate - sync_committee_with_participating OK
 + [Valid]   EF - Bellatrix - Operations - Sync Aggregate - valid_signature_future_committee  OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Bellatrix - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Operations - Voluntary Exit - invalid_incorrect_signature       OK
@@ -917,7 +868,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Bellatrix - Operations - Voluntary Exit - voluntary_exit_with_current_fork_ OK
 + [Valid]   EF - Bellatrix - Operations - Voluntary Exit - voluntary_exit_with_previous_fork OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Bellatrix - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Bellatrix - Random - randomized_0 [Preset: minimal]                         OK
@@ -937,7 +887,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Bellatrix - Random - randomized_8 [Preset: minimal]                         OK
 + [Valid]   EF - Bellatrix - Random - randomized_9 [Preset: minimal]                         OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Bellatrix - Rewards  [Preset: minimal]
 ```diff
 + EF - Bellatrix - Rewards - all_balances_too_low_for_reward [Preset: minimal]               OK
@@ -975,7 +924,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Bellatrix - Rewards - with_slashed_validators [Preset: minimal]                       OK
 + EF - Bellatrix - Rewards - with_slashed_validators_leak [Preset: minimal]                  OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Bellatrix - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -1021,7 +969,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 42/42 Fail: 0/42 Skip: 0/42
 ## EF - Bellatrix - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Bellatrix - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]      OK
@@ -1080,7 +1027,6 @@ OK: 42/42 Fail: 0/42 Skip: 0/42
 + [Valid]   EF - Bellatrix - Sanity - Blocks - sync_committee_committee_genesis__half [Prese OK
 + [Valid]   EF - Bellatrix - Sanity - Blocks - voluntary_exit [Preset: minimal]              OK
 ```
-OK: 55/55 Fail: 0/55 Skip: 0/55
 ## EF - Bellatrix - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Bellatrix - Slots - double_empty_epoch [Preset: minimal]                              OK
@@ -1090,7 +1036,6 @@ OK: 55/55 Fail: 0/55 Skip: 0/55
 + EF - Bellatrix - Slots - slots_1 [Preset: minimal]                                         OK
 + EF - Bellatrix - Slots - slots_2 [Preset: minimal]                                         OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Bellatrix - Transition  [Preset: minimal]
 ```diff
 + EF - Bellatrix - Transition - non_empty_historical_roots [Preset: minimal]                 OK
@@ -1120,23 +1065,19 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Bellatrix - Transition - transition_with_voluntary_exit_right_after_fork [Preset: min OK
 + EF - Bellatrix - Transition - transition_with_voluntary_exit_right_before_fork [Preset: mi OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Capella - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Capella - Epoch Processing - Historical summaries update [Preset: minimal]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: minimal]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -1161,7 +1102,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Capella - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -1175,7 +1115,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Capella - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -1191,12 +1130,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Capella - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
@@ -1215,7 +1152,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -1234,7 +1170,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -1243,12 +1178,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Capella - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Capella - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -1257,7 +1190,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Capella - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Capella - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -1266,7 +1198,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Capella - Finality - finality_rule_3 [Preset: minimal]                      OK
 + [Valid]   EF - Capella - Finality - finality_rule_4 [Preset: minimal]                      OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Capella - Fork  [Preset: minimal]
 ```diff
 + EF - Capella - Fork - capella_fork_random_0 [Preset: minimal]                              OK
@@ -1284,7 +1215,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Capella - Fork - fork_random_low_balances [Preset: minimal]                           OK
 + EF - Capella - Fork - fork_random_misc_balances [Preset: minimal]                          OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Capella - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Attestation - invalid_after_max_inclusion_slot       OK
@@ -1329,7 +1259,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Valid]   EF - Capella - Operations - Attestation - one_basic_attestation                  OK
 + [Valid]   EF - Capella - Operations - Attestation - previous_epoch                         OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Capella - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Attester Slashing - invalid_all_empty_indices        OK
@@ -1363,7 +1292,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Capella - Operations - Attester Slashing - proposer_index_slashed           OK
 + [Valid]   EF - Capella - Operations - Attester Slashing - with_effective_balance_disparity OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Capella - Operations - BLS to execution change  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - BLS to execution change - invalid_already_0x01       OK
@@ -1381,7 +1309,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Capella - Operations - BLS to execution change - success_not_activated      OK
 + [Valid]   EF - Capella - Operations - BLS to execution change - success_withdrawable       OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Capella - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
@@ -1391,7 +1318,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Capella - Operations - Block Header - invalid_slot_block_header             OK
 + [Valid]   EF - Capella - Operations - Block Header - basic_block_header                    OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Capella - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Deposit - invalid_bad_merkle_proof                   OK
@@ -1416,7 +1342,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Capella - Operations - Deposit - top_up__max_effective_balance              OK
 + [Valid]   EF - Capella - Operations - Deposit - top_up__zero_balance                       OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Capella - Operations - Execution Payload  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Execution Payload - invalid_bad_everything_first_pay OK
@@ -1446,7 +1371,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Capella - Operations - Execution Payload - zero_length_transaction_first_pa OK
 + [Valid]   EF - Capella - Operations - Execution Payload - zero_length_transaction_regular_ OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Capella - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Proposer Slashing - invalid_different_proposer_indic OK
@@ -1465,7 +1389,6 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + [Valid]   EF - Capella - Operations - Proposer Slashing - block_header_from_future         OK
 + [Valid]   EF - Capella - Operations - Proposer Slashing - slashed_and_proposer_index_the_s OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Capella - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Sync Aggregate - invalid_signature_bad_domain        OK
@@ -1493,7 +1416,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Capella - Operations - Sync Aggregate - sync_committee_with_participating_w OK
 + [Valid]   EF - Capella - Operations - Sync Aggregate - valid_signature_future_committee    OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Capella - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Voluntary Exit - invalid_incorrect_signature         OK
@@ -1513,7 +1435,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Capella - Operations - Voluntary Exit - voluntary_exit_with_current_fork_ve OK
 + [Valid]   EF - Capella - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_v OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Capella - Operations - Withdrawals  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_f OK
@@ -1571,7 +1492,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Capella - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 + [Valid]   EF - Capella - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 ```
-OK: 54/54 Fail: 0/54 Skip: 0/54
 ## EF - Capella - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Capella - Random - randomized_0 [Preset: minimal]                           OK
@@ -1591,7 +1511,6 @@ OK: 54/54 Fail: 0/54 Skip: 0/54
 + [Valid]   EF - Capella - Random - randomized_8 [Preset: minimal]                           OK
 + [Valid]   EF - Capella - Random - randomized_9 [Preset: minimal]                           OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Capella - Rewards  [Preset: minimal]
 ```diff
 + EF - Capella - Rewards - all_balances_too_low_for_reward [Preset: minimal]                 OK
@@ -1629,7 +1548,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Capella - Rewards - with_slashed_validators [Preset: minimal]                         OK
 + EF - Capella - Rewards - with_slashed_validators_leak [Preset: minimal]                    OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Capella - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -1679,7 +1597,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 46/46 Fail: 0/46 Skip: 0/46
 ## EF - Capella - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Capella - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]        OK
@@ -1752,7 +1669,6 @@ OK: 46/46 Fail: 0/46 Skip: 0/46
 + [Valid]   EF - Capella - Sanity - Blocks - voluntary_exit [Preset: minimal]                OK
 + [Valid]   EF - Capella - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 ```
-OK: 69/69 Fail: 0/69 Skip: 0/69
 ## EF - Capella - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Capella - Slots - double_empty_epoch [Preset: minimal]                                OK
@@ -1762,7 +1678,6 @@ OK: 69/69 Fail: 0/69 Skip: 0/69
 + EF - Capella - Slots - slots_1 [Preset: minimal]                                           OK
 + EF - Capella - Slots - slots_2 [Preset: minimal]                                           OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Capella - Transition  [Preset: minimal]
 ```diff
 + EF - Capella - Transition - non_empty_historical_roots [Preset: minimal]                   OK
@@ -1792,7 +1707,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Capella - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minim OK
 + EF - Capella - Transition - transition_with_voluntary_exit_right_before_fork [Preset: mini OK
 ```
-OK: 26/26 Fail: 0/26 Skip: 0/26
 ## EF - Capella - Unittests - Light client - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -1800,23 +1714,19 @@ OK: 26/26 Fail: 0/26 Skip: 0/26
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Deneb - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Deneb - Epoch Processing - Historical summaries update [Preset: minimal]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: minimal]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -1841,7 +1751,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Deneb - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -1855,7 +1764,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Deneb - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -1871,12 +1779,10 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Deneb - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_churn_limit__equal_to_activation_limit [Preset: minimal]     OK
@@ -1898,7 +1804,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 18/18 Fail: 0/18 Skip: 0/18
 ## EF - Deneb - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -1917,7 +1822,6 @@ OK: 18/18 Fail: 0/18 Skip: 0/18
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Deneb - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -1926,12 +1830,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Deneb - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Deneb - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -1940,7 +1842,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Deneb - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Deneb - Finality - finality_no_updates_at_genesis [Preset: minimal]         OK
@@ -1949,7 +1850,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Deneb - Finality - finality_rule_3 [Preset: minimal]                        OK
 + [Valid]   EF - Deneb - Finality - finality_rule_4 [Preset: minimal]                        OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Deneb - Fork  [Preset: minimal]
 ```diff
 + EF - Deneb - Fork - deneb_fork_random_0 [Preset: minimal]                                  OK
@@ -1967,7 +1867,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Deneb - Fork - fork_random_low_balances [Preset: minimal]                             OK
 + EF - Deneb - Fork - fork_random_misc_balances [Preset: minimal]                            OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Deneb - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Attestation - invalid_after_max_inclusion_slot         OK
@@ -2012,7 +1911,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Valid]   EF - Deneb - Operations - Attestation - one_basic_attestation                    OK
 + [Valid]   EF - Deneb - Operations - Attestation - previous_epoch                           OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Deneb - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Attester Slashing - invalid_all_empty_indices          OK
@@ -2046,7 +1944,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Deneb - Operations - Attester Slashing - proposer_index_slashed             OK
 + [Valid]   EF - Deneb - Operations - Attester Slashing - with_effective_balance_disparity   OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Deneb - Operations - BLS to execution change  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - BLS to execution change - invalid_already_0x01         OK
@@ -2064,7 +1961,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Deneb - Operations - BLS to execution change - success_not_activated        OK
 + [Valid]   EF - Deneb - Operations - BLS to execution change - success_withdrawable         OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Deneb - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Block Header - invalid_multiple_blocks_single_slot     OK
@@ -2074,7 +1970,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Deneb - Operations - Block Header - invalid_slot_block_header               OK
 + [Valid]   EF - Deneb - Operations - Block Header - basic_block_header                      OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Deneb - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Deposit - invalid_bad_merkle_proof                     OK
@@ -2099,7 +1994,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Deneb - Operations - Deposit - top_up__max_effective_balance                OK
 + [Valid]   EF - Deneb - Operations - Deposit - top_up__zero_balance                         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Deneb - Operations - Execution Payload  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Execution Payload - invalid_bad_everything_first_paylo OK
@@ -2143,7 +2037,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Deneb - Operations - Execution Payload - zero_length_transaction_regular_pa OK
 + [Valid]   EF - Deneb - Operations - Execution Payload - zeroed_commitment                  OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Deneb - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Proposer Slashing - invalid_different_proposer_indices OK
@@ -2162,7 +2055,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Deneb - Operations - Proposer Slashing - block_header_from_future           OK
 + [Valid]   EF - Deneb - Operations - Proposer Slashing - slashed_and_proposer_index_the_sam OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Deneb - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Sync Aggregate - invalid_signature_bad_domain          OK
@@ -2190,7 +2082,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Deneb - Operations - Sync Aggregate - sync_committee_with_participating_wit OK
 + [Valid]   EF - Deneb - Operations - Sync Aggregate - valid_signature_future_committee      OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Deneb - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Voluntary Exit - invalid_incorrect_signature           OK
@@ -2210,7 +2101,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Deneb - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_ver OK
 + [Valid]   EF - Deneb - Operations - Voluntary Exit - voluntary_exit_with_previous_fork_ver OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Deneb - Operations - Withdrawals  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_few OK
@@ -2268,7 +2158,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Deneb - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balan OK
 + [Valid]   EF - Deneb - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balan OK
 ```
-OK: 54/54 Fail: 0/54 Skip: 0/54
 ## EF - Deneb - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Deneb - Random - randomized_0 [Preset: minimal]                             OK
@@ -2288,7 +2177,6 @@ OK: 54/54 Fail: 0/54 Skip: 0/54
 + [Valid]   EF - Deneb - Random - randomized_8 [Preset: minimal]                             OK
 + [Valid]   EF - Deneb - Random - randomized_9 [Preset: minimal]                             OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Deneb - Rewards  [Preset: minimal]
 ```diff
 + EF - Deneb - Rewards - all_balances_too_low_for_reward [Preset: minimal]                   OK
@@ -2326,7 +2214,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Deneb - Rewards - with_slashed_validators [Preset: minimal]                           OK
 + EF - Deneb - Rewards - with_slashed_validators_leak [Preset: minimal]                      OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Deneb - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -2378,7 +2265,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    VoluntaryExit                                                                 OK
 +   Testing    Withdrawal                                                                    OK
 ```
-OK: 48/48 Fail: 0/48 Skip: 0/48
 ## EF - Deneb - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Deneb - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]          OK
@@ -2460,7 +2346,6 @@ OK: 48/48 Fail: 0/48 Skip: 0/48
 + [Valid]   EF - Deneb - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal]   OK
 + [Valid]   EF - Deneb - Sanity - Blocks - zero_blob [Preset: minimal]                       OK
 ```
-OK: 78/78 Fail: 0/78 Skip: 0/78
 ## EF - Deneb - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Deneb - Slots - double_empty_epoch [Preset: minimal]                                  OK
@@ -2470,7 +2355,6 @@ OK: 78/78 Fail: 0/78 Skip: 0/78
 + EF - Deneb - Slots - slots_1 [Preset: minimal]                                             OK
 + EF - Deneb - Slots - slots_2 [Preset: minimal]                                             OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Deneb - Transition  [Preset: minimal]
 ```diff
 + EF - Deneb - Transition - higher_churn_limit_to_lower [Preset: minimal]                    OK
@@ -2504,7 +2388,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + EF - Deneb - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minimal OK
 + EF - Deneb - Transition - transition_with_voluntary_exit_right_before_fork [Preset: minima OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Deneb - Unittests - Light client - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -2512,24 +2395,20 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Electra - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 + Effective balance updates - effective_balance_hysteresis_with_compounding_credentials [Pre OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Electra - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Electra - Epoch Processing - Historical summaries update [Preset: minimal]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: minimal]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -2554,7 +2433,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Electra - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -2568,7 +2446,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Electra - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -2584,7 +2461,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Electra - Epoch Processing - Pending consolidations [Preset: minimal]
 ```diff
 + Pending consolidations - all_consolidation_cases_together [Preset: minimal]                OK
@@ -2601,7 +2477,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + Pending consolidations - pending_consolidation_with_pending_deposit [Preset: minimal]      OK
 + Pending consolidations - skip_consolidation_when_source_slashed [Preset: minimal]          OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
 ## EF - Electra - Epoch Processing - Pending deposits [Preset: minimal]
 ```diff
 + Pending deposits - apply_pending_deposit_compounding_withdrawal_credentials_max [Preset: m OK
@@ -2650,12 +2525,10 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + Pending deposits - process_pending_deposits_withdrawable_validator [Preset: minimal]       OK
 + Pending deposits - process_pending_deposits_withdrawable_validator_not_churned [Preset: mi OK
 ```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## EF - Electra - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_churn_limit__equal_to_activation_limit [Preset: minimal]     OK
@@ -2682,7 +2555,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 23/23 Fail: 0/23 Skip: 0/23
 ## EF - Electra - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -2701,7 +2573,6 @@ OK: 23/23 Fail: 0/23 Skip: 0/23
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Electra - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -2710,12 +2581,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Electra - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Electra - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -2724,7 +2593,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Electra - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Electra - Finality - finality_no_updates_at_genesis [Preset: minimal]       OK
@@ -2733,7 +2601,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Electra - Finality - finality_rule_3 [Preset: minimal]                      OK
 + [Valid]   EF - Electra - Finality - finality_rule_4 [Preset: minimal]                      OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Electra - Fork  [Preset: minimal]
 ```diff
 + EF - Electra - Fork - electra_fork_random_0 [Preset: minimal]                              OK
@@ -2758,7 +2625,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Electra - Fork - fork_random_low_balances [Preset: minimal]                           OK
 + EF - Electra - Fork - fork_random_misc_balances [Preset: minimal]                          OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Electra - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Attestation - invalid_after_max_inclusion_slot       OK
@@ -2811,7 +2677,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Electra - Operations - Attestation - one_committee_with_gap                 OK
 + [Valid]   EF - Electra - Operations - Attestation - previous_epoch                         OK
 ```
-OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - Electra - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Attester Slashing - invalid_all_empty_indices        OK
@@ -2845,7 +2710,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 + [Valid]   EF - Electra - Operations - Attester Slashing - proposer_index_slashed           OK
 + [Valid]   EF - Electra - Operations - Attester Slashing - with_effective_balance_disparity OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Electra - Operations - BLS to execution change  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - BLS to execution change - invalid_already_0x01       OK
@@ -2863,7 +2727,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Electra - Operations - BLS to execution change - success_not_activated      OK
 + [Valid]   EF - Electra - Operations - BLS to execution change - success_withdrawable       OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Electra - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Block Header - invalid_multiple_blocks_single_slot   OK
@@ -2873,7 +2736,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Electra - Operations - Block Header - invalid_slot_block_header             OK
 + [Valid]   EF - Electra - Operations - Block Header - basic_block_header                    OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Electra - Operations - Consolidation Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Electra - Operations - Consolidation Request - basic_consolidation_in_curre OK
@@ -2910,7 +2772,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Electra - Operations - Consolidation Request - switch_to_compounding_with_e OK
 + [Valid]   EF - Electra - Operations - Consolidation Request - switch_to_compounding_with_p OK
 ```
-OK: 33/33 Fail: 0/33 Skip: 0/33
 ## EF - Electra - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Deposit - invalid_bad_merkle_proof                   OK
@@ -2935,7 +2796,6 @@ OK: 33/33 Fail: 0/33 Skip: 0/33
 + [Valid]   EF - Electra - Operations - Deposit - top_up__max_effective_balance              OK
 + [Valid]   EF - Electra - Operations - Deposit - top_up__zero_balance                       OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Electra - Operations - Deposit Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_invalid_si OK
@@ -2947,7 +2807,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_top_up_max OK
 + [Valid]   EF - Electra - Operations - Deposit Request - process_deposit_request_top_up_min OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## EF - Electra - Operations - Execution Payload  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Execution Payload - invalid_bad_everything_first_pay OK
@@ -2991,7 +2850,6 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + [Valid]   EF - Electra - Operations - Execution Payload - zero_length_transaction_regular_ OK
 + [Valid]   EF - Electra - Operations - Execution Payload - zeroed_commitment                OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Electra - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Proposer Slashing - invalid_different_proposer_indic OK
@@ -3010,7 +2868,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Electra - Operations - Proposer Slashing - block_header_from_future         OK
 + [Valid]   EF - Electra - Operations - Proposer Slashing - slashed_and_proposer_index_the_s OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Electra - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Sync Aggregate - invalid_signature_bad_domain        OK
@@ -3038,7 +2895,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Electra - Operations - Sync Aggregate - sync_committee_with_participating_w OK
 + [Valid]   EF - Electra - Operations - Sync Aggregate - valid_signature_future_committee    OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Electra - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Voluntary Exit - invalid_incorrect_signature         OK
@@ -3062,7 +2918,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Electra - Operations - Voluntary Exit - success_exit_queue__min_churn       OK
 + [Valid]   EF - Electra - Operations - Voluntary Exit - success_exit_queue__scaled_churn    OK
 ```
-OK: 20/20 Fail: 0/20 Skip: 0/20
 ## EF - Electra - Operations - Withdrawal Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Electra - Operations - Withdrawal Request - activation_epoch_less_than_shar OK
@@ -3095,7 +2950,6 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   EF - Electra - Operations - Withdrawal Request - pending_withdrawals_consume_all OK
 + [Valid]   EF - Electra - Operations - Withdrawal Request - unknown_pubkey                  OK
 ```
-OK: 29/29 Fail: 0/29 Skip: 0/29
 ## EF - Electra - Operations - Withdrawals  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_f OK
@@ -3175,7 +3029,6 @@ OK: 29/29 Fail: 0/29 Skip: 0/29
 + [Valid]   EF - Electra - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 + [Valid]   EF - Electra - Operations - Withdrawals - withdrawable_epoch_but_0_effective_bal OK
 ```
-OK: 76/76 Fail: 0/76 Skip: 0/76
 ## EF - Electra - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Electra - Random - randomized_0 [Preset: minimal]                           OK
@@ -3195,7 +3048,6 @@ OK: 76/76 Fail: 0/76 Skip: 0/76
 + [Valid]   EF - Electra - Random - randomized_8 [Preset: minimal]                           OK
 + [Valid]   EF - Electra - Random - randomized_9 [Preset: minimal]                           OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Electra - Rewards  [Preset: minimal]
 ```diff
 + EF - Electra - Rewards - all_balances_too_low_for_reward [Preset: minimal]                 OK
@@ -3233,7 +3085,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Electra - Rewards - with_slashed_validators [Preset: minimal]                         OK
 + EF - Electra - Rewards - with_slashed_validators_leak [Preset: minimal]                    OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Electra - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -3293,7 +3144,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Withdrawal                                                                    OK
 +   Testing    WithdrawalRequest                                                             OK
 ```
-OK: 56/56 Fail: 0/56 Skip: 0/56
 ## EF - Electra - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Electra - Sanity - Blocks - deposit_transition__invalid_eth1_deposits_overl OK
@@ -3390,7 +3240,6 @@ OK: 56/56 Fail: 0/56 Skip: 0/56
 + [Valid]   EF - Electra - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal] OK
 + [Valid]   EF - Electra - Sanity - Blocks - zero_blob [Preset: minimal]                     OK
 ```
-OK: 93/93 Fail: 0/93 Skip: 0/93
 ## EF - Electra - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Electra - Slots - double_empty_epoch [Preset: minimal]                                OK
@@ -3405,7 +3254,6 @@ OK: 93/93 Fail: 0/93 Skip: 0/93
 + EF - Electra - Slots - slots_1 [Preset: minimal]                                           OK
 + EF - Electra - Slots - slots_2 [Preset: minimal]                                           OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Electra - Transition  [Preset: minimal]
 ```diff
 + EF - Electra - Transition - higher_churn_limit_to_lower [Preset: minimal]                  OK
@@ -3442,7 +3290,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + EF - Electra - Transition - transition_with_voluntary_exit_right_after_fork [Preset: minim OK
 + EF - Electra - Transition - transition_with_voluntary_exit_right_before_fork [Preset: mini OK
 ```
-OK: 33/33 Fail: 0/33 Skip: 0/33
 ## EF - Electra - Unittests - Light client - Sync protocol [Preset: minimal]
 ```diff
 + process_light_client_update_finality_updated                                               OK
@@ -3450,24 +3297,20 @@ OK: 33/33 Fail: 0/33 Skip: 0/33
 + test_process_light_client_update_at_period_boundary                                        OK
 + test_process_light_client_update_not_timeout                                               OK
 ```
-OK: 4/4 Fail: 0/4 Skip: 0/4
 ## EF - Fulu - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 + Effective balance updates - effective_balance_hysteresis_with_compounding_credentials [Pre OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Fulu - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Fulu - Epoch Processing - Historical summaries update [Preset: minimal]
 ```diff
 + Historical summaries update - historical_summaries_accumulator [Preset: minimal]           OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Epoch Processing - Inactivity [Preset: minimal]
 ```diff
 + Inactivity - all_zero_inactivity_scores_empty_participation [Preset: minimal]              OK
@@ -3492,7 +3335,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Inactivity - some_slashed_zero_scores_full_participation [Preset: minimal]                 OK
 + Inactivity - some_slashed_zero_scores_full_participation_leaking [Preset: minimal]         OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Fulu - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -3506,7 +3348,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Fulu - Epoch Processing - Participation flag updates [Preset: minimal]
 ```diff
 + Participation flag updates - all_zeroed [Preset: minimal]                                  OK
@@ -3522,7 +3363,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + Participation flag updates - random_genesis [Preset: minimal]                              OK
 + Participation flag updates - slightly_larger_random [Preset: minimal]                      OK
 ```
-OK: 12/12 Fail: 0/12 Skip: 0/12
 ## EF - Fulu - Epoch Processing - Pending consolidations [Preset: minimal]
 ```diff
 + Pending consolidations - all_consolidation_cases_together [Preset: minimal]                OK
@@ -3539,7 +3379,6 @@ OK: 12/12 Fail: 0/12 Skip: 0/12
 + Pending consolidations - pending_consolidation_with_pending_deposit [Preset: minimal]      OK
 + Pending consolidations - skip_consolidation_when_source_slashed [Preset: minimal]          OK
 ```
-OK: 13/13 Fail: 0/13 Skip: 0/13
 ## EF - Fulu - Epoch Processing - Pending deposits [Preset: minimal]
 ```diff
 + Pending deposits - apply_pending_deposit_compounding_withdrawal_credentials_max [Preset: m OK
@@ -3588,12 +3427,10 @@ OK: 13/13 Fail: 0/13 Skip: 0/13
 + Pending deposits - process_pending_deposits_withdrawable_validator [Preset: minimal]       OK
 + Pending deposits - process_pending_deposits_withdrawable_validator_not_churned [Preset: mi OK
 ```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## EF - Fulu - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_churn_limit__equal_to_activation_limit [Preset: minimal]     OK
@@ -3620,7 +3457,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 23/23 Fail: 0/23 Skip: 0/23
 ## EF - Fulu - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -3639,7 +3475,6 @@ OK: 23/23 Fail: 0/23 Skip: 0/23
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Fulu - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -3648,12 +3483,10 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Fulu - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Fulu - Epoch Processing - Sync committee updates [Preset: minimal]
 ```diff
 + Sync committee updates - sync_committees_no_progress_not_at_period_boundary [Preset: minim OK
@@ -3662,7 +3495,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Sync committee updates - sync_committees_progress_misc_balances_not_genesis [Preset: minim OK
 + Sync committee updates - sync_committees_progress_not_genesis [Preset: minimal]            OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Fulu - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Fulu - Finality - finality_no_updates_at_genesis [Preset: minimal]          OK
@@ -3671,7 +3503,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Fulu - Finality - finality_rule_3 [Preset: minimal]                         OK
 + [Valid]   EF - Fulu - Finality - finality_rule_4 [Preset: minimal]                         OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Fulu - Fork  [Preset: minimal]
 ```diff
 + EF - Fulu - Fork - fork_base_state [Preset: minimal]                                       OK
@@ -3689,7 +3520,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + EF - Fulu - Fork - fulu_fork_random_low_balances [Preset: minimal]                         OK
 + EF - Fulu - Fork - fulu_fork_random_misc_balances [Preset: minimal]                        OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Fulu - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Attestation - invalid_after_max_inclusion_slot          OK
@@ -3742,7 +3572,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Valid]   EF - Fulu - Operations - Attestation - one_committee_with_gap                    OK
 + [Valid]   EF - Fulu - Operations - Attestation - previous_epoch                            OK
 ```
-OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - Fulu - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Attester Slashing - invalid_all_empty_indices           OK
@@ -3776,7 +3605,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 + [Valid]   EF - Fulu - Operations - Attester Slashing - proposer_index_slashed              OK
 + [Valid]   EF - Fulu - Operations - Attester Slashing - with_effective_balance_disparity    OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Fulu - Operations - BLS to execution change  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - BLS to execution change - invalid_already_0x01          OK
@@ -3794,7 +3622,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Valid]   EF - Fulu - Operations - BLS to execution change - success_not_activated         OK
 + [Valid]   EF - Fulu - Operations - BLS to execution change - success_withdrawable          OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Fulu - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Block Header - invalid_multiple_blocks_single_slot      OK
@@ -3804,7 +3631,6 @@ OK: 14/14 Fail: 0/14 Skip: 0/14
 + [Invalid] EF - Fulu - Operations - Block Header - invalid_slot_block_header                OK
 + [Valid]   EF - Fulu - Operations - Block Header - basic_block_header                       OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Fulu - Operations - Consolidation Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Fulu - Operations - Consolidation Request - basic_consolidation_in_current_ OK
@@ -3841,7 +3667,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Fulu - Operations - Consolidation Request - switch_to_compounding_with_exce OK
 + [Valid]   EF - Fulu - Operations - Consolidation Request - switch_to_compounding_with_pend OK
 ```
-OK: 33/33 Fail: 0/33 Skip: 0/33
 ## EF - Fulu - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Deposit - invalid_bad_merkle_proof                      OK
@@ -3866,7 +3691,6 @@ OK: 33/33 Fail: 0/33 Skip: 0/33
 + [Valid]   EF - Fulu - Operations - Deposit - top_up__max_effective_balance                 OK
 + [Valid]   EF - Fulu - Operations - Deposit - top_up__zero_balance                          OK
 ```
-OK: 21/21 Fail: 0/21 Skip: 0/21
 ## EF - Fulu - Operations - Deposit Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_invalid_sig   OK
@@ -3878,7 +3702,6 @@ OK: 21/21 Fail: 0/21 Skip: 0/21
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_top_up_max_ef OK
 + [Valid]   EF - Fulu - Operations - Deposit Request - process_deposit_request_top_up_min_ac OK
 ```
-OK: 8/8 Fail: 0/8 Skip: 0/8
 ## EF - Fulu - Operations - Execution Payload  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Execution Payload - invalid_bad_everything_first_payloa OK
@@ -3922,7 +3745,6 @@ OK: 8/8 Fail: 0/8 Skip: 0/8
 + [Valid]   EF - Fulu - Operations - Execution Payload - zero_length_transaction_regular_pay OK
 + [Valid]   EF - Fulu - Operations - Execution Payload - zeroed_commitment                   OK
 ```
-OK: 40/40 Fail: 0/40 Skip: 0/40
 ## EF - Fulu - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Proposer Slashing - invalid_different_proposer_indices  OK
@@ -3941,7 +3763,6 @@ OK: 40/40 Fail: 0/40 Skip: 0/40
 + [Valid]   EF - Fulu - Operations - Proposer Slashing - block_header_from_future            OK
 + [Valid]   EF - Fulu - Operations - Proposer Slashing - slashed_and_proposer_index_the_same OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Fulu - Operations - Sync Aggregate  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Sync Aggregate - invalid_signature_bad_domain           OK
@@ -3969,7 +3790,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Fulu - Operations - Sync Aggregate - sync_committee_with_participating_with OK
 + [Valid]   EF - Fulu - Operations - Sync Aggregate - valid_signature_future_committee       OK
 ```
-OK: 24/24 Fail: 0/24 Skip: 0/24
 ## EF - Fulu - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Voluntary Exit - invalid_incorrect_signature            OK
@@ -3993,7 +3813,6 @@ OK: 24/24 Fail: 0/24 Skip: 0/24
 + [Valid]   EF - Fulu - Operations - Voluntary Exit - success_exit_queue__min_churn          OK
 + [Valid]   EF - Fulu - Operations - Voluntary Exit - success_exit_queue__scaled_churn       OK
 ```
-OK: 20/20 Fail: 0/20 Skip: 0/20
 ## EF - Fulu - Operations - Withdrawal Request  [Preset: minimal]
 ```diff
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - activation_epoch_less_than_shard_c OK
@@ -4026,7 +3845,6 @@ OK: 20/20 Fail: 0/20 Skip: 0/20
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - pending_withdrawals_consume_all_ex OK
 + [Valid]   EF - Fulu - Operations - Withdrawal Request - unknown_pubkey                     OK
 ```
-OK: 29/29 Fail: 0/29 Skip: 0/29
 ## EF - Fulu - Operations - Withdrawals  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Operations - Withdrawals - invalid_a_lot_fully_withdrawable_too_few_ OK
@@ -4106,7 +3924,6 @@ OK: 29/29 Fail: 0/29 Skip: 0/29
 + [Valid]   EF - Fulu - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balanc OK
 + [Valid]   EF - Fulu - Operations - Withdrawals - withdrawable_epoch_but_0_effective_balanc OK
 ```
-OK: 76/76 Fail: 0/76 Skip: 0/76
 ## EF - Fulu - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Fulu - Random - randomized_0 [Preset: minimal]                              OK
@@ -4126,7 +3943,6 @@ OK: 76/76 Fail: 0/76 Skip: 0/76
 + [Valid]   EF - Fulu - Random - randomized_8 [Preset: minimal]                              OK
 + [Valid]   EF - Fulu - Random - randomized_9 [Preset: minimal]                              OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Fulu - Rewards  [Preset: minimal]
 ```diff
 + EF - Fulu - Rewards - all_balances_too_low_for_reward [Preset: minimal]                    OK
@@ -4164,7 +3980,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + EF - Fulu - Rewards - with_slashed_validators [Preset: minimal]                            OK
 + EF - Fulu - Rewards - with_slashed_validators_leak [Preset: minimal]                       OK
 ```
-OK: 34/34 Fail: 0/34 Skip: 0/34
 ## EF - Fulu - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -4227,7 +4042,6 @@ OK: 34/34 Fail: 0/34 Skip: 0/34
 +   Testing    Withdrawal                                                                    OK
 +   Testing    WithdrawalRequest                                                             OK
 ```
-OK: 59/59 Fail: 0/59 Skip: 0/59
 ## EF - Fulu - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Fulu - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]           OK
@@ -4311,7 +4125,6 @@ OK: 59/59 Fail: 0/59 Skip: 0/59
 + [Valid]   EF - Fulu - Sanity - Blocks - withdrawal_success_two_blocks [Preset: minimal]    OK
 + [Valid]   EF - Fulu - Sanity - Blocks - zero_blob [Preset: minimal]                        OK
 ```
-OK: 80/80 Fail: 0/80 Skip: 0/80
 ## EF - Fulu - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Fulu - Slots - double_empty_epoch [Preset: minimal]                                   OK
@@ -4326,7 +4139,6 @@ OK: 80/80 Fail: 0/80 Skip: 0/80
 + EF - Fulu - Slots - slots_1 [Preset: minimal]                                              OK
 + EF - Fulu - Slots - slots_2 [Preset: minimal]                                              OK
 ```
-OK: 11/11 Fail: 0/11 Skip: 0/11
 ## EF - Light client - Data collection [Preset: minimal]
 ```diff
 + Light client - Data collection - minimal/altair/light_client/data_collection/pyspec_tests/ OK
@@ -4339,7 +4151,6 @@ OK: 11/11 Fail: 0/11 Skip: 0/11
 + Light client - Data collection - minimal/deneb/light_client/data_collection/pyspec_tests/l OK
 + Light client - Data collection - minimal/electra/light_client/data_collection/pyspec_tests OK
 ```
-OK: 9/9 Fail: 0/9 Skip: 0/9
 ## EF - Light client - Single merkle proof [Preset: minimal]
 ```diff
 + Light client - Single merkle proof - minimal/altair/light_client/single_merkle_proof/Beaco OK
@@ -4362,7 +4173,6 @@ OK: 9/9 Fail: 0/9 Skip: 0/9
 + Light client - Single merkle proof - minimal/electra/light_client/single_merkle_proof/Beac OK
 + Light client - Single merkle proof - minimal/fulu/light_client/single_merkle_proof/BeaconB OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Light client - Sync [Preset: minimal]
 ```diff
 + Light client - Sync - minimal/altair/light_client/sync/pyspec_tests/advance_finality_witho OK
@@ -4396,7 +4206,6 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Light client - Sync - minimal/electra/light_client/sync/pyspec_tests/light_client_sync     OK
 + Light client - Sync - minimal/electra/light_client/sync/pyspec_tests/supply_sync_committee OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Light client - Update ranking [Preset: minimal]
 ```diff
 + Light client - Update ranking - minimal/altair/light_client/update_ranking/pyspec_tests/up OK
@@ -4405,7 +4214,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + Light client - Update ranking - minimal/deneb/light_client/update_ranking/pyspec_tests/upd OK
 + Light client - Update ranking - minimal/electra/light_client/update_ranking/pyspec_tests/u OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Merkle proof [Preset: minimal]
 ```diff
 + Merkle proof - Single merkle proof - minimal/deneb/merkle_proof/single_merkle_proof/Beacon OK
@@ -4423,23 +4231,19 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + Merkle proof - Single merkle proof - minimal/fulu/merkle_proof/single_merkle_proof/BeaconB OK
 + Merkle proof - Single merkle proof - minimal/fulu/merkle_proof/single_merkle_proof/BeaconB OK
 ```
-OK: 14/14 Fail: 0/14 Skip: 0/14
 ## EF - Phase 0 - Epoch Processing - Effective balance updates [Preset: minimal]
 ```diff
 + Effective balance updates - effective_balance_hysteresis [Preset: minimal]                 OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Eth1 data reset [Preset: minimal]
 ```diff
 + Eth1 data reset - eth1_vote_no_reset [Preset: minimal]                                     OK
 + Eth1 data reset - eth1_vote_reset [Preset: minimal]                                        OK
 ```
-OK: 2/2 Fail: 0/2 Skip: 0/2
 ## EF - Phase 0 - Epoch Processing - Historical roots update [Preset: minimal]
 ```diff
 + Historical roots update - historical_root_accumulator [Preset: minimal]                    OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Justification & Finalization [Preset: minimal]
 ```diff
 + Justification & Finalization - 123_ok_support [Preset: minimal]                            OK
@@ -4453,17 +4257,14 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Justification & Finalization - 23_poor_support [Preset: minimal]                           OK
 + Justification & Finalization - balance_threshold_with_exited_validators [Preset: minimal]  OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Phase 0 - Epoch Processing - Participation record updates [Preset: minimal]
 ```diff
 + Participation record updates - updated_participation_record [Preset: minimal]              OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - RANDAO mixes reset [Preset: minimal]
 ```diff
 + RANDAO mixes reset - updated_randao_mixes [Preset: minimal]                                OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Epoch Processing - Registry updates [Preset: minimal]
 ```diff
 + Registry updates - activation_queue_activation_and_ejection__1 [Preset: minimal]           OK
@@ -4482,7 +4283,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + Registry updates - ejection_past_churn_limit_scaled [Preset: minimal]                      OK
 + Registry updates - invalid_large_withdrawable_epoch [Preset: minimal]                      OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Phase 0 - Epoch Processing - Rewards and penalties [Preset: minimal]
 ```diff
 + Rewards and penalties - almost_empty_attestations [Preset: minimal]                        OK
@@ -4505,7 +4305,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + Rewards and penalties - random_fill_attestations [Preset: minimal]                         OK
 + Rewards and penalties - random_fill_attestations_with_leak [Preset: minimal]               OK
 ```
-OK: 19/19 Fail: 0/19 Skip: 0/19
 ## EF - Phase 0 - Epoch Processing - Slashings [Preset: minimal]
 ```diff
 + Slashings - low_penalty [Preset: minimal]                                                  OK
@@ -4514,12 +4313,10 @@ OK: 19/19 Fail: 0/19 Skip: 0/19
 + Slashings - scaled_penalties [Preset: minimal]                                             OK
 + Slashings - slashings_with_random_state [Preset: minimal]                                  OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase 0 - Epoch Processing - Slashings reset [Preset: minimal]
 ```diff
 + Slashings reset - flush_slashings [Preset: minimal]                                        OK
 ```
-OK: 1/1 Fail: 0/1 Skip: 0/1
 ## EF - Phase 0 - Operations - Attestation  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: mi OK
@@ -4564,7 +4361,6 @@ OK: 1/1 Fail: 0/1 Skip: 0/1
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: mi OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attestation  [Preset: mi OK
 ```
-OK: 41/41 Fail: 0/41 Skip: 0/41
 ## EF - Phase 0 - Operations - Attester Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
@@ -4598,7 +4394,6 @@ OK: 41/41 Fail: 0/41 Skip: 0/41
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Attester Slashing  [Pres OK
 ```
-OK: 30/30 Fail: 0/30 Skip: 0/30
 ## EF - Phase 0 - Operations - Block Header  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
@@ -4608,7 +4403,6 @@ OK: 30/30 Fail: 0/30 Skip: 0/30
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Block Header  [Preset: m OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Phase 0 - Operations - Deposit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: minima OK
@@ -4629,7 +4423,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: minima OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Deposit  [Preset: minima OK
 ```
-OK: 17/17 Fail: 0/17 Skip: 0/17
 ## EF - Phase 0 - Operations - Proposer Slashing  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
@@ -4648,7 +4441,6 @@ OK: 17/17 Fail: 0/17 Skip: 0/17
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Proposer Slashing  [Pres OK
 ```
-OK: 15/15 Fail: 0/15 Skip: 0/15
 ## EF - Phase 0 - Operations - Voluntary Exit  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
@@ -4662,7 +4454,6 @@ OK: 15/15 Fail: 0/15 Skip: 0/15
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 + [Valid]   EF - Phase 0 - Operations - EF - Phase 0 - Operations - Voluntary Exit  [Preset: OK
 ```
-OK: 10/10 Fail: 0/10 Skip: 0/10
 ## EF - Phase 0 - Rewards  [Preset: minimal]
 ```diff
 + EF - Phase 0 - Rewards - all_balances_too_low_for_reward [Preset: minimal]                 OK
@@ -4715,7 +4506,6 @@ OK: 10/10 Fail: 0/10 Skip: 0/10
 + EF - Phase 0 - Rewards - with_slashed_validators [Preset: minimal]                         OK
 + EF - Phase 0 - Rewards - with_slashed_validators_leak [Preset: minimal]                    OK
 ```
-OK: 49/49 Fail: 0/49 Skip: 0/49
 ## EF - Phase 0 - SSZ consensus objects  [Preset: minimal]
 ```diff
 +   Testing    AggregateAndProof                                                             OK
@@ -4746,7 +4536,6 @@ OK: 49/49 Fail: 0/49 Skip: 0/49
 +   Testing    Validator                                                                     OK
 +   Testing    VoluntaryExit                                                                 OK
 ```
-OK: 27/27 Fail: 0/27 Skip: 0/27
 ## EF - Phase 0 - Sanity - Slots  [Preset: minimal]
 ```diff
 + EF - Phase 0 - Slots - double_empty_epoch [Preset: minimal]                                OK
@@ -4756,7 +4545,6 @@ OK: 27/27 Fail: 0/27 Skip: 0/27
 + EF - Phase 0 - Slots - slots_1 [Preset: minimal]                                           OK
 + EF - Phase 0 - Slots - slots_2 [Preset: minimal]                                           OK
 ```
-OK: 6/6 Fail: 0/6 Skip: 0/6
 ## EF - Phase0 - Finality  [Preset: minimal]
 ```diff
 + [Valid]   EF - Phase0 - Finality - finality_no_updates_at_genesis [Preset: minimal]        OK
@@ -4765,7 +4553,6 @@ OK: 6/6 Fail: 0/6 Skip: 0/6
 + [Valid]   EF - Phase0 - Finality - finality_rule_3 [Preset: minimal]                       OK
 + [Valid]   EF - Phase0 - Finality - finality_rule_4 [Preset: minimal]                       OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
 ## EF - Phase0 - Random  [Preset: minimal]
 ```diff
 + [Valid]   EF - Phase0 - Random - randomized_0 [Preset: minimal]                            OK
@@ -4785,7 +4572,6 @@ OK: 5/5 Fail: 0/5 Skip: 0/5
 + [Valid]   EF - Phase0 - Random - randomized_8 [Preset: minimal]                            OK
 + [Valid]   EF - Phase0 - Random - randomized_9 [Preset: minimal]                            OK
 ```
-OK: 16/16 Fail: 0/16 Skip: 0/16
 ## EF - Phase0 - Sanity - Blocks  [Preset: minimal]
 ```diff
 + [Invalid] EF - Phase0 - Sanity - Blocks - invalid_all_zeroed_sig [Preset: minimal]         OK
@@ -4834,7 +4620,6 @@ OK: 16/16 Fail: 0/16 Skip: 0/16
 + [Valid]   EF - Phase0 - Sanity - Blocks - slash_and_exit_diff_index [Preset: minimal]      OK
 + [Valid]   EF - Phase0 - Sanity - Blocks - voluntary_exit [Preset: minimal]                 OK
 ```
-OK: 45/45 Fail: 0/45 Skip: 0/45
 ## ForkChoice
 ```diff
 + ForkChoice - minimal/altair/fork_choice/ex_ante/pyspec_tests/ex_ante_sandwich_with_honest_ OK
@@ -5152,7 +4937,6 @@ OK: 45/45 Fail: 0/45 Skip: 0/45
 + ForkChoice - minimal/fulu/fork_choice/withholding/pyspec_tests/withholding_attack          OK
 + ForkChoice - minimal/fulu/fork_choice/withholding/pyspec_tests/withholding_attack_unviable OK
 ```
-OK: 282/314 Fail: 0/314 Skip: 32/314
 ## Sync
 ```diff
 + Sync - minimal/bellatrix/sync/optimistic/pyspec_tests/from_syncing_to_invalid              OK
@@ -5161,7 +4945,3 @@ OK: 282/314 Fail: 0/314 Skip: 32/314
 + Sync - minimal/electra/sync/optimistic/pyspec_tests/from_syncing_to_invalid                OK
 + Sync - minimal/fulu/sync/optimistic/pyspec_tests/from_syncing_to_invalid                   OK
 ```
-OK: 5/5 Fail: 0/5 Skip: 0/5
-
----TOTAL---
-OK: 4262/4294 Fail: 0/4294 Skip: 32/4294

--- a/tests/testutil.nim
+++ b/tests/testutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -58,7 +58,8 @@ proc summarizeLongTests*(name: string) =
     status.sort do (a: (string, OrderedTable[string, Status]),
                     b: (string, OrderedTable[string, Status])) -> int: cmp(a[0], b[0])
 
-    generateReport(name & "-" & const_preset, status, width=90)
+    generateReport(
+      name & "-" & const_preset, status, width=90, withTotals=false)
   except CatchableError as exc:
     raiseAssert exc.msg
 


### PR DESCRIPTION
The totals summaries in .md test reports are frequently leading to merge conflicts and may even disincentivize adding new tests. As we only use the list of tests anyway (primarily for consensus-spec-tests comparison) we can drop the total amounts summaries from the Markdown files.