### PR TITLE
ci: update NIM_COMMIT value for dedicated job

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 /* beacon_chain
- * Copyright (c) 2019-2024 Status Research & Development GmbH
+ * Copyright (c) 2019-2025 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -187,5 +187,5 @@ def getAgentLabel() {
 }
 
 def nimCommitForJob() {
-  return JOB_NAME.contains('nimv2') ? 'v2.0.6' : ''
+  return JOB_NAME.contains('nimv2_2') ? 'upstream/version-2-2' : ''
 }


### PR DESCRIPTION
It works:
```
09:32:16  Building: build/ncli_db
09:32:16  [using Nim version upstream/version-2-2]
```
https://ci.status.im/job/nimbus-eth2/job/platforms/job/linux/job/x86_64/job/nimv2_2/view/change-requests/job/PR-7050/2/console