### PR TITLE
less verbose Electra aggregation bits logging

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -9,12 +9,11 @@
 
 import
   # Standard library
-  std/[sets, tables, hashes],
+  std/[tables, hashes],
   # Status libraries
   chronicles,
   # Internals
   ../spec/[signatures_batch, forks, helpers],
-  ../spec/datatypes/[phase0, altair, bellatrix],
   ".."/[beacon_chain_db, era_db],
   ../validators/validator_monitor,
   ./block_dag, block_pools_types_light_client

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -8,9 +8,8 @@
 {.push raises: [].}
 
 import
+  std/tables,
   chronicles,
-  std/[options, tables],
-  stew/bitops2,
   ../spec/forks
 
 export tables, forks

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -8,18 +8,18 @@
 {.push raises: [].}
 
 import
-  std/sequtils,
   results,
   chronicles,
-  ../extras,
-  ../spec/[beaconstate, helpers, network, signatures, validator],
+  ../spec/[beaconstate, helpers, signatures, validator],
   ../spec/datatypes/base,
   ./block_pools_types, blockchain_dag
 
+from std/sequtils import anyIt
 from ../spec/datatypes/electra import shortLog
+from ../spec/network import compute_subnet_for_attestation
 
 export
-  base, extras, block_pools_types, results
+  base, block_pools_types, results
 
 logScope: topics = "spec_cache"
 

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -12,7 +12,6 @@ import
   chronicles,
   results, snappy, taskpools,
   ../ncli/era,
-  ./spec/datatypes/[altair, bellatrix, phase0],
   ./spec/[beaconstate, forks, signatures_batch],
   ./consensus_object_pools/block_dag # TODO move to somewhere else to avoid circular deps
 

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -977,9 +977,12 @@ iterator getValidatorIndices*(
       continue
     yield validator_index
 
+func shortLog*(v: ElectraCommitteeValidatorsBits): auto =
+  $v.countOnes() & "/" & $v.len()
+
 func shortLog*(v: electra.Attestation | electra.TrustedAttestation): auto =
   (
-    aggregation_bits: v.aggregation_bits,
+    aggregation_bits: shortLog(v.aggregation_bits),
     committee_bits: v.committee_bits,
     data: shortLog(v.data),
     signature: shortLog(v.signature)

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,6 @@
 import
   chronos, presto/client, chronicles,
   ".."/".."/validators/slashing_protection_common,
-  ".."/datatypes/[phase0, altair, bellatrix],
   ".."/mev/[bellatrix_mev, capella_mev],
   ".."/[helpers, forks, keystore, eth2_ssz_serialization],
   "."/[rest_types, rest_common, eth2_rest_serialization]

--- a/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,7 +9,7 @@
 
 import
   chronos, presto/client,
-  ".."/[helpers, forks], ".."/datatypes/[phase0, altair],
+  ".."/[helpers, forks],
   "."/[rest_types, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization
@@ -18,7 +18,6 @@ proc getDebugChainHeadsV2*(): RestResponse[GetDebugChainHeadsV2Response] {.
      rest, endpoint: "/eth/v2/debug/beacon/heads",
      meth: MethodGet.}
   ## https://ethereum.github.io/beacon-APIs/#/Beacon/getDebugChainHeadsV2
-
 
 proc getStateV2Plain*(state_id: StateIdent): RestPlainResponse {.
      rest, endpoint: "/eth/v2/debug/beacon/states/{state_id}",

--- a/beacon_chain/spec/eth2_apis/rest_keymanager_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_keymanager_calls.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -10,7 +10,6 @@
 import
   presto/client, chronicles,
   ".."/".."/validators/slashing_protection_common,
-  ".."/datatypes/[phase0, altair],
   ".."/[helpers, forks, keystore, eth2_ssz_serialization],
   "."/[rest_types, rest_common, rest_keymanager_types, eth2_rest_serialization]
 

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -10,7 +10,6 @@
 import std/[strutils, sequtils, algorithm]
 import stew/base10, chronos, chronicles, results
 import
-  ../spec/datatypes/[phase0, altair],
   ../spec/eth2_apis/rest_types,
   ../spec/[helpers, forks, network],
   ../networking/[peer_pool, peer_scores, eth2_network],

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -10,7 +10,6 @@
 import std/[deques, heapqueue, tables, strutils, sequtils, math, typetraits]
 import stew/base10, chronos, chronicles, results
 import
-  ../spec/datatypes/[base, phase0, altair],
   ../spec/[helpers, forks],
   ../networking/[peer_pool, eth2_network],
   ../gossip_processing/block_processor,


### PR DESCRIPTION
When a module imports `beacon_chain/spec/forks`, it does not have to also import any of `beacon_chain/spec/datatypes/[phase0, altair, bellatrix, capella, deneb, electra, fulu]`.

The Electra aggregation bits can describe 1/32, one slot's worth, of all active validators on a network, which for 1M+ active validator networks should not be logged in that much detail in `shortLog(...)`-based logging.