### PR TITLE
Automate updating network configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# beacon_chain
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    directory: /
+    allow:
+      - dependency-name: vendor/mainnet
+      - dependency-name: vendor/holesky
+      - dependency-name: vendor/sepolia
+      - dependency-name: vendor/hoodi
+      - dependency-name: vendor/gnosis-chain-configs
+    schedule:
+      interval: daily
+    target-branch: unstable


### PR DESCRIPTION
Pull in latest eth2configs repo automatically.

Note dependabot cannot bump submodules to latest release, only commit.

- https://github.com/dependabot/dependabot-core/issues/1639