### PR TITLE
Bump geth to v1.15.6

### DIFF
--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -19,7 +19,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.15.5-4263936a"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.15.6-19d2b4c8"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in


### PR DESCRIPTION
- https://github.com/ethereum/go-ethereum/releases/tag/v1.15.6