### PR TITLE
adjust nextForkEpochAtEpoch() to work with BPOs

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -680,6 +680,7 @@ AllTests-mainnet
 + Stability subnets                                                                          OK
 + isNearSyncCommitteePeriod                                                                  OK
 + is_aggregator                                                                              OK
++ nextForkEpochAtEpoch with BPOs                                                             OK
 ```
 ## ImportKeystores requests [Beacon Node] [Preset: mainnet]
 ```diff

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1578,8 +1578,15 @@ func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   of ConsensusFork.Phase0:    cfg.GENESIS_FORK_VERSION
 
 func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
+  ## Used to construct the eth2 field of ENRs
   case cfg.consensusForkAtEpoch(epoch)
-  of ConsensusFork.Fulu:      FAR_FUTURE_EPOCH
+  of ConsensusFork.Fulu:
+    var res = FAR_FUTURE_EPOCH
+    for entry in cfg.BLOB_SCHEDULE:
+      if epoch >= entry.EPOCH:
+        break
+      res = entry.EPOCH
+    res
   of ConsensusFork.Electra:   cfg.FULU_FORK_EPOCH
   of ConsensusFork.Deneb:     cfg.ELECTRA_FORK_EPOCH
   of ConsensusFork.Capella:   cfg.DENEB_FORK_EPOCH

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1394,7 +1394,7 @@ func process_pending_consolidations*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.1/specs/fulu/beacon-chain.md#new-process_proposer_lookahead
-proc process_proposer_lookahead*(state: var fulu.BeaconState,
+func process_proposer_lookahead*(state: var fulu.BeaconState,
                                  cache: var StateCache):
                                  Result[void, cstring] =
   let

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -532,7 +532,7 @@ func get_beacon_proposer_indices*(
     get_beacon_proposer_indices(state, epoch)
 
 
-proc initialize_proposer_lookahead*(state: electra.BeaconState,
+func initialize_proposer_lookahead*(state: electra.BeaconState,
                                     cache: var StateCache):
                                     HashArray[Limit ((MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH), uint64] =
   let current_epoch = state.slot.epoch()

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -953,7 +953,7 @@ proc proposeBlockMEV(
 func isExcludedTestnet(cfg: RuntimeConfig): bool =
   ## Ensure that builder API testing can still occur in certain circumstances.
   cfg.DEPOSIT_CHAIN_ID == cfg.DEPOSIT_NETWORK_ID and cfg.DEPOSIT_CHAIN_ID in [
-    11155111'u64, 17000, 560048]  # Sepolia, Holesky, and Hoodi, respectively
+    17000'u64, 560048]  # Holesky and Hoodi, respectively
 
 proc collectBids(
     SBBB: typedesc, EPS: typedesc, node: BeaconNode,

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -326,3 +326,34 @@ suite "Honest validator":
           compute_inverted_shuffled_index(
             compute_shuffled_index(
               index, index_count, seed), index_count, seed) == index
+
+  test "nextForkEpochAtEpoch with BPOs":
+    var cfg = defaultRuntimeConfig
+    cfg.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
+    cfg.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+    cfg.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
+    cfg.DENEB_FORK_EPOCH = GENESIS_EPOCH
+    cfg.ELECTRA_FORK_EPOCH = 9.Epoch
+    cfg.FULU_FORK_EPOCH = 100.Epoch
+    cfg.BLOB_SCHEDULE = @[
+      BlobParameters(EPOCH: 300.Epoch, MAX_BLOBS_PER_BLOCK: 300),
+      BlobParameters(EPOCH: 250.Epoch, MAX_BLOBS_PER_BLOCK: 275),
+      BlobParameters(EPOCH: 200.Epoch, MAX_BLOBS_PER_BLOCK: 200),
+      BlobParameters(EPOCH: 150.Epoch, MAX_BLOBS_PER_BLOCK: 175),
+      BlobParameters(EPOCH: 100.Epoch, MAX_BLOBS_PER_BLOCK: 100),
+      BlobParameters(EPOCH: 9.Epoch, MAX_BLOBS_PER_BLOCK: 9)]
+    check:
+      cfg.nextForkEpochAtEpoch(9.Epoch) == 100.Epoch
+      cfg.nextForkEpochAtEpoch(10.Epoch) == 100.Epoch
+      cfg.nextForkEpochAtEpoch(11.Epoch) == 100.Epoch
+      cfg.nextForkEpochAtEpoch(99.Epoch) == 100.Epoch
+      cfg.nextForkEpochAtEpoch(100.Epoch) == 150.Epoch
+      cfg.nextForkEpochAtEpoch(101.Epoch) == 150.Epoch
+      cfg.nextForkEpochAtEpoch(150.Epoch) == 200.Epoch
+      cfg.nextForkEpochAtEpoch(199.Epoch) == 200.Epoch
+      cfg.nextForkEpochAtEpoch(200.Epoch) == 250.Epoch
+      cfg.nextForkEpochAtEpoch(201.Epoch) == 250.Epoch
+      cfg.nextForkEpochAtEpoch(250.Epoch) == 300.Epoch
+      cfg.nextForkEpochAtEpoch(299.Epoch) == 300.Epoch
+      cfg.nextForkEpochAtEpoch(300.Epoch) == FAR_FUTURE_EPOCH
+      cfg.nextForkEpochAtEpoch(301.Epoch) == FAR_FUTURE_EPOCH


### PR DESCRIPTION
It drives ENRs, which now depend on BPOs (https://github.com/ethereum/consensus-specs/pull/4406).