### PR TITLE
ncli_db: Add non zero exit code when not all era files can be written

### DIFF
--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -663,9 +663,11 @@ proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
       if (let e = io2.removeFile(name); e.isErr):
         warn "Failed to clean up incomplete era file", tmpName, error = e.error
 
-  if missingHistory:
-    notice "Some era files were not written due to missing state history - see https://nimbus.guide/trusted-node-sync.html#recreate-historical-state-access-indices for more information"
   printTimers(true, timers)
+
+  if missingHistory:
+    warn "Some era files were not written due to missing state history - see https://nimbus.guide/trusted-node-sync.html#recreate-historical-state-access-indices for more information"
+    quit QuitFailure
 
 proc cmdImportEra(conf: DbConf, cfg: RuntimeConfig) =
   let db = BeaconChainDB.new(conf.databaseDir.string)


### PR DESCRIPTION
Required in order to be able to properly alert on this failure.

See also https://github.com/status-im/nimbus-eth2/issues/7073