### PR TITLE
prevent double verification of data column sidecar kzg proofs

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -209,6 +209,7 @@ AllTests-mainnet
 + Different fork versions                                                                    OK
 + Different genesis validators roots                                                         OK
 + Different lengths and blob limits                                                          OK
++ Fusaka devnet-2                                                                            OK
 ```
 ## EF - KZG
 ```diff
@@ -646,10 +647,6 @@ AllTests-mainnet
 + Obtaining the gas limit of a missing validator returns 404 [Beacon Node] [Preset: mainnet] OK
 + Obtaining the gas limit of an unconfigured validator returns the suggested default [Beacon OK
 + Setting the gas limit on a missing validator creates a record for it [Beacon Node] [Preset OK
-```
-## Gossip fork transition
-```diff
-+ Gossip fork transition                                                                     OK
 ```
 ## Gossip validation  [Preset: mainnet]
 ```diff

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -727,27 +727,15 @@ proc storeBlock(
 
   let newPayloadTick = Moment.now()
 
-  when typeof(signedBlock).kind >= ConsensusFork.Fulu:
-    if dataColumnsOpt.isSome:
-      let
-        columns0 = dataColumnsOpt.get()
-        kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
-      if columns0.len > 0 and kzgCommits.len > 0:
-        for i in 0..<columns0.len:
-          let r =
-            verify_data_column_sidecar_kzg_proofs(columns0[i][])
-          if r.isErr:
-            debug "data column validation failed",
-              blockRoot = shortLog(signedBlock.root),
-              column_sidecar = shortLog(columns0[i][]),
-              blck = shortLog(signedBlock.message),
-              signature = shortLog(signedBlock.signature),
-              msg = r.error()
-            return err((VerifierError.Invalid, ProcessingStatus.completed))
+  # No need to verify data column sidecar kzg proofs, as
+  # there are verification processes ar every point of entry
+  # for column sidecars, more so as this verification process
+  # is expensive and latent for nodes with higher column custody.
+
   # TODO with v1.4.0, not sure this is still relevant
   # Establish blob viability before calling addHeadBlock to avoid
   # writing the block in case of blob error.
-  elif typeof(signedBlock).kind >= ConsensusFork.Deneb:
+  when typeof(signedBlock).kind >= ConsensusFork.Deneb:
     if blobsOpt.isSome:
       let blobs = blobsOpt.get()
       let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -516,7 +516,7 @@ proc verify_data_column_sidecar_inclusion_proof*(sidecar: DataColumnSidecar):
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/p2p-interface.md#verify_data_column_sidecar_kzg_proofs
 proc verify_data_column_sidecar_kzg_proofs*(sidecar: DataColumnSidecar):
-                                            Result[void, cstring] =
+                                            Result[void, string] =
   ## Verify if the KZG Proofs consisting in the `DataColumnSidecar`
   ## is valid or not.
 

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -172,9 +172,9 @@ func checkResponseSanity(
 
   Opt.some(records)
 
-func checkColumnResponse(idList: seq[DataColumnsByRootIdentifier],
-                    columns: openArray[ref DataColumnSidecar]):
-                    Opt[seq[DataColumnResponseRecord]] =
+proc checkColumnResponse(idList: seq[DataColumnsByRootIdentifier],
+                         columns: openArray[ref DataColumnSidecar]):
+                         Opt[seq[DataColumnResponseRecord]] =
   var colRec: seq[DataColumnResponseRecord]
   for colresp in columns:
     let block_root =
@@ -187,6 +187,9 @@ func checkColumnResponse(idList: seq[DataColumnsByRootIdentifier],
           return Opt.none(seq[DataColumnResponseRecord])
         # verify the inclusion proof
         colresp[].verify_data_column_sidecar_inclusion_proof().isOkOr:
+          return Opt.none(seq[DataColumnResponseRecord])
+        # verify the column kzg proof
+        colresp[].verify_data_column_sidecar_kzg_proofs().isOkOr:
           return Opt.none(seq[DataColumnResponseRecord])
         colRec.add(DataColumnResponseRecord(block_root: block_root,
                                             sidecar: colresp))


### PR DESCRIPTION
This adds a data column sidecar kzg proof verification to the req/resp domain for columns, this way every entry point of columns have a verification, hence there's no double verification in any of the entry points, especially for gossip verification flows.