### PR TITLE
Make SyncQueue to be aware of fork boundary.

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -988,6 +988,7 @@ AllTests-mainnet
 + [SyncQueue# & Backward] Smoke [3 peers] test                                               OK
 + [SyncQueue# & Backward] Smoke [single peer] test                                           OK
 + [SyncQueue# & Backward] Unviable block [3 peers] test                                      OK
++ [SyncQueue# & Backward] epochFilter() test                                                 OK
 + [SyncQueue# & Forward] Combination of missing parent and good blocks [3 peers] test        OK
 + [SyncQueue# & Forward] Empty responses should not advance queue until other peers will not OK
 + [SyncQueue# & Forward] Empty responses should not be accounted [3 peers] test              OK
@@ -996,6 +997,7 @@ AllTests-mainnet
 + [SyncQueue# & Forward] Smoke [3 peers] test                                                OK
 + [SyncQueue# & Forward] Smoke [single peer] test                                            OK
 + [SyncQueue# & Forward] Unviable block [3 peers] test                                       OK
++ [SyncQueue# & Forward] epochFilter() test                                                  OK
 + [SyncQueue#Backward] Missing parent and exponential rewind [3 peers] test                  OK
 + [SyncQueue#Backward] getRewindPoint() test                                                 OK
 + [SyncQueue#Forward] Missing parent and exponential rewind [3 peers] test                   OK

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -390,6 +390,9 @@ proc initFullNode(
     isSlotWithinWeakSubjectivityPeriod(node.dag,
       node.beaconClock.now().slotOrZero())
 
+  proc forkAtEpoch(epoch: Epoch): ConsensusFork =
+    consensusForkAtEpoch(dag.cfg, epoch)
+
   proc eventWaiter(): Future[void] {.async: (raises: [CancelledError]).} =
     await node.shutdownEvent.wait()
     bnStatus = BeaconNodeStatus.Stopping
@@ -514,7 +517,7 @@ proc initFullNode(
       SyncQueueKind.Forward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       getFrontfillSlot, isWithinWeakSubjectivityPeriod,
-      dag.tail.slot, blockVerifier,
+      dag.tail.slot, blockVerifier, forkAtEpoch,
       shutdownEvent = node.shutdownEvent,
       flags = syncManagerFlags)
     backfiller = newSyncManager[Peer, PeerId](
@@ -526,7 +529,7 @@ proc initFullNode(
       SyncQueueKind.Backward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getBackfillSlot,
       getFrontfillSlot, isWithinWeakSubjectivityPeriod,
-      dag.backfill.slot, blockVerifier, maxHeadAge = 0,
+      dag.backfill.slot, blockVerifier, forkAtEpoch, maxHeadAge = 0,
       shutdownEvent = node.shutdownEvent,
       flags = syncManagerFlags)
     clistPivotSlot =
@@ -543,7 +546,7 @@ proc initFullNode(
       SyncQueueKind.Backward, getLocalHeadSlot,
       getLocalWallSlot, getFirstSlotAtFinalizedEpoch, getUntrustedBackfillSlot,
       getFrontfillSlot, isWithinWeakSubjectivityPeriod,
-      clistPivotSlot, untrustedBlockVerifier, maxHeadAge = 0,
+      clistPivotSlot, untrustedBlockVerifier, forkAtEpoch, maxHeadAge = 0,
       shutdownEvent = node.shutdownEvent,
       flags = syncManagerFlags)
     router = (ref MessageRouter)(

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -76,6 +76,7 @@ type
     queue: SyncQueue[A]
     syncFut: Future[void].Raising([CancelledError])
     blockVerifier: BlockVerifier
+    forkAtEpoch: ForkAtEpochCallback
     inProgress*: bool
     insSyncSpeed*: float
     avgSyncSpeed*: float
@@ -122,7 +123,7 @@ proc initQueue[A, B](man: SyncManager[A, B]) =
                                man.concurrentRequestsCount,
                                man.repeatingFailuresCount,
                                man.getSafeSlot, man.blockVerifier,
-                               man.ident)
+                               man.forkAtEpoch, man.ident)
   of SyncQueueKind.Backward:
     let
       firstSlot = man.getFirstSlot()
@@ -137,8 +138,8 @@ proc initQueue[A, B](man: SyncManager[A, B]) =
                                man.chunkSize,
                                man.concurrentRequestsCount,
                                man.repeatingFailuresCount,
-                               man.getSafeSlot,
-                               man.blockVerifier, man.ident)
+                               man.getSafeSlot, man.blockVerifier,
+                               man.forkAtEpoch, man.ident)
 
 proc newSyncManager*[A, B](
     pool: PeerPool[A, B],
@@ -155,6 +156,7 @@ proc newSyncManager*[A, B](
     weakSubjectivityPeriodCb: GetBoolCallback,
     progressPivot: Slot,
     blockVerifier: BlockVerifier,
+    forkAtEpochCb: ForkAtEpochCallback,
     shutdownEvent: AsyncEvent,
     maxHeadAge = uint64(SLOTS_PER_EPOCH * 1),
     chunkSize = uint64(SLOTS_PER_EPOCH),
@@ -186,6 +188,7 @@ proc newSyncManager*[A, B](
     maxHeadAge: maxHeadAge,
     chunkSize: chunkSize,
     blockVerifier: blockVerifier,
+    forkAtEpoch: forkAtEpochCb,
     notInSyncEvent: newAsyncEvent(),
     resumeSyncEvent: newAsyncEvent(),
     direction: direction,

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -25,6 +25,8 @@ type
   BlockVerifier* =  proc(signedBlock: ForkedSignedBeaconBlock,
                          blobs: Opt[BlobSidecars], maybeFinalized: bool):
       Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).}
+  ForkAtEpochCallback* =
+    proc(epoch: Epoch): ConsensusFork {.gcsafe, raises: [].}
 
   SyncRange* = object
     slot*: Slot
@@ -95,6 +97,7 @@ type
     requests: Deque[SyncQueueItem[T]]
     getSafeSlot: GetSlotCallback
     blockVerifier: BlockVerifier
+    forkAtEpoch: ForkAtEpochCallback
     waiters: seq[SyncWaiterItem[T]]
     gapList: seq[GapItem[T]]
     lock: AsyncLock
@@ -272,7 +275,60 @@ func init[T](t: typedesc[SyncQueueItem],
 func init[T](t: typedesc[GapItem], req: SyncRequest[T]): GapItem[T] =
   GapItem[T](data: req.data, item: req.item)
 
-func next(srange: SyncRange): SyncRange {.inline.} =
+func last_slot*(epoch: Epoch): Slot =
+  ## Return the start slot of ``epoch``.
+  const maxEpoch = Epoch(FAR_FUTURE_SLOT div SLOTS_PER_EPOCH)
+  if epoch >= maxEpoch: FAR_FUTURE_SLOT
+  else: Slot(epoch * SLOTS_PER_EPOCH + (SLOTS_PER_EPOCH - 1'u64))
+
+func start_slot*(sr: SyncRange): Slot =
+  sr.slot
+
+func last_slot*(sr: SyncRange): Slot =
+  if sr.slot + (uint64(sr.count) - 1'u64) < sr.slot:
+    FAR_FUTURE_SLOT
+  else:
+    sr.slot + (uint64(sr.count) - 1'u64)
+
+proc epochFilter*[T](squeue: SyncQueue[T], srange: SyncRange): SyncRange =
+  case squeue.kind
+  of SyncQueueKind.Forward:
+    let
+      startEpoch = srange.slot.epoch()
+      startFork = squeue.forkAtEpoch(startEpoch)
+
+    var currentEpoch = startEpoch
+    while (currentEpoch.start_slot() <= srange.last_slot()) and
+          (squeue.forkAtEpoch(currentEpoch) == startFork) and
+          (currentEpoch != FAR_FUTURE_EPOCH):
+      currentEpoch += 1
+
+    if (currentEpoch.start_slot() <= srange.last_slot()) and
+       (squeue.forkAtEpoch(currentEpoch) != startFork):
+      SyncRange(
+        slot: srange.start_slot(),
+        count: currentEpoch.start_slot() - srange.slot)
+    else:
+      srange
+  of SyncQueueKind.Backward:
+    let
+      startEpoch = srange.last_slot().epoch()
+      startFork = squeue.forkAtEpoch(startEpoch)
+
+    var currentEpoch = startEpoch
+    while (currentEpoch.last_slot() >= srange.start_slot()) and
+          (squeue.forkAtEpoch(currentEpoch) == startFork) and
+          (currentEpoch != GENESIS_EPOCH):
+      currentEpoch -= 1
+
+    if (currentEpoch.last_slot() >= srange.start_slot()) and
+       (squeue.forkAtEpoch(currentEpoch) != startFork):
+      let ncount = srange.last_slot() - (currentEpoch + 1).start_slot() + 1'u64
+      SyncRange(slot: (currentEpoch + 1).start_slot(), count: ncount)
+    else:
+      srange
+
+func next[T](sq: SyncQueue[T], srange: SyncRange): SyncRange {.inline.} =
   let slot = srange.slot + srange.count
   if slot == FAR_FUTURE_SLOT:
     # Finish range
@@ -281,22 +337,22 @@ func next(srange: SyncRange): SyncRange {.inline.} =
     # Range that causes uint64 overflow, fixing.
     SyncRange.init(slot, uint64(FAR_FUTURE_SLOT - srange.count))
   else:
-    if slot + srange.count < slot:
-      SyncRange.init(slot, uint64(FAR_FUTURE_SLOT - srange.count))
+    if slot + sq.chunkSize < slot:
+      SyncRange.init(slot, uint64(FAR_FUTURE_SLOT - sq.chunkSize))
     else:
-      SyncRange.init(slot, srange.count)
+      SyncRange.init(slot, sq.chunkSize)
 
-func prev(srange: SyncRange): SyncRange {.inline.} =
+func prev[T](sq: SyncQueue[T], srange: SyncRange): SyncRange {.inline.} =
   if srange.slot == GENESIS_SLOT:
     # Start range
     srange
   else:
-    let slot = srange.slot - srange.count
+    let slot = srange.slot - sq.chunkSize
     if slot > srange.slot:
       # Range that causes uint64 underflow, fixing.
       SyncRange.init(GENESIS_SLOT, uint64(srange.slot))
     else:
-      SyncRange.init(slot, srange.count)
+      SyncRange.init(slot, sq.chunkSize)
 
 func contains(srange: SyncRange, slot: Slot): bool {.inline.} =
   ## Returns `true` if `slot` is in range of `srange`.
@@ -456,6 +512,7 @@ func init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
               failureResetThreshold: Natural,
               getSafeSlotCb: GetSlotCallback,
               blockVerifier: BlockVerifier,
+              forkAtEpoch: ForkAtEpochCallback,
               ident: string = "main"): SyncQueue[T] =
   doAssert(chunkSize > 0'u64, "Chunk size should not be zero")
   doAssert(requestsCount > 0, "Number of requests should not be zero")
@@ -471,6 +528,7 @@ func init*[T](t1: typedesc[SyncQueue], t2: typedesc[T],
     inpSlot: start,
     outSlot: start,
     blockVerifier: blockVerifier,
+    forkAtEpoch: forkAtEpoch,
     requests: initDeque[SyncQueueItem[T]](),
     lock: newAsyncLock(),
     ident: ident
@@ -575,9 +633,9 @@ proc pop*[T](sq: SyncQueue[T], peerMaxSlot: Slot, item: T): SyncRequest[T] =
 
       case sq.kind
       of SyncQueueKind.Forward:
-        lastrange.next()
+        sq.next(lastrange)
       of SyncQueueKind.Backward:
-        lastrange.prev()
+        sq.prev(lastrange)
     else:
       case sq.kind
       of SyncQueueKind.Forward:
@@ -589,7 +647,7 @@ proc pop*[T](sq: SyncQueue[T], peerMaxSlot: Slot, item: T): SyncRequest[T] =
     # Peer could not satisfy our request, returning empty one.
     SyncRequest.init(sq.kind, item)
   else:
-    let request = SyncRequest.init(sq.kind, newrange, item)
+    let request = SyncRequest.init(sq.kind, sq.epochFilter(newrange), item)
     sq.requests.addLast(SyncQueueItem.init(request))
     request
 

--- a/tests/test_sync_manager.nim
+++ b/tests/test_sync_manager.nim
@@ -45,6 +45,9 @@ func getStaticSlotCb(slot: Slot): GetSlotCallback =
     slot
   getSlot
 
+proc testforkAtEpoch(epoch: Epoch): ConsensusFork =
+  ConsensusFork.Phase0
+
 type
   BlockEntry = object
     blck*: ForkedSignedBeaconBlock
@@ -60,6 +63,10 @@ func createChain(slots: Slice[Slot]): seq[ref ForkedSignedBeaconBlock] =
 
 proc createChain(srange: SyncRange): seq[ref ForkedSignedBeaconBlock] =
   createChain(srange.slot .. (srange.slot + srange.count - 1))
+
+func cmp(request: SyncRequest[SomeTPeer], srange: Slice[Slot]): bool =
+  (request.data.start_slot() == srange.a) and
+  (request.data.last_slot() == srange.b)
 
 func createBlobs(
     blocks: var seq[ref ForkedSignedBeaconBlock],
@@ -167,14 +174,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(127), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(127)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer = SomeTPeer.init("1")
         r1 = sq.pop(Slot(127), peer)
         r2 = sq.pop(Slot(127), peer)
@@ -245,14 +254,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(127), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(127)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -366,14 +377,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(63), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(63)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -466,14 +479,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(63), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(63)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -614,14 +629,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(63), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(63)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -748,14 +765,16 @@ suite "SyncManager test suite":
                            3, # 3 concurrent requests
                            2, # 2 failures allowed
                            getStaticSlotCb(Slot(0)),
-                           verifier.collector)
+                           verifier.collector,
+                           testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(95), Slot(0),
                            32'u64, # 32 slots per request
                            3, # 3 concurrent requests
                            2, # 2 failures allowed
                            getStaticSlotCb(Slot(127)),
-                           verifier.collector)
+                           verifier.collector,
+                           testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -886,14 +905,16 @@ suite "SyncManager test suite":
                            3, # 3 concurrent requests
                            2, # 2 failures allowed
                            getStaticSlotCb(Slot(0)),
-                           verifier.collector)
+                           verifier.collector,
+                           testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(159), Slot(0),
                            32'u64, # 32 slots per request
                            3, # 3 concurrent requests
                            2, # 2 failures allowed
                            getStaticSlotCb(Slot(159)),
-                           verifier.collector)
+                           verifier.collector,
+                           testforkAtEpoch)
         slots =
           case kind
           of SyncQueueKind.Forward:
@@ -987,14 +1008,16 @@ suite "SyncManager test suite":
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(0)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
           of SyncQueueKind.Backward:
             SyncQueue.init(SomeTPeer, kind, Slot(63), Slot(0),
                             32'u64, # 32 slots per request
                             3, # 3 concurrent requests
                             2, # 2 failures allowed
                             getStaticSlotCb(Slot(63)),
-                            verifier.collector)
+                            verifier.collector,
+                            testforkAtEpoch)
         peer1 = SomeTPeer.init("1")
         peer2 = SomeTPeer.init("2")
         peer3 = SomeTPeer.init("3")
@@ -1078,6 +1101,139 @@ suite "SyncManager test suite":
 
       await noCancel wait(verifier.verifier, 2.seconds)
 
+    test "[SyncQueue# & " & $kind & "] epochFilter() test":
+      let
+        aq = newAsyncQueue[BlockEntry]()
+        scenario =
+          case kind
+          of SyncQueueKind.Forward:
+            @[
+              (
+                Slot(0), 128, 13,
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix],
+                @[Slot(0)..Slot(12), Slot(13)..Slot(25), Slot(26)..Slot(31),
+                  Slot(32)..Slot(44), Slot(45)..Slot(57), Slot(58)..Slot(63),
+                  Slot(64)..Slot(76)]
+              ),
+              (
+                Slot(0), 128, 31,
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(0)..Slot(30), Slot(31)..Slot(31), Slot(32)..Slot(62),
+                  Slot(63)..Slot(63), Slot(64)..Slot(94), Slot(95)..Slot(95),
+                  Slot(96)..Slot(126)]
+              ),
+              (
+                Slot(0), 128, 32, # Size of chunk equal to SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(0)..Slot(31), Slot(32)..Slot(63), Slot(64)..Slot(95),
+                  Slot(96)..Slot(127)]
+              ),
+              (
+                Slot(0), 192, 33, # Size of chunk bigger than SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(0)..Slot(31), Slot(32)..Slot(63), Slot(64)..Slot(95),
+                  Slot(96)..Slot(128), Slot(129)..Slot(161)]
+              ),
+              (
+                Slot(0), 192, 192, # Size of chunk bigger than SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella,
+                  ConsensusFork.Deneb, ConsensusFork.Electra],
+                @[Slot(0)..Slot(31), Slot(32)..Slot(63), Slot(64)..Slot(95),
+                  Slot(96)..Slot(127)]
+              )
+            ]
+          of SyncQueueKind.Backward:
+            @[
+              (
+                Slot(95), 96, 13,
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix],
+                @[Slot(83)..Slot(95), Slot(70)..Slot(82), Slot(64)..Slot(69),
+                  Slot(51)..Slot(63), Slot(38)..Slot(50), Slot(32)..Slot(37),
+                  Slot(19)..Slot(31), Slot(6)..Slot(18), Slot(0)..Slot(5)]
+              ),
+              (
+                Slot(127), 128, 31,
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(97)..Slot(127), Slot(96)..Slot(96), Slot(65)..Slot(95),
+                  Slot(64)..Slot(64), Slot(33)..Slot(63), Slot(32)..Slot(32),
+                  Slot(1)..Slot(31), Slot(0)..Slot(0)]
+              ),
+              (
+                Slot(127), 128, 32, # Size of chunk equal to SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(96)..Slot(127), Slot(64)..Slot(95), Slot(32)..Slot(63),
+                  Slot(0)..Slot(31)]
+              ),
+              (
+                Slot(127), 128, 33, # Size of chunk bigger than SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(96)..Slot(127), Slot(64)..Slot(95), Slot(32)..Slot(63),
+                  Slot(0)..Slot(31)]
+              ),
+              (
+                Slot(127), 128, 128, # Size of chunk bigger than SLOTS_PER_EPOCH
+                @[ConsensusFork.Phase0, ConsensusFork.Altair,
+                  ConsensusFork.Bellatrix, ConsensusFork.Capella],
+                @[Slot(96)..Slot(127), Slot(64)..Slot(95), Slot(32)..Slot(63),
+                  Slot(0)..Slot(31)]
+              )
+            ]
+
+      func epochManager(epochs: openArray[ConsensusFork]): ForkAtEpochCallback =
+        var epochsSeq = @epochs
+        proc forkAtEpoch(epoch: Epoch): ConsensusFork =
+          let index = int(epoch)
+          if index >= len(epochsSeq):
+            epochsSeq[^1]
+          elif index < 0:
+            epochsSeq[0]
+          else:
+            epochsSeq[index]
+        forkAtEpoch
+
+      for vector in scenario:
+        case kind
+        of SyncQueueKind.Forward:
+          let
+            maxSlot = vector[0] + uint64(vector[1]) - 1'u64
+            sq =
+              SyncQueue.init(SomeTPeer, kind, vector[0], maxSlot,
+                             uint64(vector[2]),
+                             9, # 8 concurrent requests
+                             2, # 2 failures allowed
+                             getStaticSlotCb(Slot(0)),
+                             collector(aq),
+                             epochManager(vector[3]))
+            peer = SomeTPeer.init("1")
+          for srange in vector[4]:
+            let request = sq.pop(maxSlot, peer)
+            check cmp(request, srange)
+        of SyncQueueKind.Backward:
+          let
+            minSlot = vector[0] + 1'u64 - uint64(vector[1])
+            maxSlot = vector[0]
+            sq =
+              SyncQueue.init(SomeTPeer, kind, vector[0], minSlot,
+                             uint64(vector[2]),
+                             9, # 8 concurrent requests
+                             2, # 2 failures allowed
+                             getStaticSlotCb(Slot(0)),
+                             collector(aq),
+                             epochManager(vector[3]))
+            peer = SomeTPeer.init("1")
+          for srange in vector[4]:
+            let request = sq.pop(maxSlot, peer)
+            check cmp(request, srange)
+
   asyncTest "[SyncQueue#Forward] Missing parent and exponential rewind " &
             "[3 peers] test":
     let
@@ -1107,7 +1263,8 @@ suite "SyncManager test suite":
                           3, # 3 concurrent requests
                           2, # 2 failures allowed
                           getStaticSlotCb(Slot(0)),
-                          verifier.collector)
+                          verifier.collector,
+                          testforkAtEpoch)
       peer1 = SomeTPeer.init("1")
       peer2 = SomeTPeer.init("2")
       peer3 = SomeTPeer.init("3")
@@ -1269,7 +1426,8 @@ suite "SyncManager test suite":
                           3, # 3 concurrent requests
                           2, # 2 failures allowed
                           getStaticSlotCb(Slot(159)),
-                          verifier.collector)
+                          verifier.collector,
+                          testforkAtEpoch)
       peer1 = SomeTPeer.init("1")
       peer2 = SomeTPeer.init("2")
       peer3 = SomeTPeer.init("3")
@@ -1437,7 +1595,7 @@ suite "SyncManager test suite":
         queue = SyncQueue.init(SomeTPeer, SyncQueueKind.Forward,
                                Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                1'u64, 3, 2, getStaticSlotCb(Slot(0)),
-                               collector(aq))
+                               collector(aq), testforkAtEpoch)
         finalizedSlot = start_slot(Epoch(0'u64))
         epochStartSlot = start_slot(Epoch(0'u64)) + 1'u64
         finishSlot = start_slot(Epoch(2'u64))
@@ -1450,7 +1608,7 @@ suite "SyncManager test suite":
         queue = SyncQueue.init(SomeTPeer, SyncQueueKind.Forward,
                                Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                1'u64, 3, 2, getStaticSlotCb(Slot(0)),
-                               collector(aq))
+                               collector(aq), testforkAtEpoch)
         finalizedSlot = start_slot(Epoch(1'u64))
         epochStartSlot = start_slot(Epoch(1'u64)) + 1'u64
         finishSlot = start_slot(Epoch(3'u64))
@@ -1463,7 +1621,7 @@ suite "SyncManager test suite":
         queue = SyncQueue.init(SomeTPeer, SyncQueueKind.Forward,
                                Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                1'u64, 3, 2, getStaticSlotCb(Slot(0)),
-                               collector(aq))
+                               collector(aq), testforkAtEpoch)
         finalizedSlot = start_slot(Epoch(0'u64))
         failSlot = Slot(0xFFFF_FFFF_FFFF_FFFFF'u64)
         failEpoch = epoch(failSlot)
@@ -1482,7 +1640,7 @@ suite "SyncManager test suite":
         queue = SyncQueue.init(SomeTPeer, SyncQueueKind.Forward,
                                Slot(0), Slot(0xFFFF_FFFF_FFFF_FFFFF'u64),
                                1'u64, 3, 2, getStaticSlotCb(Slot(0)),
-                               collector(aq))
+                               collector(aq), testforkAtEpoch)
       let
         finalizedSlot = start_slot(Epoch(1'u64))
         failSlot = Slot(0xFFFF_FFFF_FFFF_FFFFF'u64)
@@ -1505,7 +1663,8 @@ suite "SyncManager test suite":
         getSafeSlot = getStaticSlotCb(Slot(1024))
         queue = SyncQueue.init(SomeTPeer, SyncQueueKind.Backward,
                                Slot(1024), Slot(0),
-                               1'u64, 3, 2, getSafeSlot, collector(aq))
+                               1'u64, 3, 2, getSafeSlot, collector(aq),
+                               testforkAtEpoch)
         safeSlot = getSafeSlot()
 
       for i in countdown(1023, 0):


### PR DESCRIPTION
With this PR `SyncQueue` will not generate sync requests which could pass through fork boundary. It means that all requests SyncQueue generates will have only slots which belongs to single `consensusFork` only.