### PR TITLE
Provide blocks / blobs regardless of payload validation status

### DIFF
--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -181,9 +181,6 @@ template getBlobSidecarsByRange(
   for i in startIndex..endIndex:
     for j in 0..<blobsPerBlock:
       if dag.db.getBlobSidecarSZ(blockIds[i].root, BlobIndex(j), bytes):
-        if not dag.head.executionValid:
-          continue
-
         let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
           warn "Cannot read blobs sidecar size, database corrupt?",
             bytes = bytes.len(), blck = shortLog(blockIds[i])
@@ -256,13 +253,6 @@ p2pProtocol BeaconSync(version = 1,
 
     for i in startIndex..endIndex:
       if dag.getBlockSZ(blocks[i], bytes):
-        # In general, there is not much intermediate time between post-merge
-        # blocks all being optimistic and none of them being optimistic. The
-        # EL catches up, tells the CL the head is verified, and that's it.
-        if  blocks[i].slot.epoch >= dag.cfg.BELLATRIX_FORK_EPOCH and
-            not dag.head.executionValid:
-          continue
-
         let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
           warn "Cannot read block size, database corrupt?",
             bytes = bytes.len(), blck = shortLog(blocks[i])
@@ -323,13 +313,6 @@ p2pProtocol BeaconSync(version = 1,
           continue
 
       if dag.getBlockSZ(blockRef.bid, bytes):
-        # In general, there is not much intermediate time between post-merge
-        # blocks all being optimistic and none of them being optimistic. The
-        # EL catches up, tells the CL the head is verified, and that's it.
-        if  blockRef.slot.epoch >= dag.cfg.BELLATRIX_FORK_EPOCH and
-            not dag.head.executionValid:
-          continue
-
         let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
           warn "Cannot read block size, database corrupt?",
             bytes = bytes.len(), blck = shortLog(blockRef)
@@ -487,10 +470,6 @@ p2pProtocol BeaconSync(version = 1,
     for i in startIndex..endIndex:
       for k in reqColumns:
         if dag.db.getDataColumnSidecarSZ(blockIds[i].root, ColumnIndex k, bytes):
-          if blockIds[i].slot.epoch >= dag.cfg.DENEB_FORK_EPOCH and
-              not dag.head.executionValid:
-            continue
-
           let uncompressedLen = uncompressedLenFramed(bytes).valueOr:
             warn "Cannot read data column sidecar size, database corrup?",
               bytes = bytes.len, blck = shortLog(blockIds[i])


### PR DESCRIPTION
The p2p specs state:

> Non-faulty, optimistic nodes may send blocks which result in an INVALID response from an execution engine. To prevent network segregation between optimistic and non-optimistic nodes, transmission of an INVALID execution payload via the Req/Resp domain SHOULD NOT cause a node to be down-scored or disconnected. Transmission of a block which is invalid due to any consensus layer rules (i.e., not execution layer rules) MAY result in down-scoring or disconnection.

They further state:

> - Optimistic nodes must listen to block gossip to obtain a view of the head of the chain.
> - Therefore, optimistic nodes must propagate gossip blocks. Otherwise, they'd be censoring.
> - If optimistic nodes will propagate blocks via gossip, then they must respond to requests for the parent via RPC.
> - Therefore, optimistic nodes must send optimistic blocks via RPC.

- https://github.com/ethereum/consensus-specs/blob/v1.5.0/specs/bellatrix/p2p-interface.md#why-allow-invalid-payloads-on-the-p2p-network

It is unclear where the requirement to respond to parent comes from (in theory the parent could be outside the sync range...), and it is also vague what "RPC" means. However, the intention can be inferred when looking at practical triggers for Req/Resp messages:

- Status message advertising a locally unknown root
- Attestation on gossip that refers to a locally unknown block
- Gossip message of a descendant block with an unknown parent block
- Sidecar referring to unknown block

As we participate in gossip while optimistically synced, we trigger this request logic in other peers. Currently, Nimbus answers with empty resp when the primary head is optimistically synced (i.e., EL is syncing). This is actively hurting the sync performance of others, as such a resp asserts explicit non-existence of the requested data.

We could improve that by answering with `3: ResourceUnavailable` error to indicate that we are actively syncing / have pruned the data, and let the peer ask someone else for the data. Further, we could also serve the known-good data up to the finalized checkpoint or the latest valid head.

However, withholding data that we actually have available doesn't help the network, especially so in difficult to sync non-finality scenarios or when genesis syncing from archive node peers. Therefore, recommending to remove the checks that prevent answering Req/Resp while opt synced.