### PR TITLE
logs cleanup: remove unused stuff

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -954,7 +954,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       block:
         let
           version = request.headers.getString("eth-consensus-version")
-          validation =
+          validation {.used.} =
             block:
               let res =
                 if broadcast_validation.isNone():
@@ -1143,7 +1143,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       currentEpochFork =
         node.dag.cfg.consensusForkAtEpoch(node.currentSlot().epoch())
       version = request.headers.getString("eth-consensus-version")
-      validation =
+      validation {.used.} =
         if broadcast_validation.isNone():
           BroadcastValidationType.Gossip
         else:

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -509,21 +509,6 @@ proc doCreateTestnet*(config: CliConfig,
     writeFile(bootstrapFile, enr.toURI)
     echo "Wrote ", bootstrapFile
 
-type
-  DelayGenerator {.used.} = proc(): chronos.Duration {.gcsafe, raises: [].}
-
-func ethToWei(eth: UInt256): UInt256 {.used.} =
-  eth * 1000000000000000000.u256
-
-proc initWeb3(web3Url, privateKey: string): Future[Web3] {.async, used.} =
-  result = await newWeb3(web3Url)
-  if privateKey.len != 0:
-    result.privateKey = Opt.some(keys.PrivateKey.fromHex(privateKey)[])
-  else:
-    let accounts = await result.provider.eth_accounts()
-    doAssert(accounts.len > 0)
-    result.defaultAccount = accounts[0]
-
 {.pop.} # TODO confutils.nim(775, 17) Error: can raise an unlisted exception: ref IOError
 
 when isMainModule:
@@ -533,6 +518,21 @@ when isMainModule:
 
   from std/sequtils import mapIt, toSeq
   from std/terminal import readPasswordFromStdin
+
+  type
+    DelayGenerator = proc(): chronos.Duration {.gcsafe, raises: [].}
+
+  func ethToWei(eth: UInt256): UInt256 =
+    eth * 1000000000000000000.u256
+
+  proc initWeb3(web3Url, privateKey: string): Future[Web3] {.async.} =
+    result = await newWeb3(web3Url)
+    if privateKey.len != 0:
+      result.privateKey = Opt.some(keys.PrivateKey.fromHex(privateKey)[])
+    else:
+      let accounts = await result.provider.eth_accounts()
+      doAssert(accounts.len > 0)
+      result.defaultAccount = accounts[0]
 
   # Compiled version of /scripts/depositContract.v.py in this repo
   # The contract was compiled in Remix (https://remix.ethereum.org/) with vyper (remote) compiler.

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -510,12 +510,12 @@ proc doCreateTestnet*(config: CliConfig,
     echo "Wrote ", bootstrapFile
 
 type
-  DelayGenerator = proc(): chronos.Duration {.gcsafe, raises: [].}
+  DelayGenerator {.used.} = proc(): chronos.Duration {.gcsafe, raises: [].}
 
-func ethToWei(eth: UInt256): UInt256 =
+func ethToWei(eth: UInt256): UInt256 {.used.} =
   eth * 1000000000000000000.u256
 
-proc initWeb3(web3Url, privateKey: string): Future[Web3] {.async.} =
+proc initWeb3(web3Url, privateKey: string): Future[Web3] {.async, used.} =
   result = await newWeb3(web3Url)
   if privateKey.len != 0:
     result.privateKey = Opt.some(keys.PrivateKey.fromHex(privateKey)[])

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -759,7 +759,6 @@ suite "Attestation pool electra processing" & preset():
   setup:
     # Genesis state that results in 6 members per committee (2 committees total)
     const TOTAL_COMMITTEES = 2
-    let rng = HmacDrbgContext.new()
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
       cfg = genesisTestRuntimeConfig(ConsensusFork.Electra)
@@ -768,8 +767,6 @@ suite "Attestation pool electra processing" & preset():
         makeTestDB(
           TOTAL_COMMITTEES * TARGET_COMMITTEE_SIZE * SLOTS_PER_EPOCH, cfg = cfg),
         validatorMonitor, {})
-      taskpool = Taskpool.new()
-      verifier = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init())
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -78,7 +78,7 @@ suite "Attestation pool processing" & preset():
         ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 6),
         validatorMonitor, {})
       taskpool = Taskpool.new()
-      verifier = BatchVerifier.init(rng, taskpool)
+      verifier {.used.} = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init())
       pool = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -59,8 +59,6 @@ suite "BlockSlot and helpers":
       s1 = BlockRef(bid: BlockId(slot: Slot(1)), parent: s0)
       s2 = BlockRef(bid: BlockId(slot: Slot(2)), parent: s1)
       s4 = BlockRef(bid: BlockId(slot: Slot(4)), parent: s2)
