### PR TITLE
unhide BareExcept warnings and make them errors

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -178,14 +178,11 @@ if canEnableDebuggingSymbols:
 
 --define:nimOldCaseObjects # https://github.com/status-im/nim-confutils/issues/9
 
+switch("warningAsError", "BareExcept:on")
 switch("warningAsError", "UnusedImport:on")
 
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")
-
-# Too many right now to read compiler output. Warnings are legitimate, but
-# should be fixed out-of-band of `unstable` branch.
-switch("warning", "BareExcept:off")
 
 # Transitional for Nim v2.2, due to newSeqUninit replacing newSeqUninitialized.
 switch("warning", "Deprecated:off")


### PR DESCRIPTION
In the couple of years since:
- https://github.com/status-im/nim-confutils/pull/67
- https://github.com/status-im/nimbus-eth2/pull/4660
- https://github.com/status-im/nimbus-eth2/issues/4661
- https://github.com/status-im/nimbus-eth2/pull/4662
- https://github.com/status-im/nimbus-eth2/pull/4664
- https://github.com/status-im/nimbus-eth2/pull/4755

And maybe as a result of updating to Nim 2.2, these warnings appear to have vanished entirely.

There are, for the moment, some remaining localized use cases for them, such as test runners where arguably it's worth dealing with its not being architecturally defined anymore to keep the test framework robust, but in general those can be addressed by locally disabling this warning specifically there.