### PR TITLE
add more updated MEV/builder API relay list link to documentation

### DIFF
--- a/docs/the_nimbus_book/src/external-block-builder.md
+++ b/docs/the_nimbus_book/src/external-block-builder.md
@@ -56,6 +56,8 @@ Additionally, the URL of the service exposing the [builder API](https://ethereum
 
 - [EthStaker MEV relay list](https://ethstaker.cc/mev-relay-list/)
 
+- [MEV Relay List](https://www.coincashew.com/coins/overview-eth/mev-boost/mev-relay-list)
+
 - [Mainnet Relay Overview](https://beaconcha.in/relays)
 
 - [Hoodi Relay Overview](https://hoodi.beaconcha.in/relays)


### PR DESCRIPTION
https://ethstaker.cc/mev-relay-list/ seems not to have been updated as regularly lately and in particular has no Hoodi relays at all.