-      se1 = BlockRef(bid:
-        BlockId(slot: Epoch(1).start_slot()), parent: s2)
 
     check:
       s0.atSlot(Slot(0)).blck == s0

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -69,7 +69,7 @@ suite "Block processor" & preset():
       processor = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager,
         validatorMonitor, blobQuarantine, getTimeFn)
-      discard processor.runQueueProcessingLoop()
+    discard processor.runQueueProcessingLoop()
 
   asyncTest "Reverse order block add & get" & preset():
     let

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -59,7 +59,6 @@ suite "Block processor" & preset():
       processor = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager,
         validatorMonitor, blobQuarantine, getTimeFn)
-      processorFut = processor.runQueueProcessingLoop()
 
   asyncTest "Reverse order block add & get" & preset():
     let

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -59,6 +59,7 @@ suite "Block processor" & preset():
       processor = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager,
         validatorMonitor, blobQuarantine, getTimeFn)
+      discard processor.runQueueProcessingLoop()
 
   asyncTest "Reverse order block add & get" & preset():
     let

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -48,14 +48,14 @@ suite "Block pool processing" & preset():
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
       taskpool = Taskpool.new()
-      verifier = BatchVerifier.init(rng, taskpool)
-      quarantine = Quarantine.init()
+      verifier {.used.} = BatchVerifier.init(rng, taskpool)
+      quarantine {.used.} = Quarantine.init()
       state = newClone(dag.headState)
       cache = StateCache()
-      info = ForkedEpochInfo()
+      info {.used.} = ForkedEpochInfo()
       att0 = makeFullAttestations(state[], dag.tail.root, 0.Slot, cache)
-      b1 = addTestBlock(state[], cache, attestations = att0).phase0Data
-      b2 = addTestBlock(state[], cache).phase0Data
+      b1 {.used.} = addTestBlock(state[], cache, attestations = att0).phase0Data
+      b2 {.used.} = addTestBlock(state[], cache).phase0Data
 
   test "basic ops":
     check:
@@ -362,7 +362,7 @@ suite "chain DAG finalization tests" & preset():
       verifier = BatchVerifier.init(rng, taskpool)
       quarantine = Quarantine.init()
       cache = StateCache()
-      info = ForkedEpochInfo()
+      info {.used.} = ForkedEpochInfo()
 
   test "prune heads on finalization" & preset():
     # Create a fork that will not be taken

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -284,7 +284,6 @@ suite "Block pool altair processing" & preset():
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
-      quarantine = Quarantine.init()
       state = newClone(dag.headState)
       cache = StateCache()
       info = ForkedEpochInfo()
@@ -670,7 +669,6 @@ suite "Old database versions" & preset():
     var
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
-      quarantine = Quarantine.init()
 
   test "pre-1.1.0":
     # only kvstore, no immutable validator keys

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -45,13 +45,13 @@ suite "Gossip validation " & preset():
         ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3),
         validatorMonitor, {})
       taskpool = Taskpool.new()
-      verifier = BatchVerifier.init(rng, taskpool)
+      verifier {.used.} = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init())
-      pool = newClone(AttestationPool.init(dag, quarantine))
+      pool {.used.} = newClone(AttestationPool.init(dag, quarantine))
       state = newClone(dag.headState)
       cache = StateCache()
       info = ForkedEpochInfo()
