### PR TITLE
reduce per-slot state replays on low-participation networks

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1413,7 +1413,8 @@ proc doppelgangerChecked(node: BeaconNode, epoch: Epoch) =
       validator.doppelgangerChecked(epoch - 1)
 
 proc maybeUpdateActionTrackerNextEpoch(
-    node: BeaconNode, forkyState: ForkyHashedBeaconState, nextEpoch: Epoch) =
+    node: BeaconNode, forkyState: ForkyHashedBeaconState, currentSlot: Slot) =
+  let nextEpoch = currentSlot.epoch + 1
   if node.consensusManager[].actionTracker.needsUpdate(
       forkyState, nextEpoch):
     template epochRefFallback() =
@@ -1474,7 +1475,12 @@ proc maybeUpdateActionTrackerNextEpoch(
         effective_balance = forkyState.data.validators.item(
           nextEpochFirstProposer).effective_balance
 
-      if  participation_flags.has_flag(TIMELY_SOURCE_FLAG_INDEX) and
+      # Maximal potential accuracy primarily useful during the last slot of
+      # each epoch to prepare for a possible proposal the first slot of the
+      # next epoch. Otherwise, epochRefFallback is potentially very slow as
+      # it can induce a lengthy state replay.
+      if (not (currentSlot + 1).is_epoch) or
+         (participation_flags.has_flag(TIMELY_SOURCE_FLAG_INDEX) and
           participation_flags.has_flag(TIMELY_TARGET_FLAG_INDEX) and
           effective_balance == MAX_EFFECTIVE_BALANCE.Gwei and
           forkyState.data.slot.epoch != GENESIS_EPOCH and
@@ -1482,7 +1488,7 @@ proc maybeUpdateActionTrackerNextEpoch(
             nextEpochFirstProposer) == 0 and
           not effective_balance_might_update(
             forkyState.data.balances.item(nextEpochFirstProposer),
-            effective_balance):
+            effective_balance)):
         node.consensusManager[].actionTracker.updateActions(
           shufflingRef, nextEpochProposers)
       else:
@@ -1567,7 +1573,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
         node.consensusManager[].actionTracker.updateActions(
           epochRef.shufflingRef, epochRef.beacon_proposers)
 
-      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot.epoch + 1)
+      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   if node.gossipState.card > 0 and targetGossipState.card == 0:
     debug "Disabling topic subscriptions",
@@ -1713,7 +1719,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
       # missed sync committee participation via process_sync_aggregate(), but
       # attestation penalties for example, need, specific handling.
       # checked by maybeUpdateActionTrackerNextEpoch.
-      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot.epoch + 1)
+      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   let
     nextAttestationSlot =


