### PR TITLE
LC support for receipt logs that are not following Ethereum ABI

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -2360,8 +2360,6 @@ proc ETHReceiptsCreateFromJson(
         return nil
       if log.blockNumber.get != data.blockNumber:
         return nil
-      if log.data.len mod 32 != 0:
-        return nil
       if log.topics.len > 4:
         return nil
 


### PR DESCRIPTION
`data` may contain arbitrary data if using EVM assembly directly, the restriction to a multiple of 32 Bytes is not generally correct.

- https://github.com/ethereum/ethereum-org-website/pull/15096