### PR TITLE
Expose runtime `MAX_BLOBS_PER_BLOCK_ELECTRA` in REST config endpoint

### DIFF
--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -364,7 +364,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
           MAX_PENDING_DEPOSITS_PER_EPOCH:
             Base10.toString(uint64(MAX_PENDING_DEPOSITS_PER_EPOCH)),
           MAX_BLOBS_PER_BLOCK_ELECTRA:
-            Base10.toString(uint64(MAX_BLOBS_PER_BLOCK_ELECTRA)),
+            Base10.toString(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA),
           MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA:
             Base10.toString(cfg.MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA),
           MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT:


### PR DESCRIPTION
The REST config endpoint exposes the compile-time constant instead of the config value for `MAX_BLOBS_PER_BLOCK_ELECTRA`. Fix that, so that the compile-time constant can be removed eventually.