### PR TITLE
fix Nim 2.2 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ _Alternatively, fire up our [experimental Vagrant instance with Nim pre-installe
 
 <!-- TODO: Is this up to date? -->
 
-The [generic instructions from the Nimbus repo](https://github.com/status-im/nimbus/#metric-visualisation) apply here as well.
+The [generic instructions from the Nimbus repo](https://github.com/status-im/nimbus-eth1/#metric-visualisation) apply here as well.
 
 Specific steps:
 

--- a/beacon_chain/statediff.nim
+++ b/beacon_chain/statediff.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -11,19 +11,20 @@ import
   stew/assign2,
   ./spec/forks
 
-func diffModIncEpoch[maxLen, T](hl: HashArray[maxLen, T], startSlot: uint64):
-    array[SLOTS_PER_EPOCH, T] =
-  static: doAssert maxLen.uint64 mod SLOTS_PER_EPOCH == 0
+func diffModIncEpoch[maxLength, T](
+    hl: HashArray[maxLength, T], startSlot: uint64): array[SLOTS_PER_EPOCH, T] =
+  static: doAssert maxLength.uint64 mod SLOTS_PER_EPOCH == 0
   doAssert startSlot mod SLOTS_PER_EPOCH == 0
   for i in startSlot ..< startSlot + SLOTS_PER_EPOCH:
-    result[i mod SLOTS_PER_EPOCH] = hl[i mod maxLen.uint64]
+    result[i mod SLOTS_PER_EPOCH] = hl[i mod maxLength.uint64]
 
-func applyModIncrement[maxLen, T](
-    ha: var HashArray[maxLen, T], hl: array[SLOTS_PER_EPOCH, T], slot: uint64) =
+func applyModIncrement[maxLength, T](
+    ha: var HashArray[maxLength, T], hl: array[SLOTS_PER_EPOCH, T],
+    slot: uint64) =
   var indexSlot = slot
 
   for item in hl:
-    ha[indexSlot mod maxLen.uint64] = item
+    ha[indexSlot mod maxLength.uint64] = item
     indexSlot += 1
 
 func applyValidatorIdentities(
@@ -51,9 +52,9 @@ func setValidatorStatusesNoWithdrawals(
     validator[].exit_epoch = hl[i].exit_epoch
     validator[].withdrawable_epoch = hl[i].withdrawable_epoch
 
-func replaceOrAddEncodeEth1Votes[T, maxLen](
-    votes0: openArray[T], votes0_len: int, votes1: HashList[T, maxLen]):
-    (bool, List[T, maxLen]) =
+func replaceOrAddEncodeEth1Votes[T, maxLength](
+    votes0: openArray[T], votes0_len: int, votes1: HashList[T, maxLength]):
+    (bool, List[T, maxLength]) =
   let
     num_votes0 = votes0.len
     lower_bound =
@@ -67,17 +68,17 @@ func replaceOrAddEncodeEth1Votes[T, maxLen](
       else:
         num_votes0
 
-  var res = (lower_bound == 0, default(List[T, maxLen]))
+  var res = (lower_bound == 0, default(List[T, maxLength]))
   for i in lower_bound ..< votes1.len:
     if not result[1].add votes1[i]:
       raiseAssert "same limit"
   res
 
-func replaceOrAddDecodeEth1Votes[T, maxLen](
-    votes0: var HashList[T, maxLen], eth1_data_votes_replaced: bool,
-    votes1: List[T, maxLen]) =
+func replaceOrAddDecodeEth1Votes[T, maxLength](
+    votes0: var HashList[T, maxLength], eth1_data_votes_replaced: bool,
+    votes1: List[T, maxLength]) =
   if eth1_data_votes_replaced:
-    votes0 = HashList[T, maxLen]()
+    votes0 = HashList[T, maxLength]()
 
   for item in votes1:
     if not votes0.add item:
@@ -209,8 +210,8 @@ func applyDiff*(
     state: var capella.BeaconState,
     immutableValidators: openArray[ImmutableValidatorData2],
     stateDiff: BeaconStateDiff) =
-  template assign[T, maxLen](
-      tgt: var HashList[T, maxLen], src: List[T, maxLen]) =
+  template assign[T, maxLength](
+      tgt: var HashList[T, maxLength], src: List[T, maxLength]) =
     assign(tgt.data, src)
     tgt.resetCache()
 

--- a/docs/the_nimbus_book/src/migration.md
+++ b/docs/the_nimbus_book/src/migration.md
@@ -188,6 +188,6 @@ For a quick guide on how to set up a systemd service, see [our systemd guide](./
 
 ## Final thoughts
 
-If you are unsure of the safety of a step, please get in touch with us directly on [discord](https://discord.gg/nnNEBvHu3m).
+If you are unsure of the safety of a step, please get in touch with us directly on [Discord](https://discord.gg/XRxWahP).
 Additionally, we recommend testing the migration works correctly on a testnet before going ahead on mainnet.
 


### PR DESCRIPTION
Using `maxLen` triggered a warning related to SSZ types:
```
2025-05-01T13:37:43.1741475Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(129, 34) template/generic instantiation of `replaceOrAddEncodeEth1Votes` from here
2025-05-01T13:37:43.1750697Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(138, 73) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(113, 16)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
2025-05-01T13:37:43.1786012Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(137, 33) template/generic instantiation of `diffModIncEpoch` from here
2025-05-01T13:37:43.1792356Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(111, 53) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(107, 14)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
2025-05-01T13:37:43.1823054Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(138, 33) template/generic instantiation of `diffModIncEpoch` from here
2025-05-01T13:37:43.1828436Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(111, 53) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(107, 14)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
2025-05-01T13:37:43.1909849Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(220, 20) template/generic instantiation of `applyModIncrement` from here
2025-05-01T13:37:43.1915162Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(111, 53) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(107, 14)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
2025-05-01T13:37:43.1929947Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(221, 20) template/generic instantiation of `applyModIncrement` from here
2025-05-01T13:37:43.1936810Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(111, 53) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(107, 14)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
2025-05-01T13:37:43.1943149Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/statediff.nim(226, 30) template/generic instantiation of `replaceOrAddDecodeEth1Votes` from here
2025-05-01T13:37:43.1949411Z /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(138, 73) Warning: a new symbol 'maxLen' has been injected during template or generic instantiation, however 'maxLen' [genericParam declared in /github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization/types.nim(113, 16)] captured at the proc declaration will be used instead; either enable --experimental:openSym to use the injected symbol, or `bind` this captured symbol explicitly [IgnoredSymbolInjection]
```