### PR TITLE
Cleanup libunwind remnants

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -52,14 +52,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_amd64_checksum
+          name: Linux_amd64_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_amd64_checksum
+          name: Linux_amd64_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -106,14 +106,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_arm64_checksum
+          name: Linux_arm64_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_arm64_checksum
+          name: Linux_arm64_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -160,14 +160,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_arm_checksum
+          name: Linux_arm_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Linux_arm_checksum
+          name: Linux_arm_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -206,14 +206,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Windows_amd64_checksum
+          name: Windows_amd64_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: Windows_amd64_checksum
+          name: Windows_amd64_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -252,14 +252,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: macOS_amd64_checksum
+          name: macOS_amd64_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: macOS_amd64_checksum
+          name: macOS_amd64_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -298,14 +298,14 @@ jobs:
       - name: Upload BN checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: macOS_arm64_checksum
+          name: macOS_arm64_checksum_bn
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
           retention-days: 2
 
       - name: Upload VC checksum artefact
         uses: actions/upload-artifact@v4
         with:
-          name: macOS_arm64_checksum
+          name: macOS_arm64_checksum_vc
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
@@ -330,17 +330,23 @@ jobs:
           \`\`\`text
           EOF
           echo '# Linux AMD64' >> release_notes.md
-          cat Linux_amd64_checksum/* >> release_notes.md
+          cat Linux_amd64_checksum_bn/* >> release_notes.md
+          cat Linux_amd64_checksum_vc/* >> release_notes.md
           echo '# Linux ARM64' >> release_notes.md
-          cat Linux_arm64_checksum/* >> release_notes.md
+          cat Linux_arm64_checksum_bn/* >> release_notes.md
+          cat Linux_arm64_checksum_vc/* >> release_notes.md
           echo '# Linux ARM' >> release_notes.md
-          cat Linux_arm_checksum/* >> release_notes.md
+          cat Linux_arm_checksum_bn/* >> release_notes.md
+          cat Linux_arm_checksum_vc/* >> release_notes.md
           echo '# Windows AMD64' >> release_notes.md
-          cat Windows_amd64_checksum/* >> release_notes.md
+          cat Windows_amd64_checksum_bn/* >> release_notes.md
+          cat Windows_amd64_checksum_vc/* >> release_notes.md
           echo '# macOS AMD64' >> release_notes.md
-          cat macOS_amd64_checksum/* >> release_notes.md
+          cat macOS_amd64_checksum_bn/* >> release_notes.md
+          cat macOS_amd64_checksum_vc/* >> release_notes.md
           echo '# macOS ARM64' >> release_notes.md
-          cat macOS_arm64_checksum/* >> release_notes.md
+          cat macOS_arm64_checksum_bn/* >> release_notes.md
+          cat macOS_arm64_checksum_vc/* >> release_notes.md
           echo '```' >> release_notes.md
 
       - name: Delete tag
@@ -370,14 +376,20 @@ jobs:
           failOnError: false
           name: |
             Linux_amd64_archive
-            Linux_amd64_checksum
+            Linux_amd64_checksum_bn
+            Linux_amd64_checksum_vc
             Linux_arm64_archive
-            Linux_arm64_checksum
+            Linux_arm64_checksum_bn
+            Linux_arm64_checksum_vc
             Linux_arm_archive
-            Linux_arm_checksum
+            Linux_arm_checksum_bn
+            Linux_arm_checksum_vc
             Windows_amd64_archive
-            Windows_amd64_checksum
+            Windows_amd64_checksum_bn
+            Windows_amd64_checksum_vc
             macOS_amd64_archive
-            macOS_amd64_checksum
+            macOS_amd64_checksum_bn
+            macOS_amd64_checksum_vc
             macOS_arm64_archive
-            macOS_arm64_checksum
+            macOS_arm64_checksum_bn
+            macOS_arm64_checksum_vc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -432,20 +432,26 @@ jobs:
           failOnError: false
           name: |
             Linux_amd64_archive
-            Linux_amd64_checksum
+            Linux_amd64_checksum_bn
+            Linux_amd64_checksum_vc
             Linux_amd64_packages
             Linux_arm64_archive
