### PR TITLE
Some minor fixes

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -528,7 +528,7 @@ func process_withdrawal_request*(
   if is_full_exit_request:
     # Only exit validator if it has no pending withdrawals in the queue
     if pending_balance_to_withdraw == 0.Gwei:
-      initiate_validator_exit(cfg, state, index, default(ExitQueueInfo),
+      discard initiate_validator_exit(cfg, state, index, default(ExitQueueInfo),
           cache)
     return
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -528,9 +528,8 @@ func process_withdrawal_request*(
   if is_full_exit_request:
     # Only exit validator if it has no pending withdrawals in the queue
     if pending_balance_to_withdraw == 0.Gwei:
-      if initiate_validator_exit(cfg, state, index, default(ExitQueueInfo),
-          cache).isErr():
-        return
+      initiate_validator_exit(cfg, state, index, default(ExitQueueInfo),
+          cache)
     return
 
   let

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -418,9 +418,6 @@ proc check_voluntary_exit*(
     return err("Exit: not in validator set long enough")
 
   when typeof(state).kind >= ConsensusFork.Electra:
-    if voluntary_exit.validator_index >= state.validators.lenu64:
-      return err("Exit: validator index out of range")
-
     # Only exit validator if it has no pending withdrawals in the queue
     if not (get_pending_balance_to_withdraw(
         state, voluntary_exit.validator_index.ValidatorIndex) == 0.Gwei):

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -528,8 +528,7 @@ func process_withdrawal_request*(
   if is_full_exit_request:
     # Only exit validator if it has no pending withdrawals in the queue
     if pending_balance_to_withdraw == 0.Gwei:
-      discard initiate_validator_exit(cfg, state, index, default(ExitQueueInfo),
-          cache)
+      discard initiate_validator_exit(cfg, state, index, ExitQueueInfo(), cache)
     return
 
   let


### PR DESCRIPTION
This PR cleans a bit the `state_transition_block.nim`, by removing one check that was duplicated when electra goes live and a redundant return statement.