### PR TITLE
Use `MAX_BLOBS_PER_BLOCK` from config in gossip validation

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -297,7 +297,7 @@ func getMaxBlobsPerBlock(cfg: RuntimeConfig, slot: Slot): uint64 =
   if slot >= cfg.ELECTRA_FORK_EPOCH.start_slot:
     cfg.MAX_BLOBS_PER_BLOCK_ELECTRA
   else:
-    MAX_BLOBS_PER_BLOCK
+    cfg.MAX_BLOBS_PER_BLOCK
 
 template validateBeaconBlockBellatrix(
     _: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,


### PR DESCRIPTION
Start phasing out the compile-time `MAX_BLOBS_PER_BLOCK` and use the value from the network config in gossip validation instead.