### PR TITLE
Update publish-unit-test-result-action to v2

### DIFF
--- a/.github/workflows/unit-test-results.yml
+++ b/.github/workflows/unit-test-results.yml
@@ -30,7 +30,7 @@ jobs:
            done
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_file: artifacts/Event File/event.json


### PR DESCRIPTION
Update publish-unit-test-result-action to v2

Updates the GitHub Action EnricoMi/publish-unit-test-result-action from v1 to v2 to use the latest version with improved features and bug fixes.
@https://github.com/EnricoMi/publish-unit-test-result-action/releases/tag/v2.20.0 