### PR TITLE
stop testing get_next_slot_expected_withdrawals() mechanism on Deneb

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -776,7 +776,6 @@ AllTests-mainnet
 ```
 ## Nimbus remote signer/signing test (verifying-web3signer)
 ```diff
-+ Signing BeaconBlock (getBlockSignature(deneb))                                             OK
 + Signing BeaconBlock (getBlockSignature(electra))                                           OK
 + Waiting for signing node (/upcheck) test                                                   OK
 ```
@@ -785,7 +784,6 @@ AllTests-mainnet
 + Connection timeout test                                                                    OK
 + Public keys enumeration (/api/v1/eth2/publicKeys) test                                     OK
 + Public keys reload (/reload) test                                                          OK
-+ Signing BeaconBlock (getBlockSignature(deneb))                                             OK
 + Signing BeaconBlock (getBlockSignature(electra))                                           OK
 + Signing SC contribution and proof (getContributionAndProofSignature())                     OK
 + Signing SC message (getSyncCommitteeMessage())                                             OK

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -238,12 +238,8 @@ proc installApiHandlers*(node: SigningNodeRef) =
 
         let (feeRecipientIndex, blockHeader) =
           case request.beaconBlockHeader.kind
-          of ConsensusFork.Phase0 .. ConsensusFork.Bellatrix:
-            # `phase0` and `altair` blocks do not have `fee_recipient`, so
-            # we return an error.
+          of ConsensusFork.Phase0 .. ConsensusFork.Capella:
             return errorResponse(Http400, BlockIncorrectFork)
-          of ConsensusFork.Capella:
-            (GeneralizedIndex(401), request.beaconBlockHeader.data)
           of ConsensusFork.Deneb:
             (GeneralizedIndex(801), request.beaconBlockHeader.data)
           of ConsensusFork.Electra:

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1583,8 +1583,7 @@ proc process_epoch*(
   ok()
 
 proc get_validator_balance_after_epoch*(
-    cfg: RuntimeConfig, state: deneb.BeaconState | electra.BeaconState |
-    fulu.BeaconState,
+    cfg: RuntimeConfig, state: electra.BeaconState | fulu.BeaconState,
     cache: var StateCache, info: var altair.EpochInfo,
     index: ValidatorIndex): Gwei =
   # Run a subset of process_epoch() which affects an individual validator,
@@ -1668,14 +1667,6 @@ proc get_validator_balance_after_epoch*(
       discard
 
   post_epoch_balance
-
-proc get_next_slot_expected_withdrawals*(
-    cfg: RuntimeConfig, state: deneb.BeaconState, cache: var StateCache,
-    info: var altair.EpochInfo): seq[Withdrawal] =
-  get_expected_withdrawals_aux(state, (state.slot + 1).epoch) do:
-    # validator_index is defined by an injected symbol within the template
-    get_validator_balance_after_epoch(
-      cfg, state, cache, info, validator_index.ValidatorIndex)
 
 proc get_next_slot_expected_withdrawals*(
     cfg: RuntimeConfig, state: electra.BeaconState, cache: var StateCache,

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -632,36 +632,8 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
             proofs)
       elif blck is ForkedMaybeBlindedBeaconBlock:
         withForkyMaybeBlindedBlck(blck):
-          when consensusFork < ConsensusFork.Deneb:
+          when consensusFork < ConsensusFork.Electra:
             return SignatureResult.err("Invalid beacon block fork")
-          elif consensusFork == ConsensusFork.Deneb:
-            when isBlinded:
-              case v.data.remoteType
-              of RemoteSignerType.Web3Signer:
-                Web3SignerRequest.init(fork, genesis_validators_root,
-                  Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                    data: forkyMaybeBlindedBlck.toBeaconBlockHeader))
-              of RemoteSignerType.VerifyingWeb3Signer:
-                let proofs =
-                  blockPropertiesProofs(forkyMaybeBlindedBlck.body,
-                                        denebIndex)
-                Web3SignerRequest.init(fork, genesis_validators_root,
-                  Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                    data: forkyMaybeBlindedBlck.toBeaconBlockHeader), proofs)
-            else:
-              case v.data.remoteType
-              of RemoteSignerType.Web3Signer:
-                Web3SignerRequest.init(fork, genesis_validators_root,
-                  Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                    data: forkyMaybeBlindedBlck.`block`.toBeaconBlockHeader))
-              of RemoteSignerType.VerifyingWeb3Signer:
-                let proofs =
-                  blockPropertiesProofs(forkyMaybeBlindedBlck.`block`.body,
-                                        denebIndex)
-                Web3SignerRequest.init(fork, genesis_validators_root,
-                  Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                    data: forkyMaybeBlindedBlck.`block`.toBeaconBlockHeader),
-                      proofs)
           elif consensusFork == ConsensusFork.Electra:
             when isBlinded:
               case v.data.remoteType
@@ -720,21 +692,8 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
                       proofs)
       else:
         case blck.kind
-        of ConsensusFork.Phase0 .. ConsensusFork.Capella:
+        of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
           return SignatureResult.err("Invalid beacon block fork")
-        of ConsensusFork.Deneb:
-          case v.data.remoteType
-          of RemoteSignerType.Web3Signer:
-            Web3SignerRequest.init(fork, genesis_validators_root,
-              Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                data: blck.denebData.toBeaconBlockHeader))
-          of RemoteSignerType.VerifyingWeb3Signer:
-            let proofs = blockPropertiesProofs(
-              blck.denebData.body, denebIndex)
-            Web3SignerRequest.init(fork, genesis_validators_root,
-              Web3SignerForkedBeaconBlock(kind: ConsensusFork.Deneb,
-                data: blck.denebData.toBeaconBlockHeader),
-              proofs)
         of ConsensusFork.Electra:
           case v.data.remoteType
           of RemoteSignerType.Web3Signer:

--- a/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
+++ b/tests/consensus_spec/deneb/test_fixture_state_transition_epoch.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -23,7 +23,6 @@ import
 from std/sequtils import mapIt, toSeq
 from std/strutils import rsplit
 from ../../../beacon_chain/spec/datatypes/deneb import BeaconState
-from ../../teststateutil import checkPerValidatorBalanceCalc
 
 const
   RootDir = SszTestsDir/const_preset/"deneb"/"epoch_processing"
@@ -75,7 +74,6 @@ template runSuite(
 # ---------------------------------------------------------------
 runSuite(JustificationFinalizationDir, "Justification & Finalization"):
   let info = altair.EpochInfo.init(state)
-  check checkPerValidatorBalanceCalc(state)
   process_justification_and_finalization(state, info.balances)
   Result[void, cstring].ok()
 
@@ -83,7 +81,6 @@ runSuite(JustificationFinalizationDir, "Justification & Finalization"):
 # ---------------------------------------------------------------
 runSuite(InactivityDir, "Inactivity"):
   let info = altair.EpochInfo.init(state)
-  check checkPerValidatorBalanceCalc(state)
   process_inactivity_updates(cfg, state, info)
   Result[void, cstring].ok()
 

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -21,7 +21,6 @@ from ../../beacon_chain/spec/presets import
 from ./fixtures_utils import
   SSZ, SszTestsDir, hash_tree_root, loadBlock, parseTest,
   readSszBytes, toSszType
-from ../teststateutil import checkPerValidatorBalanceCalc
 
 proc runTest(
     consensusFork: static ConsensusFork,
@@ -54,15 +53,6 @@ proc runTest(
         discard state_transition(
           defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},
           noRollback).expect("should apply block")
-        withState(fhPreState[]):
-          when consensusFork == ConsensusFork.Deneb:
-            if unitTestName != "randomized_14":
-              # TODO this test as of v1.5.0-beta.2 breaks, but also probably
-              # just remove Deneb-only infrastructure of this sort, since it
-              # doesn't readily adapt to Electra regardless. For now keep to
-              # point to a potentially fixable/unexpected test case which is
-              # involves code not run outside the test suite to begin with.
-              check checkPerValidatorBalanceCalc(forkyState.data)
       else:
         let res = state_transition(
           defaultRuntimeConfig, fhPreState[], blck, cache, info, flags = {},

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -65,8 +65,6 @@ const
   AgAttestationPhase0 = "{\"data\":{\"aggregation_bits\":\"0x01\",\"signature\":\"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505\",\"data\":{\"slot\":\"1\",\"index\":\"1\",\"beacon_block_root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\",\"source\":{\"epoch\":\"1\",\"root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"},\"target\":{\"epoch\":\"1\",\"root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}}}}"
   AgAttestationElectra = "{\"data\":{\"aggregation_bits\":\"0x01\",\"committee_bits\":\"0x0000000000000001\",\"signature\":\"0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505\",\"data\":{\"slot\":\"1\",\"index\":\"1\",\"beacon_block_root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\",\"source\":{\"epoch\":\"1\",\"root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"},\"target\":{\"epoch\":\"1\",\"root\":\"0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2\"}}}}"
 
-  DenebBlockContents = "{\"signed_block\":{\"message\":{\"slot\":\"5297696\",\"proposer_index\":\"153094\",\"parent_root\":\"0xe6106533af9be918120ead7440a8006c7f123cc3cb7daf1f11d951864abea014\",\"state_root\":\"0xf86196d34500ca25d1f4e7431d4d52f6f85540bcaf97dd0d2ad9ecdb3eebcdf0\",\"body\":{\"randao_reveal\":\"0xa7efee3d5ddceb60810b23e3b5d39734696418f41dfd13a0851c7be7a72acbdceaa61e1db27513801917d72519d1c1040ccfed829faf06abe06d9964949554bf4369134b66de715ea49eb4fecf3e2b7e646f1764a1993e31e53dbc6557929c12\",\"eth1_data\":{\"deposit_root\":\"0x8ec87d7219a3c873fff3bfe206b4f923d1b471ce4ff9d6d6ecc162ef07825e14\",\"deposit_count\":\"259476\",\"block_hash\":\"0x877b6f8332c7397251ff3f0c5cecec105ff7d4cb78251b47f91fd15a86a565ab\"},\"graffiti\":\"\",\"proposer_slashings\":[],\"attester_slashings\":[],\"attestations\":[],\"deposits\":[],\"voluntary_exits\":[],\"sync_aggregate\":{\"sync_committee_bits\":\"0x733dfda7f5ffde5ade73367fcbf7fffeef7fe43777ffdffab9dbad6f7eed5fff9bfec4affdefbfaddf35bf5efbff9ffff9dfd7dbf97fbfcdfaddfeffbf95f75f\",\"sync_committee_signature\":\"0x81fdf76e797f81b0116a1c1ae5200b613c8041115223cd89e8bd5477aab13de6097a9ebf42b130c59527bbb4c96811b809353a17c717549f82d4bd336068ef0b99b1feebd4d2432a69fa77fac12b78f1fcc9d7b59edbeb381adf10b15bc4a520\"},\"execution_payload\":{\"parent_hash\":\"0x14c2242a8cfbce559e84c391f5f16d10d7719751b8558873012dc88ae5a193e8\",\"fee_recipient\":\"$1\",\"state_root\":\"0xdf8d96b2c292736d39e72e25802c2744d34d3d3c616de5b362425cab01f72fa5\",\"receipts_root\":\"0x4938a2bf640846d213b156a1a853548b369cd02917fa63d8766ab665d7930bac\",\"logs_bloom\":\"0x298610600038408c201080013832408850a00bc8f801920121840030a015310010e2a0e0108628110552062811441c84802f43825c4fc82140b036c58025a28800054c80a44025c052090a0f2c209a0400058040019ea0008e589084078048050880930113a2894082e0112408b088382402a851621042212aa40018a408d07e178c68691486411aa9a2809043b000a04c040000065a030028018540b04b1820271d00821b00c29059095022322c10a530060223240416140190056608200063c82248274ba8f0098e402041cd9f451031481a1010b8220824833520490221071898802d206348449116812280014a10a2d1c210100a30010802490f0a221849\",\"prev_randao\":\"0xc061711e135cd40531ec3ee29d17d3824c0e5f80d07f721e792ab83240aa0ab5\",\"block_number\":\"8737497\",\"gas_limit\":\"30000000\",\"gas_used\":\"16367052\",\"timestamp\":\"1680080352\",\"extra_data\":\"0xd883010b05846765746888676f312e32302e32856c696e7578\",\"base_fee_per_gas\":\"231613172261\",\"block_hash\":\"0x5aa9fd22a9238925adb2b038fd6eafc77adabf554051db5bc16ae5168a52eff6\",\"transactions\":[],\"withdrawals\":[],\"blob_gas_used\":\"2316131761\",\"excess_blob_gas\":\"231613172261\"},\"bls_to_execution_changes\":[],\"blob_kzg_commitments\":[]}},\"signature\":\"$2\"},\"kzg_proofs\":[],\"blobs\":[]}"
-
   ElectraBlockContents = "{\"signed_block\":{\"message\":{\"slot\":\"5297696\",\"proposer_index\":\"153094\",\"parent_root\":\"0xe6106533af9be918120ead7440a8006c7f123cc3cb7daf1f11d951864abea014\",\"state_root\":\"0xf86196d34500ca25d1f4e7431d4d52f6f85540bcaf97dd0d2ad9ecdb3eebcdf0\",\"body\":{\"randao_reveal\":\"0xa7efee3d5ddceb60810b23e3b5d39734696418f41dfd13a0851c7be7a72acbdceaa61e1db27513801917d72519d1c1040ccfed829faf06abe06d9964949554bf4369134b66de715ea49eb4fecf3e2b7e646f1764a1993e31e53dbc6557929c12\",\"eth1_data\":{\"deposit_root\":\"0x8ec87d7219a3c873fff3bfe206b4f923d1b471ce4ff9d6d6ecc162ef07825e14\",\"deposit_count\":\"259476\",\"block_hash\":\"0x877b6f8332c7397251ff3f0c5cecec105ff7d4cb78251b47f91fd15a86a565ab\"},\"graffiti\":\"\",\"proposer_slashings\":[],\"attester_slashings\":[],\"attestations\":[],\"deposits\":[],\"voluntary_exits\":[],\"sync_aggregate\":{\"sync_committee_bits\":\"0x733dfda7f5ffde5ade73367fcbf7fffeef7fe43777ffdffab9dbad6f7eed5fff9bfec4affdefbfaddf35bf5efbff9ffff9dfd7dbf97fbfcdfaddfeffbf95f75f\",\"sync_committee_signature\":\"0x81fdf76e797f81b0116a1c1ae5200b613c8041115223cd89e8bd5477aab13de6097a9ebf42b130c59527bbb4c96811b809353a17c717549f82d4bd336068ef0b99b1feebd4d2432a69fa77fac12b78f1fcc9d7b59edbeb381adf10b15bc4a520\"},\"execution_payload\":{\"parent_hash\":\"0x14c2242a8cfbce559e84c391f5f16d10d7719751b8558873012dc88ae5a193e8\",\"fee_recipient\":\"$1\",\"state_root\":\"0xdf8d96b2c292736d39e72e25802c2744d34d3d3c616de5b362425cab01f72fa5\",\"receipts_root\":\"0x4938a2bf640846d213b156a1a853548b369cd02917fa63d8766ab665d7930bac\",\"logs_bloom\":\"0x298610600038408c201080013832408850a00bc8f801920121840030a015310010e2a0e0108628110552062811441c84802f43825c4fc82140b036c58025a28800054c80a44025c052090a0f2c209a0400058040019ea0008e589084078048050880930113a2894082e0112408b088382402a851621042212aa40018a408d07e178c68691486411aa9a2809043b000a04c040000065a030028018540b04b1820271d00821b00c29059095022322c10a530060223240416140190056608200063c82248274ba8f0098e402041cd9f451031481a1010b8220824833520490221071898802d206348449116812280014a10a2d1c210100a30010802490f0a221849\",\"prev_randao\":\"0xc061711e135cd40531ec3ee29d17d3824c0e5f80d07f721e792ab83240aa0ab5\",\"block_number\":\"8737497\",\"gas_limit\":\"30000000\",\"gas_used\":\"16367052\",\"timestamp\":\"1680080352\",\"extra_data\":\"0xd883010b05846765746888676f312e32302e32856c696e7578\",\"base_fee_per_gas\":\"231613172261\",\"block_hash\":\"0x5aa9fd22a9238925adb2b038fd6eafc77adabf554051db5bc16ae5168a52eff6\",\"transactions\":[],\"withdrawals\":[],\"blob_gas_used\":\"2316131761\",\"excess_blob_gas\":\"231613172261\"},\"bls_to_execution_changes\":[],\"blob_kzg_commitments\":[],\"execution_requests\":{\"deposits\":[],\"withdrawals\":[],\"consolidations\":[]}}},\"signature\":\"$2\"},\"kzg_proofs\":[],\"blobs\":[]}"
 
   SigningNodeAddress = "127.0.0.1"
@@ -95,12 +93,8 @@ proc getBlock(
     feeRecipient = SigningExpectedFeeRecipient): ForkedBeaconBlock =
   try:
     case fork
-    of ConsensusFork.Phase0 .. ConsensusFork.Capella:
+    of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
       raiseAssert "Unsupported fork"
-    of ConsensusFork.Deneb:
-      ForkedBeaconBlock.init(RestJson.decode(
-        DenebBlockContents % [feeRecipient, SomeSignature],
-          DenebSignedBlockContents).signed_block.message)
     of ConsensusFork.Electra:
       ForkedBeaconBlock.init(RestJson.decode(
         ElectraBlockContents % [feeRecipient, SomeSignature],
@@ -117,12 +111,8 @@ proc getBlock(
 func init(t: typedesc[Web3SignerForkedBeaconBlock],
           forked: ForkedBeaconBlock): Web3SignerForkedBeaconBlock =
   case forked.kind
-  of ConsensusFork.Phase0 .. ConsensusFork.Capella:
-    raiseAssert "supports Deneb and later forks"
-  of ConsensusFork.Deneb:
-    Web3SignerForkedBeaconBlock(
-      kind: ConsensusFork.Deneb,
-      data: forked.denebData.toBeaconBlockHeader)
+  of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
+    raiseAssert "supports Electra and later forks"
   of ConsensusFork.Electra:
     Web3SignerForkedBeaconBlock(
       kind: ConsensusFork.Electra,
@@ -837,41 +827,6 @@ block:
         sres2.get() == rres2.get()
         sres3.get() == rres3.get()
 
-    asyncTest "Signing BeaconBlock (getBlockSignature(deneb))":
-      let
-        forked = getBlock(ConsensusFork.Deneb)
-        blockRoot = withBlck(forked): hash_tree_root(forkyBlck)
-
-        sres1 =
-          await validator1.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-        sres2 =
-          await validator2.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-        sres3 =
-          await validator3.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-        rres1 =
-          await validator4.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-        rres2 =
-          await validator5.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-        rres3 =
-          await validator6.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot, forked)
-
-      check:
-        sres1.isOk()
-        sres2.isOk()
-        sres3.isOk()
-        rres1.isOk()
-        rres2.isOk()
-        rres3.isOk()
-        sres1.get() == rres1.get()
-        sres2.get() == rres2.get()
-        sres3.get() == rres3.get()
-
     asyncTest "Signing BeaconBlock (getBlockSignature(electra))":
       let
         forked = getBlock(ConsensusFork.Electra)
@@ -1038,95 +993,6 @@ block:
         await sleepAsync(500.milliseconds)
 
       await client.closeWait()
-
-    asyncTest "Signing BeaconBlock (getBlockSignature(deneb))":
-      let
-        fork = ConsensusFork.Deneb
-        forked1 = getBlock(fork)
-        blockRoot1 = withBlck(forked1): hash_tree_root(forkyBlck)
-        forked2 = getBlock(fork, SigningOtherFeeRecipient)
-        blockRoot2 = withBlck(forked2): hash_tree_root(forkyBlck)
-        request1 = Web3SignerRequest.init(SigningFork, GenesisValidatorsRoot,
-          Web3SignerForkedBeaconBlock.init(forked1))
-        request2 = Web3SignerRequest.init(SigningFork, GenesisValidatorsRoot,
-          Web3SignerForkedBeaconBlock.init(forked1), @[])
-        remoteUrl = "http://" & SigningNodeAddress & ":" &
-                    $getNodePort(basePort, RemoteSignerType.VerifyingWeb3Signer)
-        prestoFlags = {RestClientFlag.CommaSeparatedArray}
-        rclient = RestClientRef.new(remoteUrl, prestoFlags, {})
-        publicKey1 = ValidatorPubKey.fromHex(ValidatorPubKey1).get()
-        publicKey2 = ValidatorPubKey.fromHex(ValidatorPubKey2).get()
-        publicKey3 = ValidatorPubKey.fromHex(ValidatorPubKey3).get()
-
-      check rclient.isOk()
-
-      let
-        client = rclient.get()
-        sres1 =
-          await validator1.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        sres2 =
-          await validator2.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        sres3 =
-          await validator3.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        rres1 =
-          await validator4.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        rres2 =
-          await validator5.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        rres3 =
-          await validator6.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot1, forked1)
-        bres1 =
-          await validator4.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot2, forked2)
-        bres2 =
-          await validator5.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot2, forked2)
-        bres3 =
-          await validator6.getBlockSignature(SigningFork, GenesisValidatorsRoot,
-            Slot(1), blockRoot2, forked2)
-
-      check:
-        # Local requests
-        sres1.isOk()
-        sres2.isOk()
-        sres3.isOk()
-        # Remote requests with proper Merkle proof of proper FeeRecipent field
-        rres1.isOk()
-        rres2.isOk()
-        rres3.isOk()
-        # Signature comparison
-        sres1.get() == rres1.get()
-        sres2.get() == rres2.get()
-        sres3.get() == rres3.get()
-        # Remote requests with changed FeeRecipient field
-        bres1.isErr()
-        bres2.isErr()
-        bres3.isErr()
-
-      try:
-        let
-          # `proofs` array is not present.
-          response1 = await client.signDataPlain(publicKey1, request1)
-          response2 = await client.signDataPlain(publicKey2, request1)
-          response3 = await client.signDataPlain(publicKey3, request1)
-          # `proofs` array is empty.
-          response4 = await client.signDataPlain(publicKey1, request2)
-          response5 = await client.signDataPlain(publicKey2, request2)
-          response6 = await client.signDataPlain(publicKey3, request2)
-        check:
-          response1.status == 400
-          response2.status == 400
-          response3.status == 400
-          response4.status == 400
-          response5.status == 400
-          response6.status == 400
-      finally:
-        await client.closeWait()
 
     asyncTest "Signing BeaconBlock (getBlockSignature(electra))":
       let

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
@@ -111,8 +111,7 @@ from std/sequtils import allIt
 from ".."/beacon_chain/spec/beaconstate import get_expected_withdrawals
 
 proc checkPerValidatorBalanceCalc*(
-    state: deneb.BeaconState | electra.BeaconState |
-           fulu.BeaconState): bool =
+    state: electra.BeaconState | fulu.BeaconState): bool =
   var
     info: altair.EpochInfo
     cache: StateCache


### PR DESCRIPTION
This will never be deployed on Deneb now, and create risk each time the consensus reference tests are recreated, especially with the random block sanity tests.