### PR TITLE
Use larger serialization limit when parsing fork choice tests

### DIFF
--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -137,7 +137,7 @@ proc loadOps(
                 Opt.some BlobData(
                   blobs: distinctBase(parseTest(
                     path/(step["blobs"].getStr()) & ".ssz_snappy",
-                    SSZ, List[KzgBlob, Limit MAX_BLOBS_PER_BLOCK])),
+                    SSZ, List[KzgBlob, Limit MAX_BLOB_COMMITMENTS_PER_BLOCK])),
                   proofs: step["proofs"].mapIt(
                     KzgProof(bytes: fromHex(array[48, byte], it.getStr()))))
               else:


### PR DESCRIPTION
`MAX_BLOBS_PER_BLOCK` became configurable with v1.5.0-alpha.4 specs (moved from preset to config), so use the theoretical max allowed value when parsing fork choice tests.