### PR TITLE
fix most XCannotRaiseY hints

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1845,7 +1845,7 @@ proc new(T: type Eth2Node,
          ip: Opt[IpAddress], tcpPort, udpPort: Opt[Port],
          privKey: keys.PrivateKey, discovery: bool,
          directPeers: DirectPeers, announcedAddresses: openArray[MultiAddress],
-         rng: ref HmacDrbgContext): T {.raises: [CatchableError].} =
+         rng: ref HmacDrbgContext): T =
   when not defined(local_testnet):
     let
       connectTimeout = chronos.minutes(1)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2506,7 +2506,7 @@ proc doSlashingExport(conf: BeaconNodeConf) {.raises: [IOError].}=
   db.exportSlashingInterchange(interchange, conf.exportedValidators)
   echo "Export finished: '", dir/filetrunc & ".sqlite3" , "' into '", interchange, "'"
 
-proc doSlashingImport(conf: BeaconNodeConf) {.raises: [SerializationError, IOError].} =
+proc doSlashingImport(conf: BeaconNodeConf) {.raises: [IOError].} =
   let
     dir = conf.validatorsDir()
     filetrunc = SlashingDbName

--- a/beacon_chain/statusbar.nim
+++ b/beacon_chain/statusbar.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -107,7 +107,7 @@ proc renderCells(cells: seq[StatusBarCell], sep: string) =
       stdout.write cell.content, " "
       stdout.resetAttributes()
 
-proc render*(s: var StatusBarView) {.raises: [ValueError].} =
+proc render*(s: var StatusBarView) =
   doAssert s.consumedLines == 0
 
   let

--- a/beacon_chain/validators/slashing_protection.nim
+++ b/beacon_chain/validators/slashing_protection.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -115,8 +115,7 @@ proc init*(
 
 proc loadUnchecked*(
        T: type SlashingProtectionDB,
-       basePath, dbname: string, readOnly: bool
-     ): SlashingProtectionDB {.raises:[IOError].}=
+       basePath, dbname: string, readOnly: bool): SlashingProtectionDB =
   ## Load a slashing protection DB
   ## Note: This is for CLI tool usage
   ##       this doesn't check the genesis validator root
@@ -282,12 +281,10 @@ proc registerSyntheticAttestation*(db: SlashingProtectionDB,
        source, target: Epoch) =
   db.db_v2.registerSyntheticAttestation(validator, source, target)
 
-proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus
-             {.raises: [SerializationError, IOError].} =
+proc inclSPDIR*(db: SlashingProtectionDB, spdir: SPDIR): SlashingImportStatus =
   db.db_v2.inclSPDIR(spdir)
 
-proc toSPDIR*(db: SlashingProtectionDB): SPDIR
-             {.raises: [IOError].} =
+proc toSPDIR*(db: SlashingProtectionDB): SPDIR =
   db.db_v2.toSPDIR()
 
 proc exportSlashingInterchange*(

--- a/beacon_chain/validators/slashing_protection_common.nim
+++ b/beacon_chain/validators/slashing_protection_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -277,10 +277,7 @@ chronicles.formatIt SPDIR_SignedAttestation: it.shortLog
 # --------------------------------------------
 
 proc importInterchangeV5Impl*(
-       db: auto,
-       spdir: var SPDIR
-     ): SlashingImportStatus
-      {.raises: [SerializationError, IOError].} =
+    db: auto, spdir: var SPDIR): SlashingImportStatus =
   ## Common implementation of interchange import
   ## according to https://eips.ethereum.org/EIPS/eip-3076
   ## spdir needs to be `var` as it will be sorted in-place

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1381,8 +1381,7 @@ proc registerSyntheticAttestation*(
     let status = db.sqlCommitTransaction.exec()
     checkStatus()
 
-proc toSPDIR*(db: SlashingProtectionDB_v2): SPDIR
-             {.raises: [IOError].} =
+proc toSPDIR*(db: SlashingProtectionDB_v2): SPDIR =
   ## Export the full slashing protection database
   ## to a json the Slashing Protection Database Interchange (Complete) Format
   result.metadata.interchange_format_version = "5"
@@ -1477,8 +1476,8 @@ proc toSPDIR*(db: SlashingProtectionDB_v2): SPDIR
           )
         doAssert status.isOk()
 
