### PR TITLE
ci: add lfsconfig to avoid Windows LFS cloning issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
           echo "make_cmd=${make_cmd}" >> $GITHUB_ENV
 
+      - name: Configure Global LFS fetchexclude
+        run: |
+          echo "GIT_CONFIG_PARAMETERS='lfs.fetchexclude=/public-keys/all.txt,/metadata/genesis.ssz,/parsed/parsedConsensusGenesis.json'" >> $GITHUB_ENV
+
       - name: Build Nim and Nimbus dependencies
         run: |
           ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update


### PR DESCRIPTION
This should fix errors caued by fetching big files from LFS repos:
```
Downloading public-keys/all.txt (240 MB)
Error downloading object: public-keys/all.txt (ba977b5): Smudge error:
Error downloading public-keys/all.txt (ba977b5b1da180914c934623fce187860e1b54cff939e6208533b2cb5f589e07):
batch response: This repository exceeded its LFS budget. The account responsible for the budget should increase it to restore access.
```