### PR TITLE
fix: removed unnecessary `fi` after function

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -103,5 +103,3 @@ download_status_geth_binary() {
     patchelf_when_on_nixos "$BINARY_FS_PATH"
   fi
 }
-
-fi


### PR DESCRIPTION
Fixed an issue with an unnecessary `fi` that was left after the function.
It's now removed, making the code cleaner and working properly.