### PR TITLE
nix: fix regex for fetching Nim deps commit hashes

### DIFF
--- a/nix/checksums.nix
+++ b/nix/checksums.nix
@@ -6,7 +6,7 @@ let
 in pkgs.fetchFromGitHub {
   owner = "nim-lang";
   repo = "checksums";
-  rev = tools.findKeyValue "^ +ChecksumsStableCommit = \"([a-f0-9]+)\"$" sourceFile;
+  rev = tools.findKeyValue "^ +ChecksumsStableCommit = \"([a-f0-9]+)\".*$" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
   hash = "sha256-Bm5iJoT2kAvcTexiLMFBa9oU5gf7d4rWjo3OiN7obWQ=";
 }

--- a/nix/nimble.nix
+++ b/nix/nimble.nix
@@ -7,7 +7,7 @@ in pkgs.fetchFromGitHub {
   owner = "nim-lang";
   repo = "nimble";
   fetchSubmodules = true;
-  rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".+" sourceFile;
+  rev = tools.findKeyValue "^ +NimbleStableCommit = \"([a-f0-9]+)\".*$" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
   hash = "sha256-Rz48sGUKZEAp+UySla+MlsOfsERekuGKw69Tm11fDz8=";
 }

--- a/nix/sat.nix
+++ b/nix/sat.nix
@@ -6,7 +6,7 @@ let
 in pkgs.fetchFromGitHub {
   owner = "nim-lang";
   repo = "sat";
-  rev = tools.findKeyValue "^ +SatStableCommit = \"([a-f0-9]+)\"$" sourceFile;
+  rev = tools.findKeyValue "^ +SatStableCommit = \"([a-f0-9]+)\".*$" sourceFile;
   # WARNING: Requires manual updates when Nim compiler version changes.
   hash = "sha256-JFrrSV+mehG0gP7NiQ8hYthL0cjh44HNbXfuxQNhq7c=";
 }


### PR DESCRIPTION
Since last Nim upgrade the `koch.nim` file added comments in relevant lines.
```
  NimbleStableCommit = "b1dc28450f028aead0b7cf5da8adf2267db65f89" # 0.18.2
  AtlasStableCommit = "26cecf4d0cc038d5422fc1aa737eec9c8803a82b" # 0.9
  ChecksumsStableCommit = "f8f6bd34bfa3fe12c64b919059ad856a96efcba0" # 2.0.1
  SatStableCommit = "faf1617f44d7632ee9601ebc13887644925dcc01"
```