### PR TITLE
docs: fix typos

### DIFF
--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -298,7 +298,7 @@ proc runSlotLoop*[T](node: T, startTime: BeaconTime,
 
   while true:
     # Start by waiting for the time when the slot starts. Sleeping relinquishes
-    # control to other tasks which may or may not finish within the alotted
+    # control to other tasks which may or may not finish within the allotted
     # time, so below, we need to be wary that the ship might have sailed
     # already.
     await sleepAsync(timeToNextSlot)

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -341,7 +341,7 @@ proc asyncInit(sn: SigningNodeRef) {.async: (raises: [SigningNodeError]).} =
   notice "Launching signing node", version = fullVersionStr,
          cmdParams = commandLineParams(), config = sn.config
 
-  info "Initializaing validators", path = sn.config.validatorsDir()
+  info "Initializing validators", path = sn.config.validatorsDir()
   sn.loadKeystores()
 
   if sn.attachedValidators.count() == 0:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -213,7 +213,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           # If the requested validator index was not valid within this old
           # state, it's not possible that it will sit on the sync committee.
           # Since this API must omit results for validators that don't have
-          # duties, we can simply ingnore this requested index.
+          # duties, we can simply ignore this requested index.
           # (we won't bother to validate it against a more recent state).
           continue
 


### PR DESCRIPTION
### Summary

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `alotted` → `allotted`
  - `Initializaing` → `Initializing`
  - `ingnore` → `ignore`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.