### PR TITLE
import datatypes/bellatrix as single package

### DIFF
--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -22,7 +22,7 @@ import
   ssz_serialization/[merkleization, proofs],
   ssz_serialization/types as sszTypes,
   ../digest,
-  "."/[base, phase0]
+  "."/[base, phase0, bellatrix]
 
 from kzg4844 import KzgCommitment, KzgProof
 from stew/bitops2 import log2trunc
@@ -30,7 +30,6 @@ from stew/byteutils import to0xHex
 from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
   TrustedSyncAggregate, num_active_participants
-from ./bellatrix import BloomLogs, ExecutionAddress, Transaction
 from ./capella import
   ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
   SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX

--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -17,7 +17,7 @@
 
 import
   std/[sequtils, typetraits],
-  "."/[phase0, base, electra],
+  "."/[phase0, base, bellatrix, electra],
   chronicles,
   json_serialization,
   ssz_serialization/[merkleization, proofs],
@@ -31,7 +31,6 @@ from stew/byteutils import to0xHex
 from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
   TrustedSyncAggregate, SyncnetBits, num_active_participants
-from ./bellatrix import BloomLogs, ExecutionAddress, Transaction
 from ./capella import
   ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
   SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX

--- a/beacon_chain/spec/mev/deneb_mev.nim
+++ b/beacon_chain/spec/mev/deneb_mev.nim
@@ -7,11 +7,10 @@
 
 {.push raises: [].}
 
-import ".."/datatypes/[altair, deneb]
+import ".."/datatypes/[altair, bellatrix, deneb]
 
 from stew/byteutils import to0xHex
 from ".."/datatypes/phase0 import Attestation, AttesterSlashing
-from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/eth2_merkleization import hash_tree_root
 
@@ -95,7 +94,7 @@ func toSignedBlindedBeaconBlock*(blck: deneb.SignedBeaconBlock):
         deposits: blck.message.body.deposits,
         voluntary_exits: blck.message.body.voluntary_exits,
         sync_aggregate: blck.message.body.sync_aggregate,
-        execution_payload_header: ExecutionPayloadHeader(
+        execution_payload_header: deneb.ExecutionPayloadHeader(
           parent_hash: blck.message.body.execution_payload.parent_hash,
           fee_recipient: blck.message.body.execution_payload.fee_recipient,
           state_root: blck.message.body.execution_payload.state_root,

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -7,11 +7,10 @@
 
 {.push raises: [].}
 
-import ".."/datatypes/[altair, electra]
+import ".."/datatypes/[altair, bellatrix, electra]
 
 from stew/byteutils import to0xHex
 from ".."/datatypes/phase0 import AttesterSlashing
-from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/datatypes/deneb import BlobsBundle, KzgCommitments
 from ".."/eth2_merkleization import hash_tree_root
@@ -149,7 +148,7 @@ func toSignedBlindedBeaconBlock*(blck: electra.SignedBeaconBlock):
         deposits: blck.message.body.deposits,
         voluntary_exits: blck.message.body.voluntary_exits,
         sync_aggregate: blck.message.body.sync_aggregate,
-        execution_payload_header: ExecutionPayloadHeader(
+        execution_payload_header: electra.ExecutionPayloadHeader(
           parent_hash: blck.message.body.execution_payload.parent_hash,
           fee_recipient: blck.message.body.execution_payload.fee_recipient,
           state_root: blck.message.body.execution_payload.state_root,

--- a/beacon_chain/spec/mev/fulu_mev.nim
+++ b/beacon_chain/spec/mev/fulu_mev.nim
@@ -7,11 +7,10 @@
 
 {.push raises: [].}
 
-import ".."/datatypes/[altair, fulu]
+import ".."/datatypes/[altair, bellatrix, fulu]
 
 from stew/byteutils import to0xHex
 from ".."/datatypes/phase0 import AttesterSlashing
-from ../datatypes/bellatrix import ExecutionAddress
 from ".."/datatypes/capella import SignedBLSToExecutionChange
 from ".."/datatypes/deneb import BlobsBundle, KzgCommitments
 from ".."/datatypes/electra import
@@ -20,7 +19,7 @@ from ".."/eth2_merkleization import hash_tree_root
 
 type
   BuilderBid* = object
-    header*: ExecutionPayloadHeader
+    header*: fulu.ExecutionPayloadHeader
     blob_kzg_commitments*: KzgCommitments
     execution_requests*: ExecutionRequests # [New in Electra]
     value*: UInt256
@@ -42,7 +41,7 @@ type
     deposits*: List[Deposit, Limit MAX_DEPOSITS]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
     sync_aggregate*: SyncAggregate
-    execution_payload_header*: ExecutionPayloadHeader
+    execution_payload_header*: fulu.ExecutionPayloadHeader
     bls_to_execution_changes*:
       List[SignedBLSToExecutionChange,
         Limit MAX_BLS_TO_EXECUTION_CHANGES]
@@ -72,7 +71,7 @@ type
 
   # Not spec, but suggested by spec
   BlindedExecutionPayloadAndBlobsBundle* = object
-    execution_payload_header*: ExecutionPayloadHeader
+    execution_payload_header*: fulu.ExecutionPayloadHeader
     blob_kzg_commitments*: KzgCommitments # [New in Deneb]
 
 func shortLog*(v: BlindedBeaconBlock): auto =
@@ -122,7 +121,7 @@ func toSignedBlindedBeaconBlock*(blck: fulu.SignedBeaconBlock):
         deposits: blck.message.body.deposits,
         voluntary_exits: blck.message.body.voluntary_exits,
         sync_aggregate: blck.message.body.sync_aggregate,
-        execution_payload_header: ExecutionPayloadHeader(
+        execution_payload_header: fulu.ExecutionPayloadHeader(
           parent_hash: blck.message.body.execution_payload.parent_hash,
           fee_recipient: blck.message.body.execution_payload.fee_recipient,
           state_root: blck.message.body.execution_payload.state_root,


### PR DESCRIPTION
This ensures that `ExecutionAddress`'s logging formats get imported too.