-proc inclSPDIR*(db: SlashingProtectionDB_v2, spdir: SPDIR): SlashingImportStatus
-             {.raises: [SerializationError, IOError].} =
+proc inclSPDIR*(db: SlashingProtectionDB_v2, spdir: SPDIR):
+    SlashingImportStatus =
   ## Import a Slashing Protection Database Intermediate Representation
   ## file into the specified slashing protection DB
   ##

--- a/config.nims
+++ b/config.nims
@@ -187,7 +187,16 @@ switch("warning", "CaseTransition:off")
 # Transitional for Nim v2.2, due to newSeqUninit replacing newSeqUninitialized.
 switch("warning", "Deprecated:off")
 
-# Too many of these because of Defect compat in 1.2
+#   1 nimbus-eth2/tests/consensus_spec/test_fixture_ssz_generic_types.nim(238, 28) Hint: 'sszCheck' cannot raise 'YamlConstructionError' [XCannotRaiseY]
+#   1 nimbus-eth2/tests/consensus_spec/test_fixture_ssz_generic_types.nim(238, 51) Hint: 'sszCheck' cannot raise 'YamlParserError' [XCannotRaiseY]
+#   1 nimbus-eth2/vendor/nim-testutils/testutils/moduletests.nim(17, 24) Hint: 'main' cannot raise 'CatchableError' [XCannotRaiseY]
+#   2 nimbus-eth2/tests/consensus_spec/test_fixture_light_client_sync.nim(135, 20) Hint: 'loadTestMeta' cannot raise 'YamlConstructionError' [XCannotRaiseY]
+#   2 nimbus-eth2/tests/consensus_spec/test_fixture_light_client_sync.nim(135, 43) Hint: 'loadTestMeta' cannot raise 'YamlParserError' [XCannotRaiseY]
+#   2 nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(213, 58) Hint: 'readValue' cannot raise 'IOError' [XCannotRaiseY]
+#   3 nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(369, 38) Hint: 'readValue' cannot raise 'SerializationError' [XCannotRaiseY]
+#   3 nimbus-eth2/vendor/nim-toml-serialization/toml_serialization/reader.nim(369, 58) Hint: 'readValue' cannot raise 'IOError' [XCannotRaiseY]
+#   4 nimbus-eth2/vendor/nim-serialization/serialization.nim(27, 86) Hint: 'readValue' cannot raise 'IOError' [XCannotRaiseY]
+# 116 nimbus-eth2/vendor/nim-ssz-serialization/ssz_serialization.nim(51, 77) Hint: 'writeFixedSized' cannot raise 'IOError' [XCannotRaiseY]
 switch("hint", "XCannotRaiseY:off")
 
 # Useful for Chronos metrics.

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/altair/test_fixture_ssz_consensus_objects.nim
@@ -80,10 +80,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -143,7 +143,7 @@ suite baseDescription & "Execution Payload " & preset():
   proc makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var bellatrix.BeaconState, body: bellatrix.BeaconBlockBody):
-        Result[void, cstring] {.raises: [IOError].} =
+        Result[void, cstring] =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_ssz_consensus_objects.nim
@@ -80,10 +80,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -160,7 +160,7 @@ suite baseDescription & "Execution Payload " & preset():
   func makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var capella.BeaconState, body: capella.BeaconBlockBody):
-        Result[void, cstring] {.raises: [IOError].} =
+        Result[void, cstring] =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -82,10 +82,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/capella/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/deneb/test_fixture_operations.nim
+++ b/tests/consensus_spec/deneb/test_fixture_operations.nim
@@ -163,7 +163,7 @@ suite baseDescription & "Execution Payload " & preset():
   func makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var deneb.BeaconState, body: deneb.BeaconBlockBody):
