### PR TITLE
Use correct blob subnet when `BLOB_SIDECAR_SUBNET_COUNT_*` is overridden

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -293,9 +293,8 @@ template checkedReject(
     pool: ValidatorChangePool, error: ValidationError): untyped =
   pool.dag.checkedReject(error)
 
-func getMaxBlobsPerBlock(cfg: RuntimeConfig, wallTime: BeaconTime): uint64 =
-  if min(wallTime, wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero.epoch >=
-      cfg.ELECTRA_FORK_EPOCH:
+func getMaxBlobsPerBlock(cfg: RuntimeConfig, slot: Slot): uint64 =
+  if slot >= cfg.ELECTRA_FORK_EPOCH.start_slot:
     cfg.MAX_BLOBS_PER_BLOCK_ELECTRA
   else:
     MAX_BLOBS_PER_BLOCK
@@ -379,7 +378,7 @@ template validateBeaconBlockDeneb(
   # limitation defined in Consensus Layer -- i.e. validate that
   # len(body.signed_beacon_block.message.blob_kzg_commitments) <= MAX_BLOBS_PER_BLOCK
   if not (lenu64(signed_beacon_block.message.body.blob_kzg_commitments) <=
-      dag.cfg.getMaxBlobsPerBlock(wallTime)):
+      dag.cfg.getMaxBlobsPerBlock(signed_beacon_block.message.slot)):
     return dag.checkedReject("validateBeaconBlockDeneb: too many blob commitments")
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
@@ -395,12 +394,13 @@ proc validateBlobSidecar*(
 
   # [REJECT] The sidecar's index is consistent with `MAX_BLOBS_PER_BLOCK`
   # -- i.e. `blob_sidecar.index < MAX_BLOBS_PER_BLOCK`
-  if not (blob_sidecar.index < dag.cfg.getMaxBlobsPerBlock(wallTime)):
+  if not (blob_sidecar.index < dag.cfg.getMaxBlobsPerBlock(block_header.slot)):
     return dag.checkedReject("BlobSidecar: index inconsistent")
 
   # [REJECT] The sidecar is for the correct subnet -- i.e.
   # `compute_subnet_for_blob_sidecar(blob_sidecar.index) == subnet_id`.
-  if not (compute_subnet_for_blob_sidecar(blob_sidecar.index) == subnet_id):
+  if not (dag.cfg.compute_subnet_for_blob_sidecar(
+      block_header.slot, blob_sidecar.index) == subnet_id):
     return dag.checkedReject("BlobSidecar: subnet incorrect")
 
   # [IGNORE] The sidecar is not from a future slot (with a

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -110,9 +110,16 @@ func getBlobSidecarTopic*(forkDigest: ForkDigest,
                           subnet_id: BlobId): string =
   eth2Prefix(forkDigest) & "blob_sidecar_" & $subnet_id & "/ssz_snappy"
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/validator.md#sidecar
-func compute_subnet_for_blob_sidecar*(blob_index: BlobIndex): BlobId =
-  BlobId(blob_index mod MAX_BLOBS_PER_BLOCK_ELECTRA)
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/deneb/validator.md#sidecar
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/electra/validator.md#sidecar
+func compute_subnet_for_blob_sidecar*(
+    cfg: RuntimeConfig, slot: Slot, blob_index: BlobIndex): BlobId =
+  let subnetCount =
+    if slot >= cfg.ELECTRA_FORK_EPOCH.start_slot:
+      cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+    else:
+      BLOB_SIDECAR_SUBNET_COUNT
+  BlobId(blob_index mod subnetCount)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/p2p-interface.md#compute_subnet_for_data_column_sidecar
 func compute_subnet_for_data_column_sidecar*(column_index: ColumnIndex): uint64 =

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -157,7 +157,9 @@ proc routeSignedBeaconBlock*(
     let blobs = blobsOpt.get()
     var workers = newSeq[Future[SendResult]](blobs.len)
     for i in 0..<blobs.lenu64:
-      let subnet_id = compute_subnet_for_blob_sidecar(i)
+      let subnet_id = router[].processor[]
+        .dag.cfg.compute_subnet_for_blob_sidecar(
+          blobs[i].signed_block_header.message.slot, i)
       workers[i] = router[].network.broadcastBlobSidecar(subnet_id, blobs[i])
     let allres = await allFinished(workers)
     for i in 0..<allres.len:


### PR DESCRIPTION
`BLOB_SIDECAR_SUBNET_COUNT_ELECTRA` is configurable separately from `MAX_BLOBS_PER_BLOCK_ELECTRA` to allow configs with multiple blob IDs mapped to the same gossip topic. There is no large runtime overhead in simply using the correct constant as defined by spec. If we want to restrict to values that map 1 blob to 1 topic, there should be a check.

Also fix max blobs per block computation to be based on the block slot, rather than the time at which it was received.