### PR TITLE
Move defaultDataDir procedure to nimbus_binary_common.

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -999,6 +999,11 @@ AllTests-mainnet
 + prune heads on finalization [Preset: mainnet]                                              OK
 + shutdown during finalization [Preset: mainnet]                                             OK
 ```
+## configuration paths
+```diff
++ Default path                                                                               OK
++ Path with extra path separator                                                             OK
+```
 ## createValidatorFiles()
 ```diff
 + Add keystore files [LOCAL]                                                                 OK

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -55,6 +55,7 @@ const
   defaultGasLimit* = 36_000_000
   defaultAdminListenAddressDesc* = $defaultAdminListenAddress
   defaultBeaconNodeDesc = $defaultBeaconNode
+  defaultDataDirPath* = "BeaconNode"
 
 when defined(windows):
   {.pragma: windowsOnly.}
@@ -161,7 +162,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir("BeaconNode")
+      defaultValue: config.defaultDataDir(defaultDataDirPath)
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir
@@ -897,7 +898,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir("BeaconNode")
+      defaultValue: config.defaultDataDir(defaultDataDirPath)
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir
@@ -1078,7 +1079,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store validator's keys"
-      defaultValue: config.defaultDataDir("BeaconNode")
+      defaultValue: config.defaultDataDir(defaultDataDirPath)
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -30,7 +30,7 @@ import
   ./el/el_conf,
   ./filepath
 
-from std/os import getHomeDir, parentDir, `/`
+from std/os import `/`
 from std/strutils import parseBiggestUInt, replace
 from consensus_object_pools/block_pools_types_light_client
   import LightClientDataImportMode
@@ -161,7 +161,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir()
+      defaultValue: config.defaultDataDir("BeaconNode")
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir
@@ -897,7 +897,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir()
+      defaultValue: config.defaultDataDir("BeaconNode")
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir
@@ -1078,7 +1078,7 @@ type
 
     dataDir* {.
       desc: "The directory where nimbus will store validator's keys"
-      defaultValue: config.defaultDataDir()
+      defaultValue: config.defaultDataDir("BeaconNode")
       defaultValueDesc: ""
       abbr: "d"
       name: "data-dir" .}: OutDir
@@ -1134,16 +1134,6 @@ type
   AnyConf* = BeaconNodeConf | ValidatorClientConf | SigningNodeConf
 
   Address = primitives.Address
-
-proc defaultDataDir*[Conf](config: Conf): string =
-  let dataDir = when defined(windows):
-    "AppData" / "Roaming" / "Nimbus"
-  elif defined(macosx):
-    "Library" / "Application Support" / "Nimbus"
-  else:
-    ".cache" / "nimbus"
-
-  getHomeDir() / dataDir / "BeaconNode"
 
 func dumpDir(config: AnyConf): string =
   config.dataDir / "dump"

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -39,7 +39,7 @@ type LightClientConf* = object
   # Storage
   dataDir* {.
     desc: "The directory where nimbus will store all blockchain data"
-    defaultValue: config.defaultDataDir()
+    defaultValue: config.defaultDataDir("BeaconNode")
     defaultValueDesc: ""
     abbr: "d"
     name: "data-dir" .}: OutDir

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -499,7 +499,7 @@ proc quitDoppelganger*() =
 ## Returns default OS-specific data directory for nimbus clients.
 ## Extra path levels can be added with argument "paths".
 ## "paths" should be composed by slash+directory pair(s)
-proc defaultDataDir*[Conf](config: Conf, paths: string = ""): string =
+proc defaultDataDir*[Conf](config: Conf, path: string = ""): string =
   let dataDir = when defined(windows):
     "AppData" / "Roaming" / "Nimbus"
   elif defined(macosx):
@@ -507,10 +507,5 @@ proc defaultDataDir*[Conf](config: Conf, paths: string = ""): string =
   else:
     ".cache" / "nimbus"
 
-  let finalPaths =
-    if paths.len > 0 and paths[0] != '/':
-      "/" / paths
-    else:
-      paths
+  getHomeDir() / dataDir / path
 
-  getHomeDir() / dataDir & finalPaths

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -23,6 +23,8 @@ import
   ./spec/datatypes/base,
   "."/[beacon_clock, beacon_node_status, conf, conf_common, version]
 
+from std/os import getHomeDir, parentDir, `/`
+
 when defined(posix):
   import termios
 
@@ -493,3 +495,22 @@ proc quitDoppelganger*() =
 
   const QuitDoppelganger = 129
   quit QuitDoppelganger
+
+## Returns default OS-specific data directory for nimbus clients.
+## Extra path levels can be added with argument "paths".
+## "paths" should be composed by slash+directory pair(s)
+proc defaultDataDir*[Conf](config: Conf, paths: string = ""): string =
+  let dataDir = when defined(windows):
+    "AppData" / "Roaming" / "Nimbus"
+  elif defined(macosx):
+    "Library" / "Application Support" / "Nimbus"
+  else:
+    ".cache" / "nimbus"
+
+  let finalPaths =
+    if paths.len > 0 and paths[0] != '/':
+      "/" / paths
+    else:
+      paths
+
+  getHomeDir() / dataDir & finalPaths

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -10,6 +10,7 @@
 import
   std/os,
   confutils,
