### PR TITLE
Fix incompatible uint64 chain ID remenants

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -1207,6 +1207,11 @@ ETH_RESULT_USE_CHECK
 const ETHRoot *ETHTransactionGetHash(const ETHTransaction *transaction);
 
 /**
+ * Chain ID.
+ */
+typedef ETHUInt256 ETHChainId;
+
+/**
  * Obtains the chain ID of a transaction.
  *
  * - The returned value is allocated in the given transaction.
@@ -1218,7 +1223,7 @@ const ETHRoot *ETHTransactionGetHash(const ETHTransaction *transaction);
  * @return Chain ID.
  */
 ETH_RESULT_USE_CHECK
-const uint64_t *ETHTransactionGetChainId(const ETHTransaction *transaction);
+const ETHChainId *ETHTransactionGetChainId(const ETHTransaction *transaction);
 
 /**
  * Obtains the from address of a transaction.
@@ -1570,7 +1575,7 @@ const ETHAuthorization *ETHAuthorizationListGet(
  * @return Chain ID.
  */
 ETH_RESULT_USE_CHECK
-const uint64_t *ETHAuthorizationGetChainId(
+const ETHChainId *ETHAuthorizationGetChainId(
     const ETHAuthorization *authorization);
 
 /**

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1421,7 +1421,7 @@ type
     storageKeys: seq[Eth2Digest]
 
   ETHAuthorization = object
-    chainId: UInt256
+    chainId: ChainId
     address: ExecutionAddress
     nonce: uint64
     authority: ExecutionAddress
@@ -1429,7 +1429,7 @@ type
 
   ETHTransaction = object
     hash: Eth2Digest
-    chainId: UInt256
+    chainId: ChainId
     `from`: ExecutionAddress
     nonce: uint64
     maxPriorityFeePerGas: uint64
@@ -1539,8 +1539,6 @@ proc ETHTransactionsCreateFromJson(
 
     # Construct transaction
     static:
-      doAssert sizeof(UInt256) == sizeof(ChainId)
-      doAssert sizeof(UInt256) == sizeof(data.chainId.get)
       doAssert sizeof(uint64) == sizeof(data.gas)
       doAssert sizeof(uint64) == sizeof(data.gasPrice)
       doAssert sizeof(uint64) == sizeof(data.maxPriorityFeePerGas.get)
@@ -1556,13 +1554,12 @@ proc ETHTransactionsCreateFromJson(
         return nil
     if data.authorizationList.isSome:
       for authorization in data.authorizationList.get:
-        static: doAssert sizeof(UInt256) == sizeof(authorization.chainId)
         if authorization.v > uint8.high:
           return nil
     let
       tx = eth_types.EthTransaction(
         txType: txType,
-        chainId: data.chainId.get(0.u256),
+        chainId: data.chainId.get(0.chainId),
         nonce: distinctBase(data.nonce),
         gasPrice: data.gasPrice.GasInt,
         maxPriorityFeePerGas:
@@ -1755,7 +1752,7 @@ func ETHTransactionGetHash(
   addr transaction[].hash
 
 func ETHTransactionGetChainId(
-    transaction: ptr ETHTransaction): ptr UInt256 {.exported.} =
+    transaction: ptr ETHTransaction): ptr ChainId {.exported.} =
   ## Obtains the chain ID of a transaction.
   ##
   ## * The returned value is allocated in the given transaction.
@@ -2115,7 +2112,7 @@ func ETHAuthorizationListGet(
   addr authorizationList[][authorizationIndex.int]
 
 func ETHAuthorizationGetChainId(
-    authorization: ptr ETHAuthorization): ptr UInt256 {.exported.} =
+    authorization: ptr ETHAuthorization): ptr ChainId {.exported.} =
   ## Obtains the chain ID of an authorization tuple.
   ##
   ## * The returned value is allocated in the given authorization tuple.

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -1,6 +1,6 @@
 /**
  * beacon_chain
- * Copyright (c) 2023-2024 Status Research & Development GmbH
+ * Copyright (c) 2023-2025 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -464,7 +464,7 @@ int main(void)
         printHexString(transactionHash, sizeof *transactionHash);
         printf("\n");
 
-        const uint64_t *transactionChainId = ETHTransactionGetChainId(transaction);
+        const ETHChainId *transactionChainId = ETHTransactionGetChainId(transaction);
         printf("    - chain_id: ");
         printHexStringReversed(transactionChainId, sizeof *transactionChainId);
         printf("\n");
@@ -558,7 +558,7 @@ int main(void)
             printHexString(authority, sizeof *authority);
             printf("\n");
 
-            const uint64_t *chainId = ETHAuthorizationGetChainId(authorization);
+            const ETHChainId *chainId = ETHAuthorizationGetChainId(authorization);
             printf("            - chain_id: ");
             printHexStringReversed(chainId, sizeof *chainId);
             printf("\n");


### PR DESCRIPTION
Corrects issues introduced in #7005 that changed the Nim signatures of exported API functions without adjusting the corresponding .h import header. Also use specific `ChainId` data type where it makes sense, and remove assertions that are no longer required.