### PR TITLE
Add engine_getBlobsV2 metrics

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -104,6 +104,16 @@ declareHistogram beacon_data_column_sidecar_computation_seconds,
   "Time taken to compute data column sidecar, including cells and inclusion proof",
   buckets = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, Inf]
 
+declareCounter beacon_engine_getBlobsV2_requests_total,
+  "Total number of engine_getBlobsV2 requests sent"
+
+declareCounter beacon_engine_getBlobsV2_responses_total,
+  "Total number of engine_getBlobsV2 successful responses received"
+
+declareHistogram beacon_engine_getBlobsV2_runtime_seconds,
+  "Full runtime of engine_getBlobsV2 requests",
+  buckets = [0.001, 0.005, 0.01, 0.025, 0.05, 0.75, 0.1, 0.5, 1, 1.5, 2, 5, 10]
+
 type
   DoppelgangerProtection = object
     broadcastStartEpoch*: Epoch  ##\
@@ -366,12 +376,17 @@ proc validateDataColumnSidecarFromEL*(
     let columnless = o.unsafeGet()
     withBlck(columnless):
       when consensusFork >= ConsensusFork.Fulu:
+        beacon_engine_getBlobsV2_requests_total.inc()
         let
           start_time = Moment.now()
-        let blobsFromElOpt =
-          await elManager.sendGetBlobsV2(forkyBlck)
+          blobsFromElOpt =
+            await elManager.sendGetBlobsV2(forkyBlck)
+          getBlobsV2_end_time = Moment.now()
+          getBlobsV2_dur = getBlobsV2_end_time - start_time
+        beacon_engine_getBlobsV2_runtime_seconds.observe(getBlobsV2_dur.toFloatSeconds())
         if blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
+          beacon_engine_getBlobsV2_responses_total.inc()
 
           # check lengths of array[BlobAndProofV2 with blobs
           # kzg commitments of the signed block


### PR DESCRIPTION
This PR renames `beacon_engine_getBlobsV2_runtime_seconds` to `beacon_engine_getBlobsV2_request_duration_seconds` according to the updated [metrics specs](https://github.com/ethereum/beacon-metrics/pull/14).