### PR TITLE
rm unnecessary use of std/options

### DIFF
--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -9,8 +9,7 @@
 
 import
   # Standard library
-  std/[algorithm, math, parseutils, strformat, strutils, typetraits, unicode,
-       uri, hashes],
+  std/[strformat, strutils, typetraits, unicode, uri, hashes],
   # Third-party libraries
   normalize,
   # Status libraries
@@ -23,6 +22,10 @@ import
   # Local modules
   libp2p/crypto/crypto as lcrypto,
   ./datatypes/base,  ./signatures
+
+from std/algorithm import binarySearch
+from std/math import `^`
+from std/parseutils import parseBiggestUInt
 
 export base, uri, io2, options
 
@@ -150,9 +153,9 @@ type
   ProvenProperty* = object
     path*: string
     description*: Option[string]
-    denebIndex*: Option[GeneralizedIndex]
-    electraIndex*: Option[GeneralizedIndex]
-    fuluIndex*: Option[GeneralizedIndex]
+    denebIndex*: GeneralizedIndex
+    electraIndex*: GeneralizedIndex
+    fuluIndex*: GeneralizedIndex
 
   KeystoreData* = object
     version*: uint64
@@ -729,15 +732,15 @@ func parseProvenBlockProperty*(propertyPath: string): Result[ProvenProperty, str
     debugFuluComment "We don't know yet if `GeneralizedIndex` will stay same in Fulu yet."
     ok ProvenProperty(
       path: propertyPath,
-      denebIndex: some GeneralizedIndex(801),
-      electraIndex: some GeneralizedIndex(801),
-      fuluIndex: some GeneralizedIndex(801))
+      denebIndex: GeneralizedIndex(801),
+      electraIndex: GeneralizedIndex(801),
+      fuluIndex: GeneralizedIndex(801))
   elif propertyPath == ".graffiti":
     ok ProvenProperty(
       path: propertyPath,
-      denebIndex: some GeneralizedIndex(18),
-      electraIndex: some GeneralizedIndex(18),
-      fuluIndex: some GeneralizedIndex(18))
+      denebIndex: GeneralizedIndex(18),
+      electraIndex: GeneralizedIndex(18),
+      fuluIndex: GeneralizedIndex(18))
   else:
     err("Keystores with proven properties different than " &
         "`.execution_payload.fee_recipient` and `.graffiti` " &
@@ -844,13 +847,13 @@ proc readValue*(reader: var JsonReader, value: var RemoteKeystore)
       var provenProperties = reader.readValue(seq[ProvenProperty])
       for prop in provenProperties.mitems:
         if prop.path == ".execution_payload.fee_recipient":
-          prop.denebIndex = some GeneralizedIndex(801)
-          prop.electraIndex = some GeneralizedIndex(801)
-          prop.fuluIndex = some GeneralizedIndex(801)
+          prop.denebIndex = GeneralizedIndex(801)
+          prop.electraIndex = GeneralizedIndex(801)
+          prop.fuluIndex = GeneralizedIndex(801)
         elif prop.path == ".graffiti":
-          prop.denebIndex = some GeneralizedIndex(18)
-          prop.electraIndex = some GeneralizedIndex(18)
-          prop.fuluIndex = some GeneralizedIndex(18)
+          prop.denebIndex = GeneralizedIndex(18)
+          prop.electraIndex = GeneralizedIndex(18)
+          prop.fuluIndex = GeneralizedIndex(18)
         else:
           reader.raiseUnexpectedValue("Keystores with proven properties different than " &
                                       "`.execution_payload.fee_recipient` and `.graffiti` " &

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -546,7 +546,6 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
                        ): Future[SignatureResult]
                        {.async: (raises: [CancelledError]).} =
   type SomeBlockBody =
-    capella.BeaconBlockBody |
     deneb.BeaconBlockBody |
     electra.BeaconBlockBody |
     electra_mev.BlindedBeaconBlockBody |
@@ -557,15 +556,14 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
                                  forkIndexField: untyped): seq[Web3SignerMerkleProof] =
     var proofs: seq[Web3SignerMerkleProof]
     for prop in v.data.provenBlockProperties:
-      if prop.forkIndexField.isSome:
-        let
-          idx = prop.forkIndexField.get
-          proofRes = build_proof(blockBody, idx)
-        if proofRes.isErr:
-          return err proofRes.error
-        proofs.add Web3SignerMerkleProof(
-          index: idx,
-          proof: proofRes.get)
+      let
+        idx = prop.forkIndexField
+        proofRes = build_proof(blockBody, idx)
+      if proofRes.isErr:
+        return err proofRes.error
+      proofs.add Web3SignerMerkleProof(
+        index: idx,
+        proof: proofRes.get)
     proofs
 
   case v.kind

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -135,9 +135,9 @@ suite "Remove keystore testing suite":
       check keystore.remotes[0].id == 0
       check keystore.remotes[0].pubkey.toHex == "8b9c875fbe539c6429c4fc304675062579ce47fb6b2ac6b6a1ba1188ca123a80affbfe381dbbc8e7f2437709a4c3325c"
       check keystore.provenBlockProperties.len == 1
-      check keystore.provenBlockProperties[0].denebIndex == some GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].electraIndex == some GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].fuluIndex == some GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].denebIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].electraIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].fuluIndex == GeneralizedIndex(801)
 
   test "Verifying Signer / Many remotes":
     for version in [3]:
@@ -184,6 +184,6 @@ suite "Remove keystore testing suite":
       check keystore.remotes[2].pubkey.toHex == "8f5f9e305e7fcbde94182747f5ecec573d1786e8320a920347a74c0ff5e70f12ca22607c98fdc8dbe71161db59e0ac9d"
       check keystore.threshold == 2
       check keystore.provenBlockProperties.len == 1
-      check keystore.provenBlockProperties[0].denebIndex == some GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].electraIndex == some GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].fuluIndex == some GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].denebIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].electraIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].fuluIndex == GeneralizedIndex(801)

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -263,9 +263,9 @@ func getRemoteKeystoreData(data: string, basePort: int,
         provenBlockProperties: @[
           ProvenProperty(
             path: ".execution_payload.fee_recipient",
-            fuluIndex: some GeneralizedIndex(801),
-            electraIndex: some GeneralizedIndex(801),
-            denebIndex: some GeneralizedIndex(801)
+            fuluIndex: GeneralizedIndex(801),
+            electraIndex: GeneralizedIndex(801),
+            denebIndex: GeneralizedIndex(801)
           )
         ],
         version: uint64(4),


### PR DESCRIPTION
Pre-Bellatrix forks didn't always have these, but those aren't supported by the remote signer anymore.