### PR TITLE
switch from deprecated newSeqUninitialized to newSeqUninit

### DIFF
--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -126,7 +126,7 @@ proc getBlockSSZ*(
   if len > int.high.uint64:
     return err("Invalid uncompressed size")
 
-  bytes = newSeqUninitialized[byte](len)
+  bytes = newSeqUninit[byte](len)
 
   # Where it matters, we will integrity-check the data with SSZ - no
   # need to waste cycles on crc32
@@ -171,7 +171,7 @@ proc getStateSSZ*(
         min(len, partial.get().uint64 + maxUncompressedFrameDataLen - 1)
       else: len
 
-  bytes = newSeqUninitialized[byte](wanted)
+  bytes = newSeqUninit[byte](wanted)
 
   # Where it matters, we will integrity-check the data with SSZ - no
   # need to waste cycles on crc32

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -619,7 +619,7 @@ proc writeChunkSZ(
     uncompressedLenBytes = toBytes(uncompressedLen, Leb128)
 
   var
-    data = newSeqUninitialized[byte](
+    data = newSeqUninit[byte](
       ord(responseCode.isSome) + contextBytes.len + uncompressedLenBytes.len +
       payloadSZ.len)
     pos = 0
@@ -638,7 +638,7 @@ proc writeChunk(conn: Connection,
   let
     uncompressedLenBytes = toBytes(payload.lenu64, Leb128)
   var
-    data = newSeqUninitialized[byte](
+    data = newSeqUninit[byte](
       ord(responseCode.isSome) + contextBytes.len + uncompressedLenBytes.len +
       snappy.maxCompressedLenFramed(payload.len).int)
     pos = 0
@@ -752,8 +752,8 @@ proc uncompressFramedStream(conn: Connection,
     doAssert maxCompressedFrameDataLen >= maxUncompressedFrameDataLen.uint64
 
   var
-    frameData = newSeqUninitialized[byte](maxCompressedFrameDataLen + 4)
-    output = newSeqUninitialized[byte](expectedSize)
+    frameData = newSeqUninit[byte](maxCompressedFrameDataLen + 4)
+    output = newSeqUninit[byte](expectedSize)
     written = 0
 
   while written < expectedSize:

--- a/beacon_chain/validator_bucket_sort.nim
+++ b/beacon_chain/validator_bucket_sort.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -16,11 +16,8 @@ const
   NUM_BUCKETS = 1 shl BUCKET_BITS
 
 type
-  # `newSeqUninitialized` requires its type to be SomeNumber
-  IntValidatorIndex = distinctBase ValidatorIndex
-
   BucketSortedValidators* = object
-    bucketSorted*: seq[IntValidatorIndex]
+    bucketSorted*: seq[ValidatorIndex]
     bucketUpperBounds: array[NUM_BUCKETS, uint] # avoids over/underflow checks
     extraItems*: seq[ValidatorIndex]
 
@@ -50,14 +47,14 @@ func sortValidatorBuckets*(validators: openArray[Validator]):
     bucketInsertPositions[i] = accum
   doAssert accum == validators.len.uint
   let res = (ref BucketSortedValidators)(
-    bucketSorted: newSeqUninitialized[IntValidatorIndex](validators.len),
+    bucketSorted: newSeqUninit[ValidatorIndex](validators.len),
     bucketUpperBounds: bucketInsertPositions)
 
   for i, validator in validators:
     let insertPos =
       addr bucketInsertPositions[getBucketNumber(validator.pubkey)]
     dec insertPos[]
-    res.bucketSorted[insertPos[]] = i.IntValidatorIndex
+    res.bucketSorted[insertPos[]] = i.ValidatorIndex
 
   doAssert bucketInsertPositions[0] == 0
   for i in 1 ..< NUM_BUCKETS:
@@ -85,6 +82,6 @@ func findValidatorIndex*(
         bsv.bucketUpperBounds[bucketNumber - 1]
 
   for i in lowerBounds ..< bsv.bucketUpperBounds[bucketNumber]:
-    if validators[bsv.bucketSorted[i]].pubkey == pubkey:
-      return Opt.some bsv.bucketSorted[i].ValidatorIndex
+    if validators[bsv.bucketSorted[i].distinctBase].pubkey == pubkey:
+      return Opt.some bsv.bucketSorted[i]
   Opt.none ValidatorIndex

--- a/ncli/e2store.nim
+++ b/ncli/e2store.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -95,7 +95,7 @@ proc readRecord*(f: IoHandle, data: var seq[byte]): Result[Header, string] =
     ? f.checkBytesLeft(header.len)
 
     if data.len != header.len:
-      data = newSeqUninitialized[byte](header.len)
+      data = newSeqUninit[byte](header.len)
 
     ? readFileExact(f, data)
 
@@ -123,4 +123,3 @@ proc findIndexStartOffset*(f: IoHandle): Result[int64, string] =
     bytes = count.int64 * 8 + 24
 
   ok(-bytes)
-

--- a/ncli/era.nim
+++ b/ncli/era.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -113,7 +113,7 @@ proc readIndex*(f: IoHandle): Result[Index, string] =
   # technically not an error, but we'll throw this sanity check in here..
   if slot > int32.high().uint64: return err("fishy slot")
 
-  var offsets = newSeqUninitialized[int64](count)
+  var offsets = newSeqUninit[int64](count)
   for i in 0..<count:
     let
       offset = uint64.fromBytesLE(buf.toOpenArray(pos, pos + 7))

--- a/tests/test_validator_bucket_sort.nim
+++ b/tests/test_validator_bucket_sort.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -228,8 +228,8 @@ func findValidatorIndexBruteforce(
     if validators[validatorIndex.distinctBase].pubkey == h2:
       return Opt.some validatorIndex
   for validatorIndex in bsv.bucketSorted:
-    if validators[validatorIndex].pubkey == h2:
-      return Opt.some validatorIndex.ValidatorIndex
+    if validators[validatorIndex.distinctBase].pubkey == h2:
+      return Opt.some validatorIndex
   Opt.none ValidatorIndex
 
 suite "ValidatorPubKey bucket sort":


### PR DESCRIPTION
[newSeqUninitialized](https://nim-lang.org/docs/system.html#newSeqUninitialized%2CNatural) states:
>  **Deprecated**: Use [`newSeqUninit`](https://nim-lang.org/docs/system.html#newSeqUninit%2CNatural) instead,