### PR TITLE
Remove Capella upgrade cosmetics

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2439,8 +2439,6 @@ proc updateHead*(
         handler()
 
     # Policy: Retain back through Mainnet's second latest fork.
-    ConsensusFork.Capella.logForkUpgrade(
-      dag.vanityLogs.onUpgradeToCapella)
     ConsensusFork.Deneb.logForkUpgrade(
       dag.vanityLogs.onUpgradeToDeneb)
     ConsensusFork.Electra.logForkUpgrade(

--- a/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
@@ -15,10 +15,6 @@ type
   LogProc* = proc() {.gcsafe, raises: [].}
 
   VanityLogs* = object
-    # Gets displayed on upgrade to Capella. May be displayed multiple times
-    # in case of chain reorgs around the upgrade.
-    onUpgradeToCapella*: LogProc
-
     # Gets displayed on when a BLS to execution change message for a validator
     # known by this node appears in a head block
     onKnownBlsToExecutionChange*: LogProc
@@ -41,7 +37,6 @@ type
 # Policy: Retain retired art files in the directory, but don't link them anymore
 
 proc capellaMono*()  = notice "\n" & staticRead("capella" / "mono.txt")
-proc capellaColor*() = notice "\n" & staticRead("capella" / "color.ans")
 proc capellaBlink*() = notice "\n" & staticRead("capella" / "blink.ans")
 
 proc denebMono*()  = notice "\n" & staticRead("deneb" / "mono.txt")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -146,22 +146,18 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   of StdoutLogKind.Auto: raiseAssert "inadmissable here"
   of StdoutLogKind.Colors:
     VanityLogs(
-      onUpgradeToCapella:              capellaColor,
       onKnownBlsToExecutionChange:     capellaBlink,
       onUpgradeToDeneb:                denebColor,
       onUpgradeToElectra:              electraColor,
       onKnownCompoundingChange:        electraBlink)
   of StdoutLogKind.NoColors:
     VanityLogs(
-      onUpgradeToCapella:              capellaMono,
       onKnownBlsToExecutionChange:     capellaMono,
       onUpgradeToDeneb:                denebMono,
       onUpgradeToElectra:              electraMono,
       onKnownCompoundingChange:        electraMono)
   of StdoutLogKind.Json, StdoutLogKind.None:
     VanityLogs(
-      onUpgradeToCapella:
-        (proc() = notice "🦉 Withdrowls now available 🦉"),
       onKnownBlsToExecutionChange:
         (proc() = notice "🦉 BLS to execution changed 🦉"),
       onUpgradeToDeneb:


### PR DESCRIPTION
In line with keeping transition logs for latest two mainnet forks, Capella rotates out, while Deneb / Electra are kept.