### PR TITLE
Prevent systemd restart on slashing exit code

### DIFF
--- a/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
+++ b/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
@@ -57,8 +57,8 @@ WorkingDirectory=/var/lib/nimbus
 TimeoutSec=1200
 Restart=always
 
-# Don't restart when Doppelganger detection has been activated
-RestartPreventExitStatus=129
+# Don't restart when Doppelganger or slashing detection has been activated
+RestartPreventExitStatus=129 198
 
 ExecStart=/usr/bin/nimbus_beacon_node \
   --network=${NETWORK} \


### PR DESCRIPTION
- https://github.com/status-im/nimbus-eth2/pull/7091#issuecomment-2882785318

For information, `RestartPreventExitStatus` is separated by spaces. https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#RestartPreventExitStatus=