### PR TITLE
Add option to invalidate block roots

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -122,6 +122,7 @@ AllTests-mainnet
 ```
 ## Block processor [Preset: mainnet]
 ```diff
++ Invalidate block root [Preset: mainnet]                                                    OK
 + Reverse order block add & get [Preset: mainnet]                                            OK
 ```
 ## Block quarantine

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -580,6 +580,34 @@ type
         defaultValue: false
         name: "dump" .}: bool
 
+      # Because certain EL (e.g., Geth) may return SYNCING/ACCEPTED even for
+      # execution payloads that have already been deemed INVALID in the past,
+      # this flag is needed to avoid optimistically importing beacon blocks
+      # that contain such payloads into fork choice when Nimbus is restarted.
+      # This helps manual recovery when the justified checkpoint is advanced
+      # optimistically based on attestations in blocks with invalid payloads,
+      # such as the botched Prague/Electra deployment onto the Holesky testnet.
+      #
+      # The recovery flow is as follows:
+      # (1) Upgrade to an EL version that correctly identifies the invalid block
+      # (2) Restart Nimbus with `--debug-invalidate-block-root` set to the first
+      #     block known to have an invalid execution payload. Multiple blocks
+      #     may be specified if necessary
+      # (3) If Nimbus is already synced to the canonical (but invalid) branch,
+      #     wait until the EL informs Nimbus that this head is INVALID.
+      #     Nimbus then rewinds back to the latest valid head
+      # (4) Restart Nimbus again, ensuring that `--debug-invalidate-block-root`
+      #     is set up correctly. Nimbus will re-discover the invalid branch,
+      #     but this time will not optimistically import it, preventing the
+      #     invalid branch to become canonical in its local fork choice
+      # (5) Wait for a different branch to become canonical, and keep the
+      #     `--debug-invalidate-block-root` flag present until finality has
+      #     advanced beyond the problematic chain segment
+      invalidBlockRoots* {.
+        hidden
+        desc: "List of beacon block roots that, if the EL responds with SYNCING/ACCEPTED, are treated as if their execution payload was INVALID"
+        name: "debug-invalidate-block-root" .}: seq[Eth2Digest]
+
       directPeers* {.
         desc: "The list of privileged, secure and known peers to connect and maintain the connection to. This requires a not random netkey-file. In the multiaddress format like: /ip4/<address>/tcp/<port>/p2p/<peerId-public-key>, or enr format (enr:-xx). Peering agreements are established out of band and must be reciprocal"
         name: "direct-peer" .}: seq[string]

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -87,6 +87,7 @@ type
     dumpEnabled: bool
     dumpDirInvalid: string
     dumpDirIncoming: string
+    invalidBlockRoots: seq[Eth2Digest]
 
     # Producers
     # ----------------------------------------------------------------
@@ -127,11 +128,17 @@ proc new*(T: type BlockProcessor,
           consensusManager: ref ConsensusManager,
           validatorMonitor: ref ValidatorMonitor,
           blobQuarantine: ref BlobQuarantine,
-          getBeaconTime: GetBeaconTimeFn): ref BlockProcessor =
+          getBeaconTime: GetBeaconTimeFn,
+          invalidBlockRoots: seq[Eth2Digest] = @[]): ref BlockProcessor =
+  if invalidBlockRoots.len > 0:
+    warn "Config requests blocks to be treated as invalid",
+      debugInvalidateBlockRoot = invalidBlockRoots
+
   (ref BlockProcessor)(
     dumpEnabled: dumpEnabled,
     dumpDirInvalid: dumpDirInvalid,
     dumpDirIncoming: dumpDirIncoming,
+    invalidBlockRoots: invalidBlockRoots,
     blockQueue: newAsyncQueue[BlockEntry](),
     consensusManager: consensusManager,
     validatorMonitor: validatorMonitor,
@@ -619,6 +626,10 @@ proc storeBlock(
           # based on payload timestamp (only allowed post Deneb);
           # There are no `blob_kzg_commitments` before Deneb to compare against
           discard
+
+        if signedBlock.root in self.invalidBlockRoots:
+          returnWithError "Block root treated as invalid via config",
+            $signedBlock.root
 
   let newPayloadTick = Moment.now()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -435,7 +435,7 @@ proc initFullNode(
     blockProcessor = BlockProcessor.new(
       config.dumpEnabled, config.dumpDirInvalid, config.dumpDirIncoming,
       batchVerifier, consensusManager, node.validatorMonitor,
-      blobQuarantine, getBeaconTime)
+      blobQuarantine, getBeaconTime, config.invalidBlockRoots)
 
     blockVerifier = proc(signedBlock: ForkedSignedBeaconBlock,
                          blobs: Opt[BlobSidecars], maybeFinalized: bool):

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -35,11 +35,17 @@ proc pruneAtFinalization(dag: ChainDAGRef) =
 
 suite "Block processor" & preset():
   setup:
-    let rng = HmacDrbgContext.new()
-    var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+    let
+      rng = HmacDrbgContext.new()
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+        res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+        res
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
+    var
       taskpool = Taskpool.new()
       quarantine = newClone(Quarantine.init())
       blobQuarantine = newClone(BlobQuarantine())
@@ -51,15 +57,19 @@ suite "Block processor" & preset():
         newClone(DynamicFeeRecipientsStore.init()), "",
         Opt.some default(Eth1Address), defaultGasLimit)
       state = newClone(dag.headState)
-      cache = StateCache()
-      b1 = addTestBlock(state[], cache).phase0Data
-      b2 = addTestBlock(state[], cache).phase0Data
+      cache: StateCache
+      info: ForkedEpochInfo
+    cfg.process_slots(
+      state[], cfg.lastPremergeSlotInTestCfg, cache, info, {}).expect("OK")
+    var
+      b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b2 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       getTimeFn = proc(): BeaconTime = b2.message.slot.start_beacon_time()
       batchVerifier = BatchVerifier.new(rng, taskpool)
       processor = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager,
         validatorMonitor, blobQuarantine, getTimeFn)
-      processorFut = processor.runQueueProcessingLoop()
+      processorFut {.used.} = processor.runQueueProcessingLoop()
 
   asyncTest "Reverse order block add & get" & preset():
     let
@@ -108,7 +118,7 @@ suite "Block processor" & preset():
     # check that init also reloads block graph
     var
       validatorMonitor2 = newClone(ValidatorMonitor.init())
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     check:
       # ensure we loaded the correct head state
@@ -118,3 +128,44 @@ suite "Block processor" & preset():
       dag2.getBlockRef(b2.root).isSome()
       dag2.heads.len == 1
       dag2.heads[0].root == b2.root
+
+  asyncTest "Invalidate block root" & preset():
+    let
+      processor = BlockProcessor.new(
+        false, "", "", batchVerifier, consensusManager,
+        validatorMonitor, blobQuarantine, getTimeFn,
+        invalidBlockRoots = @[b2.root])
+      processorFut = processor.runQueueProcessingLoop()
+    defer: await processorFut.cancelAndWait()
+
+    block:
+      let res = await processor[].addBlock(
+        MsgSource.gossip, ForkedSignedBeaconBlock.init(b2),
+        Opt.none(BlobSidecars))
+      check:
+        res.isErr
+        not dag.containsForkBlock(b1.root)
+        not dag.containsForkBlock(b2.root)
+
+    block:
+      let res = await processor[].addBlock(
+        MsgSource.gossip, ForkedSignedBeaconBlock.init(b1),
+        Opt.none(BlobSidecars))
+      check:
+        res.isOk
+        dag.containsForkBlock(b1.root)
+        not dag.containsForkBlock(b2.root)
+      while processor[].hasBlocks():
+        poll()
+      check:
+        dag.containsForkBlock(b1.root)
+        not dag.containsForkBlock(b2.root)
+
+    block:
+      let res = await processor[].addBlock(
+        MsgSource.gossip, ForkedSignedBeaconBlock.init(b2),
+        Opt.none(BlobSidecars))
+      check:
+        res == Result[void, VerifierError].err VerifierError.Invalid
+        dag.containsForkBlock(b1.root)
+        not dag.containsForkBlock(b2.root)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -149,6 +149,10 @@ func build_empty_execution_payload(
 
   payload
 
+func lastPremergeSlotInTestCfg*(cfg: RuntimeConfig): Slot =
+  # Merge shortly after Bellatrix
+  cfg.BELLATRIX_FORK_EPOCH.start_slot + 10
+
 proc addTestBlock*(
     state: var ForkedHashedBeaconState,
     cache: var StateCache,
@@ -191,9 +195,7 @@ proc addTestBlock*(
           # test relies on merging. So, merge only if no Capella transition.
           default(bellatrix.ExecutionPayloadForSigning)
         else:
-          # Merge shortly after Bellatrix
-          if  forkyState.data.slot >
-              cfg.BELLATRIX_FORK_EPOCH * SLOTS_PER_EPOCH + 10:
+          if forkyState.data.slot > cfg.lastPremergeSlotInTestCfg:
             if is_merge_transition_complete(forkyState.data):
               const feeRecipient = default(Eth1Address)
               build_empty_execution_payload(forkyState.data, feeRecipient)


### PR DESCRIPTION
When justification is advanced because of optimistically imported blocks that later turn out to have invalid payloads, the user needs a method to manually undo the justification. Because certain EL forget about blocks that have been invalid and return SYNCING/ACCEPTED again, the user can't simply restart Nimbus, as it would end up in the same situation again. Therefore, add a debug flag to resolve such issues, this was needed e.g. during Holesky Pectra deployment issues (canonical chain was invalid).