### PR TITLE
Fix Electra / Fulu .graffiti proven property in remote keystore

### DIFF
--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -854,8 +854,8 @@ proc readValue*(reader: var JsonReader, value: var RemoteKeystore)
         elif prop.path == ".graffiti":
           prop.capellaIndex = some GeneralizedIndex(18)
           prop.denebIndex = some GeneralizedIndex(18)
-          prop.electraIndex = some GeneralizedIndex(801)
-          prop.fuluIndex = some GeneralizedIndex(801)
+          prop.electraIndex = some GeneralizedIndex(18)
+          prop.fuluIndex = some GeneralizedIndex(18)
         else:
           reader.raiseUnexpectedValue("Keystores with proven properties different than " &
                                       "`.execution_payload.fee_recipient` and `.graffiti` " &


### PR DESCRIPTION
The gindex for Electra / Fulu when requesting `.graffiti` as proven property is incorrect:

- Electra: #6177 lacks reasoning and likely introduced copy paste error?
- Fulu: #6677 copied the broken Electra gindex, likely assuming its good

`BeaconBlockBody` has not changed. The correct gindex is still `18`.

- 13 fields total --> next pow2 is 16, so indexing starts at 16
- fields are 0-indexed, `graffiti` is at index 2
- 16 + 2 = 18