### PR TITLE
halve CI per-function stack limit to 512KiB

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -66,8 +66,8 @@ if defined(limitStackUsage):
   # available on some GCC versions but not all - run with `-d:limitStackUsage`
   # and look for .su files in "./build/", "./nimcache/" or $TMPDIR that list the
   # stack size of each function.
-  switch("passC", "-fstack-usage -Werror=stack-usage=1048576")
-  switch("passL", "-fstack-usage -Werror=stack-usage=1048576")
+  switch("passC", "-fstack-usage -Werror=stack-usage=524288")
+  switch("passL", "-fstack-usage -Werror=stack-usage=524288")
 
 if defined(windows):
   # disable timestamps in Windows PE headers - https://wiki.debian.org/ReproducibleBuilds/TimestampsInPEBinaries


### PR DESCRIPTION
It helped catch
- https://github.com/nim-lang/Nim/issues/24746

so it's worth reducing this further to try to be stricter about catching this category of issues, especially as an eventual migration towards ORC will likely trigger cases here that `refc` does not.