### PR TITLE
fix: block_pools_types

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -412,7 +412,7 @@ func earliestAvailableSlot*(dag: ChainDAGRef): Slot =
     # When the BN is backfilling, backfill slot is the earliest
     # persisted block.
     dag.backfill.slot
-  elif dag.erSlot == GENESIS_SLOT:
+  elif dag.erSlot != GENESIS_SLOT:
     # This indicates column filling due to validator custody
     # is in progress
     dag.erSlot


### PR DESCRIPTION
The logic was inverted, causing the function to return dag.erSlot (which is GENESIS_SLOT) when validator custody is inactive, instead of falling through to return dag.tail.slot. This could cause nil pointer dereferences when the code expected a valid slot value.