### PR TITLE
use Electra genesis for local testnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ local-testnet-minimal:
 		--remote-validators-count 512 \
 		--signer-type $(SIGNER_TYPE) \
 		--deneb-fork-epoch 0 \
-		--electra-fork-epoch 2 \
+		--electra-fork-epoch 0 \
 		--stop-at-epoch 6 \
 		--disable-htop \
 		--enable-payload-builder \
@@ -264,7 +264,7 @@ local-testnet-mainnet:
 		--data-dir $@ \
 		--nodes 2 \
 		--deneb-fork-epoch 0 \
-		--electra-fork-epoch 2 \
+		--electra-fork-epoch 0 \
 		--stop-at-epoch 6 \
 		--disable-htop \
 		--base-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \


### PR DESCRIPTION
It's what the EF uses (if not sometimes Fulu), and by next release none of the supported networks will be running Deneb anymore.