### PR TITLE
When requesting blobs by root, limit response size to request size

### DIFF
--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -262,7 +262,8 @@ proc fetchBlobsFromNetwork(self: RequestManager,
     debug "Requesting blobs by root", peer = peer, blobs = shortLog(idList),
                                              peer_score = peer.getScore()
 
-    let blobs = await blobSidecarsByRoot(peer, BlobIdentifierList idList)
+    let blobs = await blobSidecarsByRoot(
+      peer, BlobIdentifierList idList, maxResponseItems = idList.len)
 
     if blobs.isOk:
       var ublobs = blobs.get().asSeq()


### PR DESCRIPTION
When requesting `idList.len` blobs, the response can't be larger than `idList.len` or it is invalid.