### PR TITLE
Use fork-specific blob subnet count when subscribing to gossip topics

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1295,15 +1295,22 @@ proc addCapellaMessageHandlers(
   node.addAltairMessageHandlers(forkDigest, slot)
   node.network.subscribe(getBlsToExecutionChangeTopic(forkDigest), basicParams)
 
+proc doAddDenebMessageHandlers(
+    node: BeaconNode, forkDigest: ForkDigest, slot: Slot,
+    blobSidecarSubnetCount: uint64) =
+  node.addCapellaMessageHandlers(forkDigest, slot)
+  for topic in blobSidecarTopics(forkDigest, blobSidecarSubnetCount):
+    node.network.subscribe(topic, basicParams)
+
 proc addDenebMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
-  node.addCapellaMessageHandlers(forkDigest, slot)
-  for topic in blobSidecarTopics(forkDigest):
-    node.network.subscribe(topic, basicParams)
+  node.doAddDenebMessageHandlers(
+    forkDigest, slot, node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT)
 
 proc addElectraMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
-  node.addDenebMessageHandlers(forkDigest, slot)
+  node.doAddDenebMessageHandlers(
+    forkDigest, slot, node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA)
 
 proc addFuluMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
@@ -1324,13 +1331,19 @@ proc removeCapellaMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removeAltairMessageHandlers(forkDigest)
   node.network.unsubscribe(getBlsToExecutionChangeTopic(forkDigest))
 
-proc removeDenebMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
+proc doRemoveDenebMessageHandlers(
+    node: BeaconNode, forkDigest: ForkDigest, blobSidecarSubnetCount: uint64) =
   node.removeCapellaMessageHandlers(forkDigest)
-  for topic in blobSidecarTopics(forkDigest):
+  for topic in blobSidecarTopics(forkDigest, blobSidecarSubnetCount):
     node.network.unsubscribe(topic)
 
+proc removeDenebMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
+  node.doRemoveDenebMessageHandlers(
+    forkDigest, node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT)
+
 proc removeElectraMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
-  node.removeDenebMessageHandlers(forkDigest)
+  node.doRemoveDenebMessageHandlers(
+    forkDigest, node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA)
 
 proc removeFuluMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removeElectraMessageHandlers(forkDigest)
@@ -2083,7 +2096,12 @@ proc installMessageValidators(node: BeaconNode) =
       when consensusFork >= ConsensusFork.Deneb:
         # blob_sidecar_{subnet_id}
         # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
-        for it in BlobId:
+        let subnetCount =
+          when consensusFork >= ConsensusFork.Electra:
+            node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+          else:
+            node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT
+        for it in 0.BlobId ..< subnetCount.BlobId:
           closureScope:  # Needed for inner `proc`; don't lift it out of loop.
             let subnet_id = it
             node.network.addValidator(

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -201,7 +201,7 @@ type
 
   BlobId* = distinct uint8
     ## The blob id maps which gossip subscription to use to publish a
-    ## blob sidecar - it is distinct from the CommitteeIndex in particular
+    ## blob sidecar - it is distinct from the BlobIndex in particular
     ##
     ## The `BlobId` type is constrained to values in the range
     ## `[0, MAX_BLOBS_PER_BLOCK_ELECTRA)` during initialization.

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -118,7 +118,7 @@ func compute_subnet_for_blob_sidecar*(
     if slot >= cfg.ELECTRA_FORK_EPOCH.start_slot:
       cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
     else:
-      BLOB_SIDECAR_SUBNET_COUNT
+      cfg.BLOB_SIDECAR_SUBNET_COUNT
   BlobId(blob_index mod subnetCount)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/p2p-interface.md#compute_subnet_for_data_column_sidecar
@@ -243,8 +243,9 @@ func getSyncSubnets*(
     res.setBit(i div (SYNC_COMMITTEE_SIZE div SYNC_COMMITTEE_SUBNET_COUNT))
   res
 
-iterator blobSidecarTopics*(forkDigest: ForkDigest): string =
-  for subnet_id in BlobId:
+iterator blobSidecarTopics*(
+    forkDigest: ForkDigest, subnetCount: uint64): string =
+  for subnet_id in 0.BlobId ..< subnetCount.BlobId:
     yield getBlobSidecarTopic(forkDigest, subnet_id)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/p2p-interface.md#data_column_sidecar_subnet_id

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -80,7 +80,7 @@ suite "Honest validator":
         "/eth2/00000000/sync_committee_3/ssz_snappy"
       getBlobSidecarTopic(forkDigest, BlobId(1)) ==
         "/eth2/00000000/blob_sidecar_1/ssz_snappy"
-      toSeq(blobSidecarTopics(forkDigest)) ==
+      toSeq(blobSidecarTopics(forkDigest, subnetCount = 9)) ==
         ["/eth2/00000000/blob_sidecar_0/ssz_snappy",
          "/eth2/00000000/blob_sidecar_1/ssz_snappy",
          "/eth2/00000000/blob_sidecar_2/ssz_snappy",


### PR DESCRIPTION
We were always subscribing based on Electra blob gossip limits, despite no valid traffic being possible if those topics are used on Deneb. Use the correct limit for each fork:

- `BLOB_SIDECAR_SUBNET_COUNT` on Deneb
- `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA` on Electra and later