### PR TITLE
ensure CStringConv warning is an error

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -178,6 +178,7 @@ if canEnableDebuggingSymbols:
 --define:nimOldCaseObjects # https://github.com/status-im/nim-confutils/issues/9
 
 switch("warningAsError", "BareExcept:on")
+switch("warningAsError", "CStringConv:on")
 switch("warningAsError", "UnusedImport:on")
 
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"


### PR DESCRIPTION
When run in such a situation, would now output:
```
nimbus-eth2/beacon_chain/gossip_processing/light_client_processor.nim(542, 17) Error: implicit conversion to 'cstring' from a non-const location: $error(r); this will become a compile time error in the future [CStringConv]
```