### PR TITLE
Add error logging for partial state parsing failure in `getPartialState`

### DIFF
--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -422,8 +422,8 @@ proc getPartialState(
   try:
     readSszBytes(tmp.toOpenArray(0, partialBytes - 1), output)
     true
-  except CatchableError:
-    # TODO log?
+  except CatchableError as exc:
+    error "Failed to parse partial beacon state", slot = slot, msg = exc.msg
     false
 
 iterator getBlockIds*(


### PR DESCRIPTION
This pull request replaces the `TODO` comment with an actual error log in the `getPartialState` function of `era_db.nim`.  
It improves observability and debuggability when parsing a partial beacon state fails, by providing the slot and error message.

**Before:**
```nim
except CatchableError:
  # TODO log?
  false
```

**After:**
```nim
except CatchableError as exc:
  error "Failed to parse partial beacon state", slot = slot, msg = exc.msg
  false
```