### PR TITLE
ensure post-Electra produceAttestationData returns 0 committee_index

### DIFF
--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -16,7 +16,7 @@ import
   # Nimble packages
   chronos, confutils, presto, toml_serialization, metrics,
   chronicles, chronicles/helpers as chroniclesHelpers, chronicles/topics_registry,
-  stew/io2, metrics, metrics/chronos_httpserver,
+  stew/io2, metrics/chronos_httpserver,
 
   # Local modules
   ./spec/[helpers, keystore],

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -14,11 +14,7 @@ import ".."/[beacon_chain_db, beacon_node],
                                     attestation_pool, sync_committee_msg_pool],
        ".."/validators/beacon_validators,
        ".."/spec/[beaconstate, forks, network, state_transition_block],
-       ".."/spec/datatypes/[phase0, altair],
        "."/[rest_utils, state_ttl_cache]
-
-from ".."/spec/datatypes/bellatrix import ExecutionPayload
-from ".."/spec/datatypes/capella import ExecutionPayload
 
 export rest_utils
 
@@ -533,7 +529,10 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
               return RestApiResponse.jsonError(Http400,
                                                InvalidCommitteeIndexValueError,
                                                $res.error())
-            res.get()
+            if node.dag.cfg.consensusForkAtEpoch(qslot.epoch) >= ConsensusFork.Electra:
+              0.CommitteeIndex
+            else:
+              res.get()
         let qhead =
           block:
             let res = node.getSyncedHead(qslot)

--- a/research/fakeee.nim
+++ b/research/fakeee.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -17,7 +17,7 @@ import
   chronicles
 
 proc setupEngineAPI*(server: RpcServer) =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_newpayloadv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_newpayloadv1
   # cannot use `params` as param name. see https:#github.com/status-im/nim-json-rpc/issues/128
   server.rpc("engine_newPayloadV1") do(payload: ExecutionPayloadV1) -> PayloadStatusV1:
     info "engine_newPayloadV1",
@@ -27,7 +27,7 @@ proc setupEngineAPI*(server: RpcServer) =
       status: PayloadExecutionStatus.syncing,
     )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#engine_newpayloadv2
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_newpayloadv2
   server.rpc("engine_newPayloadV2") do(payload: ExecutionPayloadV2) -> PayloadStatusV1:
     info "engine_newPayloadV2", payload
 
@@ -35,7 +35,7 @@ proc setupEngineAPI*(server: RpcServer) =
       status: PayloadExecutionStatus.syncing,
     )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_getpayloadv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_getpayloadv1
   server.rpc("engine_getPayloadV1") do(payloadId: PayloadID) -> ExecutionPayloadV1:
     info "engine_getPayloadV1",
       id = payloadId.toHex
@@ -45,16 +45,7 @@ proc setupEngineAPI*(server: RpcServer) =
       msg: "Unknown payload"
     )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_exchangetransitionconfigurationv1
-  server.rpc("engine_exchangeTransitionConfigurationV1") do(conf: TransitionConfigurationV1) -> TransitionConfigurationV1:
-    info "engine_exchangeTransitionConfigurationV1",
-      ttd = conf.terminalTotalDifficulty,
-      number = uint64(conf.terminalBlockNumber),
-      blockHash = conf.terminalBlockHash
-
-    return conf
-
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#engine_forkchoiceupdatedv1
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_forkchoiceupdatedv1
   server.rpc("engine_forkchoiceUpdatedV1") do(
       update: ForkchoiceStateV1,
       payloadAttributes: Opt[PayloadAttributesV1]) -> ForkchoiceUpdatedResponse:
@@ -66,7 +57,7 @@ proc setupEngineAPI*(server: RpcServer) =
       payloadStatus: PayloadStatusV1(
       status: PayloadExecutionStatus.syncing))
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/shanghai.md#engine_forkchoiceupdatedv2
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_forkchoiceupdatedv2
   server.rpc("engine_forkchoiceUpdatedV2") do(
       forkchoiceState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV2]) -> ForkchoiceUpdatedResponse:
     info "engine_forkchoiceUpdatedV2",

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -17,20 +17,18 @@ import
   # Test utilities
   unittest2
 
-
 template do_check() =
   check:
     hash_tree_root(b.message) == hash_tree_root(
       b.toSignedBlindedBeaconBlock.message)
     b.signature == b.toSignedBlindedBeaconBlock.signature
 
-const
-  nondefaultEth1Data = Eth1Data(
-    deposit_root: Eth2Digest.fromHex(
-      "0x55aaf2ee893f67db190d617070bd10d1583b00194fbcfda03d89baa24626f5bb"),
-    deposit_count: 1,
-    block_hash: Eth2Digest.fromHex(
-      "0xe617d58db390a10741ab7d3de0ba9460b5df5e0772e9721fe33c0422a63b2677"))
+const nondefaultEth1Data = Eth1Data(
+  deposit_root: Eth2Digest.fromHex(
+    "0x55aaf2ee893f67db190d617070bd10d1583b00194fbcfda03d89baa24626f5bb"),
+  deposit_count: 1,
+  block_hash: Eth2Digest.fromHex(
+    "0xe617d58db390a10741ab7d3de0ba9460b5df5e0772e9721fe33c0422a63b2677"))
 
 let nondefaultValidatorSig = ValidatorSig.fromHex(
     "0xac08ca70066c6ea0525aa54dd867f82b86945818cb9305aae30f3bee13275dcf13d6d0680a47e889482ff2bb9a9f3cdb0588746f9e30c04645eda6d01bbd0ce6326ceb695294cb338ebace5b130c5b8f2e4f8efa63d63d5bb255c21a39da9c12")[]


### PR DESCRIPTION
- https://github.com/ethereum/beacon-APIs/pull/511

It's compatible regardless -- this field isn't valid in Electra unless it's 0. So this ensures that VCs which don't set 0 still might get a valid `AttestationData` in return.

Importing `spec/datatypes/[phase0, altair, bellatrix, capella, deneb, ...]` is redundant if already importing `spec/forks`.