### PR TITLE
automated consensus spec URL updating to v1.6.0-alpha.2

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -202,7 +202,6 @@ type
 
     web3ForcePolling* {.
       hidden
-      desc: "Force the use of polling when determining the head block of Eth1 (obsolete)"
       name: "web3-force-polling" .}: Option[bool]
 
     web3Urls* {.

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -1243,6 +1243,3 @@ proc testWeb3Provider*(
 
   discard request "Sync status":
     web3.provider.eth_syncing()
-
-  discard request "Latest block":
-    web3.provider.eth_getBlockByNumber(blockId("latest"), false)

--- a/beacon_chain/el/merkle_minimal.nim
+++ b/beacon_chain/el/merkle_minimal.nim
@@ -13,13 +13,12 @@
 # ---------------------------------------------------------------
 
 import
-  std/sequtils,
-  stew/endians2,
-  # Specs
   ../spec/[eth2_merkleization, digest],
   ../spec/datatypes/base
 
-template getProof*(
+from std/sequtils import mapIt
+
+template getProof(
     proofs: seq[Eth2Digest], idxParam: int): openArray[Eth2Digest] =
   let
     idx = idxParam

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -94,7 +94,7 @@ typedef struct ETHConsensusConfig ETHConsensusConfig;
  *         based on the given `config.yaml` file content - If successful.
  * @return `NULL` - If the given `config.yaml` is malformed or incompatible.
  *
- * @see https://github.com/ethereum/consensus-specs/blob/v1.5.0/configs/README.md
+ * @see https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/configs/README.md
  */
 ETH_RESULT_USE_CHECK
 ETHConsensusConfig *_Nullable ETHConsensusConfigCreateFromYaml(const char *configFileContent);

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -145,7 +145,7 @@ proc ETHBeaconStateCreateFromSsz(
   ## * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/altair/beacon-chain.md#beaconstate
   ## * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#beaconstate
   ## * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/capella/beacon-chain.md#beaconstate
-  ## * https://github.com/ethereum/consensus-specs/blob/v1.5.0/configs/README.md
+  ## * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/configs/README.md
   let
     consensusFork = ConsensusFork.decodeString($consensusVersion).valueOr:
       return nil

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -76,7 +76,7 @@ proc runVerifyKzgProofTest(suiteName, suitePath, path: string) =
       y = fromHex[32](data["input"]["y"].getStr)
       proof = fromHex[48](data["input"]["proof"].getStr)
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0/tests/formats/kzg_4844/verify_kzg_proof.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/tests/formats/kzg_4844/verify_kzg_proof.md#condition
     # "If the commitment or proof is invalid (e.g. not on the curve or not in
     # the G1 subgroup of the BLS curve) or `z` or `y` are not a valid BLS
     # field element, it should error, i.e. the output should be `null`."
@@ -209,7 +209,7 @@ proc runComputeCellsTest(suiteName, suitePath, path: string) =
       output = data["output"]
       blob = fromHex[131072](data["input"]["blob"].getStr)
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0/tests/formats/kzg_7594/compute_cells.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/tests/formats/kzg_7594/compute_cells.md#condition
     if blob.isNone:
       check output.kind == JNull
     else:
@@ -256,7 +256,7 @@ proc runVerifyCellKzgProofBatchTest(suiteName, suitePath, path: string) =
       cells = data["input"]["cells"].mapIt(fromHex[2048](it.getStr))
       proofs = data["input"]["proofs"].mapIt(fromHex[48](it.getStr))
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md#condition
+    # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/tests/formats/kzg_7594/verify_cell_kzg_proof_batch.md#condition
     # If the blob is invalid (e.g. incorrect length or one of the 32-byte
     # blocks does not represent a BLS field element) it should error, i.e. the
     # the output should be `null`.


### PR DESCRIPTION
```
git reset --hard && make update && sh <(scripts/find_unchanged_consensus_spec_files.sh v1.5.0 v1.6.0-alpha.2 .) && make update
```
Unusually for these, it also has a couple of small cleanups stemming from the EIP-6110 effort, because it's so small otherwise.

It appears that the consensus-specs repo has been mass-reformatted.