-        Result[void, cstring] {.raises: [IOError].} =
+        Result[void, cstring] =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -85,10 +85,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/deneb/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/electra/test_fixture_operations.nim
+++ b/tests/consensus_spec/electra/test_fixture_operations.nim
@@ -198,7 +198,7 @@ suite baseDescription & "Execution Payload " & preset():
   func makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var electra.BeaconState, body: electra.BeaconBlockBody):
-        Result[void, cstring] {.raises: [IOError].} =
+        Result[void, cstring] =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/electra/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/electra/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -88,10 +88,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/fulu/test_fixture_operations.nim
+++ b/tests/consensus_spec/fulu/test_fixture_operations.nim
@@ -198,7 +198,7 @@ suite baseDescription & "Execution Payload " & preset():
   func makeApplyExecutionPayloadCb(path: string): auto =
     return proc(
         preState: var fulu.BeaconState, body: fulu.BeaconBlockBody):
-        Result[void, cstring] {.raises: [IOError].} =
+        Result[void, cstring] =
       let payloadValid = os_ops.readFile(
           OpExecutionPayloadDir/"pyspec_tests"/path/"execution.yaml"
         ).contains("execution_valid: true")

--- a/tests/consensus_spec/fulu/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/fulu/test_fixture_ssz_consensus_objects.nim
@@ -90,10 +90,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
+++ b/tests/consensus_spec/phase0/test_fixture_ssz_consensus_objects.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -80,10 +80,8 @@ proc checkSSZ(
 
   # TODO check the value (requires YAML loader)
 
-proc loadExpectedHashTreeRoot(
-    dir: string
-): SSZHashTreeRoot {.raises: [
-    Exception, IOError, OSError, YamlConstructionError, YamlParserError].} =
+proc loadExpectedHashTreeRoot(dir: string): SSZHashTreeRoot
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   let s = openFileStream(dir/"roots.yaml")
   yaml.load(s, result)
   s.close()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -81,8 +81,7 @@ type
 proc initialLoad(
     path: string, db: BeaconChainDB,
     StateType, BlockType: typedesc
-): tuple[dag: ChainDAGRef, fkChoice: ref ForkChoice] {.raises: [
-    IOError, UnconsumedInput].} =
+): tuple[dag: ChainDAGRef, fkChoice: ref ForkChoice] =
   let
     forkedState = loadForkedState(
       path/"anchor_state.ssz_snappy",
@@ -102,9 +101,7 @@ proc initialLoad(
 proc loadOps(
     path: string,
     fork: ConsensusFork
-): seq[Operation] {.raises: [
-    IOError, KeyError, UnconsumedInput, ValueError,
-    YamlConstructionError, YamlParserError].} =
+): seq[Operation] {.raises: [KeyError, ValueError].} =
   let stepsYAML = os_ops.readFile(path/"steps.yaml")
   let steps = loadToJson(stepsYAML)
 
@@ -297,11 +294,7 @@ proc stepChecks(
       raiseAssert "Unsupported check '" & $check & "'"
 
 proc doRunTest(
-    path: string,
-    fork: ConsensusFork
-) {.raises: [
-    IOError, KeyError, UnconsumedInput, ValueError,
-    YamlConstructionError, YamlParserError].} =
+    path: string, fork: ConsensusFork) {.raises: [KeyError, ValueError].} =
   let db = BeaconChainDB.new("", inMemory = true)
   defer:
     db.close()

--- a/tests/consensus_spec/test_fixture_light_client_data_collection.nim
+++ b/tests/consensus_spec/test_fixture_light_client_data_collection.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -82,8 +82,7 @@ proc loadForked[T: not Opt](
 proc loadSteps(
     path: string,
     fork_digests: ForkDigests
-): seq[TestStep] {.raises: [
-    IOError, KeyError, ValueError, YamlConstructionError, YamlParserError].} =
+): seq[TestStep] {.raises: [KeyError, ValueError].} =
   template loadForked[T](t: typedesc[T], s: JsonNode): T =
     loadForked(t, s, path, fork_digests)
 

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -56,8 +56,7 @@ type
 proc loadSteps(
     path: string,
     fork_digests: ForkDigests
-): seq[TestStep] {.raises: [
-    KeyError, ValueError, YamlConstructionError, YamlParserError].} =
+): seq[TestStep] {.raises: [KeyError, ValueError].} =
   let stepsYAML = os_ops.readFile(path/"steps.yaml")
   let steps = loadToJson(stepsYAML)
 
