### PR TITLE
Limit `BlobId` to a maximum supported range

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -204,7 +204,8 @@ type
     ## blob sidecar - it is distinct from the BlobIndex in particular
     ##
     ## The `BlobId` type is constrained to values in the range
-    ## `[0, MAX_BLOBS_PER_BLOCK_ELECTRA)` during initialization.
+    ## `[0, MAX_SUPPORTED_BLOB_SIDECAR_SUBNET_COUNT)` during initialization.
+    ## The network configuration may impose further restrictions on the count!
 
   # BitVector[4] in the spec, ie 4 bits which end up encoded as a byte for
   # SSZ / hashing purposes
@@ -612,9 +613,7 @@ template makeLimitedU64*(T: untyped, limit: uint64) =
 
 makeLimitedU64(CommitteeIndex, MAX_COMMITTEES_PER_SLOT)
 makeLimitedU64(SubnetId, ATTESTATION_SUBNET_COUNT)
-
-static: doAssert MAX_BLOBS_PER_BLOCK_ELECTRA >= BLOB_SIDECAR_SUBNET_COUNT
-makeLimitedU64(BlobId, MAX_BLOBS_PER_BLOCK_ELECTRA)
+makeLimitedU64(BlobId, MAX_SUPPORTED_BLOB_SIDECAR_SUBNET_COUNT)
 
 const
   validatorIndexLimit = min(uint64(int32.high), VALIDATOR_REGISTRY_LIMIT)

--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -64,9 +64,6 @@ const
   REORG_PARENT_WEIGHT_THRESHOLD*: uint64 = 160
   REORG_MAX_EPOCHS_SINCE_FINALIZATION* = Epoch(2)
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.7/specs/deneb/p2p-interface.md#configuration
-  BLOB_SIDECAR_SUBNET_COUNT*: uint64 = 6
-
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/p2p-interface.md#configuration
   MAX_REQUEST_BLOCKS* = 1024'u64
   RESP_TIMEOUT* = 10'u64
@@ -90,6 +87,3 @@ const
   DEPOSIT_REQUEST_TYPE* = 0x00'u8
   WITHDRAWAL_REQUEST_TYPE* = 0x01'u8
   CONSOLIDATION_REQUEST_TYPE* = 0x02'u8
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/electra/beacon-chain.md#execution-1
-  MAX_BLOBS_PER_BLOCK_ELECTRA* = 9'u64

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -31,6 +31,7 @@ const
   MESSAGE_DOMAIN_INVALID_SNAPPY*: array[4, byte] = [0x00, 0x00, 0x00, 0x00]
   MESSAGE_DOMAIN_VALID_SNAPPY*: array[4, byte] = [0x01, 0x00, 0x00, 0x00]
 
+  MAX_SUPPORTED_BLOB_SIDECAR_SUBNET_COUNT*: uint64 = 9
   MAX_SUPPORTED_BLOBS_PER_BLOCK*: uint64 = 9  # revisit getShortMap(Blobs) if >9
   MAX_SUPPORTED_REQUEST_BLOB_SIDECARS*: uint64 = 1152
 
@@ -870,10 +871,10 @@ proc readRuntimeConfig*(
   checkCompatibility ATTESTATION_SUBNET_PREFIX_BITS
 
   checkCompatibility MAX_REQUEST_BLOCKS_DENEB
-  checkCompatibility BLOB_SIDECAR_SUBNET_COUNT
-  checkCompatibility MAX_BLOBS_PER_BLOCK_ELECTRA
 
   for suffix in ["", "_ELECTRA"]:
+    checkCompatibility MAX_SUPPORTED_BLOB_SIDECAR_SUBNET_COUNT,
+                       "BLOB_SIDECAR_SUBNET_COUNT" & suffix, `<=`
     checkCompatibility MAX_SUPPORTED_BLOBS_PER_BLOCK,
                        "MAX_BLOBS_PER_BLOCK" & suffix, `<=`
     checkCompatibility MAX_SUPPORTED_REQUEST_BLOB_SIDECARS,

--- a/beacon_chain/spec/presets/gnosis/deneb_preset.nim
+++ b/beacon_chain/spec/presets/gnosis/deneb_preset.nim
@@ -6,13 +6,11 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # Gnosis preset - Deneb
-# https://github.com/gnosischain/specs/blob/1648fc86cef7bc148d74cb21921d2d12ca9442ac/consensus/preset/gnosis/deneb.yaml
+# https://github.com/gnosischain/specs/blob/31f87ac73d271762ac35b3649e7639d00c73c66d/consensus/preset/gnosis/deneb.yaml
 const
   # `uint64(4096)`
   FIELD_ELEMENTS_PER_BLOB*: uint64 = 4096
   # `uint64(2**12)` (= 4096)
   MAX_BLOB_COMMITMENTS_PER_BLOCK*: uint64 = 4096
-  # `uint64(6)`
-  MAX_BLOBS_PER_BLOCK*: uint64 = 6
   # `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 12 = 17
   KZG_COMMITMENT_INCLUSION_PROOF_DEPTH* = 17

--- a/beacon_chain/spec/presets/gnosis/deneb_preset.nim
+++ b/beacon_chain/spec/presets/gnosis/deneb_preset.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
 
 # Gnosis preset - Deneb
 # https://github.com/gnosischain/specs/blob/31f87ac73d271762ac35b3649e7639d00c73c66d/consensus/preset/gnosis/deneb.yaml

--- a/beacon_chain/spec/presets/mainnet/deneb_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/deneb_preset.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/presets/mainnet/deneb_preset.nim
+++ b/beacon_chain/spec/presets/mainnet/deneb_preset.nim
@@ -8,13 +8,11 @@
 {.push raises: [].}
 
 # Mainnet preset - Deneb
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/presets/mainnet/deneb.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/presets/mainnet/deneb.yaml
 const
   # `uint64(4096)`
   FIELD_ELEMENTS_PER_BLOB*: uint64 = 4096
   # `uint64(2**12)` (= 4096)
   MAX_BLOB_COMMITMENTS_PER_BLOCK*: uint64 = 4096
-  # `uint64(6)`
-  MAX_BLOBS_PER_BLOCK*: uint64 = 6
   # `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 12 = 17
   KZG_COMMITMENT_INCLUSION_PROOF_DEPTH* = 17

--- a/beacon_chain/spec/presets/minimal/deneb_preset.nim
+++ b/beacon_chain/spec/presets/minimal/deneb_preset.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/presets/minimal/deneb_preset.nim
+++ b/beacon_chain/spec/presets/minimal/deneb_preset.nim
@@ -8,13 +8,11 @@
 {.push raises: [].}
 
 # Minimal preset - Deneb
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/presets/minimal/deneb.yaml
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/presets/minimal/deneb.yaml
 const
   # `uint64(4096)`
   FIELD_ELEMENTS_PER_BLOB*: uint64 = 4096
   # [customized]
   MAX_BLOB_COMMITMENTS_PER_BLOCK*: uint64 = 32
-  # `uint64(6)`
-  MAX_BLOBS_PER_BLOCK*: uint64 = 6
   # [customized] `floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) + 1 + ceillog2(MAX_BLOB_COMMITMENTS_PER_BLOCK)` = 4 + 1 + 5 = 10
   KZG_COMMITMENT_INCLUSION_PROOF_DEPTH* = 10


### PR DESCRIPTION
`BlobId` historically tracked `MAX_BLOBS_PER_BLOCK_ELECTRA` which is no longer correct because the network configuration may assign multiple blobs to the same subnet dynamically since v1.5.0-alpha.4. Instead, restrict it to a specific range, there is no `for x in BlobId` anywhere.