### PR TITLE
Add Electra/Fulu support to `ncli dumpBlock`

### DIFF
--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -450,19 +450,14 @@ proc cmdDumpBlock(conf: DbConf) =
     if shouldShutDown: quit QuitSuccess
     try:
       let root = Eth2Digest.fromHex(blockRoot)
-      if (let blck = db.getBlock(
-          root, phase0.TrustedSignedBeaconBlock); blck.isSome):
-        dump("./", blck.get())
-      elif (let blck = db.getBlock(
-          root, altair.TrustedSignedBeaconBlock); blck.isSome):
-        dump("./", blck.get())
-      elif (let blck = db.getBlock(root, bellatrix.TrustedSignedBeaconBlock); blck.isSome):
-        dump("./", blck.get())
-      elif (let blck = db.getBlock(root, capella.TrustedSignedBeaconBlock); blck.isSome):
-        dump("./", blck.get())
-      elif (let blck = db.getBlock(root, deneb.TrustedSignedBeaconBlock); blck.isSome):
-        dump("./", blck.get())
-      else:
+      var found = false
+      withAll(ConsensusFork):
+        if not found:
+          let blck = db.getBlock(root, consensusFork.TrustedSignedBeaconBlock)
+          if blck.isSome:
+            found = true
+            dump("./", blck.get())
+      if not found:
         echo "Couldn't load ", blockRoot
     except CatchableError as e:
       echo "Couldn't load ", blockRoot, ": ", e.msg


### PR DESCRIPTION
As the code for dumping blocks in `ncli` is not maintained, replace it with logic that automatically works with new forks. Similar semantics, except that `ConsensusFork` is now enumerated in backward direction.