### PR TITLE
Use ordered table for attestation packing

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -11,7 +11,8 @@ AllTests-mainnet
 + Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Pr OK
 + Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
 + Working with electra aggregates [Preset: mainnet]                                          OK
-+ simple add and get with electra nonzero committee [Preset: mainnet]                        OK
++ Simple add and get with electra nonzero committee [Preset: mainnet]                        OK
++ Cache coherence on chain aggregates [Preset: mainnet]                                      OK
 ```
 ## Attestation pool processing [Preset: mainnet]
 ```diff

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -9,10 +9,10 @@ AllTests-mainnet
 + Aggregated attestations with disjoint comittee bits into a single on-chain aggregate [Pres OK
 + Aggregating across committees [Preset: mainnet]                                            OK
 + Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Pr OK
-+ Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
-+ Working with electra aggregates [Preset: mainnet]                                          OK
-+ Simple add and get with electra nonzero committee [Preset: mainnet]                        OK
 + Cache coherence on chain aggregates [Preset: mainnet]                                      OK
++ Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
++ Simple add and get with electra nonzero committee [Preset: mainnet]                        OK
++ Working with electra aggregates [Preset: mainnet]                                          OK
 ```
 ## Attestation pool processing [Preset: mainnet]
 ```diff

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -102,6 +102,12 @@ type
     onPhase0AttestationAdded: OnPhase0AttestationCallback
     onSingleAttestationAdded: OnSingleAttestationCallback
 
+  CandidateKey = tuple
+    ## Search key for selecting the final candidates for
+    ## electra chain aggregates.
+    hash: Eth2Digest
+    slot: Slot
+
 logScope: topics = "attpool"
 
 declareGauge attestation_pool_block_attestation_packing_time,
@@ -1005,7 +1011,7 @@ proc getElectraAttestationsForBlock*(
   # For each round, we'll look for the best attestation and add it to the result
   # then re-score the other candidates.
   var
-    candidatesPerBlock: Table[(Eth2Digest, Slot), seq[electra.Attestation]]
+    candidatesPerBlock: OrderedTable[CandidateKey, seq[electra.Attestation]]
 
   let totalCandidates = candidates.len()
   while candidates.len > 0 and candidatesPerBlock.lenu64() <
@@ -1027,13 +1033,10 @@ proc getElectraAttestationsForBlock*(
           var e2 = entry.data
           e2.index = 0
           e2
-        key = (hash_tree_root(entry2), entry.data.slot)
+        key: CandidateKey = (hash_tree_root(entry2), entry.data.slot.Slot)
         newAtt = entry[].toElectraAttestation(entry[].aggregates[j])
 
-      candidatesPerBlock.withValue(key, candidate):
-        candidate[].add newAtt
-      do:
-        candidatesPerBlock[key] = @[newAtt]
+      candidatesPerBlock.mGetOrPut(key, @[]).add(newAtt)
 
       # Update cache so that the new votes are taken into account when updating
       # the score below

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -1033,7 +1033,7 @@ proc getElectraAttestationsForBlock*(
           var e2 = entry.data
           e2.index = 0
           e2
-        key: CandidateKey = (hash_tree_root(entry2), entry.data.slot.Slot)
+        key = (hash_tree_root(entry2), entry.data.slot.Slot)
         newAtt = entry[].toElectraAttestation(entry[].aggregates[j])
 
       candidatesPerBlock.mGetOrPut(key, @[]).add(newAtt)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -1186,7 +1186,7 @@ suite "Attestation pool electra processing" & preset():
       pool[].verifyAttestationSignature(state, cache, attestations[0])
       pool[].verifyAttestationSignature(state, cache, attestations[1])
 
-  test "simple add and get with electra nonzero committee" & preset():
+  test "Simple add and get with electra nonzero committee" & preset():
      let
        bc0 = get_beacon_committee(
          state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
@@ -1219,3 +1219,57 @@ suite "Attestation pool electra processing" & preset():
            0.CommitteeIndex).isOk
        pool[].getElectraAggregatedAttestation(1.Slot, hash_tree_root(attestation_2.data),
            1.CommitteeIndex).isOk
+
+  test "Cache coherence on chain aggregates" & preset():
+      # Add attestation from different committee
+      var maxSlot = 0.Slot
+
+      for i in 0 ..< 4:
+        let
+          bc = get_beacon_committee(
+            state[], getStateField(state[], slot), i.CommitteeIndex, cache)
+          att = makeElectraAttestation(
+            state[], state[].latest_block_root, bc[0], cache)
+        var att2 = makeElectraAttestation(
+          state[], state[].latest_block_root, bc[1], cache)
+
+        pool[].addAttestation(
+          att, @[bc[0]], att.aggregation_bits.len, att.loadSig,
+          att.data.slot.start_beacon_time)
+
+        if att.data.slot < 2:
+          pool[].addAttestation(
+            att2, @[bc[1]], att2.aggregation_bits.len, att2.loadSig,
+            att2.data.slot.start_beacon_time)
+
+        if att.data.slot > maxSlot:
+          maxSlot = att.data.slot
+
+      check process_slots(
+        defaultRuntimeConfig, state[],
+        maxSlot + MIN_ATTESTATION_INCLUSION_DELAY, cache,
+        info, {}).isOk()
+
+      let attestations = pool[].getElectraAttestationsForBlock(state[], cache)
+      check:
+        ## Considering that all structures in getElectraAttestationsForBlock
+        ## are sorted, the most relevant should be at sequence head.
+        ## Given the attestations added, the most "scored" is on
+        ## slot 1
+        attestations.len() == 2
+
+        attestations[0].aggregation_bits.countOnes() == 4
+        attestations[0].committee_bits.countOnes() == 2
+        attestations[0].data.slot == 1.Slot
+
+
+        attestations[1].aggregation_bits.countOnes() == 2
+        attestations[1].committee_bits.countOnes() == 2
+        attestations[1].data.slot == 2.Slot
+
+        check_attestation(
+          state[].electraData.data, attestations[0], {}, cache, true).isOk
+        check_attestation(
+          state[].electraData.data, attestations[1], {}, cache, true).isOk
+        pool[].verifyAttestationSignature(state, cache, attestations[0])
+        pool[].verifyAttestationSignature(state, cache, attestations[1])


### PR DESCRIPTION
In order to pack electra chained attestations, nimbus scores and aggregates with an ordered fashion to ease the packing of these attestations.

However, after the scoring and aggregation, a table (not ordered) was being used, and such, not producing optimal chain aggregates after the ordered scoring.

Solution arise from the use of an ordered table.