### PR TITLE
add MsgSource as el too

### DIFF
--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -212,6 +212,7 @@ type
     gossip = "gossip"
     api = "api"
     sync = "sync"
+    el = "el"
 
 template toGaugeValue(v: bool): int64 =
   if v: 1 else: 0

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Now with developments around `getBlobsVx`, one can now make a decision on enqueuing the block to block processor based on Messages (blobs and proofs) received from the EL side as well.

Hence, it would be incorrect to write something like `MsgSource.gossip/sync/api`.

Maybe we can coin it as `txpool` to be super accurate?