### PR DESCRIPTION
Especially on network such as Holesky with relatively low participation, it's possible for the next-epoch proposer prediction code to repeatedly trigger lengthy state replays with certain I/O systems. For example, where `FOO1`/`FOO2` are at the beginning and end of
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/nimbus_beacon_node.nim#L1411-L1416
```
WRN 2025-03-28 23:31:57.842+00:00 FOO1: using epochRefFallback()             topics="beacnde" head=eb3e5135:3941815 nextEpoch=123184
INF 2025-03-28 23:32:03.260+00:00 State replayed                             topics="chaindag" blocks=0 slots=32 current=eb3e5135:3941815@3941856 ancestor=eb3e5135:3941815@3941856 target=eb3e5135:3941815@3941888 ancestorStateRoot=8eb2a682 targetStateRoot=fc30765d found=true assignDur=1us508ns replayDur=5s418ms584us674ns
WRN 2025-03-28 23:32:03.393+00:00 FOO2: used epochRefFallback()              topics="beacnde" head=eb3e5135:3941815 nextEpoch=123184 elapsedTime=5s551ms729us634ns
```
```
WRN 2025-03-28 23:32:15.306+00:00 FOO1: using epochRefFallback()             topics="beacnde" head=c5893635:3941816 nextEpoch=123184
INF 2025-03-28 23:32:20.712+00:00 State replayed                             topics="chaindag" blocks=0 slots=32 current=c5893635:3941816@3941856 ancestor=c5893635:3941816@3941856 target=c5893635:3941816@3941888 ancestorStateRoot=b0688273 targetStateRoot=f8d1a076 found=true assignDur=1us926ns replayDur=5s406ms16us171ns
WRN 2025-03-28 23:32:20.872+00:00 FOO2: used epochRefFallback()              topics="beacnde" head=c5893635:3941816 nextEpoch=123184 elapsedTime=5s565ms840us147ns
```
```
WRN 2025-03-28 23:32:33.096+00:00 FOO1: using epochRefFallback()             topics="beacnde" head=7f3f0eca:3941820 nextEpoch=123184
INF 2025-03-28 23:32:38.505+00:00 State replayed                             topics="chaindag" blocks=0 slots=32 current=7f3f0eca:3941820@3941856 ancestor=7f3f0eca:3941820@3941856 target=7f3f0eca:3941820@3941888 ancestorStateRoot=5ae70418 targetStateRoot=6fefeb85 found=true assignDur=1us691ns replayDur=5s409ms419us478ns
WRN 2025-03-28 23:32:38.654+00:00 FOO2: used epochRefFallback()              topics="beacnde" head=7f3f0eca:3941820 nextEpoch=123184 elapsedTime=5s558ms510us784ns
```
```
WRN 2025-03-28 23:32:50.366+00:00 FOO1: using epochRefFallback()             topics="beacnde" head=c3877d36:3941821 nextEpoch=123184
INF 2025-03-28 23:32:55.778+00:00 State replayed                             topics="chaindag" blocks=0 slots=32 current=c3877d36:3941821@3941856 ancestor=c3877d36:3941821@3941856 target=c3877d36:3941821@3941888 ancestorStateRoot=005eced9 targetStateRoot=4fc060df found=true assignDur=1us763ns replayDur=5s410ms781us79ns
WRN 2025-03-28 23:32:55.936+00:00 FOO2: used epochRefFallback()              topics="beacnde" head=c3877d36:3941821 nextEpoch=123184 elapsedTime=5s569ms24us723ns
INF 2025-03-28 23:32:55.944+00:00 Slot end                                   topics="beacnde" slot=3941863 nextActionWait=n/a nextAttestationSlot=-1 nextProposalSlot=-1 syncCommitteeDuties=none head=c3877d36:3941821
```

So these state replays result from `maybeUpdateActionTrackerNextEpoch(...)` falling back from its fast path, which reliably triggers in networks such as mainnet and Sepolia with sufficiently high participation rates, to the slow path, on certain networks:
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/nimbus_beacon_node.nim#L1460-L1461

It generally shouldn't trigger in the syncing phase, but only when gossip gets enabled for the last few epochs.

However, per this PR, this is fundamentally a speculative mechanism already and it doesn't make sense to expend seconds in a slot on it:
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/validators/action_tracker.nim#L206-L213

The one time where, to be cautious with this PR, it might be useful is that last slot in an epoch, because it helps prepare for the next epoch:
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/consensus_object_pools/consensus_manager.nim#L283-L322

But indeed, BN-based validators don't depend on `action_tracker`:
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/validators/beacon_validators.nim#L1586-L1603

and neither do VC-based validators, which rather use the [getProposerDuties](https://ethereum.github.io/beacon-APIs/?urls.primaryName=v3.1.0#/Validator/getProposerDuties) beacon REST API endpoint, for example from the Nimbus validator client:
https://github.com/status-im/nimbus-eth2/blob/c00f35a99e2be159d98353b143802f6a4a952452/beacon_chain/validator_client/duties_service.nim#L499-L529

So this is a still-fundamentally-speculative mechanism which under conditions which largely appear right now in Holesky but in principle appear in general in ailing networks creates latency spike without much reason except, potentially, at the last slot in an epoch, which this PR preserves.