### PR TITLE
feat: Make BUILDER_PROPOSAL_DELAY_TOLERANCE Configurable

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -665,6 +665,7 @@ type
         defaultValue: defaultGasLimit
         name: "suggested-gas-limit" .}: uint64
 
+
       payloadBuilderEnable* {.
         desc: "Enable external payload builder"
         defaultValue: false
@@ -682,6 +683,11 @@ type
               "comparison by a percentage"
         defaultValue: 10
         name: "local-block-value-boost" .}: uint8
+
+      builderProposalDelayTolerance* {.
+        desc: "Timeout for builder proposal delay tolerance in milliseconds"
+        defaultValue: 1500
+        name: "builder-proposal-delay-tolerance" .}: int
 
       historyMode* {.
         desc: "Retention strategy for historical data (archive/prune)"

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -100,7 +100,8 @@ const
 
   # Spec is 1 second, but mev-boost indirection can induce delay when the relay
   # itself has already consumed the entire second.
-  BUILDER_PROPOSAL_DELAY_TOLERANCE* = 1500.milliseconds
+  import ../conf
+  BUILDER_PROPOSAL_DELAY_TOLERANCE* = builderProposalDelayTolerance.milliseconds
 
 func shortLog*(v: BlindedBeaconBlock): auto =
   (

--- a/docs/builder-proposal-delay-tolerance.md
+++ b/docs/builder-proposal-delay-tolerance.md
@@ -1,0 +1,18 @@
+## Builder Proposal Delay Tolerance
+
+You can now configure the builder proposal delay tolerance (MEV block builder timeout) via the following flag:
+
+```
+--builder-proposal-delay-tolerance=<milliseconds>
+```
+
+- **Default value:** 1500 (milliseconds)
+- **Description:** Timeout for builder proposal delay tolerance. Increasing this value may allow the builder extra time to gather more transactions or MEV value, potentially improving block value and network efficiency. Lower values may reduce block proposal latency.
+
+**Example usage:**
+
+```
+./nimbus_beacon_node --builder-proposal-delay-tolerance=2000
+```
+
+This option is useful for node operators who wish to tune performance for different environments or experiment with MEV builder timing.


### PR DESCRIPTION
**Description:** 

Currently, the timeout value for `BUILDER_PROPOSAL_DELAY_TOLERANCE` is hardcoded to 1500.milliseconds in [beacon_chain/spec/mev/electra_mev.nim](https://github.com/status-im/nimbus-eth2/blob/stable/beacon_chain/spec/mev/electra_mev.nim#L103). Allowing this value to be configurable would enable operators to adjust the timeout as needed for different environments or use cases.

**Motivation:** 

In some scenarios, increasing the timeout would allow the builder extra time to gather more transactions or MEV value, potentially improving block value and network efficiency. Making this value configurable allows for experimentation and optimization based on network conditions or operator needs.

**Proposed Solution:**

- Expose BUILDER_PROPOSAL_DELAY_TOLERANCE as a configurable parameter, e.g., via a config file, environment variable, or command-line flag.
- Retain the current 1500.milliseconds as the default if not explicitly set.
- Document the new configuration option for users.

**Benefits:**

- Increase validator's yield
- Greater flexibility for node operators.
- Ability to tune performance for different conditions.
- Supports experimentation and research on the effects of timeout adjustments.

