### PR TITLE
Fix _total for PeerDAS metrics

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -104,10 +104,10 @@ declareHistogram beacon_data_column_sidecar_computation_seconds,
   "Time taken to compute data column sidecar, including cells and inclusion proof",
   buckets = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, Inf]
 
-declareCounter beacon_engine_getBlobsV2_requests_total,
+declareCounter beacon_engine_getBlobsV2_requests,
   "Total number of engine_getBlobsV2 requests sent"
 
-declareCounter beacon_engine_getBlobsV2_responses_total,
+declareCounter beacon_engine_getBlobsV2_responses,
   "Total number of engine_getBlobsV2 successful responses received"
 
 declareHistogram beacon_engine_getBlobsV2_request_duration_seconds,
@@ -376,7 +376,7 @@ proc validateDataColumnSidecarFromEL*(
     let columnless = o.unsafeGet()
     withBlck(columnless):
       when consensusFork >= ConsensusFork.Fulu:
-        beacon_engine_getBlobsV2_requests_total.inc()
+        beacon_engine_getBlobsV2_requests.inc()
         let
           start_time = Moment.now()
           blobsFromElOpt =
@@ -386,7 +386,7 @@ proc validateDataColumnSidecarFromEL*(
         beacon_engine_getBlobsV2_request_duration_seconds.observe(getBlobsV2_dur.toFloatSeconds())
         if blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
-          beacon_engine_getBlobsV2_responses_total.inc()
+          beacon_engine_getBlobsV2_responses.inc()
 
           # check lengths of array[BlobAndProofV2 with blobs
           # kzg commitments of the signed block

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -43,10 +43,10 @@ declareCounter beacon_sync_messages_dropped_queue_full,
 declareCounter beacon_contributions_dropped_queue_full,
   "Number of sync committee contributions dropped because queue is full"
 
-declareCounter beacon_data_column_sidecar_processing_requests_total,
+declareCounter beacon_data_column_sidecar_processing_requests,
   "Number of data column sidecars submitted for processing"
 
-declareCounter  beacon_data_column_sidecar_processing_successes_total,
+declareCounter  beacon_data_column_sidecar_processing_successes,
   "Number of data column sidecars verified for gossip"
 
 declareHistogram beacon_data_column_sidecar_gossip_verification_seconds,
@@ -613,7 +613,7 @@ proc validateDataColumnSidecar*(
 
   template block_header: untyped = data_column_sidecar.signed_block_header.message
 
-  beacon_data_column_sidecar_processing_requests_total.inc()
+  beacon_data_column_sidecar_processing_requests.inc()
 
   let
     startTick = Moment.now()
@@ -744,7 +744,7 @@ proc validateDataColumnSidecar*(
 
   beacon_data_column_sidecar_gossip_verification_seconds.observe(validationDur.toFloatSeconds())
 
-  beacon_data_column_sidecar_processing_successes_total.inc()
+  beacon_data_column_sidecar_processing_successes.inc()
 
   ok()
 


### PR DESCRIPTION
This PR deletes `_total` suffix from PeerDAS metrics as it is duplicated by prometheus.