### PR TITLE
Rename getBlobsV2 runtime metric

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -102,7 +102,7 @@ declareHistogram data_column_sidecar_delay,
 
 declareHistogram beacon_data_column_sidecar_computation_seconds,
   "Time taken to compute data column sidecar, including cells and inclusion proof",
-  buckets = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, Inf]
+  buckets = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, Inf]
 
 declareCounter beacon_engine_getBlobsV2_requests_total,
   "Total number of engine_getBlobsV2 requests sent"
@@ -110,9 +110,9 @@ declareCounter beacon_engine_getBlobsV2_requests_total,
 declareCounter beacon_engine_getBlobsV2_responses_total,
   "Total number of engine_getBlobsV2 successful responses received"
 
-declareHistogram beacon_engine_getBlobsV2_runtime_seconds,
-  "Full runtime of engine_getBlobsV2 requests",
-  buckets = [0.001, 0.005, 0.01, 0.025, 0.05, 0.75, 0.1, 0.5, 1, 1.5, 2, 5, 10]
+declareHistogram beacon_engine_getBlobsV2_request_duration_seconds,
+  "Duration of engine_getBlobsV2 requests",
+  buckets = [0.01, 0.05, 0.1, 0.5, 1, 2.5, 5, 10]
 
 type
   DoppelgangerProtection = object
@@ -383,7 +383,7 @@ proc validateDataColumnSidecarFromEL*(
             await elManager.sendGetBlobsV2(forkyBlck)
           getBlobsV2_end_time = Moment.now()
           getBlobsV2_dur = getBlobsV2_end_time - start_time
-        beacon_engine_getBlobsV2_runtime_seconds.observe(getBlobsV2_dur.toFloatSeconds())
+        beacon_engine_getBlobsV2_request_duration_seconds.observe(getBlobsV2_dur.toFloatSeconds())
         if blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
           beacon_engine_getBlobsV2_responses_total.inc()


### PR DESCRIPTION
This PR renames `beacon_engine_getBlobsV2_runtime_seconds` to `beacon_engine_getBlobsV2_request_duration_seconds` according to the updated [metrics specs #14](https://github.com/ethereum/beacon-metrics/pull/14).