### PR TITLE
Use consistent merkleization limit for `/eth/v1/beacon/blob_sidecars`

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1702,10 +1702,12 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         res.get()
 
     # https://github.com/ethereum/beacon-APIs/blob/v2.4.2/types/deneb/blob_sidecar.yaml#L2-L28
-    # Define a list which allows for a larger-than-Deneb-valid blobs per block,
-    # per https://github.com/ethereum/beacon-APIs/pull/488 and for pre-Electra,
-    # those blobs just won't exist.
-    let data = newClone(default(List[BlobSidecar, Limit MAX_BLOBS_PER_BLOCK_ELECTRA]))
+    # The merkleization limit of the list is `MAX_BLOB_COMMITMENTS_PER_BLOCK`,
+    # the serialization limit is configurable and is:
+    # - `MAX_BLOBS_PER_BLOCK` from Deneb onward
+    # - `MAX_BLOBS_PER_BLOCK_ELECTRA` from Electra.
+    let data = newClone(default(
+      List[BlobSidecar, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK]))
 
     if indices.isErr:
       return RestApiResponse.jsonError(Http400,
@@ -1713,7 +1715,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     let indexFilter = indices.get.toHashSet
 
-    for blobIndex in 0'u64 ..< MAX_BLOBS_PER_BLOCK_ELECTRA:
+    for blobIndex in 0'u64 ..< node.dag.cfg.MAX_BLOBS_PER_BLOCK_ELECTRA:
       if indexFilter.len > 0 and blobIndex notin indexFilter:
         continue
 


### PR DESCRIPTION
Use the `MAX_BLOB_COMMITMENTS_PER_BLOCK` constant as merkleization limit for the `/eth/v1/beacon/blob_sidecars` response so that `hash_tree_root` results in same value regardless of configured serialization limits. At compile-time, we don't have access to the actual serialization limit, so using a mainnet derived value in the type definition is not flexible.