### PR TITLE
Fix incorrect getBlobForkCode for Fulu

### DIFF
--- a/beacon_chain/beacon_chain_file.nim
+++ b/beacon_chain/beacon_chain_file.nim
@@ -84,14 +84,9 @@ func getBlockForkCode(fork: ConsensusFork): uint64 =
   uint64(fork)
 
 func getBlobForkCode(fork: ConsensusFork): uint64 =
-  case fork
-  of ConsensusFork.Deneb:
-    uint64(MaxForksCount)
-  of ConsensusFork.Electra:
+  if fork >= ConsensusFork.Deneb:
     uint64(MaxForksCount) + uint64(fork) - uint64(ConsensusFork.Deneb)
-  of ConsensusFork.Fulu:
-    uint64(MaxForksCount) + uint64(fork) - uint64(ConsensusFork.Electra)
-  of ConsensusFork.Phase0 .. ConsensusFork.Capella:
+  else:
     raiseAssert "Blobs are not supported for the fork"
 
 proc init(t: typedesc[ChainFileError], k: ChainFileErrorType,


### PR DESCRIPTION
#6677 assigned blob fork code `MaxForksCount + 1` to Fulu, but this is already used for Electra. Update the logic to always base blobs relative to Deneb, in a maintenance-free way.