### PR TITLE
Add basic overview of destructors in Nim memory management section

### DIFF
--- a/docs/the_auditors_handbook/src/02.2.3_memory_management_gc.md
+++ b/docs/the_auditors_handbook/src/02.2.3_memory_management_gc.md
@@ -19,7 +19,29 @@ to cycles, Nim will add "mark-and-sweep" passes to collect them.
 
 ## Destructors
 
-TODO
+Destructors in Nim are defined with the `=destroy` procedure.
+
+They allow releasing non-memory resources, like file descriptors or sockets,
+when an object goes out of scope or is freed by the GC.
+
+They work for both stack-based objects and `ref` types.
+
+For `ref` types, destructors run when the last reference is released.
+This may be delayed in the presence of cycles.
+
+```nim
+type MyResource = object
+  fd: int
+
+proc `=destroy`(r: var MyResource) =
+  if r.fd != -1:
+    close(r.fd)
+    r.fd = -1
+```
+
+Avoid relying on destructors for timely cleanup.
+
+Use `try/finally` or explicit resource release when needed.
 
 ## Nim allocator
 


### PR DESCRIPTION
This PR replaces the `TODO` placeholder in the **Destructors** section of `02.2.3_memory_management_gc.md` with a concise explanation of how destructors work in Nim
