### PR TITLE
Move sync queue assertions to preset loader

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -31,6 +31,8 @@ const
   MESSAGE_DOMAIN_INVALID_SNAPPY*: array[4, byte] = [0x00, 0x00, 0x00, 0x00]
   MESSAGE_DOMAIN_VALID_SNAPPY*: array[4, byte] = [0x01, 0x00, 0x00, 0x00]
 
+  MAX_SUPPORTED_BLOBS_PER_BLOCK*: uint64 = 9  # revisit getShortMap(Blobs) if >9
+
 type
   Version* = distinct array[4, byte]
   Eth1Address* = web3types.Address
@@ -872,6 +874,10 @@ proc readRuntimeConfig*(
   checkCompatibility BLOB_SIDECAR_SUBNET_COUNT
   checkCompatibility MAX_BLOBS_PER_BLOCK_ELECTRA
   checkCompatibility MAX_REQUEST_BLOB_SIDECARS_ELECTRA
+
+  for suffix in ["", "_ELECTRA"]:
+    checkCompatibility MAX_SUPPORTED_BLOBS_PER_BLOCK,
+                       "MAX_BLOBS_PER_BLOCK" & suffix, `<=`
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/fork-choice.md#configuration
   # Isn't being used as a preset in the usual way: at any time, there's one correct value

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -143,11 +143,6 @@ func getShortMap*[T](
 
 proc getShortMap*[T](req: SyncRequest[T],
                      data: openArray[ref BlobSidecar]): string =
-  static:
-    doAssert(MAX_BLOBS_PER_BLOCK <= MAX_BLOBS_PER_BLOCK_ELECTRA)
-    doAssert(MAX_BLOBS_PER_BLOCK_ELECTRA < 10,
-             "getShortMap(Blobs) should be revisited")
-
   var
     res = newStringOfCap(req.data.count)
     slider = req.data.slot
@@ -175,11 +170,6 @@ proc getShortMap*[T](
     req: SyncRequest[T],
     blobs: openArray[BlobSidecars]
 ): string =
-  static:
-    doAssert(MAX_BLOBS_PER_BLOCK <= MAX_BLOBS_PER_BLOCK_ELECTRA)
-    doAssert(MAX_BLOBS_PER_BLOCK_ELECTRA < 10,
-             "getShortMap(Blobs) should be revisited")
-
   var
     res = newStringOfCap(req.data.count)
     slider = req.data.slot
@@ -980,9 +970,6 @@ proc checkResponse*[T](req: SyncRequest[T],
 
 proc checkBlobsResponse*[T](req: SyncRequest[T],
                             data: openArray[Slot]): Result[void, cstring] =
-  static:
-    doAssert(MAX_BLOBS_PER_BLOCK <= MAX_BLOBS_PER_BLOCK_ELECTRA)
-
   if len(data) == 0:
     # Impossible to verify empty response.
     return ok()


### PR DESCRIPTION
We already check in `presets.nim`:

- `MAX_BLOBS_PER_BLOCK_ELECTRA` ≥ `MAX_BLOBS_PER_BLOCK`
- Config values match preset constant values until constants phased out

The ≤ 9 check can be moved over, then sync queue no longer depends on the deprecated preset constant values and it remains a one-time check.