### PR TITLE
fix: fix floating-point division issue for size variable

### DIFF
--- a/scripts/depositContract.v.py
+++ b/scripts/depositContract.v.py
@@ -55,7 +55,7 @@ def get_deposit_root() -> bytes32:
             node = sha256(concat(self.branch[height], node))
         else:
             node = sha256(concat(node, self.zero_hashes[height]))
-        size /= 2
+        size //= 2
     return sha256(concat(node, self.to_little_endian_64(self.deposit_count), slice(zero_bytes32, start=0, len=24)))
 
 
@@ -109,7 +109,7 @@ def deposit(pubkey: bytes[PUBKEY_LENGTH],
             self.branch[height] = node
             break
         node = sha256(concat(self.branch[height], node))
-        size /= 2
+        size //= 2
 
 @public
 def drain():


### PR DESCRIPTION
I noticed that dividing the `size` variable (which is a `uint256`) using floating-point division could lead to unintended consequences. To ensure correctness, I've replaced the division with integer division using `//`, which guarantees that `size` remains an integer.

```python
size //= 2
``` 

This change ensures more predictable behavior and maintains the integrity of the variable's type.