-            Linux_arm64_checksum
+            Linux_arm64_checksum_bn
+            Linux_arm64_checksum_vc
             Linux_arm64_packages
             Linux_arm_archive
-            Linux_arm_checksum
+            Linux_arm_checksum_bn
+            Linux_arm_checksum_vc
             Linux_arm_packages
             Windows_amd64_archive
-            Windows_amd64_checksum
+            Windows_amd64_checksum_bn
+            Windows_amd64_checksum_vc
             macOS_amd64_archive
-            macOS_amd64_checksum
+            macOS_amd64_checksum_bn
+            macOS_amd64_checksum_vc
             macOS_arm64_archive
-            macOS_arm64_checksum
+            macOS_arm64_checksum_bn
+            macOS_arm64_checksum_vc
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -62,25 +62,12 @@ if [[ "${PLATFORM}" == "Windows_amd64" ]]; then
     CC="${CC}" \
     CFLAGS="-Wall -Os -DWIN32 -DNATPMP_STATICLIB -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 ${CFLAGS}" \
     libnatpmp.a &>/dev/null
-  # We set CXX and add CXXFLAGS for libunwind's C++ code, even though we don't
-  # use those C++ objects. I don't see an easy way of disabling the C++ parts in
-  # libunwind itself.
-  #
-  # "libunwind.a" combines objects produced from C and C++ code. Even though we
-  # don't link any C++-generated objects, the linker still checks them for
-  # undefined symbols, so we're forced to use g++ as a linker wrapper.
-  # For some reason, macOS's Clang doesn't need this trick, nor do native (and
-  # newer) Mingw-w64 toolchains on Windows.
-  #
   # nim-blscurve's Windows SSSE3 detection doesn't work when cross-compiling,
   # so we enable it here.
   make \
-    CC="${CC}" \
-    CXX="${CXX}" \
-    CXXFLAGS="${CXXFLAGS} -D__STDC_FORMAT_MACROS -D_WIN32_WINNT=0x0600" \
-    USE_VENDORED_LIBUNWIND=1 \
     LOG_LEVEL="TRACE" \
-    NIMFLAGS="${NIMFLAGS_COMMON} --os:windows --gcc.exe=${CC} --gcc.linkerexe=${CXX} --passL:-static -d:BLSTuseSSSE3=1" \
+    CC="${CC}" \
+    NIMFLAGS="${NIMFLAGS_COMMON} --os:windows --gcc.exe=${CC} --gcc.linkerexe=${CC} --passL:-static -d:BLSTuseSSSE3=1" \
     ${BINARIES}
 elif [[ "${PLATFORM}" == "Linux_arm32v7" ]]; then
   CC="arm-linux-gnueabihf-gcc"
@@ -142,7 +129,6 @@ elif [[ "${PLATFORM}" == "macOS_amd64" ]]; then
     RANLIB="x86_64-apple-darwin${DARWIN_VER}-ranlib" \
     DSYMUTIL="x86_64-apple-darwin${DARWIN_VER}-dsymutil" \
     FORCE_DSYMUTIL=1 \
-    USE_VENDORED_LIBUNWIND=1 \
     NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --clang.exe=${CC} --clang.linkerexe=${CC}" \
     ${BINARIES}
 elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
@@ -173,7 +159,6 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
     RANLIB="arm64-apple-darwin${DARWIN_VER}-ranlib" \
     DSYMUTIL="arm64-apple-darwin${DARWIN_VER}-dsymutil" \
     FORCE_DSYMUTIL=1 \
-    USE_VENDORED_LIBUNWIND=1 \
     NIMFLAGS="${NIMFLAGS_COMMON} --os:macosx --cpu:arm64 --passC:'-mcpu=apple-a13' --passL:'-mcpu=apple-a13' --clang.exe=${CC} --clang.linkerexe=${CC}" \
     ${BINARIES}
 elif [[ "${PLATFORM}" == "Linux_amd64_opt" ]]; then


### PR DESCRIPTION
libunwind is always vendored, we don't need to explicitly mention `USE_VENDORED_LIBUNWIND=1` anymore.