-      batchCrypto = BatchCrypto.new(
+      batchCrypto {.used.} = BatchCrypto.new(
         rng, eager = proc(): bool = false,
         genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
           "working batcher")

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -15,16 +15,12 @@ import
   ./testutil
 
 func sign(secrets: seq[SecretShare], message: seq[byte]): seq[SignatureShare] =
-  let msg = message
   return secrets.mapIt(it.key.blsSign(message).toSignatureShare(it.id))
 
 suite "Key spliting":
   let
     privateKey = ValidatorPrivKey.init("0x25295f0d1d592a90b333e26e85149708208e9f8e8bc18f6c77bd62f8ad7a6866")
     pubKey = privateKey.toPubKey.toPubKey
-    password = string.fromBytes hexToSeqByte("7465737470617373776f7264f09f9491")
-    salt = hexToSeqByte "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
-    iv = hexToSeqByte "264daa3f303d7259501c93d997d84fe6"
     rng = HmacDrbgContext.new()
     msg = rng[].generateBytes(32)
 

--- a/tests/test_key_splitting.nim
+++ b/tests/test_key_splitting.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -136,9 +136,9 @@ const
   nodeValidatorsDir = nodeDataDir / "validators"
   nodeSecretsDir = nodeDataDir / "secrets"
 
-  vcDataDir = dataDir / "validator-0"
-  vcValidatorsDir = vcDataDir / "validators"
-  vcSecretsDir = vcDataDir / "secrets"
+  # vcDataDir = dataDir / "validator-0"
+  # vcValidatorsDir = vcDataDir / "validators"
+  # vcSecretsDir = vcDataDir / "secrets"
 
 func specifiedFeeRecipient(x: int): Eth1Address =
   copyMem(addr result, unsafeAddr x, sizeof x)
@@ -2022,13 +2022,13 @@ proc delayedTests(basePort: int, pool: ref ValidatorPool,
       validatorPool: pool,
       keymanagerHost: host)
 
-    validatorClientKeymanager = KeymanagerToTest(
-      ident: "Validator Client",
-      port: basePort + PortKind.KeymanagerVC.ord,
-      validatorsDir: vcValidatorsDir,
-      secretsDir: vcSecretsDir,
-      validatorPool: pool,
-      keymanagerHost: host)
+    # validatorClientKeymanager = KeymanagerToTest(
+    #   ident: "Validator Client",
+    #   port: basePort + PortKind.KeymanagerVC.ord,
+    #   validatorsDir: vcValidatorsDir,
+    #   secretsDir: vcSecretsDir,
+    #   validatorPool: pool,
+    #   keymanagerHost: host)
 
   while bnStatus != BeaconNodeStatus.Running:
     await sleepAsync(1.seconds)

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_keystore.nim
+++ b/tests/test_keystore.nim
@@ -240,8 +240,8 @@ let
 
 suite "KeyStorage testing suite":
   setup:
-    let secret = ValidatorPrivKey.fromRaw(secretBytes).get
-    let nsecret = init(lcrypto.PrivateKey, secretNetBytes).get
+    let secret {.used.} = ValidatorPrivKey.fromRaw(secretBytes).get
+    let nsecret {.used.} = init(lcrypto.PrivateKey, secretNetBytes).get
 
   test "Load Prysm keystore":
     let keystore = parseKeystore(prysmKeystore)

--- a/tests/test_network_metadata.nim
+++ b/tests/test_network_metadata.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_network_metadata.nim
+++ b/tests/test_network_metadata.nim
@@ -17,7 +17,6 @@ import
 template checkRoot(name, root) =
   let
     metadata = getMetadataForNetwork(name)
-    cfg = metadata.cfg
     state = newClone(readSszForkedHashedBeaconState(
       metadata.cfg, metadata.genesis.bakedBytes))
 

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -21,7 +21,7 @@ from ../beacon_chain/spec/state_transition import process_slots
 
 suite "Beacon state" & preset():
   setup:
-    let cfg = defaultRuntimeConfig
+    let cfg {.used.} = defaultRuntimeConfig
 
   test "Smoke test initialize_beacon_state_from_eth1" & preset():
     let state = newClone(initialize_beacon_state_from_eth1(

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -103,7 +103,6 @@ suite "Beacon state" & preset():
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       genBlock = get_initial_beacon_block(state[])
       cache: StateCache
-      info: ForkedEpochInfo
 
     check:
       state[].phase0Data.dependent_root(Epoch(0)) == genBlock.root
@@ -143,7 +142,6 @@ suite "Beacon state" & preset():
           makeInitialDeposits(SLOTS_PER_EPOCH, {}), {skipBlsValidation}))
       genBlock = get_initial_beacon_block(state[])
       cache: StateCache
-      info: ForkedEpochInfo
 
     check:
       state[].can_advance_slots(genBlock.root, Slot(0))

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -86,7 +86,7 @@ suite "Validator change pool testing suite":
       dag = init(
         ChainDAGRef, cfg, makeTestDB(SLOTS_PER_EPOCH * 3),
         validatorMonitor, {})
-      fork = dag.forkAtEpoch(Epoch(0))
+      fork {.used.} = dag.forkAtEpoch(Epoch(0))
       genesis_validators_root = dag.genesis_validators_root
       pool = newClone(ValidatorChangePool.init(dag))
 

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2024 Status Research & Development GmbH
+# Copyright (c) 2020-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -200,7 +200,6 @@ suite "Validator change pool testing suite":
       dag.cfg, dag.headState,
       Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 1,
       cache, info, {}).expect("ok")
-    let fork = dag.forkAtEpoch(dag.headState.get_current_epoch())
 
     for i in 0'u64 .. MAX_BLS_TO_EXECUTION_CHANGES + 5:
       for j in 0'u64 .. i:
@@ -231,7 +230,6 @@ suite "Validator change pool testing suite":
       dag.cfg, dag.headState,
       Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 2,
       cache, info, {}).expect("ok")
-    let fork = dag.forkAtEpoch(dag.headState.get_current_epoch())
 
     for i in 0'u64 .. MAX_BLS_TO_EXECUTION_CHANGES + 5:
       var priorityMessages: seq[SignedBLSToExecutionChange]


### PR DESCRIPTION
The first commit removes stuff that the compiler (correctly) reports as unused.

The second commit deals with the remaining unused hints, mostly in tests where the compiler doesn't recognize that the stuff declared in a `setup:` is used in a `test:` or `check:`.