@@ -130,8 +129,10 @@ proc runTest(suiteName, path: string) =
   let relativePathComponent = path.relativeTestPathComponent()
   test "Light client - Sync - " & relativePathComponent:
     # Reduce stack size by making this a `proc`
-    proc loadTestMeta(): (RuntimeConfig, TestMeta) {.raises: [
-        Exception, IOError, PresetFileError, PresetIncompatibleError].} =
+    proc loadTestMeta(): (RuntimeConfig, TestMeta)
+        {.raises: [IOError, OSError, PresetFileError,
+                   PresetIncompatibleError, ValueError,
+                   YamlConstructionError, YamlParserError].} =
       let (cfg, _) = readRuntimeConfig(path/"config.yaml")
 
       type TestMetaYaml {.sparse.} = object

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -233,11 +233,9 @@ proc checkBitList(
 # Test dispatch for valid inputs
 # ------------------------------------------------------------------------
 
-proc sszCheck(
-    baseDir, sszType, sszSubType: string
-) {.raises: [
-    Exception, IOError, SerializationError,
-    TestSizeError, UnconsumedInput, ValueError].} =
+proc sszCheck(baseDir, sszType, sszSubType: string)
+    {.raises: [IOError, OSError, SerializationError, UnconsumedInput,
+               ValueError, YamlConstructionError, YamlParserError].} =
   let dir = baseDir/sszSubType
 
   # Hash tree root

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -26,8 +26,8 @@ type
     fork_block {.defaultVal: -1.}: int
     bls_setting {.defaultVal: 1.}: int
 
-proc getTransitionInfo(
-    testPath: string): TransitionInfo {.raises: [Exception, IOError].} =
+proc getTransitionInfo(testPath: string): TransitionInfo
+    {.raises: [IOError, OSError, YamlConstructionError, YamlParserError].} =
   var transitionInfo: TransitionInfo
   let s = openFileStream(testPath/"meta.yaml")
   defer: close(s)

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -149,8 +149,7 @@ proc statusOkOrDuplicateOrMinEpochViolation(
     return true
   return false
 
-proc runTest(identifier: string) {.raises: [IOError, SerializationError].} =
-
+proc runTest(identifier: string) =
   # The tests produce a lot of log noise
   # echo "\n\n===========================================\n\n"
 

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -22,7 +22,7 @@ type
 proc loadExampleConfig(
     content: string,
     cmdLine = newSeq[string]()
-): ExampleConfigFile {.raises: [ConfigurationError, OSError].} =
+): ExampleConfigFile {.raises: [ConfigurationError].} =
   ExampleConfigFile.load(
     cmdLine = cmdLine,
     secondarySources = proc (

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -92,8 +92,7 @@ func getNodePort(basePort: int, rt: RemoteSignerType): int =
 
 proc getBlock(
     fork: ConsensusFork,
-    feeRecipient = SigningExpectedFeeRecipient
-): ForkedBeaconBlock {.raises: [ResultError[cstring]].} =
+    feeRecipient = SigningExpectedFeeRecipient): ForkedBeaconBlock =
   try:
     case fork
     of ConsensusFork.Phase0 .. ConsensusFork.Capella:


### PR DESCRIPTION
The main reasons for remaining hints are:
- in a `vendor` submodule so out of scope of this PR; and/or
- different calling contexts do(n't) trigger the same exceptions, so naïvely fixing some of those results in compilation errors