+  ../beacon_chain/nimbus_binary_common,
   ../beacon_chain/validators/keystore_management,
   ../beacon_chain/spec/[keystore, crypto],
   ../beacon_chain/conf

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -25,7 +25,7 @@ type
       name: "remote-signer" }: seq[string]
 
     dataDir {.
-      defaultValue: config.defaultDataDir()
+      defaultValue: config.defaultDataDir("BeaconNode")
       defaultValueDesc: ""
       desc: "A Nimbus data directory"
       name: "data-dir" }: InputDir

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -42,6 +42,7 @@ import # Unit test
   ./test_light_client,
   ./test_message_signatures,
   ./test_network_metadata,
+  ./test_nimbus_binary_common,
   ./test_peer_pool,
   ./test_peerdas_helpers,
   ./test_remote_keystore,

--- a/tests/test_nimbus_binary_common.nim
+++ b/tests/test_nimbus_binary_common.nim
@@ -1,0 +1,38 @@
+# beacon_chain
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+{.used.}
+
+import
+  os,
+  unittest2,
+  stew/byteutils
+
+from  ../beacon_chain/nimbus_binary_common import defaultDataDir
+
+## expected values for dafault dir tests
+when defined(windows):
+  const expectedBase = getHomeDir() / "AppData" / "Roaming" / "Nimbus"
+elif defined(macosx):
+  const expectedBase = getHomeDir() / "Library" / "Application Support" / "Nimbus"
+else:
+  const expectedBase = getHomeDir() / ".cache" / "nimbus"
+
+suite "Nimbus clients binary common":
+  test "Default path without extra paths":
+    check defaultDataDir(()) == expectedBase
+
+  test "Relative extra path is appended":
+    check defaultDataDir((), "extra") == expectedBase / "extra"
+
+  test "Absolute extra path is used as is":
+    let absPath = "/my/absolute/path"
+    check defaultDataDir((), absPath) == expectedBase / "my" / "absolute" / "path"
+
+  test "Handles empty extra path correctly":
+    check defaultDataDir((), "") == expectedBase

--- a/tests/test_nimbus_binary_common.nim
+++ b/tests/test_nimbus_binary_common.nim
@@ -8,31 +8,27 @@
 {.push raises: [].}
 {.used.}
 
-import
-  os,
-  unittest2,
-  stew/byteutils
+import os, unittest2
 
-from  ../beacon_chain/nimbus_binary_common import defaultDataDir
+from ../beacon_chain/nimbus_binary_common import defaultDataDir
 
-## expected values for dafault dir tests
-when defined(windows):
-  const expectedBase = getHomeDir() / "AppData" / "Roaming" / "Nimbus"
-elif defined(macosx):
-  const expectedBase = getHomeDir() / "Library" / "Application Support" / "Nimbus"
-else:
-  const expectedBase = getHomeDir() / ".cache" / "nimbus"
+## expected values
+proc getExpectedPaths(paths: string=""): seq[string] =
+  let base = getHomeDir()
 
-suite "Nimbus clients binary common":
-  test "Default path without extra paths":
-    check defaultDataDir(()) == expectedBase
+  var list = @[
+    base / "AppData" / "Roaming" / "Nimbus" / paths,
+    base / "Library" / "Application Support" / "Nimbus" / paths,
+    base / ".cache" / "nimbus" / paths,
+  ]
 
-  test "Relative extra path is appended":
-    check defaultDataDir((), "extra") == expectedBase / "extra"
+  list
 
-  test "Absolute extra path is used as is":
-    let absPath = "/my/absolute/path"
-    check defaultDataDir((), absPath) == expectedBase / "my" / "absolute" / "path"
+suite "configuration paths":
+  test "Default path":
+    check defaultDataDir(()) in getExpectedPaths()
 
-  test "Handles empty extra path correctly":
-    check defaultDataDir((), "") == expectedBase
+  test "Path with extra path separator":
+    check defaultDataDir((), "/extra") in getExpectedPaths("extra")
+    check defaultDataDir((), "extra") in getExpectedPaths("extra")
+

--- a/tests/test_validator_pool.nim
+++ b/tests/test_validator_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -13,7 +13,7 @@ import
   chronos/unittest2/asynctests,
   presto, confutils,
   ../beacon_chain/validators/[validator_pool, keystore_management],
-  ../beacon_chain/[conf, beacon_node]
+  ../beacon_chain/[conf, beacon_node, nimbus_binary_common]
 
 func createPubKey(number: int8): ValidatorPubKey =
   var res = ValidatorPubKey()


### PR DESCRIPTION
This intends to fix all Nimbus clients  declaring the same function, and once its merged, unify this use on all of them.