### PR TITLE
fix(action_tracker): always compute stability subnets regardless of known validators

### DIFF
--- a/beacon_chain/validators/action_tracker.nim
+++ b/beacon_chain/validators/action_tracker.nim
@@ -137,9 +137,8 @@ func stabilitySubnets*(tracker: ActionTracker, slot: Slot): AttnetBits =
     allSubnetBits
   else:
     var res: AttnetBits
-    if tracker.knownValidators.len > 0:
-      for subnetId in compute_subscribed_subnets(tracker.nodeId, slot.epoch):
-        res[subnetId.int] = true
+    for subnetId in compute_subscribed_subnets(tracker.nodeId, slot.epoch):
+      res[subnetId.int] = true
     res
 
 proc updateSlot*(tracker: var ActionTracker, wallSlot: Slot) =

--- a/tests/test_action_tracker.nim
+++ b/tests/test_action_tracker.nim
@@ -17,7 +17,7 @@ suite "subnet tracker":
     var tracker = ActionTracker.init(default(UInt256), false)
 
     check:
-      tracker.stabilitySubnets(Slot(0)).countOnes() == 0
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 2
       tracker.aggregateSubnets(Slot(0)).countOnes() == 0
 
     tracker.registerDuty(Slot(0), SubnetId(0), ValidatorIndex(0), true)
@@ -53,7 +53,7 @@ suite "subnet tracker":
       SUBNET_SUBSCRIPTION_LEAD_TIME_SLOTS + KNOWN_VALIDATOR_DECAY + 1))
 
     check:
-      tracker.stabilitySubnets(Slot(0)).countOnes() == 0
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 2
       tracker.aggregateSubnets(Slot(0)).countOnes() == 0
 
   test "should register sync committee duties":
@@ -91,3 +91,10 @@ suite "subnet tracker":
 
     check: # should not add old duties
       not tracker.hasSyncDuty(pk0, Epoch(1024))
+
+  test "should subscribe to all subnets when flag is enabled":
+    var tracker = ActionTracker.init(default(UInt256), true)  # subscribeAllAttnets = true
+
+    check:
+      tracker.stabilitySubnets(Slot(0)).countOnes() == 64  # All 64 subnets
+      tracker.aggregateSubnets(Slot(0)).countOnes() == 0


### PR DESCRIPTION
This PR ensures the beacon node always maintains attestation subnet subscriptions, regardless of whether they have active validators. The stability subnet calculation was gated by the presence of known validators, causing nodes with empty validator sets to skip subnet subscriptions entirely, in turn causing identity responses from the beacon API to return attnets of `0x0000000000000000`.

Also of note is that the current behavior reveals whether a node is running validators

Update tests to reflect the new expected behavior.

`[Summary] 839 tests run (377.4s): 834 OK, 0 FAILED, 5 SKIPPED`



