### PR TITLE
Retain vanity specific logic back through second latest Mainnet fork

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -22,11 +22,11 @@ import
 from ../spec/datatypes/capella import TrustedSignedBeaconBlock
 from ../spec/datatypes/deneb import TrustedSignedBeaconBlock
 
-from "."/vanity_logs/vanity_logs import VanityLogs
+from "."/vanity_logs/vanity_logs import LogProc, VanityLogs
 
 export
   sets, tables, hashes, helpers, beacon_chain_db, era_db, block_dag,
-  block_pools_types_light_client, validator_monitor, VanityLogs
+  block_pools_types_light_client, validator_monitor, LogProc, VanityLogs
 
 # ChainDAG and types related to forming a DAG of blocks, keeping track of their
 # relationships and allowing various forms of lookups

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2410,7 +2410,6 @@ proc updateHead*(
 
   let
     lastHeadStateRoot = getStateRoot(dag.headState)
-    lastHeadMergeComplete = dag.headState.is_merge_transition_complete()
     lastHeadKind = dag.headState.kind
     lastKnownValidatorsChangeStatuses = getBlsToExecutionChangeStatuses(
       dag.headState, knownValidators)
@@ -2432,26 +2431,20 @@ proc updateHead*(
 
   dag.head = newHead
 
-  if  dag.headState.is_merge_transition_complete() and not
-      lastHeadMergeComplete and
-      dag.vanityLogs.onMergeTransitionBlock != nil:
-    dag.vanityLogs.onMergeTransitionBlock()
-
   if dag.headState.kind > lastHeadKind:
-    case dag.headState.kind
-    of ConsensusFork.Phase0 .. ConsensusFork.Bellatrix:
-      discard
-    of ConsensusFork.Capella:
-      if dag.vanityLogs.onUpgradeToCapella != nil:
-        dag.vanityLogs.onUpgradeToCapella()
-    of ConsensusFork.Deneb:
-      if dag.vanityLogs.onUpgradeToDeneb != nil:
-        dag.vanityLogs.onUpgradeToDeneb()
-    of ConsensusFork.Electra:
-      if dag.vanityLogs.onUpgradeToElectra != nil:
-        dag.vanityLogs.onUpgradeToElectra()
-    of ConsensusFork.Fulu:
-      discard
+    proc logForkUpgrade(consensusFork: ConsensusFork, handler: LogProc) =
+      if handler != nil and
+          dag.headState.kind >= consensusFork and
+          lastHeadKind < consensusFork:
+        handler()
+
+    # Policy: Retain back through Mainnet's second latest fork.
+    ConsensusFork.Capella.logForkUpgrade(
+      dag.vanityLogs.onUpgradeToCapella)
+    ConsensusFork.Deneb.logForkUpgrade(
+      dag.vanityLogs.onUpgradeToDeneb)
+    ConsensusFork.Electra.logForkUpgrade(
+      dag.vanityLogs.onUpgradeToElectra)
 
   if  dag.vanityLogs.onKnownBlsToExecutionChange != nil and
       checkBlsToExecutionChanges(
@@ -2566,13 +2559,6 @@ proc updateHead*(
       dag.finalizedHead = finalizedHead
 
       dag.db.updateFinalizedBlocks(newFinalized)
-
-    let oldBlockHash = dag.loadExecutionBlockHash(oldFinalizedHead.blck)
-    if oldBlockHash.isSome and oldBlockHash.unsafeGet.isZero:
-      let newBlockHash = dag.loadExecutionBlockHash(dag.finalizedHead.blck)
-      if newBlockHash.isSome and not newBlockHash.unsafeGet.isZero:
-        if dag.vanityLogs.onFinalizedMergeTransitionBlock != nil:
-          dag.vanityLogs.onFinalizedMergeTransitionBlock()
 
     # Pruning the block dag is required every time the finalized head changes
     # in order to clear out blocks that are no longer viable and should

--- a/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
@@ -12,16 +12,9 @@ import chronicles
 from std/os import `/`
 
 type
-  LogProc = proc() {.gcsafe, raises: [].}
+  LogProc* = proc() {.gcsafe, raises: [].}
 
   VanityLogs* = object
-    # Upon the merge activating, these get displayed, at least once when the
-    # head becomes post-merge and then when the merge is finalized. If chain
-    # reorgs happen around the initial merge onMergeTransitionBlock might be
-    # called several times.
-    onMergeTransitionBlock*: LogProc
-    onFinalizedMergeTransitionBlock*: LogProc
-
     # Gets displayed on upgrade to Capella. May be displayed multiple times
     # in case of chain reorgs around the upgrade.
     onUpgradeToCapella*: LogProc
@@ -44,10 +37,8 @@ type
 
 # Created by https://beatscribe.com (beatscribe#1008 on Discord)
 # These need to be the main body of the log not to be reformatted or escaped.
-
-proc bellatrixMono*()  = notice "\n" & staticRead("bellatrix" / "mono.txt")
-proc bellatrixColor*() = notice "\n" & staticRead("bellatrix" / "color.ans")
-proc bellatrixBlink*() = notice "\n" & staticRead("bellatrix" / "blink.ans")
+#
+# Policy: Retain retired art files in the directory, but don't link them anymore
 
 proc capellaMono*()  = notice "\n" & staticRead("capella" / "mono.txt")
 proc capellaColor*() = notice "\n" & staticRead("capella" / "color.ans")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -146,8 +146,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   of StdoutLogKind.Auto: raiseAssert "inadmissable here"
   of StdoutLogKind.Colors:
     VanityLogs(
-      onMergeTransitionBlock:          bellatrixColor,
-      onFinalizedMergeTransitionBlock: bellatrixBlink,
       onUpgradeToCapella:              capellaColor,
       onKnownBlsToExecutionChange:     capellaBlink,
       onUpgradeToDeneb:                denebColor,
@@ -155,8 +153,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
       onKnownCompoundingChange:        electraBlink)
   of StdoutLogKind.NoColors:
     VanityLogs(
-      onMergeTransitionBlock:          bellatrixMono,
-      onFinalizedMergeTransitionBlock: bellatrixMono,
       onUpgradeToCapella:              capellaMono,
       onKnownBlsToExecutionChange:     capellaMono,
       onUpgradeToDeneb:                denebMono,
@@ -164,10 +160,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
       onKnownCompoundingChange:        electraMono)
   of StdoutLogKind.Json, StdoutLogKind.None:
     VanityLogs(
-      onMergeTransitionBlock:
-        (proc() = notice "🐼 Proof of Stake Activated 🐼"),
-      onFinalizedMergeTransitionBlock:
-        (proc() = notice "🐼 Proof of Stake Finalized 🐼"),
       onUpgradeToCapella:
         (proc() = notice "🦉 Withdrowls now available 🦉"),
       onKnownBlsToExecutionChange:
@@ -182,7 +174,7 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
 func getVanityMascot(consensusFork: ConsensusFork): string =
   case consensusFork
   of ConsensusFork.Fulu:
-    "not decided yet?"
+    "❓"
   of ConsensusFork.Electra:
     "🦒"
   of ConsensusFork.Deneb:


### PR DESCRIPTION
To avoid accumulating vanity code, define a policy to retire old logic.