### PR TITLE
Add PeerId to validation procedures.

### DIFF
--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -357,7 +357,8 @@ proc installMessageValidators*(
           # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_finality_update
           lightClient.network.addValidator(
             getLightClientFinalityUpdateTopic(digest), proc (
-              msg: lcDataFork.LightClientFinalityUpdate
+              msg: lcDataFork.LightClientFinalityUpdate,
+              src: PeerId
             ): ValidationResult =
               validate(msg, contextFork, processLightClientFinalityUpdate))
 
@@ -365,7 +366,8 @@ proc installMessageValidators*(
           # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
           lightClient.network.addValidator(
             getLightClientOptimisticUpdateTopic(digest), proc (
-              msg: lcDataFork.LightClientOptimisticUpdate
+              msg: lcDataFork.LightClientOptimisticUpdate,
+              src: PeerId
             ): ValidationResult =
               validate(msg, contextFork, processLightClientOptimisticUpdate))
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -54,6 +54,13 @@ type
   # warning about unused import (rpc/messages).
   GossipMsg = messages.Message
 
+  ValidationSyncProc*[T] =
+    proc(msg: T, src: PeerId): ValidationResult {.gcsafe, raises: [].}
+
+  ValidationAsyncProc*[T] =
+    proc(msg: T, src: PeerId): Future[ValidationResult] {.
+      async: (raises: [CancelledError]).}
+
   SeenItem* = object
     peerId*: PeerId
     stamp*: chronos.Moment
@@ -2535,10 +2542,11 @@ proc newValidationResultFuture(v: ValidationResult): Future[ValidationResult]
   res.complete(v)
   res
 
-func addValidator*[MsgType](node: Eth2Node,
-                            topic: string,
-                            msgValidator: proc(msg: MsgType):
-                            ValidationResult {.gcsafe, raises: [].} ) =
+func addValidator*[MsgType](
+    node: Eth2Node,
+    topic: string,
+    msgValidator: ValidationSyncProc[MsgType]
+) =
   # Message validators run when subscriptions are enabled - they validate the
   # data and return an indication of whether the message should be broadcast
   # or not - validation is `async` but implemented without the macro because
@@ -2553,7 +2561,7 @@ func addValidator*[MsgType](node: Eth2Node,
       try:
         let decoded = SSZ.decode(decompressed, MsgType)
         decompressed = newSeq[byte](0) # release memory before validating
-        msgValidator(decoded) # doesn't raise!
+        msgValidator(decoded, message.fromPeer) # doesn't raise!
       except SerializationError as e:
         inc nbc_gossip_failed_ssz
         debug "Error decoding gossip",
@@ -2570,12 +2578,15 @@ func addValidator*[MsgType](node: Eth2Node,
   node.validTopics.incl topic # Only allow subscription to validated topics
   node.pubsub.addValidator(topic, execValidator)
 
-proc addAsyncValidator*[MsgType](node: Eth2Node,
-                            topic: string,
-                            msgValidator: proc(msg: MsgType):
-                            Future[ValidationResult] {.async: (raises: [CancelledError]).} ) =
-  proc execValidator(topic: string, message: GossipMsg):
-      Future[ValidationResult] {.async: (raw: true).} =
+proc addAsyncValidator*[MsgType](
+    node: Eth2Node,
+    topic: string,
+    msgValidator: ValidationAsyncProc[MsgType]
+) =
+  proc execValidator(
+      topic: string,
+      message: GossipMsg
+  ): Future[ValidationResult] {.async: (raw: true).} =
     inc nbc_gossip_messages_received
     trace "Validating incoming gossip message", len = message.data.len, topic
 
@@ -2584,7 +2595,7 @@ proc addAsyncValidator*[MsgType](node: Eth2Node,
       try:
         let decoded = SSZ.decode(decompressed, MsgType)
         decompressed = newSeq[byte](0) # release memory before validating
-        msgValidator(decoded) # doesn't raise!
+        msgValidator(decoded, message.fromPeer) # doesn't raise!
       except SerializationError as e:
         inc nbc_gossip_failed_ssz
         debug "Error decoding gossip",

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1949,7 +1949,8 @@ proc installMessageValidators(node: BeaconNode) =
       # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#beacon_block
       node.network.addValidator(
         getBeaconBlocksTopic(digest), proc (
-          signedBlock: consensusFork.SignedBeaconBlock
+          signedBlock: consensusFork.SignedBeaconBlock,
+          src: PeerId
         ): ValidationResult =
           if node.shouldSyncOptimistically(node.currentSlot):
             toValidationResult(
@@ -1968,7 +1969,7 @@ proc installMessageValidators(node: BeaconNode) =
             let subnet_id = it
             node.network.addAsyncValidator(
               getAttestationTopic(digest, subnet_id), proc (
-                attestation: SingleAttestation
+                attestation: SingleAttestation, src: PeerId
               ): Future[ValidationResult] {.
                   async: (raises: [CancelledError]).} =
                 return toValidationResult(
@@ -1981,7 +1982,7 @@ proc installMessageValidators(node: BeaconNode) =
             let subnet_id = it
             node.network.addAsyncValidator(
               getAttestationTopic(digest, subnet_id), proc (
-                attestation: phase0.Attestation
+                attestation: phase0.Attestation, src: PeerId
               ): Future[ValidationResult] {.
                   async: (raises: [CancelledError]).} =
                 return toValidationResult(
@@ -1994,7 +1995,8 @@ proc installMessageValidators(node: BeaconNode) =
       when consensusFork >= ConsensusFork.Electra:
         node.network.addAsyncValidator(
           getAggregateAndProofsTopic(digest), proc (
-            signedAggregateAndProof: electra.SignedAggregateAndProof
+            signedAggregateAndProof: electra.SignedAggregateAndProof,
+            src: PeerId
           ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
             return toValidationResult(
               await node.processor.processSignedAggregateAndProof(
@@ -2002,7 +2004,8 @@ proc installMessageValidators(node: BeaconNode) =
       else:
         node.network.addAsyncValidator(
           getAggregateAndProofsTopic(digest), proc (
-            signedAggregateAndProof: phase0.SignedAggregateAndProof
+            signedAggregateAndProof: phase0.SignedAggregateAndProof,
+            src: PeerId
           ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
             return toValidationResult(
               await node.processor.processSignedAggregateAndProof(
@@ -2014,7 +2017,8 @@ proc installMessageValidators(node: BeaconNode) =
       when consensusFork >= ConsensusFork.Electra:
         node.network.addValidator(
           getAttesterSlashingsTopic(digest), proc (
-            attesterSlashing: electra.AttesterSlashing
+            attesterSlashing: electra.AttesterSlashing,
+            src: PeerId
           ): ValidationResult =
             toValidationResult(
               node.processor[].processAttesterSlashing(
@@ -2022,7 +2026,8 @@ proc installMessageValidators(node: BeaconNode) =
       else:
         node.network.addValidator(
           getAttesterSlashingsTopic(digest), proc (
-            attesterSlashing: phase0.AttesterSlashing
+            attesterSlashing: phase0.AttesterSlashing,
+            src: PeerId
           ): ValidationResult =
             toValidationResult(
               node.processor[].processAttesterSlashing(
@@ -2032,7 +2037,8 @@ proc installMessageValidators(node: BeaconNode) =
       # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#proposer_slashing
       node.network.addValidator(
         getProposerSlashingsTopic(digest), proc (
-          proposerSlashing: ProposerSlashing
+          proposerSlashing: ProposerSlashing,
+          src: PeerId
         ): ValidationResult =
           toValidationResult(
             node.processor[].processProposerSlashing(
@@ -2042,7 +2048,8 @@ proc installMessageValidators(node: BeaconNode) =
       # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#voluntary_exit
       node.network.addValidator(
         getVoluntaryExitsTopic(digest), proc (
-          signedVoluntaryExit: SignedVoluntaryExit
+          signedVoluntaryExit: SignedVoluntaryExit,
+          src: PeerId
         ): ValidationResult =
           toValidationResult(
             node.processor[].processSignedVoluntaryExit(
@@ -2056,7 +2063,8 @@ proc installMessageValidators(node: BeaconNode) =
             let idx = subcommitteeIdx
             node.network.addAsyncValidator(
               getSyncCommitteeTopic(digest, idx), proc (
-                msg: SyncCommitteeMessage
+                msg: SyncCommitteeMessage,
+                src: PeerId
               ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
                 return toValidationResult(
                   await node.processor.processSyncCommitteeMessage(
@@ -2066,7 +2074,8 @@ proc installMessageValidators(node: BeaconNode) =
         # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/altair/p2p-interface.md#sync_committee_contribution_and_proof
         node.network.addAsyncValidator(
           getSyncCommitteeContributionAndProofTopic(digest), proc (
-            msg: SignedContributionAndProof
+            msg: SignedContributionAndProof,
+            src: PeerId
           ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
             return toValidationResult(
               await node.processor.processSignedContributionAndProof(
@@ -2076,7 +2085,8 @@ proc installMessageValidators(node: BeaconNode) =
         # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/capella/p2p-interface.md#bls_to_execution_change
         node.network.addAsyncValidator(
           getBlsToExecutionChangeTopic(digest), proc (
-            msg: SignedBLSToExecutionChange
+            msg: SignedBLSToExecutionChange,
+            src: PeerId
           ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
             return toValidationResult(
               await node.processor.processBlsToExecutionChange(
@@ -2095,7 +2105,8 @@ proc installMessageValidators(node: BeaconNode) =
             let subnet_id = it
             node.network.addValidator(
               getBlobSidecarTopic(digest, subnet_id), proc (
-                blobSidecar: deneb.BlobSidecar
+                blobSidecar: deneb.BlobSidecar,
+                src: PeerId
               ): ValidationResult =
                 toValidationResult(
                   node.processor[].processBlobSidecar(

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -132,7 +132,8 @@ proc main() {.noinline, raises: [CatchableError].} =
     let forkDigest = forkDigests[].atConsensusFork(consensusFork)
     network.addValidator(
       getBeaconBlocksTopic(forkDigest), proc (
-          signedBlock: consensusFork.SignedBeaconBlock
+          signedBlock: consensusFork.SignedBeaconBlock,
+          src: PeerId
       ): ValidationResult =
         toValidationResult(
           optimisticProcessor.processSignedBeaconBlock(signedBlock)))


### PR DESCRIPTION
This PR will allow to identify peer which was gossiped data. This data is needed when we trying to request missing roots.