### PR TITLE
setup logging before any procedure with logging involved

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2579,8 +2579,8 @@ programMain:
     # permissions are insecure.
     quit QuitFailure
 
-  setupFileLimits()
   setupLogging(config.logLevel, config.logStdout, config.logFile)
+  setupFileLimits()
 
   ## This Ctrl+C handler exits the program in non-graceful way.
   ## It's responsible for handling Ctrl+C in sub-commands such


### PR DESCRIPTION
very subtle and hard to detect bug on client start up.

![image](https://github.com/user-attachments/assets/31af976a-0c85-4ce1-842a-25556ffdeb23)
